### PR TITLE
Pool PR Linux gates on debian-ci and fedora-ci

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -32,8 +32,8 @@ jobs:
     name: Quality gates
     # Repo-scoped self-hosted only; never schedule on fork PRs.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    # Shared pool: debian-ci and fedora-ci both carry the yututui label.
-    runs-on: [self-hosted, yututui]
+    # Shared Linux pool: debian-ci and fedora-ci both carry the yututui label.
+    runs-on: [self-hosted, Linux, yututui]
     steps:
       - uses: actions/checkout@v4
 
@@ -125,8 +125,8 @@ jobs:
   linux:
     name: Linux (x64)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    # Shared pool: debian-ci and fedora-ci both carry the yututui label.
-    runs-on: [self-hosted, yututui]
+    # Shared Linux pool: debian-ci and fedora-ci both carry the yututui label.
+    runs-on: [self-hosted, Linux, yututui]
     steps:
       - uses: actions/checkout@v4
 
@@ -146,10 +146,17 @@ jobs:
 
       - name: Install Linux system dependencies
         run: |
-          # Prefer already-installed packages; apt only if missing (may need passwordless sudo).
+          # Prefer already-installed packages; install only if missing.
           if ! pkg-config --exists openssl 2>/dev/null; then
-            sudo apt-get update
-            sudo apt-get install -y libssl-dev pkg-config
+            if command -v apt-get >/dev/null; then
+              sudo apt-get update
+              sudo apt-get install -y libssl-dev pkg-config
+            elif command -v dnf >/dev/null; then
+              sudo dnf install -y openssl-devel pkgconf-pkg-config
+            else
+              echo "error: unsupported Linux package manager; install OpenSSL development headers and pkg-config" >&2
+              exit 1
+            fi
           fi
 
       - name: Clippy (warnings = errors)

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,7 +1,8 @@
 name: ci-pr
 
-# Daily PR / main merge gate on the debian-ts self-hosted runner.
+# Daily PR / main merge gate on self-hosted Linux runners (debian-ci / fedora-ci).
 # Full multi-OS release builds stay in build.yml (v* tags + workflow_dispatch).
+# Intel Mac (macos-15-intel) stays GitHub-hosted on build.yml only.
 # Optional Windows/macOS light jobs run only with label ci:windows / ci:macos
 # or workflow_dispatch inputs — never required, so offline PCs cannot block merge.
 
@@ -31,8 +32,8 @@ jobs:
     name: Quality gates
     # Repo-scoped self-hosted only; never schedule on fork PRs.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    # Match debian-ts custom labels; OS/arch come from the runner automatically.
-    runs-on: [self-hosted, debian, yututui]
+    # Shared pool: debian-ci and fedora-ci both carry the yututui label.
+    runs-on: [self-hosted, yututui]
     steps:
       - uses: actions/checkout@v4
 
@@ -124,8 +125,8 @@ jobs:
   linux:
     name: Linux (x64)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    # Match debian-ts custom labels; OS/arch come from the runner automatically.
-    runs-on: [self-hosted, debian, yututui]
+    # Shared pool: debian-ci and fedora-ci both carry the yututui label.
+    runs-on: [self-hosted, yututui]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add Fedora Tailscale host as `fedora-ci` self-hosted runner (backup / load balance with `debian-ci`).
- Change `ci-pr.yml` Quality + Linux `runs-on` to `[self-hosted, yututui]` so either Linux runner can pick jobs.
- Keep Intel Mac (`macos-15-intel`) on GitHub-hosted `build.yml` only — no KVM macOS.

## Test plan
- [x] `fedora-ci` online with labels `yututui,fedora`
- [x] Dispatch `ci-pr` — Fedora ran `Linux (x64)` and succeeded
- [ ] Merge after green checks on this PR


Made with [Cursor](https://cursor.com)