### PR TITLE
[codex] add Spotify auth fallback for headless TUI sessions

### DIFF
--- a/src/app/clipboard.rs
+++ b/src/app/clipboard.rs
@@ -1,0 +1,114 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::t;
+use crate::util::process;
+
+/// Copy `text` to the system clipboard. Mirrors `open_in_browser`: spawns the platform
+/// clipboard tool with stdio nulled and pipes `text` to its stdin, so no native clipboard crate
+/// is needed. macOS uses `pbcopy`, Windows `clip`; Linux tries `wl-copy` (Wayland) then
+/// `xclip`/`xsel` (X11). Returns whether a helper accepted the handoff; callers that only want a
+/// best-effort nicety can ignore the result.
+pub(in crate::app) fn copy_to_clipboard(text: &str) -> bool {
+    fn pipe(cmd: &mut Command, text: &str) -> bool {
+        let Ok(mut child) = cmd
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        else {
+            return false;
+        };
+
+        if let Some(mut stdin) = child.stdin.take()
+            && stdin.write_all(text.as_bytes()).is_err()
+        {
+            let _ = child.kill();
+            let _ = child.wait();
+            return false;
+        }
+
+        let start = Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => return status.success(),
+                Ok(None) if start.elapsed() < Duration::from_millis(500) => {
+                    std::thread::sleep(Duration::from_millis(25));
+                }
+                Ok(None) => return true,
+                Err(_) => return false,
+            }
+        }
+    }
+
+    if cfg!(target_os = "macos") {
+        pipe(
+            &mut process::std_command("pbcopy", process::ProcessProfile::Clipboard),
+            text,
+        )
+    } else if cfg!(target_os = "windows") {
+        pipe(
+            &mut process::std_command("clip", process::ProcessProfile::Clipboard),
+            text,
+        )
+    } else if pipe(
+        &mut process::std_command("wl-copy", process::ProcessProfile::Clipboard),
+        text,
+    ) || pipe(
+        process::std_command("xclip", process::ProcessProfile::Clipboard)
+            .args(["-selection", "clipboard"]),
+        text,
+    ) {
+        true
+    } else {
+        pipe(
+            process::std_command("xsel", process::ProcessProfile::Clipboard).arg("-ib"),
+            text,
+        )
+    }
+}
+
+pub(in crate::app) fn spotify_auth_url_status(
+    opened: bool,
+    copied: bool,
+    saved_path: Option<&std::path::Path>,
+) -> String {
+    if opened && copied {
+        t!(
+            "Approve ytm-tui in the browser (link copied as fallback)",
+            "브라우저에서 ytm-tui를 승인해 주세요 (링크는 예비용으로 복사했어요)"
+        )
+        .to_owned()
+    } else if opened {
+        t!(
+            "Approve ytm-tui in the browser",
+            "브라우저에서 ytm-tui를 승인해 주세요"
+        )
+        .to_owned()
+    } else if copied {
+        t!(
+            "Could not open browser; link copied. Paste it manually or run `ytt doctor --verbose`.",
+            "브라우저를 열 수 없어요. 링크를 복사했으니 직접 붙여넣거나 `ytt doctor --verbose`를 실행해 주세요."
+        )
+        .to_owned()
+    } else if let Some(path) = saved_path {
+        if crate::i18n::is_korean() {
+            format!(
+                "브라우저/클립보드 실패. 인증 URL 저장됨: {}",
+                path.display()
+            )
+        } else {
+            format!(
+                "Browser/clipboard failed; auth URL saved to {}",
+                path.display()
+            )
+        }
+    } else {
+        t!(
+            "Could not open browser or clipboard; run `ytt auth spotify --client-id …`.",
+            "브라우저와 클립보드를 사용할 수 없어요. `ytt auth spotify --client-id …`를 실행해 주세요."
+        )
+        .to_owned()
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -50,6 +50,7 @@ pub use state::*;
 mod ai_reducer;
 pub use ai_reducer::AiMsg;
 mod artwork;
+mod clipboard;
 mod download;
 mod keys;
 mod library;
@@ -70,6 +71,7 @@ mod search;
 mod settings_reducer;
 mod stream_metadata;
 mod streaming_reducer;
+pub(in crate::app) use clipboard::{copy_to_clipboard, spotify_auth_url_status};
 pub use streaming_reducer::StreamingMsg;
 
 /// Autoplay/streaming top-up policy and the play-error breaker threshold — single-sourced
@@ -1766,57 +1768,6 @@ fn rect_contains(rect: Rect, col: u16, row: u16) -> bool {
 }
 
 pub(crate) use crate::util::browser::open_in_browser;
-
-/// Copy `text` to the system clipboard, fire-and-forget. Mirrors `open_in_browser`: spawns the
-/// platform clipboard tool with stdio nulled and pipes `text` to its stdin, so no native
-/// clipboard crate is needed. macOS uses `pbcopy`, Windows `clip`; Linux tries `wl-copy`
-/// (Wayland) then `xclip`/`xsel` (X11), each of which self-daemonizes to keep the selection
-/// alive after we return. Any failure (tool absent) is silently ignored.
-fn copy_to_clipboard(text: &str) {
-    use std::io::Write;
-    use std::process::{Command, Stdio};
-
-    fn pipe(cmd: &mut Command, text: &str) -> bool {
-        match cmd
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-        {
-            Ok(mut child) => {
-                if let Some(mut stdin) = child.stdin.take() {
-                    let _ = stdin.write_all(text.as_bytes());
-                }
-                true
-            }
-            Err(_) => false,
-        }
-    }
-
-    if cfg!(target_os = "macos") {
-        pipe(
-            &mut process::std_command("pbcopy", process::ProcessProfile::Clipboard),
-            text,
-        );
-    } else if cfg!(target_os = "windows") {
-        pipe(
-            &mut process::std_command("clip", process::ProcessProfile::Clipboard),
-            text,
-        );
-    } else if !pipe(
-        &mut process::std_command("wl-copy", process::ProcessProfile::Clipboard),
-        text,
-    ) && !pipe(
-        process::std_command("xclip", process::ProcessProfile::Clipboard)
-            .args(["-selection", "clipboard"]),
-        text,
-    ) {
-        pipe(
-            process::std_command("xsel", process::ProcessProfile::Clipboard).arg("-ib"),
-            text,
-        );
-    }
-}
 
 /// Spawn a borderless, always-on-top mpv overlay window for `url`, returning the child so the
 /// caller can track and later close it. Stdio is nulled so mpv can't touch the TUI's terminal.

--- a/src/app/settings_reducer.rs
+++ b/src/app/settings_reducer.rs
@@ -1354,28 +1354,21 @@ impl App {
         self.dirty = true;
         match event {
             TransferEvent::AuthUrl(url) => {
+                let saved_url_path = crate::spotify::auth::save_pending_auth_url(&url)
+                    .ok()
+                    .flatten();
                 let opened = crate::util::browser::open_in_browser_checked(&url);
                 // Also copy the URL: xdg-open can fail silently (e.g. a Flatpak
                 // browser the cleared env can't resolve), and this is the only
                 // path that would otherwise leave the user no way to reach the
                 // approval page.
-                copy_to_clipboard(&url);
-                self.status.text = if opened.launched() {
-                    t!(
-                        "Approve ytm-tui in the browser (link copied as fallback)",
-                        "브라우저에서 ytm-tui를 승인해 주세요 (링크는 예비용으로 복사했어요)"
-                    )
-                    .to_owned()
-                } else {
-                    t!(
-                        "Could not open browser; link copied. Paste it manually or run `ytt doctor --verbose`.",
-                        "브라우저를 열 수 없어요. 링크를 복사했으니 직접 붙여넣거나 `ytt doctor --verbose`를 실행해 주세요."
-                    )
-                    .to_owned()
-                };
+                let copied = copy_to_clipboard(&url);
+                self.status.text =
+                    spotify_auth_url_status(opened.launched(), copied, saved_url_path.as_deref());
                 self.status.kind = StatusKind::Info;
             }
             TransferEvent::AuthDone { display_name } => {
+                let _ = crate::spotify::auth::clear_pending_auth_url();
                 let mut used_client_id = None;
                 if let Some(st) = self.settings.as_mut() {
                     st.draft.spotify_connected = true;
@@ -1405,6 +1398,7 @@ impl App {
                 }
             }
             TransferEvent::AuthError(error) => {
+                let _ = crate::spotify::auth::clear_pending_auth_url();
                 self.status.text = format!(
                     "{}: {}",
                     t!("Spotify authorization failed", "Spotify 인증 실패"),

--- a/src/spotify/auth.rs
+++ b/src/spotify/auth.rs
@@ -79,6 +79,29 @@ pub fn token_path() -> Option<PathBuf> {
         .map(|d| d.data_dir().join("spotify_token.json"))
 }
 
+pub fn pending_auth_url_path() -> Option<PathBuf> {
+    directories::ProjectDirs::from("", "", "ytm-tui")
+        .map(|d| d.data_dir().join("spotify_auth_url.txt"))
+}
+
+pub fn save_pending_auth_url(url: &str) -> std::io::Result<Option<PathBuf>> {
+    let Some(path) = pending_auth_url_path() else {
+        return Ok(None);
+    };
+    safe_fs::write_private_atomic(&path, format!("{url}\n").as_bytes())?;
+    Ok(Some(path))
+}
+
+pub fn clear_pending_auth_url() -> std::io::Result<()> {
+    let Some(path) = pending_auth_url_path() else {
+        return Ok(());
+    };
+    match std::fs::remove_file(path) {
+        Err(e) if e.kind() != std::io::ErrorKind::NotFound => Err(e),
+        _ => Ok(()),
+    }
+}
+
 /// RFC 7636 §4.1: 43–128 chars from the unreserved set. 64 gives ~380 bits of entropy.
 fn pkce_verifier() -> String {
     const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";


### PR DESCRIPTION
## What changed

- Saves the Spotify OAuth approval URL to `spotify_auth_url.txt` when a TUI auth flow starts.
- Detects early clipboard helper failures instead of treating every spawned helper as success.
- Shows clearer TUI status text when browser and clipboard handoff are unavailable.
- Clears the pending auth URL file after auth succeeds or fails.

## Why

In headless or remote Linux terminal sessions, `xdg-open` and clipboard helpers can both fail. Previously the TUI could start a Spotify auth flow without leaving the user any recoverable approval URL, making the flow look silent even though the CLI path worked.

## Validation

- `~/.fable-harness/bin/run-gates .`
  - `cargo fmt --all --check`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo test --workspace`
  - architecture/file-size/doc/ratatui-image patch checks

## Notes

A pre-existing unrelated local change in `scripts/windows-daemon-smoke.ps1` was left unstaged and is not part of this PR.