### PR TITLE
Move local import review actions off UI thread

### DIFF
--- a/src/app/artwork.rs
+++ b/src/app/artwork.rs
@@ -555,7 +555,8 @@ impl App {
             | flag(
                 self.library_ui.confirm_delete.is_some()
                     || self.library_ui.confirm_download.is_some()
-                    || self.local_mode.pending_organize_confirm.is_some(),
+                    || self.local_mode.pending_organize_confirm.is_some()
+                    || self.local_mode.pending_accept_all_confirm.is_some(),
                 ART_OVERLAY_LIBRARY_CONFIRM_BIT,
             )
             | flag(!matches!(self.mode, Mode::Player), ART_OVERLAY_NOT_PLAYER_BIT)

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -60,6 +60,18 @@ impl App {
             };
         }
 
+        // Local import accept-all is modal because it changes many review decisions at once.
+        if let Some(confirm) = self.local_mode.pending_accept_all_confirm.take() {
+            self.dirty = true;
+            let confirmed = k.code == KeyCode::Enter
+                || chord == Chord::new(KeyCode::Char('y'), KeyModifiers::empty());
+            return if confirmed {
+                self.apply_local_import_accept_all_confirm(confirm)
+            } else {
+                Vec::new()
+            };
+        }
+
         // Settings confirmations are modal: Enter or `y` confirms, anything else cancels.
         // Handle it here so the key can't leak through to the settings list.
         if let Some(confirm) = self.overlays.pending_settings_confirm.take() {
@@ -296,9 +308,10 @@ impl App {
             return Vec::new();
         }
 
-        // Local Deck owns Shift+A/`A` for "enqueue the current local result set". That chord
-        // overlaps the global animation toggle, so route it before globals only while the Local
-        // Deck list is active; filter text entry still receives typeable characters normally.
+        // Local Deck owns Shift+A/`A` for import accept-all and, outside import review rows,
+        // "enqueue the current local result set". That chord overlaps the global animation
+        // toggle, so route it before globals only while the Local Deck list is active; filter
+        // text entry still receives typeable characters normally.
         if self.mode == Mode::Library
             && self.local_dedicated_mode
             && !self.local_mode.ui.filter_editing

--- a/src/app/local.rs
+++ b/src/app/local.rs
@@ -128,18 +128,24 @@ impl App {
             self.cycle_local_pane();
             return Vec::new();
         }
+        if self.keymap.context_action(KeyContext::LocalDeck, chord)
+            == Some(Action::AcceptAllImportReview)
+            && let Some(cmds) = self.request_local_import_accept_all()
+        {
+            return cmds;
+        }
         if k.modifiers.is_empty() {
             match k.code {
                 KeyCode::Char(' ') => return self.on_player_action(Action::TogglePause),
                 KeyCode::Char('a') => {
-                    if self.local_accept_selected_import_candidate() {
-                        return Vec::new();
+                    if let Some(cmds) = self.request_local_accept_selected_import_candidate() {
+                        return cmds;
                     }
                     return self.local_enqueue_selected();
                 }
                 KeyCode::Char('c') => {
-                    if self.local_choose_next_import_candidate() {
-                        return Vec::new();
+                    if let Some(cmds) = self.request_local_choose_next_import_candidate() {
+                        return cmds;
                     }
                     self.open_queue_popup();
                     return Vec::new();
@@ -154,7 +160,11 @@ impl App {
                 KeyCode::Char('o') if self.local_open_selected_import_candidate_url() => {
                     return Vec::new();
                 }
-                KeyCode::Char('x') if self.local_skip_selected_import_row() => return Vec::new(),
+                KeyCode::Char('x') => {
+                    if let Some(cmds) = self.request_local_skip_selected_import_row() {
+                        return cmds;
+                    }
+                }
                 _ => {}
             }
         }
@@ -176,8 +186,8 @@ impl App {
             return Vec::new();
         }
         if k.modifiers.is_empty() && matches!(k.code, KeyCode::Char('r')) {
-            if self.local_reject_selected_import_row() {
-                return Vec::new();
+            if let Some(cmds) = self.request_local_reject_selected_import_row() {
+                return cmds;
             }
             if let Some(cmds) = self.local_retry_failed_import_downloads() {
                 return cmds;
@@ -449,6 +459,20 @@ impl App {
                 self.dirty = true;
                 Vec::new()
             }
+            LocalMsg::ImportReviewFinished {
+                op_id,
+                session_id,
+                source_order: _,
+                action,
+                result,
+                elapsed_ms: _,
+            } => self.apply_local_import_review_finished(op_id, session_id, action, result),
+            LocalMsg::ImportReviewAcceptAllFinished {
+                op_id,
+                session_id,
+                result,
+                elapsed_ms: _,
+            } => self.apply_local_import_accept_all_finished(op_id, session_id, result),
         }
     }
 

--- a/src/app/local_import.rs
+++ b/src/app/local_import.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use super::local_format::*;
 use super::*;
 use crate::t;
-use crate::transfer::checkpoint::{ReportCandidate, ReviewDecision};
+use crate::transfer::checkpoint::{Checkpoint, ReportCandidate, ReviewDecision};
 use crate::transfer::download_plan::{
     ImportDownloadDecision, ImportDownloadDedupeIndex, build_import_download_plan,
 };
@@ -90,7 +90,7 @@ impl App {
         session_id: &str,
         query: &str,
     ) -> Vec<crate::local::LocalRowId> {
-        if let Ok(mut session) = ImportSession::load(session_id) {
+        if let Ok(mut session) = load_import_session_recovering(session_id) {
             session.rows.sort_by(|a, b| {
                 a.source_order
                     .cmp(&b.source_order)
@@ -120,7 +120,7 @@ impl App {
     ) -> Vec<crate::local::LocalRowId> {
         let mut rows = Vec::<(i64, String, u32)>::new();
         for summary in ImportSession::list_all() {
-            let Ok(mut session) = ImportSession::load(&summary.session_id) else {
+            let Ok(mut session) = load_import_session_recovering(&summary.session_id) else {
                 continue;
             };
             session.rows.sort_by(|a, b| {
@@ -206,6 +206,9 @@ impl App {
                 if failed > 0 {
                     actions.push(t!("r retry failed", "r 실패 재시도"));
                 }
+                if import_session_accept_all_candidate_count_by_id(&session_id).unwrap_or(0) > 0 {
+                    actions.push(t!("A accept all", "A 전체 수락"));
+                }
                 actions.push(t!("d download accepted", "d 수락 곡 다운로드"));
                 actions.push(t!("m commit inbox", "m 인박스 커밋"));
                 Some(actions.join("  |  "))
@@ -223,6 +226,9 @@ impl App {
                         t!("c candidate", "c 후보"),
                         t!("x skip", "x 건너뜀"),
                     ]);
+                }
+                if import_session_accept_all_candidate_count_by_id(&session_id).unwrap_or(0) > 0 {
+                    actions.push(t!("A accept all", "A 전체 수락"));
                 }
                 if !row.errors.is_empty() {
                     actions.push(t!("r retry failed", "r 실패 재시도"));
@@ -361,7 +367,7 @@ impl App {
         session_id: &str,
         source_order: Option<u32>,
     ) -> Vec<Song> {
-        let Ok(mut session) = ImportSession::load(session_id) else {
+        let Ok(mut session) = load_import_session_recovering(session_id) else {
             return Vec::new();
         };
         session.rows.sort_by(|a, b| {
@@ -514,7 +520,7 @@ impl App {
         session_id: &str,
         source_order: Option<u32>,
     ) -> Vec<Song> {
-        let Ok(mut session) = ImportSession::load(session_id) else {
+        let Ok(mut session) = load_import_session_recovering(session_id) else {
             return Vec::new();
         };
         session.rows.sort_by(|a, b| {
@@ -546,118 +552,244 @@ impl App {
             .collect()
     }
 
-    pub(in crate::app) fn local_accept_selected_import_candidate(&mut self) -> bool {
-        let Some((session_id, source_order)) = self.selected_manual_review_import_row() else {
-            return false;
+    pub(in crate::app) fn request_local_accept_selected_import_candidate(
+        &mut self,
+    ) -> Option<Vec<Cmd>> {
+        self.request_local_import_review_action(ImportReviewAction::AcceptFirst)
+    }
+
+    pub(in crate::app) fn request_local_choose_next_import_candidate(
+        &mut self,
+    ) -> Option<Vec<Cmd>> {
+        self.request_local_import_review_action(ImportReviewAction::ChooseNext)
+    }
+
+    pub(in crate::app) fn request_local_reject_selected_import_row(&mut self) -> Option<Vec<Cmd>> {
+        self.request_local_import_review_action(ImportReviewAction::Reject)
+    }
+
+    pub(in crate::app) fn request_local_skip_selected_import_row(&mut self) -> Option<Vec<Cmd>> {
+        self.request_local_import_review_action(ImportReviewAction::Skip)
+    }
+
+    fn request_local_import_review_action(
+        &mut self,
+        action: ImportReviewAction,
+    ) -> Option<Vec<Cmd>> {
+        let (session_id, source_order) = self.selected_manual_review_import_row()?;
+        if self
+            .local_mode
+            .pending_import_reviews
+            .contains_key(&session_id)
+        {
+            self.status.kind = StatusKind::Info;
+            self.status.text = format!(
+                "{}: {session_id}",
+                t!("Import review already in progress", "임포트 검토 진행 중")
+            );
+            self.dirty = true;
+            return Some(Vec::new());
+        }
+        let op_id = self.next_local_import_review_op_id();
+        self.local_mode
+            .pending_import_reviews
+            .insert(session_id.clone(), op_id);
+        self.status.kind = StatusKind::Info;
+        self.status.text = format!(
+            "{} #{}...",
+            import_review_action_progress_label(action),
+            source_order
+        );
+        self.dirty = true;
+        Some(vec![Cmd::Local(LocalCmd::ReviewImport {
+            op_id,
+            session_id,
+            source_order,
+            action,
+        })])
+    }
+
+    pub(in crate::app) fn request_local_import_accept_all(&mut self) -> Option<Vec<Cmd>> {
+        let session_id = self.selected_import_session_id_for_organize()?;
+        if self
+            .local_mode
+            .pending_import_reviews
+            .contains_key(&session_id)
+        {
+            self.status.kind = StatusKind::Info;
+            self.status.text = format!(
+                "{}: {session_id}",
+                t!("Import review already in progress", "임포트 검토 진행 중")
+            );
+            self.dirty = true;
+            return Some(Vec::new());
+        }
+        let Ok(session) = load_import_session_recovering(&session_id) else {
+            self.status.kind = StatusKind::Error;
+            self.status.text = format!(
+                "{}: {session_id}",
+                t!("Import session not found", "임포트 세션을 찾을 수 없음")
+            );
+            self.dirty = true;
+            return Some(Vec::new());
         };
-        match crate::transfer::review_action::accept_first_candidate(&session_id, source_order) {
+        let candidate_count = import_session_accept_all_candidate_count(&session);
+        if candidate_count == 0 {
+            self.status.kind = StatusKind::Info;
+            self.status.text = t!(
+                "No import candidates to accept",
+                "수락할 임포트 후보가 없음"
+            )
+            .to_owned();
+            self.dirty = true;
+            return Some(Vec::new());
+        }
+        self.local_mode.pending_accept_all_confirm = Some(LocalImportAcceptAllConfirm {
+            session_id,
+            candidate_count,
+        });
+        self.status.kind = StatusKind::Info;
+        self.status.text = t!(
+            "Confirm accepting all import candidates",
+            "임포트 후보 전체 수락을 확인하세요"
+        )
+        .to_owned();
+        self.dirty = true;
+        Some(Vec::new())
+    }
+
+    pub(in crate::app) fn apply_local_import_accept_all_confirm(
+        &mut self,
+        confirm: LocalImportAcceptAllConfirm,
+    ) -> Vec<Cmd> {
+        self.local_mode.pending_accept_all_confirm = None;
+        if self
+            .local_mode
+            .pending_import_reviews
+            .contains_key(&confirm.session_id)
+        {
+            self.status.kind = StatusKind::Info;
+            self.status.text = format!(
+                "{}: {}",
+                t!("Import review already in progress", "임포트 검토 진행 중"),
+                confirm.session_id
+            );
+            self.dirty = true;
+            return Vec::new();
+        }
+        let op_id = self.next_local_import_review_op_id();
+        self.local_mode
+            .pending_import_reviews
+            .insert(confirm.session_id.clone(), op_id);
+        self.status.kind = StatusKind::Info;
+        self.status.text = format!(
+            "{} {}...",
+            t!("Accepting import candidates", "임포트 후보 수락 중"),
+            confirm.candidate_count
+        );
+        self.dirty = true;
+        vec![Cmd::Local(LocalCmd::ReviewImportAcceptAll {
+            op_id,
+            session_id: confirm.session_id,
+        })]
+    }
+
+    pub(in crate::app) fn apply_local_import_review_finished(
+        &mut self,
+        op_id: u64,
+        session_id: String,
+        action: ImportReviewAction,
+        result: Result<crate::transfer::review_action::ReviewActionSummary, String>,
+    ) -> Vec<Cmd> {
+        if self
+            .local_mode
+            .pending_import_reviews
+            .get(&session_id)
+            .copied()
+            != Some(op_id)
+        {
+            return Vec::new();
+        }
+        self.local_mode.pending_import_reviews.remove(&session_id);
+        match result {
             Ok(summary) => {
                 self.status.kind = StatusKind::Info;
-                self.status.text = match summary.display {
-                    Some(display) => format!(
-                        "{} #{}: {display}",
-                        t!("Accepted import row", "임포트 행 수락"),
-                        summary.source_order
-                    ),
-                    None => format!(
-                        "{} #{}",
-                        t!("Accepted import row", "임포트 행 수락"),
-                        summary.source_order
-                    ),
+                self.status.text = import_review_success_text(action, &summary);
+            }
+            Err(error) => {
+                self.status.kind = StatusKind::Error;
+                self.status.text = format!(
+                    "{}: {error}",
+                    t!("Import review failed", "임포트 검토 실패")
+                );
+            }
+        }
+        self.clamp_local_after_import_change();
+        self.dirty = true;
+        Vec::new()
+    }
+
+    pub(in crate::app) fn apply_local_import_accept_all_finished(
+        &mut self,
+        op_id: u64,
+        session_id: String,
+        result: Result<crate::transfer::review_action::ReviewBatchSummary, String>,
+    ) -> Vec<Cmd> {
+        if self
+            .local_mode
+            .pending_import_reviews
+            .get(&session_id)
+            .copied()
+            != Some(op_id)
+        {
+            return Vec::new();
+        }
+        self.local_mode.pending_import_reviews.remove(&session_id);
+        match result {
+            Ok(summary) => {
+                self.status.kind = StatusKind::Info;
+                self.status.text = if summary.accepted_count == 0 {
+                    t!(
+                        "No import candidates to accept",
+                        "수락할 임포트 후보가 없음"
+                    )
+                    .to_owned()
+                } else if crate::i18n::is_korean() {
+                    format!("임포트 후보 {}개 수락", summary.accepted_count)
+                } else {
+                    format!(
+                        "Accepted {} import candidate{}",
+                        summary.accepted_count,
+                        if summary.accepted_count == 1 { "" } else { "s" }
+                    )
                 };
             }
             Err(error) => {
                 self.status.kind = StatusKind::Error;
                 self.status.text = format!(
-                    "{}: {error:#}",
+                    "{}: {error}",
                     t!("Import review failed", "임포트 검토 실패")
                 );
             }
         }
+        self.clamp_local_after_import_change();
         self.dirty = true;
-        true
+        Vec::new()
     }
 
-    pub(in crate::app) fn local_choose_next_import_candidate(&mut self) -> bool {
-        let Some((session_id, source_order)) = self.selected_manual_review_import_row() else {
-            return false;
-        };
-        match crate::transfer::review_action::choose_next_candidate(&session_id, source_order) {
-            Ok(summary) => {
-                self.status.kind = StatusKind::Info;
-                self.status.text = match summary.display {
-                    Some(display) => format!(
-                        "{} #{}: {display}",
-                        t!("Selected import candidate", "임포트 후보 선택"),
-                        summary.source_order
-                    ),
-                    None => format!(
-                        "{} #{}",
-                        t!("Selected import candidate", "임포트 후보 선택"),
-                        summary.source_order
-                    ),
-                };
-            }
-            Err(error) => {
-                self.status.kind = StatusKind::Error;
-                self.status.text = format!(
-                    "{}: {error:#}",
-                    t!("Import review failed", "임포트 검토 실패")
-                );
-            }
-        }
-        self.dirty = true;
-        true
+    fn next_local_import_review_op_id(&mut self) -> u64 {
+        self.local_mode.next_import_review_op_id =
+            self.local_mode.next_import_review_op_id.wrapping_add(1);
+        self.local_mode.next_import_review_op_id
     }
 
-    pub(in crate::app) fn local_reject_selected_import_row(&mut self) -> bool {
-        let Some((session_id, source_order)) = self.selected_manual_review_import_row() else {
-            return false;
-        };
-        match crate::transfer::review_action::reject_row(&session_id, source_order) {
-            Ok(summary) => {
-                self.status.kind = StatusKind::Info;
-                self.status.text = format!(
-                    "{} #{}",
-                    t!("Rejected import row", "임포트 행 거부"),
-                    summary.source_order
-                );
-            }
-            Err(error) => {
-                self.status.kind = StatusKind::Error;
-                self.status.text = format!(
-                    "{}: {error:#}",
-                    t!("Import review failed", "임포트 검토 실패")
-                );
-            }
-        }
-        self.dirty = true;
-        true
-    }
-
-    pub(in crate::app) fn local_skip_selected_import_row(&mut self) -> bool {
-        let Some((session_id, source_order)) = self.selected_manual_review_import_row() else {
-            return false;
-        };
-        match crate::transfer::review_action::skip_row(&session_id, source_order) {
-            Ok(summary) => {
-                self.status.kind = StatusKind::Info;
-                self.status.text = format!(
-                    "{} #{}",
-                    t!("Skipped import row", "임포트 행 건너뜀"),
-                    summary.source_order
-                );
-            }
-            Err(error) => {
-                self.status.kind = StatusKind::Error;
-                self.status.text = format!(
-                    "{}: {error:#}",
-                    t!("Import review failed", "임포트 검토 실패")
-                );
-            }
-        }
-        self.dirty = true;
-        true
+    fn clamp_local_after_import_change(&mut self) {
+        self.local_mode.ui.selected = self
+            .local_mode
+            .ui
+            .selected
+            .min(self.local_rows_len().saturating_sub(1));
+        self.local_mode.ui.anchor = self.local_mode.ui.selected;
     }
 
     pub(in crate::app) fn request_local_import_organize_apply(&mut self) -> Vec<Cmd> {
@@ -671,7 +803,7 @@ impl App {
             self.dirty = true;
             return Vec::new();
         };
-        let Ok(session) = ImportSession::load(&session_id) else {
+        let Ok(session) = load_import_session_recovering(&session_id) else {
             self.status.kind = StatusKind::Error;
             self.status.text = format!(
                 "{}: {session_id}",
@@ -728,7 +860,7 @@ impl App {
     ) -> Vec<Cmd> {
         self.local_mode.pending_organize_confirm = None;
         let result = (|| {
-            let session = ImportSession::load(&confirm.session_id)?;
+            let session = load_import_session_recovering(&confirm.session_id)?;
             let plan = build_import_organize_plan(
                 &session,
                 &ImportOrganizeOptions {
@@ -884,7 +1016,7 @@ impl App {
     }
 
     pub(in crate::app) fn import_session_songs(&self, session_id: &str) -> Vec<Song> {
-        if let Ok(mut session) = ImportSession::load(session_id) {
+        if let Ok(mut session) = load_import_session_recovering(session_id) {
             session.rows.sort_by(|a, b| {
                 a.source_order
                     .cmp(&b.source_order)
@@ -903,8 +1035,33 @@ impl App {
     }
 }
 
+fn load_import_session_recovering(session_id: &str) -> anyhow::Result<ImportSession> {
+    match ImportSession::load(session_id) {
+        Ok(session) => Ok(session),
+        Err(session_error) => {
+            let cp = Checkpoint::load(session_id).map_err(|checkpoint_error| {
+                anyhow::anyhow!(
+                    "load import session `{session_id}` failed ({session_error:#}); checkpoint recovery failed ({checkpoint_error:#})"
+                )
+            })?;
+            let session = ImportSession::from_checkpoint(&cp);
+            session.save().map_err(|save_error| {
+                anyhow::anyhow!(
+                    "recover import session `{session_id}` from checkpoint failed while saving: {save_error}"
+                )
+            })?;
+            tracing::warn!(
+                session_id,
+                error = %session_error,
+                "recovered import session from checkpoint"
+            );
+            Ok(session)
+        }
+    }
+}
+
 fn load_import_session_row(session_id: &str, source_order: u32) -> Option<ImportSessionRow> {
-    ImportSession::load(session_id)
+    load_import_session_recovering(session_id)
         .ok()?
         .rows
         .into_iter()
@@ -915,7 +1072,7 @@ fn load_import_session_and_row(
     session_id: &str,
     source_order: u32,
 ) -> Option<(ImportSession, ImportSessionRow)> {
-    let session = ImportSession::load(session_id).ok()?;
+    let session = load_import_session_recovering(session_id).ok()?;
     let row = session
         .rows
         .iter()
@@ -926,7 +1083,7 @@ fn load_import_session_and_row(
 
 fn import_session_failed_download_count(session_id: &str) -> Option<usize> {
     Some(
-        ImportSession::load(session_id)
+        load_import_session_recovering(session_id)
             .ok()?
             .rows
             .into_iter()
@@ -1160,6 +1317,77 @@ fn import_session_row_accepts_manual_review_action(row: &ImportSessionRow) -> bo
             row.status,
             ImportSessionRowStatus::Matched | ImportSessionRowStatus::SkippedLocal
         )
+}
+
+fn import_session_accept_all_candidate_count(session: &ImportSession) -> u32 {
+    session
+        .rows
+        .iter()
+        .filter(|row| {
+            import_session_row_accepts_manual_review_action(row) && !row.candidates.is_empty()
+        })
+        .count() as u32
+}
+
+fn import_session_accept_all_candidate_count_by_id(session_id: &str) -> Option<u32> {
+    load_import_session_recovering(session_id)
+        .ok()
+        .map(|session| import_session_accept_all_candidate_count(&session))
+}
+
+fn import_review_action_progress_label(action: ImportReviewAction) -> &'static str {
+    match action {
+        ImportReviewAction::AcceptFirst => {
+            t!("Accepting import row", "임포트 행 수락 중")
+        }
+        ImportReviewAction::ChooseNext => {
+            t!("Selecting import candidate", "임포트 후보 선택 중")
+        }
+        ImportReviewAction::Reject => t!("Rejecting import row", "임포트 행 거부 중"),
+        ImportReviewAction::Skip => t!("Skipping import row", "임포트 행 건너뛰는 중"),
+    }
+}
+
+fn import_review_success_text(
+    action: ImportReviewAction,
+    summary: &crate::transfer::review_action::ReviewActionSummary,
+) -> String {
+    match action {
+        ImportReviewAction::AcceptFirst => match &summary.display {
+            Some(display) => format!(
+                "{} #{}: {display}",
+                t!("Accepted import row", "임포트 행 수락"),
+                summary.source_order
+            ),
+            None => format!(
+                "{} #{}",
+                t!("Accepted import row", "임포트 행 수락"),
+                summary.source_order
+            ),
+        },
+        ImportReviewAction::ChooseNext => match &summary.display {
+            Some(display) => format!(
+                "{} #{}: {display}",
+                t!("Selected import candidate", "임포트 후보 선택"),
+                summary.source_order
+            ),
+            None => format!(
+                "{} #{}",
+                t!("Selected import candidate", "임포트 후보 선택"),
+                summary.source_order
+            ),
+        },
+        ImportReviewAction::Reject => format!(
+            "{} #{}",
+            t!("Rejected import row", "임포트 행 거부"),
+            summary.source_order
+        ),
+        ImportReviewAction::Skip => format!(
+            "{} #{}",
+            t!("Skipped import row", "임포트 행 건너뜀"),
+            summary.source_order
+        ),
+    }
 }
 
 fn import_session_row_selected_key(row: &ImportSessionRow) -> Option<&str> {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1697,6 +1697,7 @@ impl App {
         self.library_ui.confirm_delete = None;
         self.library_ui.confirm_download = None;
         self.local_mode.pending_organize_confirm = None;
+        self.local_mode.pending_accept_all_confirm = None;
         self.playlist_picker = None;
         // These three render as top-level overlays but route input only inside Settings-mode
         // dispatch, so leaving the screen must drop them explicitly or they'd paint on top of
@@ -1789,6 +1790,7 @@ impl App {
         self.library_ui.confirm_delete = None;
         self.library_ui.confirm_download = None;
         self.local_mode.pending_organize_confirm = None;
+        self.local_mode.pending_accept_all_confirm = None;
         // Popup-like playlist surfaces dismiss on any navigation (the drill-down itself is
         // content state — it resets only on a fresh Library entry below).
         self.library_ui.create_input = None;

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -151,6 +151,21 @@ impl App {
                 }
             }
         }
+        // Local import accept-all is modal: only its Confirm/Cancel buttons act.
+        if self.local_mode.pending_accept_all_confirm.is_some() {
+            match self.mouse_target_at(col, row) {
+                Some(
+                    t @ (MouseTarget::ConfirmLocalAcceptAll | MouseTarget::CancelLocalAcceptAll),
+                ) => {
+                    return self.on_mouse_target(t);
+                }
+                _ => {
+                    self.local_mode.pending_accept_all_confirm = None;
+                    self.dirty = true;
+                    return Vec::new();
+                }
+            }
+        }
         // The "what's playing" identify overlay is modal: only its own buttons act; a
         // click anywhere else closes it (no click-through to the player/seekbar).
         if self.overlays.now_playing_overlay.is_some() {
@@ -769,6 +784,17 @@ impl App {
                 self.dirty = true;
                 Vec::new()
             }
+            MouseTarget::ConfirmLocalAcceptAll => {
+                let Some(confirm) = self.local_mode.pending_accept_all_confirm.take() else {
+                    return Vec::new();
+                };
+                self.apply_local_import_accept_all_confirm(confirm)
+            }
+            MouseTarget::CancelLocalAcceptAll => {
+                self.local_mode.pending_accept_all_confirm = None;
+                self.dirty = true;
+                Vec::new()
+            }
             MouseTarget::NowPlayingFavorite => self.now_playing_favorite(),
             MouseTarget::NowPlayingAskAi => self.now_playing_ask_ai(),
             MouseTarget::CloseNowPlaying => {
@@ -825,6 +851,7 @@ impl App {
             || self.radio_mode.pending_radio_mode_confirm.is_some()
             || self.local_mode.pending_confirm.is_some()
             || self.local_mode.pending_organize_confirm.is_some()
+            || self.local_mode.pending_accept_all_confirm.is_some()
             || self.overlays.pending_settings_confirm.is_some()
             || self.library_ui.confirm_delete.is_some()
             || self.library_ui.confirm_playlist_delete.is_some()
@@ -1383,6 +1410,7 @@ impl App {
             || self.radio_mode.pending_radio_mode_confirm.is_some()
             || self.local_mode.pending_confirm.is_some()
             || self.local_mode.pending_organize_confirm.is_some()
+            || self.local_mode.pending_accept_all_confirm.is_some()
             || self.overlays.pending_settings_confirm.is_some()
             || self.library_ui.confirm_delete.is_some()
             || self.library_ui.confirm_playlist_delete.is_some()

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -743,6 +743,9 @@ pub struct LocalMode {
     pub(in crate::app) local_mode_queue: Option<QueueSnapshot>,
     pub pending_confirm: Option<LocalModeConfirm>,
     pub pending_organize_confirm: Option<LocalOrganizeConfirm>,
+    pub pending_accept_all_confirm: Option<LocalImportAcceptAllConfirm>,
+    pub(in crate::app) pending_import_reviews: HashMap<String, u64>,
+    pub(in crate::app) next_import_review_op_id: u64,
 }
 
 /// Animation clock and redraw-coalescing counters: the monotonic frame counter that drives every

--- a/src/app/tests/local_import.rs
+++ b/src/app/tests/local_import.rs
@@ -120,6 +120,60 @@ fn save_ambiguous_import_job(job_id: &str) {
         .expect("save import session");
 }
 
+fn single_cmd(cmds: Vec<Cmd>) -> Cmd {
+    assert_eq!(cmds.len(), 1, "expected exactly one command");
+    cmds.into_iter().next().unwrap()
+}
+
+fn finish_import_review_cmd(app: &mut App, cmd: Cmd) {
+    let Cmd::Local(LocalCmd::ReviewImport {
+        op_id,
+        session_id,
+        source_order,
+        action,
+    }) = cmd
+    else {
+        panic!("expected import review command");
+    };
+    let result = match action {
+        ImportReviewAction::AcceptFirst => {
+            crate::transfer::review_action::accept_first_candidate(&session_id, source_order)
+        }
+        ImportReviewAction::ChooseNext => {
+            crate::transfer::review_action::choose_next_candidate(&session_id, source_order)
+        }
+        ImportReviewAction::Reject => {
+            crate::transfer::review_action::reject_row(&session_id, source_order)
+        }
+        ImportReviewAction::Skip => {
+            crate::transfer::review_action::skip_row(&session_id, source_order)
+        }
+    }
+    .map_err(|error| format!("{error:#}"));
+    app.update(Msg::Local(LocalMsg::ImportReviewFinished {
+        op_id,
+        session_id,
+        source_order,
+        action,
+        result,
+        elapsed_ms: 0,
+    }));
+}
+
+fn finish_import_accept_all_cmd(app: &mut App, cmd: Cmd) {
+    let Cmd::Local(LocalCmd::ReviewImportAcceptAll { op_id, session_id }) = cmd else {
+        panic!("expected import accept-all command");
+    };
+    let result = crate::transfer::review_action::accept_all_candidates(&session_id)
+        .map_err(|error| format!("{error:#}"));
+    app.update(Msg::Local(LocalMsg::ImportReviewAcceptAllFinished {
+        op_id,
+        session_id,
+        result,
+        elapsed_ms: 0,
+    }));
+}
+
 fn temp_import_root(name: &str) -> PathBuf {
     let root = std::env::temp_dir().join(format!(
         "yututui-local-import-{name}-{}",
@@ -720,6 +774,24 @@ fn local_deck_import_row_o_opens_selected_candidate_url() {
 }
 
 #[test]
+fn local_deck_recovers_corrupt_import_session_from_checkpoint() {
+    let session_id = "sp2yt-local-recover-session";
+    save_ambiguous_import_job(session_id);
+    let session_path =
+        crate::transfer::session::session_path(session_id).expect("import session path");
+    fs::write(&session_path, b"{not valid json").expect("corrupt import session");
+
+    let mut app = app_with_local_deck_index(Vec::new());
+    app.update(Msg::Key(key(KeyCode::Char('0'))));
+    app.local_mode.ui.filter_query = session_id.to_owned();
+
+    assert_eq!(app.local_rows_len(), 1);
+    let recovered =
+        crate::transfer::session::ImportSession::load(session_id).expect("load recovered session");
+    assert_eq!(recovered.rows[0].source_order, 1);
+}
+
+#[test]
 fn local_deck_import_review_keys_accept_and_reject_rows() {
     let accept_id = "sp2yt-local-review-accept";
     save_ambiguous_import_job(accept_id);
@@ -736,7 +808,12 @@ fn local_deck_import_review_keys_accept_and_reject_rows() {
     );
 
     let cmds = app.update(Msg::Key(key(KeyCode::Char('a'))));
-    assert!(cmds.is_empty());
+    let cmd = single_cmd(cmds);
+    let before =
+        crate::transfer::session::ImportSession::load(accept_id).expect("load pending session");
+    assert_eq!(before.rows[0].review_decision, None);
+    assert!(app.status.text.contains("Accepting import row"));
+    finish_import_review_cmd(&mut app, cmd);
     let accepted =
         crate::transfer::session::ImportSession::load(accept_id).expect("load accepted session");
     assert!(matches!(
@@ -768,7 +845,8 @@ fn local_deck_import_review_keys_accept_and_reject_rows() {
     app.local_mode.ui.filter_query.clear();
 
     let cmds = app.update(Msg::Key(key(KeyCode::Char('r'))));
-    assert!(cmds.is_empty());
+    let cmd = single_cmd(cmds);
+    finish_import_review_cmd(&mut app, cmd);
     let rejected =
         crate::transfer::session::ImportSession::load(reject_id).expect("load rejected session");
     assert_eq!(
@@ -795,7 +873,8 @@ fn local_deck_import_review_keys_choose_next_and_skip_rows() {
     app.local_mode.ui.filter_query.clear();
 
     let cmds = app.update(Msg::Key(key(KeyCode::Char('c'))));
-    assert!(cmds.is_empty());
+    let cmd = single_cmd(cmds);
+    finish_import_review_cmd(&mut app, cmd);
     let chosen =
         crate::transfer::session::ImportSession::load(choose_id).expect("load chosen session");
     assert!(matches!(
@@ -816,7 +895,8 @@ fn local_deck_import_review_keys_choose_next_and_skip_rows() {
     assert_eq!(app.local_rows_len(), 1);
 
     let cmds = app.update(Msg::Key(key(KeyCode::Char('x'))));
-    assert!(cmds.is_empty());
+    let cmd = single_cmd(cmds);
+    finish_import_review_cmd(&mut app, cmd);
     let skipped =
         crate::transfer::session::ImportSession::load(skip_id).expect("load skipped session");
     assert_eq!(
@@ -829,6 +909,39 @@ fn local_deck_import_review_keys_choose_next_and_skip_rows() {
         0,
         "skipped rows should leave the attention inbox"
     );
+}
+
+#[test]
+fn local_deck_shift_a_confirms_and_accepts_all_session_candidates() {
+    let session_id = "sp2yt-local-review-accept-all";
+    save_ambiguous_import_job(session_id);
+
+    let mut app = app_with_local_deck_index(Vec::new());
+    app.update(Msg::Key(key(KeyCode::Char('9'))));
+    app.local_mode.ui.filter_query = session_id.to_owned();
+    let open = double_click_target(&mut app, MouseTarget::LocalRow(0));
+    assert!(open.is_empty());
+    app.local_mode.ui.filter_query.clear();
+
+    let cmds = app.update(Msg::Key(key(KeyCode::Char('A'))));
+    assert!(cmds.is_empty());
+    assert_eq!(
+        app.local_mode
+            .pending_accept_all_confirm
+            .as_ref()
+            .map(|confirm| (confirm.session_id.clone(), confirm.candidate_count)),
+        Some((session_id.to_owned(), 1))
+    );
+
+    let cmd = single_cmd(app.update(Msg::Key(key(KeyCode::Enter))));
+    finish_import_accept_all_cmd(&mut app, cmd);
+    let accepted =
+        crate::transfer::session::ImportSession::load(session_id).expect("load accepted session");
+    assert!(matches!(
+        accepted.rows[0].review_decision,
+        Some(ReviewDecision::Accepted { ref key, .. }) if key == "dQw4w9WgXcQ"
+    ));
+    assert!(app.status.text.contains("Accepted 1 import candidate"));
 }
 
 #[test]

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -383,6 +383,16 @@ pub enum LocalCmd {
         index_path: Option<PathBuf>,
         previous: crate::local::LocalIndex,
     },
+    ReviewImport {
+        op_id: u64,
+        session_id: String,
+        source_order: u32,
+        action: ImportReviewAction,
+    },
+    ReviewImportAcceptAll {
+        op_id: u64,
+        session_id: String,
+    },
 }
 
 /// Local Deck worker results.
@@ -401,6 +411,28 @@ pub enum LocalMsg {
     ScanFailed {
         error: String,
     },
+    ImportReviewFinished {
+        op_id: u64,
+        session_id: String,
+        source_order: u32,
+        action: ImportReviewAction,
+        result: Result<crate::transfer::review_action::ReviewActionSummary, String>,
+        elapsed_ms: u128,
+    },
+    ImportReviewAcceptAllFinished {
+        op_id: u64,
+        session_id: String,
+        result: Result<crate::transfer::review_action::ReviewBatchSummary, String>,
+        elapsed_ms: u128,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportReviewAction {
+    AcceptFirst,
+    ChooseNext,
+    Reject,
+    Skip,
 }
 
 /// A clickable terminal region's semantic target.
@@ -523,6 +555,10 @@ pub enum MouseTarget {
     ConfirmLocalOrganize,
     /// Cancel button on the local import organize modal.
     CancelLocalOrganize,
+    /// Confirm button on the local import accept-all modal.
+    ConfirmLocalAcceptAll,
+    /// Cancel button on the local import accept-all modal.
+    CancelLocalAcceptAll,
     /// "Save to favorites" on the "what's playing" overlay (resolves a real YT track first).
     NowPlayingFavorite,
     /// "Tell me more" on the "what's playing" overlay — hands off to the DJ Gem view.
@@ -930,6 +966,39 @@ impl LocalOrganizeConfirm {
                 self.already_count,
                 self.skipped_count
             )
+        }
+    }
+}
+
+/// Pending confirmation before accepting every reviewable candidate in an import session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalImportAcceptAllConfirm {
+    pub session_id: String,
+    pub candidate_count: u32,
+}
+
+impl LocalImportAcceptAllConfirm {
+    pub fn title(&self) -> &'static str {
+        t!(" Accept import candidates ", " 임포트 후보 수락 ")
+    }
+
+    pub fn prompt(&self) -> String {
+        if crate::i18n::is_korean() {
+            format!("{}개 임포트 후보를 모두 수락할까요?", self.candidate_count)
+        } else {
+            format!(
+                "Accept {} import candidate{}?",
+                self.candidate_count,
+                if self.candidate_count == 1 { "" } else { "s" }
+            )
+        }
+    }
+
+    pub fn detail(&self) -> String {
+        if crate::i18n::is_korean() {
+            format!("세션: {}", self.session_id)
+        } else {
+            format!("Session: {}", self.session_id)
         }
     }
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -38,6 +38,7 @@ pub enum Action {
     /// Download every song in the current list/playlist at once (deduped), distinct from the
     /// single-track `Download`.
     DownloadAll,
+    AcceptAllImportReview,
     ToggleShuffle,
     CycleRepeat,
     CycleEq,
@@ -185,6 +186,12 @@ const ACTION_META: &[(Action, &str, &str, &str)] = &[
         "download_all",
         "Download all",
         "전체 다운로드",
+    ),
+    (
+        Action::AcceptAllImportReview,
+        "accept_all_import_review",
+        "Accept all import candidates",
+        "임포트 후보 전체 수락",
     ),
     (
         Action::ToggleShuffle,
@@ -623,6 +630,7 @@ pub enum KeyContext {
     Common,
     Global,
     Library,
+    LocalDeck,
     Playlists,
     Queue,
     SearchInput,
@@ -658,6 +666,7 @@ const CONTEXT_META: &[(KeyContext, &str, &str, &str)] = &[
     ),
     (KeyContext::Global, "global", "Global", "전역"),
     (KeyContext::Library, "library", "Library", "라이브러리"),
+    (KeyContext::LocalDeck, "local_deck", "Local Deck", "로컬 덱"),
     (
         KeyContext::Playlists,
         "playlists",
@@ -989,7 +998,20 @@ impl KeyMap {
         chord: Chord,
     ) -> Option<Conflict> {
         let existing = self.bindings.get(&(ctx, chord)).copied()?;
-        (existing != action).then_some(Conflict {
+        let animation_shadow = chord == Chord::new(KeyCode::Char('A'), KeyModifiers::empty())
+            && match ctx {
+                KeyContext::Global => {
+                    (existing, action) == (Action::ToggleAnimations, Action::AcceptAllImportReview)
+                }
+                KeyContext::LocalDeck => {
+                    (existing, action) == (Action::AcceptAllImportReview, Action::ToggleAnimations)
+                }
+                _ => false,
+            };
+        if existing == action || animation_shadow {
+            return None;
+        }
+        Some(Conflict {
             ctx,
             existing,
             chord,
@@ -1198,6 +1220,7 @@ pub fn default_bindings() -> Vec<(KeyContext, Action, Chord)> {
         (C::Library, A::LibraryRemove, key(KeyCode::Delete)),
         (C::Library, A::LibraryFilter, ch('/')),
         (C::Library, A::Back, ch('q')),
+        (C::LocalDeck, A::AcceptAllImportReview, ch('A')),
         // Playlists tab (root list of playlists + opened-playlist drill-down).
         (C::Playlists, A::Confirm, key(KeyCode::Enter)),
         (C::Playlists, A::PlayAll, ch('a')),

--- a/src/keymap/tests.rs
+++ b/src/keymap/tests.rs
@@ -251,13 +251,21 @@ fn default_bindings_are_conflict_free() {
         }
     }
     // Global chords are consulted before every per-screen handler, so a non-Global
-    // default reusing one is dead at runtime — mirror the asymmetric conflict
-    // definition of `KeyMap::conflict` (Common shadowing, by contrast, is deliberate).
+    // default reusing one is dead at runtime unless dispatch deliberately gives a
+    // local context first claim. Mirror the asymmetric conflict definition of
+    // `KeyMap::conflict` (Common shadowing, by contrast, is deliberate).
     for (ctx, action, chord) in default_bindings() {
         if ctx == KeyContext::Global {
             continue;
         }
         if let Some(&global) = by_chord.get(&(KeyContext::Global, chord)) {
+            let local_deck_accept_all_shadows_global_animation = ctx == KeyContext::LocalDeck
+                && action == Action::AcceptAllImportReview
+                && global == Action::ToggleAnimations
+                && chord == Chord::new(KeyCode::Char('A'), KeyModifiers::empty());
+            if local_deck_accept_all_shadows_global_animation {
+                continue;
+            }
             panic!(
                 "{ctx:?} {action:?}: `{}` is shadowed by Global {global:?}",
                 format_chord(chord)
@@ -1157,6 +1165,17 @@ fn text_zoom_defaults_bind_ctrl_equals_and_minus_globally() {
 }
 
 #[test]
+fn local_deck_accept_all_shadows_global_animation_toggle_on_a() {
+    let km = KeyMap::default();
+    let chord = parse_chord("A").unwrap();
+    assert_eq!(km.global_action(chord), Some(Action::ToggleAnimations));
+    assert_eq!(
+        km.action(KeyContext::LocalDeck, chord),
+        Some(Action::AcceptAllImportReview)
+    );
+}
+
+#[test]
 fn editable_entries_cover_every_binding() {
     assert_eq!(editable_entries().len(), default_bindings().len());
     assert!(
@@ -1170,6 +1189,10 @@ fn editable_entries_cover_every_binding() {
     assert!(
         editable_entries().contains(&(KeyContext::Library, Action::ToggleLocalMode)),
         "Settings > Keys should list the Local Deck mode binding"
+    );
+    assert!(
+        editable_entries().contains(&(KeyContext::LocalDeck, Action::AcceptAllImportReview)),
+        "Settings > Keys should list the Local Deck accept-all binding"
     );
     // Every action has a stable id and label.
     for (_, action, _) in default_bindings() {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1126,6 +1126,88 @@ impl RuntimeHandles {
                         );
                     });
                 }
+                crate::app::LocalCmd::ReviewImport {
+                    op_id,
+                    session_id,
+                    source_order,
+                    action,
+                } => {
+                    let tx = self.worker_tx.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let t0 = std::time::Instant::now();
+                        let result = match action {
+                            crate::app::ImportReviewAction::AcceptFirst => {
+                                crate::transfer::review_action::accept_first_candidate(
+                                    &session_id,
+                                    source_order,
+                                )
+                            }
+                            crate::app::ImportReviewAction::ChooseNext => {
+                                crate::transfer::review_action::choose_next_candidate(
+                                    &session_id,
+                                    source_order,
+                                )
+                            }
+                            crate::app::ImportReviewAction::Reject => {
+                                crate::transfer::review_action::reject_row(
+                                    &session_id,
+                                    source_order,
+                                )
+                            }
+                            crate::app::ImportReviewAction::Skip => {
+                                crate::transfer::review_action::skip_row(&session_id, source_order)
+                            }
+                        }
+                        .map_err(|error| format!("{error:#}"));
+                        let elapsed_ms = t0.elapsed().as_millis();
+                        tracing::debug!(
+                            session_id = %session_id,
+                            source_order,
+                            ?action,
+                            elapsed_ms,
+                            "finished import review action"
+                        );
+                        emit(
+                            &tx,
+                            RuntimeEvent::App(Msg::Local(
+                                crate::app::LocalMsg::ImportReviewFinished {
+                                    op_id,
+                                    session_id,
+                                    source_order,
+                                    action,
+                                    result,
+                                    elapsed_ms,
+                                },
+                            )),
+                        );
+                    });
+                }
+                crate::app::LocalCmd::ReviewImportAcceptAll { op_id, session_id } => {
+                    let tx = self.worker_tx.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let t0 = std::time::Instant::now();
+                        let result =
+                            crate::transfer::review_action::accept_all_candidates(&session_id)
+                                .map_err(|error| format!("{error:#}"));
+                        let elapsed_ms = t0.elapsed().as_millis();
+                        tracing::debug!(
+                            session_id = %session_id,
+                            elapsed_ms,
+                            "finished import review accept all"
+                        );
+                        emit(
+                            &tx,
+                            RuntimeEvent::App(Msg::Local(
+                                crate::app::LocalMsg::ImportReviewAcceptAllFinished {
+                                    op_id,
+                                    session_id,
+                                    result,
+                                    elapsed_ms,
+                                },
+                            )),
+                        );
+                    });
+                }
             },
             Cmd::Recorder(job) => {
                 // Copy/tag/delete are blocking IO — keep them off the loop task. A `Save`

--- a/src/transfer/review_action.rs
+++ b/src/transfer/review_action.rs
@@ -15,6 +15,13 @@ pub struct ReviewActionSummary {
     pub score: Option<f32>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReviewBatchSummary {
+    pub session_id: String,
+    pub accepted_count: u32,
+    pub rows: Vec<ReviewActionSummary>,
+}
+
 #[derive(Debug, Clone)]
 struct SelectedCandidate {
     key: String,
@@ -70,6 +77,36 @@ pub fn skip_row(job_id: &str, source_order: u32) -> anyhow::Result<ReviewActionS
     apply_terminal_decision(job_id, source_order, ReviewDecision::Skipped, "skipped")
 }
 
+pub fn accept_all_candidates(job_id: &str) -> anyhow::Result<ReviewBatchSummary> {
+    let mut cp = Checkpoint::load(job_id)?;
+    let mut rows = Vec::new();
+    for index in 0..cp.tracks.len() {
+        if cp.tracks[index].written {
+            continue;
+        }
+        let source_order = u32::try_from(index + 1).unwrap_or(u32::MAX);
+        let Some(selected) = first_ambiguous_candidate(&cp.tracks[index].outcome) else {
+            continue;
+        };
+        apply_accepted_candidate(&mut cp, index, selected.clone());
+        rows.push(ReviewActionSummary {
+            source_order,
+            label: "accepted",
+            key: Some(selected.key),
+            display: Some(selected.display),
+            score: Some(selected.score),
+        });
+    }
+    if !rows.is_empty() {
+        save_checkpoint_and_session(&mut cp)?;
+    }
+    Ok(ReviewBatchSummary {
+        session_id: job_id.to_owned(),
+        accepted_count: rows.len() as u32,
+        rows,
+    })
+}
+
 fn accept_candidate(
     cp: &mut Checkpoint,
     index: usize,
@@ -77,6 +114,18 @@ fn accept_candidate(
     selected: SelectedCandidate,
     label: &'static str,
 ) -> anyhow::Result<ReviewActionSummary> {
+    apply_accepted_candidate(cp, index, selected.clone());
+    save_checkpoint_and_session(cp)?;
+    Ok(ReviewActionSummary {
+        source_order,
+        label,
+        key: Some(selected.key),
+        display: Some(selected.display),
+        score: Some(selected.score),
+    })
+}
+
+fn apply_accepted_candidate(cp: &mut Checkpoint, index: usize, selected: SelectedCandidate) {
     cp.tracks[index].outcome = Some(MatchOutcome::Matched {
         key: selected.key.clone(),
         score: selected.score,
@@ -88,18 +137,10 @@ fn accept_candidate(
         score_breakdown: selected.score_breakdown,
     });
     cp.tracks[index].review_decision = Some(ReviewDecision::Accepted {
-        key: selected.key.clone(),
+        key: selected.key,
         score: selected.score,
-        display: selected.display.clone(),
+        display: selected.display,
     });
-    save_checkpoint_and_session(cp)?;
-    Ok(ReviewActionSummary {
-        source_order,
-        label,
-        key: Some(selected.key),
-        display: Some(selected.display),
-        score: Some(selected.score),
-    })
 }
 
 fn apply_terminal_decision(
@@ -180,6 +221,18 @@ fn candidates_from_outcome(outcome: &Option<MatchOutcome>) -> Vec<SelectedCandid
             .collect(),
         _ => Vec::new(),
     }
+}
+
+fn first_ambiguous_candidate(outcome: &Option<MatchOutcome>) -> Option<SelectedCandidate> {
+    let Some(MatchOutcome::Ambiguous { candidates }) = outcome else {
+        return None;
+    };
+    candidates.first().map(|candidate| SelectedCandidate {
+        key: candidate.key.clone(),
+        score: candidate.score,
+        display: candidate.display.clone(),
+        score_breakdown: candidate.score_breakdown,
+    })
 }
 
 fn selected_key(entry: &super::checkpoint::TrackEntry) -> Option<&str> {

--- a/src/transfer/session.rs
+++ b/src/transfer/session.rs
@@ -15,7 +15,9 @@ use super::{Stage, TransferDest, TransferSource};
 use crate::util::safe_fs;
 
 const IMPORT_SESSION_SCHEMA_VERSION: u32 = 1;
+const IMPORT_SESSION_SUMMARY_SCHEMA_VERSION: u32 = 1;
 const IMPORT_SESSION_MAX_BYTES: u64 = 50 * 1024 * 1024;
+const IMPORT_SESSION_SUMMARY_MAX_BYTES: u64 = 256 * 1024;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -40,6 +42,78 @@ pub struct ImportSessionSummary {
     pub source: SessionEndpoint,
     pub destination: SessionEndpoint,
     pub counts: ImportSessionCounts,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+struct ImportSessionSummaryFile {
+    schema_version: u32,
+    session_id: String,
+    stage: Stage,
+    updated_at: i64,
+    source: SessionEndpoint,
+    destination: SessionEndpoint,
+    counts: ImportSessionCounts,
+}
+
+impl Default for ImportSessionSummaryFile {
+    fn default() -> Self {
+        Self {
+            schema_version: IMPORT_SESSION_SUMMARY_SCHEMA_VERSION,
+            session_id: String::new(),
+            stage: Stage::Fetching,
+            updated_at: 0,
+            source: SessionEndpoint::default(),
+            destination: SessionEndpoint::default(),
+            counts: ImportSessionCounts::default(),
+        }
+    }
+}
+
+impl From<&ImportSession> for ImportSessionSummary {
+    fn from(session: &ImportSession) -> Self {
+        Self {
+            session_id: session.session_id.clone(),
+            stage: session.stage,
+            updated_at: session.updated_at,
+            source: session.source.clone(),
+            destination: session.destination.clone(),
+            counts: session.counts.clone(),
+        }
+    }
+}
+
+impl From<&ImportSession> for ImportSessionSummaryFile {
+    fn from(session: &ImportSession) -> Self {
+        ImportSessionSummary::from(session).into()
+    }
+}
+
+impl From<ImportSessionSummary> for ImportSessionSummaryFile {
+    fn from(summary: ImportSessionSummary) -> Self {
+        Self {
+            schema_version: IMPORT_SESSION_SUMMARY_SCHEMA_VERSION,
+            session_id: summary.session_id,
+            stage: summary.stage,
+            updated_at: summary.updated_at,
+            source: summary.source,
+            destination: summary.destination,
+            counts: summary.counts,
+        }
+    }
+}
+
+impl From<ImportSessionSummaryFile> for ImportSessionSummary {
+    fn from(file: ImportSessionSummaryFile) -> Self {
+        Self {
+            session_id: file.session_id,
+            stage: file.stage,
+            updated_at: file.updated_at,
+            source: file.source,
+            destination: file.destination,
+            counts: file.counts,
+        }
+    }
 }
 
 impl Default for ImportSession {
@@ -220,7 +294,11 @@ impl ImportSession {
         let Some(path) = session_path(&self.session_id) else {
             return Ok(());
         };
-        safe_fs::write_private_atomic_json(&path, self)
+        safe_fs::write_private_atomic_json(&path, self)?;
+        if let Some(path) = session_summary_path(&self.session_id) {
+            safe_fs::write_private_atomic_json(&path, &ImportSessionSummaryFile::from(self))?;
+        }
+        Ok(())
     }
 
     pub fn load(session_id: &str) -> anyhow::Result<Self> {
@@ -250,20 +328,22 @@ impl ImportSession {
         let mut out: Vec<ImportSessionSummary> = entries
             .filter_map(|entry| {
                 let path = entry.ok()?.path();
-                if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                let name = path.file_name()?.to_str()?;
+                let session_id = name.strip_suffix(".json")?;
+                if session_id.ends_with(".summary") {
                     return None;
                 }
-                let bytes =
-                    safe_fs::read_no_symlink_limited(&path, IMPORT_SESSION_MAX_BYTES).ok()?;
-                let session: ImportSession = serde_json::from_slice(&bytes).ok()?;
-                Some(ImportSessionSummary {
-                    session_id: session.session_id,
-                    stage: session.stage,
-                    updated_at: session.updated_at,
-                    source: session.source,
-                    destination: session.destination,
-                    counts: session.counts,
-                })
+                read_fresh_summary(session_id, &path)
+                    .or_else(|| {
+                        let bytes =
+                            safe_fs::read_no_symlink_limited(&path, IMPORT_SESSION_MAX_BYTES)
+                                .ok()?;
+                        let session: ImportSession = serde_json::from_slice(&bytes).ok()?;
+                        let summary = ImportSessionSummary::from(&session);
+                        let _ = write_session_summary(&session);
+                        Some(summary)
+                    })
+                    .or_else(|| read_session_summary(session_id))
             })
             .collect();
         out.sort_by_key(|summary| std::cmp::Reverse(summary.updated_at));
@@ -491,6 +571,55 @@ pub fn session_path(session_id: &str) -> Option<PathBuf> {
     Some(sessions_dir()?.join(format!("{}.json", safe_session_id(session_id)?)))
 }
 
+fn session_summary_path(session_id: &str) -> Option<PathBuf> {
+    Some(sessions_dir()?.join(format!("{}.summary.json", safe_session_id(session_id)?)))
+}
+
+fn read_fresh_summary(
+    session_id: &str,
+    session_path: &std::path::Path,
+) -> Option<ImportSessionSummary> {
+    let summary_path = session_summary_path(session_id)?;
+    if summary_is_older_than_session(&summary_path, session_path) {
+        return None;
+    }
+    read_session_summary(session_id)
+}
+
+fn read_session_summary(session_id: &str) -> Option<ImportSessionSummary> {
+    let summary_path = session_summary_path(session_id)?;
+    let bytes =
+        safe_fs::read_no_symlink_limited(&summary_path, IMPORT_SESSION_SUMMARY_MAX_BYTES).ok()?;
+    let file: ImportSessionSummaryFile = serde_json::from_slice(&bytes).ok()?;
+    if file.schema_version != IMPORT_SESSION_SUMMARY_SCHEMA_VERSION || file.session_id != session_id
+    {
+        return None;
+    }
+    Some(file.into())
+}
+
+fn summary_is_older_than_session(
+    summary_path: &std::path::Path,
+    session_path: &std::path::Path,
+) -> bool {
+    let Ok(summary_modified) = std::fs::metadata(summary_path).and_then(|meta| meta.modified())
+    else {
+        return true;
+    };
+    let Ok(session_modified) = std::fs::metadata(session_path).and_then(|meta| meta.modified())
+    else {
+        return false;
+    };
+    summary_modified < session_modified
+}
+
+fn write_session_summary(session: &ImportSession) -> std::io::Result<()> {
+    let Some(path) = session_summary_path(&session.session_id) else {
+        return Ok(());
+    };
+    safe_fs::write_private_atomic_json(&path, &ImportSessionSummaryFile::from(session))
+}
+
 fn sessions_dir() -> Option<PathBuf> {
     crate::paths::data_dir().map(|d| d.join("transfers").join("sessions"))
 }
@@ -695,6 +824,28 @@ mod tests {
             .display(),
             "kind"
         );
+    }
+
+    #[test]
+    fn save_writes_summary_sidecar_used_by_list_all() {
+        let cp = Checkpoint::new(
+            "sp2yt-session-summary-sidecar".to_owned(),
+            spec(TransferDest::LocalPlaylist {
+                name: Some("Imported".to_owned()),
+            }),
+            vec![entry(input("Matched", &["A"]), None, false)],
+        );
+        let session = ImportSession::from_checkpoint(&cp);
+        session.save().expect("save import session");
+        let summary_path = session_summary_path(&session.session_id).expect("summary path");
+        assert!(summary_path.exists(), "summary sidecar should be written");
+
+        let summary = ImportSession::list_all()
+            .into_iter()
+            .find(|summary| summary.session_id == session.session_id)
+            .expect("summary from list_all");
+        assert_eq!(summary.session_id, session.session_id);
+        assert_eq!(summary.counts.total, 1);
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -77,6 +77,9 @@ pub fn render(frame: &mut Frame, app: &App) {
     if let Some(confirm) = &app.local_mode.pending_organize_confirm {
         views::local::render_local_organize_confirm(frame, app, area, confirm);
     }
+    if let Some(confirm) = &app.local_mode.pending_accept_all_confirm {
+        views::local::render_local_accept_all_confirm(frame, app, area, confirm);
+    }
     // A keybinding-conflict warning (Keys tab) is modal — it sits above everything else.
     if let Some(conflict) = &app.overlays.key_conflict {
         views::settings::render_conflict(frame, app, area, conflict);

--- a/src/ui/views/help.rs
+++ b/src/ui/views/help.rs
@@ -749,6 +749,17 @@ mod tests {
     }
 
     #[test]
+    fn local_deck_group_lists_accept_all_import_candidates() {
+        let _guard = crate::i18n::lock_for_test();
+        let app = App::new(100);
+        let local_deck = help_groups(&app)
+            .into_iter()
+            .find_map(|(title, rows)| (title == "Local Deck").then_some(rows))
+            .expect("local deck group");
+        assert!(local_deck.contains(&("A".to_owned(), "Accept all import candidates".to_owned())));
+    }
+
+    #[test]
     fn player_lists_delete_current_queue_binding() {
         let _guard = crate::i18n::lock_for_test();
         let app = App::new(100);

--- a/src/ui/views/local.rs
+++ b/src/ui/views/local.rs
@@ -7,7 +7,8 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use crate::app::{
-    App, LocalModeConfirm, LocalOrganizeConfirm, LocalSection, MouseTarget, ScrollSurface,
+    App, LocalImportAcceptAllConfirm, LocalModeConfirm, LocalOrganizeConfirm, LocalSection,
+    MouseTarget, ScrollSurface,
 };
 use crate::t;
 use crate::theme::ThemeRole as R;
@@ -572,6 +573,68 @@ pub fn render_local_organize_confirm(
         buttons::Seg::label("    "),
         buttons::Seg::button(
             MouseTarget::CancelLocalOrganize,
+            t!(" Cancel (Esc) ", " 취소 (Esc) "),
+        ),
+    ];
+    buttons::render_segments(
+        frame,
+        app,
+        rows[4],
+        &segs,
+        crate::ui::confirm_button_style(app),
+        crate::ui::confirm_gap_style(app),
+        Alignment::Center,
+    );
+    crate::ui::seal_popup_background(frame, app, popup);
+    crate::ui::mark_art_rows_for_popup(frame, app, popup);
+}
+
+pub fn render_local_accept_all_confirm(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    confirm: &LocalImportAcceptAllConfirm,
+) {
+    let popup = centered_fixed(area, 72, 9);
+    crate::ui::render_popup_background(frame, app, popup);
+
+    let block = Block::default()
+        .title(confirm.title())
+        .borders(Borders::ALL)
+        .border_style(crate::ui::confirm_border_style(app))
+        .style(crate::ui::popup_style(app, R::TextPrimary));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Min(1),
+    ])
+    .split(inner);
+    frame.render_widget(
+        Paragraph::new(confirm.prompt())
+            .alignment(Alignment::Center)
+            .style(crate::ui::popup_style(app, R::TextPrimary)),
+        rows[1],
+    );
+    frame.render_widget(
+        Paragraph::new(confirm.detail())
+            .alignment(Alignment::Center)
+            .style(crate::ui::popup_style(app, R::TextMuted)),
+        rows[2],
+    );
+
+    let segs = [
+        buttons::Seg::button(
+            MouseTarget::ConfirmLocalAcceptAll,
+            t!(" Accept (Enter) ", " 수락 (Enter) "),
+        ),
+        buttons::Seg::label("    "),
+        buttons::Seg::button(
+            MouseTarget::CancelLocalAcceptAll,
             t!(" Cancel (Esc) ", " 취소 (Esc) "),
         ),
     ];


### PR DESCRIPTION
## Summary

- Move Local Deck import review actions (`a` accept, `c` choose, `r` reject, `x` skip) from the UI input path into `LocalCmd` background work.
- Add session-level pending guards and completion messages so repeated review writes do not overlap.
- Add `A` / Shift+A accept-all for the current import session, with a confirmation modal and cheat sheet/key settings entry.
- Add import session summary sidecars for cheaper `list_all()` and recover corrupt session JSON from checkpoint data when Local Deck loads sessions.

## Why

Accepting an import candidate was doing checkpoint load/save, session regeneration, and session save synchronously inside key handling. On larger local import sessions that can make the terminal feel stuck after pressing `a`.

## Impact

The existing review actions keep the same semantics, but disk-heavy persistence now runs off the UI loop. The new accept-all action batches all reviewable ambiguous rows in the current import session and writes checkpoint/session once.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `bash scripts/check-architecture.sh && bash scripts/check-file-size.sh && bash scripts/check-doc-honesty.sh && bash scripts/check-ratatui-image-patch.sh`
- `git diff --check`

Note: `~/.fable-harness/bin/run-gates .` could not run directly from this separate worktree because `.claude/harness/project-profile.json` is not present in the worktree. The gate commands from the original profile were run manually in this worktree and passed.
