### PR TITLE
[codex] Prepare 1.6.2 browser auth release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "ytm-tui"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ytm-tui"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2024"
 description = "A fast terminal UI for YouTube Music — search, radio, synced lyrics, album art, and downloads, driven by mpv and yt-dlp."
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           lib = pkgs.lib;
           ytm-tui = pkgs.rustPlatform.buildRustPackage {
             pname = "ytm-tui";
-            version = "1.6.1"; # keep in sync with Cargo.toml
+            version = "1.6.2"; # keep in sync with Cargo.toml
 
             # Drop build artifacts and flake results from the copied source so the store path
             # stays small and rebuilds aren't invalidated by a local `target/`.
@@ -72,7 +72,7 @@
           # correct hash to paste here (docs/gui/04 §9 risk 2).
           guiDist = pkgs.buildNpmPackage {
             pname = "ytm-tui-gui";
-            version = "1.6.1";
+            version = "1.6.1"; # private GUI package version; not part of the release surface
             src = ./gui;
             npmDepsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
             dontNpmInstall = true;
@@ -84,7 +84,7 @@
           };
           ytm-tui-desktop = pkgs.rustPlatform.buildRustPackage {
             pname = "ytm-tui-desktop";
-            version = "1.6.1"; # keep in sync with Cargo.toml + gui/package.json
+            version = "1.6.2"; # keep the ytt-desktop binary version in sync with Cargo.toml
             src = desktopSrc;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = [ pkgs.makeWrapper pkgs.pkg-config ];

--- a/gui/tests/accounts.test.ts
+++ b/gui/tests/accounts.test.ts
@@ -57,7 +57,7 @@ describe('AccountsStore', () => {
   it('opens the browser on an auth-url push', () => {
     const t = new MockTransport();
     const store = new AccountsStore(new Client(t));
-    const auth: AccountsAuthUrl = { kind: 'accounts_auth_url', service: 'lastfm', url: 'https://x/y' };
+    const auth: AccountsAuthUrl = { kind: 'accounts_auth_url', service: 'spotify', url: 'https://x/y' };
     t.emit({ v: 1, kind: 'event', topic: 'accounts', payload: auth });
     expect(t.last('win', 'openUrl').payload).toMatchObject({ url: 'https://x/y' });
     // Not a snapshot — the model is untouched by an auth-url frame.

--- a/src/app/settings_reducer.rs
+++ b/src/app/settings_reducer.rs
@@ -1354,17 +1354,25 @@ impl App {
         self.dirty = true;
         match event {
             TransferEvent::AuthUrl(url) => {
-                open_in_browser(&url);
+                let opened = crate::util::browser::open_in_browser_checked(&url);
                 // Also copy the URL: xdg-open can fail silently (e.g. a Flatpak
                 // browser the cleared env can't resolve), and this is the only
                 // path that would otherwise leave the user no way to reach the
                 // approval page.
                 copy_to_clipboard(&url);
-                self.status.text = t!(
-                    "Approve ytm-tui in the browser (link copied — paste it if nothing opened)",
-                    "브라우저에서 ytm-tui를 승인해 주세요 (링크를 클립보드에 복사했어요 — 안 열리면 붙여넣기)"
-                )
-                .to_owned();
+                self.status.text = if opened.launched() {
+                    t!(
+                        "Approve ytm-tui in the browser (link copied as fallback)",
+                        "브라우저에서 ytm-tui를 승인해 주세요 (링크는 예비용으로 복사했어요)"
+                    )
+                    .to_owned()
+                } else {
+                    t!(
+                        "Could not open browser; link copied. Paste it manually or run `ytt doctor --verbose`.",
+                        "브라우저를 열 수 없어요. 링크를 복사했으니 직접 붙여넣거나 `ytt doctor --verbose`를 실행해 주세요."
+                    )
+                    .to_owned()
+                };
                 self.status.kind = StatusKind::Info;
             }
             TransferEvent::AuthDone { display_name } => {
@@ -1504,17 +1512,25 @@ impl App {
         self.dirty = true;
         match event {
             ScrobbleEvent::AuthUrl(url) => {
-                open_in_browser(&url);
+                let opened = crate::util::browser::open_in_browser_checked(&url);
                 // Also copy the URL: xdg-open can fail silently (e.g. a Flatpak
                 // browser the cleared env can't resolve), and this is the only
                 // path that would otherwise leave the user no way to reach the
                 // approval page.
                 copy_to_clipboard(&url);
-                self.status.text = t!(
-                    "Approve ytm-tui in the browser (link copied — paste it if nothing opened)",
-                    "브라우저에서 ytm-tui를 승인해 주세요 (링크를 클립보드에 복사했어요 — 안 열리면 붙여넣기)"
-                )
-                .to_owned();
+                self.status.text = if opened.launched() {
+                    t!(
+                        "Approve ytm-tui in the browser (link copied as fallback)",
+                        "브라우저에서 ytm-tui를 승인해 주세요 (링크는 예비용으로 복사했어요)"
+                    )
+                    .to_owned()
+                } else {
+                    t!(
+                        "Could not open browser; link copied. Paste it manually or run `ytt doctor --verbose`.",
+                        "브라우저를 열 수 없어요. 링크를 복사했으니 직접 붙여넣거나 `ytt doctor --verbose`를 실행해 주세요."
+                    )
+                    .to_owned()
+                };
                 self.status.kind = StatusKind::Info;
                 Vec::new()
             }

--- a/src/desktop/bridge.rs
+++ b/src/desktop/bridge.rs
@@ -137,12 +137,19 @@ pub fn dispatch(body: &str) -> BridgeAction {
 
 fn parse_win(env: &OutEnvelope) -> WinOp {
     let text = || env.payload.as_str().unwrap_or_default().to_string();
+    let url = || {
+        env.payload
+            .as_str()
+            .or_else(|| env.payload.get("url").and_then(|v| v.as_str()))
+            .unwrap_or_default()
+            .to_string()
+    };
     match env.name.as_str() {
         "drag" => WinOp::Drag,
         "hide" => WinOp::Hide,
         "openDevtools" => WinOp::OpenDevtools,
         "copyText" => WinOp::CopyText(text()),
-        "openUrl" => WinOp::OpenUrl(text()),
+        "openUrl" => WinOp::OpenUrl(url()),
         "startDaemon" => WinOp::StartDaemon,
         "persist" => WinOp::Persist(env.payload.to_string()),
         other => WinOp::Unknown(other.to_string()),
@@ -195,6 +202,16 @@ mod tests {
         assert_eq!(
             dispatch(r#"{"v":1,"kind":"win","name":"copyText","payload":"hello"}"#),
             BridgeAction::Win(WinOp::CopyText("hello".to_string()))
+        );
+        assert_eq!(
+            dispatch(r#"{"v":1,"kind":"win","name":"openUrl","payload":"https://example.test"}"#),
+            BridgeAction::Win(WinOp::OpenUrl("https://example.test".to_string()))
+        );
+        assert_eq!(
+            dispatch(
+                r#"{"v":1,"kind":"win","name":"openUrl","payload":{"url":"https://example.test"}}"#
+            ),
+            BridgeAction::Win(WinOp::OpenUrl("https://example.test".to_string()))
         );
     }
 

--- a/src/desktop/platform/macos.rs
+++ b/src/desktop/platform/macos.rs
@@ -323,7 +323,18 @@ impl MacTrayApp {
                 }
             }
             bridge::WinOp::StartDaemon => self.start_daemon(false),
-            // copyText/openUrl/openDevtools/persist land at M1; ignore unknowns.
+            bridge::WinOp::OpenUrl(url) => {
+                if !url.trim().is_empty() {
+                    let opened = crate::util::browser::open_in_browser_checked(&url);
+                    if !opened.launched() {
+                        report_error(format_args!(
+                            "could not open URL in browser: {}",
+                            opened.failure_summary()
+                        ));
+                    }
+                }
+            }
+            // copyText/openDevtools/persist land at M1; ignore unknowns.
             _ => {}
         }
     }

--- a/src/desktop/platform/macos.rs
+++ b/src/desktop/platform/macos.rs
@@ -323,15 +323,13 @@ impl MacTrayApp {
                 }
             }
             bridge::WinOp::StartDaemon => self.start_daemon(false),
-            bridge::WinOp::OpenUrl(url) => {
-                if !url.trim().is_empty() {
-                    let opened = crate::util::browser::open_in_browser_checked(&url);
-                    if !opened.launched() {
-                        report_error(format_args!(
-                            "could not open URL in browser: {}",
-                            opened.failure_summary()
-                        ));
-                    }
+            bridge::WinOp::OpenUrl(url) if !url.trim().is_empty() => {
+                let opened = crate::util::browser::open_in_browser_checked(&url);
+                if !opened.launched() {
+                    report_error(format_args!(
+                        "could not open URL in browser: {}",
+                        opened.failure_summary()
+                    ));
                 }
             }
             // copyText/openDevtools/persist land at M1; ignore unknowns.

--- a/src/desktop/platform/windows.rs
+++ b/src/desktop/platform/windows.rs
@@ -376,15 +376,13 @@ impl WindowsTrayApp {
                 }
             }
             bridge::WinOp::StartDaemon => self.start_daemon(false),
-            bridge::WinOp::OpenUrl(url) => {
-                if !url.trim().is_empty() {
-                    let opened = crate::util::browser::open_in_browser_checked(&url);
-                    if !opened.launched() {
-                        report_error(format_args!(
-                            "could not open URL in browser: {}",
-                            opened.failure_summary()
-                        ));
-                    }
+            bridge::WinOp::OpenUrl(url) if !url.trim().is_empty() => {
+                let opened = crate::util::browser::open_in_browser_checked(&url);
+                if !opened.launched() {
+                    report_error(format_args!(
+                        "could not open URL in browser: {}",
+                        opened.failure_summary()
+                    ));
                 }
             }
             // copyText/openDevtools/persist land at M1; ignore unknowns.

--- a/src/desktop/platform/windows.rs
+++ b/src/desktop/platform/windows.rs
@@ -376,7 +376,18 @@ impl WindowsTrayApp {
                 }
             }
             bridge::WinOp::StartDaemon => self.start_daemon(false),
-            // copyText/openUrl/openDevtools/persist land at M1; ignore unknowns.
+            bridge::WinOp::OpenUrl(url) => {
+                if !url.trim().is_empty() {
+                    let opened = crate::util::browser::open_in_browser_checked(&url);
+                    if !opened.launched() {
+                        report_error(format_args!(
+                            "could not open URL in browser: {}",
+                            opened.failure_summary()
+                        ));
+                    }
+                }
+            }
+            // copyText/openDevtools/persist land at M1; ignore unknowns.
             _ => {}
         }
     }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -11,6 +11,8 @@
 use crate::deps::{self, Need};
 use crate::{config, i18n};
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "linux")]
+use std::time::Duration;
 
 /// Run the diagnostic, printing a report, and return the process exit code.
 pub fn run() -> i32 {
@@ -255,6 +257,9 @@ fn run_inner(verbose: bool) -> i32 {
             Some(found) => println!("  ✓ {clip_label} ({found})"),
             None => println!("  ✗ {clip_label} (wl-copy/xclip/xsel)"),
         }
+        if verbose {
+            print_linux_browser_verbose();
+        }
         println!();
     }
 
@@ -280,6 +285,120 @@ fn run_inner(verbose: bool) -> i32 {
         );
         1
     }
+}
+
+#[cfg(target_os = "linux")]
+fn print_linux_browser_verbose() {
+    println!("  browser diagnostics:");
+    print_path_probe("xdg-open");
+    print_path_probe("xdg-settings");
+    print_path_probe("xdg-mime");
+    print_path_probe("gio");
+    println!(
+        "    xdg-settings default-web-browser: {}",
+        command_stdout("xdg-settings", &["get", "default-web-browser"])
+    );
+    println!(
+        "    xdg-mime http handler: {}",
+        command_stdout("xdg-mime", &["query", "default", "x-scheme-handler/http"])
+    );
+    println!(
+        "    xdg-mime https handler: {}",
+        command_stdout("xdg-mime", &["query", "default", "x-scheme-handler/https"])
+    );
+    println!(
+        "    gio http handler: {}",
+        command_stdout("gio", &["mime", "x-scheme-handler/http"])
+    );
+    println!(
+        "    gio https handler: {}",
+        command_stdout("gio", &["mime", "x-scheme-handler/https"])
+    );
+    println!("    environment:");
+    for key in [
+        "DISPLAY",
+        "WAYLAND_DISPLAY",
+        "XDG_CURRENT_DESKTOP",
+        "DESKTOP_SESSION",
+        "XDG_SESSION_TYPE",
+        "XDG_RUNTIME_DIR",
+        "DBUS_SESSION_BUS_ADDRESS",
+        "XDG_DATA_DIRS",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "BROWSER",
+        "SNAP",
+        "SNAP_NAME",
+        "FLATPAK_ID",
+        "WSL_DISTRO_NAME",
+        "WSL_INTEROP",
+    ] {
+        println!("      {key}: {}", env_value(key));
+    }
+    println!(
+        "    wsl detected: {}",
+        if linux_wsl_detected() { "yes" } else { "no" }
+    );
+    println!(
+        "    ytm-tui DesktopOpen preserves: DISPLAY, WAYLAND_DISPLAY, XAUTHORITY, \
+         XDG_RUNTIME_DIR, XDG_CONFIG_HOME, XDG_CACHE_HOME, XDG_DATA_HOME, \
+         DBUS_SESSION_BUS_ADDRESS, XDG_DATA_DIRS, XDG_CURRENT_DESKTOP, \
+         DESKTOP_SESSION, BROWSER"
+    );
+}
+
+#[cfg(target_os = "linux")]
+fn print_path_probe(bin: &str) {
+    match deps::resolve_on_path(bin) {
+        Some(path) => println!("    {bin}: {}", path.display()),
+        None => println!("    {bin}: missing"),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn command_stdout(program: &str, args: &[&str]) -> String {
+    if !deps::on_path(program) {
+        return "missing".to_owned();
+    }
+    let mut cmd = crate::util::process::std_command(
+        program,
+        crate::util::process::ProcessProfile::DesktopOpen,
+    );
+    cmd.args(args);
+    match crate::util::process::std_output_limited(cmd, Duration::from_secs(2), 4096) {
+        Ok(out) if out.status.success() => {
+            let text = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+            if text.is_empty() {
+                "(empty)".to_owned()
+            } else {
+                text
+            }
+        }
+        Ok(out) => format!("failed ({})", out.status),
+        Err(e) => format!("error: {e}"),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn env_value(key: &str) -> String {
+    std::env::var(key)
+        .map(|v| {
+            if v.is_empty() {
+                "(empty)".to_owned()
+            } else {
+                v
+            }
+        })
+        .unwrap_or_else(|_| "(unset)".to_owned())
+}
+
+#[cfg(target_os = "linux")]
+fn linux_wsl_detected() -> bool {
+    std::env::var_os("WSL_DISTRO_NAME").is_some()
+        || std::env::var_os("WSL_INTEROP").is_some()
+        || std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .map(|s| s.to_ascii_lowercase().contains("microsoft"))
+            .unwrap_or(false)
 }
 
 /// The "Managed yt-dlp" section: whether the app-managed copy is enabled/installed,

--- a/src/scrobble/auth_cli.rs
+++ b/src/scrobble/auth_cli.rs
@@ -107,7 +107,14 @@ async fn connect_lastfm() -> i32 {
     println!();
     println!("  {url}");
     println!();
-    crate::util::browser::open_in_browser(&url);
+    let opened = crate::util::browser::open_in_browser_checked(&url);
+    if !opened.launched() {
+        eprintln!(
+            "ytt auth lastfm: could not open a browser automatically: {}",
+            opened.failure_summary()
+        );
+        eprintln!("ytt auth lastfm: paste the URL above into your browser to continue.");
+    }
     println!("Waiting for approval (up to 5 minutes; Ctrl-C to abort)…");
 
     let deadline = Instant::now() + AUTH_BUDGET;

--- a/src/transfer/cli.rs
+++ b/src/transfer/cli.rs
@@ -798,7 +798,14 @@ async fn connect(client_id_flag: Option<String>) -> i32 {
         println!();
         println!("  {url}");
         println!();
-        crate::util::browser::open_in_browser(&url);
+        let opened = crate::util::browser::open_in_browser_checked(&url);
+        if !opened.launched() {
+            eprintln!(
+                "ytt auth spotify: could not open a browser automatically: {}",
+                opened.failure_summary()
+            );
+            eprintln!("ytt auth spotify: paste the URL above into your browser to continue.");
+        }
         println!("Waiting for approval (up to 5 minutes; Ctrl-C to abort)…");
     })
     .await;

--- a/src/util/browser.rs
+++ b/src/util/browser.rs
@@ -1,37 +1,334 @@
 //! Opening URLs in the system browser, shared by the TUI (About card, account
 //! connect flows) and one-shot CLI commands (`ytt auth …`).
 
-use std::process::Stdio;
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use crate::util::process;
 
+const EARLY_EXIT_WINDOW: Duration = Duration::from_millis(700);
+const STDERR_TAIL_MAX: usize = 2 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserOpenReport {
+    pub status: BrowserOpenStatus,
+    pub attempts: Vec<BrowserOpenAttempt>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrowserOpenStatus {
+    /// The opener exited successfully or stayed alive long enough to imply handoff.
+    Launched,
+    /// Every opener failed before the handoff window elapsed.
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserOpenAttempt {
+    pub opener: String,
+    pub outcome: BrowserOpenOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BrowserOpenOutcome {
+    SpawnFailed(String),
+    Exited { code: Option<i32>, stderr: String },
+    StillRunning,
+}
+
+impl BrowserOpenReport {
+    pub fn launched(&self) -> bool {
+        self.status == BrowserOpenStatus::Launched
+    }
+
+    pub fn opener(&self) -> Option<&str> {
+        self.attempts.last().map(|a| a.opener.as_str())
+    }
+
+    pub fn failure_summary(&self) -> String {
+        self.attempts
+            .iter()
+            .map(|attempt| {
+                let outcome = match &attempt.outcome {
+                    BrowserOpenOutcome::SpawnFailed(e) => format!("spawn failed: {e}"),
+                    BrowserOpenOutcome::Exited { code, stderr } => {
+                        let code = code
+                            .map(|c| c.to_string())
+                            .unwrap_or_else(|| "signal".to_string());
+                        if stderr.trim().is_empty() {
+                            format!("exited with {code}")
+                        } else {
+                            format!("exited with {code}: {}", stderr.trim())
+                        }
+                    }
+                    BrowserOpenOutcome::StillRunning => "still running".to_string(),
+                };
+                format!("{} ({outcome})", attempt.opener)
+            })
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+}
+
 /// Open `url` in the system's default browser, fire-and-forget. Spawns the platform opener
 /// (`open` / `xdg-open` / `cmd start`) detached with stdio nulled so it can't touch the TUI's
-/// terminal; any failure (no opener installed) is ignored — callers always show the URL too.
+/// terminal. Any failure is ignored here; auth flows that need user-visible diagnostics should
+/// call [`open_in_browser_checked`] directly.
 pub fn open_in_browser(url: &str) {
-    let mut cmd = if cfg!(target_os = "macos") {
-        let mut c = process::std_command("open", process::ProcessProfile::DesktopOpen);
-        c.arg(url);
-        c
-    } else if cfg!(target_os = "windows") {
-        // `start` is a cmd builtin; the empty "" is its (ignored) window-title argument.
-        let mut c = process::std_command("cmd", process::ProcessProfile::DesktopOpen);
-        c.args(["/C", "start", "", url]);
-        c
-    } else {
-        let mut c = process::std_command("xdg-open", process::ProcessProfile::DesktopOpen);
-        c.arg(url);
-        c
-    };
-    let _ = cmd
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn();
+    let _ = open_in_browser_checked(url);
+}
+
+/// Open `url` in the system browser and return enough detail for auth surfaces to explain a
+/// definite failure. A helper that stays alive after [`EARLY_EXIT_WINDOW`] is treated as a
+/// successful handoff because several desktop openers keep a broker process around.
+pub fn open_in_browser_checked(url: &str) -> BrowserOpenReport {
+    let mut attempts = Vec::new();
+    for candidate in open_candidates(url) {
+        let attempt = run_candidate(candidate);
+        let launched = matches!(
+            attempt.outcome,
+            BrowserOpenOutcome::Exited { code: Some(0), .. } | BrowserOpenOutcome::StillRunning
+        );
+        attempts.push(attempt);
+        if launched {
+            return BrowserOpenReport {
+                status: BrowserOpenStatus::Launched,
+                attempts,
+            };
+        }
+    }
+    BrowserOpenReport {
+        status: BrowserOpenStatus::Failed,
+        attempts,
+    }
 }
 
 /// Open a local file or folder with the system's default handler (the same platform openers
 /// as [`open_in_browser`], which all accept a path). Fire-and-forget.
 pub fn open_path(path: &std::path::Path) {
     open_in_browser(&path.to_string_lossy());
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OpenCandidate {
+    opener: String,
+    program: String,
+    args: Vec<String>,
+}
+
+fn open_candidates(url: &str) -> Vec<OpenCandidate> {
+    if cfg!(target_os = "macos") {
+        vec![candidate("open", "open", [url])]
+    } else if cfg!(target_os = "windows") {
+        vec![candidate("cmd start", "cmd", ["/C", "start", "", url])]
+    } else {
+        linux_open_candidates(url, std::env::var("BROWSER").ok().as_deref(), detect_wsl())
+    }
+}
+
+fn linux_open_candidates(url: &str, browser_env: Option<&str>, is_wsl: bool) -> Vec<OpenCandidate> {
+    let mut out = Vec::new();
+    out.push(candidate("xdg-open", "xdg-open", [url]));
+    if is_wsl {
+        out.push(candidate("wslview", "wslview", [url]));
+        out.push(candidate("wsl-open", "wsl-open", [url]));
+        out.push(candidate(
+            "powershell.exe Start-Process",
+            "powershell.exe",
+            ["-NoProfile", "-Command", "Start-Process", url],
+        ));
+    }
+    out.extend([
+        candidate("gio open", "gio", ["open", url]),
+        candidate("kde-open5", "kde-open5", [url]),
+        candidate("kde-open", "kde-open", [url]),
+        candidate("gnome-open", "gnome-open", [url]),
+        candidate("exo-open", "exo-open", [url]),
+    ]);
+    if let Some(browser) = browser_env {
+        out.extend(browser_env_candidates(url, browser).into_iter().take(3));
+    }
+    out
+}
+
+fn candidate<'a>(
+    opener: impl Into<String>,
+    program: impl Into<String>,
+    args: impl IntoIterator<Item = &'a str>,
+) -> OpenCandidate {
+    OpenCandidate {
+        opener: opener.into(),
+        program: program.into(),
+        args: args.into_iter().map(str::to_owned).collect(),
+    }
+}
+
+fn run_candidate(candidate: OpenCandidate) -> BrowserOpenAttempt {
+    let mut cmd = process::std_command(&candidate.program, process::ProcessProfile::DesktopOpen);
+    cmd.args(&candidate.args);
+    let outcome = run_command(&mut cmd);
+    BrowserOpenAttempt {
+        opener: candidate.opener,
+        outcome,
+    }
+}
+
+fn run_command(cmd: &mut Command) -> BrowserOpenOutcome {
+    let mut child = match cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(e) => return BrowserOpenOutcome::SpawnFailed(e.to_string()),
+    };
+
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let stderr = child.stderr.take().map(read_tail).unwrap_or_default();
+                return BrowserOpenOutcome::Exited {
+                    code: status.code(),
+                    stderr,
+                };
+            }
+            Ok(None) if start.elapsed() < EARLY_EXIT_WINDOW => {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Ok(None) => return BrowserOpenOutcome::StillRunning,
+            Err(e) => return BrowserOpenOutcome::SpawnFailed(e.to_string()),
+        }
+    }
+}
+
+fn read_tail(mut reader: impl Read) -> String {
+    let mut buf = Vec::new();
+    let _ = reader
+        .by_ref()
+        .take((STDERR_TAIL_MAX + 1) as u64)
+        .read_to_end(&mut buf);
+    if buf.len() > STDERR_TAIL_MAX {
+        let excess = buf.len() - STDERR_TAIL_MAX;
+        buf.drain(..excess);
+    }
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+fn detect_wsl() -> bool {
+    if std::env::var_os("WSL_DISTRO_NAME").is_some() || std::env::var_os("WSL_INTEROP").is_some() {
+        return true;
+    }
+    std::fs::read_to_string("/proc/sys/kernel/osrelease")
+        .map(|s| s.to_ascii_lowercase().contains("microsoft"))
+        .unwrap_or(false)
+}
+
+fn browser_env_candidates(url: &str, browser_env: &str) -> Vec<OpenCandidate> {
+    browser_env
+        .split(':')
+        .filter_map(|entry| parse_browser_env_entry(url, entry.trim()))
+        .collect()
+}
+
+fn parse_browser_env_entry(url: &str, entry: &str) -> Option<OpenCandidate> {
+    if entry.is_empty()
+        || entry.chars().any(|c| {
+            matches!(
+                c,
+                ';' | '&' | '|' | '`' | '$' | '>' | '<' | '\n' | '\r' | '"'
+            )
+        })
+    {
+        return None;
+    }
+    let mut parts: Vec<String> = entry.split_whitespace().map(str::to_owned).collect();
+    let program = parts.first()?.clone();
+    let base = program.rsplit('/').next().unwrap_or(&program);
+    if matches!(base, "echo" | "printf" | "true" | "false") {
+        return None;
+    }
+    let mut replaced = false;
+    for arg in parts.iter_mut().skip(1) {
+        if arg.contains("%s") {
+            *arg = arg.replace("%s", url);
+            replaced = true;
+        }
+    }
+    if !replaced {
+        parts.push(url.to_owned());
+    }
+    Some(OpenCandidate {
+        opener: format!("$BROWSER:{base}"),
+        program,
+        args: parts.into_iter().skip(1).collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linux_candidates_start_with_xdg_and_include_desktop_fallbacks() {
+        let candidates = linux_open_candidates("https://example.test", None, false);
+        let openers: Vec<_> = candidates.iter().map(|c| c.opener.as_str()).collect();
+        assert_eq!(openers.first(), Some(&"xdg-open"));
+        assert!(openers.contains(&"gio open"));
+        assert!(openers.contains(&"kde-open5"));
+        assert!(!openers.contains(&"wslview"));
+    }
+
+    #[test]
+    fn linux_candidates_include_wsl_fallbacks_when_detected() {
+        let candidates = linux_open_candidates("https://example.test", None, true);
+        let openers: Vec<_> = candidates.iter().map(|c| c.opener.as_str()).collect();
+        assert!(openers.contains(&"wslview"));
+        assert!(openers.contains(&"wsl-open"));
+        assert!(openers.contains(&"powershell.exe Start-Process"));
+    }
+
+    #[test]
+    fn browser_env_candidates_are_shell_free() {
+        let candidates = browser_env_candidates(
+            "https://example.test",
+            "firefox --new-tab %s:echo %s:bad;rm:chromium",
+        );
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|c| c.opener.as_str())
+                .collect::<Vec<_>>(),
+            vec!["$BROWSER:firefox", "$BROWSER:chromium"]
+        );
+        assert_eq!(
+            candidates[0].args,
+            vec!["--new-tab".to_string(), "https://example.test".to_string()]
+        );
+        assert_eq!(candidates[1].args, vec!["https://example.test".to_string()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn command_failure_captures_exit_and_stderr() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "echo opener failed >&2; exit 7"]);
+        match run_command(&mut cmd) {
+            BrowserOpenOutcome::Exited { code, stderr } => {
+                assert_eq!(code, Some(7));
+                assert!(stderr.contains("opener failed"));
+            }
+            other => panic!("expected failed exit, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn long_running_command_is_treated_as_handoff() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 2"]);
+        assert_eq!(run_command(&mut cmd), BrowserOpenOutcome::StillRunning);
+    }
 }


### PR DESCRIPTION
## Summary

- Bump the Rust package release version to `1.6.2` and sync the release-facing Nix flake package versions.
- Make browser opening for Spotify/Last.fm auth return actionable failure details instead of silently swallowing opener failures.
- Add Linux browser diagnostics to `ytt doctor --verbose` and keep auth URLs copied as the manual fallback.
- Handle desktop bridge `openUrl` payloads in both string and `{ url }` forms.

## Release scope

The full GUI app remains non-shipping for this release. The existing workflow still releases `ytt` on all platforms and `ytt-desktop` on macOS/Windows only. The private GUI dist version in `flake.nix` remains tied to the GUI package rather than the release tag.

## Verification

- `~/.fable-harness/bin/run-gates .`
- `cargo clippy --features desktop --bin ytt-desktop -- -D warnings`
- `cargo clippy --features desktop --target x86_64-apple-darwin --bin ytt-desktop -- -D warnings`
- `nix eval --raw .#packages.x86_64-linux.ytm-tui.version`
- `nix eval --raw .#packages.aarch64-darwin.ytm-tui.version`
- `nix eval --raw .#packages.aarch64-darwin.ytm-tui-desktop.version`

## Manual release step

After human review and merge to `main`, create/push `v1.6.2` from the merged commit to trigger the release workflow. I did not create or push a `v*` tag because this repository marks that as a protected release action.
