### PR TITLE
Harden unsafe/FFI lint policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,12 @@ keywords = ["youtube-music", "tui", "music", "mpv", "yt-dlp"]
 categories = ["command-line-utilities", "multimedia::audio"]
 readme = "README.md"
 
+[lints.rust]
+unsafe_op_in_unsafe_fn = "deny"
+
+[lints.clippy]
+undocumented_unsafe_blocks = "deny"
+
 # The shipped command is `ytt` — short to type and what the README/installers expose.
 # The crate keeps the longer `yututui` name (and the config/data dir string stays
 # "yututui"), so this only renames the produced binary, nothing user-facing.

--- a/crates/ratatui-image/Cargo.toml
+++ b/crates/ratatui-image/Cargo.toml
@@ -35,6 +35,15 @@ keywords = [
 license = "MIT"
 repository = "https://github.com/ratatui/ratatui-image"
 
+[lints.rust]
+unsafe_op_in_unsafe_fn = "deny"
+
+[lints.clippy]
+undocumented_unsafe_blocks = "deny"
+# Vendored upstream noise: keep the fork rebaseable; do not mass-refactor for these.
+result_large_err = "allow"
+items_after_test_module = "allow"
+
 [package.metadata.docs.rs]
 features = ["crossterm"]
 rustdoc-args = [

--- a/crates/ratatui-image/src/picker.rs
+++ b/crates/ratatui-image/src/picker.rs
@@ -397,6 +397,8 @@ fn enable_raw_mode() -> Result<impl FnOnce() -> Result<()>> {
     let utf16: Vec<u16> = "CONIN$\0".encode_utf16().collect();
     let utf16_ptr: *const u16 = utf16.as_ptr();
 
+    // SAFETY: `utf16_ptr` points to a NUL-terminated "CONIN$" buffer that lives for
+    // the call; CreateFileW returns a Result-wrapped console input handle.
     let in_handle = unsafe {
         FileSystem::CreateFileW(
             PCWSTR(utf16_ptr),
@@ -410,13 +412,19 @@ fn enable_raw_mode() -> Result<impl FnOnce() -> Result<()>> {
     }?;
 
     let mut original_in_mode = CONSOLE_MODE::default();
+    // SAFETY: `in_handle` is the console input handle returned by CreateFileW and
+    // `original_in_mode` is valid output storage.
     unsafe { Console::GetConsoleMode(in_handle, &mut original_in_mode) }?;
 
     let requested_in_modes = !ENABLE_ECHO_INPUT & !ENABLE_LINE_INPUT & !ENABLE_PROCESSED_INPUT;
     let in_mode = original_in_mode & requested_in_modes;
+    // SAFETY: `in_handle` is a console input handle and `in_mode` is derived from the
+    // current mode by clearing documented raw-input flags.
     unsafe { Console::SetConsoleMode(in_handle, in_mode) }?;
 
     Ok(move || {
+        // SAFETY: restores the saved mode on the same console input handle; failure is
+        // returned to the caller.
         unsafe { Console::SetConsoleMode(in_handle, original_in_mode) }?;
         Ok(())
     })
@@ -522,8 +530,12 @@ fn wait_readable(timeout: Duration) -> Result<bool> {
     use windows::Win32::System::Console::{GetStdHandle, STD_INPUT_HANDLE};
     use windows::Win32::System::Threading::WaitForSingleObject;
 
+    // SAFETY: STD_INPUT_HANDLE is the documented selector and the Result captures
+    // invalid-handle failures.
     let handle = unsafe { GetStdHandle(STD_INPUT_HANDLE) }?;
     let millis: u32 = timeout.as_millis().try_into().unwrap_or(u32::MAX);
+    // SAFETY: waiting on the console input handle is a bounded read readiness probe;
+    // timeout conversion saturates and the result is compared to WAIT_OBJECT_0.
     let result = unsafe { WaitForSingleObject(handle, millis) };
     Ok(result == WAIT_OBJECT_0)
 }

--- a/crates/ratatui-image/src/protocol/halfblocks/chafa.rs
+++ b/crates/ratatui-image/src/protocol/halfblocks/chafa.rs
@@ -21,6 +21,11 @@ const CHAFA_PIXEL_RGB8: u32 = 8;
 
 // FFI declarations - linked via build.rs (static or dynamic based on feature)
 #[cfg_attr(feature = "chafa-dyn", link(name = "chafa"))]
+/// # Safety
+/// The linked chafa library must provide ABI-compatible symbols matching these
+/// declarations; callers must pass only chafa-owned pointers and valid pixel buffers.
+// SAFETY: declarations mirror the chafa C API signatures used below; link features
+// choose the library, and call sites validate pointer lifetimes/ownership.
 unsafe extern "C" {
     fn chafa_symbol_map_new() -> ChafaSymbolMap;
     fn chafa_symbol_map_add_by_tags(symbol_map: ChafaSymbolMap, tags: u32);
@@ -48,13 +53,22 @@ struct ChafaState {
     symbol_map: ChafaSymbolMap,
 }
 
-// SAFETY: The chafa library functions are thread-safe for independent canvases.
-// The symbol_map is created once and only read afterwards.
+/// # Safety
+/// The cached symbol map is initialized once, then shared read-only across encode
+/// calls; canvases remain per-call and are not shared between threads.
+// SAFETY: chafa supports reading a symbol map from independent canvases; Drop owns
+// the single unref when the process-global cache is torn down.
 unsafe impl Send for ChafaState {}
+/// # Safety
+/// Same invariant as `Send`: shared access never mutates the cached symbol map after
+/// initialization, and each encode call owns its canvas/config.
+// SAFETY: the raw pointer is treated as immutable after setup and is only freed once.
 unsafe impl Sync for ChafaState {}
 
 impl Drop for ChafaState {
     fn drop(&mut self) {
+        // SAFETY: `symbol_map` was returned by `chafa_symbol_map_new` and is owned by
+        // this state; Drop releases it exactly once.
         unsafe {
             chafa_symbol_map_unref(self.symbol_map);
         }
@@ -64,6 +78,8 @@ impl Drop for ChafaState {
 static CHAFA: OnceLock<ChafaState> = OnceLock::new();
 
 fn init_chafa() -> ChafaState {
+    // SAFETY: creates a chafa symbol map, configures it before sharing, and transfers
+    // ownership to `ChafaState` for a single unref in Drop.
     unsafe {
         let symbol_map = chafa_symbol_map_new();
         chafa_symbol_map_add_by_tags(symbol_map, CHAFA_SYMBOL_TAG_ALL);
@@ -78,6 +94,8 @@ pub fn encode(img: &DynamicImage, size: Size) -> Option<Vec<HalfBlock>> {
     let width = size.width;
     let height = size.height;
 
+    // SAFETY: config/canvas pointers are created by chafa constructors and released
+    // once; the RGB buffer lives through `draw_all_pixels`, and output pointers are valid.
     unsafe {
         let config = chafa_canvas_config_new();
         chafa_canvas_config_set_symbol_map(config, chafa.symbol_map);

--- a/scripts/check-unsafe-inventory.sh
+++ b/scripts/check-unsafe-inventory.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+pattern='\bunsafe(\s*\{|\s+fn|\s+impl|\s+extern|\s+trait)'
+matches=$(mktemp)
+unexpected=$(mktemp)
+trap 'rm -f "$matches" "$unexpected"' EXIT
+
+if ! rg -n --with-filename "$pattern" src crates/ratatui-image/src > "$matches"; then
+  echo "unsafe inventory ok"
+  exit 0
+fi
+
+is_allowed() {
+  case "$1" in
+    crates/ratatui-image/src/picker.rs) return 0 ;;
+    crates/ratatui-image/src/protocol/halfblocks/chafa.rs) return 0 ;;
+    src/bin/yututray.rs) return 0 ;;
+    src/daemon/mod.rs) return 0 ;;
+    src/desktop/platform/windows.rs) return 0 ;;
+    src/desktop/single_instance.rs) return 0 ;;
+    src/desktop/startup.rs) return 0 ;;
+    src/media/identity.rs) return 0 ;;
+    src/media/macos.rs) return 0 ;;
+    src/media/smtc.rs) return 0 ;;
+    src/player/lifetime.rs) return 0 ;;
+    src/test_util/env.rs) return 0 ;;
+    src/util/process.rs) return 0 ;;
+    src/util/runtime.rs) return 0 ;;
+    src/util/safe_fs.rs) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+while IFS=: read -r file line rest; do
+  if ! is_allowed "$file"; then
+    printf '%s:%s:%s\n' "$file" "$line" "$rest" >> "$unexpected"
+  fi
+done < "$matches"
+
+if [ -s "$unexpected" ]; then
+  echo "error: unsafe appears outside the reviewed path allowlist:" >&2
+  cat "$unexpected" >&2
+  exit 1
+fi
+
+echo "unsafe inventory ok"

--- a/src/bin/yututray.rs
+++ b/src/bin/yututray.rs
@@ -171,6 +171,8 @@ async fn run_polling() {
 fn attach_parent_console() {
     use windows_sys::Win32::System::Console::{ATTACH_PARENT_PROCESS, AttachConsole};
     // Best-effort: fails when there is no parent console, which is fine.
+    // SAFETY: ATTACH_PARENT_PROCESS is the documented sentinel; failure only means
+    // this process has no attachable parent console.
     unsafe {
         AttachConsole(ATTACH_PARENT_PROCESS);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1446,6 +1446,7 @@ mod hardening_tests;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::env::{with_var, with_vars};
 
     #[test]
     fn defaults_have_full_volume() {
@@ -1879,21 +1880,21 @@ mod tests {
             gemini_api_key: Some("from_config".to_owned()),
             ..Config::default()
         };
-        // SAFETY: single-threaded test; set+unset around the calls.
-        unsafe { std::env::set_var("GEMINI_API_KEY", "  from_env  ") };
-        assert_eq!(cfg.effective_gemini_api_key().as_deref(), Some("from_env"));
-        unsafe { std::env::remove_var("GEMINI_API_KEY") };
-        assert_eq!(
-            cfg.effective_gemini_api_key().as_deref(),
-            Some("from_config")
-        );
-
+        with_var("GEMINI_API_KEY", Some("  from_env  "), || {
+            assert_eq!(cfg.effective_gemini_api_key().as_deref(), Some("from_env"));
+        });
         // Empty/whitespace key reads as unset.
         let blank = Config {
             gemini_api_key: Some("   ".to_owned()),
             ..Config::default()
         };
-        assert_eq!(blank.effective_gemini_api_key(), None);
+        with_var("GEMINI_API_KEY", None, || {
+            assert_eq!(
+                cfg.effective_gemini_api_key().as_deref(),
+                Some("from_config")
+            );
+            assert_eq!(blank.effective_gemini_api_key(), None);
+        });
     }
 
     #[test]
@@ -2054,19 +2055,22 @@ mod tests {
             mpv_path: Some(PathBuf::from("/pin/mpv")),
             ..Default::default()
         };
-        // SAFETY: single-threaded test; set+unset around the calls.
-        unsafe { std::env::remove_var("YTM_YTDLP") };
-        unsafe { std::env::remove_var("YTM_MPV") };
-        assert_eq!(pinned.ytdlp_override(), Some(PathBuf::from("/pin/yt-dlp")));
-        assert_eq!(pinned.mpv_program(), "/pin/mpv");
+        with_vars(&[("YTM_YTDLP", None), ("YTM_MPV", None)], || {
+            assert_eq!(pinned.ytdlp_override(), Some(PathBuf::from("/pin/yt-dlp")));
+            assert_eq!(pinned.mpv_program(), "/pin/mpv");
+        });
 
         // Env vars beat the config paths.
-        unsafe { std::env::set_var("YTM_YTDLP", "/env/yt-dlp") };
-        unsafe { std::env::set_var("YTM_MPV", "/env/mpv") };
-        assert_eq!(pinned.ytdlp_override(), Some(PathBuf::from("/env/yt-dlp")));
-        assert_eq!(pinned.mpv_program(), "/env/mpv");
-        unsafe { std::env::remove_var("YTM_YTDLP") };
-        unsafe { std::env::remove_var("YTM_MPV") };
+        with_vars(
+            &[
+                ("YTM_YTDLP", Some("/env/yt-dlp")),
+                ("YTM_MPV", Some("/env/mpv")),
+            ],
+            || {
+                assert_eq!(pinned.ytdlp_override(), Some(PathBuf::from("/env/yt-dlp")));
+                assert_eq!(pinned.mpv_program(), "/env/mpv");
+            },
+        );
     }
 
     #[test]
@@ -2148,55 +2152,35 @@ mod tests {
 
     #[test]
     fn env_overrides_download_dir() {
-        // SAFETY: single-threaded test; we set+unset around the call.
-        unsafe { std::env::set_var("YTM_DOWNLOAD_DIR", "/tmp/ytm-dl-test") };
-        let dir = Config::default().effective_download_dir();
-        unsafe { std::env::remove_var("YTM_DOWNLOAD_DIR") };
-        assert_eq!(dir, PathBuf::from("/tmp/ytm-dl-test"));
+        with_var("YTM_DOWNLOAD_DIR", Some("/tmp/ytm-dl-test"), || {
+            assert_eq!(
+                Config::default().effective_download_dir(),
+                PathBuf::from("/tmp/ytm-dl-test")
+            );
+        });
     }
 
     #[test]
     fn download_concurrency_defaults_clamps_and_honors_env() {
-        let old = std::env::var_os("YTM_DOWNLOAD_CONCURRENCY");
-        unsafe { std::env::remove_var("YTM_DOWNLOAD_CONCURRENCY") };
-
-        assert_eq!(
-            Config::default().effective_download_concurrency(),
-            DOWNLOAD_CONCURRENCY_DEFAULT
-        );
-        let high = Config {
-            download_concurrency: Some(99),
-            ..Config::default()
+        let configured = |download_concurrency| {
+            Config {
+                download_concurrency,
+                ..Config::default()
+            }
+            .effective_download_concurrency()
         };
-        assert_eq!(
-            high.effective_download_concurrency(),
-            DOWNLOAD_CONCURRENCY_MAX
-        );
-        let zero = Config {
-            download_concurrency: Some(0),
-            ..Config::default()
-        };
-        assert_eq!(
-            zero.effective_download_concurrency(),
-            DOWNLOAD_CONCURRENCY_MIN
-        );
 
-        unsafe { std::env::set_var("YTM_DOWNLOAD_CONCURRENCY", "99") };
-        assert_eq!(
-            Config::default().effective_download_concurrency(),
-            DOWNLOAD_CONCURRENCY_MAX
-        );
-        unsafe { std::env::set_var("YTM_DOWNLOAD_CONCURRENCY", "not-a-number") };
-        let configured = Config {
-            download_concurrency: Some(1),
-            ..Config::default()
-        };
-        assert_eq!(configured.effective_download_concurrency(), 1);
-
-        match old {
-            Some(v) => unsafe { std::env::set_var("YTM_DOWNLOAD_CONCURRENCY", v) },
-            None => unsafe { std::env::remove_var("YTM_DOWNLOAD_CONCURRENCY") },
-        }
+        with_var("YTM_DOWNLOAD_CONCURRENCY", None, || {
+            assert_eq!(configured(None), DOWNLOAD_CONCURRENCY_DEFAULT);
+            assert_eq!(configured(Some(99)), DOWNLOAD_CONCURRENCY_MAX);
+            assert_eq!(configured(Some(0)), DOWNLOAD_CONCURRENCY_MIN);
+        });
+        with_var("YTM_DOWNLOAD_CONCURRENCY", Some("99"), || {
+            assert_eq!(configured(None), DOWNLOAD_CONCURRENCY_MAX);
+        });
+        with_var("YTM_DOWNLOAD_CONCURRENCY", Some("not-a-number"), || {
+            assert_eq!(configured(Some(1)), 1);
+        });
     }
 
     #[test]

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -906,6 +906,8 @@ fn spawn_daemon_process(options: &StartOptions) -> Result<(), DaemonError> {
         use std::os::unix::process::CommandExt;
         // Become a real background daemon on Unix/macOS too. Without a new session, the child
         // stays tied to the launching shell and can receive SIGHUP when that shell exits.
+        // SAFETY: `pre_exec` runs in the child after fork and before exec; `setsid` is
+        // an async-signal-safe syscall and reports failure through errno.
         unsafe {
             cmd.pre_exec(|| {
                 if libc::setsid() == -1 {
@@ -930,6 +932,8 @@ fn spawn_daemon_process(options: &StartOptions) -> Result<(), DaemonError> {
         // daemon start | Out-String` hung forever; the CI smoke's Invoke-Checked hit
         // the same). The client is about to exit and spawns nothing else, so stripping
         // the inherit flag from its std handles closes the leak at the source.
+        // SAFETY: `GetStdHandle` returns process-owned pseudo/real handles; invalid or
+        // null handles are skipped, and clearing HANDLE_FLAG_INHERIT is best-effort.
         unsafe {
             use windows_sys::Win32::Foundation::{
                 HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE, SetHandleInformation,

--- a/src/desktop/platform/windows.rs
+++ b/src/desktop/platform/windows.rs
@@ -1072,6 +1072,8 @@ fn set_app_user_model_id() {
         .encode_utf16()
         .chain(std::iter::once(0))
         .collect::<Vec<_>>();
+    // SAFETY: `app_id` is NUL-terminated UTF-16 and lives for the duration of the
+    // Shell API call; the HRESULT is checked for failure.
     let hr = unsafe { SetCurrentProcessExplicitAppUserModelID(app_id.as_ptr()) };
     if hr < 0 {
         report_error(format_args!(

--- a/src/desktop/single_instance.rs
+++ b/src/desktop/single_instance.rs
@@ -42,11 +42,16 @@ struct WindowsMutex(windows_sys::Win32::Foundation::HANDLE);
 #[cfg(windows)]
 impl Drop for WindowsMutex {
     fn drop(&mut self) {
+        // SAFETY: `WindowsMutex` owns this handle and drops it once when the guard
+        // leaves scope; CloseHandle failure only means the handle was already invalid.
         unsafe { windows_sys::Win32::Foundation::CloseHandle(self.0) };
     }
 }
-// The mutex handle is owned solely by the main thread's guard; the raw HANDLE is not shared.
 #[cfg(windows)]
+/// # Safety
+/// The mutex handle is owned by the guard and is never concurrently accessed through
+/// shared Rust references; moving the owner to another thread preserves ownership.
+// SAFETY: `WindowsMutex` has unique ownership of the raw HANDLE and Drop closes it.
 unsafe impl Send for WindowsMutex {}
 
 #[cfg(unix)]
@@ -59,6 +64,8 @@ pub fn acquire() -> io::Result<Acquire> {
         .truncate(false)
         .open(&path)?;
     // Advisory, non-blocking exclusive lock on the open file description.
+    // SAFETY: `file.as_raw_fd()` is valid for the lifetime of `file`; flock reports
+    // contention or OS errors via its return value.
     let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
     if rc == 0 {
         Ok(Acquire::Primary(InstanceGuard { _lock: file }))
@@ -81,11 +88,17 @@ pub fn acquire() -> io::Result<Acquire> {
         .encode_utf16()
         .chain(std::iter::once(0))
         .collect();
+    // SAFETY: the mutex name is NUL-terminated and lives for the call; null security
+    // attributes request defaults and errors are checked via the returned handle.
     let handle = unsafe { CreateMutexW(std::ptr::null(), 0, wide.as_ptr()) };
     if handle.is_null() {
         return Err(io::Error::last_os_error());
     }
+    // SAFETY: `GetLastError` is read immediately after CreateMutexW on this thread,
+    // as required for detecting an existing named mutex.
     if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
+        // SAFETY: this branch does not take ownership for the process; close the
+        // newly opened mutex handle before reporting AlreadyRunning.
         unsafe { windows_sys::Win32::Foundation::CloseHandle(handle) };
         Ok(Acquire::AlreadyRunning)
     } else {
@@ -185,6 +198,8 @@ mod tests {
             .truncate(false)
             .open(&path)
             .unwrap();
+        // SAFETY: `a` owns a valid fd and flock returns -1/errno instead of UB on
+        // contention or platform failure.
         let rc_a = unsafe { libc::flock(a.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
         assert_eq!(rc_a, 0, "first holder should acquire");
 
@@ -195,6 +210,8 @@ mod tests {
             .truncate(false)
             .open(&path)
             .unwrap();
+        // SAFETY: `b` owns a distinct valid fd for the same path; LOCK_NB reports
+        // contention via -1/EWOULDBLOCK.
         let rc_b = unsafe { libc::flock(b.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
         assert_eq!(
             rc_b, -1,
@@ -202,6 +219,7 @@ mod tests {
         );
 
         drop(a); // releasing lets the next holder in
+        // SAFETY: after dropping `a`, `b` remains a valid fd and can acquire the lock.
         let rc_b2 = unsafe { libc::flock(b.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
         assert_eq!(rc_b2, 0, "after release the lock is available");
         let _ = std::fs::remove_file(&path);

--- a/src/desktop/startup.rs
+++ b/src/desktop/startup.rs
@@ -96,6 +96,8 @@ fn platform_install(_exe: &Path, command: &str) -> Result<(), StartupError> {
     };
 
     let mut key: HKEY = null_mut();
+    // SAFETY: `RUN_KEY` is passed as a NUL-terminated UTF-16 string; output `key`
+    // points to valid storage and the return code is checked before use.
     let rc = unsafe {
         RegCreateKeyExW(
             HKEY_CURRENT_USER,
@@ -115,6 +117,8 @@ fn platform_install(_exe: &Path, command: &str) -> Result<(), StartupError> {
 
     let command_wide = wide(command);
     let bytes = bytes_len(&command_wide)?;
+    // SAFETY: `key` is a successfully opened registry handle; `command_wide` is
+    // NUL-terminated UTF-16 and `bytes` covers the buffer in bytes.
     let rc = unsafe {
         RegSetValueExW(
             key,
@@ -125,6 +129,8 @@ fn platform_install(_exe: &Path, command: &str) -> Result<(), StartupError> {
             bytes,
         )
     };
+    // SAFETY: `key` is owned by this function after RegCreateKeyExW succeeds and is
+    // closed exactly once before returning.
     unsafe {
         RegCloseKey(key);
     }
@@ -183,6 +189,8 @@ fn platform_uninstall() -> Result<(), StartupError> {
     };
 
     let mut key: HKEY = null_mut();
+    // SAFETY: `RUN_KEY` is a NUL-terminated UTF-16 string; output `key` storage is
+    // valid and the return code is checked before any handle use.
     let rc = unsafe {
         RegOpenKeyExW(
             HKEY_CURRENT_USER,
@@ -199,7 +207,11 @@ fn platform_uninstall() -> Result<(), StartupError> {
         return Err(registry_error("open HKCU Run", rc));
     }
 
+    // SAFETY: `key` is a valid open registry handle and the value name is
+    // NUL-terminated for the duration of the call.
     let rc = unsafe { RegDeleteValueW(key, wide(RUN_VALUE_NAME).as_ptr()) };
+    // SAFETY: `key` is owned by this function after RegOpenKeyExW succeeds and is
+    // closed exactly once before returning.
     unsafe {
         RegCloseKey(key);
     }
@@ -238,6 +250,8 @@ fn platform_status() -> Result<StartupStatus, StartupError> {
     };
 
     let mut key: HKEY = null_mut();
+    // SAFETY: `RUN_KEY` is a NUL-terminated UTF-16 string; output `key` storage is
+    // valid and the return code is checked before any handle use.
     let rc = unsafe {
         RegOpenKeyExW(
             HKEY_CURRENT_USER,
@@ -257,6 +271,8 @@ fn platform_status() -> Result<StartupStatus, StartupError> {
     let name = wide(RUN_VALUE_NAME);
     let mut value_type = 0u32;
     let mut bytes = 0u32;
+    // SAFETY: `key` and `name` are valid; null data buffer requests the required byte
+    // size, which Windows writes into `bytes`.
     let rc = unsafe {
         RegQueryValueExW(
             key,
@@ -268,18 +284,21 @@ fn platform_status() -> Result<StartupStatus, StartupError> {
         )
     };
     if rc == ERROR_FILE_NOT_FOUND {
+        // SAFETY: close the valid query handle before returning Disabled.
         unsafe {
             RegCloseKey(key);
         }
         return Ok(StartupStatus::Disabled);
     }
     if rc != ERROR_SUCCESS {
+        // SAFETY: close the valid query handle before returning the registry error.
         unsafe {
             RegCloseKey(key);
         }
         return Err(registry_error("query HKCU Run value", rc));
     }
     if value_type != REG_SZ || bytes == 0 {
+        // SAFETY: close the valid query handle before returning Disabled.
         unsafe {
             RegCloseKey(key);
         }
@@ -287,6 +306,8 @@ fn platform_status() -> Result<StartupStatus, StartupError> {
     }
 
     let mut buffer = vec![0u16; (bytes as usize).div_ceil(2)];
+    // SAFETY: `buffer` has at least the byte length reported by the size query;
+    // Windows writes UTF-16 data and updates `bytes`.
     let rc = unsafe {
         RegQueryValueExW(
             key,
@@ -297,6 +318,8 @@ fn platform_status() -> Result<StartupStatus, StartupError> {
             &mut bytes,
         )
     };
+    // SAFETY: `key` is owned by this function after RegOpenKeyExW succeeds and is
+    // closed exactly once after the final query.
     unsafe {
         RegCloseKey(key);
     }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1129,187 +1129,159 @@ fn dir_is_writable(dir: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
-    use std::sync::{Mutex, MutexGuard};
 
-    fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: Mutex<()> = Mutex::new(());
-        LOCK.lock().unwrap_or_else(|e| e.into_inner())
-    }
+    use crate::test_util::env::{with_var, with_vars};
 
-    struct EnvRestore(Vec<(String, Option<OsString>)>);
+    const TERMINAL_ENV: &[(&str, Option<&str>)] = &[
+        ("KITTY_WINDOW_ID", None),
+        ("WEZTERM_EXECUTABLE", None),
+        ("KONSOLE_VERSION", None),
+        ("WT_SESSION", None),
+        ("TERM", None),
+        ("TERM_PROGRAM", None),
+    ];
 
-    impl EnvRestore {
-        fn capture(names: &[&str]) -> Self {
-            Self(
-                names
-                    .iter()
-                    .map(|name| ((*name).to_owned(), std::env::var_os(name)))
-                    .collect(),
-            )
-        }
-    }
-
-    impl Drop for EnvRestore {
-        fn drop(&mut self) {
-            for (name, value) in &self.0 {
-                match value {
-                    Some(value) => unsafe { std::env::set_var(name, value) },
-                    None => unsafe { std::env::remove_var(name) },
-                }
-            }
-        }
-    }
-
-    fn clear_terminal_image_env() -> EnvRestore {
-        const NAMES: &[&str] = &[
-            "KITTY_WINDOW_ID",
-            "WEZTERM_EXECUTABLE",
-            "KONSOLE_VERSION",
-            "WT_SESSION",
-            "TERM",
-            "TERM_PROGRAM",
-        ];
-        let restore = EnvRestore::capture(NAMES);
-        for name in NAMES {
-            unsafe { std::env::remove_var(name) };
-        }
-        restore
+    fn with_terminal_env<T>(vars: &[(&str, Option<&str>)], f: impl FnOnce() -> T) -> T {
+        let mut scoped = TERMINAL_ENV.to_vec();
+        scoped.extend_from_slice(vars);
+        with_vars(&scoped, f)
     }
 
     #[test]
     fn terminal_doctor_detects_common_protocol_hints_without_probing() {
-        let _guard = env_lock();
-        let _restore = EnvRestore::capture(&["YTM_TUI_TEXT_SIZING"]);
-        unsafe { std::env::remove_var("YTM_TUI_TEXT_SIZING") };
-        assert_eq!(
-            terminal_image_protocol(Some("xterm-kitty"), None, false),
-            "kitty"
-        );
-        assert_eq!(
-            terminal_image_protocol(Some("xterm-256color"), Some("WezTerm"), false),
-            "iterm2_or_kitty_or_sixel"
-        );
-        assert_eq!(
-            terminal_image_protocol(Some("xterm-256color"), Some("iTerm.app"), false),
-            "iterm2"
-        );
-        assert_eq!(
-            terminal_image_protocol(Some("xterm-256color"), None, true),
-            "sixel_versioned"
-        );
-        assert_eq!(
-            terminal_zoom_mode(Some("xterm-kitty"), None, false),
-            "osc66_versioned"
-        );
-        assert_eq!(
-            terminal_zoom_mode(Some("xterm-256color"), None, true),
-            "decdhl_expected"
-        );
+        with_var("YTM_TUI_TEXT_SIZING", None, || {
+            assert_eq!(
+                terminal_image_protocol(Some("xterm-kitty"), None, false),
+                "kitty"
+            );
+            assert_eq!(
+                terminal_image_protocol(Some("xterm-256color"), Some("WezTerm"), false),
+                "iterm2_or_kitty_or_sixel"
+            );
+            assert_eq!(
+                terminal_image_protocol(Some("xterm-256color"), Some("iTerm.app"), false),
+                "iterm2"
+            );
+            assert_eq!(
+                terminal_image_protocol(Some("xterm-256color"), None, true),
+                "sixel_versioned"
+            );
+            assert_eq!(
+                terminal_zoom_mode(Some("xterm-kitty"), None, false),
+                "osc66_versioned"
+            );
+            assert_eq!(
+                terminal_zoom_mode(Some("xterm-256color"), None, true),
+                "decdhl_expected"
+            );
+        });
     }
 
     #[test]
     fn terminal_doctor_covers_protocol_keyboard_and_zoom_edges() {
-        let _guard = env_lock();
-        let _restore = EnvRestore::capture(&["YTM_TUI_TEXT_SIZING"]);
-        unsafe { std::env::remove_var("YTM_TUI_TEXT_SIZING") };
+        with_var("YTM_TUI_TEXT_SIZING", None, || {
+            assert_eq!(terminal_image_protocol(Some("foot"), None, false), "sixel");
+            assert_eq!(
+                terminal_image_protocol(Some("mintty"), None, false),
+                "sixel"
+            );
+            assert_eq!(
+                terminal_image_protocol(Some("konsole"), None, false),
+                "kitty_or_sixel"
+            );
+            assert_eq!(
+                terminal_image_protocol(Some("ghostty"), Some("ignored"), false),
+                "kitty"
+            );
+            assert_eq!(
+                terminal_image_protocol(Some("linux"), None, false),
+                "halfblocks_or_retro"
+            );
+            assert_eq!(
+                terminal_image_protocol(Some("dumb"), None, false),
+                "unknown"
+            );
+            assert_eq!(
+                terminal_zoom_mode(Some("plain"), Some("Ghostty"), false),
+                "unknown_probe_required"
+            );
+            assert_eq!(
+                terminal_zoom_mode(Some("plain"), Some("WezTerm"), false),
+                "unknown_probe_required"
+            );
+            assert_eq!(terminal_zoom_mode(Some("plain"), None, false), "unknown");
+            assert_eq!(
+                terminal_keyboard_hint(Some("foot"), None, false),
+                Some(true)
+            );
+            assert_eq!(
+                terminal_keyboard_hint(Some("xterm"), Some("ghostty"), false),
+                Some(true)
+            );
+            assert_eq!(
+                terminal_keyboard_hint(Some("xterm"), None, true),
+                Some(true)
+            );
+        });
 
-        assert_eq!(terminal_image_protocol(Some("foot"), None, false), "sixel");
-        assert_eq!(
-            terminal_image_protocol(Some("mintty"), None, false),
-            "sixel"
-        );
-        assert_eq!(
-            terminal_image_protocol(Some("konsole"), None, false),
-            "kitty_or_sixel"
-        );
-        assert_eq!(
-            terminal_image_protocol(Some("ghostty"), Some("ignored"), false),
-            "kitty"
-        );
-        assert_eq!(
-            terminal_image_protocol(Some("linux"), None, false),
-            "halfblocks_or_retro"
-        );
-        assert_eq!(
-            terminal_image_protocol(Some("dumb"), None, false),
-            "unknown"
-        );
-
-        assert_eq!(
-            terminal_zoom_mode(Some("plain"), Some("Ghostty"), false),
-            "unknown_probe_required"
-        );
-        assert_eq!(
-            terminal_zoom_mode(Some("plain"), Some("WezTerm"), false),
-            "unknown_probe_required"
-        );
-        assert_eq!(terminal_zoom_mode(Some("plain"), None, false), "unknown");
-
-        unsafe { std::env::set_var("YTM_TUI_TEXT_SIZING", "false") };
-        assert_eq!(terminal_zoom_mode(None, None, false), "none_forced");
-        unsafe { std::env::set_var("YTM_TUI_TEXT_SIZING", "DHL") };
-        assert_eq!(terminal_zoom_mode(None, None, false), "decdhl_forced");
-        unsafe { std::env::set_var("YTM_TUI_TEXT_SIZING", "probe") };
-        assert_eq!(terminal_zoom_mode(None, None, false), "probe_requested");
-
-        assert_eq!(
-            terminal_keyboard_hint(Some("foot"), None, false),
-            Some(true)
-        );
-        assert_eq!(
-            terminal_keyboard_hint(Some("xterm"), Some("ghostty"), false),
-            Some(true)
-        );
-        assert_eq!(
-            terminal_keyboard_hint(Some("xterm"), None, true),
-            Some(true)
-        );
+        with_var("YTM_TUI_TEXT_SIZING", Some("false"), || {
+            assert_eq!(terminal_zoom_mode(None, None, false), "none_forced");
+        });
+        with_var("YTM_TUI_TEXT_SIZING", Some("DHL"), || {
+            assert_eq!(terminal_zoom_mode(None, None, false), "decdhl_forced");
+        });
+        with_var("YTM_TUI_TEXT_SIZING", Some("probe"), || {
+            assert_eq!(terminal_zoom_mode(None, None, false), "probe_requested");
+        });
     }
 
     #[test]
     fn terminal_doctor_reports_native_hint_timeout_and_override_guidance() {
-        let _guard = env_lock();
-        let _restore = clear_terminal_image_env();
-
-        assert!(!terminal_native_image_hint(
-            Some("xterm-256color"),
-            Some("plain-terminal"),
-            false
-        ));
-        assert_eq!(terminal_image_probe_timeout_ms(false), 250);
-        assert!(
-            terminal_image_override_suggestions(
+        with_terminal_env(&[], || {
+            assert!(!terminal_native_image_hint(
                 Some("xterm-256color"),
                 Some("plain-terminal"),
                 false
-            )
-            .is_empty()
-        );
+            ));
+            assert_eq!(terminal_image_probe_timeout_ms(false), 250);
+            assert!(
+                terminal_image_override_suggestions(
+                    Some("xterm-256color"),
+                    Some("plain-terminal"),
+                    false
+                )
+                .is_empty()
+            );
+        });
 
-        assert!(terminal_native_image_hint(Some("foot"), None, false));
-        assert_eq!(terminal_image_probe_timeout_ms(true), 700);
-        assert_eq!(
-            terminal_image_override_suggestions(Some("foot"), None, false),
-            vec!["YTM_TUI_IMAGE_PROTOCOL=sixel"]
-        );
+        with_terminal_env(&[("TERM", Some("foot"))], || {
+            assert!(terminal_native_image_hint(Some("foot"), None, false));
+            assert_eq!(terminal_image_probe_timeout_ms(true), 700);
+            assert_eq!(
+                terminal_image_override_suggestions(Some("foot"), None, false),
+                vec!["YTM_TUI_IMAGE_PROTOCOL=sixel"]
+            );
+        });
 
-        assert!(terminal_native_image_hint(Some("ghostty"), None, false));
-        assert_eq!(
-            terminal_image_override_suggestions(Some("ghostty"), None, false),
-            vec!["YTM_TUI_IMAGE_PROTOCOL=kitty"]
-        );
+        with_terminal_env(&[("TERM", Some("ghostty"))], || {
+            assert!(terminal_native_image_hint(Some("ghostty"), None, false));
+            assert_eq!(
+                terminal_image_override_suggestions(Some("ghostty"), None, false),
+                vec!["YTM_TUI_IMAGE_PROTOCOL=kitty"]
+            );
+        });
 
-        unsafe { std::env::set_var("WEZTERM_EXECUTABLE", "wezterm") };
-        assert!(terminal_native_image_hint(None, None, false));
-        assert_eq!(
-            terminal_image_override_suggestions(None, None, false),
-            vec![
-                "YTM_TUI_IMAGE_PROTOCOL=iterm2",
-                "YTM_TUI_IMAGE_PROTOCOL=kitty",
-                "YTM_TUI_IMAGE_PROTOCOL=sixel"
-            ]
-        );
+        with_terminal_env(&[("WEZTERM_EXECUTABLE", Some("wezterm"))], || {
+            assert!(terminal_native_image_hint(None, None, false));
+            assert_eq!(
+                terminal_image_override_suggestions(None, None, false),
+                vec![
+                    "YTM_TUI_IMAGE_PROTOCOL=iterm2",
+                    "YTM_TUI_IMAGE_PROTOCOL=kitty",
+                    "YTM_TUI_IMAGE_PROTOCOL=sixel"
+                ]
+            );
+        });
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,9 @@ pub mod update;
 pub mod util;
 pub mod zoom;
 
+#[cfg(test)]
+pub mod test_util;
+
 #[cfg(feature = "desktop")]
 pub mod desktop;
 

--- a/src/media/identity.rs
+++ b/src/media/identity.rs
@@ -38,6 +38,8 @@ pub fn adopt_process_identity() {
     use windows_sys::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID;
 
     let id = wide(APP_USER_MODEL_ID);
+    // SAFETY: `id` is NUL-terminated UTF-16 and lives for the Shell call; failure is
+    // intentionally ignored because process identity is cosmetic.
     unsafe {
         let _ = SetCurrentProcessExplicitAppUserModelID(id.as_ptr());
     }
@@ -139,6 +141,8 @@ fn write_registration(icon: Option<&std::path::Path>) -> Result<(), String> {
 
     let key_path = format!(r"Software\Classes\AppUserModelId\{APP_USER_MODEL_ID}");
     let mut key: HKEY = null_mut();
+    // SAFETY: `key_path` is provided as NUL-terminated UTF-16; `key` points to valid
+    // output storage and the return code gates subsequent handle use.
     let rc = unsafe {
         RegCreateKeyExW(
             HKEY_CURRENT_USER,
@@ -160,6 +164,8 @@ fn write_registration(icon: Option<&std::path::Path>) -> Result<(), String> {
         let data = wide(value);
         let bytes =
             u32::try_from(data.len() * 2).map_err(|_| format!("value for {name} is too long"))?;
+        // SAFETY: `key` is the open registration key; `name` and `data` are
+        // NUL-terminated UTF-16 buffers valid for this call.
         let rc = unsafe {
             RegSetValueExW(
                 key,
@@ -183,6 +189,8 @@ fn write_registration(icon: Option<&std::path::Path>) -> Result<(), String> {
     {
         result = set("IconUri", &icon.display().to_string());
     }
+    // SAFETY: `key` is owned by this function after RegCreateKeyExW succeeds and is
+    // closed exactly once after all value writes.
     unsafe {
         RegCloseKey(key);
     }
@@ -223,31 +231,49 @@ fn write_start_menu_shortcut(icon: Option<&std::path::Path>) -> Result<std::path
     struct ComGuard;
     impl Drop for ComGuard {
         fn drop(&mut self) {
+            // SAFETY: this guard is constructed only after successful CoInitializeEx
+            // on the current thread, so it balances that COM apartment initialization.
             unsafe { CoUninitialize() };
         }
     }
+    // SAFETY: initializes COM for this thread before creating ShellLink COM objects;
+    // failure is converted into an error and no COM APIs run before success.
     unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) }
         .ok()
         .map_err(|e| format!("CoInitializeEx failed: {e}"))?;
     let _com = ComGuard;
 
     let result: windows::core::Result<()> = (|| {
+        // SAFETY: COM is initialized on this thread and ShellLink is an in-proc COM
+        // class; errors are propagated through the windows Result.
         let link: IShellLinkW =
             unsafe { CoCreateInstance(&ShellLink, None, CLSCTX_INPROC_SERVER) }?;
+        // SAFETY: the executable path buffer is NUL-terminated UTF-16 and lives until
+        // SetPath returns; ShellLink copies the value.
         unsafe { link.SetPath(PCWSTR(wide(&exe.display().to_string()).as_ptr())) }?;
         if let Some(icon) = icon {
+            // SAFETY: the icon path buffer is NUL-terminated UTF-16 and lives until
+            // SetIconLocation returns; ShellLink copies the value.
             unsafe { link.SetIconLocation(PCWSTR(wide(&icon.display().to_string()).as_ptr()), 0) }?;
         }
 
         let store: IPropertyStore = link.cast()?;
         let value = PROPVARIANT::from(APP_USER_MODEL_ID);
+        // SAFETY: PKEY_AppUserModel_ID expects a string PROPVARIANT; `value` is kept
+        // alive until SetValue returns and the HRESULT is checked.
         unsafe { store.SetValue(&PKEY_APP_USER_MODEL_ID, &value) }?;
+        // SAFETY: commits the property store for the live ShellLink COM object; errors
+        // are propagated to the caller.
         unsafe { store.Commit() }?;
 
         let file: IPersistFile = link.cast()?;
+        // SAFETY: the shortcut path is NUL-terminated UTF-16 and lives until Save
+        // returns; `true` permits overwrite and HRESULT is checked.
         unsafe { file.Save(PCWSTR(wide(&lnk.display().to_string()).as_ptr()), true) }?;
 
         // Readback: the stamp must round-trip or the flyout will still say Unknown app.
+        // SAFETY: reads the same string property from the live property store; the
+        // returned PROPVARIANT owns its data through the windows crate wrapper.
         let back = unsafe { store.GetValue(&PKEY_APP_USER_MODEL_ID) }?;
         let back = back.to_string();
         if back != APP_USER_MODEL_ID {

--- a/src/media/macos.rs
+++ b/src/media/macos.rs
@@ -58,7 +58,10 @@ pub struct Backend {
 
 impl Backend {
     pub fn new(sink: CommandSink) -> Result<Self> {
+        // SAFETY: objc2 exposes these MediaPlayer singleton accessors as unsafe; they
+        // return retained Objective-C objects or abort through the binding on contract failure.
         let center = unsafe { MPNowPlayingInfoCenter::defaultCenter() };
+        // SAFETY: same singleton contract as above for the remote command center.
         let commands = unsafe { MPRemoteCommandCenter::sharedCommandCenter() };
         let backend = Self {
             center,
@@ -73,6 +76,8 @@ impl Backend {
     /// Drain the main run loop / main dispatch queue once, non-blocking. Remote
     /// command handlers registered below are delivered during this call.
     pub fn pump(&mut self) {
+        // SAFETY: called on the backend's main-thread owner; mode is the constant
+        // default run-loop mode, duration is zero, so this only pumps pending work.
         unsafe {
             CFRunLoop::run_in_mode(kCFRunLoopDefaultMode, 0.0, false);
         }
@@ -80,6 +85,8 @@ impl Backend {
 
     fn register_commands(&self, sink: &CommandSink) {
         let c = &self.commands;
+        // SAFETY: all commands come from the live MPRemoteCommandCenter singleton and
+        // handler blocks only enqueue app commands before returning to MediaPlayer.
         unsafe {
             register(&c.playCommand(), sink, |_| Some(MediaCommand::Play));
             register(&c.pauseCommand(), sink, |_| Some(MediaCommand::Pause));
@@ -133,6 +140,8 @@ impl Backend {
     }
 
     pub fn apply(&mut self, snapshot: &MediaSnapshot, changes: MediaChanges) {
+        // SAFETY: the backend owns all retained MediaPlayer/Foundation objects on the
+        // main thread and writes only Foundation object values matching Apple's keys.
         unsafe {
             match &snapshot.track {
                 None => {
@@ -247,9 +256,9 @@ impl Backend {
 
     /// Build a fresh now-playing dictionary for the current track.
     ///
-    /// # Safety-ish
-    /// Callers hold no aliases to the returned dictionary; all values are proper
-    /// Foundation objects, so `insert`'s type expectations hold.
+    /// # Safety
+    /// Must be called on the backend's main-thread owner. Inserted values must match
+    /// the Foundation object types expected by the MediaPlayer now-playing keys.
     unsafe fn build_info(
         &mut self,
         snapshot: &MediaSnapshot,
@@ -258,6 +267,8 @@ impl Backend {
         let Some(track) = &snapshot.track else {
             return info;
         };
+        // SAFETY: keys and values are MediaPlayer/Foundation constants and objects
+        // with the exact types expected by NSMutableDictionary insertion.
         unsafe {
             info.insert(MPMediaItemPropertyTitle, &*NSString::from_str(&track.title));
             if !track.artist.is_empty() {
@@ -301,6 +312,10 @@ impl Backend {
 
     /// Attach the cached artwork file (if any) to `info`, loading + wrapping it in
     /// an `MPMediaItemArtwork` once per file.
+    ///
+    /// # Safety
+    /// `info` must be a mutable now-playing dictionary owned by this backend, and
+    /// the retained artwork object must outlive its insertion into that dictionary.
     unsafe fn set_artwork(
         &mut self,
         info: &NSMutableDictionary<NSString, AnyObject>,
@@ -316,6 +331,8 @@ impl Backend {
             self.artwork = Some((path, artwork));
         }
         if let Some((_, artwork)) = &self.artwork {
+            // SAFETY: `artwork` is retained by `self.artwork`; the key expects an
+            // MPMediaItemArtwork Foundation object.
             unsafe {
                 info.insert(MPMediaItemPropertyArtwork, artwork.as_ref());
             }
@@ -326,6 +343,8 @@ impl Backend {
 impl Drop for Backend {
     fn drop(&mut self) {
         // Tear the session down so quitting never leaves a ghost Now Playing entry.
+        // SAFETY: `self` still owns the retained MediaPlayer objects; removing targets
+        // and clearing now-playing info are valid shutdown calls for these commands.
         unsafe {
             self.center.setNowPlayingInfo(None);
             self.center
@@ -364,6 +383,10 @@ fn effective_rate(snapshot: &MediaSnapshot) -> f64 {
 /// Register a handler on `command` that maps the event to a [`MediaCommand`] and
 /// forwards it through the sink. Handlers must return immediately (spec C-1): the
 /// actual work happens on the app's reducer thread.
+///
+/// # Safety
+/// `command` must be a live `MPRemoteCommand` from the command center, and MediaPlayer
+/// must call the block with a non-null event pointer for the block's dynamic lifetime.
 unsafe fn register<F>(command: &MPRemoteCommand, sink: &CommandSink, map: F)
 where
     F: Fn(&MPRemoteCommandEvent) -> Option<MediaCommand> + 'static,
@@ -371,6 +394,8 @@ where
     let sink = std::sync::Arc::clone(sink);
     let handler = RcBlock::new(
         move |event: NonNull<MPRemoteCommandEvent>| -> MPRemoteCommandHandlerStatus {
+            // SAFETY: MediaPlayer invokes the block with a valid event pointer for
+            // the duration of the callback; we do not store the borrowed reference.
             let event = unsafe { event.as_ref() };
             match map(event) {
                 Some(cmd) => {
@@ -381,6 +406,8 @@ where
             }
         },
     );
+    // SAFETY: `command` is live for this registration call and the block is copied by
+    // MediaPlayer; failure is reported by the Objective-C binding rather than UB.
     unsafe {
         command.setEnabled(true);
         let _token = command.addTargetWithHandler(&handler);
@@ -410,6 +437,8 @@ fn load_artwork(path: &std::path::Path) -> Option<Retained<MPMediaItemArtwork>> 
         // The captured `Retained` keeps the image alive for the block's lifetime.
         NonNull::from(&*image)
     });
+    // SAFETY: the request handler always returns a non-null NSImage retained by the
+    // copied block, and `bounds` is finite positive fallback image geometry.
     Some(unsafe {
         MPMediaItemArtwork::initWithBoundsSize_requestHandler(
             MPMediaItemArtwork::alloc(),

--- a/src/media/smtc.rs
+++ b/src/media/smtc.rs
@@ -92,6 +92,8 @@ impl Backend {
 
     pub fn apply(&mut self, snapshot: &MediaSnapshot, changes: MediaChanges) {
         if self.tx.send((snapshot.clone(), changes)).is_ok() {
+            // SAFETY: `worker_thread_id` was captured from the live SMTC worker after
+            // its message queue was created; a failed post only drops this wake-up.
             unsafe {
                 let _ =
                     PostThreadMessageW(self.worker_thread_id, WM_APP_UPDATE, WPARAM(0), LPARAM(0));
@@ -102,6 +104,8 @@ impl Backend {
 
 impl Drop for Backend {
     fn drop(&mut self) {
+        // SAFETY: best-effort shutdown post to the worker thread id captured at
+        // startup; failure is harmless because join handles already-ended threads.
         unsafe {
             let _ = PostThreadMessageW(self.worker_thread_id, WM_QUIT, WPARAM(0), LPARAM(0));
         }
@@ -138,12 +142,16 @@ fn worker(
             return;
         }
     };
+    // SAFETY: `GetCurrentThreadId` has no preconditions and identifies this worker
+    // thread for later `PostThreadMessageW` wake-ups.
     let thread_id = unsafe { GetCurrentThreadId() };
     let _ = ready_tx.send(Ok(thread_id));
 
     // The message pump: SMTC event delivery and our posted wake-ups both flow
     // through here. Thread messages (hwnd == 0) are handled inline; anything for
     // the hidden window goes through DefWindowProc.
+    // SAFETY: `msg` points to valid storage for the duration of the pump; Win32
+    // message APIs report termination/errors through return values.
     unsafe {
         let mut msg = MSG::default();
         while GetMessageW(&mut msg, None, 0, 0).as_bool() {
@@ -170,6 +178,8 @@ fn worker(
 }
 
 fn init_session(sink: &CommandSink) -> Result<Session> {
+    // SAFETY: all Win32/WinRT calls are made on this dedicated worker thread after
+    // RoInitialize; handles and HRESULT/Result values are checked before use.
     unsafe {
         // Per-thread WinRT init; a "already initialized" style failure is fine.
         let _ = RoInitialize(RO_INIT_MULTITHREADED);
@@ -457,6 +467,8 @@ impl Session {
                 .track
                 .as_ref()
                 .is_some_and(|t| !t.is_live && t.duration.is_some());
+        // SAFETY: thread timers use a null HWND, so WM_TIMER is delivered to this
+        // worker's message queue; the returned timer id is stored for KillTimer.
         unsafe {
             if want && self.timer_id == 0 {
                 // Thread timer (no window): WM_TIMER lands in the pump directly.
@@ -501,6 +513,8 @@ impl Session {
             let _ = updater.Update();
         }
         let _ = self.smtc.SetIsEnabled(false);
+        // SAFETY: `timer_id` was returned by SetTimer for this thread, and `hwnd` was
+        // created by this worker; both calls are best-effort during teardown.
         unsafe {
             if self.timer_id != 0 {
                 let _ = KillTimer(None, self.timer_id);
@@ -513,12 +527,20 @@ impl Session {
 /// The hidden window needs no behavior of its own — everything defers to
 /// `DefWindowProcW` (which the `windows` crate wraps as a plain fn, so it can't be
 /// used as a `WNDPROC` directly).
+///
+/// # Safety
+/// Windows calls this function with the standard window-procedure ABI and message
+/// parameters for the hidden SMTC window; the function forwards them unchanged.
+// SAFETY: this function is installed as a WNDPROC for the hidden window and matches
+// the required system ABI; all parameters are forwarded to DefWindowProcW.
 unsafe extern "system" fn default_wndproc(
     hwnd: HWND,
     msg: u32,
     wparam: WPARAM,
     lparam: LPARAM,
 ) -> LRESULT {
+    // SAFETY: parameters are forwarded exactly as received from the window manager;
+    // DefWindowProcW owns validation and returns the default result.
     unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) }
 }
 

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -120,81 +120,53 @@ fn emit_native(title: String, body: String) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
-    use std::sync::{Mutex, MutexGuard};
 
-    fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: Mutex<()> = Mutex::new(());
-        LOCK.lock().unwrap_or_else(|e| e.into_inner())
-    }
+    use crate::test_util::env::with_vars;
 
-    struct EnvRestore(Vec<(String, Option<OsString>)>);
+    const DETECT_ENV: &[(&str, Option<&str>)] = &[
+        ("TERM", None),
+        ("TERM_PROGRAM", None),
+        ("TMUX", None),
+        ("KITTY_WINDOW_ID", None),
+        ("WEZTERM_PANE", None),
+        ("VTE_VERSION", None),
+        ("WT_SESSION", None),
+    ];
 
-    impl EnvRestore {
-        fn capture(names: &[&str]) -> Self {
-            Self(
-                names
-                    .iter()
-                    .map(|name| ((*name).to_owned(), std::env::var_os(name)))
-                    .collect(),
-            )
-        }
-    }
-
-    impl Drop for EnvRestore {
-        fn drop(&mut self) {
-            for (name, value) in &self.0 {
-                match value {
-                    Some(value) => unsafe { std::env::set_var(name, value) },
-                    None => unsafe { std::env::remove_var(name) },
-                }
-            }
-        }
-    }
-
-    fn clear_env(names: &[&str]) {
-        for name in names {
-            unsafe { std::env::remove_var(name) };
-        }
+    fn with_detect_env<T>(vars: &[(&str, Option<&str>)], f: impl FnOnce() -> T) -> T {
+        let mut scoped = DETECT_ENV.to_vec();
+        scoped.extend_from_slice(vars);
+        with_vars(&scoped, f)
     }
 
     #[test]
     fn detect_maps_terminal_environment_to_osc_capability() {
-        let _guard = env_lock();
-        const NAMES: &[&str] = &[
-            "TERM",
-            "TERM_PROGRAM",
-            "TMUX",
-            "KITTY_WINDOW_ID",
-            "WEZTERM_PANE",
-            "VTE_VERSION",
-            "WT_SESSION",
-        ];
-        let _restore = EnvRestore::capture(NAMES);
-        clear_env(NAMES);
+        with_detect_env(&[], || {
+            let none = Notifier::detect();
+            assert_eq!(none.osc, Osc::None);
+            assert!(!none.tmux);
+        });
 
-        let none = Notifier::detect();
-        assert_eq!(none.osc, Osc::None);
-        assert!(!none.tmux);
+        with_detect_env(&[("KITTY_WINDOW_ID", Some("1"))], || {
+            assert_eq!(Notifier::detect().osc, Osc::SevenSevenSeven);
+        });
 
-        unsafe { std::env::set_var("KITTY_WINDOW_ID", "1") };
-        assert_eq!(Notifier::detect().osc, Osc::SevenSevenSeven);
-        unsafe { std::env::remove_var("KITTY_WINDOW_ID") };
+        with_detect_env(&[("TERM_PROGRAM", Some("WezTerm"))], || {
+            assert_eq!(Notifier::detect().osc, Osc::SevenSevenSeven);
+        });
+        with_detect_env(&[("TERM_PROGRAM", Some("Apple_Terminal"))], || {
+            assert_eq!(Notifier::detect().osc, Osc::Nine);
+        });
 
-        unsafe { std::env::set_var("TERM_PROGRAM", "WezTerm") };
-        assert_eq!(Notifier::detect().osc, Osc::SevenSevenSeven);
-        unsafe { std::env::set_var("TERM_PROGRAM", "Apple_Terminal") };
-        assert_eq!(Notifier::detect().osc, Osc::Nine);
+        with_detect_env(&[("WT_SESSION", Some("abc"))], || {
+            assert_eq!(Notifier::detect().osc, Osc::Nine);
+        });
 
-        unsafe { std::env::remove_var("TERM_PROGRAM") };
-        unsafe { std::env::set_var("WT_SESSION", "abc") };
-        assert_eq!(Notifier::detect().osc, Osc::Nine);
-
-        unsafe { std::env::remove_var("WT_SESSION") };
-        unsafe { std::env::set_var("TERM", "screen-256color") };
-        let tmux = Notifier::detect();
-        assert_eq!(tmux.osc, Osc::None);
-        assert!(tmux.tmux);
+        with_detect_env(&[("TERM", Some("screen-256color"))], || {
+            let tmux = Notifier::detect();
+            assert_eq!(tmux.osc, Osc::None);
+            assert!(tmux.tmux);
+        });
     }
 
     #[test]

--- a/src/player/lifetime.rs
+++ b/src/player/lifetime.rs
@@ -49,6 +49,8 @@ pub fn kill_mpv_now() {
 #[cfg(unix)]
 fn kill_pid(pid: u32) {
     // SIGKILL is async-signal-safe and a single syscall — usable from the panic hook.
+    // SAFETY: `pid` came from the spawned mpv child registry; if it has exited or is
+    // no longer signalable, `kill` reports an error that this best-effort path ignores.
     unsafe {
         libc::kill(pid as libc::pid_t, libc::SIGKILL);
     }
@@ -154,6 +156,8 @@ pub fn assign_to_job(process_handle: std::os::windows::io::RawHandle) -> Option<
         SetInformationJobObject,
     };
 
+    // SAFETY: all Win32 handles used here are either returned by the preceding API
+    // call or supplied by the mpv child process; errors are checked after each call.
     unsafe {
         let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
         if job.is_null() {
@@ -185,6 +189,8 @@ pub fn assign_to_job(process_handle: std::os::windows::io::RawHandle) -> Option<
 
 #[cfg(windows)]
 fn close_handle(handle: windows_sys::Win32::Foundation::HANDLE) {
+    // SAFETY: callers pass an owned Win32 handle that must be closed exactly once;
+    // CloseHandle failure only means the handle was already invalid.
     unsafe {
         windows_sys::Win32::Foundation::CloseHandle(handle);
     }
@@ -207,6 +213,11 @@ pub fn install_console_ctrl_handler() {
     };
 
     // `windows-sys` models Win32 `BOOL` as a plain `i32` (1 = TRUE, 0 = FALSE).
+    /// # Safety
+    /// Called only by the Windows console subsystem with the documented control-event
+    /// code; the handler does not dereference raw pointers or retain OS-owned state.
+    // SAFETY: registered only through SetConsoleCtrlHandler with the required system
+    // ABI; the body performs only atomic pid access and a best-effort kill.
     unsafe extern "system" fn handler(ctrl_type: u32) -> i32 {
         kill_mpv_now();
         match ctrl_type {
@@ -217,6 +228,8 @@ pub fn install_console_ctrl_handler() {
         }
     }
 
+    // SAFETY: `handler` has the required system ABI and static lifetime; failure to
+    // register is reported by the return value and only weakens prompt cleanup.
     unsafe {
         if SetConsoleCtrlHandler(Some(handler), 1) == 0 {
             tracing::warn!("SetConsoleCtrlHandler failed");

--- a/src/terminal_runtime/art.rs
+++ b/src/terminal_runtime/art.rs
@@ -241,53 +241,24 @@ pub(crate) fn log_art_picker(picker: Option<&ratatui_image::picker::Picker>) {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsString;
-    use std::sync::{Mutex, MutexGuard};
-
+    use crate::test_util::env::{with_var, with_vars};
     use ratatui_image::picker::ProtocolType;
 
     use super::*;
 
-    fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: Mutex<()> = Mutex::new(());
-        LOCK.lock().unwrap_or_else(|e| e.into_inner())
-    }
+    const TERMINAL_ENV: &[(&str, Option<&str>)] = &[
+        ("KITTY_WINDOW_ID", None),
+        ("WEZTERM_EXECUTABLE", None),
+        ("KONSOLE_VERSION", None),
+        ("WT_SESSION", None),
+        ("TERM", None),
+        ("TERM_PROGRAM", None),
+    ];
 
-    struct EnvRestore(Vec<(String, Option<OsString>)>);
-
-    impl EnvRestore {
-        fn capture(names: &[&str]) -> Self {
-            Self(
-                names
-                    .iter()
-                    .map(|name| ((*name).to_string(), std::env::var_os(name)))
-                    .collect(),
-            )
-        }
-    }
-
-    impl Drop for EnvRestore {
-        fn drop(&mut self) {
-            for (name, value) in &self.0 {
-                match value {
-                    Some(value) => unsafe { std::env::set_var(name.as_str(), value.as_os_str()) },
-                    None => unsafe { std::env::remove_var(name.as_str()) },
-                }
-            }
-        }
-    }
-
-    fn set_env(name: &str, value: Option<&str>) {
-        match value {
-            Some(value) => unsafe { std::env::set_var(name, value) },
-            None => unsafe { std::env::remove_var(name) },
-        }
-    }
-
-    fn with_env<T>(name: &str, value: Option<&str>, f: impl FnOnce() -> T) -> T {
-        let _restore = EnvRestore::capture(&[name]);
-        set_env(name, value);
-        f()
+    fn with_terminal_env<T>(vars: &[(&str, Option<&str>)], f: impl FnOnce() -> T) -> T {
+        let mut scoped = TERMINAL_ENV.to_vec();
+        scoped.extend_from_slice(vars);
+        with_vars(&scoped, f)
     }
 
     #[test]
@@ -317,66 +288,52 @@ mod tests {
 
     #[test]
     fn image_protocol_override_reads_environment_exactly() {
-        let _guard = env_lock();
-        with_env("YTM_TUI_IMAGE_PROTOCOL", Some("kitty"), || {
+        with_var("YTM_TUI_IMAGE_PROTOCOL", Some("kitty"), || {
             assert_eq!(image_protocol_override(), Some(ProtocolType::Kitty));
         });
-        with_env("YTM_TUI_IMAGE_PROTOCOL", Some("unsupported"), || {
+        with_var("YTM_TUI_IMAGE_PROTOCOL", Some("unsupported"), || {
             assert_eq!(image_protocol_override(), None);
         });
-        with_env("YTM_TUI_IMAGE_PROTOCOL", None, || {
+        with_var("YTM_TUI_IMAGE_PROTOCOL", None, || {
             assert_eq!(image_protocol_override(), None);
         });
     }
 
     #[test]
     fn terminal_native_image_hints_follow_known_env_vars() {
-        let _guard = env_lock();
-        const NAMES: &[&str] = &[
-            "KITTY_WINDOW_ID",
-            "WEZTERM_EXECUTABLE",
-            "KONSOLE_VERSION",
-            "WT_SESSION",
-            "TERM",
-            "TERM_PROGRAM",
-        ];
-        let _restore = EnvRestore::capture(NAMES);
-        for name in NAMES {
-            unsafe { std::env::remove_var(name) };
-        }
-        assert!(!terminal_has_native_image_hint());
+        with_terminal_env(&[], || assert!(!terminal_has_native_image_hint()));
 
-        with_env("KITTY_WINDOW_ID", Some("1"), || {
+        with_terminal_env(&[("KITTY_WINDOW_ID", Some("1"))], || {
             assert!(terminal_has_native_image_hint());
         });
-        with_env("TERM", Some("xterm-kitty"), || {
+        with_terminal_env(&[("TERM", Some("xterm-kitty"))], || {
             assert!(terminal_has_native_image_hint());
         });
-        with_env("WT_SESSION", Some("1"), || {
+        with_terminal_env(&[("WT_SESSION", Some("1"))], || {
             assert!(terminal_has_native_image_hint());
         });
-        with_env("TERM", Some("foot"), || {
+        with_terminal_env(&[("TERM", Some("foot"))], || {
             assert!(terminal_has_native_image_hint());
         });
-        with_env("TERM", Some("mintty"), || {
+        with_terminal_env(&[("TERM", Some("mintty"))], || {
             assert!(terminal_has_native_image_hint());
         });
-        with_env("TERM", Some("mlterm"), || {
+        with_terminal_env(&[("TERM", Some("mlterm"))], || {
             assert!(terminal_has_native_image_hint());
         });
-        with_env("TERM", Some("rio"), || {
+        with_terminal_env(&[("TERM", Some("rio"))], || {
             assert!(terminal_has_native_image_hint());
         });
-        with_env("TERM", Some("contour"), || {
+        with_terminal_env(&[("TERM", Some("contour"))], || {
             assert!(terminal_has_native_image_hint());
         });
-        with_env("TERM_PROGRAM", Some("WezTerm"), || {
+        with_terminal_env(&[("TERM_PROGRAM", Some("WezTerm"))], || {
             assert!(terminal_has_native_image_hint());
         });
-        with_env("TERM_PROGRAM", Some("iTerm.app"), || {
+        with_terminal_env(&[("TERM_PROGRAM", Some("iTerm.app"))], || {
             assert!(terminal_has_native_image_hint());
         });
-        with_env("TERM_PROGRAM", Some("plain-terminal"), || {
+        with_terminal_env(&[("TERM_PROGRAM", Some("plain-terminal"))], || {
             assert!(!terminal_has_native_image_hint());
         });
     }
@@ -395,63 +352,45 @@ mod tests {
 
     #[test]
     fn trusted_protocol_hint_uses_only_strong_native_hints() {
-        let _guard = env_lock();
-        const NAMES: &[&str] = &[
-            "KITTY_WINDOW_ID",
-            "WEZTERM_EXECUTABLE",
-            "KONSOLE_VERSION",
-            "WT_SESSION",
-            "TERM",
-            "TERM_PROGRAM",
-        ];
-        let _restore = EnvRestore::capture(NAMES);
-        for name in NAMES {
-            unsafe { std::env::remove_var(name) };
-        }
+        with_terminal_env(&[], || assert_eq!(trusted_protocol_hint(), None));
 
-        assert_eq!(trusted_protocol_hint(), None);
-
-        with_env("KITTY_WINDOW_ID", Some("1"), || {
+        with_terminal_env(&[("KITTY_WINDOW_ID", Some("1"))], || {
             assert_eq!(trusted_protocol_hint(), Some(ProtocolType::Kitty));
         });
-        with_env("TERM", Some("xterm-kitty"), || {
+        with_terminal_env(&[("TERM", Some("xterm-kitty"))], || {
             assert_eq!(trusted_protocol_hint(), Some(ProtocolType::Kitty));
         });
-        with_env("TERM", Some("ghostty"), || {
+        with_terminal_env(&[("TERM", Some("ghostty"))], || {
             assert_eq!(trusted_protocol_hint(), Some(ProtocolType::Kitty));
         });
-        with_env("TERM_PROGRAM", Some("iTerm.app"), || {
+        with_terminal_env(&[("TERM_PROGRAM", Some("iTerm.app"))], || {
             assert_eq!(trusted_protocol_hint(), Some(ProtocolType::Iterm2));
         });
-        with_env("WT_SESSION", Some("1"), || {
+        with_terminal_env(&[("WT_SESSION", Some("1"))], || {
             assert_eq!(trusted_protocol_hint(), None);
         });
-        with_env("TERM", Some("foot"), || {
+        with_terminal_env(&[("TERM", Some("foot"))], || {
             assert_eq!(trusted_protocol_hint(), None);
         });
     }
 
     #[test]
     fn terminal_probe_cache_key_changes_with_relevant_environment() {
-        let _guard = env_lock();
-        let _restore = EnvRestore::capture(&["YTM_TUI_IMAGE_PROTOCOL"]);
-        set_env("YTM_TUI_IMAGE_PROTOCOL", None);
-        let base = terminal_probe_cache_key();
-        with_env("YTM_TUI_IMAGE_PROTOCOL", Some("sixel"), || {
+        let base = with_var("YTM_TUI_IMAGE_PROTOCOL", None, terminal_probe_cache_key);
+        with_var("YTM_TUI_IMAGE_PROTOCOL", Some("sixel"), || {
             assert_ne!(terminal_probe_cache_key(), base);
         });
     }
 
     #[test]
     fn env_nonempty_distinguishes_absent_empty_and_present() {
-        let _guard = env_lock();
-        with_env("YTM_TUI_TEST_ENV_NONEMPTY", None, || {
+        with_var("YTM_TUI_TEST_ENV_NONEMPTY", None, || {
             assert!(!env_nonempty("YTM_TUI_TEST_ENV_NONEMPTY"));
         });
-        with_env("YTM_TUI_TEST_ENV_NONEMPTY", Some(""), || {
+        with_var("YTM_TUI_TEST_ENV_NONEMPTY", Some(""), || {
             assert!(!env_nonempty("YTM_TUI_TEST_ENV_NONEMPTY"));
         });
-        with_env("YTM_TUI_TEST_ENV_NONEMPTY", Some("1"), || {
+        with_var("YTM_TUI_TEST_ENV_NONEMPTY", Some("1"), || {
             assert!(env_nonempty("YTM_TUI_TEST_ENV_NONEMPTY"));
         });
     }

--- a/src/test_util/env.rs
+++ b/src/test_util/env.rs
@@ -1,0 +1,152 @@
+//! Edition 2024: `set_var`/`remove_var` are unsafe. Quarantine all test env
+//! mutation here behind a process-global lock.
+//!
+//! Prefer [`with_var`] / [`with_vars`]. Do not call [`set_var`] / [`remove_var`] /
+//! [`EnvRestore::capture`] from inside a `with_*` closure unless you rely on the
+//! reentrant path below (same-thread nesting is supported; cross-thread still serializes).
+
+use std::cell::Cell;
+use std::ffi::{OsStr, OsString};
+use std::sync::{Mutex, MutexGuard};
+
+thread_local! {
+    static LOCK_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+struct DepthGuard;
+
+impl Drop for DepthGuard {
+    fn drop(&mut self) {
+        LOCK_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+    }
+}
+
+/// Process-global env mutex. Prefer [`with_vars`] over holding this across custom logic.
+pub fn env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn enter_locked(guard: MutexGuard<'static, ()>) -> (MutexGuard<'static, ()>, DepthGuard) {
+    LOCK_DEPTH.with(|depth| depth.set(depth.get() + 1));
+    (guard, DepthGuard)
+}
+
+fn acquire_lock() -> Option<(MutexGuard<'static, ()>, DepthGuard)> {
+    if LOCK_DEPTH.with(|depth| depth.get() > 0) {
+        // Already held on this thread (e.g. inside `with_vars`); skip re-lock.
+        None
+    } else {
+        Some(enter_locked(env_lock()))
+    }
+}
+
+pub fn set_var<K, V>(name: K, value: V)
+where
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    let _owned = acquire_lock();
+    // SAFETY: process-global env mutation; serialized by env_lock / same-thread depth; test-only.
+    unsafe { std::env::set_var(name, value) };
+}
+
+pub fn remove_var<K>(name: K)
+where
+    K: AsRef<OsStr>,
+{
+    let _owned = acquire_lock();
+    // SAFETY: process-global env mutation; serialized by env_lock / same-thread depth; test-only.
+    unsafe { std::env::remove_var(name) };
+}
+
+pub struct EnvRestore {
+    values: Vec<(String, Option<OsString>)>,
+}
+
+impl EnvRestore {
+    pub fn capture(names: &[&str]) -> Self {
+        let _owned = acquire_lock();
+        Self {
+            values: capture_env(names),
+        }
+    }
+}
+
+impl Drop for EnvRestore {
+    fn drop(&mut self) {
+        let _owned = acquire_lock();
+        restore_env(&self.values);
+    }
+}
+
+pub fn with_var<T>(name: &str, value: Option<&str>, f: impl FnOnce() -> T) -> T {
+    with_vars(&[(name, value)], f)
+}
+
+pub fn with_vars<T>(vars: &[(&str, Option<&str>)], f: impl FnOnce() -> T) -> T {
+    let (_guard, _depth) = enter_locked(env_lock());
+    let names: Vec<&str> = vars.iter().map(|(name, _)| *name).collect();
+    let restore = ScopedEnvRestore {
+        values: capture_env(&names),
+    };
+    for (name, value) in vars {
+        match value {
+            Some(value) => set_var_unlocked(name, value),
+            None => remove_var_unlocked(name),
+        }
+    }
+    let result = f();
+    drop(restore);
+    result
+}
+
+struct ScopedEnvRestore {
+    values: Vec<(String, Option<OsString>)>,
+}
+
+impl Drop for ScopedEnvRestore {
+    fn drop(&mut self) {
+        restore_env(&self.values);
+    }
+}
+
+fn capture_env(names: &[&str]) -> Vec<(String, Option<OsString>)> {
+    let mut values = Vec::new();
+    for name in names {
+        if values
+            .iter()
+            .any(|(captured, _): &(String, Option<OsString>)| captured == name)
+        {
+            continue;
+        }
+        values.push(((*name).to_owned(), std::env::var_os(name)));
+    }
+    values
+}
+
+fn restore_env(values: &[(String, Option<OsString>)]) {
+    for (name, value) in values {
+        match value {
+            Some(value) => set_var_unlocked(name, value),
+            None => remove_var_unlocked(name),
+        }
+    }
+}
+
+fn set_var_unlocked<K, V>(name: K, value: V)
+where
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    // SAFETY: caller holds env_lock (or same-thread depth); test-only module.
+    unsafe { std::env::set_var(name, value) };
+}
+
+fn remove_var_unlocked<K>(name: K)
+where
+    K: AsRef<OsStr>,
+{
+    // SAFETY: caller holds env_lock (or same-thread depth); test-only module.
+    unsafe { std::env::remove_var(name) };
+}

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -1,0 +1,1 @@
+pub mod env;

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -946,33 +946,8 @@ fn update() -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsString;
-
     use super::*;
-
-    struct EnvRestore(Vec<(String, Option<OsString>)>);
-
-    impl EnvRestore {
-        fn capture(names: &[&str]) -> Self {
-            Self(
-                names
-                    .iter()
-                    .map(|name| ((*name).to_owned(), std::env::var_os(name)))
-                    .collect(),
-            )
-        }
-    }
-
-    impl Drop for EnvRestore {
-        fn drop(&mut self) {
-            for (name, value) in &self.0 {
-                match value {
-                    Some(value) => unsafe { std::env::set_var(name, value) },
-                    None => unsafe { std::env::remove_var(name) },
-                }
-            }
-        }
-    }
+    use crate::test_util::env::with_var;
 
     fn temp_path(name: &str) -> PathBuf {
         std::env::temp_dir().join(format!("yututui-tools-cli-{name}-{}", std::process::id()))
@@ -1082,19 +1057,18 @@ mod tests {
 
     #[test]
     fn active_env_override_trims_and_ignores_empty_values() {
-        let _restore = EnvRestore::capture(&["YTM_YTDLP"]);
-
-        unsafe { std::env::remove_var("YTM_YTDLP") };
-        assert_eq!(active_env_ytdlp_override(), None);
-
-        unsafe { std::env::set_var("YTM_YTDLP", "   ") };
-        assert_eq!(active_env_ytdlp_override(), None);
-
-        unsafe { std::env::set_var("YTM_YTDLP", "  /opt/bin/yt-dlp  ") };
-        assert_eq!(
-            active_env_ytdlp_override().as_deref(),
-            Some("/opt/bin/yt-dlp")
-        );
+        with_var("YTM_YTDLP", None, || {
+            assert_eq!(active_env_ytdlp_override(), None);
+        });
+        with_var("YTM_YTDLP", Some("   "), || {
+            assert_eq!(active_env_ytdlp_override(), None);
+        });
+        with_var("YTM_YTDLP", Some("  /opt/bin/yt-dlp  "), || {
+            assert_eq!(
+                active_env_ytdlp_override().as_deref(),
+                Some("/opt/bin/yt-dlp")
+            );
+        });
     }
 
     #[test]
@@ -1160,14 +1134,13 @@ mod tests {
 
     #[test]
     fn resolve_pin_target_reports_missing_system_when_path_is_empty() {
-        let _restore = EnvRestore::capture(&["PATH"]);
-        unsafe { std::env::set_var("PATH", "") };
+        with_var("PATH", Some(""), || {
+            let err = resolve_pin_target(&UseTarget::System, false).unwrap_err();
+            assert!(err.contains("system yt-dlp was not found"));
 
-        let err = resolve_pin_target(&UseTarget::System, false).unwrap_err();
-        assert!(err.contains("system yt-dlp was not found"));
-
-        let err = resolve_pin_target(&UseTarget::System, true).unwrap_err();
-        assert!(err.contains("system yt-dlp"));
+            let err = resolve_pin_target(&UseTarget::System, true).unwrap_err();
+            assert!(err.contains("system yt-dlp"));
+        });
     }
 
     #[test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1228,8 +1228,7 @@ mod tests {
                 let dir =
                     std::env::temp_dir().join(format!("ytt-tools-state-{}", std::process::id()));
                 std::fs::create_dir_all(&dir).unwrap();
-                // SAFETY: test-only; set once before any concurrent reader can care.
-                unsafe { std::env::set_var("YTM_TOOLS_DIR", &dir) };
+                crate::test_util::env::set_var("YTM_TOOLS_DIR", &dir);
             });
         }
 

--- a/src/tools/ytdlp.rs
+++ b/src/tools/ytdlp.rs
@@ -1192,6 +1192,8 @@ fn retry_file_op(mut op: impl FnMut() -> std::io::Result<()>) -> std::io::Result
 
 #[cfg(test)]
 mod tests {
+    use crate::test_util::env::with_var;
+
     use super::*;
 
     #[test]
@@ -1263,7 +1265,6 @@ mod tests {
     #[test]
     fn preserve_current_records_previous_slot_metadata() {
         let _guard = crate::i18n::lock_for_test();
-        let original_tools_dir = std::env::var_os("YTM_TOOLS_DIR");
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|duration| duration.as_nanos())
@@ -1271,33 +1272,29 @@ mod tests {
         let dir =
             std::env::temp_dir().join(format!("ytt-ytdlp-prev-{}-{nanos}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
-        unsafe { std::env::set_var("YTM_TOOLS_DIR", &dir) };
+        let dir_value = dir.to_string_lossy();
+        with_var("YTM_TOOLS_DIR", Some(dir_value.as_ref()), || {
+            let dest = managed_path().unwrap();
+            std::fs::write(&dest, b"previous-binary").unwrap();
+            let (mtime, len) = file_stamp(&dest).unwrap();
+            let sha256 = sha256_file(&dest).unwrap();
+            let mut state = ManagedState {
+                channel: Some(YtdlpChannel::Nightly),
+                version: Some("2026.07.03.234421".to_owned()),
+                sha256: Some(sha256.clone()),
+                installed_mtime_unix: Some(mtime),
+                installed_len: Some(len),
+                ..ManagedState::default()
+            };
 
-        let dest = managed_path().unwrap();
-        std::fs::write(&dest, b"previous-binary").unwrap();
-        let (mtime, len) = file_stamp(&dest).unwrap();
-        let sha256 = sha256_file(&dest).unwrap();
-        let mut state = ManagedState {
-            channel: Some(YtdlpChannel::Nightly),
-            version: Some("2026.07.03.234421".to_owned()),
-            sha256: Some(sha256.clone()),
-            installed_mtime_unix: Some(mtime),
-            installed_len: Some(len),
-            ..ManagedState::default()
-        };
-
-        assert!(preserve_current_as_previous(&dest, &mut state).unwrap());
-        let previous = previous_managed_path().unwrap();
-        assert_eq!(std::fs::read(&previous).unwrap(), b"previous-binary");
-        assert_eq!(state.previous_channel, Some(YtdlpChannel::Nightly));
-        assert_eq!(state.previous_version.as_deref(), Some("2026.07.03.234421"));
-        assert_eq!(state.previous_sha256.as_deref(), Some(sha256.as_str()));
-        assert!(previous_stamp_matches(&previous, &state));
-
-        match original_tools_dir {
-            Some(value) => unsafe { std::env::set_var("YTM_TOOLS_DIR", value) },
-            None => unsafe { std::env::remove_var("YTM_TOOLS_DIR") },
-        }
+            assert!(preserve_current_as_previous(&dest, &mut state).unwrap());
+            let previous = previous_managed_path().unwrap();
+            assert_eq!(std::fs::read(&previous).unwrap(), b"previous-binary");
+            assert_eq!(state.previous_channel, Some(YtdlpChannel::Nightly));
+            assert_eq!(state.previous_version.as_deref(), Some("2026.07.03.234421"));
+            assert_eq!(state.previous_sha256.as_deref(), Some(sha256.as_str()));
+            assert!(previous_stamp_matches(&previous, &state));
+        });
         #[cfg(windows)]
         let _ = retry_file_op(|| std::fs::remove_dir_all(&dir));
         #[cfg(not(windows))]

--- a/src/util/process.rs
+++ b/src/util/process.rs
@@ -235,6 +235,8 @@ fn kill_and_wait_std(child: &mut std::process::Child, profile: ProcessProfile) {
     {
         // Best effort: the direct child may already have exited; the group kill catches
         // still-running yt-dlp helpers such as ffmpeg that inherited the process group.
+        // SAFETY: negative pid targets the child's process group; `kill` is a single
+        // syscall and any ESRCH/EPERM failure is intentionally ignored as best-effort cleanup.
         unsafe {
             libc::kill(-pid, libc::SIGKILL);
         }
@@ -252,6 +254,8 @@ pub async fn kill_and_wait_tokio(child: &mut tokio::process::Child, profile: Pro
         && let Some(id) = child.id()
         && let Ok(pid) = libc::pid_t::try_from(id)
     {
+        // SAFETY: same process-group kill contract as the std child path; failure only
+        // means the group no longer exists or cannot be signaled, so cleanup continues.
         unsafe {
             libc::kill(-pid, libc::SIGKILL);
         }
@@ -586,6 +590,8 @@ mod tests {
             .parse()
             .expect("pid file should contain a pid");
         for _ in 0..20 {
+            // SAFETY: signal 0 probes process existence without delivery; a stale or
+            // unauthorized pid just reports failure through errno/false.
             let alive = unsafe { libc::kill(pid, 0) == 0 };
             if !alive {
                 let _ = std::fs::remove_dir_all(&root);

--- a/src/util/runtime.rs
+++ b/src/util/runtime.rs
@@ -28,6 +28,8 @@ fn user_tag() -> String {
 
 #[cfg(unix)]
 fn uid_tag() -> String {
+    // SAFETY: `geteuid` has no preconditions and returns the effective uid for the
+    // current process; failure is not represented by this libc API.
     unsafe { libc::geteuid() }.to_string()
 }
 
@@ -41,9 +43,12 @@ fn secure_existing_runtime_base(path: &Path) -> bool {
     let Ok(meta) = std::fs::symlink_metadata(path) else {
         return false;
     };
+    // SAFETY: `geteuid` has no preconditions; comparing metadata ownership is a
+    // read-only permission check for the already-stat'ed runtime directory.
+    let euid = unsafe { libc::geteuid() };
     meta.is_dir()
         && !meta.file_type().is_symlink()
-        && meta.uid() == unsafe { libc::geteuid() }
+        && meta.uid() == euid
         && (meta.permissions().mode() & 0o077) == 0
 }
 

--- a/src/util/safe_fs.rs
+++ b/src/util/safe_fs.rs
@@ -80,7 +80,10 @@ fn private_file_mode() -> u32 {
 
 #[cfg(unix)]
 fn is_owned_by_current_user(meta: &fs::Metadata) -> bool {
-    meta.uid() == unsafe { libc::geteuid() }
+    // SAFETY: `geteuid` has no preconditions and cannot fail; the returned uid is
+    // only compared against metadata ownership.
+    let euid = unsafe { libc::geteuid() };
+    meta.uid() == euid
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Deny `unsafe_op_in_unsafe_fn` and `clippy::undocumented_unsafe_blocks` in yututui and the ratatui-image fork (no workspace promotion — fork defaults still enable `chafa-dyn`).
- Quarantine Edition 2024 test `env::set_var`/`remove_var` behind `src/test_util/env.rs` with a process-global lock (and same-thread reentrancy), removing duplicated `EnvRestore` helpers across seven call sites.
- Document production FFI/`unsafe` sites with `// SAFETY:` comments and add `scripts/check-unsafe-inventory.sh` as a path allowlist gate (not `deny(unsafe_code)`).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --features desktop --all-targets -- -D warnings`
- [x] `cargo clippy --features desktop --bin yututray -- -D warnings`
- [x] `cargo clippy --manifest-path crates/ratatui-image/Cargo.toml --no-default-features --features crossterm,tokio --all-targets -- -D warnings`
- [x] `cargo clippy --target x86_64-pc-windows-gnu --all-targets -- -D warnings`
- [x] `cargo clippy --target x86_64-pc-windows-gnu --features desktop --all-targets -- -D warnings`
- [x] `bash scripts/check-unsafe-inventory.sh`
- [x] `cargo test --workspace`
- [ ] CI 3-OS matrix (especially Windows SMTC/registry/COM paths)
- [ ] Optional follow-up: wire `check-unsafe-inventory.sh` into `.github/workflows/build.yml` quality job (local harness is gitignored)


Made with [Cursor](https://cursor.com)