### PR TITLE
Harden Spotify→YTM import against yt-dlp 403 soft-fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ cookies.txt
 /.agents/
 /.codex/
 /.codex-worktrees/
+
+# Cursor IDE / debug session artifacts
+.cursor/

--- a/src/transfer/engine.rs
+++ b/src/transfer/engine.rs
@@ -467,6 +467,23 @@ async fn match_stage(
                 )
                 .await;
         }
+        // Surface matching start immediately — otherwise the CLI looks hung while the
+        // first concurrent yt-dlp searches run (often many seconds with no progress).
+        progress(TransferProgress {
+            job_id: cp.job_id.clone(),
+            stage: Stage::Matching,
+            done: 0,
+            total,
+            matched: 0,
+            auto_accepted: 0,
+            ambiguous: 0,
+            not_found: 0,
+            written: written_count(&cp.tracks),
+            current: pending
+                .first()
+                .map(|(_, input)| input.display())
+                .unwrap_or_default(),
+        });
         let mut stream = futures::stream::iter(pending)
             .map(|(idx, input)| {
                 let state = shared_state.clone();
@@ -1341,12 +1358,26 @@ fn spotify_job_error(e: SpotifyError) -> JobError {
 }
 
 fn ytm_job_error(e: anyhow::Error) -> JobError {
-    // YTM failures mid-job (expired cookie, throttling) are the classic resume case.
+    // Mid-job YTM/yt-dlp failures are resumable. Do not blame cookies when the cause is
+    // clearly a public yt-dlp search / YouTube API rejection.
+    let detail = format!("{e:#}");
+    let detail_lc = detail.to_ascii_lowercase();
+    let ytdlp_search = detail_lc.contains("yt-dlp")
+        || detail_lc.contains("unable to download api page")
+        || detail_lc.contains("http error 403")
+        || detail_lc.contains("403 forbidden")
+        || detail_lc.contains("http error 429")
+        || detail_lc.contains("too many requests")
+        || detail_lc.contains("rate-limited")
+        || crate::tools::classify_ytdlp_failure(&detail).is_some();
+    let context = if ytdlp_search {
+        "YouTube/yt-dlp search failed — wait and retry, or run `ytt tools update` / `ytt doctor --verbose`; then resume this job"
+    } else {
+        "YouTube Music request failed — after fixing the cookie you can resume this job"
+    };
     JobError {
         resumable: true,
-        error: e.context(
-            "YouTube Music request failed — after fixing the cookie you can resume this job",
-        ),
+        error: e.context(context),
     }
 }
 

--- a/src/transfer/engine/tests.rs
+++ b/src/transfer/engine/tests.rs
@@ -399,6 +399,26 @@ fn provider_errors_are_classified_for_resume_safety() {
             .to_string()
             .contains("YouTube Music request failed")
     );
+    assert!(
+        ytm_error
+            .error
+            .to_string()
+            .contains("after fixing the cookie")
+    );
+
+    let ytdlp_error = ytm_job_error(anyhow!(
+        "yt-dlp search exited with status exit status: 1 (ERROR: query \"x\" page 1: Unable to download API page: HTTP Error 403: Forbidden)"
+    ));
+    assert!(ytdlp_error.resumable);
+    let msg = format!("{:#}", ytdlp_error.error);
+    assert!(
+        msg.contains("YouTube/yt-dlp search failed"),
+        "yt-dlp 403 must not blame cookies: {msg}"
+    );
+    assert!(
+        !msg.contains("after fixing the cookie"),
+        "yt-dlp 403 must not blame cookies: {msg}"
+    );
 }
 
 #[test]

--- a/src/transfer/matching/tests.rs
+++ b/src/transfer/matching/tests.rs
@@ -1,3 +1,4 @@
+use super::ytm_retrieval::{is_noisy_video_fallback_query, video_search_error_is_soft};
 use super::*;
 
 fn input(title: &str, artists: &[&str], album: Option<&str>, dur: Option<u32>) -> TrackInput {
@@ -254,7 +255,36 @@ fn ytm_catalog_plan_uses_only_fast_primary_queries_before_fallbacks() {
     let fallback = ytm_fallback_query_plan(&input);
     assert!(!fallback.contains(&"Primary Song Title".to_owned()));
     assert!(fallback.contains(&"Primary Song Title official audio".to_owned()));
-    assert!(fallback.contains(&"Primary Song Title topic".to_owned()));
+    assert!(
+        !fallback.contains(&"Primary Song Title topic".to_owned()),
+        "bare topic suffix is filtered from video fallback"
+    );
+    assert!(
+        !fallback.iter().any(|q| q.ends_with(" 2024")),
+        "year-suffix variants are filtered from video fallback: {fallback:?}"
+    );
+}
+
+#[test]
+fn noisy_video_fallback_query_filter_drops_topic_and_year_suffix() {
+    assert!(is_noisy_video_fallback_query("Aimyon Marigold topic"));
+    assert!(is_noisy_video_fallback_query(
+        "21univ. Sticker picture 2022"
+    ));
+    assert!(!is_noisy_video_fallback_query(
+        "Primary Song Title official audio"
+    ));
+    assert!(!is_noisy_video_fallback_query(
+        "Primary Song Title Album Name"
+    ));
+}
+
+#[test]
+fn video_search_errors_are_soft_at_matching_boundary() {
+    let err = anyhow::anyhow!(
+        "yt-dlp search exited with status exit status: 1 (ERROR: query \"Aimyon Marigold topic\" page 1: Unable to download API page: HTTP Error 403: Forbidden)"
+    );
+    assert!(video_search_error_is_soft(&err));
 }
 
 #[test]

--- a/src/transfer/matching/ytm_retrieval.rs
+++ b/src/transfer/matching/ytm_retrieval.rs
@@ -311,7 +311,32 @@ pub fn ytm_fallback_query_plan(input: &TrackInput) -> Vec<String> {
     ytm_query_plan(input)
         .into_iter()
         .filter(|query| !fast.contains(&normalize(query)))
+        // Under degraded catalog search, every fallback hits yt-dlp. Drop variants that
+        // mostly amplify 403s without unique signal (`… topic`, bare year suffixes).
+        .filter(|query| !is_noisy_video_fallback_query(query))
         .collect()
+}
+
+/// Video-fallback queries that add little unique signal and inflate yt-dlp call volume.
+pub(crate) fn is_noisy_video_fallback_query(query: &str) -> bool {
+    let query = query.trim_end();
+    if query.ends_with(" topic") {
+        return true;
+    }
+    if let Some((_, year)) = query.rsplit_once(' ')
+        && year.len() == 4
+        && year.chars().all(|c| c.is_ascii_digit())
+    {
+        return true;
+    }
+    false
+}
+
+/// Transfer matching soft-fails yt-dlp video-search errors so one bad query cannot abort
+/// a whole playlist job. Video search is the noisy path; catalog already soft-fails the
+/// same way. Engine consecutive-failure abort still covers systemic Err from other paths.
+pub(crate) fn video_search_error_is_soft(_err: &anyhow::Error) -> bool {
+    true
 }
 
 pub(crate) async fn match_track_ytm_shared(
@@ -354,8 +379,20 @@ pub(crate) async fn match_track_ytm_shared(
     }
 
     if !matches!(outcome, MatchOutcome::Matched { .. }) {
+        // Soft-continue on video-search errors: one yt-dlp 403 must not promote to a
+        // whole-track Err (engine consecutive-failure abort). Keep candidates already found.
         for query in ytm_fallback_query_plan(input) {
-            let songs = shared_video_songs(api, &query, search_config, state).await?;
+            let songs = match shared_video_songs(api, &query, search_config, state).await {
+                Ok(songs) => songs,
+                Err(error) => {
+                    tracing::warn!(
+                        query = %query,
+                        error = %crate::util::sanitize::sanitize_error_text(format!("{error:#}")),
+                        "transfer video search failed; continuing with remaining fallback queries"
+                    );
+                    continue;
+                }
+            };
             for (song, kind) in &songs {
                 if !candidates.iter().any(|c| c.key == song.video_id) {
                     candidates.push(MatchCandidate::from_song_with_kind(song, (*kind).into()));
@@ -366,10 +403,15 @@ pub(crate) async fn match_track_ytm_shared(
                 break;
             }
         }
-        let preflighted =
-            preflight_ytm_candidates_shared(api, input, cfg, &mut candidates, state).await;
-        state.diagnostics.lock().await.preflight_lookups += preflighted;
-        outcome = best_outcome(input, &candidates, cfg);
+        // Early-stop can produce Matched inside the loop above. Do NOT still run
+        // yt-dlp metadata preflight in that case — it re-spawns slow/403-prone
+        // lookups and keeps the CLI stuck at 0/N with no progress.
+        if !matches!(outcome, MatchOutcome::Matched { .. }) {
+            let preflighted =
+                preflight_ytm_candidates_shared(api, input, cfg, &mut candidates, state).await;
+            state.diagnostics.lock().await.preflight_lookups += preflighted;
+            outcome = best_outcome(input, &candidates, cfg);
+        }
     }
 
     state.memo.lock().await.insert(key, outcome.clone());
@@ -442,7 +484,23 @@ async fn shared_video_songs(
         .await
         .expect("video semaphore should not close");
     state.pace.lock().await.tick().await;
-    let songs = api.search_transfer_video(query, search_config).await?;
+    // Soft-fail like catalog/album: yt-dlp 403/exit-1 must become Ok([]) so matching
+    // records NotFound instead of a track-level Err that trips the engine streak abort.
+    let songs = match api.search_transfer_video(query, search_config).await {
+        Ok(songs) => songs,
+        Err(error) => {
+            debug_assert!(
+                video_search_error_is_soft(&error),
+                "video search errors are soft-failed at the matching boundary"
+            );
+            tracing::warn!(
+                query = %query,
+                error = %crate::util::sanitize::sanitize_error_text(format!("{error:#}")),
+                "transfer video search soft-failed; treating as no results"
+            );
+            Vec::new()
+        }
+    };
     state.diagnostics.lock().await.video_searches += 1;
     let songs = songs
         .into_iter()
@@ -562,11 +620,20 @@ async fn preflight_ytm_candidates_shared(
 }
 
 fn needs_transfer_preflight(candidate: &MatchCandidate) -> bool {
+    // Flat yt-dlp search already carries duration/channel for most rows. Full
+    // `--dump-single-json` metadata enrichment is the hang we saw under 403
+    // pressure (preflight_before with no preflight_after for 75s+). Skip when
+    // the flat row is already rich enough for scoring.
     !candidate.preflighted
         && matches!(
             candidate.source_kind,
             CandidateSourceKind::YoutubeVideoSearch | CandidateSourceKind::Unknown
         )
+        && (candidate.duration_secs.is_none()
+            || candidate
+                .channel
+                .as_ref()
+                .is_none_or(|c| c.trim().is_empty()))
 }
 
 fn apply_transfer_preflight(
@@ -659,7 +726,15 @@ fn should_stop_ytm_search(outcome: &MatchOutcome, cfg: &MatchConfig) -> bool {
                 MatchPolicy::Aggressive => cfg.accept,
                 MatchPolicy::Exhaustive => unreachable!("handled above"),
             };
-            *total >= target && quality_source
+            // Under authenticated-catalog degrade, video-only matches never carry
+            // catalog_song/trusted_channel/official_like. Requiring quality_source then
+            // forces every fallback query (multi-second yt-dlp each) and looks hung.
+            // Strict still wants a quality signal; Balanced/Aggressive stop on score alone.
+            match cfg.policy {
+                MatchPolicy::Strict => *total >= target && quality_source,
+                MatchPolicy::Balanced | MatchPolicy::Aggressive => *total >= target,
+                MatchPolicy::Exhaustive => unreachable!("handled above"),
+            }
         }
         MatchOutcome::Matched { .. } => true,
         _ => false,


### PR DESCRIPTION
## Summary
- Soft-fail yt-dlp video fallback search (403 no longer aborts the whole import job)
- Balanced/Aggressive early-stop on score alone when catalog quality signals are missing
- Skip redundant transfer preflight once a match already has duration/channel
- Ignore `.cursor/` so debug session logs cannot be committed again

## Test plan
- [x] Local clippy/fmt clean on the transfer matching changes
- [ ] CI `Quality gates` + `Linux (x64)` green
- [ ] Merge to main once required checks pass

Made with [Cursor](https://cursor.com)