### PR TITLE
Scan nested download folders for Local Deck and Downloads

### DIFF
--- a/src/app/local.rs
+++ b/src/app/local.rs
@@ -555,6 +555,7 @@ impl App {
                 crate::local::LocalScanRoot {
                     path,
                     recursive: root.recursive(),
+                    max_depth: None,
                 },
             );
         }

--- a/src/app/local_format.rs
+++ b/src/app/local_format.rs
@@ -10,6 +10,13 @@ pub(in crate::app) fn push_local_scan_root(
 ) {
     if let Some(existing) = roots.iter_mut().find(|existing| existing.path == root.path) {
         existing.recursive |= root.recursive;
+        if existing.recursive {
+            existing.max_depth = None;
+        } else if existing.max_depth.is_none() {
+            existing.max_depth = root.max_depth;
+        } else if let Some(incoming) = root.max_depth {
+            existing.max_depth = Some(existing.max_depth.unwrap_or(0).max(incoming));
+        }
     } else {
         roots.push(root);
     }

--- a/src/app/tests/local.rs
+++ b/src/app/tests/local.rs
@@ -1077,6 +1077,7 @@ fn settings_local_music_root_persists_and_rescans_active_local_deck() {
             crate::local::LocalScanRoot {
                 path: PathBuf::from("/tmp/ytt-local-library"),
                 recursive: false,
+                max_depth: None,
             },
         ]
     );
@@ -1117,6 +1118,7 @@ fn closing_settings_with_local_root_toggles_rescans_active_local_deck() {
         &vec![crate::local::LocalScanRoot {
             path: music,
             recursive: false,
+            max_depth: None,
         }]
     );
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -645,8 +645,8 @@ pub const LOCAL_IMPORT_PATH_TEMPLATE_DEFAULT: &str =
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct LocalConfig {
-    /// Include the configured/default download folder as a non-recursive scan root.
-    /// `None` preserves the default for older config files.
+    /// Include the configured/default download folder as a depth-limited scan root
+    /// (up to Artist/Album nesting). `None` preserves the default for older config files.
     pub include_download_dir: Option<bool>,
     /// Additional user music folders. The current Settings UI edits the first entry; the Vec
     /// leaves room for a later multi-root editor without another config migration.

--- a/src/library.rs
+++ b/src/library.rs
@@ -278,40 +278,34 @@ pub(crate) fn library_path() -> Option<PathBuf> {
     crate::paths::data_dir().map(|d| d.join("library.json"))
 }
 
+/// Max directory depth under the download root (`Artist/Album/track` = depth 2).
+const DOWNLOADS_MAX_DEPTH: u32 = 2;
+
 /// Scan the configured download directory for directly playable local audio files.
 ///
-/// The downloader writes files directly under this folder, so this intentionally stays
-/// non-recursive and bounded. Missing/unreadable directories simply produce an empty list.
+/// Walks up to [`DOWNLOADS_MAX_DEPTH`] directory levels so mixed layouts work:
+/// root files, `Artist/track`, and `Artist/Album/track`. Deeper nesting is skipped.
+/// Missing/unreadable directories simply produce an empty list.
 pub fn scan_downloads(dir: &Path) -> DownloadScan {
-    let Ok(entries) = fs::read_dir(dir) else {
-        return DownloadScan {
-            limit: DOWNLOADS_MAX,
-            ..DownloadScan::default()
-        };
-    };
-    // Bounded top-K by lowercased filename: keep at most DOWNLOADS_MAX entries while streaming
-    // the directory (a max-heap drops the current largest once full), so a folder with far more
-    // files than the cap uses O(cap) memory instead of collecting + sorting the whole listing.
-    // Output is the alphabetically-first DOWNLOADS_MAX — the same set/order as before.
+    // Bounded top-K by lowercased relative path: keep at most DOWNLOADS_MAX entries while
+    // streaming the walk (a max-heap drops the current largest once full), so a folder with
+    // far more files than the cap uses O(cap) memory instead of collecting + sorting everything.
+    // Output is the alphabetically-first DOWNLOADS_MAX.
     use std::collections::BinaryHeap;
     let mut heap: BinaryHeap<(String, PathBuf)> = BinaryHeap::new();
     let mut truncated = false;
-    for entry in entries.filter_map(Result::ok) {
-        let path = entry.path();
-        let is_file = entry.file_type().ok().is_some_and(|t| t.is_file());
-        if !(is_file && is_audio_file(&path)) {
-            continue;
-        }
+    walk_download_audio(dir, 0, &mut |path| {
         let key = path
-            .file_name()
-            .map(|s| s.to_string_lossy().to_lowercase())
-            .unwrap_or_default();
-        heap.push((key, path));
+            .strip_prefix(dir)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .to_lowercase();
+        heap.push((key, path.to_path_buf()));
         if heap.len() > DOWNLOADS_MAX {
             truncated = true;
             heap.pop(); // drop the largest key, keeping the smallest DOWNLOADS_MAX
         }
-    }
+    });
     let mut kept = heap.into_vec();
     kept.sort_by(|a, b| a.0.cmp(&b.0));
     DownloadScan {
@@ -319,6 +313,39 @@ pub fn scan_downloads(dir: &Path) -> DownloadScan {
         truncated,
         limit: DOWNLOADS_MAX,
     }
+}
+
+fn walk_download_audio(dir: &Path, depth: u32, on_audio: &mut dyn FnMut(&Path)) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if is_hidden_path(&path) {
+            continue;
+        }
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            if depth < DOWNLOADS_MAX_DEPTH {
+                walk_download_audio(&path, depth + 1, on_audio);
+            }
+            continue;
+        }
+        if file_type.is_file() && is_audio_file(&path) {
+            on_audio(&path);
+        }
+    }
+}
+
+fn is_hidden_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with('.'))
 }
 
 fn is_audio_file(path: &Path) -> bool {
@@ -520,12 +547,25 @@ mod tests {
         fs::write(dir.join("b.MP3"), b"").unwrap();
         fs::write(dir.join("a.m4a"), b"").unwrap();
         fs::write(dir.join("note.txt"), b"").unwrap();
-        fs::create_dir_all(dir.join("album")).unwrap();
-        fs::write(dir.join("album").join("nested.flac"), b"").unwrap();
+        fs::create_dir_all(dir.join("Artist").join("Album")).unwrap();
+        fs::write(dir.join("Artist").join("cover.mp3"), b"").unwrap();
+        fs::write(dir.join("Artist").join("Album").join("nested.flac"), b"").unwrap();
+        fs::create_dir_all(dir.join("Artist").join("Album").join("extra")).unwrap();
+        fs::write(
+            dir.join("Artist")
+                .join("Album")
+                .join("extra")
+                .join("too-deep.wav"),
+            b"",
+        )
+        .unwrap();
+        fs::create_dir_all(dir.join(".hidden")).unwrap();
+        fs::write(dir.join(".hidden").join("secret.mp3"), b"").unwrap();
 
         let scan = scan_downloads(&dir);
         let titles: Vec<&str> = scan.songs.iter().map(|s| s.title.as_str()).collect();
-        assert_eq!(titles, vec!["a", "b"]);
+        // Sorted by lowercased relative path: a, Artist/Album/nested, Artist/cover, b
+        assert_eq!(titles, vec!["a", "nested", "cover", "b"]);
         assert!(!scan.truncated);
         assert_eq!(scan.limit, DOWNLOADS_MAX);
         assert!(scan.songs.iter().all(Song::is_local));

--- a/src/local/scan.rs
+++ b/src/local/scan.rs
@@ -255,6 +255,8 @@ where
         let modified_at = metadata_modified_unix(&metadata);
         let fingerprint = FileFingerprint::path_mtime_size(&canonical, modified_at, metadata.len());
         if let Some(track) = self.previous.find_unchanged(&fingerprint) {
+            // Cheap path-hint fill still runs on reuse: older indexes may lack
+            // artist/album that folder names can supply without re-reading tags.
             let mut track = track.clone();
             apply_path_metadata_fallback(&mut track, root, &canonical);
             self.seen_ids.push(track.id.clone());

--- a/src/local/scan.rs
+++ b/src/local/scan.rs
@@ -255,8 +255,10 @@ where
         let modified_at = metadata_modified_unix(&metadata);
         let fingerprint = FileFingerprint::path_mtime_size(&canonical, modified_at, metadata.len());
         if let Some(track) = self.previous.find_unchanged(&fingerprint) {
+            let mut track = track.clone();
+            apply_path_metadata_fallback(&mut track, root, &canonical);
             self.seen_ids.push(track.id.clone());
-            self.tracks.push(track.clone());
+            self.tracks.push(track);
             self.summary.reused += 1;
             self.emit_progress(Some(canonical));
             return;
@@ -568,6 +570,35 @@ mod tests {
         assert_eq!(track.artist, vec!["Tag Artist"]);
         assert_eq!(track.album.as_deref(), Some("Tag Album"));
         assert_eq!(track.album_artist.as_deref(), Some("Tag Album Artist"));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn reused_tracks_apply_path_metadata_fallback() {
+        let dir = temp_dir();
+        let album_dir = dir.join("Folder Artist").join("Folder Album");
+        fs::create_dir_all(&album_dir).unwrap();
+        fs::write(album_dir.join("song.mp3"), b"not audio").unwrap();
+
+        let first = scan_roots(
+            &[LocalScanRoot::download(dir.clone())],
+            &LocalIndex::default(),
+        );
+        let mut legacy_track = first.index.tracks()[0].clone();
+        legacy_track.artist.clear();
+        legacy_track.album = None;
+        legacy_track.album_artist = None;
+        let mut previous = LocalIndex::default();
+        previous.set_tracks(vec![legacy_track]);
+
+        let second = scan_roots(&[LocalScanRoot::download(dir.clone())], &previous);
+
+        assert_eq!(second.summary.reused, 1);
+        let track = &second.index.tracks()[0];
+        assert_eq!(track.artist, vec!["Folder Artist"]);
+        assert_eq!(track.album.as_deref(), Some("Folder Album"));
+        assert_eq!(track.album_artist.as_deref(), Some("Folder Artist"));
 
         let _ = fs::remove_dir_all(dir);
     }

--- a/src/local/scan.rs
+++ b/src/local/scan.rs
@@ -12,10 +12,18 @@ use super::model::{FileFingerprint, LocalTrack, LocalTrackId};
 
 const AUDIO_EXTENSIONS: &[&str] = &["aac", "flac", "m4a", "mp3", "ogg", "opus", "wav", "wma"];
 
+/// Max directory depth for the download-folder scan root (`Artist/Album/track` = 2).
+pub const DOWNLOAD_SCAN_MAX_DEPTH: u32 = 2;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LocalScanRoot {
     pub path: PathBuf,
     pub recursive: bool,
+    /// When set, descend at most this many directory levels below the root
+    /// (files at depth 0..=max_depth are indexed). Ignored when `recursive` is true
+    /// after merge with a full music root.
+    #[serde(default)]
+    pub max_depth: Option<u32>,
 }
 
 impl LocalScanRoot {
@@ -23,6 +31,7 @@ impl LocalScanRoot {
         Self {
             path,
             recursive: false,
+            max_depth: Some(DOWNLOAD_SCAN_MAX_DEPTH),
         }
     }
 
@@ -30,6 +39,7 @@ impl LocalScanRoot {
         Self {
             path,
             recursive: true,
+            max_depth: None,
         }
     }
 }
@@ -145,10 +155,17 @@ where
             self.emit_progress(Some(root.path.clone()));
             return;
         }
-        self.scan_dir(&root_path, root.recursive);
+        self.scan_dir(&root_path, &root_path, 0, root.recursive, root.max_depth);
     }
 
-    fn scan_dir(&mut self, dir: &Path, recursive: bool) {
+    fn scan_dir(
+        &mut self,
+        root: &Path,
+        dir: &Path,
+        depth: u32,
+        recursive: bool,
+        max_depth: Option<u32>,
+    ) {
         let entries = match fs::read_dir(dir) {
             Ok(entries) => entries,
             Err(error) => {
@@ -194,8 +211,13 @@ where
                 continue;
             }
             if file_type.is_dir() {
-                if recursive {
-                    self.scan_dir(&path, recursive);
+                let can_descend = if recursive {
+                    true
+                } else {
+                    max_depth.is_some_and(|max| depth < max)
+                };
+                if can_descend {
+                    self.scan_dir(root, &path, depth + 1, recursive, max_depth);
                 } else {
                     self.summary.skipped += 1;
                     self.emit_progress(Some(path));
@@ -212,11 +234,11 @@ where
                 self.emit_progress(Some(path));
                 continue;
             }
-            self.scan_file(path);
+            self.scan_file(root, path);
         }
     }
 
-    fn scan_file(&mut self, path: PathBuf) {
+    fn scan_file(&mut self, root: &Path, path: PathBuf) {
         self.summary.seen += 1;
         let canonical = canonical_or_original(&path);
         let metadata = match fs::metadata(&canonical) {
@@ -256,6 +278,7 @@ where
                 message: format!("download sidecar could not be read: {error}"),
             }),
         }
+        apply_path_metadata_fallback(&mut read.track, root, &canonical);
         if was_known_path {
             self.summary.changed += 1;
         } else {
@@ -323,6 +346,72 @@ fn apply_download_sidecar(track: &mut LocalTrack, sidecar: &crate::downloads::Do
     track.import_source_order = sidecar.import_source_order.filter(|order| *order > 0);
 }
 
+/// Fill empty artist/album fields from parent folder names relative to `root`.
+///
+/// - 0 dirs under root → no hints
+/// - 1 dir → artist = that folder
+/// - 2+ dirs → artist = first component, album = last component
+fn apply_path_metadata_fallback(track: &mut LocalTrack, root: &Path, file: &Path) {
+    let Some((artist_hint, album_hint)) = path_metadata_hints(root, file) else {
+        return;
+    };
+    let artist_empty = track.artist.is_empty()
+        || track
+            .artist
+            .iter()
+            .all(|a| a.eq_ignore_ascii_case("local file"));
+    if artist_empty {
+        track.artist = vec![artist_hint.clone()];
+    }
+    if track
+        .album_artist
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .is_none()
+    {
+        track.album_artist = Some(artist_hint);
+    }
+    if track
+        .album
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .is_none()
+        && let Some(album) = album_hint
+    {
+        track.album = Some(album);
+    }
+}
+
+fn path_metadata_hints(root: &Path, file: &Path) -> Option<(String, Option<String>)> {
+    let parent = file.parent()?;
+    let relative = parent.strip_prefix(root).ok()?;
+    let components: Vec<String> = relative
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(name) => {
+                let s = name.to_string_lossy();
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_owned())
+                }
+            }
+            _ => None,
+        })
+        .collect();
+    match components.as_slice() {
+        [] => None,
+        [artist] => Some((artist.clone(), None)),
+        [artist, ..] => {
+            let album = components.last().cloned();
+            Some((artist.clone(), album))
+        }
+    }
+}
+
 fn clean_sidecar_text(text: &str) -> Option<String> {
     let text = text.trim();
     if text.is_empty() {
@@ -374,11 +463,100 @@ mod tests {
     }
 
     #[test]
-    fn download_root_is_non_recursive() {
+    fn download_root_walks_two_directory_levels() {
         let dir = temp_dir();
-        fs::create_dir_all(dir.join("nested")).unwrap();
+        fs::create_dir_all(dir.join("Artist").join("Album").join("extra")).unwrap();
         fs::write(dir.join("a.mp3"), b"not audio").unwrap();
-        fs::write(dir.join("nested").join("b.flac"), b"not audio").unwrap();
+        fs::write(dir.join("Artist").join("b.flac"), b"not audio").unwrap();
+        fs::write(dir.join("Artist").join("Album").join("c.m4a"), b"not audio").unwrap();
+        fs::write(
+            dir.join("Artist").join("Album").join("extra").join("d.wav"),
+            b"not audio",
+        )
+        .unwrap();
+
+        let result = scan_roots(
+            &[LocalScanRoot::download(dir.clone())],
+            &LocalIndex::default(),
+        );
+
+        let mut titles: Vec<_> = result
+            .index
+            .tracks()
+            .iter()
+            .map(|track| track.title.as_str())
+            .collect();
+        titles.sort_unstable();
+        assert_eq!(titles, vec!["a", "b", "c"]);
+        assert_eq!(result.summary.seen, 3);
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn path_metadata_fallback_fills_empty_artist_and_album() {
+        let dir = temp_dir();
+        fs::create_dir_all(dir.join("Isegye Rockstar").join("Debut")).unwrap();
+        fs::write(
+            dir.join("Isegye Rockstar").join("Debut").join("song.mp3"),
+            b"not audio",
+        )
+        .unwrap();
+        fs::write(dir.join("Isegye Rockstar").join("cover.flac"), b"not audio").unwrap();
+
+        let result = scan_roots(
+            &[LocalScanRoot::download(dir.clone())],
+            &LocalIndex::default(),
+        );
+
+        let album_track = result
+            .index
+            .tracks()
+            .iter()
+            .find(|t| t.title == "song")
+            .expect("album track");
+        assert_eq!(album_track.artist, vec!["Isegye Rockstar"]);
+        assert_eq!(album_track.album.as_deref(), Some("Debut"));
+        assert_eq!(album_track.album_artist.as_deref(), Some("Isegye Rockstar"));
+
+        let cover = result
+            .index
+            .tracks()
+            .iter()
+            .find(|t| t.title == "cover")
+            .expect("artist-level track");
+        assert_eq!(cover.artist, vec!["Isegye Rockstar"]);
+        assert!(cover.album.is_none());
+        assert_eq!(cover.album_artist.as_deref(), Some("Isegye Rockstar"));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn path_metadata_fallback_does_not_override_sidecar() {
+        let dir = temp_dir();
+        fs::create_dir_all(dir.join("Folder Artist").join("Folder Album")).unwrap();
+        let audio = dir
+            .join("Folder Artist")
+            .join("Folder Album")
+            .join("Sidecar Track [abc123def45].m4a");
+        fs::write(&audio, b"not audio").unwrap();
+        let mut song = crate::api::Song::from_search(
+            "abc123def45",
+            "Canonical Title",
+            "Tag Artist",
+            "3:03",
+            Some("Tag Album".to_owned()),
+        );
+        song = song.with_catalog_metadata(
+            Some("Tag Album Artist".to_owned()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        crate::downloads::write_sidecar(&song, &audio).unwrap();
 
         let result = scan_roots(
             &[LocalScanRoot::download(dir.clone())],
@@ -386,8 +564,10 @@ mod tests {
         );
 
         assert_eq!(result.index.tracks().len(), 1);
-        assert_eq!(result.index.tracks()[0].title, "a");
-        assert_eq!(result.summary.seen, 1);
+        let track = &result.index.tracks()[0];
+        assert_eq!(track.artist, vec!["Tag Artist"]);
+        assert_eq!(track.album.as_deref(), Some("Tag Album"));
+        assert_eq!(track.album_artist.as_deref(), Some("Tag Album Artist"));
 
         let _ = fs::remove_dir_all(dir);
     }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1148,7 +1148,9 @@ mod tests {
     fn mpv_ytdl_raw_options_pin_web_safari_only_with_cookies() {
         let with_cookies = mpv_ytdl_raw_option_args(Some(Path::new("/tmp/cookies.txt")));
         assert!(
-            with_cookies.iter().any(|a| a.contains("cookies=/tmp/cookies.txt")),
+            with_cookies
+                .iter()
+                .any(|a| a.contains("cookies=/tmp/cookies.txt")),
             "{with_cookies:?}"
         );
         assert!(


### PR DESCRIPTION
## Summary
- Walk the download root up to depth 2 so mixed layouts (`track`, `Artist/track`, `Artist/Album/track`) show up in both the Downloads tab and Local Deck.
- Fill empty Local Deck artist/album fields from folder names after tags and sidecars, without overriding existing metadata.
- Keep fully recursive music roots unchanged; merging a recursive root with the download path still clears the depth cap.

## Test plan
- [x] `cargo test -p yututui --lib local::scan::`
- [x] `cargo test -p yututui --lib library::tests::scan_downloads`
- [x] Related Local Deck scan-root merge tests
- [ ] Confirm Downloads tab lists nested files under `~/Music/yututui`
- [ ] Confirm Local Deck Artists/Albums group by folder names when tags are empty
- [ ] Confirm Library nav double-click still toggles Local Deck


Made with [Cursor](https://cursor.com)