### PR TITLE
Optimize runtime scheduling and persistence

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -10,6 +10,7 @@ mod hardening_tests;
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
@@ -23,6 +24,8 @@ pub use url_guard::{validate_playable_url_destination, validate_playback_target_
 
 const STREAMING_YTDLP_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 const STREAMING_YTDLP_CACHE_MAX: usize = 512;
+const API_INTERACTIVE_QUEUE: usize = 256;
+const API_BULK_QUEUE: usize = 256;
 pub const MAX_TITLE_CHARS: usize = 300;
 pub const MAX_ARTIST_CHARS: usize = 200;
 pub const MAX_ALBUM_CHARS: usize = 200;
@@ -754,6 +757,24 @@ impl ApiCommandKind {
             ApiCommandKind::PlaylistTracks => "playlist tracks",
         }
     }
+
+    fn lane(self) -> ApiLane {
+        match self {
+            ApiCommandKind::Search
+            | ApiCommandKind::GuiSearch
+            | ApiCommandKind::ResolveTrack
+            | ApiCommandKind::SearchPlaylists => ApiLane::Interactive,
+            ApiCommandKind::Streaming
+            | ApiCommandKind::StreamingPreflight
+            | ApiCommandKind::PlaylistTracks => ApiLane::Bulk,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApiLane {
+    Interactive,
+    Bulk,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -870,12 +891,17 @@ pub struct GuiSearchGroup {
 
 /// Handle for issuing API requests; results return as [`ApiEvent`]s.
 pub struct ApiHandle {
-    tx: Sender<ApiCmd>,
+    interactive_tx: Sender<ApiCmd>,
+    bulk_tx: Sender<ApiCmd>,
 }
 
 impl ApiHandle {
     fn enqueue(&self, cmd: ApiCmd) -> Result<(), ApiEnqueueError> {
-        self.tx.try_send(cmd).map_err(|err| match err {
+        let tx = match cmd.kind().lane() {
+            ApiLane::Interactive => &self.interactive_tx,
+            ApiLane::Bulk => &self.bulk_tx,
+        };
+        tx.try_send(cmd).map_err(|err| match err {
             TrySendError::Full(cmd) => ApiEnqueueError::Full { kind: cmd.kind() },
             TrySendError::Closed(cmd) => ApiEnqueueError::Closed { kind: cmd.kind() },
         })
@@ -998,13 +1024,24 @@ where
     // Bounded with a generous cap; the human-rate UI producer never fills it in normal use,
     // but a stalled network + command burst drops new commands (`try_send`) rather than
     // growing the inbox without bound.
-    let (tx, rx) = mpsc::channel(512);
+    let (interactive_tx, interactive_rx) = mpsc::channel(API_INTERACTIVE_QUEUE);
+    let (bulk_tx, bulk_rx) = mpsc::channel(API_BULK_QUEUE);
     tokio::spawn(async move {
         let (api, mode) = init_api(cookie).await;
         emit(ApiEvent::ModeResolved { mode, had_cookie });
-        run_actor(api, rx, emit).await;
+        let api = Arc::new(api);
+        let emit = Arc::new(emit);
+        tokio::spawn(run_interactive_actor(
+            Arc::clone(&api),
+            interactive_rx,
+            Arc::clone(&emit),
+        ));
+        run_bulk_actor(api, bulk_rx, emit).await;
     });
-    ApiHandle { tx }
+    ApiHandle {
+        interactive_tx,
+        bulk_tx,
+    }
 }
 
 /// Run one GUI search: per-catalog groups. A concrete `source` yields one group; `All`
@@ -1063,14 +1100,13 @@ async fn init_api(cookie: Option<String>) -> (ytmusic::YtMusicApi, ApiMode) {
     (api, mode)
 }
 
-async fn run_actor<F>(api: ytmusic::YtMusicApi, mut rx: Receiver<ApiCmd>, emit: F)
-where
+async fn run_interactive_actor<F>(
+    api: Arc<ytmusic::YtMusicApi>,
+    mut rx: Receiver<ApiCmd>,
+    emit: Arc<F>,
+) where
     F: Fn(ApiEvent) + Send + Sync + 'static,
 {
-    let mut streaming_ytdlp_cache: HashMap<
-        (String, StreamingMode, SearchSource),
-        (Instant, Vec<Song>),
-    > = HashMap::new();
     while let Some(cmd) = rx.recv().await {
         match cmd {
             ApiCmd::Search {
@@ -1193,6 +1229,28 @@ where
                 };
                 emit(event);
             }
+            ApiCmd::PlaylistTracks { .. }
+            | ApiCmd::Streaming { .. }
+            | ApiCmd::StreamingPreflight { .. } => {
+                tracing::warn!(
+                    kind = ?cmd.kind(),
+                    "bulk API command arrived on interactive lane"
+                );
+            }
+        }
+    }
+}
+
+async fn run_bulk_actor<F>(api: Arc<ytmusic::YtMusicApi>, mut rx: Receiver<ApiCmd>, emit: Arc<F>)
+where
+    F: Fn(ApiEvent) + Send + Sync + 'static,
+{
+    let mut streaming_ytdlp_cache: HashMap<
+        (String, StreamingMode, SearchSource),
+        (Instant, Vec<Song>),
+    > = HashMap::new();
+    while let Some(cmd) = rx.recv().await {
+        match cmd {
             ApiCmd::PlaylistTracks {
                 playlist_id,
                 title,
@@ -1378,6 +1436,15 @@ where
                     seed_video_id,
                     songs,
                 });
+            }
+            ApiCmd::Search { .. }
+            | ApiCmd::GuiSearch { .. }
+            | ApiCmd::ResolveTrack { .. }
+            | ApiCmd::SearchPlaylists { .. } => {
+                tracing::warn!(
+                    kind = ?cmd.kind(),
+                    "interactive API command arrived on bulk lane"
+                );
             }
         }
     }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -285,10 +285,25 @@ fn youtube_playlist_rows_keep_playlist_identity_out_of_track_playback() {
     assert!(playable_channel.prefetch_target().is_none());
 }
 
+fn test_api_handle(
+    interactive_cap: usize,
+    bulk_cap: usize,
+) -> (ApiHandle, Receiver<ApiCmd>, Receiver<ApiCmd>) {
+    let (interactive_tx, interactive_rx) = mpsc::channel(interactive_cap);
+    let (bulk_tx, bulk_rx) = mpsc::channel(bulk_cap);
+    (
+        ApiHandle {
+            interactive_tx,
+            bulk_tx,
+        },
+        interactive_rx,
+        bulk_rx,
+    )
+}
+
 #[test]
 fn api_handle_reports_full_queue() {
-    let (tx, _rx) = mpsc::channel(1);
-    let handle = ApiHandle { tx };
+    let (handle, _interactive_rx, _bulk_rx) = test_api_handle(1, 1);
 
     handle
         .search(1, "first", SearchSource::Youtube, SearchConfig::default())
@@ -307,9 +322,8 @@ fn api_handle_reports_full_queue() {
 
 #[test]
 fn api_handle_reports_closed_queue() {
-    let (tx, rx) = mpsc::channel(1);
-    drop(rx);
-    let handle = ApiHandle { tx };
+    let (handle, interactive_rx, _bulk_rx) = test_api_handle(1, 1);
+    drop(interactive_rx);
 
     let err = handle
         .search(1, "lost", SearchSource::Youtube, SearchConfig::default())
@@ -325,8 +339,7 @@ fn api_handle_reports_closed_queue() {
 
 #[test]
 fn api_handle_enqueues_all_command_kinds_with_payloads() {
-    let (tx, mut rx) = mpsc::channel(8);
-    let handle = ApiHandle { tx };
+    let (handle, mut interactive_rx, mut bulk_rx) = test_api_handle(8, 8);
 
     handle
         .gui_search(7, "gui", SearchSource::All, SearchConfig::default())
@@ -359,7 +372,7 @@ fn api_handle_enqueues_all_command_kinds_with_payloads() {
         .unwrap();
 
     assert!(matches!(
-        rx.try_recv().unwrap(),
+        interactive_rx.try_recv().unwrap(),
         ApiCmd::GuiSearch {
             ticket: 7,
             source: SearchSource::All,
@@ -367,7 +380,15 @@ fn api_handle_enqueues_all_command_kinds_with_payloads() {
         }
     ));
     assert!(matches!(
-        rx.try_recv().unwrap(),
+        interactive_rx.try_recv().unwrap(),
+        ApiCmd::ResolveTrack { seq: 9, .. }
+    ));
+    assert!(matches!(
+        interactive_rx.try_recv().unwrap(),
+        ApiCmd::SearchPlaylists { request_id: 10, .. }
+    ));
+    assert!(matches!(
+        bulk_rx.try_recv().unwrap(),
         ApiCmd::Streaming {
             limit: 12,
             mode: StreamingMode::Discovery,
@@ -375,27 +396,30 @@ fn api_handle_enqueues_all_command_kinds_with_payloads() {
         }
     ));
     assert!(matches!(
-        rx.try_recv().unwrap(),
+        bulk_rx.try_recv().unwrap(),
         ApiCmd::StreamingPreflight {
             mode: StreamingMode::Focused,
             ..
         }
     ));
     assert!(matches!(
-        rx.try_recv().unwrap(),
-        ApiCmd::ResolveTrack { seq: 9, .. }
-    ));
-    assert!(matches!(
-        rx.try_recv().unwrap(),
-        ApiCmd::SearchPlaylists { request_id: 10, .. }
-    ));
-    assert!(matches!(
-        rx.try_recv().unwrap(),
+        bulk_rx.try_recv().unwrap(),
         ApiCmd::PlaylistTracks {
             intent: PlaylistIntent::Import,
             ..
         }
     ));
+}
+
+#[test]
+fn api_command_kinds_route_to_expected_lanes() {
+    assert_eq!(ApiCommandKind::Search.lane(), ApiLane::Interactive);
+    assert_eq!(ApiCommandKind::GuiSearch.lane(), ApiLane::Interactive);
+    assert_eq!(ApiCommandKind::ResolveTrack.lane(), ApiLane::Interactive);
+    assert_eq!(ApiCommandKind::SearchPlaylists.lane(), ApiLane::Interactive);
+    assert_eq!(ApiCommandKind::Streaming.lane(), ApiLane::Bulk);
+    assert_eq!(ApiCommandKind::StreamingPreflight.lane(), ApiLane::Bulk);
+    assert_eq!(ApiCommandKind::PlaylistTracks.lane(), ApiLane::Bulk);
 }
 
 #[test]

--- a/src/app/ai_reducer.rs
+++ b/src/app/ai_reducer.rs
@@ -220,11 +220,12 @@ impl App {
             .suggestions_selected
             .min(self.ai.suggestions.len() - 1);
         let requested_songs = self.ai.suggestions.clone();
-        self.queue.set(requested_songs.clone(), start);
+        let romanize_cmds = self.request_romanization_for_songs(&requested_songs);
+        self.queue.set(requested_songs, start);
         self.status.text.clear();
         let song = self.queue.current().cloned();
         let mut cmds = self.load_song(song);
-        cmds.extend(self.request_romanization_for_songs(&requested_songs));
+        cmds.extend(romanize_cmds);
         cmds
     }
 

--- a/src/app/library_reducer.rs
+++ b/src/app/library_reducer.rs
@@ -345,13 +345,13 @@ impl App {
         if songs.is_empty() {
             return Vec::new();
         }
-        let requested_songs = songs.clone();
+        let romanize_cmds = self.request_romanization_for_songs(&songs);
         self.queue.set(songs, self.library_ui.selected);
         self.mode = Mode::Player;
         self.status.text.clear();
         let song = self.queue.current().cloned();
         let mut cmds = self.load_song(song);
-        cmds.extend(self.request_romanization_for_songs(&requested_songs));
+        cmds.extend(romanize_cmds);
         cmds
     }
 

--- a/src/app/local.rs
+++ b/src/app/local.rs
@@ -325,7 +325,7 @@ impl App {
         if songs.is_empty() {
             return Vec::new();
         }
-        let requested_songs = songs.clone();
+        let romanize_cmds = self.request_romanization_for_songs(&songs);
         let shuffle_changed = !self.queue.shuffle;
         self.queue.set(songs, start);
         self.queue.set_shuffle(true);
@@ -333,7 +333,7 @@ impl App {
         self.status.text.clear();
         let song = self.queue.current().cloned();
         let mut cmds = self.load_song(song);
-        cmds.extend(self.request_romanization_for_songs(&requested_songs));
+        cmds.extend(romanize_cmds);
         if shuffle_changed {
             cmds.push(self.save_playback_modes_cmd());
         }

--- a/src/app/media_reducer.rs
+++ b/src/app/media_reducer.rs
@@ -9,6 +9,7 @@
 //! Outbound: [`App::media_snapshot`] is the single translation from app state to the
 //! platform-independent [`MediaSnapshot`] the adapters publish to the OS.
 
+use std::hash::{Hash, Hasher};
 use std::time::Instant;
 
 use super::*;
@@ -18,6 +19,70 @@ use crate::media::{
 use crate::streaming::candidate::parse_duration_secs;
 
 impl App {
+    pub fn media_scrobble_heartbeat_active(&self) -> bool {
+        self.queue.current().is_some() && !self.playback.paused
+    }
+
+    pub fn media_fingerprint(&self) -> u64 {
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        let current = self.queue.current();
+        current.map(|song| song.video_id.as_str()).hash(&mut h);
+        self.playback.paused.hash(&mut h);
+        self.playback.speed.to_bits().hash(&mut h);
+        self.playback.volume.hash(&mut h);
+        self.playback.position_epoch.hash(&mut h);
+        self.queue.shuffle.hash(&mut h);
+        match self.queue.repeat {
+            crate::queue::Repeat::Off => 0u8,
+            crate::queue::Repeat::All => 1,
+            crate::queue::Repeat::One => 2,
+        }
+        .hash(&mut h);
+        self.queue.len().hash(&mut h);
+        self.queue.position().hash(&mut h);
+        self.queue
+            .peek_next()
+            .map(|song| song.video_id.as_str())
+            .hash(&mut h);
+        self.media_can_seek().hash(&mut h);
+        self.playback.duration.map(f64::to_bits).hash(&mut h);
+
+        if let Some(song) = current {
+            let is_live = song.is_radio_station();
+            is_live.hash(&mut h);
+            self.display_title(song).as_ref().hash(&mut h);
+            self.display_artist(song).as_ref().hash(&mut h);
+            if is_live {
+                if let Some(now) = &self.playback.stream_now_playing {
+                    now.title.as_deref().hash(&mut h);
+                    now.artist.as_deref().hash(&mut h);
+                    now.raw.hash(&mut h);
+                }
+            } else {
+                song.album.as_deref().hash(&mut h);
+                song.duration.hash(&mut h);
+            }
+            song.youtube_id().hash(&mut h);
+            song.local_path.hash(&mut h);
+            if song.local_path.is_some() && song.youtube_id().is_none() {
+                self.library.rev.hash(&mut h);
+                self.library_ui.downloaded_rev.hash(&mut h);
+                self.library.favorites.len().hash(&mut h);
+                self.library.history.len().hash(&mut h);
+                self.library_ui.downloaded.len().hash(&mut h);
+            }
+            self.library.is_favorite(&song.video_id).hash(&mut h);
+            self.signals.is_disliked(&song.video_id).hash(&mut h);
+            self.media_art
+                .as_ref()
+                .filter(|art| art.key == song.video_id)
+                .map(|art| (&art.key, &art.path))
+                .hash(&mut h);
+        }
+
+        h.finish()
+    }
+
     /// Apply one OS media-session command, returning effects for the run loop.
     pub(in crate::app) fn apply_media(&mut self, cmd: MediaCommand) -> Vec<Cmd> {
         tracing::debug!(?cmd, "media command");
@@ -409,6 +474,34 @@ mod tests {
         app.playback.duration = Some(180.0);
         app.playback.time_pos = Some(10.0);
         app.playback.paused = false;
+    }
+
+    #[test]
+    fn media_fingerprint_ignores_non_media_selection_state() {
+        let mut app = app_with_queue(2);
+        mark_loaded(&mut app);
+        let before = app.media_fingerprint();
+
+        app.library_ui.selected = 1;
+        app.search.selected = 1;
+        app.queue_popup.cursor = 1;
+        app.queue_popup.anchor = 1;
+
+        assert_eq!(app.media_fingerprint(), before);
+    }
+
+    #[test]
+    fn media_fingerprint_tracks_position_epochs_not_time_pos_ticks() {
+        let mut app = app_with_queue(1);
+        mark_loaded(&mut app);
+        let before = app.media_fingerprint();
+
+        app.playback.time_pos = Some(11.0);
+        app.playback.time_pos_at = Some(Instant::now());
+        assert_eq!(app.media_fingerprint(), before);
+
+        app.bump_position_epoch(PositionEpochReason::Seek);
+        assert_ne!(app.media_fingerprint(), before);
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -64,6 +64,7 @@ pub use mouse::HitMap;
 mod now_playing;
 mod now_playing_reducer;
 mod player;
+mod prefetch;
 pub use player::PlayerMsg;
 mod playlists_reducer;
 mod queue;
@@ -122,8 +123,6 @@ const DEFAULT_PAGE_ROWS: usize = 10;
 /// Volume step / ceiling, single-sourced with the headless daemon in
 /// [`crate::playback_policy`] so the bound can't drift between the two owners.
 pub(crate) use crate::playback_policy::{VOLUME_MAX, VOLUME_STEP};
-/// Cap on cached prefetched stream URLs (bounded memory; we only look a step ahead).
-const RESOLVED_MAX: usize = 999;
 /// Cap on local download-folder rows held in memory.
 const DOWNLOADED_TRACKS_MAX: usize = 999;
 /// Playback-speed change per `>`/`<` press.
@@ -1288,7 +1287,9 @@ impl App {
                 self.library_ui.downloaded_rev = self.library_ui.downloaded_rev.wrapping_add(1);
                 let truncated = scan.truncated;
                 let limit = scan.limit;
-                self.library_ui.downloaded = self.enrich_downloads(scan.songs);
+                let downloaded = self.enrich_downloads(scan.songs);
+                let romanize_cmds = self.request_romanization_for_songs(&downloaded);
+                self.library_ui.downloaded = downloaded;
                 let len = self.library_len();
                 if self.library_ui.selected >= len {
                     self.library_ui.selected = len.saturating_sub(1);
@@ -1304,8 +1305,7 @@ impl App {
                     );
                 }
                 self.dirty = true;
-                let downloaded = self.library_ui.downloaded.clone();
-                return self.request_romanization_for_songs(&downloaded);
+                return romanize_cmds;
             }
             Msg::Local(msg) => return self.apply_local_msg(msg),
             Msg::LyricsResult { video_id, lines } => {
@@ -1406,9 +1406,6 @@ impl App {
                     stream_url,
                 } => {
                     // Bounded prefetch cache; no redraw (purely a skip-latency optimization).
-                    if self.prefetch.resolved.len() >= RESOLVED_MAX {
-                        self.prefetch.resolved.clear();
-                    }
                     self.prefetch.resolved.insert(video_id.clone(), stream_url);
                     // A pending self-heal retry: the freshly-updated yt-dlp resolved the
                     // failed track — reload it now through the direct CDN URL just cached
@@ -1489,12 +1486,12 @@ impl App {
                 }
                 AiMsg::PlayTracks(songs) => {
                     if !songs.is_empty() {
-                        let requested_songs = songs.clone();
+                        let romanize_cmds = self.request_romanization_for_songs(&songs);
                         self.queue.set(songs, 0);
                         self.status.text.clear();
                         let song = self.queue.current().cloned();
                         let mut cmds = self.load_song(song);
-                        cmds.extend(self.request_romanization_for_songs(&requested_songs));
+                        cmds.extend(romanize_cmds);
                         return cmds;
                     }
                 }
@@ -1502,12 +1499,12 @@ impl App {
                     return self.extend_queue_from_streaming(songs);
                 }
                 AiMsg::Suggestions(songs) => {
+                    let cmds = self.request_romanization_for_songs(&songs);
                     self.ai.suggestions = songs;
                     self.ai.suggestions_selected = 0;
                     self.bridges.ai_scroll.reset();
                     self.dirty = true;
-                    let suggestions = self.ai.suggestions.clone();
-                    return self.request_romanization_for_songs(&suggestions);
+                    return cmds;
                 }
                 AiMsg::SetAutoplay(on) => {
                     // Music-mode invariant: DJ Gem can't enable autoplay while repeat is on.
@@ -1567,12 +1564,12 @@ impl App {
                     if let Some(songs) = self.playlists.find(&key).map(|p| p.songs.clone())
                         && !songs.is_empty()
                     {
-                        let requested_songs = songs.clone();
+                        let romanize_cmds = self.request_romanization_for_songs(&songs);
                         self.queue.set(songs, 0);
                         self.status.text.clear();
                         let song = self.queue.current().cloned();
                         let mut cmds = self.load_song(song);
-                        cmds.extend(self.request_romanization_for_songs(&requested_songs));
+                        cmds.extend(romanize_cmds);
                         return cmds;
                     }
                 }

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -1235,7 +1235,7 @@ impl App {
                 self.clear_artwork();
                 // Use a prefetched direct URL if we have one (instant skip); else hand mpv
                 // the track's own playback target (watch URL or local file path).
-                let prefetched_url = self.prefetch.resolved.get(&song.video_id).cloned();
+                let prefetched_url = self.prefetch.resolved.get_fresh_url(&song.video_id);
                 let (url, prefetched) = match prefetched_url {
                     Some(prefetched) => {
                         match crate::api::validate_playable_url(song.source, &prefetched) {
@@ -1289,7 +1289,7 @@ impl App {
                     && let Some(watch_url) = next.prefetch_target()
                 {
                     let video_id = next.video_id.clone();
-                    if !self.prefetch.resolved.contains_key(&video_id) {
+                    if !self.prefetch.resolved.contains_fresh(&video_id) {
                         cmds.push(Cmd::Resolve {
                             video_id,
                             watch_url,

--- a/src/app/playlists_reducer.rs
+++ b/src/app/playlists_reducer.rs
@@ -86,13 +86,13 @@ impl App {
             self.dirty = true;
             return Vec::new();
         }
-        let requested_songs = songs.clone();
+        let romanize_cmds = self.request_romanization_for_songs(&songs);
         self.queue.set(songs, 0);
         self.mode = Mode::Player;
         self.status.text.clear();
         let song = self.queue.current().cloned();
         let mut cmds = self.load_song(song);
-        cmds.extend(self.request_romanization_for_songs(&requested_songs));
+        cmds.extend(romanize_cmds);
         cmds
     }
 

--- a/src/app/prefetch.rs
+++ b/src/app/prefetch.rs
@@ -1,0 +1,101 @@
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+/// Resolved stream URLs are yt-dlp CDN URLs: useful for immediate skips, but not durable.
+pub(in crate::app) const PREFETCH_TTL: Duration = Duration::from_secs(60 * 60);
+const PREFETCH_MAX: usize = 64;
+
+pub(in crate::app) struct ResolvedStream {
+    url: String,
+    inserted_at: Instant,
+}
+
+#[derive(Default)]
+pub struct PrefetchCache {
+    entries: HashMap<String, ResolvedStream>,
+    /// Most-recently-used last.
+    order: VecDeque<String>,
+}
+
+impl PrefetchCache {
+    pub(in crate::app) fn insert(&mut self, video_id: String, url: String) {
+        self.insert_at(video_id, url, Instant::now());
+    }
+
+    pub(in crate::app) fn get_fresh_url(&mut self, video_id: &str) -> Option<String> {
+        if !self.is_fresh(video_id) {
+            self.remove(video_id);
+            return None;
+        }
+        self.touch(video_id);
+        self.entries.get(video_id).map(|entry| entry.url.clone())
+    }
+
+    pub(in crate::app) fn contains_fresh(&mut self, video_id: &str) -> bool {
+        if !self.is_fresh(video_id) {
+            self.remove(video_id);
+            return false;
+        }
+        self.touch(video_id);
+        true
+    }
+
+    pub(in crate::app) fn remove(&mut self, video_id: &str) {
+        self.entries.remove(video_id);
+        self.order.retain(|existing| existing != video_id);
+    }
+
+    #[cfg(test)]
+    pub(in crate::app) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[cfg(test)]
+    pub(in crate::app) fn insert_at(
+        &mut self,
+        video_id: String,
+        url: String,
+        inserted_at: Instant,
+    ) {
+        self.insert_inner(video_id, url, inserted_at);
+    }
+
+    #[cfg(not(test))]
+    fn insert_at(&mut self, video_id: String, url: String, inserted_at: Instant) {
+        self.insert_inner(video_id, url, inserted_at);
+    }
+
+    fn insert_inner(&mut self, video_id: String, url: String, inserted_at: Instant) {
+        self.prune_expired();
+        self.order.retain(|existing| existing != &video_id);
+        self.entries
+            .insert(video_id.clone(), ResolvedStream { url, inserted_at });
+        self.order.push_back(video_id);
+        while self.entries.len() > PREFETCH_MAX {
+            if let Some(oldest) = self.order.pop_front() {
+                self.entries.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn is_fresh(&self, video_id: &str) -> bool {
+        self.entries
+            .get(video_id)
+            .is_some_and(|entry| entry.inserted_at.elapsed() < PREFETCH_TTL)
+    }
+
+    fn touch(&mut self, video_id: &str) {
+        self.order.retain(|existing| existing != video_id);
+        self.order.push_back(video_id.to_owned());
+    }
+
+    fn prune_expired(&mut self) {
+        let now = Instant::now();
+        self.entries
+            .retain(|_, entry| now.duration_since(entry.inserted_at) < PREFETCH_TTL);
+        self.order
+            .retain(|video_id| self.entries.contains_key(video_id));
+    }
+}

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -547,17 +547,18 @@ impl App {
         match intent {
             PlaylistIntent::Play => {
                 // Mirror `AiMsg::PlayTracks`: replace the queue and start at the top.
-                let requested = songs.clone();
+                let requested_len = songs.len();
+                let romanize_cmds = self.request_romanization_for_songs(&songs);
                 self.queue.set(songs, 0);
                 let song = self.queue.current().cloned();
                 let mut cmds = self.load_song(song);
-                cmds.extend(self.request_romanization_for_songs(&requested));
+                cmds.extend(romanize_cmds);
                 // After load_song, which clears the transient status.
                 self.status.kind = StatusKind::Info;
                 self.status.text = if crate::i18n::is_korean() {
-                    format!("플레이리스트 재생: {title} ({}곡)", requested.len())
+                    format!("플레이리스트 재생: {title} ({requested_len}곡)")
                 } else {
-                    format!("Playing playlist: {title} ({} tracks)", requested.len())
+                    format!("Playing playlist: {title} ({requested_len} tracks)")
                 };
                 cmds
             }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -70,6 +70,7 @@ pub struct RenderBridges {
     pub marquee_key: Cell<Option<(ScrollSurface, usize)>>,
     pub marquee_origin: Cell<u64>,
     pub marquee_ran: Cell<bool>,
+    pub marquee_cache: RefCell<crate::ui::marquee::MarqueeCache>,
 }
 
 impl RenderBridges {
@@ -268,7 +269,7 @@ pub struct Playback {
 #[derive(Default)]
 pub struct Prefetch {
     /// Pre-resolved direct stream URLs, keyed by `video_id` (for instant skip).
-    pub resolved: HashMap<String, String>,
+    pub resolved: super::prefetch::PrefetchCache,
     /// Whether the current track was loaded from a prefetched direct URL (vs the watch
     /// URL mpv resolves itself). Recorded so a playback error can note the likelier cause
     /// (a stale prefetched CDN URL) in the log.

--- a/src/app/streaming_reducer.rs
+++ b/src/app/streaming_reducer.rs
@@ -572,7 +572,7 @@ impl App {
             && let Some(watch_url) = next.prefetch_target()
         {
             let video_id = next.video_id.clone();
-            if !self.prefetch.resolved.contains_key(&video_id) {
+            if !self.prefetch.resolved.contains_fresh(&video_id) {
                 cmds.push(Cmd::Resolve {
                     video_id,
                     watch_url,

--- a/src/app/tests/lyrics_art_download.rs
+++ b/src/app/tests/lyrics_art_download.rs
@@ -224,6 +224,38 @@ fn skip_uses_prefetched_url_when_available() {
 }
 
 #[test]
+fn skip_drops_stale_prefetched_url_and_falls_back() {
+    let mut app = app_playing(3, 0);
+    app.prefetch.resolved.insert_at(
+        "id1".to_owned(),
+        "https://cdn.example/stale-id1".to_owned(),
+        std::time::Instant::now()
+            - crate::app::prefetch::PREFETCH_TTL
+            - std::time::Duration::from_millis(1),
+    );
+
+    let cmds = app.update(Msg::Key(key(KeyCode::Char('.'))));
+
+    assert_loads_video(&cmds, "id1");
+    assert!(!app.prefetch.resolved.contains_fresh("id1"));
+}
+
+#[test]
+fn prefetch_cache_lru_caps_without_clearing_everything() {
+    let mut app = App::new(100);
+    for i in 0..65 {
+        app.update(StreamingMsg::Resolved {
+            video_id: format!("id{i}"),
+            stream_url: format!("https://cdn.example/stream-id{i}"),
+        });
+    }
+
+    assert_eq!(app.prefetch.resolved.len(), 64);
+    assert!(!app.prefetch.resolved.contains_fresh("id0"));
+    assert!(app.prefetch.resolved.contains_fresh("id64"));
+}
+
+#[test]
 fn skip_without_prefetch_falls_back_to_watch_url() {
     let mut app = app_playing(3, 0);
     let cmds = app.update(Msg::Key(key(KeyCode::Char('.')))); // no Resolved arrived

--- a/src/artwork.rs
+++ b/src/artwork.rs
@@ -117,7 +117,7 @@ async fn fetch_remote(client: &reqwest::Client, video_id: &str) -> Option<Vec<u8
 
 /// Read embedded cover art from a local audio file (off-thread; lofty parses tags).
 async fn fetch_local(path: PathBuf) -> Option<Vec<u8>> {
-    tokio::task::spawn_blocking(move || local_cover_bytes(&path))
+    crate::util::blocking::spawn_io(move || local_cover_bytes(&path))
         .await
         .ok()
         .flatten()
@@ -130,7 +130,7 @@ fn local_cover_bytes(path: &std::path::Path) -> Option<Vec<u8>> {
 
 /// Decode the raw bytes and downscale to [`MAX_DIM`] (off-thread — decode/resize is CPU).
 async fn decode_scaled(bytes: Vec<u8>) -> Option<DynamicImage> {
-    tokio::task::spawn_blocking(move || {
+    crate::util::blocking::spawn_cpu(move || {
         // Decode-bomb-guarded decode (shared): a hostile/corrupt image can't spike RAM.
         let img = crate::util::art::decode_untrusted(&bytes)?;
         Some(if img.width() > MAX_DIM || img.height() > MAX_DIM {

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,8 @@ use crate::streaming::StreamingConfig;
 use crate::t;
 use crate::theme::ThemeConfig;
 
+mod recovery;
+
 /// Clamp range for playback speed (matches the `>`/`<` controls and the settings slider).
 pub const SPEED_MIN: f64 = 0.5;
 pub const SPEED_MAX: f64 = 2.0;
@@ -804,41 +806,7 @@ impl Config {
     /// present-but-unloadable file is set aside *before* the defaults `save()` below can
     /// overwrite it — matching `safe_fs::load_json_or_default_limited`'s backup-aside policy.
     fn load_from(path: &std::path::Path) -> Self {
-        match safe_fs::read_no_symlink_limited(path, MAX_CONFIG_BYTES) {
-            Ok(bytes) => match String::from_utf8(bytes) {
-                Ok(text) => {
-                    // Fast path: schema unchanged since this file was written.
-                    if let Ok(cfg) = serde_json::from_str::<Config>(&text) {
-                        return cfg;
-                    }
-                    // Schema drifted (a renamed enum, retyped field, …): keep every field
-                    // that still fits instead of resetting the whole config to defaults.
-                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
-                        return safe_fs::recover_lenient::<Config>(value);
-                    }
-                    // Present but not JSON at all: preserve it rather than clobbering.
-                    let _ = safe_fs::backup_aside_secret(path);
-                }
-                // Present but not valid UTF-8: preserve rather than clobber.
-                Err(_) => {
-                    let _ = safe_fs::backup_aside_secret(path);
-                }
-            },
-            // Oversize (`read_no_symlink_limited` reports it as `InvalidData`): preserve.
-            Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
-                let _ = safe_fs::backup_too_large_secret(path);
-            }
-            // Missing / permission / symlink: nothing safe to preserve. (First run is a
-            // missing file; a symlink is left intact because `save()` refuses to follow it.)
-            Err(_) => {}
-        }
-        // First run (or unreadable/corrupt, now backed up): migrate from the old app, persist.
-        let mut cfg = Config::default();
-        if let Some(old) = old_config_path() {
-            import_old_from(&old, &mut cfg);
-        }
-        let _ = cfg.save_to(path);
-        cfg
+        recovery::load_from_path(path)
     }
 
     /// Persist atomically (write a temp file, then rename over the target).

--- a/src/config/recovery.rs
+++ b/src/config/recovery.rs
@@ -1,0 +1,56 @@
+use super::*;
+
+pub(super) fn load_from_path(path: &std::path::Path) -> Config {
+    let can_persist_default = match safe_fs::read_no_symlink_limited(path, MAX_CONFIG_BYTES) {
+        Ok(bytes) => match String::from_utf8(bytes) {
+            Ok(text) => {
+                // Fast path: schema unchanged since this file was written.
+                if let Ok(cfg) = serde_json::from_str::<Config>(&text) {
+                    return crate::persist::replay_journaled_snapshot(
+                        crate::persist::StoreKind::Config,
+                        path,
+                        cfg,
+                        MAX_CONFIG_BYTES,
+                    );
+                }
+                // Schema drifted: keep every field that still fits instead of resetting.
+                if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
+                    let cfg = safe_fs::recover_lenient::<Config>(value);
+                    return crate::persist::replay_journaled_snapshot(
+                        crate::persist::StoreKind::Config,
+                        path,
+                        cfg,
+                        MAX_CONFIG_BYTES,
+                    );
+                }
+                safe_fs::backup_aside_secret(path).is_ok()
+            }
+            Err(_) => safe_fs::backup_aside_secret(path).is_ok(),
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+            safe_fs::backup_too_large_secret(path).is_ok()
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(_) => safe_fs::backup_unreadable_secret(path).is_ok(),
+    };
+
+    let mut cfg = Config::default();
+    if let Some(old) = old_config_path() {
+        import_old_from(&old, &mut cfg);
+    }
+    cfg = crate::persist::replay_journaled_snapshot(
+        crate::persist::StoreKind::Config,
+        path,
+        cfg,
+        MAX_CONFIG_BYTES,
+    );
+    if can_persist_default {
+        let _ = cfg.save_to(path);
+    } else {
+        tracing::error!(
+            path = %path.display(),
+            "refusing to overwrite unreadable/corrupt config because recovery backup failed"
+        );
+    }
+    cfg
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -20,6 +20,7 @@ use crate::util::event_policy::{
 use crate::util::process::{self, ProcessProfile};
 
 mod engine;
+mod must_deliver;
 #[cfg(test)]
 mod parity_tests;
 
@@ -321,6 +322,7 @@ enum DaemonTelemetrySlot {
 struct DaemonEventSender {
     tx: mpsc::Sender<DaemonEvent>,
     telemetry: Arc<Mutex<LatestEventBuffer<DaemonTelemetrySlot, DaemonEvent>>>,
+    must_deliver_overflow: Arc<must_deliver::DaemonMustDeliverOverflow>,
 }
 
 impl DaemonEventSender {
@@ -328,6 +330,7 @@ impl DaemonEventSender {
         Self {
             tx,
             telemetry: Arc::new(Mutex::new(LatestEventBuffer::new(DAEMON_TELEMETRY_SLOTS))),
+            must_deliver_overflow: Arc::new(must_deliver::DaemonMustDeliverOverflow::new()),
         }
     }
 
@@ -345,16 +348,16 @@ fn emit_daemon_event(tx: &DaemonEventSender, event: DaemonEvent) -> bool {
     if matches!(policy, EventPolicy::CoalesceLatest { .. }) {
         return emit_daemon_coalesced(tx, event, event_kind, policy);
     }
-    emit_daemon_direct(&tx.tx, event, event_kind, policy)
+    emit_daemon_direct(tx, event, event_kind, policy)
 }
 
 fn emit_daemon_direct(
-    tx: &mpsc::Sender<DaemonEvent>,
+    tx: &DaemonEventSender,
     event: DaemonEvent,
     event_kind: &'static str,
     policy: EventPolicy,
 ) -> bool {
-    match tx.try_send(event) {
+    match tx.tx.try_send(event) {
         Ok(()) => true,
         Err(mpsc::error::TrySendError::Full(event))
             if matches!(policy, EventPolicy::MustDeliver { .. }) =>
@@ -367,7 +370,8 @@ fn emit_daemon_direct(
                 drop_reason = "must_deliver_delayed",
                 "daemon owner event queue full; deferring must-deliver event"
             );
-            defer_daemon_must_deliver(tx.clone(), event, event_kind, policy);
+            tx.must_deliver_overflow
+                .push(tx.tx.clone(), event, event_kind, policy);
             true
         }
         Err(mpsc::error::TrySendError::Full(_)) => {
@@ -392,7 +396,7 @@ fn emit_daemon_coalesced(
     policy: EventPolicy,
 ) -> bool {
     let Some(slot) = event.telemetry_slot() else {
-        return emit_daemon_direct(&tx.tx, event, event_kind, policy);
+        return emit_daemon_direct(tx, event, event_kind, policy);
     };
     let insert = tx
         .telemetry
@@ -415,7 +419,7 @@ fn emit_daemon_coalesced(
     }
     if insert.should_wake {
         emit_daemon_direct(
-            &tx.tx,
+            tx,
             DaemonEvent::TelemetryWake,
             DaemonEvent::TelemetryWake.kind(),
             DaemonEvent::TelemetryWake.policy(),
@@ -432,39 +436,6 @@ fn daemon_full_queue_reason(policy: EventPolicy) -> &'static str {
         EventPolicy::DropIfStale { .. } => "stale_or_full",
         EventPolicy::CoalesceLatest { .. } => "coalesced_wake_full",
         EventPolicy::MustDeliver { .. } => "must_deliver_failed",
-    }
-}
-
-fn defer_daemon_must_deliver(
-    tx: mpsc::Sender<DaemonEvent>,
-    event: DaemonEvent,
-    event_kind: &'static str,
-    policy: EventPolicy,
-) {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        handle.spawn(async move {
-            if tx.send(event).await.is_err() {
-                tracing::error!(
-                    event_policy = policy.name(),
-                    event_lane = policy.lane().map(Lane::name).unwrap_or("none"),
-                    event_kind,
-                    drop_reason = "must_deliver_failed",
-                    "daemon owner event queue closed before must-deliver event was accepted"
-                );
-            }
-        });
-    } else {
-        std::thread::spawn(move || {
-            if tx.blocking_send(event).is_err() {
-                tracing::error!(
-                    event_policy = policy.name(),
-                    event_lane = policy.lane().map(Lane::name).unwrap_or("none"),
-                    event_kind,
-                    drop_reason = "must_deliver_failed",
-                    "daemon owner event queue closed before must-deliver event was accepted"
-                );
-            }
-        });
     }
 }
 
@@ -870,7 +841,12 @@ fn dispatch_engine_effects(
                 let tx = event_tx.clone();
                 tokio::spawn(async move {
                     crate::tools::ytdlp::clear_probe_cache();
-                    let outcome = crate::tools::ytdlp::check_and_update(&tools, &|_| {}).await;
+                    let outcome = crate::tools::ytdlp::rollback_or_check_and_update(
+                        &tools,
+                        &|_| {},
+                        "daemon playback self-heal",
+                    )
+                    .await;
                     let updated = matches!(
                         outcome,
                         crate::tools::ytdlp::UpdateOutcome::Installed { .. }

--- a/src/daemon/must_deliver.rs
+++ b/src/daemon/must_deliver.rs
@@ -1,0 +1,129 @@
+use std::collections::VecDeque;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+use tokio::sync::mpsc;
+
+use crate::util::event_policy::{EventLane as Lane, EventPolicy};
+
+use super::DaemonEvent;
+
+const DAEMON_MUST_DELIVER_OVERFLOW_MAX: usize = 1024;
+
+struct DeferredDaemonEvent {
+    event: DaemonEvent,
+    event_kind: &'static str,
+    policy: EventPolicy,
+}
+
+pub(super) struct DaemonMustDeliverOverflow {
+    queue: Mutex<VecDeque<DeferredDaemonEvent>>,
+    drainer_running: AtomicBool,
+}
+
+impl DaemonMustDeliverOverflow {
+    pub(super) fn new() -> Self {
+        Self {
+            queue: Mutex::new(VecDeque::new()),
+            drainer_running: AtomicBool::new(false),
+        }
+    }
+
+    pub(super) fn push(
+        self: &Arc<Self>,
+        tx: mpsc::Sender<DaemonEvent>,
+        event: DaemonEvent,
+        event_kind: &'static str,
+        policy: EventPolicy,
+    ) {
+        let item = DeferredDaemonEvent {
+            event,
+            event_kind,
+            policy,
+        };
+        let start_drainer = {
+            let mut queue = self.queue.lock().unwrap_or_else(|e| e.into_inner());
+            if queue.len() >= DAEMON_MUST_DELIVER_OVERFLOW_MAX {
+                drop(queue);
+                tracing::warn!(
+                    event_policy = policy.name(),
+                    event_lane = policy.lane().map(Lane::name).unwrap_or("none"),
+                    event_kind,
+                    drop_reason = "must_deliver_overflow_fallback",
+                    "daemon must-deliver overflow full; falling back to direct deferred send"
+                );
+                defer_must_deliver_direct(tx, item.event, item.event_kind, item.policy);
+                return;
+            }
+            queue.push_back(item);
+            !self.drainer_running.swap(true, Ordering::AcqRel)
+        };
+        if start_drainer {
+            spawn_drainer(Arc::clone(self), tx);
+        }
+    }
+
+    fn pop_or_stop(&self) -> Option<DeferredDaemonEvent> {
+        let mut queue = self.queue.lock().unwrap_or_else(|e| e.into_inner());
+        match queue.pop_front() {
+            Some(item) => Some(item),
+            None => {
+                self.drainer_running.store(false, Ordering::Release);
+                None
+            }
+        }
+    }
+}
+
+fn spawn_drainer(overflow: Arc<DaemonMustDeliverOverflow>, tx: mpsc::Sender<DaemonEvent>) {
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        handle.spawn(async move {
+            while let Some(item) = overflow.pop_or_stop() {
+                if tx.send(item.event).await.is_err() {
+                    log_closed(item.event_kind, item.policy);
+                }
+            }
+        });
+    } else {
+        std::thread::spawn(move || {
+            while let Some(item) = overflow.pop_or_stop() {
+                if tx.blocking_send(item.event).is_err() {
+                    log_closed(item.event_kind, item.policy);
+                }
+            }
+        });
+    }
+}
+
+fn defer_must_deliver_direct(
+    tx: mpsc::Sender<DaemonEvent>,
+    event: DaemonEvent,
+    event_kind: &'static str,
+    policy: EventPolicy,
+) {
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        handle.spawn(async move {
+            if tx.send(event).await.is_err() {
+                log_closed(event_kind, policy);
+            }
+        });
+    } else {
+        std::thread::spawn(move || {
+            if tx.blocking_send(event).is_err() {
+                log_closed(event_kind, policy);
+            }
+        });
+    }
+}
+
+fn log_closed(event_kind: &'static str, policy: EventPolicy) {
+    tracing::error!(
+        event_policy = policy.name(),
+        event_lane = policy.lane().map(Lane::name).unwrap_or("none"),
+        event_kind,
+        drop_reason = "must_deliver_failed",
+        "daemon owner event queue closed before must-deliver event was accepted"
+    );
+}

--- a/src/downloads.rs
+++ b/src/downloads.rs
@@ -138,6 +138,12 @@ impl DownloadStore {
         // Schema-drift tolerant: one changed field no longer discards download history.
         let mut store =
             safe_fs::load_json_or_default_limited::<DownloadStore>(&path, STORE_MAX_BYTES);
+        store = crate::persist::replay_journaled_snapshot(
+            crate::persist::StoreKind::Downloads,
+            &path,
+            store,
+            STORE_MAX_BYTES,
+        );
         store.tracks.truncate(STORE_MAX);
         store
     }
@@ -341,7 +347,7 @@ fn sidecar_temp_path(path: &Path) -> PathBuf {
     path.with_file_name(format!(".{name}.tmp.{}-{nanos}", std::process::id()))
 }
 
-fn store_path() -> Option<PathBuf> {
+pub(crate) fn store_path() -> Option<PathBuf> {
     crate::paths::data_dir().map(|d| d.join("downloads.json"))
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,10 +8,13 @@
 use std::time::{Duration, Instant};
 
 use crossterm::event::{
-    Event, KeyCode, KeyEventKind, KeyModifiers, ModifierKeyCode, MouseButton, MouseEventKind,
+    Event, EventStream, KeyCode, KeyEventKind, KeyModifiers, ModifierKeyCode, MouseButton,
+    MouseEventKind,
 };
+use futures::{FutureExt, StreamExt};
 
 use crate::app::Msg;
+use crate::zoom::ZoomHandle;
 
 /// Two left-presses within this window at the same cell count as a double-click.
 const DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(400);
@@ -24,6 +27,34 @@ pub struct Translator {
     /// Whether a left-button press has not yet been released. Some terminals report motion
     /// during a press as `Moved` rather than `Drag`, so keep enough state to preserve dragging.
     left_down: bool,
+}
+
+pub enum InputPoll {
+    Ready,
+    Empty,
+    Closed,
+}
+
+pub fn poll_terminal_input_now(
+    events: &mut EventStream,
+    input: &mut Translator,
+    zoom: &ZoomHandle,
+    out: &mut Option<Msg>,
+) -> InputPoll {
+    loop {
+        match events.next().now_or_never() {
+            Some(Some(Ok(ev))) => {
+                let (cs, rs) = zoom.mouse_scale();
+                if let Some(msg) = input.translate(ev, cs, rs) {
+                    *out = Some(msg);
+                    return InputPoll::Ready;
+                }
+            }
+            Some(Some(Err(_))) => continue,
+            Some(None) => return InputPoll::Closed,
+            None => return InputPoll::Empty,
+        }
+    }
 }
 
 impl Default for Translator {

--- a/src/library.rs
+++ b/src/library.rs
@@ -62,6 +62,12 @@ impl Library {
         // aside instead of being read wholesale into memory at startup.
         const MAX_BYTES: u64 = 50 * 1024 * 1024;
         let mut lib = safe_fs::load_json_or_default_limited::<Library>(&path, MAX_BYTES);
+        lib = crate::persist::replay_journaled_snapshot(
+            crate::persist::StoreKind::Library,
+            &path,
+            lib,
+            MAX_BYTES,
+        );
         lib.trim_to_caps();
         lib
     }
@@ -268,7 +274,7 @@ impl Library {
     }
 }
 
-fn library_path() -> Option<PathBuf> {
+pub(crate) fn library_path() -> Option<PathBuf> {
     crate::paths::data_dir().map(|d| d.join("library.json"))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -849,7 +849,7 @@ async fn run(
             while let Ok(newer) = art_resize_rx.try_recv() {
                 request = newer;
             }
-            match tokio::task::spawn_blocking(move || request.resize_encode()).await {
+            match yututui::util::blocking::spawn_cpu(move || request.resize_encode()).await {
                 Ok(Ok(response)) => {
                     runtime::emit(&art_resize_msg_tx, RuntimeEvent::ArtworkResized(response));
                 }
@@ -1049,8 +1049,16 @@ async fn run(
         // Mostly blocks until input or a worker message arrives. Outside text-entry fields,
         // a low-rate redraw scrubs IME preedit text that some terminals paint without
         // sending an input event to the app.
-        let msg = if let Some(msg) = pending_worker_msgs.pop_front() {
-            msg
+        let msg = if !pending_worker_msgs.is_empty() {
+            let mut polled_input = None;
+            match event::poll_terminal_input_now(&mut events, &mut input, &zoom, &mut polled_input)
+            {
+                event::InputPoll::Ready => polled_input.expect("ready input message"),
+                event::InputPoll::Empty => pending_worker_msgs
+                    .pop_front()
+                    .expect("pending worker message"),
+                event::InputPoll::Closed => break,
+            }
         } else {
             tokio::select! {
                 maybe = events.next() => match maybe {
@@ -1072,11 +1080,7 @@ async fn run(
                         for event in worker_tx.drain_coalesced() {
                             pending_worker_msgs.push_back(event.into());
                         }
-                        if let Some(msg) = pending_worker_msgs.pop_front() {
-                            msg
-                        } else {
-                            continue;
-                        }
+                        continue;
                     } else {
                         // Owner lane (docs/gui/02 §8/§14): session subscribe ops run here,
                         // between reducer turns, and never become a Msg — the Publisher emits
@@ -1124,6 +1128,7 @@ async fn run(
         // anything a media snapshot reads, so skip rebuilding it (snapshot construction
         // allocates ~10 Strings, and AnimTick fires at up to the configured FPS).
         let media_inert = matches!(&msg, Msg::AnimTick | Msg::StatusTick);
+        let media_before = (!media_inert).then(|| app.media_fingerprint());
         for cmd in app.update(msg) {
             // Desktop notifications are handled here (not in `RuntimeHandles`) because the OSC
             // path writes to the terminal's stdout, which this scope owns; do it between frames
@@ -1163,17 +1168,30 @@ async fn run(
         // it must keep working when media controls are disabled (publish early-returns).
         // Scrobble cadence is unaffected by the inert skip: elapsed time is credited from
         // the 1 Hz PlayerTimePos observations, which always take this path.
-        media.set_enabled(app.config.effective_media_controls());
-        if !media_inert {
+        let media_enabled = app.config.effective_media_controls();
+        let media_enabled_changed = media.set_enabled(media_enabled);
+        let media_observed_turn = media_before.is_some();
+        let media_changed = media_before.is_some_and(|before| before != app.media_fingerprint());
+        let scrobble_due = media_observed_turn
+            && app.media_scrobble_heartbeat_active()
+            && handles.scrobble_heartbeat_due();
+        let publish_due = media_changed || (media_enabled_changed && media_enabled);
+        if media_changed || scrobble_due || publish_due {
             let snapshot = app.media_snapshot();
-            handles.scrobble_observe(&snapshot);
-            media.publish(snapshot);
-            // v8 push: fingerprint-diffed, so this is a cheap compare when nothing
-            // session-visible changed. Shares the inert gate — AnimTick/StatusTick
-            // turns can't change anything the publisher watches (audited by tests).
-            if let Some(publisher) = publisher.as_mut() {
-                publisher.observe(&app.core_view());
+            if media_changed || scrobble_due {
+                handles.scrobble_observe(&snapshot);
             }
+            if publish_due {
+                media.publish(snapshot);
+            }
+        }
+        // v8 push: fingerprint-diffed internally. Avoid building the borrowed core view
+        // on idle standalone turns after the publisher has primed its baselines.
+        if !media_inert
+            && let Some(publisher) = publisher.as_mut()
+            && publisher.should_observe(media_changed || media_enabled_changed)
+        {
+            publisher.observe(&app.core_view());
         }
         perf.maybe_log(&app);
     }

--- a/src/media/artwork.rs
+++ b/src/media/artwork.rs
@@ -179,7 +179,7 @@ async fn fetch_remote(client: &reqwest::Client, video_id: &str) -> Option<Vec<u8
 /// Read embedded cover art from a local audio file (off-thread; lofty parses tags).
 async fn fetch_local(path: PathBuf) -> Option<Vec<u8>> {
     // Shared with the TUI art actor; caps the embedded-cover size before copy.
-    tokio::task::spawn_blocking(move || crate::util::art::local_cover_bytes(&path))
+    crate::util::blocking::spawn_io(move || crate::util::art::local_cover_bytes(&path))
         .await
         .ok()
         .flatten()
@@ -189,7 +189,7 @@ async fn fetch_local(path: PathBuf) -> Option<Vec<u8>> {
 /// (temp file + rename so a crash never leaves a truncated cache entry).
 async fn store_processed(bytes: Vec<u8>, path: &Path) -> bool {
     let path = path.to_path_buf();
-    tokio::task::spawn_blocking(move || {
+    crate::util::blocking::spawn_cpu(move || {
         // Decode-bomb-guarded decode (shared with the TUI art actor).
         let img = crate::util::art::decode_untrusted(&bytes)?;
         let side = img.width().min(img.height());

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -374,9 +374,9 @@ impl MediaSession {
 
     /// Live enable/disable (the Settings toggle). Disabling tears the OS session down
     /// (no ghost entry); re-enabling brings it back with the next published snapshot.
-    pub fn set_enabled(&mut self, enabled: bool) {
+    pub fn set_enabled(&mut self, enabled: bool) -> bool {
         if enabled == self.enabled {
-            return;
+            return false;
         }
         self.enabled = enabled;
         self.activated = false;
@@ -386,6 +386,7 @@ impl MediaSession {
         if !enabled {
             self.backend = None; // Drop tears down the platform session.
         }
+        true
     }
 
     /// Whether the run loop should drive [`Self::pump`] on a short interval.

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -17,9 +17,13 @@
 //!   data, not payment ledgers.
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Duration;
 
+use serde::de::DeserializeOwned;
+use sha2::{Digest, Sha256};
 use tokio::sync::{Notify, mpsc, oneshot};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -112,6 +116,36 @@ impl Snapshot {
         }
     }
 
+    fn storage_path(&self) -> Option<PathBuf> {
+        match self {
+            Snapshot::Library(_) => crate::library::library_path(),
+            Snapshot::Signals(_) => crate::signals::signals_path(),
+            Snapshot::Downloads(_) => crate::downloads::store_path(),
+            Snapshot::Config(_) => crate::config::config_path(),
+            Snapshot::Playlists(_) => crate::playlists::playlists_path(),
+            Snapshot::Station(_) => crate::station::station_path(),
+            Snapshot::RomanizedTitles(_) => crate::romanize::cache_path(),
+            Snapshot::Session(_) => crate::session::session_cache_path(),
+            #[cfg(test)]
+            Snapshot::Test { .. } => None,
+        }
+    }
+
+    fn to_json_bytes(&self) -> serde_json::Result<Vec<u8>> {
+        match self {
+            Snapshot::Library(s) => serde_json::to_vec_pretty(s),
+            Snapshot::Signals(s) => serde_json::to_vec_pretty(s),
+            Snapshot::Downloads(s) => serde_json::to_vec_pretty(s),
+            Snapshot::Config(s) => serde_json::to_vec_pretty(s),
+            Snapshot::Playlists(s) => serde_json::to_vec_pretty(s),
+            Snapshot::Station(s) => serde_json::to_vec_pretty(s),
+            Snapshot::RomanizedTitles(s) => serde_json::to_vec_pretty(s),
+            Snapshot::Session(s) => serde_json::to_vec_pretty(s),
+            #[cfg(test)]
+            Snapshot::Test { .. } => serde_json::to_vec(&serde_json::Value::Null),
+        }
+    }
+
     fn label(&self) -> &'static str {
         #[cfg(test)]
         if let Snapshot::Test { label, .. } = self {
@@ -139,6 +173,15 @@ fn debounce(kind: StoreKind) -> Duration {
 }
 
 type SharedPending = Arc<Mutex<HashMap<StoreKind, Snapshot>>>;
+
+const INTENT_JOURNAL_MAX_BYTES: u64 = 1024 * 1024;
+const INTENT_SNAPSHOT_MAX_BYTES: u64 = 64 * 1024 * 1024;
+
+struct JournalIntent {
+    kind: StoreKind,
+    path: PathBuf,
+    bytes: Vec<u8>,
+}
 
 enum PersistMsg {
     DeleteRomanizedTitles,
@@ -281,7 +324,8 @@ async fn run_actor(
                     lock(&pending).remove(&StoreKind::RomanizedTitles);
                     due.remove(&StoreKind::RomanizedTitles);
                     retries.remove(&StoreKind::RomanizedTitles);
-                    let result = tokio::task::spawn_blocking(
+                    clear_store_journal_for_kind(StoreKind::RomanizedTitles);
+                    let result = crate::util::blocking::spawn_io(
                         crate::romanize::RomanizeCache::delete_saved,
                     )
                     .await;
@@ -290,16 +334,19 @@ async fn run_actor(
                     }
                 }
                 Some(PersistMsg::Flush(ack)) => {
+                    journal_pending_snapshots(&pending).await;
                     let clean = write_stores(&pending, &mut due, &mut retries, &events, true).await;
                     let _ = ack.send(clean);
                 }
                 // All senders dropped (quit already flushed; this is a backstop).
                 None => {
+                    journal_pending_snapshots(&pending).await;
                     write_stores(&pending, &mut due, &mut retries, &events, true).await;
                     break;
                 }
             },
             _ = dirty.notified() => {
+                journal_pending_snapshots(&pending).await;
                 arm_due_for_pending(&pending, &mut due);
             },
             _ = tokio::time::sleep_until(next_due.unwrap_or_else(tokio::time::Instant::now)),
@@ -357,6 +404,207 @@ fn emit_persist_event(events: &EventSinkSlot, event: PersistEvent) {
     if let Some(emit) = sink {
         emit(event);
     }
+}
+
+async fn journal_pending_snapshots(pending: &SharedPending) {
+    let intents: Vec<JournalIntent> = {
+        let guard = lock(pending);
+        guard
+            .values()
+            .filter_map(|snapshot| {
+                let path = snapshot.storage_path()?;
+                let bytes = match snapshot.to_json_bytes() {
+                    Ok(bytes) => bytes,
+                    Err(error) => {
+                        tracing::warn!(
+                            store = snapshot.kind().label(),
+                            error = %error,
+                            "failed to encode persistence intent"
+                        );
+                        return None;
+                    }
+                };
+                Some(JournalIntent {
+                    kind: snapshot.kind(),
+                    path,
+                    bytes,
+                })
+            })
+            .collect()
+    };
+    if intents.is_empty() {
+        return;
+    }
+    let result = crate::util::blocking::spawn_io(move || {
+        for intent in intents {
+            if let Err(error) = write_journal_intent(&intent) {
+                tracing::warn!(
+                    store = intent.kind.label(),
+                    error = %error,
+                    "failed to write persistence intent"
+                );
+            }
+        }
+    })
+    .await;
+    if let Err(error) = result {
+        tracing::warn!(error = %error, "persistence intent task failed");
+    }
+}
+
+fn write_journal_intent(intent: &JournalIntent) -> std::io::Result<()> {
+    let Some(journal_path) = intent_journal_path(&intent.path) else {
+        return Ok(());
+    };
+    let Some(sidecar_path) = intent_sidecar_path(&intent.path) else {
+        return Ok(());
+    };
+    crate::util::safe_fs::write_private_atomic(&sidecar_path, &intent.bytes)?;
+    let sidecar = sidecar_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| std::io::Error::other("invalid intent sidecar name"))?;
+    let record = serde_json::json!({
+        "v": 1,
+        "op": "replace",
+        "kind": intent.kind.label(),
+        "sidecar": sidecar,
+        "sha256": sha256_hex(&intent.bytes),
+    });
+    crate::util::safe_fs::append_private_jsonl_durable(&journal_path, &record.to_string())
+}
+
+fn clear_store_journal_for_kind(kind: StoreKind) {
+    let path = match kind {
+        StoreKind::Library => crate::library::library_path(),
+        StoreKind::Signals => crate::signals::signals_path(),
+        StoreKind::Downloads => crate::downloads::store_path(),
+        StoreKind::Config => crate::config::config_path(),
+        StoreKind::Playlists => crate::playlists::playlists_path(),
+        StoreKind::Station => crate::station::station_path(),
+        StoreKind::RomanizedTitles => crate::romanize::cache_path(),
+        StoreKind::Session => crate::session::session_cache_path(),
+    };
+    if let Some(path) = path {
+        clear_store_journal(&path);
+    }
+}
+
+fn clear_store_journal(path: &Path) {
+    for path in [intent_journal_path(path), intent_sidecar_path(path)]
+        .into_iter()
+        .flatten()
+    {
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %error,
+                    "failed to remove persistence intent"
+                );
+            }
+        }
+    }
+}
+
+pub(crate) fn replay_journaled_snapshot<T>(
+    kind: StoreKind,
+    path: &Path,
+    current: T,
+    max_bytes: u64,
+) -> T
+where
+    T: DeserializeOwned,
+{
+    let Some(journal_path) = intent_journal_path(path) else {
+        return current;
+    };
+    let Ok(bytes) =
+        crate::util::safe_fs::read_no_symlink_limited(&journal_path, INTENT_JOURNAL_MAX_BYTES)
+    else {
+        return current;
+    };
+    let Ok(text) = String::from_utf8(bytes) else {
+        return current;
+    };
+    for line in text.lines().rev() {
+        let Ok(record) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if record.get("v").and_then(|v| v.as_u64()) != Some(1)
+            || record.get("op").and_then(|v| v.as_str()) != Some("replace")
+            || record.get("kind").and_then(|v| v.as_str()) != Some(kind.label())
+        {
+            continue;
+        }
+        let Some(sidecar_name) = record.get("sidecar").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(expected_hash) = record.get("sha256").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(sidecar_path) = sibling_path_from_record(path, sidecar_name) else {
+            continue;
+        };
+        let cap = max_bytes.min(INTENT_SNAPSHOT_MAX_BYTES);
+        let Ok(snapshot_bytes) = crate::util::safe_fs::read_no_symlink_limited(&sidecar_path, cap)
+        else {
+            continue;
+        };
+        if sha256_hex(&snapshot_bytes) != expected_hash {
+            tracing::warn!(
+                store = kind.label(),
+                "discarding persistence intent with checksum mismatch"
+            );
+            continue;
+        }
+        match serde_json::from_slice::<T>(&snapshot_bytes) {
+            Ok(snapshot) => {
+                tracing::info!(store = kind.label(), "replayed pending persistence intent");
+                return snapshot;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    store = kind.label(),
+                    error = %error,
+                    "discarding invalid persistence intent"
+                );
+            }
+        }
+    }
+    current
+}
+
+fn intent_journal_path(path: &Path) -> Option<PathBuf> {
+    sibling_with_suffix(path, ".intent.jsonl")
+}
+
+fn intent_sidecar_path(path: &Path) -> Option<PathBuf> {
+    sibling_with_suffix(path, ".intent.latest.json")
+}
+
+fn sibling_with_suffix(path: &Path, suffix: &str) -> Option<PathBuf> {
+    let name = path.file_name()?.to_str()?;
+    Some(path.with_file_name(format!("{name}{suffix}")))
+}
+
+fn sibling_path_from_record(path: &Path, name: &str) -> Option<PathBuf> {
+    let recorded = Path::new(name);
+    if recorded.file_name().and_then(|file| file.to_str()) != Some(name) {
+        return None;
+    }
+    path.parent().map(|parent| parent.join(name))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
 }
 
 fn requeue_failed_snapshot(
@@ -455,7 +703,7 @@ async fn write_stores(
         let Some(snapshot) = lock(pending).remove(&kind) else {
             continue;
         };
-        let result = tokio::task::spawn_blocking(move || {
+        let result = crate::util::blocking::spawn_io(move || {
             let outcome = snapshot.write();
             (outcome, snapshot)
         })
@@ -466,6 +714,9 @@ async fn write_stores(
             }
             Err(e) => tracing::warn!(error = %e, "persist write task failed"),
             Ok((Ok(()), snapshot)) => {
+                if let Some(path) = snapshot.storage_path() {
+                    clear_store_journal(&path);
+                }
                 retries.remove(&snapshot.kind());
             }
         }
@@ -478,6 +729,18 @@ mod tests {
     use super::*;
     use std::panic::AssertUnwindSafe;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use serde::{Deserialize, Serialize};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let mut bytes = [0u8; 8];
+        getrandom::fill(&mut bytes).unwrap();
+        let suffix = bytes.iter().map(|b| format!("{b:02x}")).collect::<String>();
+        std::env::temp_dir().join(format!(
+            "yututui-persist-{name}-{}-{suffix}",
+            std::process::id()
+        ))
+    }
 
     #[test]
     fn debounce_windows_match_store_durability_policy() {
@@ -505,6 +768,34 @@ mod tests {
 
         let guard = lock(&pending);
         assert!(guard.is_empty());
+    }
+
+    #[test]
+    fn journaled_snapshot_replays_and_clears() {
+        #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+        struct Tiny {
+            value: u8,
+        }
+
+        let dir = temp_dir("intent");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("tiny.json");
+        let bytes = serde_json::to_vec_pretty(&Tiny { value: 7 }).unwrap();
+
+        write_journal_intent(&JournalIntent {
+            kind: StoreKind::Config,
+            path: path.clone(),
+            bytes,
+        })
+        .unwrap();
+
+        let replayed = replay_journaled_snapshot(StoreKind::Config, &path, Tiny { value: 1 }, 1024);
+        assert_eq!(replayed, Tiny { value: 7 });
+
+        clear_store_journal(&path);
+        let replayed = replay_journaled_snapshot(StoreKind::Config, &path, Tiny { value: 1 }, 1024);
+        assert_eq!(replayed, Tiny { value: 1 });
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[tokio::test]

--- a/src/player/ipc.rs
+++ b/src/player/ipc.rs
@@ -70,7 +70,12 @@ pub async fn connect_retry(path: &str) -> io::Result<Stream> {
 /// Drive one mpv connection: subscribe to progress properties, then loop forwarding
 /// mpv events to the runtime (`emit`) and writing player commands (`cmd_rx`) to mpv.
 /// Returns when mpv closes the connection or all command senders drop.
-pub async fn run_actor(conn: Stream, mut cmd_rx: Receiver<PlayerCmd>, emit: EventSink) {
+pub async fn run_actor(
+    conn: Stream,
+    mut urgent_rx: Receiver<PlayerCmd>,
+    mut cmd_rx: Receiver<PlayerCmd>,
+    emit: EventSink,
+) {
     let mut state = DispatchState::default();
 
     // Subscribe to the properties the player view needs. IDs are arbitrary but stable.
@@ -94,10 +99,19 @@ pub async fn run_actor(conn: Stream, mut cmd_rx: Receiver<PlayerCmd>, emit: Even
     let mut reader = BufReader::new(&conn);
     let mut line: Vec<u8> = Vec::new();
     let mut request_id: u64 = 10;
+    let mut urgent_closed = false;
 
     loop {
         line.clear();
         tokio::select! {
+            biased;
+            cmd = urgent_rx.recv(), if !urgent_closed => match cmd {
+                None => urgent_closed = true,
+                Some(cmd) => {
+                    request_id += 1;
+                    dispatch_command(&conn, &emit, &mut state, request_id, cmd).await;
+                }
+            },
             // Bounded read (shared with the remote protocol): a well-behaved mpv sends tiny
             // JSON lines, so a line past the cap means a broken/hostile endpoint — tear down
             // rather than let one line grow memory without limit.
@@ -116,63 +130,80 @@ pub async fn run_actor(conn: Stream, mut cmd_rx: Receiver<PlayerCmd>, emit: Even
                 None => break, // all senders dropped: shutting down
                 Some(cmd) => {
                     request_id += 1;
-                    let (json, label) = match cmd {
-                        PlayerCmd::Load(url) => {
-                            let url = match crate::api::validate_playback_target_for_handoff(&url).await {
-                                Ok(url) => url,
-                                Err(error) => {
-                                    tracing::warn!(%error, "blocked unsafe playback URL");
-                                    emit(PlayerEvent::Error(format!("blocked playback URL: {error}")));
-                                    continue;
-                                }
-                            };
-                            state.last_sent_time_sec = None;
-                            state.last_sent_cache_sec = None;
-                            state.duration_known = false;
-                            (proto::cmd_loadfile(&url, "replace", request_id), "loadfile".to_owned())
-                        },
-                        PlayerCmd::Stop => {
-                            state.last_sent_time_sec = None;
-                            state.last_sent_cache_sec = None;
-                            state.duration_known = false;
-                            (proto::cmd_stop(request_id), "stop".to_owned())
-                        },
-                        PlayerCmd::CyclePause => {
-                            (proto::cmd_cycle("pause", request_id), "cycle pause".to_owned())
-                        }
-                        PlayerCmd::SeekRelative(secs) => {
-                            (proto::cmd_seek_relative(secs, request_id), "seek".to_owned())
-                        }
-                        PlayerCmd::SeekAbsolute(secs) => {
-                            (proto::cmd_seek_absolute(secs, request_id), "seek".to_owned())
-                        }
-                        PlayerCmd::SetVolume(vol) => {
-                            (proto::cmd_set_volume(vol, request_id), "set volume".to_owned())
-                        }
-                        PlayerCmd::SetAudioFilter(af) => {
-                            (
-                                proto::cmd_set_property("af", &serde_json::Value::from(af), request_id),
-                                "set af".to_owned(),
-                            )
-                        }
-                        PlayerCmd::AfCommand { label, param, value } => {
-                            (
-                                proto::cmd_af_command(&label, &param, &value, request_id),
-                                "af-command".to_owned(),
-                            )
-                        }
-                        PlayerCmd::SetProperty { name, value } => {
-                            let label = format!("set_property {name}");
-                            (proto::cmd_set_property(&name, &value, request_id), label)
-                        }
-                    };
-                    remember_pending_command(&mut state, request_id, label);
-                    if let Err(e) = write_json(&conn, &json).await {
-                        tracing::warn!(error = %e, "failed to write mpv command");
-                    }
+                    dispatch_command(&conn, &emit, &mut state, request_id, cmd).await;
                 }
             },
         }
+    }
+}
+
+async fn dispatch_command(
+    conn: &Stream,
+    emit: &EventSink,
+    state: &mut DispatchState,
+    request_id: u64,
+    cmd: PlayerCmd,
+) {
+    let (json, label) = match cmd {
+        PlayerCmd::Load(url) => {
+            let url = match crate::api::validate_playback_target_for_handoff(&url).await {
+                Ok(url) => url,
+                Err(error) => {
+                    tracing::warn!(%error, "blocked unsafe playback URL");
+                    emit(PlayerEvent::Error(format!("blocked playback URL: {error}")));
+                    return;
+                }
+            };
+            state.last_sent_time_sec = None;
+            state.last_sent_cache_sec = None;
+            state.duration_known = false;
+            (
+                proto::cmd_loadfile(&url, "replace", request_id),
+                "loadfile".to_owned(),
+            )
+        }
+        PlayerCmd::Stop => {
+            state.last_sent_time_sec = None;
+            state.last_sent_cache_sec = None;
+            state.duration_known = false;
+            (proto::cmd_stop(request_id), "stop".to_owned())
+        }
+        PlayerCmd::CyclePause => (
+            proto::cmd_cycle("pause", request_id),
+            "cycle pause".to_owned(),
+        ),
+        PlayerCmd::SeekRelative(secs) => (
+            proto::cmd_seek_relative(secs, request_id),
+            "seek".to_owned(),
+        ),
+        PlayerCmd::SeekAbsolute(secs) => (
+            proto::cmd_seek_absolute(secs, request_id),
+            "seek".to_owned(),
+        ),
+        PlayerCmd::SetVolume(vol) => (
+            proto::cmd_set_volume(vol, request_id),
+            "set volume".to_owned(),
+        ),
+        PlayerCmd::SetAudioFilter(af) => (
+            proto::cmd_set_property("af", &serde_json::Value::from(af), request_id),
+            "set af".to_owned(),
+        ),
+        PlayerCmd::AfCommand {
+            label,
+            param,
+            value,
+        } => (
+            proto::cmd_af_command(&label, &param, &value, request_id),
+            "af-command".to_owned(),
+        ),
+        PlayerCmd::SetProperty { name, value } => {
+            let label = format!("set_property {name}");
+            (proto::cmd_set_property(&name, &value, request_id), label)
+        }
+    };
+    remember_pending_command(state, request_id, label);
+    if let Err(e) = write_json(conn, &json).await {
+        tracing::warn!(error = %e, "failed to write mpv command");
     }
 }
 

--- a/src/player/lifetime.rs
+++ b/src/player/lifetime.rs
@@ -316,19 +316,28 @@ pub fn reap_orphans(dir: &Path) {
 }
 
 /// Confirm a candidate really is *our* mpv before killing it, defeating pid reuse: an unrelated
-/// mpv won't carry our unique `--input-ipc-server=<socket>` path in its command line. Falls back
-/// to permissive (the name check already applied) when we recorded no socket (a pre-upgrade
-/// record) or the OS won't expose this process's command line.
+/// mpv won't carry our unique `--input-ipc-server=<socket>` path in its command line.
 fn mpv_identity_matches(proc_: &sysinfo::Process, record: &Lifeline) -> bool {
+    let args: Vec<String> = proc_
+        .cmd()
+        .iter()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect();
+    mpv_identity_matches_args(&args, record)
+}
+
+fn mpv_identity_matches_args(args: &[String], record: &Lifeline) -> bool {
     if record.mpv_socket.is_empty() {
+        // Legacy records had no socket identity; keep the historical name-check-only fallback.
         return true;
     }
-    let cmd = proc_.cmd();
-    if cmd.is_empty() {
-        return true; // command line unavailable on this platform/process; rely on the name check
+    if args.is_empty() {
+        // New records have a unique socket identity. If the OS will not expose argv, do not risk
+        // killing an unrelated user-started mpv after PID reuse.
+        return false;
     }
-    cmd.iter()
-        .any(|arg| arg.to_string_lossy().contains(record.mpv_socket.as_str()))
+    args.iter()
+        .any(|arg| arg.contains(record.mpv_socket.as_str()))
 }
 
 #[cfg(test)]
@@ -399,5 +408,35 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn identity_matching_requires_socket_when_record_has_one() {
+        let legacy = Lifeline {
+            app_pid: 1,
+            mpv_pid: 2,
+            mpv_socket: String::new(),
+            written_at: unix_now(),
+        };
+        assert!(mpv_identity_matches_args(&[], &legacy));
+
+        let record = Lifeline {
+            app_pid: 1,
+            mpv_pid: 2,
+            mpv_socket: "/tmp/ytm-ipc-abc.sock".to_owned(),
+            written_at: unix_now(),
+        };
+        assert!(!mpv_identity_matches_args(&[], &record));
+        assert!(!mpv_identity_matches_args(
+            &["mpv".to_owned(), "--idle=yes".to_owned()],
+            &record
+        ));
+        assert!(mpv_identity_matches_args(
+            &[
+                "mpv".to_owned(),
+                "--input-ipc-server=/tmp/ytm-ipc-abc.sock".to_owned()
+            ],
+            &record
+        ));
     }
 }

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -12,12 +12,16 @@ pub mod proto;
 pub mod video;
 
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use serde_json::Value;
 use tokio::process::Child;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::{self, Sender};
 
 /// Commands the reducer sends to the player actor.
 pub enum PlayerCmd {
@@ -44,6 +48,27 @@ pub enum PlayerCmd {
     },
     /// Set an arbitrary mpv property (e.g. `speed`).
     SetProperty { name: String, value: Value },
+}
+
+enum CmdLossPolicy {
+    Critical,
+    LatestWins,
+}
+
+impl PlayerCmd {
+    fn loss_policy(&self) -> CmdLossPolicy {
+        match self {
+            PlayerCmd::Load(_)
+            | PlayerCmd::Stop
+            | PlayerCmd::CyclePause
+            | PlayerCmd::SetAudioFilter(_)
+            | PlayerCmd::SetProperty { .. } => CmdLossPolicy::Critical,
+            PlayerCmd::SeekRelative(_)
+            | PlayerCmd::SeekAbsolute(_)
+            | PlayerCmd::SetVolume(_)
+            | PlayerCmd::AfCommand { .. } => CmdLossPolicy::LatestWins,
+        }
+    }
 }
 
 /// Events emitted by the mpv IPC actor.
@@ -76,17 +101,182 @@ pub(crate) type EventSink = Arc<dyn Fn(PlayerEvent) + Send + Sync>;
 /// non-blocking and silently no-op if the actor has gone away.
 pub struct PlayerHandle {
     tx: Sender<PlayerCmd>,
+    urgent_tx: Sender<PlayerCmd>,
+    latest: Arc<Mutex<LatestPending>>,
+    latest_drain_running: Arc<AtomicBool>,
 }
 
 impl PlayerHandle {
     pub fn send(&self, cmd: PlayerCmd) {
-        if self.tx.try_send(cmd).is_err() {
-            tracing::warn!("player command queue full or closed; dropping command");
+        match cmd.loss_policy() {
+            CmdLossPolicy::Critical => self.send_critical(cmd),
+            CmdLossPolicy::LatestWins => self.send_latest(cmd),
+        }
+    }
+
+    fn send_critical(&self, cmd: PlayerCmd) {
+        match self.urgent_tx.try_send(cmd) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(cmd)) => {
+                let tx = self.urgent_tx.clone();
+                if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                    handle.spawn(async move {
+                        if tokio::time::timeout(Duration::from_millis(250), tx.send(cmd))
+                            .await
+                            .is_err()
+                        {
+                            tracing::warn!(
+                                "player urgent command queue stayed full; dropping critical command"
+                            );
+                        }
+                    });
+                } else {
+                    tracing::warn!(
+                        "player urgent command queue full outside runtime; dropping critical command"
+                    );
+                }
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                tracing::warn!("player actor stopped before critical command");
+            }
+        }
+    }
+
+    fn send_latest(&self, cmd: PlayerCmd) {
+        match self.tx.try_send(cmd) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(cmd)) => {
+                self.latest
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .push(cmd);
+                self.spawn_latest_drain();
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                tracing::debug!("player actor stopped before latest-wins command");
+            }
         }
     }
 
     pub fn load(&self, url: impl Into<String>) {
         self.send(PlayerCmd::Load(url.into()));
+    }
+
+    fn spawn_latest_drain(&self) {
+        if self.latest_drain_running.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let tx = self.tx.clone();
+        let latest = Arc::clone(&self.latest);
+        let running = Arc::clone(&self.latest_drain_running);
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(drain_latest_queue(tx, latest, running));
+        } else {
+            self.latest_drain_running.store(false, Ordering::Release);
+            tracing::debug!("player latest-wins command queued outside runtime");
+        }
+    }
+}
+
+#[derive(Default)]
+struct LatestPending {
+    seek_relative: f64,
+    seek_absolute: Option<f64>,
+    volume: Option<i64>,
+    af_commands: Vec<PlayerCmd>,
+}
+
+impl LatestPending {
+    fn push(&mut self, cmd: PlayerCmd) {
+        match cmd {
+            PlayerCmd::SeekRelative(secs) => self.seek_relative += secs,
+            PlayerCmd::SeekAbsolute(secs) => self.seek_absolute = Some(secs),
+            PlayerCmd::SetVolume(vol) => self.volume = Some(vol),
+            PlayerCmd::AfCommand {
+                label,
+                param,
+                value,
+            } => {
+                self.af_commands.retain(|cmd| {
+                    !matches!(
+                        cmd,
+                        PlayerCmd::AfCommand {
+                            label: existing_label,
+                            param: existing_param,
+                            ..
+                        } if existing_label == &label && existing_param == &param
+                    )
+                });
+                self.af_commands.push(PlayerCmd::AfCommand {
+                    label,
+                    param,
+                    value,
+                });
+            }
+            cmd => self.af_commands.push(cmd),
+        }
+    }
+
+    fn take_one(&mut self) -> Option<PlayerCmd> {
+        if self.seek_relative != 0.0 {
+            let secs = self.seek_relative;
+            self.seek_relative = 0.0;
+            return Some(PlayerCmd::SeekRelative(secs));
+        }
+        if let Some(secs) = self.seek_absolute.take() {
+            return Some(PlayerCmd::SeekAbsolute(secs));
+        }
+        if let Some(vol) = self.volume.take() {
+            return Some(PlayerCmd::SetVolume(vol));
+        }
+        if self.af_commands.is_empty() {
+            None
+        } else {
+            Some(self.af_commands.remove(0))
+        }
+    }
+
+    fn has_pending(&self) -> bool {
+        self.seek_relative != 0.0
+            || self.seek_absolute.is_some()
+            || self.volume.is_some()
+            || !self.af_commands.is_empty()
+    }
+}
+
+async fn drain_latest_queue(
+    tx: Sender<PlayerCmd>,
+    latest: Arc<Mutex<LatestPending>>,
+    running: Arc<AtomicBool>,
+) {
+    loop {
+        loop {
+            let permit = match tx.reserve().await {
+                Ok(permit) => permit,
+                Err(_) => {
+                    running.store(false, Ordering::Release);
+                    return;
+                }
+            };
+            let Some(cmd) = latest
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take_one()
+            else {
+                drop(permit);
+                break;
+            };
+            permit.send(cmd);
+        }
+
+        running.store(false, Ordering::Release);
+        let still_pending = latest
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .has_pending();
+        if !still_pending || running.swap(true, Ordering::AcqRel) {
+            return;
+        }
     }
 }
 
@@ -151,10 +341,17 @@ where
 
     let (tx, rx) =
         crate::util::backpressure::bounded_channel(crate::util::backpressure::PLAYER_CMD_QUEUE);
-    tokio::spawn(ipc::run_actor(conn, rx, Arc::new(emit)));
+    let (urgent_tx, urgent_rx) =
+        crate::util::backpressure::bounded_channel(crate::util::backpressure::PLAYER_CMD_QUEUE);
+    tokio::spawn(ipc::run_actor(conn, urgent_rx, rx, Arc::new(emit)));
 
     Ok((
-        PlayerHandle { tx },
+        PlayerHandle {
+            tx,
+            urgent_tx,
+            latest: Arc::new(Mutex::new(LatestPending::default())),
+            latest_drain_running: Arc::new(AtomicBool::new(false)),
+        },
         Mpv {
             child,
             ipc_path,
@@ -162,4 +359,94 @@ where
             job,
         },
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_handle(tx: Sender<PlayerCmd>, urgent_tx: Sender<PlayerCmd>) -> PlayerHandle {
+        PlayerHandle {
+            tx,
+            urgent_tx,
+            latest: Arc::new(Mutex::new(LatestPending::default())),
+            latest_drain_running: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    #[test]
+    fn latest_pending_coalesces_lossy_commands() {
+        let mut pending = LatestPending::default();
+        pending.push(PlayerCmd::SeekRelative(2.0));
+        pending.push(PlayerCmd::SeekRelative(3.5));
+        pending.push(PlayerCmd::SeekAbsolute(10.0));
+        pending.push(PlayerCmd::SeekAbsolute(12.0));
+        pending.push(PlayerCmd::SetVolume(20));
+        pending.push(PlayerCmd::SetVolume(30));
+        pending.push(PlayerCmd::AfCommand {
+            label: "eq".to_owned(),
+            param: "gain".to_owned(),
+            value: "1".to_owned(),
+        });
+        pending.push(PlayerCmd::AfCommand {
+            label: "eq".to_owned(),
+            param: "gain".to_owned(),
+            value: "2".to_owned(),
+        });
+
+        match pending.take_one() {
+            Some(PlayerCmd::SeekRelative(secs)) => assert_eq!(secs, 5.5),
+            _ => panic!("expected coalesced relative seek"),
+        }
+        match pending.take_one() {
+            Some(PlayerCmd::SeekAbsolute(secs)) => assert_eq!(secs, 12.0),
+            _ => panic!("expected latest absolute seek"),
+        }
+        match pending.take_one() {
+            Some(PlayerCmd::SetVolume(vol)) => assert_eq!(vol, 30),
+            _ => panic!("expected latest volume"),
+        }
+        match pending.take_one() {
+            Some(PlayerCmd::AfCommand {
+                label,
+                param,
+                value,
+            }) => {
+                assert_eq!(label, "eq");
+                assert_eq!(param, "gain");
+                assert_eq!(value, "2");
+            }
+            _ => panic!("expected latest af command"),
+        }
+        assert!(pending.take_one().is_none());
+    }
+
+    #[tokio::test]
+    async fn critical_commands_use_urgent_lane_when_normal_queue_is_full() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let (urgent_tx, mut urgent_rx) = mpsc::channel(1);
+        assert!(tx.try_send(PlayerCmd::SetVolume(1)).is_ok());
+        let handle = test_handle(tx, urgent_tx);
+
+        handle.send(PlayerCmd::Stop);
+
+        assert!(matches!(urgent_rx.try_recv(), Ok(PlayerCmd::Stop)));
+        assert!(matches!(rx.try_recv(), Ok(PlayerCmd::SetVolume(1))));
+    }
+
+    #[tokio::test]
+    async fn latest_wins_commands_buffer_when_normal_queue_is_full() {
+        let (tx, _rx) = mpsc::channel(1);
+        let (urgent_tx, _urgent_rx) = mpsc::channel(1);
+        assert!(tx.try_send(PlayerCmd::SetVolume(1)).is_ok());
+        let handle = test_handle(tx, urgent_tx);
+
+        handle.send(PlayerCmd::SetVolume(80));
+
+        let mut latest = handle
+            .latest
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(matches!(latest.take_one(), Some(PlayerCmd::SetVolume(80))));
+    }
 }

--- a/src/playlists.rs
+++ b/src/playlists.rs
@@ -89,6 +89,12 @@ impl Playlists {
         // into memory. Loaded entries are then count-repaired to the same caps as mutations.
         let mut playlists =
             safe_fs::load_json_or_default_limited::<Playlists>(&path, MAX_PLAYLISTS_BYTES);
+        playlists = crate::persist::replay_journaled_snapshot(
+            crate::persist::StoreKind::Playlists,
+            &path,
+            playlists,
+            MAX_PLAYLISTS_BYTES,
+        );
         let report = playlists.repair_loaded();
         (playlists, report)
     }
@@ -323,7 +329,7 @@ fn sanitize_loaded_song(song: &mut Song) -> bool {
     changed
 }
 
-fn playlists_path() -> Option<PathBuf> {
+pub(crate) fn playlists_path() -> Option<PathBuf> {
     crate::paths::data_dir().map(|d| d.join("playlists.json"))
 }
 

--- a/src/remote/publish.rs
+++ b/src/remote/publish.rs
@@ -182,6 +182,16 @@ impl Publisher {
         }
     }
 
+    pub fn should_observe(&self, state_changed: bool) -> bool {
+        state_changed
+            || self.last_player.is_none()
+            || self.last_queue_rev == 0
+            || self.last_settings.is_none()
+            || self.hub.any_subscribed(Topic::Player)
+            || self.hub.any_subscribed(Topic::Queue)
+            || self.hub.any_subscribed(Topic::Settings)
+    }
+
     /// Owner-lane handler for [`super::server::RemoteEvent::SessionSubscribe`]: record
     /// the subscriptions, emit one initial snapshot per **newly** subscribed topic, then
     /// the `Reply{ok}` — all into this session's queue, in that order (docs/gui/02 §6).

--- a/src/romanize.rs
+++ b/src/romanize.rs
@@ -90,7 +90,13 @@ impl RomanizeCache {
             return Self::default();
         };
         // Schema-drift tolerant: keeps cached romanizations across incompatible changes.
-        safe_fs::load_json_or_default_limited::<RomanizeCache>(&path, CACHE_MAX_BYTES)
+        let cache = safe_fs::load_json_or_default_limited::<RomanizeCache>(&path, CACHE_MAX_BYTES);
+        crate::persist::replay_journaled_snapshot(
+            crate::persist::StoreKind::RomanizedTitles,
+            &path,
+            cache,
+            CACHE_MAX_BYTES,
+        )
     }
 
     pub fn save(&self) -> std::io::Result<()> {
@@ -218,7 +224,7 @@ impl RomanizeCache {
     }
 }
 
-fn cache_path() -> Option<PathBuf> {
+pub(crate) fn cache_path() -> Option<PathBuf> {
     crate::paths::data_dir().map(|d| d.join(CACHE_FILE))
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,6 +4,7 @@
 //! This module is the single orchestration boundary that maps those events back into
 //! reducer messages.
 
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use ratatui_image::thread::ResizeResponse;
@@ -15,6 +16,8 @@ use crate::player::{PlayerCmd, PlayerHandle};
 use crate::util::event_policy::{
     EventKey as Key, EventLane as Lane, EventPolicy, LatestEventBuffer,
 };
+
+mod must_deliver;
 
 pub enum RuntimeEvent {
     App(Msg),
@@ -651,6 +654,7 @@ enum RuntimeTelemetrySlot {
 pub struct RuntimeSender {
     tx: Sender<RuntimeEvent>,
     telemetry: Arc<Mutex<LatestEventBuffer<RuntimeTelemetrySlot, RuntimeEvent>>>,
+    must_deliver_overflow: Arc<must_deliver::MustDeliverOverflow>,
 }
 
 impl RuntimeSender {
@@ -658,6 +662,7 @@ impl RuntimeSender {
         Self {
             tx,
             telemetry: Arc::new(Mutex::new(LatestEventBuffer::new(RUNTIME_TELEMETRY_SLOTS))),
+            must_deliver_overflow: Arc::new(must_deliver::MustDeliverOverflow::new()),
         }
     }
 
@@ -682,16 +687,16 @@ pub fn emit(tx: &RuntimeSender, event: RuntimeEvent) -> bool {
     if matches!(policy, EventPolicy::CoalesceLatest { .. }) {
         return emit_coalesced(tx, event, event_kind, policy);
     }
-    emit_direct(&tx.tx, event, event_kind, policy)
+    emit_direct(tx, event, event_kind, policy)
 }
 
 fn emit_direct(
-    tx: &Sender<RuntimeEvent>,
+    tx: &RuntimeSender,
     event: RuntimeEvent,
     event_kind: &'static str,
     policy: EventPolicy,
 ) -> bool {
-    match tx.try_send(event) {
+    match tx.tx.try_send(event) {
         Ok(()) => true,
         Err(TrySendError::Full(event)) if matches!(policy, EventPolicy::MustDeliver { .. }) => {
             tracing::warn!(
@@ -702,7 +707,8 @@ fn emit_direct(
                 drop_reason = "must_deliver_delayed",
                 "runtime owner event queue full; deferring must-deliver event"
             );
-            defer_must_deliver(tx.clone(), event, event_kind, policy);
+            tx.must_deliver_overflow
+                .push(tx.tx.clone(), event, event_kind, policy);
             true
         }
         Err(TrySendError::Full(_)) => {
@@ -727,7 +733,7 @@ fn emit_coalesced(
     policy: EventPolicy,
 ) -> bool {
     let Some(slot) = event.telemetry_slot() else {
-        return emit_direct(&tx.tx, event, event_kind, policy);
+        return emit_direct(tx, event, event_kind, policy);
     };
     let insert = tx
         .telemetry
@@ -750,7 +756,7 @@ fn emit_coalesced(
     }
     if insert.should_wake {
         emit_direct(
-            &tx.tx,
+            tx,
             RuntimeEvent::TelemetryWake,
             RuntimeEvent::TelemetryWake.kind(),
             RuntimeEvent::TelemetryWake.policy(),
@@ -770,36 +776,82 @@ fn full_queue_reason(policy: EventPolicy) -> &'static str {
     }
 }
 
-fn defer_must_deliver(
-    tx: Sender<RuntimeEvent>,
-    event: RuntimeEvent,
-    event_kind: &'static str,
-    policy: EventPolicy,
-) {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        handle.spawn(async move {
-            if tx.send(event).await.is_err() {
-                tracing::error!(
-                    event_policy = policy.name(),
-                    event_lane = policy.lane().map(Lane::name).unwrap_or("none"),
-                    event_kind,
-                    drop_reason = "must_deliver_failed",
-                    "runtime owner event queue closed before must-deliver event was accepted"
-                );
+const PENDING_PLAYER_CMDS_MAX: usize = 64;
+
+#[derive(Default)]
+struct PendingPlayerCmds {
+    cmds: VecDeque<PlayerCmd>,
+}
+
+impl PendingPlayerCmds {
+    fn push(&mut self, cmd: PlayerCmd) {
+        match &cmd {
+            PlayerCmd::Load(_) => {
+                self.cmds
+                    .retain(|existing| !matches!(existing, PlayerCmd::Load(_)));
             }
-        });
-    } else {
-        std::thread::spawn(move || {
-            if tx.blocking_send(event).is_err() {
-                tracing::error!(
-                    event_policy = policy.name(),
-                    event_lane = policy.lane().map(Lane::name).unwrap_or("none"),
-                    event_kind,
-                    drop_reason = "must_deliver_failed",
-                    "runtime owner event queue closed before must-deliver event was accepted"
-                );
+            PlayerCmd::SetVolume(_) => {
+                self.cmds
+                    .retain(|existing| !matches!(existing, PlayerCmd::SetVolume(_)));
             }
-        });
+            PlayerCmd::SetAudioFilter(_) => {
+                self.cmds
+                    .retain(|existing| !matches!(existing, PlayerCmd::SetAudioFilter(_)));
+            }
+            PlayerCmd::SetProperty { name, .. } => {
+                self.cmds.retain(|existing| {
+                    !matches!(existing, PlayerCmd::SetProperty { name: existing_name, .. } if existing_name == name)
+                });
+            }
+            PlayerCmd::Stop
+            | PlayerCmd::CyclePause
+            | PlayerCmd::SeekRelative(_)
+            | PlayerCmd::SeekAbsolute(_)
+            | PlayerCmd::AfCommand { .. } => {}
+        }
+        self.cmds.push_back(cmd);
+        while self.cmds.len() > PENDING_PLAYER_CMDS_MAX {
+            let idx = self
+                .cmds
+                .iter()
+                .position(|cmd| !matches!(cmd, PlayerCmd::Load(_)))
+                .unwrap_or(0);
+            if let Some(dropped) = self.cmds.remove(idx) {
+                tracing::warn!(
+                    kind = player_cmd_kind(&dropped),
+                    "pending player command buffer full; dropping oldest queued command"
+                );
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn drain(&mut self) -> Vec<PlayerCmd> {
+        self.cmds.drain(..).collect()
+    }
+
+    fn clear(&mut self) {
+        self.cmds.clear();
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.cmds.len()
+    }
+}
+
+fn player_cmd_kind(cmd: &PlayerCmd) -> &'static str {
+    match cmd {
+        PlayerCmd::Load(_) => "load",
+        PlayerCmd::Stop => "stop",
+        PlayerCmd::CyclePause => "cycle_pause",
+        PlayerCmd::SeekRelative(_) => "seek_relative",
+        PlayerCmd::SeekAbsolute(_) => "seek_absolute",
+        PlayerCmd::SetVolume(_) => "set_volume",
+        PlayerCmd::SetAudioFilter(_) => "set_audio_filter",
+        PlayerCmd::AfCommand { .. } => "af_command",
+        PlayerCmd::SetProperty { .. } => "set_property",
     }
 }
 
@@ -822,7 +874,7 @@ pub fn remote_sink(
 pub struct RuntimeHandles {
     worker_tx: RuntimeSender,
     player_handle: Option<PlayerHandle>,
-    pending_player_cmds: Vec<PlayerCmd>,
+    pending_player_cmds: PendingPlayerCmds,
     player_failed: bool,
     _mpv_guard: Option<crate::player::Mpv>,
     /// Command sender for the *current* video overlay's IPC client. Replaced wholesale
@@ -858,7 +910,7 @@ impl RuntimeHandles {
         Self {
             worker_tx,
             player_handle: None,
-            pending_player_cmds: Vec::new(),
+            pending_player_cmds: PendingPlayerCmds::default(),
             player_failed: false,
             _mpv_guard: None,
             video_handle: None,
@@ -879,6 +931,10 @@ impl RuntimeHandles {
     /// must survive `media_controls: false`.
     pub fn scrobble_observe(&mut self, snapshot: &crate::media::MediaSnapshot) {
         self.scrobble_handle.observe(snapshot);
+    }
+
+    pub fn scrobble_heartbeat_due(&self) -> bool {
+        self.scrobble_handle.heartbeat_due()
     }
 
     /// Best-effort queue flush on quit, bounded by `budget`.
@@ -923,7 +979,7 @@ impl RuntimeHandles {
                 if let Ok(url) = std::env::var("YTM_PLAY_URL") {
                     handle.load(url);
                 }
-                for cmd in self.pending_player_cmds.drain(..) {
+                for cmd in self.pending_player_cmds.drain() {
                     handle.send(cmd);
                 }
                 self.player_handle = Some(handle);
@@ -1060,35 +1116,47 @@ impl RuntimeHandles {
             Cmd::ScanDownloads(dir) => {
                 // Directory scan does per-file IO — keep it off the loop task too.
                 let tx = self.worker_tx.clone();
-                tokio::task::spawn_blocking(move || {
-                    let scan = crate::library::scan_downloads(&dir);
-                    emit(&tx, RuntimeEvent::App(Msg::DownloadsScanned(scan)));
+                tokio::spawn(async move {
+                    if let Err(error) = crate::util::blocking::spawn_io(move || {
+                        let scan = crate::library::scan_downloads(&dir);
+                        emit(&tx, RuntimeEvent::App(Msg::DownloadsScanned(scan)));
+                    })
+                    .await
+                    {
+                        tracing::warn!(%error, "download scan task failed");
+                    }
                 });
             }
             Cmd::Local(cmd) => match cmd {
                 crate::app::LocalCmd::LoadIndex { index_path } => {
                     let tx = self.worker_tx.clone();
-                    tokio::task::spawn_blocking(move || {
-                        let load = index_path
-                            .as_deref()
-                            .map(crate::local::LocalIndex::load_with_diagnostics)
-                            .unwrap_or_default();
-                        let warnings = load
-                            .warnings
-                            .into_iter()
-                            .map(|warning| crate::local::ScanError {
-                                path: warning.path,
-                                message: warning.message,
-                            })
-                            .collect();
-                        emit(
-                            &tx,
-                            RuntimeEvent::App(Msg::Local(crate::app::LocalMsg::IndexLoaded {
-                                index_path,
-                                index: load.index,
-                                warnings,
-                            })),
-                        );
+                    tokio::spawn(async move {
+                        if let Err(error) = crate::util::blocking::spawn_io(move || {
+                            let load = index_path
+                                .as_deref()
+                                .map(crate::local::LocalIndex::load_with_diagnostics)
+                                .unwrap_or_default();
+                            let warnings = load
+                                .warnings
+                                .into_iter()
+                                .map(|warning| crate::local::ScanError {
+                                    path: warning.path,
+                                    message: warning.message,
+                                })
+                                .collect();
+                            emit(
+                                &tx,
+                                RuntimeEvent::App(Msg::Local(crate::app::LocalMsg::IndexLoaded {
+                                    index_path,
+                                    index: load.index,
+                                    warnings,
+                                })),
+                            );
+                        })
+                        .await
+                        {
+                            tracing::warn!(%error, "local index load task failed");
+                        }
                     });
                 }
                 crate::app::LocalCmd::ScanRoots {
@@ -1097,33 +1165,42 @@ impl RuntimeHandles {
                     previous,
                 } => {
                     let tx = self.worker_tx.clone();
-                    tokio::task::spawn_blocking(move || {
-                        let progress_tx = tx.clone();
-                        let mut result =
-                            crate::local::scan_roots_with_progress(&roots, &previous, |progress| {
-                                emit(
-                                    &progress_tx,
-                                    RuntimeEvent::App(Msg::Local(
-                                        crate::app::LocalMsg::ScanProgress(progress),
-                                    )),
-                                );
-                            });
-                        if let Some(path) = index_path.as_deref()
-                            && let Err(error) = result.index.save(path)
+                    tokio::spawn(async move {
+                        if let Err(error) = crate::util::blocking::spawn_io(move || {
+                            let progress_tx = tx.clone();
+                            let mut result = crate::local::scan_roots_with_progress(
+                                &roots,
+                                &previous,
+                                |progress| {
+                                    emit(
+                                        &progress_tx,
+                                        RuntimeEvent::App(Msg::Local(
+                                            crate::app::LocalMsg::ScanProgress(progress),
+                                        )),
+                                    );
+                                },
+                            );
+                            if let Some(path) = index_path.as_deref()
+                                && let Err(error) = result.index.save(path)
+                            {
+                                result.errors.push(crate::local::ScanError {
+                                    path: path.to_path_buf(),
+                                    message: format!("could not save local index: {error}"),
+                                });
+                                result.summary.errors = result.errors.len();
+                            }
+                            emit(
+                                &tx,
+                                RuntimeEvent::App(Msg::Local(crate::app::LocalMsg::ScanFinished {
+                                    index_path,
+                                    result,
+                                })),
+                            );
+                        })
+                        .await
                         {
-                            result.errors.push(crate::local::ScanError {
-                                path: path.to_path_buf(),
-                                message: format!("could not save local index: {error}"),
-                            });
-                            result.summary.errors = result.errors.len();
+                            tracing::warn!(%error, "local root scan task failed");
                         }
-                        emit(
-                            &tx,
-                            RuntimeEvent::App(Msg::Local(crate::app::LocalMsg::ScanFinished {
-                                index_path,
-                                result,
-                            })),
-                        );
                     });
                 }
             },
@@ -1131,9 +1208,15 @@ impl RuntimeHandles {
                 // Copy/tag/delete are blocking IO — keep them off the loop task. A `Save`
                 // reports back; `Discard`/`WipeTemp` are fire-and-forget.
                 let tx = self.worker_tx.clone();
-                tokio::task::spawn_blocking(move || {
-                    if let Some(event) = crate::recorder::job::run(job) {
-                        emit(&tx, RuntimeEvent::App(Msg::Recorder(event)));
+                tokio::spawn(async move {
+                    if let Err(error) = crate::util::blocking::spawn_io(move || {
+                        if let Some(event) = crate::recorder::job::run(job) {
+                            emit(&tx, RuntimeEvent::App(Msg::Recorder(event)));
+                        }
+                    })
+                    .await
+                    {
+                        tracing::warn!(%error, "recorder file task failed");
                     }
                 });
             }
@@ -1190,9 +1273,13 @@ impl RuntimeHandles {
                 tokio::spawn(async move {
                     let progress_tx = tx.clone();
                     crate::tools::ytdlp::clear_probe_cache();
-                    let outcome = crate::tools::ytdlp::check_and_update(&tools, &move |event| {
-                        emit(&progress_tx, RuntimeEvent::Tools(event));
-                    })
+                    let outcome = crate::tools::ytdlp::rollback_or_check_and_update(
+                        &tools,
+                        &move |event| {
+                            emit(&progress_tx, RuntimeEvent::Tools(event));
+                        },
+                        "playback self-heal",
+                    )
                     .await;
                     let updated = matches!(
                         outcome,

--- a/src/runtime/must_deliver.rs
+++ b/src/runtime/must_deliver.rs
@@ -1,0 +1,129 @@
+use std::collections::VecDeque;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+use tokio::sync::mpsc::Sender;
+
+use crate::util::event_policy::{EventLane as Lane, EventPolicy};
+
+use super::RuntimeEvent;
+
+const MUST_DELIVER_OVERFLOW_MAX: usize = 1024;
+
+struct DeferredRuntimeEvent {
+    event: RuntimeEvent,
+    event_kind: &'static str,
+    policy: EventPolicy,
+}
+
+pub(super) struct MustDeliverOverflow {
+    queue: Mutex<VecDeque<DeferredRuntimeEvent>>,
+    drainer_running: AtomicBool,
+}
+
+impl MustDeliverOverflow {
+    pub(super) fn new() -> Self {
+        Self {
+            queue: Mutex::new(VecDeque::new()),
+            drainer_running: AtomicBool::new(false),
+        }
+    }
+
+    pub(super) fn push(
+        self: &Arc<Self>,
+        tx: Sender<RuntimeEvent>,
+        event: RuntimeEvent,
+        event_kind: &'static str,
+        policy: EventPolicy,
+    ) {
+        let item = DeferredRuntimeEvent {
+            event,
+            event_kind,
+            policy,
+        };
+        let start_drainer = {
+            let mut queue = self.queue.lock().unwrap_or_else(|e| e.into_inner());
+            if queue.len() >= MUST_DELIVER_OVERFLOW_MAX {
+                drop(queue);
+                tracing::warn!(
+                    event_policy = policy.name(),
+                    event_lane = policy.lane().map(Lane::name).unwrap_or("none"),
+                    event_kind,
+                    drop_reason = "must_deliver_overflow_fallback",
+                    "runtime must-deliver overflow full; falling back to direct deferred send"
+                );
+                defer_direct(tx, item.event, item.event_kind, item.policy);
+                return;
+            }
+            queue.push_back(item);
+            !self.drainer_running.swap(true, Ordering::AcqRel)
+        };
+        if start_drainer {
+            spawn_drainer(Arc::clone(self), tx);
+        }
+    }
+
+    fn pop_or_stop(&self) -> Option<DeferredRuntimeEvent> {
+        let mut queue = self.queue.lock().unwrap_or_else(|e| e.into_inner());
+        match queue.pop_front() {
+            Some(item) => Some(item),
+            None => {
+                self.drainer_running.store(false, Ordering::Release);
+                None
+            }
+        }
+    }
+}
+
+fn spawn_drainer(overflow: Arc<MustDeliverOverflow>, tx: Sender<RuntimeEvent>) {
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        handle.spawn(async move {
+            while let Some(item) = overflow.pop_or_stop() {
+                if tx.send(item.event).await.is_err() {
+                    log_closed(item.event_kind, item.policy);
+                }
+            }
+        });
+    } else {
+        std::thread::spawn(move || {
+            while let Some(item) = overflow.pop_or_stop() {
+                if tx.blocking_send(item.event).is_err() {
+                    log_closed(item.event_kind, item.policy);
+                }
+            }
+        });
+    }
+}
+
+fn defer_direct(
+    tx: Sender<RuntimeEvent>,
+    event: RuntimeEvent,
+    event_kind: &'static str,
+    policy: EventPolicy,
+) {
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        handle.spawn(async move {
+            if tx.send(event).await.is_err() {
+                log_closed(event_kind, policy);
+            }
+        });
+    } else {
+        std::thread::spawn(move || {
+            if tx.blocking_send(event).is_err() {
+                log_closed(event_kind, policy);
+            }
+        });
+    }
+}
+
+fn log_closed(event_kind: &'static str, policy: EventPolicy) {
+    tracing::error!(
+        event_policy = policy.name(),
+        event_lane = policy.lane().map(Lane::name).unwrap_or("none"),
+        event_kind,
+        drop_reason = "must_deliver_failed",
+        "runtime owner event queue closed before must-deliver event was accepted"
+    );
+}

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -35,6 +35,61 @@ fn update_status() -> crate::update::UpdateStatus {
     }
 }
 
+#[test]
+fn pending_player_cmds_coalesce_latest_setters_and_load() {
+    let mut pending = PendingPlayerCmds::default();
+    pending.push(PlayerCmd::SetVolume(10));
+    pending.push(PlayerCmd::SetProperty {
+        name: "speed".to_owned(),
+        value: serde_json::json!(1.2),
+    });
+    pending.push(PlayerCmd::Load("https://example.invalid/old".to_owned()));
+    pending.push(PlayerCmd::CyclePause);
+    pending.push(PlayerCmd::SetVolume(30));
+    pending.push(PlayerCmd::SetProperty {
+        name: "speed".to_owned(),
+        value: serde_json::json!(1.5),
+    });
+    pending.push(PlayerCmd::Load("https://example.invalid/new".to_owned()));
+
+    let drained = pending.drain();
+
+    assert_eq!(drained.len(), 4);
+    assert!(
+        drained
+            .iter()
+            .any(|cmd| matches!(cmd, PlayerCmd::CyclePause))
+    );
+    assert!(
+        drained
+            .iter()
+            .any(|cmd| matches!(cmd, PlayerCmd::SetVolume(30)))
+    );
+    assert!(drained.iter().any(|cmd| {
+        matches!(cmd, PlayerCmd::SetProperty { name, value } if name == "speed" && value == &serde_json::json!(1.5))
+    }));
+    assert!(drained.iter().any(|cmd| {
+        matches!(cmd, PlayerCmd::Load(url) if url == "https://example.invalid/new")
+    }));
+}
+
+#[test]
+fn pending_player_cmds_cap_keeps_latest_load() {
+    let mut pending = PendingPlayerCmds::default();
+    pending.push(PlayerCmd::Load(
+        "https://example.invalid/current".to_owned(),
+    ));
+    for i in 0..80 {
+        pending.push(PlayerCmd::SeekRelative(i as f64));
+    }
+
+    assert_eq!(pending.len(), PENDING_PLAYER_CMDS_MAX);
+    let drained = pending.drain();
+    assert!(drained.iter().any(|cmd| {
+        matches!(cmd, PlayerCmd::Load(url) if url == "https://example.invalid/current")
+    }));
+}
+
 fn assert_policy(event: RuntimeEvent, expected: EventPolicy) {
     assert_eq!(event.policy(), expected);
 }

--- a/src/scrobble/mod.rs
+++ b/src/scrobble/mod.rs
@@ -158,6 +158,11 @@ impl ScrobbleHandle {
         }
     }
 
+    pub fn heartbeat_due(&self) -> bool {
+        self.last_sent
+            .is_none_or(|t| t.elapsed().as_secs_f64() >= 1.0)
+    }
+
     pub fn reconfigure(&self, settings: ScrobbleSettings) {
         let _ = self
             .tx

--- a/src/session.rs
+++ b/src/session.rs
@@ -112,6 +112,12 @@ impl SessionCache {
         // holds is itself capped on restore.
         const MAX_BYTES: u64 = 32 * 1024 * 1024;
         let cache = safe_fs::load_json_or_default_limited::<SessionCache>(path, MAX_BYTES);
+        let cache = crate::persist::replay_journaled_snapshot(
+            crate::persist::StoreKind::Session,
+            path,
+            cache,
+            MAX_BYTES,
+        );
         if cache.schema_version != SESSION_SCHEMA_VERSION
             || cache.app_version != env!("CARGO_PKG_VERSION")
         {
@@ -130,7 +136,7 @@ impl SessionCache {
     }
 }
 
-fn session_cache_path() -> Option<PathBuf> {
+pub(crate) fn session_cache_path() -> Option<PathBuf> {
     crate::paths::cache_dir().map(|d| d.join(SESSION_CACHE_FILE))
 }
 

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -95,6 +95,12 @@ impl Signals {
         };
         // Schema-drift tolerant: a renamed field can no longer wipe the whole play history.
         let mut sig = safe_fs::load_json_or_default_limited::<Signals>(&path, SIGNALS_MAX_BYTES);
+        sig = crate::persist::replay_journaled_snapshot(
+            crate::persist::StoreKind::Signals,
+            &path,
+            sig,
+            SIGNALS_MAX_BYTES,
+        );
         sig.enforce_caps();
         sig
     }
@@ -309,7 +315,7 @@ pub fn unix_now() -> i64 {
         .unwrap_or(0)
 }
 
-fn signals_path() -> Option<PathBuf> {
+pub(crate) fn signals_path() -> Option<PathBuf> {
     crate::paths::data_dir().map(|d| d.join("signals.json"))
 }
 

--- a/src/station.rs
+++ b/src/station.rs
@@ -116,7 +116,13 @@ impl StationStore {
         // Schema-drift tolerant: preserves the active station across incompatible changes.
         // Size-capped like the sibling Playlists load.
         const MAX_BYTES: u64 = 16 * 1024 * 1024;
-        safe_fs::load_json_or_default_limited::<StationStore>(&path, MAX_BYTES)
+        let store = safe_fs::load_json_or_default_limited::<StationStore>(&path, MAX_BYTES);
+        crate::persist::replay_journaled_snapshot(
+            crate::persist::StoreKind::Station,
+            &path,
+            store,
+            MAX_BYTES,
+        )
     }
 
     /// Persist atomically (temp file + rename). A missing data dir is a no-op.
@@ -148,7 +154,7 @@ fn normalize_keys(names: &[String]) -> Vec<String> {
     out
 }
 
-fn station_path() -> Option<PathBuf> {
+pub(crate) fn station_path() -> Option<PathBuf> {
     crate::paths::data_dir().map(|d| d.join("station.json"))
 }
 

--- a/src/tools/ytdlp.rs
+++ b/src/tools/ytdlp.rs
@@ -5,6 +5,7 @@
 //! ```text
 //! tools/
 //!   yt-dlp[.exe]     the managed standalone binary (official release asset)
+//!   yt-dlp.previous[.exe] previous verified managed binary for playback self-heal rollback
 //!   ytdlp.json       ManagedState: channel/version/check timestamps + probe cache
 //!   .update.lock     cross-process single-flight for downloads (bandwidth dedup)
 //!   .yt-dlp.tmp-<pid> in-flight download (atomically renamed into place)
@@ -38,6 +39,8 @@ use crate::util::safe_fs;
 
 use super::{ToolsEvent, YtdlpChannel};
 
+mod rollback;
+
 /// Upper bound on probe-cache entries (override + managed + system is 3; a few
 /// spares for paths that moved).
 const PROBE_CACHE_MAX: usize = 8;
@@ -59,6 +62,18 @@ pub struct ManagedState {
     pub installed_mtime_unix: Option<u64>,
     /// Last verified byte length of the installed managed binary.
     pub installed_len: Option<u64>,
+    /// Channel of the previous verified managed binary, if one is retained.
+    pub previous_channel: Option<YtdlpChannel>,
+    /// Version (release tag) of the previous verified managed binary.
+    pub previous_version: Option<String>,
+    /// Hex SHA-256 the previous managed binary was verified against.
+    pub previous_sha256: Option<String>,
+    /// Last verified mtime of the previous managed binary.
+    pub previous_mtime_unix: Option<u64>,
+    /// Last verified byte length of the previous managed binary.
+    pub previous_len: Option<u64>,
+    /// Unix seconds of the last automatic rollback.
+    pub last_rollback_unix: Option<u64>,
     /// Unix seconds of the last *successful* update check.
     pub last_check_unix: Option<u64>,
     /// Unix seconds of the last check *attempt* (backoff for failing networks).
@@ -103,6 +118,16 @@ pub fn managed_path() -> Option<PathBuf> {
         "yt-dlp.exe"
     } else {
         "yt-dlp"
+    };
+    tools_dir().map(|d| d.join(name))
+}
+
+/// Last verified managed binary retained for rollback after a bad update.
+pub fn previous_managed_path() -> Option<PathBuf> {
+    let name = if cfg!(windows) {
+        "yt-dlp.previous.exe"
+    } else {
+        "yt-dlp.previous"
     };
     tools_dir().map(|d| d.join(name))
 }
@@ -250,6 +275,55 @@ async fn managed_installation_matches(
         return Err("metadata file stamp does not match installed binary".to_owned());
     }
     Ok(actual)
+}
+
+fn preserve_current_as_previous(dest: &Path, state: &mut ManagedState) -> std::io::Result<bool> {
+    let Some(previous) = previous_managed_path() else {
+        return Ok(false);
+    };
+    let Some(version) = state.version.clone() else {
+        return Ok(false);
+    };
+    let Some(sha256) = state.sha256.clone() else {
+        return Ok(false);
+    };
+    if !dest.is_file() || !state_stamp_matches(dest, state) {
+        return Ok(false);
+    }
+
+    copy_binary_atomic(dest, &previous)?;
+    let Some((mtime, len)) = file_stamp(&previous) else {
+        return Ok(false);
+    };
+    state.previous_channel = state.channel;
+    state.previous_version = Some(version);
+    state.previous_sha256 = Some(sha256);
+    state.previous_mtime_unix = Some(mtime);
+    state.previous_len = Some(len);
+    Ok(true)
+}
+
+fn previous_stamp_matches(path: &Path, state: &ManagedState) -> bool {
+    file_stamp(path).is_some_and(|(mtime, len)| {
+        state.previous_mtime_unix == Some(mtime) && state.previous_len == Some(len)
+    })
+}
+
+fn record_current_from_inspection(
+    state: &mut ManagedState,
+    channel: Option<YtdlpChannel>,
+    inspection: &BinaryInspection,
+) {
+    state.channel = channel;
+    state.version = Some(inspection.version.clone());
+    state.sha256 = Some(inspection.sha256.clone());
+    state.installed_mtime_unix = Some(inspection.mtime_unix);
+    state.installed_len = Some(inspection.len);
+}
+
+fn remove_probe_cache_for(path: &Path, state: &mut ManagedState) {
+    let path_str = path.to_string_lossy().into_owned();
+    state.probe_cache.retain(|e| e.path != path_str);
 }
 
 /// Probe a binary's version through the persistent cache: a hit for the same
@@ -413,6 +487,21 @@ pub async fn check_and_update(
     outcome
 }
 
+pub async fn rollback_or_check_and_update(
+    cfg: &ToolsConfig,
+    progress: &(dyn Fn(ToolsEvent) + Sync),
+    reason: &str,
+) -> UpdateOutcome {
+    match rollback::to_previous(cfg, reason).await {
+        UpdateOutcome::Installed { version } => UpdateOutcome::Installed { version },
+        UpdateOutcome::AlreadyCurrent => UpdateOutcome::AlreadyCurrent,
+        UpdateOutcome::Unavailable(error) => {
+            tracing::debug!(error = %error, "managed yt-dlp rollback unavailable");
+            check_and_update(cfg, progress).await
+        }
+    }
+}
+
 async fn check_and_update_inner(
     cfg: &ToolsConfig,
     progress: &(dyn Fn(ToolsEvent) + Sync),
@@ -527,6 +616,17 @@ async fn check_and_update_inner(
             "checksum mismatch for {asset} {tag} — download discarded"
         ));
     }
+    match preserve_current_as_previous(&dest, &mut state) {
+        Ok(true) => {}
+        Ok(false) => {}
+        Err(error) => {
+            tracing::warn!(
+                path = %dest.display(),
+                error = %error,
+                "failed to preserve previous managed yt-dlp before update"
+            );
+        }
+    }
     if let Err(e) = install_file(&tmp, &dest) {
         let _ = std::fs::remove_file(&tmp);
         save_state(&state);
@@ -553,15 +653,10 @@ async fn check_and_update_inner(
         ));
     }
 
-    state.channel = Some(channel);
-    state.version = Some(tag.clone());
-    state.sha256 = Some(installed.sha256);
-    state.installed_mtime_unix = Some(installed.mtime_unix);
-    state.installed_len = Some(installed.len);
+    record_current_from_inspection(&mut state, Some(channel), &installed);
     state.last_check_unix = Some(now_unix());
     // The fresh binary re-probes on next selection (its mtime/len changed anyway).
-    let dest_str = dest.to_string_lossy().into_owned();
-    state.probe_cache.retain(|e| e.path != dest_str);
+    remove_probe_cache_for(&dest, &mut state);
     save_state(&state);
 
     super::refresh_selection(cfg).await;
@@ -1029,6 +1124,55 @@ pub(crate) fn install_file(tmp: &Path, dest: &Path) -> std::io::Result<()> {
     }
 }
 
+fn copy_binary_to_install_temp(src: &Path, dir: &Path) -> std::io::Result<PathBuf> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let tmp = dir.join(format!(".yt-dlp.rollback-{}-{nanos}", std::process::id()));
+    std::fs::copy(src, &tmp)?;
+    let file = std::fs::OpenOptions::new().read(true).open(&tmp)?;
+    file.sync_all()?;
+    drop(file);
+    Ok(tmp)
+}
+
+fn copy_binary_atomic(src: &Path, dest: &Path) -> std::io::Result<()> {
+    let Some(dir) = dest.parent() else {
+        return Err(std::io::Error::other("destination has no parent"));
+    };
+    safe_fs::ensure_private_dir(dir)?;
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let name = dest
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("yt-dlp.previous");
+    let tmp = dest.with_file_name(format!(".{name}.tmp-{}-{nanos}", std::process::id()));
+    std::fs::copy(src, &tmp)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755))?;
+    }
+    let file = std::fs::OpenOptions::new().read(true).open(&tmp)?;
+    file.sync_all()?;
+    drop(file);
+    #[cfg(windows)]
+    {
+        retry_file_op(|| {
+            let _ = std::fs::remove_file(dest);
+            std::fs::rename(&tmp, dest)
+        })
+    }
+    #[cfg(not(windows))]
+    {
+        std::fs::rename(&tmp, dest)
+    }
+}
+
 #[cfg(windows)]
 fn retry_file_op(mut op: impl FnMut() -> std::io::Result<()>) -> std::io::Result<()> {
     let mut last = None;
@@ -1058,6 +1202,12 @@ mod tests {
             sha256: Some("ab".repeat(32)),
             installed_mtime_unix: Some(1_780_000_050),
             installed_len: Some(42),
+            previous_channel: Some(YtdlpChannel::Stable),
+            previous_version: Some("2026.06.30".to_owned()),
+            previous_sha256: Some("cd".repeat(32)),
+            previous_mtime_unix: Some(1_780_000_040),
+            previous_len: Some(41),
+            last_rollback_unix: Some(1_780_000_120),
             last_check_unix: Some(1_780_000_000),
             last_attempt_unix: Some(1_780_000_100),
             probe_cache: vec![ProbeEntry {
@@ -1072,6 +1222,10 @@ mod tests {
         assert_eq!(back.version.as_deref(), Some("2026.07.03.234421"));
         assert_eq!(back.installed_mtime_unix, Some(1_780_000_050));
         assert_eq!(back.installed_len, Some(42));
+        assert_eq!(back.previous_channel, Some(YtdlpChannel::Stable));
+        assert_eq!(back.previous_version.as_deref(), Some("2026.06.30"));
+        assert_eq!(back.previous_len, Some(41));
+        assert_eq!(back.last_rollback_unix, Some(1_780_000_120));
         assert_eq!(back.probe_cache, state.probe_cache);
 
         // An empty/older file loads as defaults (never fails).
@@ -1103,6 +1257,42 @@ mod tests {
                     .to_string_lossy()
                     .starts_with("yt-dlp")
             );
+        }
+    }
+
+    #[test]
+    fn preserve_current_records_previous_slot_metadata() {
+        let _guard = crate::i18n::lock_for_test();
+        let original_tools_dir = std::env::var_os("YTM_TOOLS_DIR");
+        let dir = std::env::temp_dir().join(format!("ytt-ytdlp-prev-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        unsafe { std::env::set_var("YTM_TOOLS_DIR", &dir) };
+
+        let dest = managed_path().unwrap();
+        std::fs::write(&dest, b"previous-binary").unwrap();
+        let (mtime, len) = file_stamp(&dest).unwrap();
+        let sha256 = sha256_file(&dest).unwrap();
+        let mut state = ManagedState {
+            channel: Some(YtdlpChannel::Nightly),
+            version: Some("2026.07.03.234421".to_owned()),
+            sha256: Some(sha256.clone()),
+            installed_mtime_unix: Some(mtime),
+            installed_len: Some(len),
+            ..ManagedState::default()
+        };
+
+        assert!(preserve_current_as_previous(&dest, &mut state).unwrap());
+        let previous = previous_managed_path().unwrap();
+        assert_eq!(std::fs::read(&previous).unwrap(), b"previous-binary");
+        assert_eq!(state.previous_channel, Some(YtdlpChannel::Nightly));
+        assert_eq!(state.previous_version.as_deref(), Some("2026.07.03.234421"));
+        assert_eq!(state.previous_sha256.as_deref(), Some(sha256.as_str()));
+        assert!(previous_stamp_matches(&previous, &state));
+
+        let _ = std::fs::remove_dir_all(&dir);
+        match original_tools_dir {
+            Some(value) => unsafe { std::env::set_var("YTM_TOOLS_DIR", value) },
+            None => unsafe { std::env::remove_var("YTM_TOOLS_DIR") },
         }
     }
 

--- a/src/tools/ytdlp/rollback.rs
+++ b/src/tools/ytdlp/rollback.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+pub(super) async fn to_previous(cfg: &ToolsConfig, reason: &str) -> UpdateOutcome {
+    use UpdateOutcome::Unavailable;
+
+    if !cfg.managed_enabled() {
+        return Unavailable("managed yt-dlp is disabled".into());
+    }
+    if !matches!(
+        crate::tools::ytdlp_selection().map(|selection| selection.source),
+        Some(crate::tools::YtdlpSource::Managed)
+    ) {
+        return Unavailable("managed yt-dlp is not the active selection".into());
+    }
+    let (Some(dir), Some(dest), Some(previous)) =
+        (tools_dir(), managed_path(), previous_managed_path())
+    else {
+        return Unavailable("no data directory on this platform".into());
+    };
+    if !previous.is_file() {
+        return Unavailable("no previous managed yt-dlp binary retained".into());
+    }
+    let Some(_lock) = acquire_update_lock_observing(&dir).await else {
+        crate::tools::refresh_selection(cfg).await;
+        return Unavailable("another update is already running".into());
+    };
+
+    let mut state = load_state();
+    if let Some(expected) = state.previous_sha256.as_deref()
+        && previous_stamp_matches(&previous, &state)
+    {
+        match sha256_file(&previous) {
+            Ok(actual) if expected.eq_ignore_ascii_case(&actual) => {}
+            Ok(_) => return Unavailable("previous yt-dlp checksum mismatch".into()),
+            Err(error) => {
+                return Unavailable(format!(
+                    "cannot hash previous yt-dlp {}: {error}",
+                    previous.display()
+                ));
+            }
+        }
+    }
+
+    let installed = match inspect_binary(&previous).await {
+        Ok(inspection) => inspection,
+        Err(error) => {
+            return Unavailable(format!("previous managed yt-dlp is not usable: {error}"));
+        }
+    };
+    if let Some(expected) = state.previous_version.as_deref()
+        && installed.version != expected
+    {
+        return Unavailable(format!(
+            "previous yt-dlp reports {}, expected {expected}",
+            installed.version
+        ));
+    }
+
+    let tmp = match copy_binary_to_install_temp(&previous, &dir) {
+        Ok(tmp) => tmp,
+        Err(error) => {
+            return Unavailable(format!(
+                "failed to stage previous yt-dlp {}: {error}",
+                previous.display()
+            ));
+        }
+    };
+    if let Err(error) = install_file(&tmp, &dest) {
+        let _ = std::fs::remove_file(&tmp);
+        return Unavailable(format!(
+            "failed to rollback managed yt-dlp {}: {error}",
+            dest.display()
+        ));
+    }
+
+    let current = match inspect_binary(&dest).await {
+        Ok(inspection) => inspection,
+        Err(error) => {
+            return Unavailable(format!(
+                "rolled back managed yt-dlp failed verification: {error}"
+            ));
+        }
+    };
+    if current.sha256 != installed.sha256 || current.version != installed.version {
+        return Unavailable("rolled back yt-dlp does not match previous binary".into());
+    }
+
+    let previous_channel = state.previous_channel;
+    record_current_from_inspection(&mut state, previous_channel, &current);
+    state.last_rollback_unix = Some(now_unix());
+    remove_probe_cache_for(&dest, &mut state);
+    save_state(&state);
+    crate::tools::refresh_selection(cfg).await;
+    tracing::warn!(
+        reason,
+        version = %current.version,
+        "rolled back managed yt-dlp to previous binary"
+    );
+    UpdateOutcome::Installed {
+        version: current.version,
+    }
+}

--- a/src/ui/anim.rs
+++ b/src/ui/anim.rs
@@ -34,8 +34,11 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::app::{App, Mode, ScrollSurface};
+use crate::app::{App, Mode};
 use crate::theme::ThemeRole as R;
+use crate::ui::marquee::col_window;
+
+pub use crate::ui::marquee::selected_marquee;
 
 /// One-shot effect windows, in wall-clock milliseconds. `App::detect_fx` arms the clock with
 /// these; the matching render helpers here derive their progress from the same values, so
@@ -147,71 +150,6 @@ fn put_char(buf: &mut Buffer, x: u16, y: u16, ch: char, style: Style) {
     if let Some(cell) = buf.cell_mut((x, y)) {
         cell.set_char(ch).set_style(style);
     }
-}
-
-/// Extract the `[start_col, start_col + width)` display-column slice of `s` (CJK-aware), used for
-/// the title marquee window.
-fn col_window(s: &str, start_col: usize, width: usize) -> String {
-    let mut out = String::new();
-    let mut col = 0usize;
-    let mut taken = 0usize;
-    for ch in s.chars() {
-        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if col < start_col {
-            col += w;
-            continue;
-        }
-        if taken + w > width {
-            break;
-        }
-        out.push(ch);
-        taken += w;
-    }
-    out
-}
-
-/// One marquee column-step per this many animation frames (~5 cols/s at the default
-/// 30 fps tick — slow enough to read along), and how many steps the window holds at the
-/// text's head before it starts crawling, so a freshly selected row reads naturally from
-/// its beginning.
-const MARQUEE_FRAME_DIV: u64 = 6;
-const MARQUEE_START_HOLD: u64 = 4;
-
-/// The always-on selected-row marquee: the visible slice of the focused list's cursor-row
-/// text. When it fits in `avail` columns it comes back unchanged; when it overflows, a
-/// wrap-around window (three-space gap) crawls left one column per [`MARQUEE_FRAME_DIV`]
-/// frames, restarting from the head whenever the cursor moves to a different row.
-///
-/// Unlike every other effect this runs with the animation masters OFF too — reading a
-/// clipped row shouldn't require opting into eye-candy. Recording the row in
-/// `bridges.marquee_ran` is what keeps the animation clock awake for it
-/// (`App::animation_active` ORs the flag in), so the phase source below never freezes
-/// while a clipped row is selected.
-pub fn selected_marquee(
-    app: &App,
-    surface: ScrollSurface,
-    index: usize,
-    text: &str,
-    avail: usize,
-) -> String {
-    let total = UnicodeWidthStr::width(text);
-    if avail <= 4 || total <= avail {
-        return text.to_owned();
-    }
-    let key = Some((surface, index));
-    if app.bridges.marquee_key.get() != key {
-        app.bridges.marquee_key.set(key);
-        app.bridges.marquee_origin.set(app.anim_frame());
-    }
-    app.bridges.marquee_ran.set(true);
-    let loop_s = format!("{text}   ");
-    let period = UnicodeWidthStr::width(loop_s.as_str()).max(1);
-    let elapsed = app
-        .anim_frame()
-        .wrapping_sub(app.bridges.marquee_origin.get());
-    let start =
-        ((elapsed / MARQUEE_FRAME_DIV).saturating_sub(MARQUEE_START_HOLD)) as usize % period;
-    col_window(&format!("{loop_s}{loop_s}"), start, avail)
 }
 
 // ── element-level effects ───────────────────────────────────────────────────
@@ -1349,7 +1287,7 @@ fn bounce(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{App, Msg};
+    use crate::app::{App, Msg, ScrollSurface};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use std::time::{Duration, Instant};

--- a/src/ui/marquee.rs
+++ b/src/ui/marquee.rs
@@ -1,0 +1,88 @@
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::app::{App, ScrollSurface};
+
+const MARQUEE_FRAME_DIV: u64 = 6;
+const MARQUEE_START_HOLD: u64 = 4;
+
+#[derive(Default)]
+pub struct MarqueeCache {
+    key: Option<(ScrollSurface, usize)>,
+    text: String,
+    avail: usize,
+    looped_twice: String,
+    period: usize,
+}
+
+impl MarqueeCache {
+    fn refresh(
+        &mut self,
+        surface: ScrollSurface,
+        index: usize,
+        text: &str,
+        avail: usize,
+        width: usize,
+    ) {
+        let key = Some((surface, index));
+        if self.key == key && self.avail == avail && self.text == text {
+            return;
+        }
+        self.key = key;
+        self.avail = avail;
+        self.text.clear();
+        self.text.push_str(text);
+        self.looped_twice.clear();
+        self.looped_twice.reserve(text.len().saturating_mul(2) + 6);
+        self.looped_twice.push_str(text);
+        self.looped_twice.push_str("   ");
+        self.looped_twice.push_str(text);
+        self.looped_twice.push_str("   ");
+        self.period = width.saturating_add(3).max(1);
+    }
+}
+
+pub(crate) fn col_window(s: &str, start_col: usize, width: usize) -> String {
+    let mut out = String::with_capacity(width.min(s.len()));
+    let mut col = 0usize;
+    let mut taken = 0usize;
+    for ch in s.chars() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if col < start_col {
+            col += w;
+            continue;
+        }
+        if taken + w > width {
+            break;
+        }
+        out.push(ch);
+        taken += w;
+    }
+    out
+}
+
+pub fn selected_marquee(
+    app: &App,
+    surface: ScrollSurface,
+    index: usize,
+    text: &str,
+    avail: usize,
+) -> String {
+    let total = UnicodeWidthStr::width(text);
+    if avail <= 4 || total <= avail {
+        return text.to_owned();
+    }
+    let key = Some((surface, index));
+    if app.bridges.marquee_key.get() != key {
+        app.bridges.marquee_key.set(key);
+        app.bridges.marquee_origin.set(app.anim_frame());
+    }
+    app.bridges.marquee_ran.set(true);
+    let elapsed = app
+        .anim_frame()
+        .wrapping_sub(app.bridges.marquee_origin.get());
+    let mut cache = app.bridges.marquee_cache.borrow_mut();
+    cache.refresh(surface, index, text, avail, total);
+    let start =
+        ((elapsed / MARQUEE_FRAME_DIV).saturating_sub(MARQUEE_START_HOLD)) as usize % cache.period;
+    col_window(&cache.looped_twice, start, avail)
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,6 +3,7 @@
 pub mod anim;
 pub mod ascii_art;
 pub mod buttons;
+pub mod marquee;
 pub mod mascot;
 pub mod retro;
 pub mod scroll;

--- a/src/ui/views/ai.rs
+++ b/src/ui/views/ai.rs
@@ -86,7 +86,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             };
             frame.render_widget(
                 Paragraph::new(
-                    Line::from(app.status.text.clone())
+                    Line::from(app.status.text.as_str())
                         .style(app.theme.style(role))
                         .alignment(Alignment::Center),
                 ),

--- a/src/ui/views/library.rs
+++ b/src/ui/views/library.rs
@@ -70,7 +70,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             };
             frame.render_widget(
                 Paragraph::new(
-                    Line::from(app.status.text.clone())
+                    Line::from(app.status.text.as_str())
                         .style(app.theme.style(role))
                         .alignment(Alignment::Center),
                 ),

--- a/src/ui/views/player.rs
+++ b/src/ui/views/player.rs
@@ -74,7 +74,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             };
             frame.render_widget(
                 Paragraph::new(
-                    Line::from(app.status.text.clone())
+                    Line::from(app.status.text.as_str())
                         .style(app.theme.style(role))
                         .alignment(Alignment::Center),
                 ),
@@ -341,7 +341,7 @@ fn render_status_line(frame: &mut Frame, app: &App, area: Rect) {
 /// drop away, so the clickable toggles never fall off the right edge.
 fn status_line_parts_at(
     app: &App,
-    gap: &str,
+    gap: &'static str,
     minimal: bool,
 ) -> Vec<(Option<MouseTarget>, Cow<'static, str>)> {
     let retro = app.retro_mode();
@@ -365,7 +365,7 @@ fn status_line_parts_at(
         let (pos, _) = app.queue.position();
         // Clickable (opens the queue window) but styled exactly like the labels around it,
         // so the line looks unchanged — same as the `S:`/`R:` toggles next to it.
-        parts.push((None, Cow::Owned(gap.to_owned())));
+        parts.push((None, Cow::Borrowed(gap)));
         parts.push((
             Some(MouseTarget::QueuePos),
             Cow::Owned(format!("{pos}/{}", app.queue.len())),
@@ -377,7 +377,7 @@ fn status_line_parts_at(
     if let Some(cur) = app.queue.current() {
         let liked = app.library.is_favorite(&cur.video_id);
         let disliked = app.signals.is_disliked(&cur.video_id);
-        parts.push((None, Cow::Owned(gap.to_owned())));
+        parts.push((None, Cow::Borrowed(gap)));
         parts.push((
             Some(MouseTarget::Player(Action::CycleRating)),
             Cow::Borrowed(rating_glyph(liked, disliked, retro)),
@@ -390,7 +390,7 @@ fn status_line_parts_at(
     // On a live radio stream the same two slots (and the same actions/keys behind them)
     // read as the live transport instead: `LIVE:` sync verdict, `SYNC:` re-sync.
     if app.current_is_radio_stream() {
-        parts.push((None, Cow::Owned(gap.to_owned())));
+        parts.push((None, Cow::Borrowed(gap)));
         parts.push((
             Some(MouseTarget::Player(Action::ToggleShuffle)),
             Cow::Owned(format!(
@@ -398,7 +398,7 @@ fn status_line_parts_at(
                 live_sync_glyph(app.radio_live_synced(), retro)
             )),
         ));
-        parts.push((None, Cow::Owned(gap.to_owned())));
+        parts.push((None, Cow::Borrowed(gap)));
         parts.push((
             Some(MouseTarget::Player(Action::CycleRepeat)),
             Cow::Owned(format!("SYNC:{}", resync_glyph(retro))),
@@ -406,7 +406,7 @@ fn status_line_parts_at(
         // The "what's playing" card — now ICY-metadata-backed, so always offered on a live
         // radio stream, DJ Gem or not. A text label, not a glyph: EAW-ambiguous symbols
         // (♪ …) render wide on some CJK terminals and would drift every later hit rect.
-        parts.push((None, Cow::Owned(gap.to_owned())));
+        parts.push((None, Cow::Borrowed(gap)));
         parts.push((
             Some(MouseTarget::Player(Action::IdentifyNowPlaying)),
             Cow::Borrowed(t!("ID?", "지듣노")),
@@ -415,19 +415,19 @@ fn status_line_parts_at(
         // text label (not a glyph) for the same EAW-neutral reason as `ID?` above — an
         // ambiguous-width mark would drift later hit rects on some CJK terminals.
         if app.recorder.is_recording() {
-            parts.push((None, Cow::Owned(gap.to_owned())));
+            parts.push((None, Cow::Borrowed(gap)));
             parts.push((
                 Some(MouseTarget::Player(Action::ToggleRecordings)),
                 Cow::Borrowed(t!("REC", "녹음")),
             ));
         }
     } else {
-        parts.push((None, Cow::Owned(gap.to_owned())));
+        parts.push((None, Cow::Borrowed(gap)));
         parts.push((
             Some(MouseTarget::Player(Action::ToggleShuffle)),
             Cow::Owned(format!("S:{}", shuffle_glyph(app.queue.shuffle, retro))),
         ));
-        parts.push((None, Cow::Owned(gap.to_owned())));
+        parts.push((None, Cow::Borrowed(gap)));
         parts.push((
             Some(MouseTarget::Player(Action::CycleRepeat)),
             Cow::Owned(format!("R:{}", repeat_glyph(app.queue.repeat, retro))),
@@ -436,7 +436,7 @@ fn status_line_parts_at(
     if !minimal && (app.playback.speed - 1.0).abs() > f64::EPSILON {
         parts.push((None, Cow::Owned(format!("{gap}{:.1}x", app.playback.speed))));
     }
-    parts.push((None, Cow::Owned(gap.to_owned())));
+    parts.push((None, Cow::Borrowed(gap)));
     parts.push((
         Some(MouseTarget::EqMenu),
         Cow::Owned(format!("eq:{}", app.audio.preset.label())),
@@ -448,7 +448,7 @@ fn status_line_parts_at(
     if app.streaming_active() {
         // Show the station's mode (Focused/Balanced/Discovery) as a click target that opens the
         // mode dropdown — same affordance as the `eq:` label next to it.
-        parts.push((None, Cow::Owned(gap.to_owned())));
+        parts.push((None, Cow::Borrowed(gap)));
         parts.push((
             Some(MouseTarget::StreamingMenu),
             Cow::Owned(format!(

--- a/src/ui/views/search.rs
+++ b/src/ui/views/search.rs
@@ -59,7 +59,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             };
             frame.render_widget(
                 Paragraph::new(
-                    Line::from(app.status.text.clone())
+                    Line::from(app.status.text.as_str())
                         .style(app.theme.style(role))
                         .alignment(Alignment::Center),
                 ),

--- a/src/ui/views/settings.rs
+++ b/src/ui/views/settings.rs
@@ -165,7 +165,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             };
             frame.render_widget(
                 Paragraph::new(
-                    Line::from(app.status.text.clone())
+                    Line::from(app.status.text.as_str())
                         .style(theme.style(role))
                         .alignment(Alignment::Center),
                 ),

--- a/src/util/blocking.rs
+++ b/src/util/blocking.rs
@@ -1,0 +1,44 @@
+//! Shared budget for `spawn_blocking` work.
+//!
+//! Tokio's blocking pool can grow under pressure. The app already keeps the async runtime small,
+//! so CPU-heavy image work and IO-heavy scans/saves get explicit process-wide budgets too.
+
+use std::sync::{Arc, LazyLock};
+
+use tokio::sync::Semaphore;
+use tokio::task::JoinError;
+
+static CPU_BLOCKING: LazyLock<Arc<Semaphore>> = LazyLock::new(|| Arc::new(Semaphore::new(2)));
+static IO_BLOCKING: LazyLock<Arc<Semaphore>> = LazyLock::new(|| Arc::new(Semaphore::new(2)));
+
+pub async fn spawn_cpu<F, R>(work: F) -> Result<R, JoinError>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    spawn_with_budget(Arc::clone(&CPU_BLOCKING), work).await
+}
+
+pub async fn spawn_io<F, R>(work: F) -> Result<R, JoinError>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    spawn_with_budget(Arc::clone(&IO_BLOCKING), work).await
+}
+
+async fn spawn_with_budget<F, R>(budget: Arc<Semaphore>, work: F) -> Result<R, JoinError>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let permit = budget
+        .acquire_owned()
+        .await
+        .expect("blocking budget semaphore is never closed");
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        work()
+    })
+    .await
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -17,6 +17,7 @@ pub fn finite_or_f32(x: f32, default: f32) -> f32 {
 
 pub mod art;
 pub mod backpressure;
+pub mod blocking;
 pub mod browser;
 pub mod event_policy;
 pub mod format;

--- a/src/util/safe_fs.rs
+++ b/src/util/safe_fs.rs
@@ -7,6 +7,7 @@
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use std::time::UNIX_EPOCH;
 
 use serde::Serialize;
@@ -35,6 +36,36 @@ pub struct RecoveryBackup {
     pub label: String,
     pub len: u64,
     pub modified_unix: Option<u64>,
+}
+
+static DO_NOT_CLOBBER: OnceLock<Mutex<Vec<PathBuf>>> = OnceLock::new();
+
+fn do_not_clobber() -> &'static Mutex<Vec<PathBuf>> {
+    DO_NOT_CLOBBER.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn mark_do_not_clobber(path: &Path) {
+    let mut guard = do_not_clobber()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if !guard.iter().any(|p| p == path) {
+        guard.push(path.to_path_buf());
+    }
+}
+
+fn is_do_not_clobber(path: &Path) -> bool {
+    do_not_clobber()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .iter()
+        .any(|p| p == path)
+}
+
+fn clear_do_not_clobber(path: &Path) {
+    do_not_clobber()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .retain(|p| p != path);
 }
 
 #[cfg(unix)]
@@ -216,6 +247,18 @@ pub fn write_private_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
         ensure_private_dir(dir)?;
     }
     reject_symlink(path)?;
+    if is_do_not_clobber(path) {
+        if path.exists() {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!(
+                    "refusing to overwrite {} after recovery backup failed",
+                    path.display()
+                ),
+            ));
+        }
+        clear_do_not_clobber(path);
+    }
     let tmp = temp_path_for(path)?;
     let write_result = (|| {
         let mut file = create_private_file(&tmp)?;
@@ -425,6 +468,7 @@ where
         }
     };
     let Ok(text) = String::from_utf8(bytes) else {
+        let _ = backup_with_label(path, "unreadable");
         return T::default();
     };
     if let Ok(value) = serde_json::from_str::<T>(&text) {
@@ -606,6 +650,11 @@ pub fn backup_too_large_secret(path: &Path) -> io::Result<PathBuf> {
     backup_with_label_retained(path, "too-large", SECRET_BACKUP_RETENTION)
 }
 
+/// Secret-bearing backup for present-but-unreadable files.
+pub fn backup_unreadable_secret(path: &Path) -> io::Result<PathBuf> {
+    backup_with_label_retained(path, "unreadable", SECRET_BACKUP_RETENTION)
+}
+
 /// List app-created recovery backups for `path` without reading their contents.
 pub fn recovery_backups(path: &Path) -> io::Result<Vec<RecoveryBackup>> {
     recovery_backups_for_labels(path, RECOVERY_BACKUP_LABELS)
@@ -641,10 +690,39 @@ fn backup_with_label_inner(path: &Path, label: &str) -> io::Result<PathBuf> {
                 return Ok(bak);
             }
             Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
-            Err(e) => return Err(e),
+            Err(_) => match backup_by_copy(path, &bak) {
+                Ok(()) => return Ok(bak),
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(e) => {
+                    mark_do_not_clobber(path);
+                    return Err(e);
+                }
+            },
         }
     }
-    Err(io::Error::other("too many backups"))
+    let err = io::Error::other("too many backups");
+    mark_do_not_clobber(path);
+    Err(err)
+}
+
+fn backup_by_copy(path: &Path, bak: &Path) -> io::Result<()> {
+    let mut src = open_no_symlink(path)?;
+    let meta = src.metadata()?;
+    if !meta.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("not a regular file: {}", path.display()),
+        ));
+    }
+    let mut dst = create_private_file(bak)?;
+    io::copy(&mut src, &mut dst)?;
+    dst.sync_all()?;
+    drop(dst);
+    #[cfg(unix)]
+    fs::set_permissions(bak, fs::Permissions::from_mode(private_file_mode()))?;
+    fs::remove_file(path)?;
+    sync_parent_dir(path)?;
+    Ok(())
 }
 
 fn rotate_recovery_backups(
@@ -824,6 +902,12 @@ mod tests {
         assert!(!path.exists());
         assert!(path.with_extension("too-large.bak").exists());
 
+        // Invalid UTF-8 under the cap is still present-but-unreadable and must be preserved.
+        write_private_atomic(&path, &[0xff, 0xfe, 0xfd]).unwrap();
+        assert_eq!(load_json_or_default_limited::<S>(&path, 1024), S::default());
+        assert!(!path.exists());
+        assert!(path.with_extension("unreadable.bak").exists());
+
         // Missing file → default (no panic, no backup).
         let _ = fs::remove_dir_all(&dir);
         assert_eq!(load_json_or_default_limited::<S>(&path, 1024), S::default());
@@ -851,6 +935,39 @@ mod tests {
         let missing = dir.join("missing.json");
         assert_eq!(load_json_or_default::<S>(&missing), S::default());
         assert!(!missing.with_extension("unreadable.bak").exists());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn copy_backup_preserves_original_when_linking_is_unavailable() {
+        let dir = temp_root("backup-copy");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("s.json");
+        let bak = path.with_extension("corrupt.bak");
+        fs::write(&path, b"copy-me").unwrap();
+
+        backup_by_copy(&path, &bak).unwrap();
+
+        assert!(!path.exists());
+        assert_eq!(fs::read(&bak).unwrap(), b"copy-me");
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn failed_recovery_blocks_default_overwrite_until_original_is_removed() {
+        let dir = temp_root("backup-guard");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("s.json");
+        fs::write(&path, b"original").unwrap();
+
+        mark_do_not_clobber(&path);
+        let err = write_private_atomic(&path, b"replacement").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(fs::read(&path).unwrap(), b"original");
+
+        fs::remove_file(&path).unwrap();
+        write_private_atomic(&path, b"replacement").unwrap();
+        assert_eq!(fs::read(&path).unwrap(), b"replacement");
         let _ = fs::remove_dir_all(dir);
     }
 


### PR DESCRIPTION
## Summary
- Harden corrupt config/state recovery so preserved originals are not overwritten when backup fails, including invalid UTF-8 recovery coverage.
- Add persistence intent journaling/replay for important user actions and wire replay through persisted stores.
- Tighten mpv reaper identity checks, add ytdlp rollback handling, and classify player commands so critical playback commands are not silently lost under queue pressure.
- Include the broader runtime scheduling and allocation work already on this branch, including bounded must-deliver overflow draining, safer blocking helpers, and reduced hot-path churn.
- Keep the changes internal to runtime, persistence, process lifetime, and tool-management stability; no intentional UI/UX changes.

## Why
This branch targets the last failure boundaries around data preservation, shutdown/crash recovery, mpv process ownership, queue backpressure, managed tool rollback, and bursty runtime scheduling without changing the terminal interaction model.

## Validation
- `~/.fable-harness/bin/run-gates .` passed
  - fmt PASS
  - clippy PASS
  - test PASS
  - arch PASS
- Gate log: `/Users/ochi/.fable-harness/logs/gates/yututui-20260709-085415.log`
- Focused checks also covered safe_fs/config recovery, persistence, player queue behavior, mpv lifetime, and ytdlp tests.