### PR TITLE
Improve radio and DJ Gem interaction polish

### DIFF
--- a/src/app/ai_reducer.rs
+++ b/src/app/ai_reducer.rs
@@ -72,6 +72,21 @@ impl App {
         self.dirty = true;
     }
 
+    /// Cycle the committed DJ Gem model from the chat screen. Unlike the Settings tab, this
+    /// is not draft state: the visible model, saved config, and live actor all update now.
+    pub(in crate::app) fn cycle_ai_model_from_chat(&mut self) -> Vec<Cmd> {
+        let next = self.ai.model.cycled(true);
+        self.ai.model = next;
+        self.config.gemini_model = next;
+        self.status.kind = StatusKind::Info;
+        self.status.text = format!("DJ Gem model: {}", next.label());
+        self.dirty = true;
+        vec![
+            Cmd::Persist(PersistCmd::Config(Box::new(self.config.clone()))),
+            Cmd::SetAiModel(next),
+        ]
+    }
+
     pub(in crate::app) fn on_key_ai(&mut self, k: KeyEvent) -> Vec<Cmd> {
         match self.ai.focus {
             AiFocus::Input => {

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -553,6 +553,8 @@ impl App {
             MouseTarget::AiInput => Vec::new(),
             MouseTarget::AiSubmit if self.mode == Mode::Ai => self.submit_ai_prompt(),
             MouseTarget::AiSubmit => Vec::new(),
+            MouseTarget::AiModel if self.mode == Mode::Ai => self.cycle_ai_model_from_chat(),
+            MouseTarget::AiModel => Vec::new(),
             MouseTarget::AiSuggestionRow(i) if self.mode == Mode::Ai => {
                 if i < self.ai.suggestions.len() {
                     self.ai.suggestions_selected = i;

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -44,10 +44,10 @@ impl From<PlayerMsg> for Msg {
     }
 }
 
-/// How far behind the live edge still counts as "in sync" (a healthy at-edge stream keeps
-/// a single-digit-seconds forward buffer; 15 avoids false ✗ on bursty stations while
-/// catching any real pause-behind).
-pub(in crate::app) const LIVE_SYNC_THRESHOLD_SECS: f64 = 15.0;
+/// How far behind mpv's newest demuxed sample still counts as "in sync". A practical
+/// at-edge radio stream can sit around 17s behind `demuxer-cache-time`; 20s covers that
+/// normal forward buffer plus jitter while still catching real timeshift drift.
+pub(in crate::app) const LIVE_SYNC_THRESHOLD_SECS: f64 = 20.0;
 /// Re-sync seeks this far short of the newest demuxed data, never into the undemuxed tail.
 pub(in crate::app) const LIVE_EDGE_SEEK_MARGIN_SECS: f64 = 2.0;
 /// A `demuxer-cache-time` older than this (while playing) no longer proves we're at the

--- a/src/app/tests/ai.rs
+++ b/src/app/tests/ai.rs
@@ -218,6 +218,64 @@ fn ai_submit_button_matches_enter_submit() {
 }
 
 #[test]
+fn ai_model_label_renders_under_prompt_and_not_on_nav_border() {
+    let mut app = App::new(100);
+    app.mode = Mode::Ai;
+    app.ai.model = crate::ai::GeminiModel::Latest;
+
+    let buf = render_app_buffer(&app, 80, 24);
+    assert!(
+        !buffer_row(&buf, 0).contains("Latest"),
+        "model label should no longer ride the top nav border"
+    );
+    assert!(
+        (0..buf.area.height).any(|y| buffer_row(&buf, y).contains("Model: Latest")),
+        "model label should render below the prompt"
+    );
+
+    let model = app
+        .hits
+        .regions()
+        .iter()
+        .find(|b| b.target == MouseTarget::AiModel)
+        .map(|b| b.rect)
+        .expect("model label hit rect");
+    let input = app
+        .hits
+        .regions()
+        .iter()
+        .find(|b| b.target == MouseTarget::AiInput)
+        .map(|b| b.rect)
+        .expect("prompt input hit rect");
+    assert!(
+        model.y > input.y,
+        "model label should sit below prompt input: model={model:?} input={input:?}"
+    );
+}
+
+#[test]
+fn clicking_ai_model_label_cycles_model_live_and_persists() {
+    let mut app = App::new(100);
+    app.mode = Mode::Ai;
+    app.ai.model = crate::ai::GeminiModel::FlashLite;
+    app.config.gemini_model = crate::ai::GeminiModel::FlashLite;
+    let next = app.ai.model.cycled(true);
+
+    let cmds = click_target(&mut app, MouseTarget::AiModel);
+
+    assert_eq!(app.ai.model, next);
+    assert_eq!(app.config.gemini_model, next);
+    assert_eq!(save_config(&cmds).unwrap().gemini_model, next);
+    assert!(
+        cmds.iter()
+            .any(|c| matches!(c, Cmd::SetAiModel(model) if *model == next)),
+        "click should hot-swap the running DJ Gem actor"
+    );
+    assert_eq!(app.status.kind, StatusKind::Info);
+    assert!(app.status.text.contains(next.label()));
+}
+
+#[test]
 fn ai_suggestion_rows_are_clickable_choices() {
     let mut app = App::new(100);
     app.mode = Mode::Ai;

--- a/src/app/tests/dropdowns_popups.rs
+++ b/src/app/tests/dropdowns_popups.rs
@@ -16,6 +16,50 @@ fn rendering_player_registers_streaming_menu_when_autoplay_on() {
 }
 
 #[test]
+fn radio_and_local_confirm_buttons_have_taller_click_targets() {
+    let mut app = App::new(100);
+    app.radio_mode.pending_radio_mode_confirm = Some(RadioModeConfirm::Enter);
+    render_app(&app);
+    assert_tall_hit(&app, MouseTarget::ConfirmRadioMode);
+    assert_tall_hit(&app, MouseTarget::CancelRadioMode);
+
+    app.radio_mode.pending_radio_mode_confirm = None;
+    app.local_mode.pending_confirm = Some(LocalModeConfirm::Enter);
+    render_app(&app);
+    assert_tall_hit(&app, MouseTarget::ConfirmLocalMode);
+    assert_tall_hit(&app, MouseTarget::CancelLocalMode);
+}
+
+#[test]
+fn local_organize_confirm_buttons_have_taller_click_targets() {
+    let mut app = App::new(100);
+    app.local_mode.pending_organize_confirm = Some(LocalOrganizeConfirm {
+        session_id: "sp2yt-session".to_owned(),
+        root: std::path::PathBuf::from("/tmp/music"),
+        move_count: 2,
+        already_count: 1,
+        skipped_count: 0,
+    });
+    render_app(&app);
+    assert_tall_hit(&app, MouseTarget::ConfirmLocalOrganize);
+    assert_tall_hit(&app, MouseTarget::CancelLocalOrganize);
+}
+
+fn assert_tall_hit(app: &App, target: MouseTarget) {
+    let rect = app
+        .hits
+        .regions()
+        .iter()
+        .find(|b| b.target == target)
+        .map(|b| b.rect)
+        .unwrap_or_else(|| panic!("missing hit rect for {target:?}"));
+    assert!(
+        rect.height >= 2,
+        "{target:?} should have a taller click target, got {rect:?}"
+    );
+}
+
+#[test]
 fn streaming_dropdown_renders_mode_rows_when_open() {
     let mut app = app_playing(2, 0);
     app.autoplay_streaming = true;

--- a/src/app/tests/radio_sync.rs
+++ b/src/app/tests/radio_sync.rs
@@ -33,7 +33,15 @@ fn radio_live_sync_verdict_follows_behind_distance() {
     assert_eq!(app.radio_behind_secs().map(|b| b as i64), Some(5));
     assert_eq!(app.radio_live_synced(), Some(true));
 
-    app.update(PlayerMsg::CacheTime(Some(180.0)));
+    app.update(PlayerMsg::CacheTime(Some(117.0)));
+    assert_eq!(app.radio_behind_secs().map(|b| b as i64), Some(17));
+    assert_eq!(app.radio_live_synced(), Some(true));
+
+    app.update(PlayerMsg::CacheTime(Some(120.0)));
+    assert_eq!(app.radio_behind_secs().map(|b| b as i64), Some(20));
+    assert_eq!(app.radio_live_synced(), Some(true));
+
+    app.update(PlayerMsg::CacheTime(Some(130.0)));
     assert_eq!(app.radio_live_synced(), Some(false));
 
     // A regular track never gets a verdict, even with cache reports flowing.
@@ -47,7 +55,7 @@ fn radio_live_sync_verdict_follows_behind_distance() {
 fn stale_cache_time_degrades_synced_to_unknown_but_keeps_behind() {
     let mut app = radio_playing("groove");
     app.update(PlayerMsg::TimePos(100.0));
-    app.update(PlayerMsg::CacheTime(Some(103.0)));
+    app.update(PlayerMsg::CacheTime(Some(117.0)));
     // An old at-edge report proves nothing while playing (mpv freezes the property
     // once the forward buffer saturates) → unknown.
     app.playback.cache_time_at = Some(Instant::now() - Duration::from_secs(30));
@@ -56,9 +64,30 @@ fn stale_cache_time_degrades_synced_to_unknown_but_keeps_behind() {
     app.playback.cache_time = Some(200.0);
     assert_eq!(app.radio_live_synced(), Some(false));
     // While paused the frozen report stays authoritative (behind only grows).
-    app.playback.cache_time = Some(103.0);
+    app.playback.cache_time = Some(117.0);
     app.playback.paused = true;
     assert_eq!(app.radio_live_synced(), Some(true));
+}
+
+#[test]
+fn radio_repeat_key_at_normal_live_buffer_does_not_seek_or_reconnect() {
+    let mut app = radio_playing("groove");
+    app.update(PlayerMsg::TimePos(100.0));
+    app.update(PlayerMsg::CacheTime(Some(117.0)));
+
+    let cmds = app.update(Msg::Key(key(KeyCode::Char('r'))));
+
+    assert!(
+        cmds.is_empty(),
+        "normal live buffer should need no player command"
+    );
+    assert!(app.radio_resync_at.is_none());
+    assert_eq!(app.status.kind, StatusKind::Info);
+    assert!(
+        app.status.text.contains("live edge") || app.status.text.contains("실시간"),
+        "status should report live, got {:?}",
+        app.status.text
+    );
 }
 
 #[test]

--- a/src/app/tests/zoom_retro_nav.rs
+++ b/src/app/tests/zoom_retro_nav.rs
@@ -309,27 +309,28 @@ fn nav_arrows_hollow_at_first_and_last_tab() {
 }
 
 #[test]
-fn ai_model_label_yields_to_nav_when_narrow() {
+fn ai_model_label_stays_off_nav_border_when_narrow() {
     let _guard = crate::i18n::lock_for_test();
     let mut app = App::new(100);
     app.mode = Mode::Ai;
-    // Pin the model so the label under test is stable (the reported artifact was the
-    // "Latest" label surviving as a clipped "est" after the nav's ▶ arrow).
+    // Pin the model so the label under test is stable. The label now lives below the prompt,
+    // so no part of it should survive on the nav border at any width.
     app.ai.model = crate::ai::GeminiModel::Latest;
 
-    // Wide: the model label rides the right end of the border row, as before.
-    let (_, top) = render_at(&app, 100, 30);
+    let (targets, top) = render_at(&app, 100, 30);
     assert!(
-        top.contains("Latest"),
-        "wide: the model label should show: {top:?}"
+        !top.contains("Latest"),
+        "wide: the model label should not be on the nav border: {top:?}"
+    );
+    assert!(
+        targets.contains(&MouseTarget::AiModel),
+        "wide: the model label should remain clickable below the prompt"
     );
 
-    // Narrow: the nav strip needs the row — the label disappears entirely instead of
-    // leaving a clipped tail (this used to render as a stray \"est\" after the ▶ arrow).
     let (_, top) = render_at(&app, 30, 30);
     assert!(
         !top.contains("Latest") && !top.contains("est"),
-        "narrow: no label and no clipped remnant: {top:?}"
+        "narrow: no model label and no clipped remnant on the nav border: {top:?}"
     );
 }
 

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -467,6 +467,8 @@ pub enum MouseTarget {
     AiInput,
     /// The DJ Gem prompt submit button.
     AiSubmit,
+    /// The DJ Gem model label under the prompt — cycles the active model.
+    AiModel,
     /// A pickable DJ Gem suggestion row.
     AiSuggestionRow(usize),
     /// The `N/M` queue-position label on the player status line — opens the queue window.

--- a/src/ui/buttons.rs
+++ b/src/ui/buttons.rs
@@ -91,6 +91,64 @@ pub fn render_segments(
     label_style: Style,
     alignment: Alignment,
 ) {
+    render_segments_inner(
+        frame,
+        app,
+        area,
+        segments,
+        SegmentRenderOptions {
+            button_style,
+            label_style,
+            alignment,
+            hit_height: 1,
+            center_vertically: false,
+        },
+    );
+}
+
+/// Render a control strip in `area`, vertically centering its text while allowing clickable
+/// segments to publish a taller hit rect. Used by confirmation popups whose buttons need
+/// more vertical target area without changing normal one-line controls.
+pub fn render_segments_with_hit_height(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    segments: &[Seg<'_>],
+    styles: (Style, Style),
+    alignment: Alignment,
+    hit_height: u16,
+) {
+    let (button_style, label_style) = styles;
+    render_segments_inner(
+        frame,
+        app,
+        area,
+        segments,
+        SegmentRenderOptions {
+            button_style,
+            label_style,
+            alignment,
+            hit_height,
+            center_vertically: true,
+        },
+    );
+}
+
+struct SegmentRenderOptions {
+    button_style: Style,
+    label_style: Style,
+    alignment: Alignment,
+    hit_height: u16,
+    center_vertically: bool,
+}
+
+fn render_segments_inner(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    segments: &[Seg<'_>],
+    opts: SegmentRenderOptions,
+) {
     let mut widths = Vec::with_capacity(segments.len());
     let mut total = 0u16;
     for seg in segments {
@@ -98,7 +156,7 @@ pub fn render_segments(
         total = total.saturating_add(width);
         widths.push(width);
     }
-    let mut x = match alignment {
+    let mut x = match opts.alignment {
         Alignment::Center => area.x + area.width.saturating_sub(total) / 2,
         Alignment::Right => area.x + area.width.saturating_sub(total),
         Alignment::Left => area.x,
@@ -114,24 +172,42 @@ pub fn render_segments(
                 .saturating_add(width)
                 .saturating_add(seg.hit_pad)
                 .min(area.right());
+            let hit_h = opts.hit_height.min(area.height);
+            let hit_y = if opts.center_vertically {
+                area.y + area.height.saturating_sub(hit_h) / 2
+            } else {
+                area.y
+            };
             app.register_mouse_button(
                 Rect {
                     x: x0,
-                    y: area.y,
+                    y: hit_y,
                     width: end.saturating_sub(x0),
-                    height: area.height.min(1),
+                    height: hit_h,
                 },
                 target,
             );
-            button_style
+            opts.button_style
         } else {
-            label_style
+            opts.label_style
         };
         spans.push(Span::styled(seg.text, style));
         x = x.saturating_add(width);
     }
 
-    frame.render_widget(Paragraph::new(Line::from(spans).alignment(alignment)), area);
+    let text_area = if opts.center_vertically {
+        Rect {
+            y: area.y + area.height.saturating_sub(1) / 2,
+            height: area.height.min(1),
+            ..area
+        }
+    } else {
+        area
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(spans).alignment(opts.alignment)),
+        text_area,
+    );
 }
 
 /// Every screen in nav order. Radio mode swaps only the player tab's *label*

--- a/src/ui/views/ai.rs
+++ b/src/ui/views/ai.rs
@@ -38,7 +38,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
     // The nav strip rides the top border line itself; `render_nav` overlays only the cells
     // its text covers, so the border keeps drawing on either side of it.
-    let nav_used = buttons::render_nav(
+    buttons::render_nav(
         frame,
         app,
         Rect {
@@ -48,23 +48,6 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             height: 1,
         },
     );
-
-    // Model indicator on the right end of the same border line — metadata, not chrome.
-    // Drawn only when it fully clears the nav strip: a partially covered label reads as
-    // stray garbage (a narrow window used to leave "est" of " Latest " past the strip).
-    let label = format!(" {} ", app.ai.model.label());
-    let label_w = buttons::text_width(&label);
-    if inner.width.saturating_sub(nav_used) >= label_w.saturating_add(1) {
-        frame.render_widget(
-            Paragraph::new(Line::from(label).style(app.theme.style(R::TextMuted))),
-            Rect {
-                x: inner.right().saturating_sub(label_w),
-                y: area.y,
-                width: label_w,
-                height: 1,
-            },
-        );
-    }
 
     let rows = Layout::vertical([
         Constraint::Length(2), // reserved top band (aligns with Settings/Library)
@@ -101,7 +84,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     }
     render_input(frame, app, rows[3]);
 
-    buttons::render_help_button(frame, app, rows[4]);
+    render_footer(frame, app, rows[4]);
 
     // DJ Gem mascot sits in the upper-center-right while the start screen shows.
     // Drawn last so it overlays cleanly; it hides once a conversation begins.
@@ -112,6 +95,39 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
 fn render_mascot(frame: &mut Frame, app: &App, inner: Rect) {
     crate::ui::mascot::render_dj_gem(frame, app, inner);
+}
+
+fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
+    buttons::render_help_button(frame, app, area);
+
+    let label = format!(" Model: {} ", app.ai.model.label());
+    let label_w = buttons::text_width(&label);
+    let key_label = app.help_footer();
+    let mouse_label = if app.retro_mode() {
+        t!("mouse", "마우스").to_owned()
+    } else {
+        format!("🖱 {}", t!("mouse", "마우스"))
+    };
+    let help_w = buttons::text_width(key_label.as_str())
+        .saturating_add(buttons::text_width("   "))
+        .saturating_add(buttons::text_width(mouse_label.as_str()));
+    let help_left = area.x + area.width.saturating_sub(help_w) / 2;
+    if area.x.saturating_add(label_w).saturating_add(1) <= help_left {
+        let model_area = Rect {
+            width: label_w,
+            ..area
+        };
+        let segs = [buttons::Seg::button(MouseTarget::AiModel, label.as_str())];
+        buttons::render_segments(
+            frame,
+            app,
+            model_area,
+            &segs,
+            app.theme.style(R::Accent).add_modifier(Modifier::BOLD),
+            app.theme.style(R::TextMuted),
+            Alignment::Left,
+        );
+    }
 }
 
 fn render_transcript(frame: &mut Frame, app: &App, area: Rect) {

--- a/src/ui/views/local.rs
+++ b/src/ui/views/local.rs
@@ -470,7 +470,7 @@ pub fn render_local_mode_confirm(
     area: Rect,
     confirm: LocalModeConfirm,
 ) {
-    let popup = centered_fixed(area, 64, 9);
+    let popup = centered_fixed(area, 64, 11);
     crate::ui::render_popup_background(frame, app, popup);
 
     let block = Block::default()
@@ -486,7 +486,8 @@ pub fn render_local_mode_confirm(
         Constraint::Length(1),
         Constraint::Length(1),
         Constraint::Length(1),
-        Constraint::Min(1),
+        Constraint::Length(3),
+        Constraint::Min(0),
     ])
     .split(inner);
     frame.render_widget(
@@ -513,14 +514,17 @@ pub fn render_local_mode_confirm(
             t!(" Cancel (Esc) ", " 취소 (Esc) "),
         ),
     ];
-    buttons::render_segments(
+    buttons::render_segments_with_hit_height(
         frame,
         app,
         rows[4],
         &segs,
-        crate::ui::confirm_button_style(app),
-        crate::ui::confirm_gap_style(app),
+        (
+            crate::ui::confirm_button_style(app),
+            crate::ui::confirm_gap_style(app),
+        ),
         Alignment::Center,
+        3,
     );
     crate::ui::seal_popup_background(frame, app, popup);
     crate::ui::mark_art_rows_for_popup(frame, app, popup);
@@ -532,7 +536,7 @@ pub fn render_local_organize_confirm(
     area: Rect,
     confirm: &LocalOrganizeConfirm,
 ) {
-    let popup = centered_fixed(area, 72, 9);
+    let popup = centered_fixed(area, 72, 11);
     crate::ui::render_popup_background(frame, app, popup);
 
     let block = Block::default()
@@ -548,7 +552,8 @@ pub fn render_local_organize_confirm(
         Constraint::Length(1),
         Constraint::Length(1),
         Constraint::Length(1),
-        Constraint::Min(1),
+        Constraint::Length(3),
+        Constraint::Min(0),
     ])
     .split(inner);
     frame.render_widget(
@@ -575,14 +580,17 @@ pub fn render_local_organize_confirm(
             t!(" Cancel (Esc) ", " 취소 (Esc) "),
         ),
     ];
-    buttons::render_segments(
+    buttons::render_segments_with_hit_height(
         frame,
         app,
         rows[4],
         &segs,
-        crate::ui::confirm_button_style(app),
-        crate::ui::confirm_gap_style(app),
+        (
+            crate::ui::confirm_button_style(app),
+            crate::ui::confirm_gap_style(app),
+        ),
         Alignment::Center,
+        3,
     );
     crate::ui::seal_popup_background(frame, app, popup);
     crate::ui::mark_art_rows_for_popup(frame, app, popup);

--- a/src/ui/views/player.rs
+++ b/src/ui/views/player.rs
@@ -1330,7 +1330,7 @@ pub fn render_radio_mode_confirm(
     area: Rect,
     confirm: RadioModeConfirm,
 ) {
-    let popup = centered_fixed(area, 60, 9);
+    let popup = centered_fixed(area, 60, 11);
     crate::ui::render_popup_background(frame, app, popup);
 
     let block = Block::default()
@@ -1346,7 +1346,8 @@ pub fn render_radio_mode_confirm(
         Constraint::Length(1),
         Constraint::Length(1),
         Constraint::Length(1),
-        Constraint::Min(1),
+        Constraint::Length(3),
+        Constraint::Min(0),
     ])
     .split(inner);
     frame.render_widget(
@@ -1373,14 +1374,17 @@ pub fn render_radio_mode_confirm(
             t!(" Cancel (Esc) ", " 취소 (Esc) "),
         ),
     ];
-    buttons::render_segments(
+    buttons::render_segments_with_hit_height(
         frame,
         app,
         rows[4],
         &segs,
-        crate::ui::confirm_button_style(app),
-        crate::ui::confirm_gap_style(app),
+        (
+            crate::ui::confirm_button_style(app),
+            crate::ui::confirm_gap_style(app),
+        ),
         Alignment::Center,
+        3,
     );
     crate::ui::seal_popup_background(frame, app, popup);
     crate::ui::mark_art_rows_for_popup(frame, app, popup);


### PR DESCRIPTION
## Summary
- enlarge the clickable Confirm/Cancel hit bands in Radio mode, Local Deck, and Local organize confirmation popups
- move the DJ Gem model label from the top-right border to the lower-left prompt footer and make it clickable to cycle models
- widen the Radio live-sync threshold to account for the normal ~17s live buffer and avoid unnecessary resync/reconnect actions while effectively live

## Impact
- confirmation dialogs are easier to click without changing the existing keyboard flow
- DJ Gem model switching is available directly from the chat surface, matching the existing live settings behavior
- Radio mode no longer reports or treats a normal live-edge buffer as out of sync

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `bash scripts/check-architecture.sh`
- `bash scripts/check-file-size.sh`
- `bash scripts/check-doc-honesty.sh`
- `bash scripts/check-ratatui-image-patch.sh`
- isolated tmux verify: Radio/Local popups, DJ Gem footer label, and clickable model cycling
