### PR TITLE
Release 1.6.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "yututui"
-version = "1.6.24"
+version = "1.6.25"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui"
-version = "1.6.24"
+version = "1.6.25"
 edition = "2024"
 description = "A fast terminal UI for YouTube Music — search, radio, synced lyrics, album art, and downloads, driven by mpv and yt-dlp."
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           lib = pkgs.lib;
           yututui = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui";
-            version = "1.6.24"; # keep in sync with Cargo.toml
+            version = "1.6.25"; # keep in sync with Cargo.toml
 
             # Drop build artifacts and flake results from the copied source so the store path
             # stays small and rebuilds aren't invalidated by a local `target/`.
@@ -84,7 +84,7 @@
           };
           yututui-desktop = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui-desktop";
-            version = "1.6.23"; # keep the yututray binary version in sync with Cargo.toml
+            version = "1.6.25"; # keep the yututray binary version in sync with Cargo.toml
             src = desktopSrc;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = [ pkgs.makeWrapper pkgs.pkg-config ];

--- a/scripts/size-baseline.tsv
+++ b/scripts/size-baseline.tsv
@@ -11,5 +11,6 @@
 1578	src/api/mod.rs
 1566	src/ai/mod.rs
 1552	src/transfer/matching.rs
+1547	src/transfer/engine.rs
 1515	src/tools/ytdlp.rs
 1515	src/app/mouse.rs

--- a/src/api/ytmusic.rs
+++ b/src/api/ytmusic.rs
@@ -2,9 +2,9 @@
 //!
 //! - **Authenticated** (browser cookie): ytmapi-rs `search_songs` → the clean YouTube
 //!   Music *song* catalog.
-//! - **Anonymous**: ytmapi-rs can't search unauthenticated (YTM gates the catalog and
-//!   returns "No results"), so we shell out to `yt-dlp "ytsearch…"` — public YouTube,
-//!   no auth, directly playable, and yt-dlp is already a dependency for playback.
+//! - **Anonymous**: general song search uses `yt-dlp "ytsearch…"` because YTM gates the
+//!   song catalog. Transfer matching may make one bounded, cooldown-protected probe of
+//!   YTM's Videos filter before the same public fallback.
 
 use std::collections::HashSet;
 use std::sync::Mutex;
@@ -21,31 +21,42 @@ use crate::streaming::{self, StreamingConfig, StreamingMode};
 use crate::util::{format, http, sanitize};
 
 mod transfer_api;
+mod video_metadata;
 pub use transfer_api::{TransferAlbum, TransferAlbumCandidate, TransferAlbumTrack};
+pub(crate) use video_metadata::YtdlpVideoMeta;
+#[cfg(test)]
+use video_metadata::{YtdlpAudioSummary, json_bool, parse_ytdlp_video_meta};
+use video_metadata::{enrich_video_meta, reject_enriched};
 
 /// How many results a search returns, for both backends. The anonymous yt-dlp path asks
 /// for exactly this many; the authenticated path pages through continuations until it has
 /// at least this many (or runs out). Capped at 50 — `ytdlp_search` clamps to the same.
 const SEARCH_RESULT_LIMIT: usize = 50;
 const STREAMING_PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(8);
-/// When authenticated (innertube) search parsing fails, we fall back to yt-dlp — but only for
-/// a cooldown, not the rest of the session. A one-shot permanent latch turned a single
-/// transient glitch (a momentary network blip, a partial page) into a session-long quality
-/// downgrade with no recovery short of a restart. After the cooldown the authenticated path is
-/// retried; if it's genuinely gated it just degrades again.
-static AUTH_SEARCH_DEGRADED_UNTIL: Mutex<Option<Instant>> = Mutex::new(None);
+/// Authenticated search falls back to yt-dlp while its short circuit is open. Requiring two
+/// consecutive hard failures prevents one partial page or network hiccup from degrading a large
+/// import for ten minutes; a successful query resets the streak immediately.
+#[derive(Debug, Default)]
+struct AuthSearchHealth {
+    consecutive_failures: u8,
+    degraded_until: Option<Instant>,
+}
+
+static AUTH_SEARCH_HEALTH: Mutex<AuthSearchHealth> = Mutex::new(AuthSearchHealth {
+    consecutive_failures: 0,
+    degraded_until: None,
+});
 const AUTH_DEGRADE_COOLDOWN: Duration = Duration::from_secs(600);
+const AUTH_FAILURES_BEFORE_DEGRADE: u8 = 2;
 
 /// Whether authenticated search is currently in its degraded cooldown. Clears the latch once
 /// the cooldown has elapsed so the next search retries the authenticated path.
 fn auth_search_degraded() -> bool {
-    let mut guard = AUTH_SEARCH_DEGRADED_UNTIL
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
-    match *guard {
+    let mut guard = AUTH_SEARCH_HEALTH.lock().unwrap_or_else(|e| e.into_inner());
+    match guard.degraded_until {
         Some(until) if Instant::now() < until => true,
         Some(_) => {
-            *guard = None;
+            *guard = AuthSearchHealth::default();
             false
         }
         None => false,
@@ -54,12 +65,16 @@ fn auth_search_degraded() -> bool {
 
 /// Enter the degraded cooldown after an authenticated-search parse failure.
 fn mark_auth_search_degraded() {
-    let until = Instant::now()
-        .checked_add(AUTH_DEGRADE_COOLDOWN)
-        .unwrap_or_else(Instant::now);
-    *AUTH_SEARCH_DEGRADED_UNTIL
-        .lock()
-        .unwrap_or_else(|e| e.into_inner()) = Some(until);
+    let mut guard = AUTH_SEARCH_HEALTH.lock().unwrap_or_else(|e| e.into_inner());
+    guard.consecutive_failures = guard.consecutive_failures.saturating_add(1);
+    if guard.consecutive_failures >= AUTH_FAILURES_BEFORE_DEGRADE {
+        let now = Instant::now();
+        guard.degraded_until = Some(now.checked_add(AUTH_DEGRADE_COOLDOWN).unwrap_or(now));
+    }
+}
+
+fn mark_auth_search_healthy() {
+    *AUTH_SEARCH_HEALTH.lock().unwrap_or_else(|e| e.into_inner()) = AuthSearchHealth::default();
 }
 
 const PROVIDER_SEARCH_TIMEOUT: Duration = Duration::from_secs(12);
@@ -101,6 +116,7 @@ pub enum YtMusicApi {
 #[serde(rename_all = "snake_case")]
 pub enum YoutubeSearchKind {
     YtmCatalogSong,
+    YtmCatalogVideo,
     YoutubeVideoSearch,
 }
 
@@ -450,9 +466,8 @@ impl YtMusicApi {
         &self,
         query: &str,
     ) -> Result<Vec<(Song, YoutubeSearchKind)>> {
-        // Once one authenticated search comes back empty/unparseable this process, they
-        // all will (Google gates innertube search behind browser attestation as of
-        // mid-2026) — skip the wasted round-trip and go straight to yt-dlp.
+        // Once repeated authenticated searches open the provider breaker, skip the wasted
+        // round-trip and go straight to yt-dlp until the bounded cooldown expires.
         if auth_search_degraded() {
             return Ok(ytdlp_search(query, SEARCH_RESULT_LIMIT)
                 .await?
@@ -474,7 +489,7 @@ impl YtMusicApi {
                         mark_auth_search_degraded();
                         tracing::warn!(
                             error = %sanitize::sanitize_error_text(format!("{e:#}")),
-                            "authenticated search parse failed; using yt-dlp for the rest of this session"
+                            "authenticated search failed; using yt-dlp for this query"
                         );
                         return Ok(ytdlp_search(query, SEARCH_RESULT_LIMIT)
                             .await?
@@ -483,6 +498,7 @@ impl YtMusicApi {
                             .collect());
                     }
                 };
+                mark_auth_search_healthy();
                 Ok(songs
                     .into_iter()
                     .map(|song| (song, YoutubeSearchKind::YtmCatalogSong))
@@ -498,7 +514,7 @@ impl YtMusicApi {
 
     /// The upstream YouTube Music watch-playlist continuation for a seed track.
     /// (`get_watch_playlist_from_video_id`) — YTM's own "up next" mix, far better seeded than a
-    /// blind text search. Authenticated uses the logged-in client; anonymous spins up an
+    /// blind text search. Authenticated uses the logged-in client; anonymous reuses a lazy
     /// unauthenticated client (the query isn't login-gated, though YTM may still return nothing
     /// without a cookie — the caller treats an error/empty result as "fall back to yt-dlp").
     pub(crate) async fn streaming_continuation(&self, seed_video_id: &str) -> Result<Vec<Song>> {
@@ -508,9 +524,7 @@ impl YtMusicApi {
                 .await
                 .context("watch-playlist (authenticated) failed")?,
             Self::Anonymous => {
-                let client = YtMusic::new_unauthenticated()
-                    .await
-                    .context("anonymous YouTube Music client init failed")?;
+                let client = transfer_api::anonymous_ytmusic_client().await?;
                 client
                     .get_watch_playlist_from_video_id(VideoID::from_raw(seed_video_id))
                     .await
@@ -568,6 +582,12 @@ async fn ytdlp_flat_search(
     cmd.arg(&spec)
         .arg("--flat-playlist")
         .arg("--dump-single-json")
+        // yt-dlp already retries extractor requests, but its default zero-delay retries can
+        // hammer the same YouTube endpoint three times inside a transient 403/429 window.
+        // A short extractor-only delay lets the provider recover without slowing successful
+        // searches or unrelated download retries.
+        .arg("--retry-sleep")
+        .arg("extractor:1")
         .arg("--no-warnings");
     let json =
         crate::tools::run_ytdlp_json(cmd, YTDLP_SEARCH_TIMEOUT, YTDLP_JSON_MAX, "search").await?;
@@ -945,109 +965,10 @@ async fn lookup_video_song(video_id: &str) -> Song {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub(crate) struct YtdlpVideoMeta {
-    pub title: String,
-    pub channel: String,
-    pub duration_secs: Option<u32>,
-    pub live_status: Option<String>,
-    pub is_live: Option<bool>,
-    pub was_live: Option<bool>,
-    pub media_type: Option<String>,
-    pub description: Option<String>,
-}
-
-async fn enrich_video_meta(video_id: &str) -> Result<YtdlpVideoMeta> {
-    let url = format!("https://www.youtube.com/watch?v={video_id}");
-    let mut cmd = ytmusic_ytdlp_command();
-    cmd.arg("--dump-single-json")
-        .arg("--no-playlist")
-        .arg("--no-warnings")
-        .arg(&url);
-    let json = crate::tools::run_ytdlp_json(
-        cmd,
-        STREAMING_PREFLIGHT_TIMEOUT,
-        YTDLP_JSON_MAX,
-        "metadata lookup",
-    )
-    .await?;
-    Ok(YtdlpVideoMeta {
-        title: json_string(&json, &["title"]).unwrap_or_default(),
-        channel: json_string(&json, &["channel", "uploader"]).unwrap_or_default(),
-        duration_secs: json
-            .get("duration")
-            .and_then(serde_json::Value::as_f64)
-            .filter(|d| d.is_finite() && *d >= 0.0)
-            .map(|d| d.round() as u32),
-        live_status: json_string(&json, &["live_status"]),
-        is_live: json_bool(&json, &["is_live"]),
-        was_live: json_bool(&json, &["was_live"]),
-        media_type: json_string(&json, &["media_type"]),
-        description: json_string(&json, &["description"]),
-    })
-}
-
-impl YtMusicApi {
-    pub(crate) async fn youtube_video_metadata(&self, video_id: &str) -> Result<YtdlpVideoMeta> {
-        enrich_video_meta(video_id).await
-    }
-}
-
 fn json_string(json: &serde_json::Value, keys: &[&str]) -> Option<String> {
     keys.iter()
         .find_map(|key| json.get(key).and_then(serde_json::Value::as_str))
         .map(str::to_owned)
-}
-
-fn json_bool(json: &serde_json::Value, keys: &[&str]) -> Option<bool> {
-    keys.iter()
-        .find_map(|key| json.get(key).and_then(serde_json::Value::as_bool))
-}
-
-fn reject_enriched(meta: &YtdlpVideoMeta, mode: StreamingMode, cfg: &StreamingConfig) -> bool {
-    if meta.is_live == Some(true) {
-        return true;
-    }
-    if matches!(
-        meta.live_status.as_deref(),
-        Some("is_live" | "is_upcoming" | "post_live")
-    ) {
-        return true;
-    }
-    if matches!(meta.media_type.as_deref(), Some("playlist" | "multi_video")) {
-        return true;
-    }
-    if let Some(duration) = meta.duration_secs {
-        let mode_max = match mode {
-            StreamingMode::Focused => 8 * 60,
-            StreamingMode::Balanced => 12 * 60,
-            StreamingMode::Discovery => 15 * 60,
-        };
-        let max_duration = cfg.max_duration_secs.min(mode_max);
-        if duration < cfg.min_duration_secs || duration > max_duration {
-            return true;
-        }
-    }
-    let rich_title = match meta.description.as_deref() {
-        Some(desc) if !desc.trim().is_empty() => format!("{} {}", meta.title, desc),
-        _ => meta.title.clone(),
-    };
-    let decision = streaming::musicgate::decide(
-        &rich_title,
-        &meta.channel,
-        streaming::CandidateSource::YtdlpStreaming,
-        mode,
-    );
-    if decision.action == streaming::musicgate::GateAction::Reject {
-        return true;
-    }
-    let risk = streaming::musicgate::non_music_risk_score(&rich_title, &meta.channel);
-    let music_tier = streaming::musicgate::music_tier_score(&meta.title, &meta.channel);
-    if mode == StreamingMode::Focused && decision.action == streaming::musicgate::GateAction::Demote
-    {
-        return true;
-    }
-    risk >= 0.70 && music_tier <= 0.0 && meta.was_live != Some(true)
 }
 
 fn streaming_queries(seed: &str, mode: StreamingMode) -> Vec<String> {
@@ -1593,26 +1514,36 @@ fi
     }
 
     #[test]
-    fn auth_search_degrade_latch_expires_and_clears() {
-        *AUTH_SEARCH_DEGRADED_UNTIL
-            .lock()
-            .unwrap_or_else(|e| e.into_inner()) = None;
+    fn auth_search_breaker_requires_a_streak_resets_and_expires() {
+        mark_auth_search_healthy();
         assert!(!auth_search_degraded());
 
         mark_auth_search_degraded();
+        assert!(
+            !auth_search_degraded(),
+            "one transient failure stays closed"
+        );
+        mark_auth_search_healthy();
+        assert!(!auth_search_degraded(), "success clears the failure streak");
+
+        mark_auth_search_degraded();
+        mark_auth_search_degraded();
         assert!(auth_search_degraded());
 
-        *AUTH_SEARCH_DEGRADED_UNTIL
+        AUTH_SEARCH_HEALTH
             .lock()
-            .unwrap_or_else(|e| e.into_inner()) = Some(Instant::now() - Duration::from_millis(1));
+            .unwrap_or_else(|e| e.into_inner())
+            .degraded_until = Some(Instant::now() - Duration::from_millis(1));
         assert!(!auth_search_degraded());
         assert!(
-            AUTH_SEARCH_DEGRADED_UNTIL
+            AUTH_SEARCH_HEALTH
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
+                .degraded_until
                 .is_none(),
             "expired degraded-search latch should clear itself"
         );
+        mark_auth_search_healthy();
     }
 
     #[test]
@@ -1655,6 +1586,79 @@ fi
         );
         assert_eq!(json_bool(&json, &["live", "was_live"]), Some(true));
         assert_eq!(json_bool(&json, &["missing", "live"]), None);
+    }
+
+    #[test]
+    fn ytdlp_metadata_mapper_keeps_authority_and_bounded_audio_summary() {
+        let meta = parse_ytdlp_video_meta(&serde_json::json!({
+            "title": "Artist - Song (Official Video)",
+            "channel": "ArtistVEVO",
+            "channel_id": "UCchannel",
+            "uploader_id": "artistvevo",
+            "channel_is_verified": true,
+            "availability": "public",
+            "extractor": "youtube",
+            "extractor_key": "Youtube",
+            "duration": 201.4,
+            "live_status": "not_live",
+            "is_live": false,
+            "was_live": false,
+            "media_type": "video",
+            "description": "Provided to YouTube by Label",
+            "requested_formats": [
+                {"format_id": "137", "ext": "mp4", "vcodec": "avc1", "acodec": "none"},
+                {
+                    "format_id": "140",
+                    "format_note": "medium",
+                    "audio_ext": "m4a",
+                    "vcodec": "none",
+                    "acodec": "mp4a.40.2",
+                    "abr": 129.5,
+                    "asr": 44100
+                }
+            ],
+            "formats": [
+                {"format_id": "18", "vcodec": "avc1", "acodec": "mp4a.40.2", "abr": 96},
+                {"format_id": "140", "vcodec": "none", "acodec": "mp4a.40.2", "abr": 129.5},
+                {"format_id": "251", "vcodec": "none", "acodec": "opus", "abr": 160},
+                {"format_id": "137", "vcodec": "avc1", "acodec": "none"}
+            ]
+        }));
+
+        assert_eq!(meta.channel_id.as_deref(), Some("UCchannel"));
+        assert_eq!(meta.uploader_id.as_deref(), Some("artistvevo"));
+        assert_eq!(meta.channel_is_verified, Some(true));
+        assert_eq!(meta.availability.as_deref(), Some("public"));
+        assert_eq!(meta.extractor.as_deref(), Some("youtube"));
+        assert_eq!(meta.audio.selected_format_id.as_deref(), Some("140"));
+        assert_eq!(
+            meta.audio.selected_audio_codec.as_deref(),
+            Some("mp4a.40.2")
+        );
+        assert_eq!(meta.audio.selected_audio_bitrate_kbps, Some(129.5));
+        assert_eq!(meta.audio.selected_sample_rate_hz, Some(44_100));
+        assert_eq!(meta.audio.available_audio_formats, Some(3));
+        assert_eq!(meta.audio.available_audio_only_formats, Some(2));
+        assert_eq!(meta.audio.max_audio_bitrate_kbps, Some(160.0));
+    }
+
+    #[test]
+    fn ytdlp_metadata_added_fields_default_when_reading_legacy_json() {
+        let meta: YtdlpVideoMeta = serde_json::from_value(serde_json::json!({
+            "title": "Legacy",
+            "channel": "Artist",
+            "duration_secs": 180,
+            "live_status": null,
+            "is_live": false,
+            "was_live": false,
+            "media_type": "video",
+            "description": null
+        }))
+        .expect("legacy metadata remains readable");
+
+        assert_eq!(meta.channel_id, None);
+        assert_eq!(meta.channel_is_verified, None);
+        assert_eq!(meta.audio, YtdlpAudioSummary::default());
     }
 
     #[test]
@@ -2252,6 +2256,7 @@ fi
             was_live: None,
             media_type: None,
             description: Some("conversation and commentary".to_owned()),
+            ..YtdlpVideoMeta::default()
         };
         assert!(reject_enriched(&meta, StreamingMode::Balanced, &cfg));
 
@@ -2264,6 +2269,7 @@ fi
             was_live: None,
             media_type: None,
             description: None,
+            ..YtdlpVideoMeta::default()
         };
         assert!(reject_enriched(&meta, StreamingMode::Discovery, &cfg));
     }
@@ -2280,6 +2286,7 @@ fi
             was_live: None,
             media_type: None,
             description: None,
+            ..YtdlpVideoMeta::default()
         };
         assert!(!reject_enriched(&meta, StreamingMode::Focused, &cfg));
     }
@@ -2300,6 +2307,7 @@ fi
             was_live: None,
             media_type: None,
             description: None,
+            ..YtdlpVideoMeta::default()
         };
         assert!(reject_enriched(&meta, StreamingMode::Balanced, &cfg));
 
@@ -2332,6 +2340,7 @@ fi
             was_live: Some(true),
             media_type: None,
             description: Some("official live performance".to_owned()),
+            ..YtdlpVideoMeta::default()
         };
         assert!(reject_enriched(&meta, StreamingMode::Balanced, &cfg));
         assert!(!reject_enriched(&meta, StreamingMode::Discovery, &cfg));

--- a/src/api/ytmusic/transfer_api.rs
+++ b/src/api/ytmusic/transfer_api.rs
@@ -1,17 +1,166 @@
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
 use anyhow::{Context, Result, bail};
 use futures::StreamExt;
 use ytmapi_rs::YtMusic;
-use ytmapi_rs::auth::BrowserToken;
+use ytmapi_rs::auth::noauth::NoAuthToken;
+use ytmapi_rs::auth::{AuthToken, BrowserToken};
 use ytmapi_rs::common::{AlbumID, YoutubeID};
+use ytmapi_rs::parse::{SearchResultAlbum, SearchResultSong, SearchResultVideo, SearchResults};
 use ytmapi_rs::query::SearchQuery;
-use ytmapi_rs::query::search::{FilteredSearch, SongsFilter};
+use ytmapi_rs::query::search::{
+    AlbumsFilter, BasicSearch, FilteredSearch, SongsFilter, VideosFilter,
+};
 
 use super::{
-    SEARCH_RESULT_LIMIT, YtMusicApi, auth_search_degraded, mark_auth_search_degraded, ytdlp_search,
+    SEARCH_RESULT_LIMIT, YtMusicApi, auth_search_degraded, mark_auth_search_degraded,
+    mark_auth_search_healthy, ytdlp_search,
 };
 use crate::api::Song;
 use crate::search_source::{SearchConfig, SearchSource};
 use crate::util::sanitize;
+
+/// The video catalog is a best-effort quality stage, so it gets a deliberately short
+/// budget before transfer matching falls through to public yt-dlp search.
+const TRANSFER_VIDEO_SEARCH_TIMEOUT: Duration = Duration::from_secs(6);
+/// Authenticated song lookup is an optional high-quality source during transfer matching.
+/// Keep it bounded so a stalled first-party request cannot consume the whole per-track
+/// matching budget; timeout follows the same breaker path as other hard catalog failures.
+const TRANSFER_SONG_SEARCH_TIMEOUT: Duration = Duration::from_secs(8);
+/// Album prefill is an optimization, not a prerequisite for per-track matching. Keep both
+/// first-party album calls bounded independently so an unresponsive catalog cannot consume
+/// the import's per-track progress indefinitely.
+const TRANSFER_ALBUM_SEARCH_TIMEOUT: Duration = Duration::from_secs(8);
+const TRANSFER_ALBUM_DETAIL_TIMEOUT: Duration = Duration::from_secs(8);
+const TRANSFER_VIDEO_DEGRADE_COOLDOWN: Duration = Duration::from_secs(120);
+const TRANSFER_VIDEO_FAILURES_BEFORE_DEGRADE: u8 = 2;
+/// Transfer ranking only needs a bounded finalist pool; the interactive Search screen keeps
+/// its wider 50-row result set through `SEARCH_RESULT_LIMIT`.
+const TRANSFER_YTM_RESULT_LIMIT: usize = 20;
+const TRANSFER_PUBLIC_RESULT_LIMIT: usize = 15;
+
+/// ytmapi-rs 0.3.2 treats several legitimate empty filtered-search layouts as parser errors.
+/// Keep this deliberately exact: unrelated parser, authentication, and transport errors must
+/// still trip the appropriate provider breaker instead of being hidden by the broad fallback.
+const FILTERED_SEARCH_MISSING_MUSIC_SHELF: &str = "Expected /contents/tabbedSearchResultsRenderer/tabs/0/tabRenderer/content/sectionListRenderer/contents to contain a /musicShelfRenderer/contents";
+
+fn filtered_search_missing_music_shelf(error: &str) -> bool {
+    error == FILTERED_SEARCH_MISSING_MUSIC_SHELF
+}
+
+/// Reuse the anonymous handle: constructing it fetches YTM visitor configuration and the
+/// underlying HTTP client owns a connection pool. Failed construction is deliberately not
+/// cached; the video cooldown below prevents a hot retry loop while still allowing recovery.
+static ANONYMOUS_YTM_CLIENT: tokio::sync::OnceCell<YtMusic<NoAuthToken>> =
+    tokio::sync::OnceCell::const_new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TransferVideoAuthMode {
+    Browser,
+    Anonymous,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TransferVideoHealth {
+    consecutive_failures: u8,
+    degraded_until: Option<Instant>,
+}
+
+#[derive(Debug, Default)]
+struct TransferVideoCooldowns {
+    browser: TransferVideoHealth,
+    anonymous: TransferVideoHealth,
+}
+
+impl TransferVideoCooldowns {
+    fn slot_mut(&mut self, mode: TransferVideoAuthMode) -> &mut TransferVideoHealth {
+        match mode {
+            TransferVideoAuthMode::Browser => &mut self.browser,
+            TransferVideoAuthMode::Anonymous => &mut self.anonymous,
+        }
+    }
+
+    fn degraded_at(&mut self, mode: TransferVideoAuthMode, now: Instant) -> bool {
+        let slot = self.slot_mut(mode);
+        match slot.degraded_until {
+            Some(until) if now < until => true,
+            Some(_) => {
+                *slot = TransferVideoHealth::default();
+                false
+            }
+            None => false,
+        }
+    }
+
+    fn record_failure_at(&mut self, mode: TransferVideoAuthMode, now: Instant) {
+        if self.degraded_at(mode, now) {
+            return;
+        }
+        let slot = self.slot_mut(mode);
+        slot.consecutive_failures = slot.consecutive_failures.saturating_add(1);
+        if slot.consecutive_failures >= TRANSFER_VIDEO_FAILURES_BEFORE_DEGRADE {
+            slot.degraded_until = Some(
+                now.checked_add(TRANSFER_VIDEO_DEGRADE_COOLDOWN)
+                    .unwrap_or(now),
+            );
+        }
+    }
+
+    fn record_success(&mut self, mode: TransferVideoAuthMode) {
+        *self.slot_mut(mode) = TransferVideoHealth::default();
+    }
+}
+
+static TRANSFER_VIDEO_COOLDOWNS: Mutex<TransferVideoCooldowns> =
+    Mutex::new(TransferVideoCooldowns {
+        browser: TransferVideoHealth {
+            consecutive_failures: 0,
+            degraded_until: None,
+        },
+        anonymous: TransferVideoHealth {
+            consecutive_failures: 0,
+            degraded_until: None,
+        },
+    });
+
+fn transfer_video_auth_mode(api: &YtMusicApi) -> TransferVideoAuthMode {
+    match api {
+        YtMusicApi::Browser(_) => TransferVideoAuthMode::Browser,
+        YtMusicApi::Anonymous => TransferVideoAuthMode::Anonymous,
+    }
+}
+
+fn transfer_video_search_degraded(mode: TransferVideoAuthMode) -> bool {
+    TRANSFER_VIDEO_COOLDOWNS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .degraded_at(mode, Instant::now())
+}
+
+fn record_transfer_video_search_failure(mode: TransferVideoAuthMode) {
+    TRANSFER_VIDEO_COOLDOWNS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .record_failure_at(mode, Instant::now());
+}
+
+fn record_transfer_video_search_success(mode: TransferVideoAuthMode) {
+    TRANSFER_VIDEO_COOLDOWNS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .record_success(mode);
+}
+
+pub(super) async fn anonymous_ytmusic_client() -> Result<&'static YtMusic<NoAuthToken>> {
+    ANONYMOUS_YTM_CLIENT
+        .get_or_try_init(|| async {
+            YtMusic::new_unauthenticated()
+                .await
+                .context("anonymous YouTube Music client init failed")
+        })
+        .await
+}
 
 #[derive(Debug, Clone)]
 pub struct TransferAlbumCandidate {
@@ -43,6 +192,27 @@ pub struct TransferAlbumTrack {
 }
 
 impl YtMusicApi {
+    /// Whether this process can currently query the authenticated YTM song catalog.
+    ///
+    /// Transfer matching uses this as a cheap capability check before taking a pacing
+    /// slot. Anonymous sessions have no catalog backend, and an authenticated parser
+    /// failure opens a cooldown during which retrying every query is known to fail.
+    pub(crate) fn transfer_catalog_available(&self) -> bool {
+        matches!(self, Self::Browser(_)) && !auth_search_degraded()
+    }
+
+    /// Whether the first-party YTM video catalog can be attempted without entering a
+    /// known-failing cooldown. Video failures are isolated from the song-catalog cooldown:
+    /// a layout or attestation failure here must not suppress otherwise healthy song results.
+    pub(crate) fn transfer_video_catalog_available(&self) -> bool {
+        !transfer_video_search_degraded(transfer_video_auth_mode(self))
+    }
+
+    /// Search the authenticated song catalog. The boolean is `true` when an authenticated
+    /// catalog became unavailable (or was already in its degraded cooldown), rather than
+    /// when a successful query merely returned no rows. Anonymous callers retain the
+    /// existing `(empty, false)` result; routing code should use
+    /// [`Self::transfer_catalog_available`] to distinguish that capability state.
     pub async fn search_transfer_catalog(
         &self,
         query: &str,
@@ -60,18 +230,89 @@ impl YtMusicApi {
         let Self::Browser(client) = self else {
             return Ok((Vec::new(), false));
         };
-        let songs = match search_catalog_songs(client, query).await {
-            Ok(songs) => songs,
-            Err(error) => {
+        let search = search_catalog_songs_first_page(client, query, TRANSFER_YTM_RESULT_LIMIT);
+        match tokio::time::timeout(TRANSFER_SONG_SEARCH_TIMEOUT, search).await {
+            Ok(Ok(songs)) => {
+                mark_auth_search_healthy();
+                Ok((songs, false))
+            }
+            Ok(Err(error)) => {
                 mark_auth_search_degraded();
                 tracing::warn!(
                     error = %sanitize::sanitize_error_text(format!("{error:#}")),
                     "authenticated transfer catalog search failed"
                 );
-                return Ok((Vec::new(), true));
+                Ok((Vec::new(), true))
+            }
+            Err(_) => {
+                mark_auth_search_degraded();
+                tracing::warn!(
+                    timeout_ms = TRANSFER_SONG_SEARCH_TIMEOUT.as_millis(),
+                    "authenticated transfer catalog search timed out"
+                );
+                Ok((Vec::new(), true))
+            }
+        }
+    }
+
+    /// Search YTM's first-party **Videos** filter before the public yt-dlp fallback.
+    ///
+    /// The boolean reports a degraded/unavailable provider attempt. A successful empty
+    /// result is `(empty, false)`, allowing callers to distinguish a real empty page from
+    /// a timeout/parser/anonymous-attestation failure while falling through in either case.
+    /// Podcast `VideoEpisode` rows are intentionally excluded.
+    pub async fn search_transfer_video_catalog(
+        &self,
+        query: &str,
+        config: &SearchConfig,
+    ) -> Result<(Vec<Song>, bool)> {
+        if !config.is_enabled(SearchSource::Youtube) {
+            bail!(
+                "{} is disabled in Settings → General",
+                SearchSource::Youtube.label()
+            );
+        }
+
+        let mode = transfer_video_auth_mode(self);
+        if transfer_video_search_degraded(mode) {
+            return Ok((Vec::new(), true));
+        }
+
+        let search = async {
+            match self {
+                Self::Browser(client) => search_catalog_videos(client, query).await,
+                Self::Anonymous => {
+                    let client = anonymous_ytmusic_client().await?;
+                    search_catalog_videos(client, query).await
+                }
             }
         };
-        Ok((songs, false))
+
+        let result = tokio::time::timeout(TRANSFER_VIDEO_SEARCH_TIMEOUT, search).await;
+        match result {
+            Ok(Ok(songs)) => {
+                record_transfer_video_search_success(mode);
+                Ok((songs, false))
+            }
+            Ok(Err(error)) => {
+                record_transfer_video_search_failure(mode);
+                tracing::warn!(
+                    error = %sanitize::sanitize_error_text(format!("{error:#}")),
+                    auth_mode = ?mode,
+                    "YTM transfer video catalog search failed"
+                );
+                Ok((Vec::new(), true))
+            }
+            Err(_) => {
+                record_transfer_video_search_failure(mode);
+                tracing::warn!(
+                    auth_mode = ?mode,
+                    timeout_ms = TRANSFER_VIDEO_SEARCH_TIMEOUT.as_millis(),
+                    "YTM transfer video catalog search timed out"
+                );
+                Ok((Vec::new(), true))
+            }
+        }
     }
 
     pub async fn search_transfer_video(
@@ -85,7 +326,7 @@ impl YtMusicApi {
                 SearchSource::Youtube.label()
             );
         }
-        ytdlp_search(query, SEARCH_RESULT_LIMIT).await
+        ytdlp_search(query, TRANSFER_PUBLIC_RESULT_LIMIT).await
     }
 
     pub async fn search_transfer_albums(
@@ -99,19 +340,23 @@ impl YtMusicApi {
                 SearchSource::Youtube.label()
             );
         }
-        if auth_search_degraded() {
-            return Ok(Vec::new());
-        }
         let Self::Browser(client) = self else {
             return Ok(Vec::new());
         };
-        let albums = match client.search_albums(query).await {
-            Ok(albums) => albums,
-            Err(error) => {
-                mark_auth_search_degraded();
+        let search = search_catalog_albums_first_page(client, query);
+        let albums = match tokio::time::timeout(TRANSFER_ALBUM_SEARCH_TIMEOUT, search).await {
+            Ok(Ok(albums)) => albums,
+            Ok(Err(error)) => {
                 tracing::warn!(
                     error = %sanitize::sanitize_error_text(format!("{error:#}")),
                     "authenticated transfer album search failed"
+                );
+                return Ok(Vec::new());
+            }
+            Err(_) => {
+                tracing::warn!(
+                    timeout_ms = TRANSFER_ALBUM_SEARCH_TIMEOUT.as_millis(),
+                    "authenticated transfer album search timed out"
                 );
                 return Ok(Vec::new());
             }
@@ -130,16 +375,27 @@ impl YtMusicApi {
     }
 
     pub async fn transfer_album_tracks(&self, album_id: &str) -> Result<Option<TransferAlbum>> {
-        if auth_search_degraded() {
-            return Ok(None);
-        }
         let Self::Browser(client) = self else {
             return Ok(None);
         };
-        let album = client
-            .get_album(AlbumID::from_raw(album_id))
-            .await
-            .context("fetching YouTube Music album tracks failed")?;
+        let fetch = client.get_album(AlbumID::from_raw(album_id));
+        let album = match tokio::time::timeout(TRANSFER_ALBUM_DETAIL_TIMEOUT, fetch).await {
+            Ok(Ok(album)) => album,
+            Ok(Err(error)) => {
+                tracing::warn!(
+                    error = %sanitize::sanitize_error_text(format!("{error:#}")),
+                    "authenticated transfer album detail failed"
+                );
+                return Ok(None);
+            }
+            Err(_) => {
+                tracing::warn!(
+                    timeout_ms = TRANSFER_ALBUM_DETAIL_TIMEOUT.as_millis(),
+                    "authenticated transfer album detail timed out"
+                );
+                return Ok(None);
+            }
+        };
         let artist = album
             .artists
             .iter()
@@ -174,14 +430,80 @@ impl YtMusicApi {
     }
 }
 
+async fn basic_search_first_page<A: AuthToken>(
+    client: &YtMusic<A>,
+    query: &str,
+) -> Result<SearchResults> {
+    let q: SearchQuery<BasicSearch> = query.into();
+    Ok(client.query(q).await?)
+}
+
+async fn search_catalog_songs_first_page<A: AuthToken>(
+    client: &YtMusic<A>,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<Song>> {
+    let q: SearchQuery<FilteredSearch<SongsFilter>> = query.into();
+    let rows = match client.query(q).await {
+        Ok(rows) => rows,
+        Err(error) if filtered_search_missing_music_shelf(&error.to_string()) => {
+            tracing::debug!(
+                "YTM filtered song search omitted its music shelf; retrying as a basic search"
+            );
+            basic_search_first_page(client, query).await?.songs
+        }
+        Err(error) => return Err(error.into()),
+    };
+    Ok(rows
+        .into_iter()
+        .take(limit)
+        .map(song_from_catalog_search)
+        .collect())
+}
+
+async fn search_catalog_albums_first_page<A: AuthToken>(
+    client: &YtMusic<A>,
+    query: &str,
+) -> Result<Vec<SearchResultAlbum>> {
+    let q: SearchQuery<FilteredSearch<AlbumsFilter>> = query.into();
+    match client.query(q).await {
+        Ok(rows) => Ok(rows),
+        Err(error) if filtered_search_missing_music_shelf(&error.to_string()) => {
+            tracing::debug!(
+                "YTM filtered album search omitted its music shelf; retrying as a basic search"
+            );
+            Ok(basic_search_first_page(client, query).await?.albums)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn song_from_catalog_search(row: SearchResultSong) -> Song {
+    Song::from_search(
+        row.video_id.get_raw(),
+        row.title,
+        row.artist,
+        row.duration,
+        row.album.map(|album| album.name),
+    )
+}
+
 pub(super) async fn search_catalog_songs(
     client: &YtMusic<BrowserToken>,
     query: &str,
 ) -> Result<Vec<Song>> {
+    search_catalog_songs_bounded(client, query, SEARCH_RESULT_LIMIT).await
+}
+
+async fn search_catalog_songs_bounded(
+    client: &YtMusic<BrowserToken>,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<Song>> {
     let q: SearchQuery<FilteredSearch<SongsFilter>> = query.into();
     let mut pages = std::pin::pin!(client.stream(&q));
     let mut songs = Vec::new();
-    while songs.len() < SEARCH_RESULT_LIMIT
+    while songs.len() < limit
         && let Some(page) = pages.next().await
     {
         let page = match page {
@@ -190,17 +512,196 @@ pub(super) async fn search_catalog_songs(
             Err(_) => break,
         };
         for s in page {
-            songs.push(Song::from_search(
-                s.video_id.get_raw(),
-                s.title,
-                s.artist,
-                s.duration,
-                s.album.map(|a| a.name),
-            ));
-            if songs.len() >= SEARCH_RESULT_LIMIT {
+            songs.push(song_from_catalog_search(s));
+            if songs.len() >= limit {
                 break;
             }
         }
     }
     Ok(songs)
+}
+
+async fn search_catalog_videos<A: AuthToken>(
+    client: &YtMusic<A>,
+    query: &str,
+) -> Result<Vec<Song>> {
+    let q: SearchQuery<FilteredSearch<VideosFilter>> = query.into();
+    let rows = match client.query(q).await {
+        Ok(rows) => rows,
+        Err(error) if filtered_search_missing_music_shelf(&error.to_string()) => {
+            tracing::debug!(
+                "YTM filtered video search omitted its music shelf; retrying as a basic search"
+            );
+            basic_search_first_page(client, query).await?.videos
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let mut videos = Vec::new();
+    append_catalog_videos(&mut videos, rows);
+    Ok(videos)
+}
+
+fn append_catalog_videos(
+    videos: &mut Vec<Song>,
+    rows: impl IntoIterator<Item = SearchResultVideo>,
+) {
+    for row in rows {
+        match row {
+            SearchResultVideo::Video {
+                title,
+                channel_name,
+                video_id,
+                length,
+                ..
+            } => videos.push(Song::from_search(
+                video_id.get_raw(),
+                title,
+                channel_name,
+                length,
+                None,
+            )),
+            SearchResultVideo::VideoEpisode { .. } => {}
+        }
+        if videos.len() >= TRANSFER_YTM_RESULT_LIMIT {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transfer_result_budgets_stay_below_interactive_search() {
+        assert_eq!(TRANSFER_YTM_RESULT_LIMIT, 20);
+        assert_eq!(TRANSFER_PUBLIC_RESULT_LIMIT, 15);
+        assert_eq!(TRANSFER_SONG_SEARCH_TIMEOUT, Duration::from_secs(8));
+        assert_eq!(TRANSFER_ALBUM_SEARCH_TIMEOUT, Duration::from_secs(8));
+        assert_eq!(TRANSFER_ALBUM_DETAIL_TIMEOUT, Duration::from_secs(8));
+        const {
+            assert!(TRANSFER_YTM_RESULT_LIMIT < SEARCH_RESULT_LIMIT);
+            assert!(TRANSFER_PUBLIC_RESULT_LIMIT < TRANSFER_YTM_RESULT_LIMIT);
+        }
+    }
+
+    #[test]
+    fn filtered_search_classifier_only_accepts_the_known_missing_shelf_error() {
+        assert!(filtered_search_missing_music_shelf(
+            FILTERED_SEARCH_MISSING_MUSIC_SHELF
+        ));
+        assert!(!filtered_search_missing_music_shelf(
+            "Expected /contents/tabbedSearchResultsRenderer/tabs/0/tabRenderer/content/sectionListRenderer/contents to contain a /musicCardShelfRenderer/contents"
+        ));
+        assert!(!filtered_search_missing_music_shelf(
+            "authenticated search failed: Expected /contents/tabbedSearchResultsRenderer/tabs/0/tabRenderer/content/sectionListRenderer/contents to contain a /musicShelfRenderer/contents"
+        ));
+        assert!(!filtered_search_missing_music_shelf(
+            "Web error <HTTP status client error (401 Unauthorized)> received."
+        ));
+    }
+
+    #[test]
+    fn video_breaker_requires_two_consecutive_failures_and_success_resets_it() {
+        let now = Instant::now();
+        let mut cooldowns = TransferVideoCooldowns::default();
+
+        cooldowns.record_failure_at(TransferVideoAuthMode::Browser, now);
+        assert!(!cooldowns.degraded_at(TransferVideoAuthMode::Browser, now));
+        assert_eq!(cooldowns.browser.consecutive_failures, 1);
+
+        cooldowns.record_success(TransferVideoAuthMode::Browser);
+        assert_eq!(cooldowns.browser, TransferVideoHealth::default());
+
+        cooldowns.record_failure_at(TransferVideoAuthMode::Browser, now);
+        cooldowns.record_failure_at(TransferVideoAuthMode::Browser, now);
+        assert!(cooldowns.degraded_at(TransferVideoAuthMode::Browser, now));
+    }
+
+    #[test]
+    fn video_breaker_is_per_auth_mode_and_expiry_starts_a_fresh_streak() {
+        let now = Instant::now();
+        let mut cooldowns = TransferVideoCooldowns::default();
+        cooldowns.record_failure_at(TransferVideoAuthMode::Anonymous, now);
+        cooldowns.record_failure_at(TransferVideoAuthMode::Anonymous, now);
+
+        assert!(cooldowns.degraded_at(TransferVideoAuthMode::Anonymous, now));
+        assert!(!cooldowns.degraded_at(TransferVideoAuthMode::Browser, now));
+        assert!(!cooldowns.degraded_at(
+            TransferVideoAuthMode::Anonymous,
+            now + TRANSFER_VIDEO_DEGRADE_COOLDOWN + Duration::from_millis(1)
+        ));
+        assert_eq!(cooldowns.anonymous, TransferVideoHealth::default());
+
+        let after_cooldown = now + TRANSFER_VIDEO_DEGRADE_COOLDOWN + Duration::from_millis(2);
+        cooldowns.record_failure_at(TransferVideoAuthMode::Anonymous, after_cooldown);
+        assert!(!cooldowns.degraded_at(TransferVideoAuthMode::Anonymous, after_cooldown));
+        assert_eq!(cooldowns.anonymous.consecutive_failures, 1);
+    }
+
+    #[test]
+    fn catalog_video_mapper_excludes_video_episodes() {
+        // SearchResultVideo's variants are non-exhaustive to downstream Rust code, so
+        // deserialize the public serde representation to exercise the real mapper without
+        // constructing an upstream private-shape value or touching the network.
+        let rows: Vec<SearchResultVideo> = serde_json::from_value(serde_json::json!([
+            {
+                "Video": {
+                    "title": "Artist - Song (Official Video)",
+                    "channel_name": "Artist",
+                    "video_id": "aaa111bbb22",
+                    "views": "12M views",
+                    "length": "3:42",
+                    "thumbnails": []
+                }
+            },
+            {
+                "VideoEpisode": {
+                    "title": "Episode 4",
+                    "date": { "Recorded": { "date": "2026" } },
+                    "channel_name": "Podcast",
+                    "episode_id": "bbb222ccc33",
+                    "thumbnails": []
+                }
+            }
+        ]))
+        .expect("valid upstream video result representation");
+        let mut songs = Vec::new();
+        append_catalog_videos(&mut songs, rows);
+
+        assert_eq!(songs.len(), 1);
+        assert_eq!(songs[0].video_id, "aaa111bbb22");
+        assert_eq!(songs[0].title, "Artist - Song (Official Video)");
+        assert_eq!(songs[0].artist, "Artist");
+        assert_eq!(songs[0].duration, "3:42");
+    }
+
+    #[test]
+    fn catalog_video_mapper_stops_at_transfer_budget() {
+        let rows = (0..(TRANSFER_YTM_RESULT_LIMIT + 5))
+            .map(|index| {
+                serde_json::json!({
+                    "Video": {
+                        "title": format!("Song {index}"),
+                        "channel_name": "Artist",
+                        "video_id": format!("vid{index:08}"),
+                        "views": "1 view",
+                        "length": "3:00",
+                        "thumbnails": []
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        let rows: Vec<SearchResultVideo> = serde_json::from_value(serde_json::Value::Array(rows))
+            .expect("valid upstream video rows");
+        let mut songs = Vec::new();
+
+        append_catalog_videos(&mut songs, rows);
+
+        assert_eq!(songs.len(), TRANSFER_YTM_RESULT_LIMIT);
+        assert_eq!(
+            songs.last().map(|song| song.title.as_str()),
+            Some("Song 19")
+        );
+    }
 }

--- a/src/api/ytmusic/transfer_api.rs
+++ b/src/api/ytmusic/transfer_api.rs
@@ -508,6 +508,18 @@ async fn search_catalog_songs_bounded(
     {
         let page = match page {
             Ok(page) => page,
+            Err(e) if songs.is_empty() && filtered_search_missing_music_shelf(&e.to_string()) => {
+                tracing::debug!(
+                    "YTM filtered song search omitted its music shelf; retrying as a basic search"
+                );
+                return Ok(basic_search_first_page(client, query)
+                    .await?
+                    .songs
+                    .into_iter()
+                    .take(limit)
+                    .map(song_from_catalog_search)
+                    .collect());
+            }
             Err(e) if songs.is_empty() => return Err(e.into()),
             Err(_) => break,
         };

--- a/src/api/ytmusic/video_metadata.rs
+++ b/src/api/ytmusic/video_metadata.rs
@@ -1,0 +1,247 @@
+use anyhow::Result;
+
+use crate::streaming::{self, StreamingConfig, StreamingMode};
+
+use super::{
+    STREAMING_PREFLIGHT_TIMEOUT, YTDLP_JSON_MAX, YtMusicApi, json_string, ytmusic_ytdlp_command,
+};
+
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct YtdlpAudioSummary {
+    #[serde(default)]
+    pub selected_format_id: Option<String>,
+    #[serde(default)]
+    pub selected_format_note: Option<String>,
+    #[serde(default)]
+    pub selected_extension: Option<String>,
+    #[serde(default)]
+    pub selected_audio_codec: Option<String>,
+    #[serde(default)]
+    pub selected_audio_bitrate_kbps: Option<f64>,
+    #[serde(default)]
+    pub selected_sample_rate_hz: Option<u32>,
+    #[serde(default)]
+    pub available_audio_formats: Option<u32>,
+    #[serde(default)]
+    pub available_audio_only_formats: Option<u32>,
+    #[serde(default)]
+    pub max_audio_bitrate_kbps: Option<f64>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub(crate) struct YtdlpVideoMeta {
+    pub title: String,
+    pub channel: String,
+    #[serde(default)]
+    pub channel_id: Option<String>,
+    #[serde(default)]
+    pub uploader_id: Option<String>,
+    /// A yt-dlp/YouTube verification signal only. This is not proof that the channel is
+    /// an Official Artist Channel and must never be treated as such by ranking policy.
+    #[serde(default)]
+    pub channel_is_verified: Option<bool>,
+    #[serde(default)]
+    pub availability: Option<String>,
+    #[serde(default)]
+    pub extractor: Option<String>,
+    #[serde(default)]
+    pub extractor_key: Option<String>,
+    #[serde(default)]
+    pub audio: YtdlpAudioSummary,
+    pub duration_secs: Option<u32>,
+    pub live_status: Option<String>,
+    pub is_live: Option<bool>,
+    pub was_live: Option<bool>,
+    pub media_type: Option<String>,
+    pub description: Option<String>,
+}
+
+pub(super) async fn enrich_video_meta(video_id: &str) -> Result<YtdlpVideoMeta> {
+    let url = format!("https://www.youtube.com/watch?v={video_id}");
+    let mut cmd = ytmusic_ytdlp_command();
+    cmd.arg("--dump-single-json")
+        .arg("--no-playlist")
+        .arg("--no-warnings")
+        .arg(&url);
+    let json = crate::tools::run_ytdlp_json(
+        cmd,
+        STREAMING_PREFLIGHT_TIMEOUT,
+        YTDLP_JSON_MAX,
+        "metadata lookup",
+    )
+    .await?;
+    Ok(parse_ytdlp_video_meta(&json))
+}
+
+pub(super) fn parse_ytdlp_video_meta(json: &serde_json::Value) -> YtdlpVideoMeta {
+    YtdlpVideoMeta {
+        title: json_string(json, &["title"]).unwrap_or_default(),
+        channel: json_string(json, &["channel", "uploader"]).unwrap_or_default(),
+        channel_id: json_string(json, &["channel_id"]),
+        uploader_id: json_string(json, &["uploader_id"]),
+        channel_is_verified: json_bool(json, &["channel_is_verified"]),
+        availability: json_string(json, &["availability"]),
+        extractor: json_string(json, &["extractor"]),
+        extractor_key: json_string(json, &["extractor_key"]),
+        audio: parse_ytdlp_audio_summary(json),
+        duration_secs: json
+            .get("duration")
+            .and_then(serde_json::Value::as_f64)
+            .filter(|d| d.is_finite() && *d >= 0.0)
+            .map(|d| d.round() as u32),
+        live_status: json_string(json, &["live_status"]),
+        is_live: json_bool(json, &["is_live"]),
+        was_live: json_bool(json, &["was_live"]),
+        media_type: json_string(json, &["media_type"]),
+        description: json_string(json, &["description"]),
+    }
+}
+
+fn parse_ytdlp_audio_summary(json: &serde_json::Value) -> YtdlpAudioSummary {
+    let selected = json
+        .get("requested_formats")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|formats| formats.iter().find(|format| has_audio_codec(format)))
+        .or_else(|| has_audio_codec(json).then_some(json));
+
+    let formats = json
+        .get("formats")
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::as_slice);
+    let available_audio_formats = formats.map(|formats| {
+        u32::try_from(
+            formats
+                .iter()
+                .filter(|format| has_audio_codec(format))
+                .count(),
+        )
+        .unwrap_or(u32::MAX)
+    });
+    let available_audio_only_formats = formats.map(|formats| {
+        u32::try_from(
+            formats
+                .iter()
+                .filter(|format| {
+                    has_audio_codec(format)
+                        && json_string(format, &["vcodec"]).as_deref() == Some("none")
+                })
+                .count(),
+        )
+        .unwrap_or(u32::MAX)
+    });
+    let max_audio_bitrate_kbps = formats.and_then(|formats| {
+        formats
+            .iter()
+            .filter(|format| has_audio_codec(format))
+            .filter_map(audio_bitrate_kbps)
+            .max_by(f64::total_cmp)
+    });
+
+    YtdlpAudioSummary {
+        selected_format_id: selected.and_then(|value| json_string(value, &["format_id"])),
+        selected_format_note: selected.and_then(|value| json_string(value, &["format_note"])),
+        selected_extension: selected.and_then(|value| {
+            json_string(value, &["audio_ext", "ext"]).filter(|ext| ext != "none")
+        }),
+        selected_audio_codec: selected
+            .and_then(|value| json_string(value, &["acodec"]))
+            .filter(|codec| !codec.eq_ignore_ascii_case("none")),
+        selected_audio_bitrate_kbps: selected.and_then(audio_bitrate_kbps),
+        selected_sample_rate_hz: selected.and_then(|value| json_u32(value, &["asr"])),
+        available_audio_formats,
+        available_audio_only_formats,
+        max_audio_bitrate_kbps,
+    }
+}
+
+fn has_audio_codec(json: &serde_json::Value) -> bool {
+    json_string(json, &["acodec"])
+        .is_some_and(|codec| !codec.trim().is_empty() && !codec.eq_ignore_ascii_case("none"))
+}
+
+fn audio_bitrate_kbps(json: &serde_json::Value) -> Option<f64> {
+    json_f64(json, &["abr"]).or_else(|| {
+        if json_string(json, &["vcodec"]).as_deref() == Some("none") {
+            json_f64(json, &["tbr"])
+        } else {
+            None
+        }
+    })
+}
+
+pub(super) fn json_bool(json: &serde_json::Value, keys: &[&str]) -> Option<bool> {
+    keys.iter()
+        .find_map(|key| json.get(key).and_then(serde_json::Value::as_bool))
+}
+
+fn json_f64(json: &serde_json::Value, keys: &[&str]) -> Option<f64> {
+    keys.iter().find_map(|key| {
+        let value = json.get(key)?;
+        value
+            .as_f64()
+            .or_else(|| value.as_str()?.parse::<f64>().ok())
+            .filter(|number| number.is_finite() && *number >= 0.0)
+    })
+}
+
+fn json_u32(json: &serde_json::Value, keys: &[&str]) -> Option<u32> {
+    json_f64(json, keys).and_then(|number| {
+        (number <= f64::from(u32::MAX) && number.fract() == 0.0).then_some(number as u32)
+    })
+}
+
+pub(super) fn reject_enriched(
+    meta: &YtdlpVideoMeta,
+    mode: StreamingMode,
+    cfg: &StreamingConfig,
+) -> bool {
+    if meta.is_live == Some(true) {
+        return true;
+    }
+    if matches!(
+        meta.live_status.as_deref(),
+        Some("is_live" | "is_upcoming" | "post_live")
+    ) {
+        return true;
+    }
+    if matches!(meta.media_type.as_deref(), Some("playlist" | "multi_video")) {
+        return true;
+    }
+    if let Some(duration) = meta.duration_secs {
+        let mode_max = match mode {
+            StreamingMode::Focused => 8 * 60,
+            StreamingMode::Balanced => 12 * 60,
+            StreamingMode::Discovery => 15 * 60,
+        };
+        let max_duration = cfg.max_duration_secs.min(mode_max);
+        if duration < cfg.min_duration_secs || duration > max_duration {
+            return true;
+        }
+    }
+    let rich_title = match meta.description.as_deref() {
+        Some(desc) if !desc.trim().is_empty() => format!("{} {}", meta.title, desc),
+        _ => meta.title.clone(),
+    };
+    let decision = streaming::musicgate::decide(
+        &rich_title,
+        &meta.channel,
+        streaming::CandidateSource::YtdlpStreaming,
+        mode,
+    );
+    if decision.action == streaming::musicgate::GateAction::Reject {
+        return true;
+    }
+    let risk = streaming::musicgate::non_music_risk_score(&rich_title, &meta.channel);
+    let music_tier = streaming::musicgate::music_tier_score(&meta.title, &meta.channel);
+    if mode == StreamingMode::Focused && decision.action == streaming::musicgate::GateAction::Demote
+    {
+        return true;
+    }
+    risk >= 0.70 && music_tier <= 0.0 && meta.was_live != Some(true)
+}
+
+impl YtMusicApi {
+    pub(crate) async fn youtube_video_metadata(&self, video_id: &str) -> Result<YtdlpVideoMeta> {
+        enrich_video_meta(video_id).await
+    }
+}

--- a/src/app/artwork.rs
+++ b/src/app/artwork.rs
@@ -556,7 +556,8 @@ impl App {
                 self.library_ui.confirm_delete.is_some()
                     || self.library_ui.confirm_download.is_some()
                     || self.local_mode.pending_organize_confirm.is_some()
-                    || self.local_mode.pending_accept_all_confirm.is_some(),
+                    || self.local_mode.pending_accept_all_confirm.is_some()
+                    || self.local_mode.pending_import_record_delete.is_some(),
                 ART_OVERLAY_LIBRARY_CONFIRM_BIT,
             )
             | flag(!matches!(self.mode, Mode::Player), ART_OVERLAY_NOT_PLAYER_BIT)

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -72,6 +72,18 @@ impl App {
             };
         }
 
+        // Import history deletion removes resumability artifacts, so it requires confirmation.
+        if let Some(session_id) = self.local_mode.pending_import_record_delete.take() {
+            self.dirty = true;
+            let confirmed = k.code == KeyCode::Enter
+                || chord == Chord::new(KeyCode::Char('y'), KeyModifiers::empty());
+            return if confirmed {
+                self.apply_local_import_record_delete(session_id)
+            } else {
+                Vec::new()
+            };
+        }
+
         // Settings confirmations are modal: Enter or `y` confirms, anything else cancels.
         // Handle it here so the key can't leak through to the settings list.
         if let Some(confirm) = self.overlays.pending_settings_confirm.take() {

--- a/src/app/local.rs
+++ b/src/app/local.rs
@@ -209,6 +209,7 @@ impl App {
             }
             Some(Action::Download) => self.local_download_selected(),
             Some(Action::DownloadAll) => self.local_download_visible(),
+            Some(Action::LibraryRemove) => self.request_local_import_record_delete(),
             Some(Action::Back) => self.local_back_or_exit(),
             Some(Action::MoveUp) => {
                 let step = self.nav_repeat_step(Action::MoveUp);

--- a/src/app/local_import.rs
+++ b/src/app/local_import.rs
@@ -18,6 +18,179 @@ use crate::transfer::organize_plan::{
 use crate::transfer::session::{ImportSession, ImportSessionRow, ImportSessionRowStatus};
 
 impl App {
+    pub(in crate::app) fn intercept_local_import_modal_mouse_click(
+        &mut self,
+        col: u16,
+        row: u16,
+    ) -> Option<Vec<Cmd>> {
+        if self.local_mode.pending_organize_confirm.is_some() {
+            return Some(match self.mouse_target_at(col, row) {
+                Some(
+                    target @ (MouseTarget::ConfirmLocalOrganize | MouseTarget::CancelLocalOrganize),
+                ) => self.on_mouse_target(target),
+                _ => {
+                    self.local_mode.pending_organize_confirm = None;
+                    self.dirty = true;
+                    Vec::new()
+                }
+            });
+        }
+        if self.local_mode.pending_accept_all_confirm.is_some() {
+            return Some(match self.mouse_target_at(col, row) {
+                Some(
+                    target @ (MouseTarget::ConfirmLocalAcceptAll
+                    | MouseTarget::CancelLocalAcceptAll),
+                ) => self.on_mouse_target(target),
+                _ => {
+                    self.local_mode.pending_accept_all_confirm = None;
+                    self.dirty = true;
+                    Vec::new()
+                }
+            });
+        }
+        if self.local_mode.pending_import_record_delete.is_some() {
+            return Some(match self.mouse_target_at(col, row) {
+                Some(
+                    target @ (MouseTarget::ConfirmLocalImportDelete
+                    | MouseTarget::CancelLocalImportDelete),
+                ) => self.on_mouse_target(target),
+                _ => {
+                    self.local_mode.pending_import_record_delete = None;
+                    self.dirty = true;
+                    Vec::new()
+                }
+            });
+        }
+        None
+    }
+
+    pub(crate) fn local_import_confirmation_open(&self) -> bool {
+        self.local_mode.pending_organize_confirm.is_some()
+            || self.local_mode.pending_accept_all_confirm.is_some()
+            || self.local_mode.pending_import_record_delete.is_some()
+    }
+
+    pub(crate) fn local_import_record_deletable(&self, row: &crate::local::LocalRowId) -> bool {
+        let crate::local::LocalRowId::ImportSession(session_id) = row else {
+            return false;
+        };
+        ImportSession::record_exists(session_id)
+    }
+
+    pub(in crate::app) fn request_local_import_record_delete(&mut self) -> Vec<Cmd> {
+        let selected = self
+            .local_visible_rows()
+            .get(self.local_mode.ui.selected)
+            .cloned();
+        let session_id = match selected {
+            Some(crate::local::LocalRowId::ImportSession(session_id)) => Some(session_id),
+            _ => self
+                .local_mode
+                .ui
+                .drill
+                .last()
+                .and_then(|drill| match drill {
+                    LocalDrill::ImportSession(session_id) => Some(session_id.clone()),
+                    _ => None,
+                }),
+        };
+        let Some(session_id) = session_id else {
+            return Vec::new();
+        };
+        self.prepare_local_import_record_delete(session_id);
+        Vec::new()
+    }
+
+    pub(in crate::app) fn request_local_import_record_delete_id(
+        &mut self,
+        session_id: String,
+    ) -> Vec<Cmd> {
+        if let Some(index) = self.local_visible_rows().iter().position(
+            |row| matches!(row, crate::local::LocalRowId::ImportSession(id) if id == &session_id),
+        ) {
+            self.local_mode.ui.selected = index;
+            self.local_mode.ui.anchor = index;
+        }
+        self.prepare_local_import_record_delete(session_id);
+        Vec::new()
+    }
+
+    fn prepare_local_import_record_delete(&mut self, session_id: String) {
+        if !ImportSession::record_exists(&session_id) {
+            self.status.kind = StatusKind::Info;
+            self.status.text = t!(
+                "No saved import record exists; imported songs were left unchanged.",
+                "저장된 임포트 기록이 없습니다. 임포트한 곡은 변경하지 않았습니다."
+            )
+            .to_owned();
+            self.dirty = true;
+            return;
+        }
+        self.local_mode.pending_import_record_delete = Some(session_id);
+        self.dirty = true;
+    }
+
+    pub(in crate::app) fn apply_local_import_record_delete(
+        &mut self,
+        session_id: String,
+    ) -> Vec<Cmd> {
+        self.local_mode.pending_import_record_delete = None;
+        match ImportSession::delete_record(&session_id) {
+            Ok(removed) => {
+                if matches!(
+                    self.local_mode.ui.drill.last(),
+                    Some(LocalDrill::ImportSession(open_id)) if open_id == &session_id
+                ) {
+                    self.local_mode.ui.drill.pop();
+                }
+                self.local_mode.ui.selected = self
+                    .local_mode
+                    .ui
+                    .selected
+                    .min(self.local_rows_len().saturating_sub(1));
+                self.local_mode.ui.anchor = self.local_mode.ui.selected;
+                self.status.kind = StatusKind::Info;
+                self.status.text = if removed == 0 {
+                    t!(
+                        "Import record was already absent; imported songs were left unchanged.",
+                        "임포트 기록이 이미 없습니다. 임포트한 곡은 변경하지 않았습니다."
+                    )
+                    .to_owned()
+                } else if crate::i18n::is_korean() {
+                    format!(
+                        "임포트 기록 {session_id} 삭제 완료 ({removed}개 파일). 임포트한 곡, 오디오 파일, 플레이리스트는 유지했습니다."
+                    )
+                } else {
+                    format!(
+                        "Deleted import record {session_id} ({removed} artifacts). Imported songs, audio files, and playlists were kept."
+                    )
+                };
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                self.status.kind = StatusKind::Info;
+                self.status.text = format!(
+                    "{}: {session_id}",
+                    t!(
+                        "Import is still active; try deleting its record after it finishes",
+                        "임포트가 아직 진행 중입니다. 완료된 뒤 기록 삭제를 다시 시도하세요"
+                    )
+                );
+            }
+            Err(error) => {
+                self.status.kind = StatusKind::Error;
+                self.status.text = format!(
+                    "{}: {error}",
+                    t!(
+                        "Could not delete import record",
+                        "임포트 기록을 삭제하지 못했습니다"
+                    )
+                );
+            }
+        }
+        self.dirty = true;
+        Vec::new()
+    }
+
     pub(in crate::app) fn local_import_session_rows_for_query(
         &self,
         query: &str,
@@ -53,6 +226,12 @@ impl App {
                     .or_insert((0, summary.updated_at, None));
             entry.1 = entry.1.max(summary.updated_at);
             entry.2 = Some(summary);
+        }
+        for record in ImportSession::list_record_entries() {
+            let entry = sessions
+                .entry(record.session_id)
+                .or_insert((0, record.updated_at, None));
+            entry.1 = entry.1.max(record.updated_at);
         }
         let mut rows: Vec<_> = sessions.into_iter().collect();
         rows.sort_by(|a, b| b.1.1.cmp(&a.1.1).then_with(|| a.0.cmp(&b.0)));
@@ -219,6 +398,9 @@ impl App {
                 }
                 actions.push(t!("d download accepted", "d 수락 곡 다운로드"));
                 actions.push(t!("m commit inbox", "m 인박스 커밋"));
+                if ImportSession::record_exists(&session_id) {
+                    actions.push(t!("Del delete record", "Del 기록 삭제"));
+                }
                 Some(actions.join("  |  "))
             }
             crate::local::LocalRowId::ImportSessionRow {
@@ -257,6 +439,13 @@ impl App {
                 actions.push(t!("s search", "s 검색"));
                 if row.local_path.as_deref().is_some_and(path_is_import_inbox) {
                     actions.push(t!("m commit", "m 커밋"));
+                }
+                if matches!(
+                    self.local_mode.ui.drill.last(),
+                    Some(LocalDrill::ImportSession(open_id)) if open_id == &session_id
+                ) && ImportSession::record_exists(&session_id)
+                {
+                    actions.push(t!("Del delete session record", "Del 세션 기록 삭제"));
                 }
                 (!actions.is_empty()).then(|| actions.join("  |  "))
             }
@@ -1098,13 +1287,35 @@ fn load_import_session_recovering(session_id: &str) -> anyhow::Result<ImportSess
     match ImportSession::load(session_id) {
         Ok(session) => Ok(session),
         Err(session_error) => {
+            let _guard = match crate::transfer::session::ImportRecordGuard::try_acquire(session_id)
+            {
+                Ok(guard) => guard,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    // Another process (or another view refresh) may already be repairing this
+                    // same corrupt session from its checkpoint. Wait only for that short repair
+                    // window; never block the TUI for the lifetime of an active import.
+                    for _ in 0..50 {
+                        if let Ok(session) = ImportSession::load(session_id) {
+                            return Ok(session);
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(2));
+                    }
+                    return Err(anyhow::anyhow!(
+                        "import session `{session_id}` is being updated and is not readable yet"
+                    ));
+                }
+                Err(error) => return Err(error.into()),
+            };
+            if let Ok(session) = ImportSession::load(session_id) {
+                return Ok(session);
+            }
             let cp = Checkpoint::load(session_id).map_err(|checkpoint_error| {
                 anyhow::anyhow!(
                     "load import session `{session_id}` failed ({session_error:#}); checkpoint recovery failed ({checkpoint_error:#})"
                 )
             })?;
             let session = ImportSession::from_checkpoint(&cp);
-            session.save().map_err(|save_error| {
+            session.save_unlocked().map_err(|save_error| {
                 anyhow::anyhow!(
                     "recover import session `{session_id}` from checkpoint failed while saving: {save_error}"
                 )

--- a/src/app/local_import_helpers.rs
+++ b/src/app/local_import_helpers.rs
@@ -20,6 +20,7 @@ pub(in crate::app) fn import_session_row_status_label(row: &ImportSessionRow) ->
         ImportSessionRowStatus::Ambiguous => "review",
         ImportSessionRowStatus::NotFound => "missing",
         ImportSessionRowStatus::SkippedLocal => "skipped",
+        ImportSessionRowStatus::SkippedCapacity => "capacity",
     }
 }
 
@@ -42,6 +43,10 @@ pub(in crate::app) fn import_session_row_status_detail(
         ImportSessionRowStatus::NotFound => Some(t!(
             "no usable YouTube Music candidate was found",
             "사용 가능한 YouTube Music 후보를 찾지 못했어요"
+        )),
+        ImportSessionRowStatus::SkippedCapacity => Some(t!(
+            "the destination playlist reached its track limit",
+            "대상 플레이리스트가 곡 수 제한에 도달했어요"
         )),
         _ => None,
     }
@@ -189,7 +194,9 @@ pub(in crate::app) fn import_session_row_accepts_manual_review_action(
         && row.local_path.is_none()
         && !matches!(
             row.status,
-            ImportSessionRowStatus::Matched | ImportSessionRowStatus::SkippedLocal
+            ImportSessionRowStatus::Matched
+                | ImportSessionRowStatus::SkippedLocal
+                | ImportSessionRowStatus::SkippedCapacity
         )
 }
 

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -42,7 +42,7 @@ impl HitMap {
             .iter()
             .rev()
             .find(|b| rect_contains(b.rect, col, row))
-            .copied()
+            .cloned()
     }
 
     /// The target of the topmost region covering `(col, row)`, if any.
@@ -136,35 +136,8 @@ impl App {
                 }
             }
         }
-        // Local import organize is modal: only its Confirm/Cancel buttons act.
-        if self.local_mode.pending_organize_confirm.is_some() {
-            match self.mouse_target_at(col, row) {
-                Some(
-                    t @ (MouseTarget::ConfirmLocalOrganize | MouseTarget::CancelLocalOrganize),
-                ) => {
-                    return self.on_mouse_target(t);
-                }
-                _ => {
-                    self.local_mode.pending_organize_confirm = None;
-                    self.dirty = true;
-                    return Vec::new();
-                }
-            }
-        }
-        // Local import accept-all is modal: only its Confirm/Cancel buttons act.
-        if self.local_mode.pending_accept_all_confirm.is_some() {
-            match self.mouse_target_at(col, row) {
-                Some(
-                    t @ (MouseTarget::ConfirmLocalAcceptAll | MouseTarget::CancelLocalAcceptAll),
-                ) => {
-                    return self.on_mouse_target(t);
-                }
-                _ => {
-                    self.local_mode.pending_accept_all_confirm = None;
-                    self.dirty = true;
-                    return Vec::new();
-                }
-            }
+        if let Some(cmds) = self.intercept_local_import_modal_mouse_click(col, row) {
+            return cmds;
         }
         // The "what's playing" identify overlay is modal: only its own buttons act; a
         // click anywhere else closes it (no click-through to the player/seekbar).
@@ -625,6 +598,12 @@ impl App {
                 self.local_row_click(i)
             }
             MouseTarget::LocalRow(_) => Vec::new(),
+            MouseTarget::LocalImportDel(session_id)
+                if self.mode == Mode::Library && self.local_dedicated_mode =>
+            {
+                self.request_local_import_record_delete_id(session_id)
+            }
+            MouseTarget::LocalImportDel(_) => Vec::new(),
             MouseTarget::MouseHelp => {
                 self.overlays.help_visible = false;
                 self.overlays.mouse_help_visible = true;
@@ -822,6 +801,17 @@ impl App {
                 self.dirty = true;
                 Vec::new()
             }
+            MouseTarget::ConfirmLocalImportDelete => {
+                let Some(session_id) = self.local_mode.pending_import_record_delete.take() else {
+                    return Vec::new();
+                };
+                self.apply_local_import_record_delete(session_id)
+            }
+            MouseTarget::CancelLocalImportDelete => {
+                self.local_mode.pending_import_record_delete = None;
+                self.dirty = true;
+                Vec::new()
+            }
             MouseTarget::NowPlayingFavorite => self.now_playing_favorite(),
             MouseTarget::NowPlayingAskAi => self.now_playing_ask_ai(),
             MouseTarget::CloseNowPlaying => {
@@ -877,8 +867,7 @@ impl App {
             || self.overlays.key_conflict.is_some()
             || self.radio_mode.pending_radio_mode_confirm.is_some()
             || self.local_mode.pending_confirm.is_some()
-            || self.local_mode.pending_organize_confirm.is_some()
-            || self.local_mode.pending_accept_all_confirm.is_some()
+            || self.local_import_confirmation_open()
             || self.overlays.pending_settings_confirm.is_some()
             || self.library_ui.confirm_delete.is_some()
             || self.library_ui.confirm_playlist_delete.is_some()
@@ -1436,8 +1425,7 @@ impl App {
             || self.overlays.key_conflict.is_some()
             || self.radio_mode.pending_radio_mode_confirm.is_some()
             || self.local_mode.pending_confirm.is_some()
-            || self.local_mode.pending_organize_confirm.is_some()
-            || self.local_mode.pending_accept_all_confirm.is_some()
+            || self.local_import_confirmation_open()
             || self.overlays.pending_settings_confirm.is_some()
             || self.library_ui.confirm_delete.is_some()
             || self.library_ui.confirm_playlist_delete.is_some()

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -31,6 +31,7 @@ impl App {
         self.library_ui.confirm_download = None;
         self.local_mode.pending_organize_confirm = None;
         self.local_mode.pending_accept_all_confirm = None;
+        self.local_mode.pending_import_record_delete = None;
         self.playlist_picker = None;
         // These three render as top-level overlays but route input only inside Settings-mode
         // dispatch, so leaving the screen must drop them explicitly or they'd paint on top of
@@ -124,6 +125,7 @@ impl App {
         self.library_ui.confirm_download = None;
         self.local_mode.pending_organize_confirm = None;
         self.local_mode.pending_accept_all_confirm = None;
+        self.local_mode.pending_import_record_delete = None;
         // Popup-like playlist surfaces dismiss on any navigation (the drill-down itself is
         // content state - it resets only on a fresh Library entry below).
         self.library_ui.create_input = None;

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -753,6 +753,8 @@ pub struct LocalMode {
     pub pending_confirm: Option<LocalModeConfirm>,
     pub pending_organize_confirm: Option<LocalOrganizeConfirm>,
     pub pending_accept_all_confirm: Option<LocalImportAcceptAllConfirm>,
+    /// Import-history artifact selected for confirmed deletion. Imported songs are retained.
+    pub pending_import_record_delete: Option<String>,
     pub(in crate::app) pending_accept_write_summaries: HashMap<String, u32>,
     pub(in crate::app) pending_import_reviews: HashMap<String, u64>,
     pub(in crate::app) next_import_review_op_id: u64,

--- a/src/app/tests/local_import.rs
+++ b/src/app/tests/local_import.rs
@@ -484,6 +484,7 @@ fn local_deck_import_sessions_include_saved_session_rows_without_tracks() {
             not_found: 1,
             ..crate::transfer::session::ImportSessionCounts::default()
         },
+        defer_reason: None,
         rows: vec![
             crate::transfer::session::ImportSessionRow {
                 row_id: "row-00001".to_owned(),
@@ -700,6 +701,169 @@ fn local_deck_import_sessions_include_saved_session_rows_without_tracks() {
             .expect("linked row should load local path")
             .contains("/tmp/inbox/Linked.m4a")
     );
+}
+
+#[test]
+fn delete_key_confirms_then_removes_saved_import_history() {
+    let session_id = "sp2yt-local-delete-key";
+    save_ambiguous_import_job(session_id);
+    let mut app = app_with_local_deck_index(Vec::new());
+    app.update(Msg::Key(key(KeyCode::Char('9'))));
+    app.local_mode.ui.filter_query = session_id.to_owned();
+    assert_eq!(app.local_rows_len(), 1);
+
+    let cmds = app.update(Msg::Key(key(KeyCode::Delete)));
+    assert!(cmds.is_empty());
+    assert_eq!(
+        app.local_mode.pending_import_record_delete.as_deref(),
+        Some(session_id)
+    );
+    assert!(crate::transfer::session::ImportSession::record_exists(
+        session_id
+    ));
+    render_app(&app);
+    assert!(
+        app.hits
+            .regions()
+            .iter()
+            .any(|hit| hit.target == MouseTarget::ConfirmLocalImportDelete)
+    );
+
+    app.update(Msg::Key(key(KeyCode::Enter)));
+    assert!(app.local_mode.pending_import_record_delete.is_none());
+    assert!(!crate::transfer::session::ImportSession::record_exists(
+        session_id
+    ));
+    assert_eq!(app.local_rows_len(), 0);
+    assert!(app.status.text.contains(session_id));
+}
+
+#[test]
+fn active_import_record_delete_fails_immediately_without_removing_history() {
+    let session_id = "sp2yt-local-delete-active";
+    save_ambiguous_import_job(session_id);
+    let mut app = app_with_local_deck_index(Vec::new());
+    app.update(Msg::Key(key(KeyCode::Char('9'))));
+    app.local_mode.ui.filter_query = session_id.to_owned();
+    app.update(Msg::Key(key(KeyCode::Delete)));
+    let guard = crate::transfer::session::ImportRecordGuard::try_acquire(session_id)
+        .expect("hold active import lock");
+
+    let cmds = app.update(Msg::Key(key(KeyCode::Enter)));
+
+    assert!(cmds.is_empty());
+    assert!(app.local_mode.pending_import_record_delete.is_none());
+    assert!(crate::transfer::session::ImportSession::record_exists(
+        session_id
+    ));
+    assert_eq!(app.status.kind, StatusKind::Info);
+    assert!(app.status.text.contains(session_id));
+    drop(guard);
+    crate::transfer::session::ImportSession::delete_record(session_id)
+        .expect("clean active record fixture");
+}
+
+#[test]
+fn import_row_delete_button_keeps_imported_track_after_confirm() {
+    let session_id = "sp2yt-local-delete-mouse";
+    save_ambiguous_import_job(session_id);
+    let mut track = local_deck_track(
+        "/tmp/music/import/delete/01 Keep.m4a",
+        "Keep",
+        &["Artist"],
+        Some("Album"),
+        Some("Artist"),
+        &["Pop"],
+        20,
+    );
+    track.import_session_id = Some(session_id.to_owned());
+    track.import_source_order = Some(1);
+    let mut app = app_with_local_deck_index(vec![track]);
+    app.update(Msg::Key(key(KeyCode::Char('9'))));
+    app.local_mode.ui.filter_query = session_id.to_owned();
+
+    let cmds = click_target(&mut app, MouseTarget::LocalImportDel(session_id.to_owned()));
+    assert!(cmds.is_empty());
+    assert_eq!(
+        app.local_mode.pending_import_record_delete.as_deref(),
+        Some(session_id)
+    );
+    let cmds = click_target(&mut app, MouseTarget::ConfirmLocalImportDelete);
+    assert!(cmds.is_empty());
+    assert!(!crate::transfer::session::ImportSession::record_exists(
+        session_id
+    ));
+
+    assert_eq!(app.local_rows_len(), 1, "track provenance grouping remains");
+    assert_eq!(app.local_mode.index.index.tracks().len(), 1);
+    assert_eq!(
+        app.local_mode.index.index.tracks()[0]
+            .import_session_id
+            .as_deref(),
+        Some(session_id)
+    );
+    assert!(
+        app.local_row_text(&app.local_visible_rows()[0])
+            .contains("1 track")
+    );
+}
+
+#[test]
+fn import_delete_mouse_target_keeps_rendered_session_id_after_rows_change() {
+    let rendered_id = "sp2yt-local-delete-stable-rendered";
+    let now_visible_id = "sp2yt-local-delete-stable-visible";
+    save_ambiguous_import_job(rendered_id);
+    save_ambiguous_import_job(now_visible_id);
+    let mut app = app_with_local_deck_index(Vec::new());
+    app.update(Msg::Key(key(KeyCode::Char('9'))));
+    app.local_mode.ui.filter_query = rendered_id.to_owned();
+    render_app(&app);
+    let (col, row) = button_center(&app, MouseTarget::LocalImportDel(rendered_id.to_owned()));
+
+    // Simulate an async refresh/re-sort between the last render and delivery of that frame's
+    // click. The hit target must retain the rendered id instead of resolving display index 0.
+    app.local_mode.ui.filter_query = now_visible_id.to_owned();
+    let cmds = app.update(Msg::MouseClick { col, row });
+    assert!(cmds.is_empty());
+    assert_eq!(
+        app.local_mode.pending_import_record_delete.as_deref(),
+        Some(rendered_id)
+    );
+
+    app.local_mode.pending_import_record_delete = None;
+    crate::transfer::session::ImportSession::delete_record(rendered_id)
+        .expect("clean rendered session fixture");
+    crate::transfer::session::ImportSession::delete_record(now_visible_id)
+        .expect("clean visible session fixture");
+}
+
+#[test]
+fn orphan_report_without_session_document_is_visible_and_deletable() {
+    let session_id = "sp2yt-local-delete-orphan-report";
+    let report_path = crate::transfer::checkpoint::report_path(session_id).expect("report path");
+    std::fs::create_dir_all(report_path.parent().expect("report parent"))
+        .expect("create transfers dir");
+    std::fs::write(&report_path, b"{}").expect("write orphan report");
+
+    let mut app = app_with_local_deck_index(Vec::new());
+    app.update(Msg::Key(key(KeyCode::Char('9'))));
+    app.local_mode.ui.filter_query = session_id.to_owned();
+    assert_eq!(
+        app.local_visible_rows(),
+        vec![crate::local::LocalRowId::ImportSession(
+            session_id.to_owned()
+        )]
+    );
+    assert!(
+        app.local_import_record_deletable(&crate::local::LocalRowId::ImportSession(
+            session_id.to_owned()
+        ))
+    );
+
+    app.request_local_import_record_delete();
+    app.apply_local_import_record_delete(session_id.to_owned());
+    assert!(!report_path.exists());
+    assert!(app.local_visible_rows().is_empty());
 }
 
 #[test]

--- a/src/app/tests/render_hit_targets.rs
+++ b/src/app/tests/render_hit_targets.rs
@@ -72,7 +72,11 @@ fn rendering_settings_registers_clickable_controls() {
         let backend = TestBackend::new(80, 32);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
-        app.hits.regions().iter().map(|b| b.target).collect()
+        app.hits
+            .regions()
+            .iter()
+            .map(|b| b.target.clone())
+            .collect()
     };
 
     // Graphics: a Toggle (RetroMode, field 0), a Select (ThemePreset, field 1), a Toggle

--- a/src/app/tests/support.rs
+++ b/src/app/tests/support.rs
@@ -580,7 +580,7 @@ pub(super) fn dropdown_popup_rect(
         .hits
         .regions()
         .iter()
-        .filter_map(|b| is_row(b.target).then_some(b.rect))
+        .filter_map(|b| is_row(b.target.clone()).then_some(b.rect))
         .collect();
     assert!(
         !rects.is_empty(),
@@ -588,7 +588,7 @@ pub(super) fn dropdown_popup_rect(
         app.hits
             .regions()
             .iter()
-            .map(|b| b.target)
+            .map(|b| b.target.clone())
             .collect::<Vec<_>>()
     );
 
@@ -705,7 +705,12 @@ pub(super) fn render_at(app: &App, w: u16, h: u16) -> (Vec<MouseTarget>, String)
         .map(|x| buf.cell((x, 0)).map(|c| c.symbol()).unwrap_or(" "))
         .collect::<Vec<_>>()
         .join("");
-    let targets = app.hits.regions().iter().map(|b| b.target).collect();
+    let targets = app
+        .hits
+        .regions()
+        .iter()
+        .map(|b| b.target.clone())
+        .collect();
     (targets, top)
 }
 

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -436,7 +436,7 @@ pub enum ImportReviewAction {
 }
 
 /// A clickable terminal region's semantic target.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MouseTarget {
     Global(Action),
     Player(Action),
@@ -472,6 +472,9 @@ pub enum MouseTarget {
     LocalNav(usize),
     /// A row in the Local Deck list, by display index.
     LocalRow(usize),
+    /// The trailing `✗` on a saved Local Deck import-session row. Carries the exact persisted
+    /// job id so a re-sort between render and click can never redirect the destructive action.
+    LocalImportDel(String),
     /// The footer mouse-help icon. Mouse-only: no keybinding maps to this overlay.
     MouseHelp,
     /// A Settings tab header, by index into [`SettingsTab::ALL`].
@@ -565,6 +568,9 @@ pub enum MouseTarget {
     ConfirmLocalAcceptAll,
     /// Cancel button on the local import accept-all modal.
     CancelLocalAcceptAll,
+    /// Buttons on the local import-history delete confirmation.
+    ConfirmLocalImportDelete,
+    CancelLocalImportDelete,
     /// "Save to favorites" on the "what's playing" overlay (resolves a real YT track first).
     NowPlayingFavorite,
     /// "Tell me more" on the "what's playing" overlay — hands off to the DJ Gem view.
@@ -599,7 +605,7 @@ pub enum MouseTarget {
     RecordingBrowseRow(usize),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MouseButtonRegion {
     pub rect: Rect,
     pub target: MouseTarget,

--- a/src/playlists.rs
+++ b/src/playlists.rs
@@ -19,7 +19,7 @@ use crate::util::safe_fs;
 
 /// Caps (bounded memory).
 const PLAYLISTS_MAX: usize = 999;
-const SONGS_PER_PLAYLIST_MAX: usize = 999;
+pub(crate) const SONGS_PER_PLAYLIST_MAX: usize = 999;
 /// Upper bound on `playlists.json` when loading. With ≤999 playlists × ≤999 tracks written,
 /// a legitimate file is comfortably under this; a larger one is corrupt/hostile and set aside.
 const MAX_PLAYLISTS_BYTES: u64 = 50 * 1024 * 1024;
@@ -195,6 +195,39 @@ impl Playlists {
             Some(i) => Self::push_song(&mut self.playlists[i], song),
             None => AddResult::NotFound,
         }
+    }
+
+    /// Bulk append with one destination lookup and one de-duplication set. Results stay
+    /// aligned with `songs`, allowing resumable import callers to checkpoint each row.
+    pub(crate) fn add_many(&mut self, key: &str, songs: Vec<Song>) -> Vec<AddResult> {
+        let key = key.trim();
+        let idx = self.playlists.iter().position(|p| p.id == key).or_else(|| {
+            self.playlists
+                .iter()
+                .position(|p| p.name.eq_ignore_ascii_case(key))
+        });
+        let Some(idx) = idx else {
+            return vec![AddResult::NotFound; songs.len()];
+        };
+        let playlist = &mut self.playlists[idx];
+        let mut present = playlist
+            .songs
+            .iter()
+            .map(|song| song.video_id.clone())
+            .collect::<HashSet<_>>();
+        let mut results = Vec::with_capacity(songs.len());
+        for song in songs {
+            if present.contains(&song.video_id) {
+                results.push(AddResult::Duplicate);
+            } else if playlist.songs.len() >= SONGS_PER_PLAYLIST_MAX {
+                results.push(AddResult::Full);
+            } else {
+                present.insert(song.video_id.clone());
+                playlist.songs.push(song);
+                results.push(AddResult::Added);
+            }
+        }
+        results
     }
 
     /// Remove the playlist matched by `key` (id or name), returning it so callers can
@@ -381,6 +414,38 @@ mod tests {
         assert_eq!(p.add("mix", song("a")), AddResult::Duplicate); // same id, by name
         assert_eq!(p.add("missing", song("b")), AddResult::NotFound);
         assert_eq!(p.find("mix").unwrap().songs.len(), 1);
+    }
+
+    #[test]
+    fn add_many_preserves_order_and_dedupes_in_one_pass() {
+        let mut playlists = Playlists::default();
+        playlists.create("Mix").unwrap();
+        assert_eq!(playlists.add("Mix", song("existing")), AddResult::Added);
+
+        let results = playlists.add_many(
+            "Mix",
+            vec![song("existing"), song("new"), song("new"), song("last")],
+        );
+
+        assert_eq!(
+            results,
+            vec![
+                AddResult::Duplicate,
+                AddResult::Added,
+                AddResult::Duplicate,
+                AddResult::Added,
+            ]
+        );
+        assert_eq!(
+            playlists
+                .find("Mix")
+                .unwrap()
+                .songs
+                .iter()
+                .map(|song| song.video_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["existing", "new", "last"]
+        );
     }
 
     #[test]

--- a/src/spotify/client.rs
+++ b/src/spotify/client.rs
@@ -4,6 +4,7 @@
 //! secret-safe errors. Exclusive `&mut self` ownership (one task per client) is what
 //! makes refresh single-flight — documented invariant, no mutex.
 
+use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
 use serde::de::DeserializeOwned;
@@ -21,6 +22,10 @@ use crate::util::sanitize::sanitize_error_text;
 /// otherwise loop forever and grow the result Vec without limit.
 const MAX_PAGES: u32 = 20_000;
 const PAGE_LIMIT: u32 = 50;
+/// Reserve from Spotify's reported `total`, but never trust it with an unbounded allocation.
+/// This matches the transfer engine's hard work cap and removes repeated Vec growth for the
+/// common large-playlist path without letting a hostile envelope request gigabytes.
+const MAX_INITIAL_RESERVE_ITEMS: usize = 10_000;
 
 /// Minimum interval between calls (gentle, well under any documented limit).
 const PACE: Duration = Duration::from_millis(250);
@@ -30,6 +35,172 @@ const RATE_WAIT_MAX: Duration = Duration::from_secs(60);
 const RATE_BUDGET: Duration = Duration::from_secs(300);
 /// Transient network/5xx retries (short — jobs checkpoint and resume anyway).
 const TRANSIENT_RETRIES: u32 = 2;
+const TRANSIENT_BACKOFF_BASE: Duration = Duration::from_millis(400);
+const TRANSIENT_BACKOFF_JITTER_MAX_MS: u64 = 200;
+
+fn reserve_reported_total<T>(out: &mut Vec<T>, total: u32) {
+    let target = reported_reserve_target(total);
+    if target <= out.capacity() {
+        return;
+    }
+    let additional = target.saturating_sub(out.len());
+    if let Err(error) = out.try_reserve(additional) {
+        // Allocation failure is not an API failure: Vec can still grow normally while rows
+        // arrive, and the process allocator remains the final authority.
+        tracing::debug!(%error, target, "could not preallocate Spotify page results");
+    }
+}
+
+fn reported_reserve_target(total: u32) -> usize {
+    usize::try_from(total)
+        .unwrap_or(MAX_INITIAL_RESERVE_ITEMS)
+        .min(MAX_INITIAL_RESERVE_ITEMS)
+}
+
+fn extend_oldest_playable_from_newest_page(
+    oldest_first: &mut Vec<SpotifyTrack>,
+    page: &[RawTrackItem],
+    max_tracks: usize,
+) {
+    for item in page.iter().rev() {
+        if let Some(track) = simplify(item) {
+            oldest_first.push(track);
+            if oldest_first.len() >= max_tracks {
+                break;
+            }
+        }
+    }
+}
+
+fn extend_playlist_page(
+    out: &mut Vec<SpotifyTrack>,
+    page: &[RawTrackItem],
+    max_tracks: Option<usize>,
+    skipped: &mut u32,
+) {
+    for item in page {
+        if max_tracks.is_some_and(|max| out.len() >= max) {
+            break;
+        }
+        if let Some(track) = simplify(item) {
+            out.push(track);
+        } else {
+            *skipped = skipped.saturating_add(1);
+        }
+    }
+}
+
+fn response_page_is_monotonic(
+    last_end: &mut Option<u32>,
+    offset: u32,
+    item_count: usize,
+    endpoint: &'static str,
+) -> Result<(), SpotifyError> {
+    let expected = last_end.unwrap_or(0);
+    if offset != expected {
+        tracing::warn!(
+            endpoint,
+            offset,
+            expected,
+            "Spotify pagination returned a non-contiguous page"
+        );
+        return Err(SpotifyError::Network(format!(
+            "{endpoint} pagination expected offset {expected}, got {offset}"
+        )));
+    }
+    let count = u32::try_from(item_count).unwrap_or(u32::MAX);
+    *last_end = Some(offset.saturating_add(count));
+    Ok(())
+}
+
+fn response_total_is_stable(
+    expected_total: &mut Option<u32>,
+    total: u32,
+    endpoint: &'static str,
+) -> Result<(), SpotifyError> {
+    match *expected_total {
+        Some(expected) if expected != total => Err(SpotifyError::Network(format!(
+            "{endpoint} pagination total changed from {expected} to {total}"
+        ))),
+        Some(_) => Ok(()),
+        None => {
+            *expected_total = Some(total);
+            Ok(())
+        }
+    }
+}
+
+fn next_page_url(
+    next: Option<String>,
+    pages: u32,
+    current_offset: u32,
+    current_items: usize,
+    visited: &mut HashSet<String>,
+    endpoint: &'static str,
+) -> Result<Option<String>, SpotifyError> {
+    let Some(next) = next else {
+        return Ok(None);
+    };
+    if pages >= MAX_PAGES {
+        tracing::warn!(pages, endpoint, "Spotify pagination hit the page ceiling");
+        return Err(SpotifyError::Network(format!(
+            "{endpoint} pagination exceeded {MAX_PAGES} pages"
+        )));
+    }
+    if visited.contains(&next) {
+        tracing::warn!(pages, endpoint, "Spotify pagination repeated a next URL");
+        return Err(SpotifyError::Network(format!(
+            "{endpoint} pagination repeated a continuation"
+        )));
+    }
+    if let Ok(parsed) = reqwest::Url::parse(&next)
+        && let Some(next_offset) = parsed.query_pairs().find_map(|(key, value)| {
+            (key == "offset")
+                .then(|| value.parse::<u32>().ok())
+                .flatten()
+        })
+    {
+        let count = u32::try_from(current_items).unwrap_or(u32::MAX);
+        let expected_next = current_offset.saturating_add(count);
+        if count == 0 || next_offset != expected_next {
+            tracing::warn!(
+                pages,
+                endpoint,
+                current_offset,
+                next_offset,
+                expected_next,
+                "Spotify pagination returned a non-contiguous next URL"
+            );
+            return Err(SpotifyError::Network(format!(
+                "{endpoint} pagination expected next offset {expected_next}, got {next_offset}"
+            )));
+        }
+    }
+    visited.insert(next.clone());
+    Ok(Some(next))
+}
+
+fn retry_after_wait(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    let requested = match headers.get(reqwest::header::RETRY_AFTER) {
+        Some(value) => value.to_str().ok()?.trim().parse::<u64>().ok()?,
+        None => 2,
+    };
+    let wait = Duration::from_secs(requested).max(Duration::from_secs(1));
+    (wait <= RATE_WAIT_MAX).then_some(wait)
+}
+
+fn can_replay_after_transient_failure(method: &reqwest::Method) -> bool {
+    matches!(
+        *method,
+        reqwest::Method::GET | reqwest::Method::HEAD | reqwest::Method::OPTIONS
+    )
+}
+
+fn transient_backoff(attempt: u32) -> Duration {
+    let multiplier = 1u32 << attempt.min(8);
+    TRANSIENT_BACKOFF_BASE.saturating_mul(multiplier)
+        + Duration::from_millis(fastrand::u64(0..=TRANSIENT_BACKOFF_JITTER_MAX_MS))
+}
 
 #[derive(Debug, Clone)]
 pub enum SpotifyError {
@@ -136,23 +307,33 @@ impl SpotifyClient {
     pub async fn my_playlists(&mut self) -> Result<Vec<SpotifyPlaylist>, SpotifyError> {
         let mut out = Vec::new();
         let mut url = format!("{API_BASE}/me/playlists?limit={PAGE_LIMIT}");
+        let mut visited = HashSet::from([url.clone()]);
+        let mut last_end = None;
+        let mut expected_total = None;
         let mut pages = 0u32;
         loop {
             pages += 1;
             let page: Paging<RawPlaylist> =
                 self.request_json(reqwest::Method::GET, url, None).await?;
-            out.extend(page.items.into_iter().map(SpotifyPlaylist::from));
-            match page.next {
-                Some(next) if pages < MAX_PAGES => url = next,
-                Some(_) => {
-                    tracing::warn!(
-                        pages,
-                        "Spotify my-playlists pagination hit the page ceiling; result truncated"
-                    );
-                    return Ok(out);
-                }
-                None => return Ok(out),
+            let item_count = page.items.len();
+            response_page_is_monotonic(&mut last_end, page.offset, item_count, "my_playlists")?;
+            response_total_is_stable(&mut expected_total, page.total, "my_playlists")?;
+            if pages == 1 {
+                reserve_reported_total(&mut out, page.total);
             }
+            out.extend(page.items.into_iter().map(SpotifyPlaylist::from));
+            let Some(next) = next_page_url(
+                page.next,
+                pages,
+                page.offset,
+                item_count,
+                &mut visited,
+                "my_playlists",
+            )?
+            else {
+                return Ok(out);
+            };
+            url = next;
         }
     }
 
@@ -182,29 +363,75 @@ impl SpotifyClient {
         id: &str,
         on_page: &mut (dyn FnMut(u32, u32) + Send),
     ) -> Result<Vec<SpotifyTrack>, SpotifyError> {
-        let fields = "items(added_at,is_local,item(type,id,uri,name,duration_ms,explicit,is_local,is_playable,disc_number,track_number,artists(name,id,uri,external_urls(spotify)),album(id,uri,name,album_type,total_tracks,release_date,release_date_precision,images(url,width,height),artists(name,id,uri,external_urls(spotify)),external_urls(spotify)),external_ids(isrc),external_urls(spotify),restrictions(reason),linked_from(id,uri))),total,next";
+        self.playlist_tracks_bounded(id, None, on_page)
+            .await
+            .map(|(tracks, _)| tracks)
+    }
+
+    /// Transfer-only bounded playlist fetch. It stops once `max_tracks` playable rows have
+    /// been collected and reports only genuinely unmatchable rows encountered in fetched pages.
+    pub(crate) async fn playlist_tracks_for_transfer(
+        &mut self,
+        id: &str,
+        max_tracks: usize,
+        on_page: &mut (dyn FnMut(u32, u32) + Send),
+    ) -> Result<(Vec<SpotifyTrack>, u32), SpotifyError> {
+        self.playlist_tracks_bounded(id, Some(max_tracks), on_page)
+            .await
+    }
+
+    async fn playlist_tracks_bounded(
+        &mut self,
+        id: &str,
+        max_tracks: Option<usize>,
+        on_page: &mut (dyn FnMut(u32, u32) + Send),
+    ) -> Result<(Vec<SpotifyTrack>, u32), SpotifyError> {
+        if max_tracks == Some(0) {
+            return Ok((Vec::new(), 0));
+        }
+        let fields = "items(added_at,is_local,item(type,id,uri,name,duration_ms,explicit,is_local,is_playable,disc_number,track_number,artists(name,id,uri,external_urls(spotify)),album(id,uri,name,album_type,total_tracks,release_date,release_date_precision,images(url,width,height),artists(name,id,uri,external_urls(spotify)),external_urls(spotify)),external_ids(isrc),external_urls(spotify),restrictions(reason),linked_from(id,uri))),total,next,offset,limit";
         let mut url = format!("{API_BASE}/playlists/{id}/items?limit={PAGE_LIMIT}&fields={fields}");
         let mut out = Vec::new();
         let mut seen = 0u32;
+        let mut skipped = 0u32;
+        let mut visited = HashSet::from([url.clone()]);
+        let mut last_end = None;
+        let mut expected_total = None;
         let mut pages = 0u32;
         loop {
             pages += 1;
             let page: Paging<RawTrackItem> =
                 self.request_json(reqwest::Method::GET, url, None).await?;
-            seen += page.items.len() as u32;
-            out.extend(page.items.iter().filter_map(simplify));
-            on_page(seen.min(page.total.max(seen)), page.total);
-            match page.next {
-                Some(next) if pages < MAX_PAGES => url = next,
-                Some(_) => {
-                    tracing::warn!(
-                        pages,
-                        "Spotify playlist pagination hit the page ceiling; result truncated"
-                    );
-                    return Ok(out);
-                }
-                None => return Ok(out),
+            let item_count = page.items.len();
+            response_page_is_monotonic(&mut last_end, page.offset, item_count, "playlist_tracks")?;
+            response_total_is_stable(&mut expected_total, page.total, "playlist_tracks")?;
+            if pages == 1 {
+                let reserve = max_tracks
+                    .map(|max| page.total.min(u32::try_from(max).unwrap_or(u32::MAX)))
+                    .unwrap_or(page.total);
+                reserve_reported_total(&mut out, reserve);
             }
+            seen = seen.saturating_add(u32::try_from(item_count).unwrap_or(u32::MAX));
+            extend_playlist_page(&mut out, &page.items, max_tracks, &mut skipped);
+            let progress_total = max_tracks
+                .map(|max| page.total.min(u32::try_from(max).unwrap_or(u32::MAX)))
+                .unwrap_or(page.total);
+            on_page(seen.min(progress_total), progress_total);
+            if max_tracks.is_some_and(|max| out.len() >= max) {
+                return Ok((out, skipped));
+            }
+            let Some(next) = next_page_url(
+                page.next,
+                pages,
+                page.offset,
+                item_count,
+                &mut visited,
+                "playlist_tracks",
+            )?
+            else {
+                return Ok((out, skipped));
+            };
+            url = next;
         }
     }
 
@@ -217,26 +444,153 @@ impl SpotifyClient {
         let mut url = format!("{API_BASE}/me/tracks?limit={PAGE_LIMIT}");
         let mut out = Vec::new();
         let mut seen = 0u32;
+        let mut visited = HashSet::from([url.clone()]);
+        let mut last_end = None;
+        let mut expected_total = None;
         let mut pages = 0u32;
         loop {
             pages += 1;
             let page: Paging<RawTrackItem> =
                 self.request_json(reqwest::Method::GET, url, None).await?;
-            seen += page.items.len() as u32;
+            let item_count = page.items.len();
+            response_page_is_monotonic(&mut last_end, page.offset, item_count, "liked_tracks")?;
+            response_total_is_stable(&mut expected_total, page.total, "liked_tracks")?;
+            if pages == 1 {
+                reserve_reported_total(&mut out, page.total);
+            }
+            seen = seen.saturating_add(u32::try_from(item_count).unwrap_or(u32::MAX));
             out.extend(page.items.iter().filter_map(simplify));
-            on_page(seen.min(page.total.max(seen)), page.total);
-            match page.next {
-                Some(next) if pages < MAX_PAGES => url = next,
-                Some(_) => {
-                    tracing::warn!(
-                        pages,
-                        "Spotify liked-tracks pagination hit the page ceiling; result truncated"
-                    );
+            on_page(seen, page.total);
+            let Some(next) = next_page_url(
+                page.next,
+                pages,
+                page.offset,
+                item_count,
+                &mut visited,
+                "liked_tracks",
+            )?
+            else {
+                return Ok(out);
+            };
+            url = next;
+        }
+    }
+
+    /// Fetch the oldest `max_tracks` playable saved tracks without downloading a larger
+    /// newest-first library in full. The returned order remains newest-first, matching
+    /// [`liked_tracks`], so callers can reverse once for chronological import.
+    pub(crate) async fn liked_tracks_for_transfer(
+        &mut self,
+        max_tracks: usize,
+        on_page: &mut (dyn FnMut(u32, u32) + Send),
+    ) -> Result<Vec<SpotifyTrack>, SpotifyError> {
+        if max_tracks == 0 {
+            return Ok(Vec::new());
+        }
+
+        let first_url = format!("{API_BASE}/me/tracks?limit={PAGE_LIMIT}&offset=0");
+        let first: Paging<RawTrackItem> = self
+            .request_json(reqwest::Method::GET, first_url.clone(), None)
+            .await?;
+        if first.offset != 0 {
+            return Err(SpotifyError::Network(format!(
+                "liked_tracks_for_transfer expected first offset 0, got {}",
+                first.offset
+            )));
+        }
+        let total = first.total;
+        if usize::try_from(total).unwrap_or(usize::MAX) <= max_tracks {
+            let mut out = Vec::new();
+            reserve_reported_total(&mut out, total);
+            let mut seen = 0u32;
+            let mut visited = HashSet::from([first_url]);
+            let mut last_end = None;
+            let mut expected_total = Some(total);
+            let mut pages = 0u32;
+            let mut page = first;
+            loop {
+                pages += 1;
+                let item_count = page.items.len();
+                response_page_is_monotonic(
+                    &mut last_end,
+                    page.offset,
+                    item_count,
+                    "liked_tracks_for_transfer",
+                )?;
+                response_total_is_stable(
+                    &mut expected_total,
+                    page.total,
+                    "liked_tracks_for_transfer",
+                )?;
+                seen = seen.saturating_add(u32::try_from(item_count).unwrap_or(u32::MAX));
+                out.extend(page.items.iter().filter_map(simplify));
+                on_page(seen.min(total), total);
+                let Some(next) = next_page_url(
+                    page.next,
+                    pages,
+                    page.offset,
+                    item_count,
+                    &mut visited,
+                    "liked_tracks_for_transfer",
+                )?
+                else {
                     return Ok(out);
-                }
-                None => return Ok(out),
+                };
+                page = self.request_json(reqwest::Method::GET, next, None).await?;
             }
         }
+
+        let target = u32::try_from(max_tracks).unwrap_or(u32::MAX).min(total);
+        let mut oldest_first = Vec::with_capacity(max_tracks.min(MAX_INITIAL_RESERVE_ITEMS));
+        let mut upper = total;
+        let mut pages = 0u32;
+        let mut requested_offsets = HashSet::new();
+        while upper > 0 && oldest_first.len() < max_tracks {
+            pages += 1;
+            if pages > MAX_PAGES {
+                return Err(SpotifyError::Network(format!(
+                    "liked_tracks_for_transfer pagination exceeded {MAX_PAGES} pages"
+                )));
+            }
+            let limit = PAGE_LIMIT.min(upper);
+            let offset = upper - limit;
+            if !requested_offsets.insert(offset) {
+                return Err(SpotifyError::Network(
+                    "liked_tracks_for_transfer pagination repeated an offset".to_owned(),
+                ));
+            }
+            let url = format!("{API_BASE}/me/tracks?limit={limit}&offset={offset}");
+            let page: Paging<RawTrackItem> =
+                self.request_json(reqwest::Method::GET, url, None).await?;
+            if page.total != total {
+                return Err(SpotifyError::Network(format!(
+                    "liked_tracks_for_transfer library changed during pagination (expected total {total}, got {})",
+                    page.total
+                )));
+            }
+            if page.offset != offset {
+                return Err(SpotifyError::Network(format!(
+                    "liked_tracks_for_transfer expected offset {offset}, got {}",
+                    page.offset
+                )));
+            }
+            if page.items.len() != usize::try_from(limit).unwrap_or(usize::MAX) {
+                return Err(SpotifyError::Network(format!(
+                    "liked_tracks_for_transfer returned {} of {limit} rows at offset {offset}",
+                    page.items.len()
+                )));
+            }
+            extend_oldest_playable_from_newest_page(&mut oldest_first, &page.items, max_tracks);
+            on_page(
+                u32::try_from(oldest_first.len())
+                    .unwrap_or(u32::MAX)
+                    .min(target),
+                target,
+            );
+            upper = offset;
+        }
+        oldest_first.reverse();
+        Ok(oldest_first)
     }
 
     /// Create a private playlist; returns its id.
@@ -322,6 +676,8 @@ impl SpotifyClient {
     ) -> Result<T, SpotifyError> {
         let mut refreshed = false;
         let mut transient_left = TRANSIENT_RETRIES;
+        let mut transient_attempt = 0u32;
+        let replay_safe = can_replay_after_transient_failure(&method);
         loop {
             // Self-pace every call.
             if let Some(last) = self.last_call {
@@ -352,9 +708,17 @@ impl SpotifyClient {
             }
             let resp = match req.send().await {
                 Ok(resp) => resp,
-                Err(_) if transient_left > 0 => {
+                Err(error) if replay_safe && transient_left > 0 => {
+                    let wait = transient_backoff(transient_attempt);
                     transient_left -= 1;
-                    tokio::time::sleep(Duration::from_millis(1200)).await;
+                    transient_attempt += 1;
+                    tracing::debug!(
+                        attempt = transient_attempt,
+                        wait_ms = wait.as_millis(),
+                        error = %sanitize_error_text(format!("{error}")),
+                        "retrying transient Spotify network failure"
+                    );
+                    tokio::time::sleep(wait).await;
                     continue;
                 }
                 Err(e) => {
@@ -369,24 +733,32 @@ impl SpotifyClient {
                 continue;
             }
             if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                let wait = resp
-                    .headers()
-                    .get(reqwest::header::RETRY_AFTER)
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| v.parse::<u64>().ok())
-                    .map_or(Duration::from_secs(2), Duration::from_secs);
-                let wait = wait.min(RATE_WAIT_MAX).max(Duration::from_secs(1));
-                if self.rate_waited + wait > RATE_BUDGET {
+                let Some(wait) = retry_after_wait(resp.headers()) else {
+                    return Err(SpotifyError::RateLimited);
+                };
+                let total_wait = self.rate_waited.saturating_add(wait);
+                if total_wait > RATE_BUDGET {
                     return Err(SpotifyError::RateLimited);
                 }
-                self.rate_waited += wait;
+                self.rate_waited = total_wait;
                 tracing::info!(secs = wait.as_secs(), "spotify 429; waiting");
                 tokio::time::sleep(wait).await;
                 continue;
             }
-            if status.is_server_error() && transient_left > 0 {
+            if (status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT)
+                && replay_safe
+                && transient_left > 0
+            {
+                let wait = transient_backoff(transient_attempt);
                 transient_left -= 1;
-                tokio::time::sleep(Duration::from_millis(1200)).await;
+                transient_attempt += 1;
+                tracing::debug!(
+                    attempt = transient_attempt,
+                    wait_ms = wait.as_millis(),
+                    status = status.as_u16(),
+                    "retrying transient Spotify HTTP failure"
+                );
+                tokio::time::sleep(wait).await;
                 continue;
             }
             if !status.is_success() {
@@ -498,6 +870,234 @@ mod tests {
         assert_eq!(client.token.refresh_token, "refresh");
     }
 
+    #[test]
+    fn reported_page_total_preallocation_is_bounded_by_the_work_cap() {
+        assert_eq!(reported_reserve_target(0), 0);
+        assert_eq!(reported_reserve_target(237), 237);
+        assert_eq!(reported_reserve_target(u32::MAX), MAX_INITIAL_RESERVE_ITEMS);
+
+        let mut rows = Vec::<u8>::new();
+        reserve_reported_total(&mut rows, 237);
+        assert!(rows.capacity() >= 237);
+    }
+
+    fn raw_track(name: &str) -> RawTrackItem {
+        serde_json::from_value(serde_json::json!({
+            "track": {
+                "type": "track",
+                "uri": format!("spotify:track:{name}"),
+                "name": name,
+                "artists": [],
+                "album": { "name": "Album", "artists": [] }
+            }
+        }))
+        .expect("raw track fixture")
+    }
+
+    #[test]
+    fn bounded_playlist_page_fold_keeps_first_playable_rows_and_exact_skips() {
+        let invalid = RawTrackItem::default();
+        let mut out = Vec::new();
+        let mut skipped = 0;
+
+        extend_playlist_page(
+            &mut out,
+            &[raw_track("a"), invalid.clone(), raw_track("b")],
+            Some(3),
+            &mut skipped,
+        );
+        extend_playlist_page(
+            &mut out,
+            &[invalid, raw_track("c"), raw_track("beyond-cap")],
+            Some(3),
+            &mut skipped,
+        );
+
+        assert_eq!(
+            out.iter()
+                .map(|track| track.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+        assert_eq!(skipped, 2);
+    }
+
+    #[test]
+    fn liked_tail_page_fold_returns_oldest_selection_in_newest_first_api_order() {
+        let invalid = RawTrackItem::default();
+        let mut oldest_first = Vec::new();
+
+        // Tail pages arrive newest-first while pagination walks from the end backwards.
+        // Invalid old rows force another page; only the oldest three playable rows survive.
+        extend_oldest_playable_from_newest_page(
+            &mut oldest_first,
+            &[raw_track("newer-tail"), invalid],
+            3,
+        );
+        extend_oldest_playable_from_newest_page(
+            &mut oldest_first,
+            &[raw_track("newer"), raw_track("middle")],
+            3,
+        );
+        assert_eq!(
+            oldest_first
+                .iter()
+                .map(|track| track.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["newer-tail", "middle", "newer"]
+        );
+
+        oldest_first.reverse();
+        assert_eq!(
+            oldest_first
+                .iter()
+                .map(|track| track.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["newer", "middle", "newer-tail"]
+        );
+    }
+
+    #[test]
+    fn pagination_guards_require_contiguous_offsets_stable_totals_and_unique_urls() {
+        let mut wrong_first = None;
+        assert!(response_page_is_monotonic(&mut wrong_first, 5, 50, "test").is_err());
+
+        let mut last_end = None;
+        assert!(response_page_is_monotonic(&mut last_end, 0, 50, "test").is_ok());
+        assert!(response_page_is_monotonic(&mut last_end, 50, 50, "test").is_ok());
+        assert!(response_page_is_monotonic(&mut last_end, 75, 50, "test").is_err());
+        assert!(response_page_is_monotonic(&mut last_end, 150, 50, "test").is_err());
+
+        let mut expected_total = None;
+        assert!(response_total_is_stable(&mut expected_total, 100, "test").is_ok());
+        assert!(response_total_is_stable(&mut expected_total, 100, "test").is_ok());
+        assert!(response_total_is_stable(&mut expected_total, 99, "test").is_err());
+
+        let initial = "https://api.spotify.com/v1/me/tracks?offset=0&limit=50".to_owned();
+        let next = "https://api.spotify.com/v1/me/tracks?offset=50&limit=50".to_owned();
+        let mut visited = HashSet::from([initial]);
+        assert_eq!(
+            next_page_url(Some(next.clone()), 1, 0, 50, &mut visited, "test")
+                .expect("monotonic continuation"),
+            Some(next.clone())
+        );
+        assert!(
+            next_page_url(Some(next), 2, 50, 50, &mut visited, "test").is_err(),
+            "a repeated next URL must stop pagination"
+        );
+
+        let mut visited = HashSet::new();
+        assert!(
+            next_page_url(
+                Some("https://api.spotify.com/v1/me/tracks?offset=49&limit=50".to_owned()),
+                1,
+                0,
+                50,
+                &mut visited,
+                "test"
+            )
+            .is_err(),
+            "overlapping offset must stop pagination"
+        );
+        let mut visited = HashSet::new();
+        assert!(
+            next_page_url(
+                Some("https://api.spotify.com/v1/me/tracks?offset=100&limit=50".to_owned()),
+                1,
+                0,
+                50,
+                &mut visited,
+                "test"
+            )
+            .is_err(),
+            "a continuation gap must stop pagination"
+        );
+    }
+
+    #[test]
+    fn retry_after_and_transient_retry_policies_are_bounded_and_replay_safe() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        assert_eq!(retry_after_wait(&headers), Some(Duration::from_secs(2)));
+
+        headers.insert(reqwest::header::RETRY_AFTER, "0".parse().unwrap());
+        assert_eq!(retry_after_wait(&headers), Some(Duration::from_secs(1)));
+        headers.insert(reqwest::header::RETRY_AFTER, "60".parse().unwrap());
+        assert_eq!(retry_after_wait(&headers), Some(RATE_WAIT_MAX));
+        headers.insert(reqwest::header::RETRY_AFTER, "61".parse().unwrap());
+        assert_eq!(retry_after_wait(&headers), None);
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            "not-delay-seconds".parse().unwrap(),
+        );
+        assert_eq!(retry_after_wait(&headers), None);
+
+        assert!(can_replay_after_transient_failure(&reqwest::Method::GET));
+        assert!(!can_replay_after_transient_failure(&reqwest::Method::POST));
+        let first = transient_backoff(0);
+        assert!(first >= TRANSIENT_BACKOFF_BASE);
+        assert!(
+            first
+                <= TRANSIENT_BACKOFF_BASE + Duration::from_millis(TRANSIENT_BACKOFF_JITTER_MAX_MS)
+        );
+        let second = transient_backoff(1);
+        assert!(second >= TRANSIENT_BACKOFF_BASE.saturating_mul(2));
+        assert!(
+            second
+                <= TRANSIENT_BACKOFF_BASE.saturating_mul(2)
+                    + Duration::from_millis(TRANSIENT_BACKOFF_JITTER_MAX_MS)
+        );
+    }
+
+    async fn read_spotify_test_request(stream: &mut tokio::net::TcpStream) -> String {
+        let mut request = Vec::new();
+        let mut buf = [0u8; 1024];
+        loop {
+            let n = stream.read(&mut buf).await.expect("read spotify request");
+            if n == 0 {
+                break;
+            }
+            request.extend_from_slice(&buf[..n]);
+            if let Some(head_end) = request.windows(4).position(|w| w == b"\r\n\r\n") {
+                let head = String::from_utf8_lossy(&request[..head_end + 4]);
+                let content_len = head
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                    .unwrap_or(0);
+                if request.len() >= head_end + 4 + content_len {
+                    break;
+                }
+            }
+        }
+        String::from_utf8_lossy(&request).into_owned()
+    }
+
+    async fn write_spotify_test_response(
+        stream: &mut tokio::net::TcpStream,
+        status: &str,
+        headers: &[(String, String)],
+        body: &str,
+    ) {
+        let mut response = format!(
+            "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n",
+            body.len()
+        );
+        for (name, value) in headers {
+            response.push_str(&format!("{name}: {value}\r\n"));
+        }
+        response.push_str("\r\n");
+        response.push_str(body);
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("write spotify response");
+        let _ = stream.shutdown().await;
+    }
+
     async fn serve_spotify_once(
         status: &str,
         headers: &[(&str, &str)],
@@ -515,46 +1115,40 @@ mod tests {
         let body = body.to_owned();
         let handle = tokio::spawn(async move {
             let (mut stream, _) = listener.accept().await.expect("accept spotify request");
-            let mut request = Vec::new();
-            let mut buf = [0u8; 1024];
-            loop {
-                let n = stream.read(&mut buf).await.expect("read spotify request");
-                if n == 0 {
-                    break;
-                }
-                request.extend_from_slice(&buf[..n]);
-                if let Some(head_end) = request.windows(4).position(|w| w == b"\r\n\r\n") {
-                    let head = String::from_utf8_lossy(&request[..head_end + 4]);
-                    let content_len = head
-                        .lines()
-                        .find_map(|line| {
-                            let (name, value) = line.split_once(':')?;
-                            name.eq_ignore_ascii_case("content-length")
-                                .then(|| value.trim().parse::<usize>().ok())
-                                .flatten()
-                        })
-                        .unwrap_or(0);
-                    if request.len() >= head_end + 4 + content_len {
-                        break;
-                    }
-                }
-            }
+            let request = read_spotify_test_request(&mut stream).await;
+            write_spotify_test_response(&mut stream, &status, &headers, &body).await;
+            request
+        });
+        (format!("http://{addr}/v1/test"), handle)
+    }
 
-            let mut response = format!(
-                "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n",
-                body.len()
-            );
-            for (name, value) in headers {
-                response.push_str(&format!("{name}: {value}\r\n"));
+    async fn serve_transient_then_success() -> (String, tokio::task::JoinHandle<Vec<String>>) {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind spotify retry test server");
+        let addr = listener
+            .local_addr()
+            .expect("spotify retry test server address");
+        let handle = tokio::spawn(async move {
+            let mut requests = Vec::with_capacity(2);
+            for (status, body) in [
+                (
+                    "503 Service Unavailable",
+                    r#"{"error":{"message":"temporary"}}"#,
+                ),
+                ("200 OK", r#"{"ok":true}"#),
+            ] {
+                let (mut stream, _) = listener.accept().await.expect("accept retry request");
+                requests.push(read_spotify_test_request(&mut stream).await);
+                write_spotify_test_response(
+                    &mut stream,
+                    status,
+                    &[("Content-Type".to_owned(), "application/json".to_owned())],
+                    body,
+                )
+                .await;
             }
-            response.push_str("\r\n");
-            response.push_str(&body);
-            stream
-                .write_all(response.as_bytes())
-                .await
-                .expect("write spotify response");
-            let _ = stream.shutdown().await;
-            String::from_utf8_lossy(&request).into_owned()
+            requests
         });
         (format!("http://{addr}/v1/test"), handle)
     }
@@ -588,6 +1182,22 @@ mod tests {
                 .contains("authorization: bearer access")
         );
         assert!(request.contains(r#""name":"Roadtrip""#));
+    }
+
+    #[tokio::test]
+    async fn request_json_retries_replay_safe_get_after_transient_server_failure() {
+        let (url, requests) = serve_transient_then_success().await;
+        let mut client = SpotifyClient::with_token(token());
+
+        let body: serde_json::Value = client
+            .request_json(reqwest::Method::GET, url, None)
+            .await
+            .expect("GET should recover after one bounded transient retry");
+
+        assert_eq!(body["ok"], true);
+        let requests = requests.await.expect("captured retry requests");
+        assert_eq!(requests.len(), 2);
+        assert!(requests.iter().all(|request| request.starts_with("GET ")));
     }
 
     #[tokio::test]
@@ -651,5 +1261,59 @@ mod tests {
             .await
             .expect_err("exhausted rate budget returns immediately");
         assert!(matches!(err, SpotifyError::RateLimited));
+    }
+
+    #[tokio::test]
+    async fn request_json_aborts_when_retry_after_exceeds_single_wait_cap() {
+        let (url, request) = serve_spotify_once(
+            "429 Too Many Requests",
+            &[("Content-Type", "application/json"), ("Retry-After", "61")],
+            r#"{"error":{"message":"wait longer"}}"#,
+        )
+        .await;
+        let mut client = SpotifyClient::with_token(token());
+
+        let err = client
+            .request_json::<serde_json::Value>(reqwest::Method::GET, url, None)
+            .await
+            .expect_err("over-cap Retry-After must defer instead of retrying early");
+
+        assert!(matches!(err, SpotifyError::RateLimited));
+        assert_eq!(client.rate_waited, Duration::ZERO);
+        assert!(request.await.expect("captured 429 request").contains("GET"));
+    }
+
+    #[tokio::test]
+    async fn request_json_does_not_replay_ambiguous_post_on_server_failure() {
+        let (url, request) = serve_spotify_once(
+            "503 Service Unavailable",
+            &[("Content-Type", "application/json")],
+            r#"{"error":{"message":"try later"}}"#,
+        )
+        .await;
+        let mut client = SpotifyClient::with_token(token());
+
+        let err = client
+            .request_json::<serde_json::Value>(
+                reqwest::Method::POST,
+                url,
+                Some(serde_json::json!({"uris": ["spotify:track:test"]})),
+            )
+            .await
+            .expect_err("ambiguous POST failure must not be replayed automatically");
+
+        assert!(matches!(
+            err,
+            SpotifyError::Api {
+                status: 503,
+                ref message
+            } if message == "try later"
+        ));
+        assert!(
+            request
+                .await
+                .expect("captured 503 request")
+                .contains("POST")
+        );
     }
 }

--- a/src/spotify/client.rs
+++ b/src/spotify/client.rs
@@ -574,9 +574,9 @@ impl SpotifyClient {
                     page.offset
                 )));
             }
-            if page.items.len() != usize::try_from(limit).unwrap_or(usize::MAX) {
+            if page.items.len() > usize::try_from(limit).unwrap_or(usize::MAX) {
                 return Err(SpotifyError::Network(format!(
-                    "liked_tracks_for_transfer returned {} of {limit} rows at offset {offset}",
+                    "liked_tracks_for_transfer returned {} rows for limit {limit} at offset {offset}",
                     page.items.len()
                 )));
             }

--- a/src/spotify/models.rs
+++ b/src/spotify/models.rs
@@ -17,6 +17,13 @@ pub struct Paging<T> {
     pub next: Option<String>,
     #[serde(default)]
     pub total: u32,
+    /// Spotify's offset envelopes include these on every page. Keeping them lets the
+    /// client reject a repeated/overlapping continuation before duplicate rows grow the
+    /// transfer input indefinitely.
+    #[serde(default)]
+    pub offset: u32,
+    #[serde(default)]
+    pub limit: u32,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/transfer/checkpoint.rs
+++ b/src/transfer/checkpoint.rs
@@ -4,15 +4,18 @@
 //! human-facing summary lands next to it as `<job-id>.report.json`.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use super::matching::{MatchOutcome, MatchScoreBreakdown, TrackInput};
 use super::{JobSpec, Stage};
 use crate::util::safe_fs;
 
 pub const CHECKPOINT_VERSION: u32 = 1;
+const CHECKPOINT_JOURNAL_VERSION: u32 = 1;
+const CHECKPOINT_JOURNAL_MAX_BYTES: u64 = 64 * 1024 * 1024;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Checkpoint {
@@ -40,6 +43,19 @@ pub struct Checkpoint {
     /// so resumed jobs can explain why rows landed in review without storing every probe.
     #[serde(default, skip_serializing_if = "MatchStats::is_empty")]
     pub match_stats: MatchStats,
+    /// A systemic provider/budget failure pauses the job without fabricating
+    /// `NotFound` outcomes. Completed rows remain durable and unresolved rows stay
+    /// pending for the next resume.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub defer_reason: Option<JobDeferReason>,
+    /// Bounded, source-order keyed evidence for unresolved/review rows. Keeping this
+    /// outside `TrackEntry` preserves the compact hot row and old checkpoint shape.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub match_traces: BTreeMap<u32, MatchTrace>,
+    /// Snapshot generation makes journal compaction crash-safe: if the atomic
+    /// snapshot wins but deleting the old journal does not, stale records are ignored.
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    journal_generation: u64,
     pub tracks: Vec<TrackEntry>,
 }
 
@@ -91,6 +107,9 @@ impl Checkpoint {
             source_name: None,
             skipped_local: 0,
             match_stats: MatchStats::default(),
+            defer_reason: None,
+            match_traces: BTreeMap::new(),
+            journal_generation: 0,
             tracks,
         }
     }
@@ -101,12 +120,16 @@ impl Checkpoint {
             .ok_or_else(|| anyhow::anyhow!("no data directory on this platform"))?;
         let text = safe_fs::read_to_string_no_symlink(&path)
             .with_context(|| format!("no checkpoint for job `{job_id}`"))?;
-        let cp: Checkpoint = serde_json::from_str(&text).context("checkpoint is corrupt")?;
+        let mut cp: Checkpoint = serde_json::from_str(&text).context("checkpoint is corrupt")?;
         if cp.version != CHECKPOINT_VERSION {
             bail!(
                 "checkpoint version {} is not supported (expected {CHECKPOINT_VERSION})",
                 cp.version
             );
+        }
+        if let Some(path) = checkpoint_journal_path(job_id) {
+            replay_checkpoint_journal(&mut cp, &path)
+                .context("checkpoint outcome journal is corrupt")?;
         }
         Ok(cp)
     }
@@ -116,7 +139,67 @@ impl Checkpoint {
         let Some(path) = checkpoint_path(&self.job_id) else {
             return Ok(());
         };
-        safe_fs::write_private_atomic_json(&path, self)
+        let previous_generation = self.journal_generation;
+        self.journal_generation = self.journal_generation.saturating_add(1);
+        if let Err(error) = safe_fs::write_private_atomic_json(&path, self) {
+            self.journal_generation = previous_generation;
+            return Err(error);
+        }
+        clear_checkpoint_journal(&self.job_id)
+    }
+
+    /// Append one changed track to the compact checkpoint's outcome journal. A later
+    /// durable append syncs all earlier non-durable records in the same file, allowing
+    /// the engine to coalesce fsync while keeping a bounded crash-loss window.
+    pub fn append_track_journal(&self, index: usize, durable: bool) -> std::io::Result<u64> {
+        self.append_tracks_journal(std::slice::from_ref(&index), durable)
+    }
+
+    /// Append several changed tracks with one file open and, when requested, one fsync.
+    /// Each row remains an independently checksummed JSONL record for crash replay.
+    pub fn append_tracks_journal(&self, indexes: &[usize], durable: bool) -> std::io::Result<u64> {
+        if indexes.is_empty() {
+            return Ok(0);
+        }
+        let Some(path) = checkpoint_journal_path(&self.job_id) else {
+            return Ok(0);
+        };
+        let block = self.track_journal_block(indexes)?;
+        if durable {
+            safe_fs::append_private_jsonl_durable(&path, &block)?;
+        } else {
+            safe_fs::append_private_jsonl(&path, &block)?;
+        }
+        Ok(block.len() as u64 + 1)
+    }
+
+    fn track_journal_block(&self, indexes: &[usize]) -> std::io::Result<String> {
+        let mut lines = Vec::with_capacity(indexes.len());
+        for &index in indexes {
+            let Some(entry) = self.tracks.get(index) else {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("track index {index} is out of range"),
+                ));
+            };
+            let payload = CheckpointJournalPayload {
+                checkpoint_version: self.version,
+                journal_generation: self.journal_generation,
+                job_id: self.job_id.clone(),
+                source_order: index as u32 + 1,
+                outcome: entry.outcome.clone(),
+                review_decision: entry.review_decision.clone(),
+                written: entry.written,
+            };
+            let checksum = journal_checksum(&payload)?;
+            let record = CheckpointJournalRecord {
+                version: CHECKPOINT_JOURNAL_VERSION,
+                payload,
+                checksum,
+            };
+            lines.push(serde_json::to_string(&record).map_err(std::io::Error::other)?);
+        }
+        Ok(lines.join("\n"))
     }
 
     /// Known jobs, newest first: `(job_id, stage, updated_at)`.
@@ -145,6 +228,114 @@ impl Checkpoint {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CheckpointJournalPayload {
+    checkpoint_version: u32,
+    #[serde(default)]
+    journal_generation: u64,
+    job_id: String,
+    source_order: u32,
+    outcome: Option<MatchOutcome>,
+    review_decision: Option<ReviewDecision>,
+    written: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CheckpointJournalRecord {
+    version: u32,
+    payload: CheckpointJournalPayload,
+    checksum: String,
+}
+
+fn journal_checksum(payload: &CheckpointJournalPayload) -> std::io::Result<String> {
+    let bytes = serde_json::to_vec(payload).map_err(std::io::Error::other)?;
+    let digest = Sha256::digest(bytes);
+    Ok(format!("{digest:x}"))
+}
+
+fn checkpoint_journal_path(job_id: &str) -> Option<PathBuf> {
+    Some(transfers_dir()?.join(format!("{}.journal.jsonl", safe_job_id(job_id)?)))
+}
+
+fn replay_checkpoint_journal(cp: &mut Checkpoint, path: &Path) -> anyhow::Result<()> {
+    let bytes = match safe_fs::read_no_symlink_limited(path, CHECKPOINT_JOURNAL_MAX_BYTES) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    let ends_with_newline = bytes.ends_with(b"\n");
+    // Lossy decoding lets a crash in the middle of a multi-byte character become the
+    // same ignored final fragment as any other truncated JSON. Interior corruption is
+    // still rejected when that line fails JSON decoding.
+    let text = String::from_utf8_lossy(&bytes);
+    let lines = text.split('\n').collect::<Vec<_>>();
+    for (line_index, line) in lines.iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let is_last_fragment = line_index + 1 == lines.len() && !ends_with_newline;
+        let record = match serde_json::from_str::<CheckpointJournalRecord>(line) {
+            Ok(record) => record,
+            Err(_) if is_last_fragment => {
+                tracing::warn!(
+                    job = %cp.job_id,
+                    "ignoring truncated final checkpoint journal record"
+                );
+                break;
+            }
+            Err(error) => return Err(error.into()),
+        };
+        if record.version != CHECKPOINT_JOURNAL_VERSION
+            || record.payload.checkpoint_version != cp.version
+            || record.payload.job_id != cp.job_id
+        {
+            anyhow::bail!("checkpoint journal record scope/version mismatch");
+        }
+        if journal_checksum(&record.payload)? != record.checksum {
+            anyhow::bail!("checkpoint journal checksum mismatch");
+        }
+        if record.payload.journal_generation < cp.journal_generation {
+            continue;
+        }
+        if record.payload.journal_generation > cp.journal_generation {
+            anyhow::bail!("checkpoint journal generation is newer than its snapshot");
+        }
+        let Some(index) = record
+            .payload
+            .source_order
+            .checked_sub(1)
+            .map(|value| value as usize)
+        else {
+            anyhow::bail!("checkpoint journal source order is zero");
+        };
+        let Some(entry) = cp.tracks.get_mut(index) else {
+            anyhow::bail!(
+                "checkpoint journal source order {} is out of range",
+                record.payload.source_order
+            );
+        };
+        entry.outcome = record.payload.outcome;
+        entry.review_decision = record.payload.review_decision;
+        entry.written = record.payload.written;
+    }
+    Ok(())
+}
+
+fn clear_checkpoint_journal(job_id: &str) -> std::io::Result<()> {
+    let Some(path) = checkpoint_journal_path(job_id) else {
+        return Ok(());
+    };
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn is_zero_u64(value: &u64) -> bool {
+    *value == 0
+}
+
 fn transfers_dir() -> Option<PathBuf> {
     crate::paths::data_dir().map(|d| d.join("transfers"))
 }
@@ -167,7 +358,80 @@ pub fn report_path(job_id: &str) -> Option<PathBuf> {
     Some(transfers_dir()?.join(format!("{}.report.json", safe_job_id(job_id)?)))
 }
 
-const TRANSFER_REPORT_SCHEMA_VERSION: u32 = 4;
+const TRANSFER_REPORT_SCHEMA_VERSION: u32 = 5;
+
+pub const MAX_MATCH_TRACE_PROBES: usize = 16;
+pub const MAX_MATCH_TRACE_CANDIDATES: usize = 5;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct JobDeferReason {
+    pub code: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
+    /// Sanitized, bounded human-facing context; never store provider bodies/cookies.
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_after_secs: Option<u64>,
+    pub deferred_at: i64,
+}
+
+impl JobDeferReason {
+    pub fn new(code: impl Into<String>, backend: Option<&str>, message: impl AsRef<str>) -> Self {
+        let sanitized = crate::util::sanitize::sanitize_error_text(message.as_ref());
+        Self {
+            code: code.into(),
+            backend: backend.map(str::to_owned),
+            message: sanitized.chars().take(500).collect(),
+            retry_after_secs: None,
+            deferred_at: crate::signals::unix_now(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ProbeTrace {
+    pub backend: String,
+    pub intent: String,
+    pub query: String,
+    pub status: String,
+    pub result_count: u32,
+    pub elapsed_ms: u64,
+    pub queue_ms: u64,
+    pub pace_ms: u64,
+    pub attempt: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct MatchTrace {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub probes: Vec<ProbeTrace>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub candidates: Vec<ReportCandidate>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_reason: Option<String>,
+}
+
+impl MatchTrace {
+    pub fn push_probe(&mut self, mut probe: ProbeTrace) {
+        if self.probes.len() >= MAX_MATCH_TRACE_PROBES {
+            return;
+        }
+        probe.query = probe.query.chars().take(300).collect();
+        self.probes.push(probe);
+    }
+
+    pub fn set_candidates(&mut self, candidates: impl IntoIterator<Item = ReportCandidate>) {
+        self.candidates = candidates
+            .into_iter()
+            .take(MAX_MATCH_TRACE_CANDIDATES)
+            .collect();
+    }
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
@@ -179,10 +443,33 @@ pub struct MatchStats {
     pub album_tracks_matched: u32,
     pub catalog_searches: u32,
     pub video_searches: u32,
+    pub ytm_video_catalog_searches: u32,
+    pub public_video_searches: u32,
     pub preflight_lookups: u32,
     pub authenticated_catalog_degraded: u32,
     pub query_cache_hits: u32,
     pub video_meta_cache_hits: u32,
+    pub catalog_http_pages: u32,
+    pub video_process_spawns: u32,
+    pub preflight_process_spawns: u32,
+    pub successful_empty_probes: u32,
+    pub retries: u32,
+    pub circuit_opens: u32,
+    pub deferred_jobs: u32,
+    pub capacity_skipped: u32,
+    pub candidates_fetched: u32,
+    pub candidates_deduped: u32,
+    pub candidates_rejected: u32,
+    pub candidates_review_only: u32,
+    pub cache_evictions: u32,
+    pub checkpoint_bytes: u64,
+    pub checkpoint_flushes: u32,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub provider_errors: BTreeMap<String, u32>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub terminal_reasons: BTreeMap<String, u32>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub elapsed_ms: BTreeMap<String, u64>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub source_kinds: BTreeMap<String, u32>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -199,10 +486,30 @@ impl MatchStats {
             && self.album_tracks_matched == 0
             && self.catalog_searches == 0
             && self.video_searches == 0
+            && self.ytm_video_catalog_searches == 0
+            && self.public_video_searches == 0
             && self.preflight_lookups == 0
             && self.authenticated_catalog_degraded == 0
             && self.query_cache_hits == 0
             && self.video_meta_cache_hits == 0
+            && self.catalog_http_pages == 0
+            && self.video_process_spawns == 0
+            && self.preflight_process_spawns == 0
+            && self.successful_empty_probes == 0
+            && self.retries == 0
+            && self.circuit_opens == 0
+            && self.deferred_jobs == 0
+            && self.capacity_skipped == 0
+            && self.candidates_fetched == 0
+            && self.candidates_deduped == 0
+            && self.candidates_rejected == 0
+            && self.candidates_review_only == 0
+            && self.cache_evictions == 0
+            && self.checkpoint_bytes == 0
+            && self.checkpoint_flushes == 0
+            && self.provider_errors.is_empty()
+            && self.terminal_reasons.is_empty()
+            && self.elapsed_ms.is_empty()
             && self.source_kinds.is_empty()
             && self.quality_tiers.is_empty()
             && self.reason_codes.is_empty()
@@ -229,6 +536,24 @@ impl MatchStats {
             *self.reason_codes.entry(code.to_owned()).or_default() += 1;
         }
     }
+
+    pub fn bump_provider_error(&mut self, code: &str) {
+        if !code.is_empty() {
+            *self.provider_errors.entry(code.to_owned()).or_default() += 1;
+        }
+    }
+
+    pub fn bump_terminal_reason(&mut self, code: &str) {
+        if !code.is_empty() {
+            *self.terminal_reasons.entry(code.to_owned()).or_default() += 1;
+        }
+    }
+
+    pub fn add_elapsed_ms(&mut self, stage: &str, elapsed_ms: u64) {
+        if !stage.is_empty() {
+            *self.elapsed_ms.entry(stage.to_owned()).or_default() += elapsed_ms;
+        }
+    }
 }
 
 /// The end-of-job summary (also serialized next to the checkpoint).
@@ -243,11 +568,18 @@ pub struct TransferReport {
     pub written: u32,
     pub ambiguous: Vec<ReportRow>,
     pub not_found: Vec<ReportRow>,
+    /// Pending rows that were not searched to completion because the job was deferred.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deferred: Vec<ReportRow>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capacity_skipped: Vec<ReportRow>,
     pub skipped_local: u32,
     pub duplicates_dropped: u32,
     pub elapsed_secs: u64,
     #[serde(default, skip_serializing_if = "MatchStats::is_empty")]
     pub match_stats: MatchStats,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub defer_reason: Option<JobDeferReason>,
 }
 
 impl Default for TransferReport {
@@ -261,10 +593,13 @@ impl Default for TransferReport {
             written: 0,
             ambiguous: Vec::new(),
             not_found: Vec::new(),
+            deferred: Vec::new(),
+            capacity_skipped: Vec::new(),
             skipped_local: 0,
             duplicates_dropped: 0,
             elapsed_secs: 0,
             match_stats: MatchStats::default(),
+            defer_reason: None,
         }
     }
 }
@@ -328,9 +663,13 @@ pub struct ReportRow {
     pub reason_codes: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duration_delta_secs: Option<i32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub executed_probes: Vec<ProbeTrace>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_reason: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReportCandidate {
     pub key: String,
     pub score: f32,
@@ -359,6 +698,15 @@ impl TransferReport {
         );
         if self.auto_accepted > 0 {
             out.push_str(&format!(", {} auto-accepted", self.auto_accepted));
+        }
+        if !self.deferred.is_empty() {
+            out.push_str(&format!(", {} deferred", self.deferred.len()));
+        }
+        if !self.capacity_skipped.is_empty() {
+            out.push_str(&format!(
+                ", {} skipped at destination capacity",
+                self.capacity_skipped.len()
+            ));
         }
         if self.skipped_local > 0 {
             out.push_str(&format!(", {} local/episode skipped", self.skipped_local));
@@ -524,5 +872,302 @@ mod tests {
         assert!(text.contains("2 auto-accepted"));
         assert!(text.contains("1 ambiguous"));
         assert!(text.contains("local/episode skipped"));
+    }
+
+    #[test]
+    fn old_checkpoint_json_defaults_trace_and_defer_fields() {
+        let mut cp = Checkpoint::new("sp2yt-old-shape".to_owned(), spec(), vec![entry("one")]);
+        cp.defer_reason = Some(JobDeferReason::new(
+            "backend_unavailable",
+            Some("public_video"),
+            "HTTP 403 cookie=secret",
+        ));
+        cp.match_traces.insert(
+            1,
+            MatchTrace {
+                terminal_reason: Some("backend_unavailable".to_owned()),
+                ..MatchTrace::default()
+            },
+        );
+        let mut value = serde_json::to_value(&cp).unwrap();
+        value.as_object_mut().unwrap().remove("defer_reason");
+        value.as_object_mut().unwrap().remove("match_traces");
+
+        let old: Checkpoint = serde_json::from_value(value).unwrap();
+
+        assert!(old.defer_reason.is_none());
+        assert!(old.match_traces.is_empty());
+    }
+
+    #[test]
+    fn match_trace_is_bounded_and_sanitized() {
+        let mut trace = MatchTrace::default();
+        for index in 0..(MAX_MATCH_TRACE_PROBES + 5) {
+            trace.push_probe(ProbeTrace {
+                backend: "catalog".to_owned(),
+                intent: "primary".to_owned(),
+                query: format!("{index}-{}", "x".repeat(500)),
+                status: "empty".to_owned(),
+                ..ProbeTrace::default()
+            });
+        }
+        trace.set_candidates((0..10).map(|index| ReportCandidate {
+            key: format!("key-{index}"),
+            score: 0.5,
+            display: "candidate".to_owned(),
+            score_breakdown: None,
+        }));
+
+        assert_eq!(trace.probes.len(), MAX_MATCH_TRACE_PROBES);
+        assert!(trace.probes.iter().all(|probe| probe.query.len() <= 300));
+        assert_eq!(trace.candidates.len(), MAX_MATCH_TRACE_CANDIDATES);
+    }
+
+    fn journal_record(cp: &Checkpoint, index: usize) -> String {
+        let entry = &cp.tracks[index];
+        let payload = CheckpointJournalPayload {
+            checkpoint_version: cp.version,
+            journal_generation: cp.journal_generation,
+            job_id: cp.job_id.clone(),
+            source_order: index as u32 + 1,
+            outcome: entry.outcome.clone(),
+            review_decision: entry.review_decision.clone(),
+            written: entry.written,
+        };
+        let checksum = journal_checksum(&payload).unwrap();
+        serde_json::to_string(&CheckpointJournalRecord {
+            version: CHECKPOINT_JOURNAL_VERSION,
+            payload,
+            checksum,
+        })
+        .unwrap()
+    }
+
+    fn journal_temp(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "yututui-transfer-journal-{name}-{}-{}.jsonl",
+            std::process::id(),
+            crate::signals::unix_now()
+        ))
+    }
+
+    #[test]
+    fn journal_replays_latest_track_state() {
+        let mut source = Checkpoint::new(
+            "sp2yt-journal-replay".to_owned(),
+            spec(),
+            vec![entry("one")],
+        );
+        source.tracks[0].outcome = Some(MatchOutcome::NotFound);
+        source.tracks[0].written = true;
+        let line = journal_record(&source, 0);
+        let path = journal_temp("replay");
+        safe_fs::append_private_jsonl(&path, &line).unwrap();
+
+        let mut target = Checkpoint::new(
+            "sp2yt-journal-replay".to_owned(),
+            spec(),
+            vec![entry("one")],
+        );
+        replay_checkpoint_journal(&mut target, &path).unwrap();
+
+        assert!(matches!(
+            target.tracks[0].outcome,
+            Some(MatchOutcome::NotFound)
+        ));
+        assert!(target.tracks[0].written);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn batched_journal_block_replays_every_row_and_latest_record_wins() {
+        let mut source = Checkpoint::new(
+            "sp2yt-journal-batch".to_owned(),
+            spec(),
+            vec![entry("one"), entry("two")],
+        );
+        source.tracks[0].outcome = Some(MatchOutcome::NotFound);
+        source.tracks[1].outcome = Some(MatchOutcome::NotFound);
+        source.tracks[1].written = true;
+        let first_block = source.track_journal_block(&[0, 1]).unwrap();
+        assert_eq!(first_block.lines().count(), 2);
+
+        source.tracks[0].outcome = Some(MatchOutcome::Matched {
+            key: "latest-video".to_owned(),
+            score: 0.95,
+            display: "A — one".to_owned(),
+            title: Some("one".to_owned()),
+            artist: Some("A".to_owned()),
+            album: None,
+            duration_secs: Some(200),
+            score_breakdown: None,
+        });
+        let latest_block = source.track_journal_block(&[0]).unwrap();
+        assert!(source.track_journal_block(&[2]).is_err());
+
+        let path = journal_temp("batch");
+        safe_fs::append_private_jsonl(&path, &first_block).unwrap();
+        safe_fs::append_private_jsonl(&path, &latest_block).unwrap();
+        let physical = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(physical.lines().count(), 3);
+
+        let mut target = Checkpoint::new(
+            "sp2yt-journal-batch".to_owned(),
+            spec(),
+            vec![entry("one"), entry("two")],
+        );
+        replay_checkpoint_journal(&mut target, &path).unwrap();
+
+        assert!(matches!(
+            target.tracks[0].outcome,
+            Some(MatchOutcome::Matched { ref key, .. }) if key == "latest-video"
+        ));
+        assert!(matches!(
+            target.tracks[1].outcome,
+            Some(MatchOutcome::NotFound)
+        ));
+        assert!(target.tracks[1].written);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn journal_ignores_stale_record_after_snapshot_generation_advances() {
+        let mut stale =
+            Checkpoint::new("sp2yt-journal-stale".to_owned(), spec(), vec![entry("one")]);
+        stale.journal_generation = 7;
+        stale.tracks[0].outcome = Some(MatchOutcome::NotFound);
+        stale.tracks[0].written = true;
+        let path = journal_temp("stale");
+        safe_fs::append_private_jsonl(&path, &journal_record(&stale, 0)).unwrap();
+
+        // This models the state after an atomic snapshot write succeeded but removing
+        // the compacted journal did not: the snapshot generation is now newer than
+        // every record left in the old journal.
+        let mut snapshot =
+            Checkpoint::new("sp2yt-journal-stale".to_owned(), spec(), vec![entry("one")]);
+        snapshot.journal_generation = 8;
+        snapshot.tracks[0].outcome = Some(MatchOutcome::Matched {
+            key: "snapshot-video".to_owned(),
+            score: 0.95,
+            display: "A — one".to_owned(),
+            title: Some("one".to_owned()),
+            artist: Some("A".to_owned()),
+            album: None,
+            duration_secs: Some(200),
+            score_breakdown: None,
+        });
+
+        replay_checkpoint_journal(&mut snapshot, &path).unwrap();
+
+        assert!(matches!(
+            snapshot.tracks[0].outcome,
+            Some(MatchOutcome::Matched { ref key, .. }) if key == "snapshot-video"
+        ));
+        assert!(!snapshot.tracks[0].written);
+        assert_eq!(snapshot.journal_generation, 8);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn journal_rejects_generation_newer_than_snapshot() {
+        let mut future = Checkpoint::new(
+            "sp2yt-journal-future".to_owned(),
+            spec(),
+            vec![entry("one")],
+        );
+        future.journal_generation = 4;
+        future.tracks[0].outcome = Some(MatchOutcome::NotFound);
+        let path = journal_temp("future");
+        safe_fs::append_private_jsonl(&path, &journal_record(&future, 0)).unwrap();
+
+        let mut snapshot = Checkpoint::new(
+            "sp2yt-journal-future".to_owned(),
+            spec(),
+            vec![entry("one")],
+        );
+        snapshot.journal_generation = 3;
+
+        let error = replay_checkpoint_journal(&mut snapshot, &path).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("journal generation is newer than its snapshot"),
+            "{error:#}"
+        );
+        assert!(snapshot.tracks[0].outcome.is_none());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn journal_rejects_record_from_another_job_scope() {
+        let foreign = Checkpoint::new(
+            "sp2yt-journal-foreign".to_owned(),
+            spec(),
+            vec![entry("one")],
+        );
+        let path = journal_temp("foreign");
+        safe_fs::append_private_jsonl(&path, &journal_record(&foreign, 0)).unwrap();
+
+        let mut target = Checkpoint::new(
+            "sp2yt-journal-target".to_owned(),
+            spec(),
+            vec![entry("one")],
+        );
+        let error = replay_checkpoint_journal(&mut target, &path).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("journal record scope/version mismatch"),
+            "{error:#}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn journal_ignores_only_a_truncated_final_record() {
+        let cp = Checkpoint::new(
+            "sp2yt-journal-truncated".to_owned(),
+            spec(),
+            vec![entry("one")],
+        );
+        let path = journal_temp("truncated");
+        safe_fs::append_private_jsonl(&path, &journal_record(&cp, 0)).unwrap();
+        use std::io::Write as _;
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"{\"version\":1")
+            .unwrap();
+
+        let mut target = Checkpoint::new(
+            "sp2yt-journal-truncated".to_owned(),
+            spec(),
+            vec![entry("one")],
+        );
+        replay_checkpoint_journal(&mut target, &path).unwrap();
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn journal_rejects_corrupt_interior_record() {
+        let cp = Checkpoint::new(
+            "sp2yt-journal-corrupt".to_owned(),
+            spec(),
+            vec![entry("one")],
+        );
+        let path = journal_temp("corrupt");
+        safe_fs::append_private_jsonl(&path, "{not-json").unwrap();
+        safe_fs::append_private_jsonl(&path, &journal_record(&cp, 0)).unwrap();
+
+        let mut target = Checkpoint::new(
+            "sp2yt-journal-corrupt".to_owned(),
+            spec(),
+            vec![entry("one")],
+        );
+        assert!(replay_checkpoint_journal(&mut target, &path).is_err());
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/src/transfer/checkpoint.rs
+++ b/src/transfer/checkpoint.rs
@@ -944,7 +944,12 @@ mod tests {
     }
 
     fn journal_temp(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!(
+        let dir = std::env::temp_dir().join(format!(
+            "yututui-transfer-journal-tests-{}",
+            std::process::id()
+        ));
+        safe_fs::ensure_private_dir(&dir).unwrap();
+        dir.join(format!(
             "yututui-transfer-journal-{name}-{}-{}.jsonl",
             std::process::id(),
             crate::signals::unix_now()

--- a/src/transfer/cli.rs
+++ b/src/transfer/cli.rs
@@ -796,6 +796,7 @@ fn row_status_label(status: ImportSessionRowStatus) -> &'static str {
         ImportSessionRowStatus::Ambiguous => "review",
         ImportSessionRowStatus::NotFound => "not_found",
         ImportSessionRowStatus::SkippedLocal => "skipped",
+        ImportSessionRowStatus::SkippedCapacity => "capacity",
     }
 }
 

--- a/src/transfer/download_cli.rs
+++ b/src/transfer/download_cli.rs
@@ -152,6 +152,7 @@ mod tests {
             source: SessionEndpoint::default(),
             destination: SessionEndpoint::default(),
             counts: Default::default(),
+            defer_reason: None,
             rows: vec![ImportSessionRow {
                 row_id: "row-00001".to_owned(),
                 source_order: 1,

--- a/src/transfer/download_plan.rs
+++ b/src/transfer/download_plan.rs
@@ -337,6 +337,7 @@ mod tests {
             source: SessionEndpoint::default(),
             destination: SessionEndpoint::default(),
             counts,
+            defer_reason: None,
             rows,
         }
     }

--- a/src/transfer/engine.rs
+++ b/src/transfer/engine.rs
@@ -624,6 +624,7 @@ async fn match_stage(
         heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         heartbeat.tick().await;
         let mut capacity_reached = false;
+        let mut computed_capacity_skips = 0u32;
         let mut ready_by_source = BTreeMap::new();
         let mut next_source_sequence = 0usize;
         let mut stream_finished = false;
@@ -690,46 +691,26 @@ async fn match_stage(
             while let Some((idx, input, result)) =
                 take_ready_in_source_order(&mut ready_by_source, &mut next_source_sequence)
             {
-                let outcome = result.outcome;
-                if cache_write_enabled
-                    && let Some(cache) = match_cache.as_mut()
-                    && matches!(outcome, MatchOutcome::Matched { .. })
-                {
-                    cache.save_match(&input, &outcome);
-                    cache_dirty = true;
-                }
-                let trace = result.trace;
-                record_match_outcome_stats(&mut cp.match_stats, &outcome);
-                record_match_trace_stats(&mut cp.match_stats, &trace);
-                increment_outcome_counts(
-                    &outcome,
+                capacity_reached |= commit_ytm_match_result(
+                    cp,
+                    idx,
+                    input,
+                    result.outcome,
+                    result.trace,
+                    cache_write_enabled,
+                    &mut match_cache,
+                    &mut cache_dirty,
+                    &mut local_capacity_keys,
+                    &mut journal,
                     &mut matched_count,
                     &mut ambiguous_count,
                     &mut not_found_count,
-                );
-                cp.match_traces.insert(idx as u32 + 1, trace);
-                cp.tracks[idx].outcome = Some(outcome);
-                if let Some(keys) = local_capacity_keys.as_mut()
-                    && let Some(key) = effective_write_key(&cp.tracks[idx], cp.spec.take_best)
-                {
-                    keys.insert(key.to_owned());
-                    capacity_reached = keys.len() >= crate::playlists::SONGS_PER_PLAYLIST_MAX;
-                }
-                journal.append(cp, idx)?;
-                completed_count = completed_count.saturating_add(1);
-
-                progress(TransferProgress {
-                    job_id: cp.job_id.clone(),
-                    stage: Stage::Matching,
-                    done: completed_count,
+                    &mut completed_count,
+                    &mut computed_capacity_skips,
+                    matching_written,
                     total,
-                    matched: matched_count,
-                    auto_accepted: 0,
-                    ambiguous: ambiguous_count,
-                    not_found: not_found_count,
-                    written: matching_written,
-                    current: input.display(),
-                });
+                    progress,
+                )?;
                 if capacity_reached {
                     break 'matching;
                 }
@@ -740,10 +721,36 @@ async fn match_stage(
             }
         }
         if capacity_reached {
+            for (_, (idx, input, result)) in std::mem::take(&mut ready_by_source) {
+                commit_ytm_match_result(
+                    cp,
+                    idx,
+                    input,
+                    result.outcome,
+                    result.trace,
+                    cache_write_enabled,
+                    &mut match_cache,
+                    &mut cache_dirty,
+                    &mut local_capacity_keys,
+                    &mut journal,
+                    &mut matched_count,
+                    &mut ambiguous_count,
+                    &mut not_found_count,
+                    &mut completed_count,
+                    &mut computed_capacity_skips,
+                    matching_written,
+                    total,
+                    progress,
+                )?;
+            }
+            if computed_capacity_skips > 0 {
+                record_capacity_skips(&mut cp.match_stats, computed_capacity_skips);
+            }
             // This is a deterministic in-memory bulk transition followed immediately by the
             // compact stage snapshot below. Journaling thousands of synthetic capacity rows
             // would add one open/write per row (and periodic fsyncs) without protecting any
-            // provider result; a crash simply recomputes the same boundary on resume.
+            // provider result; buffered provider results were committed above, and a crash
+            // simply recomputes the same boundary on resume.
             mark_pending_capacity_skipped(cp);
         }
         if cache_write_enabled && let Some(cache) = match_cache.as_mut() {
@@ -772,6 +779,94 @@ fn take_ready_in_source_order<T>(
     let value = ready.remove(next_sequence)?;
     *next_sequence = next_sequence.saturating_add(1);
     Some(value)
+}
+
+fn commit_ytm_match_result(
+    cp: &mut Checkpoint,
+    idx: usize,
+    input: TrackInput,
+    outcome: MatchOutcome,
+    trace: MatchTrace,
+    cache_write_enabled: bool,
+    match_cache: &mut Option<TransferMatchCache>,
+    cache_dirty: &mut bool,
+    local_capacity_keys: &mut Option<HashSet<String>>,
+    journal: &mut MatchJournalCadence,
+    matched_count: &mut u32,
+    ambiguous_count: &mut u32,
+    not_found_count: &mut u32,
+    completed_count: &mut u32,
+    computed_capacity_skips: &mut u32,
+    matching_written: u32,
+    total: u32,
+    progress: &mut (dyn FnMut(TransferProgress) + Send),
+) -> Result<bool, JobError> {
+    let current = input.display();
+    if cache_write_enabled
+        && let Some(cache) = match_cache.as_mut()
+        && matches!(outcome, MatchOutcome::Matched { .. })
+    {
+        cache.save_match(&input, &outcome);
+        *cache_dirty = true;
+    }
+    cp.tracks[idx].outcome = Some(outcome);
+    let capacity_reached = enforce_local_capacity_for_committed_entry(
+        cp,
+        idx,
+        local_capacity_keys,
+        computed_capacity_skips,
+    );
+    let outcome = cp.tracks[idx]
+        .outcome
+        .as_ref()
+        .expect("committed match has an outcome");
+    record_match_outcome_stats(&mut cp.match_stats, outcome);
+    record_match_trace_stats(&mut cp.match_stats, &trace);
+    increment_outcome_counts(outcome, matched_count, ambiguous_count, not_found_count);
+    cp.match_traces.insert(idx as u32 + 1, trace);
+    journal.append(cp, idx)?;
+    *completed_count = (*completed_count).saturating_add(1);
+
+    progress(TransferProgress {
+        job_id: cp.job_id.clone(),
+        stage: Stage::Matching,
+        done: *completed_count,
+        total,
+        matched: *matched_count,
+        auto_accepted: 0,
+        ambiguous: *ambiguous_count,
+        not_found: *not_found_count,
+        written: matching_written,
+        current,
+    });
+    Ok(capacity_reached)
+}
+
+fn enforce_local_capacity_for_committed_entry(
+    cp: &mut Checkpoint,
+    idx: usize,
+    local_capacity_keys: &mut Option<HashSet<String>>,
+    computed_capacity_skips: &mut u32,
+) -> bool {
+    let Some(keys) = local_capacity_keys.as_mut() else {
+        return false;
+    };
+    let capacity = crate::playlists::SONGS_PER_PLAYLIST_MAX;
+    let Some(key) = effective_write_key(&cp.tracks[idx], cp.spec.take_best).map(str::to_owned)
+    else {
+        return keys.len() >= capacity;
+    };
+    if cp.tracks[idx].written || keys.contains(&key) {
+        return keys.len() >= capacity;
+    }
+    if keys.len() < capacity {
+        keys.insert(key);
+    } else {
+        cp.tracks[idx].outcome = Some(MatchOutcome::SkippedCapacity);
+        cp.tracks[idx].review_decision = None;
+        *computed_capacity_skips = (*computed_capacity_skips).saturating_add(1);
+    }
+    keys.len() >= capacity
 }
 
 fn auto_accept_ambiguous_candidates(cp: &mut Checkpoint) -> Result<u32, JobError> {

--- a/src/transfer/engine.rs
+++ b/src/transfer/engine.rs
@@ -55,6 +55,23 @@ struct MatchJournalCadence {
     last_durable: Instant,
 }
 
+struct MatchCommitContext<'a> {
+    cp: &'a mut Checkpoint,
+    cache_write_enabled: bool,
+    match_cache: &'a mut Option<TransferMatchCache>,
+    cache_dirty: &'a mut bool,
+    local_capacity_keys: &'a mut Option<HashSet<String>>,
+    journal: &'a mut MatchJournalCadence,
+    matched_count: &'a mut u32,
+    ambiguous_count: &'a mut u32,
+    not_found_count: &'a mut u32,
+    completed_count: &'a mut u32,
+    computed_capacity_skips: &'a mut u32,
+    matching_written: u32,
+    total: u32,
+    progress: &'a mut (dyn FnMut(TransferProgress) + Send),
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct WriteProgressCounts {
     matched: u32,
@@ -691,26 +708,24 @@ async fn match_stage(
             while let Some((idx, input, result)) =
                 take_ready_in_source_order(&mut ready_by_source, &mut next_source_sequence)
             {
-                capacity_reached |= commit_ytm_match_result(
+                let mut commit = MatchCommitContext {
                     cp,
-                    idx,
-                    input,
-                    result.outcome,
-                    result.trace,
                     cache_write_enabled,
-                    &mut match_cache,
-                    &mut cache_dirty,
-                    &mut local_capacity_keys,
-                    &mut journal,
-                    &mut matched_count,
-                    &mut ambiguous_count,
-                    &mut not_found_count,
-                    &mut completed_count,
-                    &mut computed_capacity_skips,
+                    match_cache: &mut match_cache,
+                    cache_dirty: &mut cache_dirty,
+                    local_capacity_keys: &mut local_capacity_keys,
+                    journal: &mut journal,
+                    matched_count: &mut matched_count,
+                    ambiguous_count: &mut ambiguous_count,
+                    not_found_count: &mut not_found_count,
+                    completed_count: &mut completed_count,
+                    computed_capacity_skips: &mut computed_capacity_skips,
                     matching_written,
                     total,
                     progress,
-                )?;
+                };
+                capacity_reached |=
+                    commit_ytm_match_result(&mut commit, idx, input, result.outcome, result.trace)?;
                 if capacity_reached {
                     break 'matching;
                 }
@@ -722,26 +737,23 @@ async fn match_stage(
         }
         if capacity_reached {
             for (_, (idx, input, result)) in std::mem::take(&mut ready_by_source) {
-                commit_ytm_match_result(
+                let mut commit = MatchCommitContext {
                     cp,
-                    idx,
-                    input,
-                    result.outcome,
-                    result.trace,
                     cache_write_enabled,
-                    &mut match_cache,
-                    &mut cache_dirty,
-                    &mut local_capacity_keys,
-                    &mut journal,
-                    &mut matched_count,
-                    &mut ambiguous_count,
-                    &mut not_found_count,
-                    &mut completed_count,
-                    &mut computed_capacity_skips,
+                    match_cache: &mut match_cache,
+                    cache_dirty: &mut cache_dirty,
+                    local_capacity_keys: &mut local_capacity_keys,
+                    journal: &mut journal,
+                    matched_count: &mut matched_count,
+                    ambiguous_count: &mut ambiguous_count,
+                    not_found_count: &mut not_found_count,
+                    completed_count: &mut completed_count,
+                    computed_capacity_skips: &mut computed_capacity_skips,
                     matching_written,
                     total,
                     progress,
-                )?;
+                };
+                commit_ytm_match_result(&mut commit, idx, input, result.outcome, result.trace)?;
             }
             if computed_capacity_skips > 0 {
                 record_capacity_skips(&mut cp.match_stats, computed_capacity_skips);
@@ -782,61 +794,53 @@ fn take_ready_in_source_order<T>(
 }
 
 fn commit_ytm_match_result(
-    cp: &mut Checkpoint,
+    context: &mut MatchCommitContext<'_>,
     idx: usize,
     input: TrackInput,
     outcome: MatchOutcome,
     trace: MatchTrace,
-    cache_write_enabled: bool,
-    match_cache: &mut Option<TransferMatchCache>,
-    cache_dirty: &mut bool,
-    local_capacity_keys: &mut Option<HashSet<String>>,
-    journal: &mut MatchJournalCadence,
-    matched_count: &mut u32,
-    ambiguous_count: &mut u32,
-    not_found_count: &mut u32,
-    completed_count: &mut u32,
-    computed_capacity_skips: &mut u32,
-    matching_written: u32,
-    total: u32,
-    progress: &mut (dyn FnMut(TransferProgress) + Send),
 ) -> Result<bool, JobError> {
     let current = input.display();
-    if cache_write_enabled
-        && let Some(cache) = match_cache.as_mut()
+    if context.cache_write_enabled
+        && let Some(cache) = context.match_cache.as_mut()
         && matches!(outcome, MatchOutcome::Matched { .. })
     {
         cache.save_match(&input, &outcome);
-        *cache_dirty = true;
+        *context.cache_dirty = true;
     }
-    cp.tracks[idx].outcome = Some(outcome);
+    context.cp.tracks[idx].outcome = Some(outcome);
     let capacity_reached = enforce_local_capacity_for_committed_entry(
-        cp,
+        context.cp,
         idx,
-        local_capacity_keys,
-        computed_capacity_skips,
+        context.local_capacity_keys,
+        context.computed_capacity_skips,
     );
-    let outcome = cp.tracks[idx]
+    let outcome = context.cp.tracks[idx]
         .outcome
         .as_ref()
         .expect("committed match has an outcome");
-    record_match_outcome_stats(&mut cp.match_stats, outcome);
-    record_match_trace_stats(&mut cp.match_stats, &trace);
-    increment_outcome_counts(outcome, matched_count, ambiguous_count, not_found_count);
-    cp.match_traces.insert(idx as u32 + 1, trace);
-    journal.append(cp, idx)?;
-    *completed_count = (*completed_count).saturating_add(1);
+    record_match_outcome_stats(&mut context.cp.match_stats, outcome);
+    record_match_trace_stats(&mut context.cp.match_stats, &trace);
+    increment_outcome_counts(
+        outcome,
+        context.matched_count,
+        context.ambiguous_count,
+        context.not_found_count,
+    );
+    context.cp.match_traces.insert(idx as u32 + 1, trace);
+    context.journal.append(context.cp, idx)?;
+    *context.completed_count = (*context.completed_count).saturating_add(1);
 
-    progress(TransferProgress {
-        job_id: cp.job_id.clone(),
+    (context.progress)(TransferProgress {
+        job_id: context.cp.job_id.clone(),
         stage: Stage::Matching,
-        done: *completed_count,
-        total,
-        matched: *matched_count,
+        done: *context.completed_count,
+        total: context.total,
+        matched: *context.matched_count,
         auto_accepted: 0,
-        ambiguous: *ambiguous_count,
-        not_found: *not_found_count,
-        written: matching_written,
+        ambiguous: *context.ambiguous_count,
+        not_found: *context.not_found_count,
+        written: context.matching_written,
         current,
     });
     Ok(capacity_reached)

--- a/src/transfer/engine.rs
+++ b/src/transfer/engine.rs
@@ -2,18 +2,20 @@
 //! meaningful boundary so any abort resumes idempotently. One plain async fn — the CLI
 //! runs it on its own runtime, the TUI actor on a worker task.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail};
 use futures::StreamExt;
 
 use super::checkpoint::ReviewDecision;
-use super::checkpoint::{Checkpoint, ReportCandidate, ReportRow, TrackEntry, TransferReport};
+use super::checkpoint::{
+    Checkpoint, MatchStats, MatchTrace, ReportCandidate, ReportRow, TrackEntry, TransferReport,
+};
 use super::match_cache::TransferMatchCache;
 use super::matching::{
     MatchCandidate, MatchConfig, MatchOutcome, Pacing, SharedYtmMatchState, TrackInput,
-    best_outcome, match_track_ytm_shared, spotify_query_plan, ytm_query_plan,
+    best_outcome, match_track_ytm_shared, spotify_query_plan,
 };
 use super::{
     FileFormat, JobSpec, MatchPolicy, Stage, TransferDest, TransferProgress, TransferSource,
@@ -28,6 +30,10 @@ use album_prefill::{
     apply_persistent_cache, merge_ytm_diagnostics, prefill_album_matches,
     record_match_outcome_stats,
 };
+mod reporting;
+use reporting::*;
+mod job_errors;
+use job_errors::*;
 
 /// Every job caps its work list here (YTM's own playlist cap is ~5,000 anyway).
 const TRACK_CAP: usize = 10_000;
@@ -40,6 +46,86 @@ const YTM_LIKE_PAUSE: Duration = Duration::from_millis(1200);
 const SPOTIFY_ADD_CHUNK: usize = 100;
 /// Checkpoint flush cadence during matching/like-writing.
 const CHECKPOINT_EVERY: usize = 10;
+/// Matching outcomes use the append-only journal between compact snapshots. Bound the
+/// interval between durable appends even when a small job advances slowly.
+const MATCH_JOURNAL_DURABLE_EVERY: Duration = Duration::from_secs(1);
+
+struct MatchJournalCadence {
+    pending: usize,
+    last_durable: Instant,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct WriteProgressCounts {
+    matched: u32,
+    ambiguous: u32,
+    not_found: u32,
+    written: u32,
+}
+
+impl WriteProgressCounts {
+    fn from_checkpoint(cp: &Checkpoint) -> Self {
+        let (matched, ambiguous, not_found) = outcome_counts(&cp.tracks);
+        Self {
+            matched,
+            ambiguous,
+            not_found,
+            written: written_count(&cp.tracks),
+        }
+    }
+
+    fn record_written(&mut self, count: usize) {
+        self.written = self.written.saturating_add(count as u32);
+    }
+}
+
+struct EnsuredDestination {
+    id: String,
+    created_in_run: bool,
+}
+
+impl MatchJournalCadence {
+    fn new() -> Self {
+        Self {
+            pending: 0,
+            last_durable: Instant::now(),
+        }
+    }
+
+    fn next_is_durable(&mut self) -> bool {
+        self.pending += 1;
+        let durable = self.pending >= CHECKPOINT_EVERY
+            || self.last_durable.elapsed() >= MATCH_JOURNAL_DURABLE_EVERY;
+        if durable {
+            self.pending = 0;
+            self.last_durable = Instant::now();
+        }
+        durable
+    }
+
+    fn append(&mut self, cp: &mut Checkpoint, index: usize) -> Result<(), JobError> {
+        let durable = self.next_is_durable();
+        let bytes = cp
+            .append_track_journal(index, durable)
+            .map_err(|error| JobError::fatal(error.into()))?;
+        cp.match_stats.checkpoint_bytes = cp.match_stats.checkpoint_bytes.saturating_add(bytes);
+        if durable && bytes > 0 {
+            cp.match_stats.checkpoint_flushes = cp.match_stats.checkpoint_flushes.saturating_add(1);
+        }
+        Ok(())
+    }
+}
+
+fn append_write_journal(cp: &mut Checkpoint, indexes: &[usize]) -> Result<(), JobError> {
+    let bytes = cp
+        .append_tracks_journal(indexes, true)
+        .map_err(|error| JobError::fatal(error.into()))?;
+    cp.match_stats.checkpoint_bytes = cp.match_stats.checkpoint_bytes.saturating_add(bytes);
+    if bytes > 0 {
+        cp.match_stats.checkpoint_flushes = cp.match_stats.checkpoint_flushes.saturating_add(1);
+    }
+    Ok(())
+}
 
 /// What a failed job means for the caller: `resumable` failures keep their checkpoint
 /// and print/emit the `resume` hint.
@@ -94,6 +180,8 @@ pub async fn run_job(
     ctx: &mut JobCtx,
     progress: &mut (dyn FnMut(TransferProgress) + Send),
 ) -> Result<TransferReport, JobError> {
+    let _record_guard = super::session::ImportRecordGuard::try_acquire_if_persistable(&job_id)
+        .map_err(|error| JobError::fatal(error.into()))?;
     let started = Instant::now();
     if let Some(spotify) = ctx.spotify.as_mut() {
         spotify.reset_rate_budget();
@@ -155,6 +243,7 @@ pub async fn run_job(
     // later `resume` performs exactly the writes).
     if !cp.spec.dry_run {
         write_stage(&mut cp, ctx, progress, &mut report).await?;
+        rebuild_report_after_write(&cp, skipped_local, &mut report);
         cp.stage = Stage::Done;
         cp.save().map_err(|e| JobError::fatal(e.into()))?;
         save_import_session(&cp);
@@ -171,6 +260,8 @@ pub async fn write_reviewed_local_job(
     job_id: &str,
     progress: &mut (dyn FnMut(TransferProgress) + Send),
 ) -> Result<TransferReport, JobError> {
+    let _record_guard = super::session::ImportRecordGuard::try_acquire_if_persistable(job_id)
+        .map_err(|error| JobError::fatal(error.into()))?;
     let started = Instant::now();
     let mut cp = Checkpoint::load(job_id).map_err(JobError::fatal)?;
     if !matches!(cp.spec.dest, TransferDest::LocalPlaylist { .. }) {
@@ -180,6 +271,9 @@ pub async fn write_reviewed_local_job(
     }
     cp.spec.dry_run = false;
     cp.stage = Stage::Writing;
+    if let Some(mut keys) = local_destination_keys(&cp) {
+        enforce_matched_capacity(&mut cp, &mut keys);
+    }
     cp.save().map_err(|e| JobError::fatal(e.into()))?;
     save_import_session(&cp);
 
@@ -191,6 +285,7 @@ pub async fn write_reviewed_local_job(
         market: None,
     };
     write_stage(&mut cp, &mut ctx, progress, &mut report).await?;
+    rebuild_report_after_write(&cp, cp.skipped_local, &mut report);
     cp.stage = Stage::Done;
     cp.save().map_err(|e| JobError::fatal(e.into()))?;
     save_import_session(&cp);
@@ -229,11 +324,10 @@ async fn fetch_source(
             let spotify = ctx.spotify()?;
             let meta = spotify.playlist_meta(id).await.map_err(spotify_job_error)?;
             let mut on_page = |done: u32, total: u32| beat(done, total, meta.name.clone());
-            let tracks = spotify
-                .playlist_tracks(id, &mut on_page)
+            let (tracks, skipped) = spotify
+                .playlist_tracks_for_transfer(id, TRACK_CAP, &mut on_page)
                 .await
                 .map_err(spotify_job_error)?;
-            let skipped = meta.total.saturating_sub(tracks.len() as u32);
             (
                 meta.name,
                 tracks.iter().map(TrackInput::from_spotify).collect(),
@@ -244,7 +338,7 @@ async fn fetch_source(
             let spotify = ctx.spotify()?;
             let mut on_page = |done: u32, total: u32| beat(done, total, "Liked Songs".to_owned());
             let mut tracks = spotify
-                .liked_tracks(&mut on_page)
+                .liked_tracks_for_transfer(TRACK_CAP, &mut on_page)
                 .await
                 .map_err(spotify_job_error)?;
             // Spotify returns newest-first; import oldest-first so the YTM like
@@ -369,6 +463,9 @@ async fn match_stage(
     ctx: &mut JobCtx,
     progress: &mut (dyn FnMut(TransferProgress) + Send),
 ) -> Result<(), JobError> {
+    // A prior provider defer describes the previous attempt. Keep the aggregate counter,
+    // but only expose an active reason when this attempt also has to pause.
+    cp.defer_reason = None;
     let cfg = MatchConfig {
         accept: cp.spec.min_score,
         ambiguous_floor: (cp.spec.min_score - 0.20).max(0.40),
@@ -391,8 +488,16 @@ async fn match_stage(
         }
     });
     let mut cache_dirty = false;
-    if cache_read_enabled && let Some(cache) = match_cache.as_ref() {
+    if cache_read_enabled && let Some(cache) = match_cache.as_mut() {
+        cache_dirty |= cache.retain_compatible_matches(&cfg);
         cache_dirty |= apply_persistent_cache(cp, cache);
+    }
+    let mut local_capacity_keys = local_destination_keys(cp);
+    if let Some(keys) = local_capacity_keys.as_mut() {
+        enforce_matched_capacity(cp, keys);
+        if keys.len() >= crate::playlists::SONGS_PER_PLAYLIST_MAX {
+            mark_pending_capacity_skipped(cp);
+        }
     }
     if !to_spotify && cp.tracks.iter().any(|track| track.outcome.is_none()) {
         let ytm = ctx.ytm()?;
@@ -407,10 +512,24 @@ async fn match_stage(
                 &mut pace,
             )
             .await
-            .map_err(|e| checkpointed(cp, ytm_job_error(e)))?;
+            .map_err(|error| defer_ytm_match_error(cp, None, error))?;
         }
     }
+    if let Some(keys) = local_capacity_keys.as_mut() {
+        enforce_matched_capacity(cp, keys);
+        if keys.len() >= crate::playlists::SONGS_PER_PLAYLIST_MAX {
+            mark_pending_capacity_skipped(cp);
+        }
+    }
+    let (mut matched_count, mut ambiguous_count, mut not_found_count) = outcome_counts(&cp.tracks);
+    let mut completed_count = cp
+        .tracks
+        .iter()
+        .filter(|entry| entry.outcome.is_some())
+        .count() as u32;
+    let matching_written = written_count(&cp.tracks);
     if to_spotify {
+        let mut journal = MatchJournalCadence::new();
         for idx in 0..cp.tracks.len() {
             if cp.tracks[idx].outcome.is_some() {
                 continue; // resumed work
@@ -422,29 +541,32 @@ async fn match_stage(
                 .await
                 .map_err(|e| checkpointed(cp, e))?;
             record_match_outcome_stats(&mut cp.match_stats, &outcome);
+            increment_outcome_counts(
+                &outcome,
+                &mut matched_count,
+                &mut ambiguous_count,
+                &mut not_found_count,
+            );
             cp.tracks[idx].outcome = Some(outcome);
+            journal.append(cp, idx)?;
+            completed_count = completed_count.saturating_add(1);
 
-            let (matched, ambiguous, not_found) = outcome_counts(&cp.tracks);
             progress(TransferProgress {
                 job_id: cp.job_id.clone(),
                 stage: Stage::Matching,
-                done: (idx + 1) as u32,
+                done: completed_count,
                 total,
-                matched,
+                matched: matched_count,
                 auto_accepted: 0,
-                ambiguous,
-                not_found,
-                written: written_count(&cp.tracks),
+                ambiguous: ambiguous_count,
+                not_found: not_found_count,
+                written: matching_written,
                 current: input.display(),
             });
-            if (idx + 1) % CHECKPOINT_EVERY == 0 {
-                cp.save().map_err(|e| JobError::fatal(e.into()))?;
-            }
         }
-    } else {
-        // One weird track must not kill a 300-track job: an isolated search failure
-        // becomes NotFound (reported, retryable via --rematch). A *streak* means the
-        // backend itself died (cookie, network) — abort resumably then.
+    } else if cp.tracks.iter().any(|entry| entry.outcome.is_none()) {
+        // Provider/search failures are not negative match evidence. Pause immediately
+        // and leave the failed row pending so resume can retry it without --rematch.
         let ytm = ctx.ytm()?;
         let pending = cp
             .tracks
@@ -472,20 +594,20 @@ async fn match_stage(
         progress(TransferProgress {
             job_id: cp.job_id.clone(),
             stage: Stage::Matching,
-            done: 0,
+            done: completed_count,
             total,
-            matched: 0,
+            matched: matched_count,
             auto_accepted: 0,
-            ambiguous: 0,
-            not_found: 0,
-            written: written_count(&cp.tracks),
+            ambiguous: ambiguous_count,
+            not_found: not_found_count,
+            written: matching_written,
             current: pending
                 .first()
                 .map(|(_, input)| input.display())
                 .unwrap_or_default(),
         });
-        let mut stream = futures::stream::iter(pending)
-            .map(|(idx, input)| {
+        let mut stream = futures::stream::iter(pending.into_iter().enumerate())
+            .map(|(source_sequence, (idx, input))| {
                 let state = shared_state.clone();
                 let match_cfg = cfg;
                 let search_config = search_config.clone();
@@ -493,62 +615,136 @@ async fn match_stage(
                     let outcome =
                         match_track_ytm_shared(ytm, &input, &match_cfg, &search_config, &state)
                             .await;
-                    (idx, input, outcome)
+                    (source_sequence, idx, input, outcome)
                 }
             })
             .buffer_unordered(ytm_track_concurrency());
-        let mut consecutive_failures = 0u32;
-        let mut completed = 0u32;
-        while let Some((idx, input, result)) = stream.next().await {
-            let outcome = match result {
-                Ok(outcome) => {
-                    consecutive_failures = 0;
-                    if cache_write_enabled
-                        && let Some(cache) = match_cache.as_mut()
-                        && matches!(outcome, MatchOutcome::Matched { .. })
-                    {
-                        cache.save_match(&input, &outcome);
-                        cache_dirty = true;
-                    }
-                    outcome
-                }
-                Err(e) => {
-                    consecutive_failures += 1;
-                    if consecutive_failures >= 5 {
-                        return Err(checkpointed(cp, ytm_job_error(e)));
-                    }
-                    tracing::warn!(
-                        track = %input.display(),
-                        error = %crate::util::sanitize::sanitize_error_text(format!("{e:#}")),
-                        "match lookup failed; recording as not-found"
-                    );
-                    MatchOutcome::NotFound
+        let mut journal = MatchJournalCadence::new();
+        let mut heartbeat = tokio::time::interval(Duration::from_secs(2));
+        heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        heartbeat.tick().await;
+        let mut capacity_reached = false;
+        let mut ready_by_source = BTreeMap::new();
+        let mut next_source_sequence = 0usize;
+        let mut stream_finished = false;
+        'matching: loop {
+            let next = tokio::select! {
+                item = stream.next() => item,
+                _ = heartbeat.tick() => {
+                    progress(TransferProgress {
+                        job_id: cp.job_id.clone(),
+                        stage: Stage::Matching,
+                        done: completed_count,
+                        total,
+                        matched: matched_count,
+                        auto_accepted: 0,
+                        ambiguous: ambiguous_count,
+                        not_found: not_found_count,
+                        written: matching_written,
+                        current: "provider work in flight".to_owned(),
+                    });
+                    continue;
                 }
             };
-            record_match_outcome_stats(&mut cp.match_stats, &outcome);
-            cp.tracks[idx].outcome = Some(outcome);
-            completed += 1;
-
-            let (matched, ambiguous, not_found) = outcome_counts(&cp.tracks);
-            progress(TransferProgress {
-                job_id: cp.job_id.clone(),
-                stage: Stage::Matching,
-                done: cp
-                    .tracks
-                    .iter()
-                    .filter(|entry| entry.outcome.is_some())
-                    .count() as u32,
-                total,
-                matched,
-                auto_accepted: 0,
-                ambiguous,
-                not_found,
-                written: written_count(&cp.tracks),
-                current: input.display(),
-            });
-            if completed.is_multiple_of(CHECKPOINT_EVERY as u32) {
-                cp.save().map_err(|e| JobError::fatal(e.into()))?;
+            match next {
+                Some((source_sequence, idx, input, Ok(result))) => {
+                    ready_by_source.insert(source_sequence, (idx, input, result));
+                }
+                Some((_, idx, input, Err(failure))) => {
+                    // A systemic provider failure must stop new buffered work as soon as it is
+                    // observed, even when an earlier source row is still in flight. Parking the
+                    // error in `ready_by_source` would let later yt-dlp calls continue until the
+                    // ordered commit cursor eventually reached this row.
+                    drop(stream);
+                    tracing::warn!(
+                        track = %input.display(),
+                        error = %crate::util::sanitize::sanitize_error_text(format!("{:#}", failure.error)),
+                        "match lookup failed; deferring the resumable job"
+                    );
+                    record_match_trace_stats(&mut cp.match_stats, &failure.trace);
+                    cp.match_traces.insert(idx as u32 + 1, failure.trace);
+                    if cache_write_enabled && let Some(cache) = match_cache.as_mut() {
+                        let snapshot = shared_state.cache_snapshot().await;
+                        cache_dirty |=
+                            cache.merge_query_cache(snapshot.queries, snapshot.video_metadata);
+                    }
+                    merge_ytm_diagnostics(&mut cp.match_stats, shared_state.diagnostics().await);
+                    if cache_dirty
+                        && cache_write_enabled
+                        && let Some(cache) = match_cache.as_mut()
+                    {
+                        let maintenance = cache.save();
+                        cp.match_stats.cache_evictions = cp
+                            .match_stats
+                            .cache_evictions
+                            .saturating_add(maintenance.removed().try_into().unwrap_or(u32::MAX));
+                    }
+                    return Err(defer_ytm_match_error(cp, Some(idx), failure.error));
+                }
+                None => stream_finished = true,
             }
+
+            // Provider calls finish out of order, but committing in frozen source order keeps
+            // the last local-playlist slot deterministic. The unordered stream still backfills
+            // completed provider slots, so one slow early track does not stop later retrieval.
+            while let Some((idx, input, result)) =
+                take_ready_in_source_order(&mut ready_by_source, &mut next_source_sequence)
+            {
+                let outcome = result.outcome;
+                if cache_write_enabled
+                    && let Some(cache) = match_cache.as_mut()
+                    && matches!(outcome, MatchOutcome::Matched { .. })
+                {
+                    cache.save_match(&input, &outcome);
+                    cache_dirty = true;
+                }
+                let trace = result.trace;
+                record_match_outcome_stats(&mut cp.match_stats, &outcome);
+                record_match_trace_stats(&mut cp.match_stats, &trace);
+                increment_outcome_counts(
+                    &outcome,
+                    &mut matched_count,
+                    &mut ambiguous_count,
+                    &mut not_found_count,
+                );
+                cp.match_traces.insert(idx as u32 + 1, trace);
+                cp.tracks[idx].outcome = Some(outcome);
+                if let Some(keys) = local_capacity_keys.as_mut()
+                    && let Some(key) = effective_write_key(&cp.tracks[idx], cp.spec.take_best)
+                {
+                    keys.insert(key.to_owned());
+                    capacity_reached = keys.len() >= crate::playlists::SONGS_PER_PLAYLIST_MAX;
+                }
+                journal.append(cp, idx)?;
+                completed_count = completed_count.saturating_add(1);
+
+                progress(TransferProgress {
+                    job_id: cp.job_id.clone(),
+                    stage: Stage::Matching,
+                    done: completed_count,
+                    total,
+                    matched: matched_count,
+                    auto_accepted: 0,
+                    ambiguous: ambiguous_count,
+                    not_found: not_found_count,
+                    written: matching_written,
+                    current: input.display(),
+                });
+                if capacity_reached {
+                    break 'matching;
+                }
+            }
+            if stream_finished {
+                debug_assert!(ready_by_source.is_empty());
+                break;
+            }
+        }
+        if capacity_reached {
+            // This is a deterministic in-memory bulk transition followed immediately by the
+            // compact stage snapshot below. Journaling thousands of synthetic capacity rows
+            // would add one open/write per row (and periodic fsyncs) without protecting any
+            // provider result; a crash simply recomputes the same boundary on resume.
+            mark_pending_capacity_skipped(cp);
         }
         if cache_write_enabled && let Some(cache) = match_cache.as_mut() {
             let snapshot = shared_state.cache_snapshot().await;
@@ -558,12 +754,24 @@ async fn match_stage(
     }
     if cache_dirty
         && cache_write_enabled
-        && let Some(cache) = match_cache.as_ref()
+        && let Some(cache) = match_cache.as_mut()
     {
-        cache.save();
+        let maintenance = cache.save();
+        cp.match_stats.cache_evictions = cp
+            .match_stats
+            .cache_evictions
+            .saturating_add(maintenance.removed().try_into().unwrap_or(u32::MAX));
     }
-    cp.save().map_err(|e| JobError::fatal(e.into()))?;
     Ok(())
+}
+
+fn take_ready_in_source_order<T>(
+    ready: &mut BTreeMap<usize, T>,
+    next_sequence: &mut usize,
+) -> Option<T> {
+    let value = ready.remove(next_sequence)?;
+    *next_sequence = next_sequence.saturating_add(1);
+    Some(value)
 }
 
 fn auto_accept_ambiguous_candidates(cp: &mut Checkpoint) -> Result<u32, JobError> {
@@ -571,6 +779,10 @@ fn auto_accept_ambiguous_candidates(cp: &mut Checkpoint) -> Result<u32, JobError
         return Ok(0);
     };
     let mut accepted = 0u32;
+    let mut capacity_keys = local_destination_keys(cp);
+    if let Some(keys) = capacity_keys.as_mut() {
+        enforce_matched_capacity(cp, keys);
+    }
     for entry in &mut cp.tracks {
         if entry.written || entry.review_decision.is_some() {
             continue;
@@ -578,19 +790,22 @@ fn auto_accept_ambiguous_candidates(cp: &mut Checkpoint) -> Result<u32, JobError
         let Some(MatchOutcome::Ambiguous { candidates }) = &entry.outcome else {
             continue;
         };
-        let Some(candidate) = candidates.first() else {
+        let Some(candidate) = best_safe_ambiguous_candidate(candidates) else {
             continue;
         };
         let candidate = candidate.clone();
         if candidate.score < min_score {
             continue;
         }
-        if candidate
-            .score_breakdown
-            .as_ref()
-            .is_some_and(|score| score.accept_blocked || score.reject_reason.is_some())
+        if let Some(keys) = capacity_keys.as_mut()
+            && !keys.contains(&candidate.key)
         {
-            continue;
+            if keys.len() >= crate::playlists::SONGS_PER_PLAYLIST_MAX {
+                entry.outcome = Some(MatchOutcome::SkippedCapacity);
+                record_capacity_skips(&mut cp.match_stats, 1);
+                continue;
+            }
+            keys.insert(candidate.key.clone());
         }
         entry.review_decision = Some(ReviewDecision::Accepted {
             key: candidate.key.clone(),
@@ -672,12 +887,16 @@ async fn write_stage(
 
     match cp.spec.dest.clone() {
         TransferDest::YtmLikes => {
-            let mut done = 0u32;
-            for (idx, key) in writes {
-                if cp.tracks[idx].written {
-                    done += 1;
-                    continue;
-                }
+            let pending: Vec<(usize, String)> = writes
+                .into_iter()
+                .filter(|(idx, _)| !cp.tracks[*idx].written)
+                .collect();
+            let pending_count = pending.len();
+            let mut done = total - pending_count as u32;
+            report.written += done;
+            let mut progress_counts = WriteProgressCounts::from_checkpoint(cp);
+            let mut journal_batch = Vec::with_capacity(CHECKPOINT_EVERY);
+            for (pending_index, (idx, key)) in pending.into_iter().enumerate() {
                 // rate_song is idempotent server-side, so a crash between the call and
                 // the checkpoint flush re-likes harmlessly on resume.
                 ctx.ytm()?
@@ -685,33 +904,53 @@ async fn write_stage(
                     .await
                     .map_err(|e| checkpointed(cp, ytm_job_error(e)))?;
                 cp.tracks[idx].written = true;
+                journal_batch.push(idx);
+                progress_counts.record_written(1);
                 report.written += 1;
                 done += 1;
-                progress(progress_write(cp, done, total, idx, report.auto_accepted));
-                if (done as usize).is_multiple_of(CHECKPOINT_EVERY) {
-                    cp.save().map_err(|e| JobError::fatal(e.into()))?;
+                progress(progress_write(
+                    cp,
+                    done,
+                    total,
+                    idx,
+                    report.auto_accepted,
+                    progress_counts,
+                ));
+                if journal_batch.len() >= CHECKPOINT_EVERY {
+                    append_write_journal(cp, &journal_batch)?;
+                    journal_batch.clear();
                 }
-                tokio::time::sleep(YTM_LIKE_PAUSE).await;
+                if pending_index + 1 < pending_count {
+                    tokio::time::sleep(YTM_LIKE_PAUSE).await;
+                }
             }
+            append_write_journal(cp, &journal_batch)?;
         }
         TransferDest::YtmNewPlaylist { .. } | TransferDest::YtmExistingPlaylist { .. } => {
-            let dest_id = ensure_ytm_dest(cp, ctx).await?;
-            reconcile_written_ytm(cp, ctx, &dest_id).await?;
+            let destination = ensure_ytm_dest(cp, ctx).await?;
+            if !destination.created_in_run {
+                reconcile_written_ytm(cp, ctx, &destination.id).await?;
+            }
             let pending: Vec<(usize, String)> = writes
                 .into_iter()
                 .filter(|(idx, _)| !cp.tracks[*idx].written)
                 .collect();
             let mut done = total - pending.len() as u32;
             report.written += done;
-            for chunk in pending.chunks(YTM_ADD_CHUNK) {
+            let mut progress_counts = WriteProgressCounts::from_checkpoint(cp);
+            let chunks = pending.chunks(YTM_ADD_CHUNK);
+            let chunk_count = chunks.len();
+            for (chunk_index, chunk) in chunks.enumerate() {
                 let ids: Vec<String> = chunk.iter().map(|(_, key)| key.clone()).collect();
                 ctx.ytm()?
-                    .add_items_to_account_playlist(&dest_id, &ids)
+                    .add_items_to_account_playlist(&destination.id, &ids)
                     .await
                     .map_err(|e| checkpointed(cp, ytm_job_error(e)))?;
                 for (idx, _) in chunk {
                     cp.tracks[*idx].written = true;
                 }
+                append_write_journal(cp, &chunk.iter().map(|(idx, _)| *idx).collect::<Vec<_>>())?;
+                progress_counts.record_written(chunk.len());
                 done += chunk.len() as u32;
                 report.written += chunk.len() as u32;
                 progress(progress_write(
@@ -720,32 +959,39 @@ async fn write_stage(
                     total,
                     chunk.last().unwrap().0,
                     report.auto_accepted,
+                    progress_counts,
                 ));
-                cp.save().map_err(|e| JobError::fatal(e.into()))?;
-                tokio::time::sleep(YTM_ADD_PAUSE).await;
+                if should_pause_after_chunk(chunk_index, chunk_count) {
+                    tokio::time::sleep(YTM_ADD_PAUSE).await;
+                }
             }
         }
         TransferDest::SpotifyNewPlaylist { .. } => {
-            let dest_id = ensure_spotify_dest(cp, ctx).await?;
-            reconcile_written_spotify(cp, ctx, &dest_id).await?;
+            let destination = ensure_spotify_dest(cp, ctx).await?;
+            if !destination.created_in_run {
+                reconcile_written_spotify(cp, ctx, &destination.id).await?;
+            }
             let pending: Vec<(usize, String)> = writes
                 .into_iter()
                 .filter(|(idx, _)| !cp.tracks[*idx].written)
                 .collect();
             let mut done = total - pending.len() as u32;
             report.written += done;
+            let mut progress_counts = WriteProgressCounts::from_checkpoint(cp);
             for chunk in pending.chunks(SPOTIFY_ADD_CHUNK) {
                 let uris: Vec<String> = chunk.iter().map(|(_, key)| key.clone()).collect();
                 {
                     let spotify = ctx.spotify()?;
                     spotify
-                        .add_tracks(&dest_id, &uris)
+                        .add_tracks(&destination.id, &uris)
                         .await
                         .map_err(|e| checkpointed(cp, spotify_job_error(e)))?;
                 }
                 for (idx, _) in chunk {
                     cp.tracks[*idx].written = true;
                 }
+                append_write_journal(cp, &chunk.iter().map(|(idx, _)| *idx).collect::<Vec<_>>())?;
+                progress_counts.record_written(chunk.len());
                 done += chunk.len() as u32;
                 report.written += chunk.len() as u32;
                 progress(progress_write(
@@ -754,8 +1000,8 @@ async fn write_stage(
                     total,
                     chunk.last().unwrap().0,
                     report.auto_accepted,
+                    progress_counts,
                 ));
-                cp.save().map_err(|e| JobError::fatal(e.into()))?;
             }
         }
         TransferDest::File { .. } => unreachable!("file exports take the export_file path"),
@@ -764,27 +1010,17 @@ async fn write_stage(
     Ok(())
 }
 
+fn should_pause_after_chunk(chunk_index: usize, chunk_count: usize) -> bool {
+    chunk_index < chunk_count.saturating_sub(1)
+}
+
 fn collect_writes_without_deduping(cp: &Checkpoint) -> Vec<(usize, String)> {
     let mut writes = Vec::new();
     for (idx, entry) in cp.tracks.iter().enumerate() {
-        let key = match (&entry.review_decision, &entry.outcome, cp.spec.take_best) {
-            (Some(ReviewDecision::Rejected | ReviewDecision::Skipped), _, _) => continue,
-            (Some(ReviewDecision::Accepted { key, .. }), _, _) => key.clone(),
-            (_, Some(MatchOutcome::Matched { key, .. }), _) => key.clone(),
-            (_, Some(MatchOutcome::Ambiguous { candidates }), true) => {
-                match candidates.iter().find(|candidate| {
-                    candidate
-                        .score_breakdown
-                        .as_ref()
-                        .is_none_or(|score| !score.accept_blocked && score.reject_reason.is_none())
-                }) {
-                    Some(best) => best.key.clone(),
-                    None => continue,
-                }
-            }
-            _ => continue,
+        let Some(key) = effective_write_key(entry, cp.spec.take_best) else {
+            continue;
         };
-        writes.push((idx, key));
+        writes.push((idx, key.to_owned()));
     }
     writes
 }
@@ -794,30 +1030,48 @@ fn collect_writes(cp: &Checkpoint, report: &mut TransferReport) -> Vec<(usize, S
     let mut seen: HashSet<String> = HashSet::new();
     let mut writes: Vec<(usize, String)> = Vec::new();
     for (idx, entry) in cp.tracks.iter().enumerate() {
-        let key = match (&entry.review_decision, &entry.outcome, cp.spec.take_best) {
-            (Some(ReviewDecision::Rejected | ReviewDecision::Skipped), _, _) => continue,
-            (Some(ReviewDecision::Accepted { key, .. }), _, _) => key.clone(),
-            (_, Some(MatchOutcome::Matched { key, .. }), _) => key.clone(),
-            (_, Some(MatchOutcome::Ambiguous { candidates }), true) => {
-                match candidates.iter().find(|candidate| {
-                    candidate
-                        .score_breakdown
-                        .as_ref()
-                        .is_none_or(|score| !score.accept_blocked && score.reject_reason.is_none())
-                }) {
-                    Some(best) => best.key.clone(),
-                    None => continue,
-                }
-            }
-            _ => continue,
+        let Some(key) = effective_write_key(entry, cp.spec.take_best) else {
+            continue;
         };
-        if !seen.insert(key.clone()) {
+        if !seen.insert(key.to_owned()) {
             report.duplicates_dropped += 1;
             continue;
         }
-        writes.push((idx, key));
+        writes.push((idx, key.to_owned()));
     }
     writes
+}
+
+fn best_safe_ambiguous_candidate(
+    candidates: &[super::matching::AmbiguousCandidate],
+) -> Option<&super::matching::AmbiguousCandidate> {
+    candidates
+        .iter()
+        .filter(|candidate| {
+            candidate
+                .score_breakdown
+                .as_ref()
+                .is_none_or(|score| !score.accept_blocked && score.reject_reason.is_none())
+        })
+        .max_by(|left, right| left.score.total_cmp(&right.score))
+}
+
+/// The exact destination key a row would write under the current review/take-best policy.
+/// Capacity accounting and write collection deliberately share this function so a review row
+/// cannot pass preflight and then overflow the local store later.
+fn effective_write_key(entry: &TrackEntry, take_best: bool) -> Option<&str> {
+    match &entry.review_decision {
+        Some(ReviewDecision::Rejected | ReviewDecision::Skipped) => return None,
+        Some(ReviewDecision::Accepted { key, .. }) => return Some(key),
+        None => {}
+    }
+    match &entry.outcome {
+        Some(MatchOutcome::Matched { key, .. }) => Some(key),
+        Some(MatchOutcome::Ambiguous { candidates }) if take_best => {
+            best_safe_ambiguous_candidate(candidates).map(|candidate| candidate.key.as_str())
+        }
+        _ => None,
+    }
 }
 
 /// Write matches into the app's own playlist store (`playlists.json`): visible in the
@@ -834,8 +1088,9 @@ fn write_local(
         .clone()
         .unwrap_or_else(|| "Imported playlist".to_owned());
     let mut store = crate::playlists::Playlists::load();
-    let key = match store.list().iter().find(|p| p.name == name) {
-        Some(existing) => existing.id.clone(),
+    let existing_id = find_local_destination(&store, cp).map(|playlist| playlist.id.clone());
+    let key = match existing_id {
+        Some(existing_id) => existing_id,
         None => store.create(&name).ok_or_else(|| {
             JobError::fatal(anyhow!("could not create the local playlist `{name}`"))
         })?,
@@ -848,37 +1103,32 @@ fn write_local(
         .collect();
     let total = pending.len() as u32;
     let mut done = 0u32;
-    let mut present: HashSet<String> = store
-        .find(&key)
-        .map(|playlist| {
-            playlist
-                .songs
-                .iter()
-                .map(|song| song.video_id.clone())
-                .collect()
+    let mut progress_counts = WriteProgressCounts::from_checkpoint(cp);
+    let prepared = pending
+        .into_iter()
+        .map(|(idx, video_id)| {
+            let song = song_for_entry(&cp.tracks[idx], &video_id, &cp.job_id, idx as u32 + 1);
+            (idx, song)
         })
-        .unwrap_or_default();
-    for (idx, video_id) in pending {
-        if present.contains(&video_id) {
-            cp.tracks[idx].written = true;
-            done += 1;
-            progress(progress_write(cp, done, total, idx, report.auto_accepted));
-            continue;
-        }
-        let song = song_for_entry(&cp.tracks[idx], &video_id, &cp.job_id, idx as u32 + 1);
-        match store.add(&key, song) {
+        .collect::<Vec<_>>();
+    let results = store.add_many(
+        &key,
+        prepared.iter().map(|(_, song)| song.clone()).collect(),
+    );
+    for ((idx, _), result) in prepared.into_iter().zip(results) {
+        match result {
             crate::playlists::AddResult::Added => {
                 cp.tracks[idx].written = true;
                 report.written += 1;
-                present.insert(video_id);
             }
             crate::playlists::AddResult::Duplicate => {
                 cp.tracks[idx].written = true;
-                present.insert(video_id);
             }
             crate::playlists::AddResult::Full => {
-                tracing::warn!("local playlist `{name}` is full; remaining tracks skipped");
-                break;
+                tracing::warn!("local playlist `{name}` is full; track skipped at capacity");
+                cp.tracks[idx].outcome = Some(MatchOutcome::SkippedCapacity);
+                cp.tracks[idx].review_decision = None;
+                record_capacity_skips(&mut cp.match_stats, 1);
             }
             crate::playlists::AddResult::NotFound => {
                 return Err(JobError::fatal(anyhow!(
@@ -886,8 +1136,16 @@ fn write_local(
                 )));
             }
         }
+        progress_counts.record_written(1);
         done += 1;
-        progress(progress_write(cp, done, total, idx, report.auto_accepted));
+        progress(progress_write(
+            cp,
+            done,
+            total,
+            idx,
+            report.auto_accepted,
+            progress_counts,
+        ));
     }
     store
         .save()
@@ -953,9 +1211,15 @@ fn song_for_entry(entry: &TrackEntry, video_id: &str, job_id: &str, source_order
 
 /// Create (once) or find the YTM destination playlist; the id is checkpointed before
 /// the first add so a resume never creates a duplicate.
-async fn ensure_ytm_dest(cp: &mut Checkpoint, ctx: &mut JobCtx) -> Result<String, JobError> {
+async fn ensure_ytm_dest(
+    cp: &mut Checkpoint,
+    ctx: &mut JobCtx,
+) -> Result<EnsuredDestination, JobError> {
     if let Some(id) = &cp.dest_id {
-        return Ok(id.clone());
+        return Ok(EnsuredDestination {
+            id: id.clone(),
+            created_in_run: false,
+        });
     }
     let ytm = ctx.ytm()?;
     let existing = ytm
@@ -963,12 +1227,12 @@ async fn ensure_ytm_dest(cp: &mut Checkpoint, ctx: &mut JobCtx) -> Result<String
         .await
         .map_err(|e| checkpointed(cp, ytm_job_error(e)))?;
     let dest = cp.spec.dest.clone();
-    let id = match &dest {
+    let (id, created_in_run) = match &dest {
         // Append-or-create: a `--to-playlist NAME` target that doesn't exist yet is
         // simply created under that exact name (no collision suffixing).
         TransferDest::YtmExistingPlaylist { name } => {
             match existing.iter().find(|(_, title, _)| title == name) {
-                Some((id, _, _)) => id.clone(),
+                Some((id, _, _)) => (id.clone(), false),
                 None => {
                     let description = format!("Imported by YuTuTui! (job {})", cp.job_id);
                     let id = ytm
@@ -976,7 +1240,7 @@ async fn ensure_ytm_dest(cp: &mut Checkpoint, ctx: &mut JobCtx) -> Result<String
                         .await
                         .map_err(|e| checkpointed(cp, ytm_job_error(e)))?;
                     cp.dest_name = Some(name.clone());
-                    id
+                    (id, true)
                 }
             }
         }
@@ -999,17 +1263,23 @@ async fn ensure_ytm_dest(cp: &mut Checkpoint, ctx: &mut JobCtx) -> Result<String
                 .await
                 .map_err(|e| checkpointed(cp, ytm_job_error(e)))?;
             cp.dest_name = Some(name);
-            id
+            (id, true)
         }
     };
     cp.dest_id = Some(id.clone());
     cp.save().map_err(|e| JobError::fatal(e.into()))?;
-    Ok(id)
+    Ok(EnsuredDestination { id, created_in_run })
 }
 
-async fn ensure_spotify_dest(cp: &mut Checkpoint, ctx: &mut JobCtx) -> Result<String, JobError> {
+async fn ensure_spotify_dest(
+    cp: &mut Checkpoint,
+    ctx: &mut JobCtx,
+) -> Result<EnsuredDestination, JobError> {
     if let Some(id) = &cp.dest_id {
-        return Ok(id.clone());
+        return Ok(EnsuredDestination {
+            id: id.clone(),
+            created_in_run: false,
+        });
     }
     let name = cp
         .dest_name
@@ -1029,10 +1299,10 @@ async fn ensure_spotify_dest(cp: &mut Checkpoint, ctx: &mut JobCtx) -> Result<St
         .map_err(|e| checkpointed(cp, spotify_job_error(e)))?
         .into_iter()
         .find(|p| p.name == name);
-    let id = match existing {
-        Some(p) => p.id,
+    let (id, created_in_run) = match existing {
+        Some(p) => (p.id, false),
         None => match spotify.create_playlist(&name, &description).await {
-            Ok(id) => id,
+            Ok(id) => (id, true),
             Err(SpotifyError::NotAllowlisted) => {
                 return Err(checkpointed(
                     cp,
@@ -1050,7 +1320,7 @@ async fn ensure_spotify_dest(cp: &mut Checkpoint, ctx: &mut JobCtx) -> Result<St
     };
     cp.dest_id = Some(id.clone());
     cp.save().map_err(|e| JobError::fatal(e.into()))?;
-    Ok(id)
+    Ok(EnsuredDestination { id, created_in_run })
 }
 
 /// Belt-and-braces resume idempotency: whatever already made it into the destination
@@ -1061,18 +1331,12 @@ async fn reconcile_written_ytm(
     ctx: &mut JobCtx,
     dest_id: &str,
 ) -> Result<(), JobError> {
-    if !cp.tracks.iter().any(|t| t.written) && cp.stage == Stage::Writing {
-        // Fresh write stage on a fresh playlist: nothing to reconcile unless resuming.
-        if cp.dest_id.is_none() {
-            return Ok(());
-        }
-    }
-    let present: HashSet<String> = ctx
+    let songs = ctx
         .ytm()?
         .playlist_tracks_full(dest_id)
         .await
-        .map(|songs| songs.into_iter().map(|s| s.video_id).collect())
-        .unwrap_or_default();
+        .map_err(|e| checkpointed(cp, ytm_job_error(e)))?;
+    let present: HashSet<String> = songs.into_iter().map(|song| song.video_id).collect();
     if present.is_empty() {
         return Ok(());
     }
@@ -1091,13 +1355,13 @@ async fn reconcile_written_spotify(
     ctx: &mut JobCtx,
     dest_id: &str,
 ) -> Result<(), JobError> {
-    let spotify = ctx.spotify()?;
     let mut on_page = |_done: u32, _total: u32| {};
-    let present: HashSet<String> = spotify
-        .playlist_tracks(dest_id, &mut on_page)
-        .await
-        .map(|tracks| tracks.into_iter().map(|t| t.uri).collect())
-        .unwrap_or_default();
+    let tracks = {
+        let spotify = ctx.spotify()?;
+        spotify.playlist_tracks(dest_id, &mut on_page).await
+    }
+    .map_err(|e| checkpointed(cp, spotify_job_error(e)))?;
+    let present: HashSet<String> = tracks.into_iter().map(|track| track.uri).collect();
     if present.is_empty() {
         return Ok(());
     }
@@ -1171,213 +1435,12 @@ async fn export_file(
     })
 }
 
-// Shared helpers -----------------------------------------------------------------------
-
-fn outcome_counts(tracks: &[TrackEntry]) -> (u32, u32, u32) {
-    let mut matched = 0;
-    let mut ambiguous = 0;
-    let mut not_found = 0;
-    for t in tracks {
-        match &t.outcome {
-            Some(MatchOutcome::Matched { .. }) => matched += 1,
-            Some(MatchOutcome::Ambiguous { .. }) => ambiguous += 1,
-            Some(MatchOutcome::NotFound) => not_found += 1,
-            _ => {}
-        }
-    }
-    (matched, ambiguous, not_found)
-}
-
-fn build_report(cp: &Checkpoint, skipped_local: u32) -> TransferReport {
-    let (matched, _, _) = outcome_counts(&cp.tracks);
-    let searched_ytm = !matches!(cp.spec.dest, TransferDest::SpotifyNewPlaylist { .. });
-    let mut report = TransferReport {
-        job_id: cp.job_id.clone(),
-        total: cp.tracks.len() as u32,
-        matched,
-        skipped_local,
-        match_stats: cp.match_stats.clone(),
-        ..TransferReport::default()
-    };
-    for (idx, entry) in cp.tracks.iter().enumerate() {
-        match &entry.outcome {
-            Some(MatchOutcome::Ambiguous { candidates }) => {
-                let report_candidates: Vec<ReportCandidate> = candidates
-                    .iter()
-                    .map(|c| ReportCandidate {
-                        key: c.key.clone(),
-                        score: c.score,
-                        display: c.display.clone(),
-                        score_breakdown: c.score_breakdown.clone(),
-                    })
-                    .collect();
-                let note = candidates
-                    .iter()
-                    .map(|c| format!("{} ({:.2})", c.display, c.score))
-                    .collect::<Vec<_>>()
-                    .join(" | ");
-                let mut row = report_row_base(entry, idx, note);
-                if searched_ytm && entry.input.known_video_id.is_none() {
-                    row.search_queries = ytm_query_plan(&entry.input);
-                }
-                row.selected_key = report_candidates.first().map(|c| c.key.clone());
-                row.selected_score = report_candidates.first().map(|c| c.score);
-                if let Some(score) = report_candidates
-                    .first()
-                    .and_then(|candidate| candidate.score_breakdown.as_ref())
-                {
-                    apply_report_quality(&mut row, score);
-                }
-                row.candidates = report_candidates;
-                report.ambiguous.push(row);
-            }
-            Some(MatchOutcome::NotFound) => {
-                let mut row = report_row_base(entry, idx, "no match on the destination".to_owned());
-                if searched_ytm && entry.input.known_video_id.is_none() {
-                    row.search_queries = ytm_query_plan(&entry.input);
-                }
-                report.not_found.push(row);
-            }
-            _ => {}
-        }
-    }
-    report
-}
-
-fn report_row_base(entry: &TrackEntry, idx: usize, note: String) -> ReportRow {
-    ReportRow {
-        title: entry.input.title.clone(),
-        artists: entry.input.artists.join(", "),
-        note,
-        source_order: Some(idx as u32 + 1),
-        source_key: Some(entry.input.source_key.clone()),
-        source_url: entry.input.source_url.clone(),
-        album: entry.input.album.clone(),
-        album_artists: entry.input.album_artists.clone(),
-        album_id: entry.input.album_id.clone(),
-        album_uri: entry.input.album_uri.clone(),
-        album_release_date: entry.input.album_release_date.clone(),
-        album_release_date_precision: entry.input.album_release_date_precision.clone(),
-        album_total_tracks: entry.input.album_total_tracks,
-        album_type: entry.input.album_type.clone(),
-        album_art_url: entry.input.album_art_url.clone(),
-        disc_number: entry.input.disc_number,
-        track_number: entry.input.track_number,
-        duration_secs: entry.input.duration_secs,
-        isrc: entry.input.isrc.clone(),
-        explicit: entry.input.explicit,
-        candidates: Vec::new(),
-        selected_key: None,
-        selected_score: None,
-        search_queries: Vec::new(),
-        source_kind: None,
-        quality_tier: None,
-        reject_reason: None,
-        reason_codes: Vec::new(),
-        duration_delta_secs: None,
-    }
-}
-
-fn apply_report_quality(row: &mut ReportRow, score: &super::matching::MatchScoreBreakdown) {
-    if !score.source_kind.is_empty() {
-        row.source_kind = Some(score.source_kind.clone());
-    }
-    if !score.quality_tier.is_empty() {
-        row.quality_tier = Some(score.quality_tier.clone());
-    }
-    row.reject_reason = score.reject_reason.clone();
-    row.reason_codes = score.reason_codes.clone();
-    row.duration_delta_secs = score.duration_delta_secs;
-}
-
-fn progress_write(
-    cp: &Checkpoint,
-    done: u32,
-    total: u32,
-    idx: usize,
-    auto_accepted: u32,
-) -> TransferProgress {
-    let (matched, ambiguous, not_found) = outcome_counts(&cp.tracks);
-    TransferProgress {
-        job_id: cp.job_id.clone(),
-        stage: Stage::Writing,
-        done,
-        total,
-        matched,
-        auto_accepted,
-        ambiguous,
-        not_found,
-        written: written_count(&cp.tracks),
-        current: cp
-            .tracks
-            .get(idx)
-            .map(|t| t.input.display())
-            .unwrap_or_default(),
-    }
-}
-
-fn written_count(tracks: &[TrackEntry]) -> u32 {
-    tracks.iter().filter(|track| track.written).count() as u32
-}
-
 fn progress_beat(job_id: &str, stage: Stage) -> impl FnMut(u32, u32, String) + use<> {
     let job_id = job_id.to_owned();
     move |_done, _total, _current| {
         // Fetch pagination is fast; per-page progress is deliberately not surfaced (the
         // interesting stages report per-track). Hook kept for symmetry/debugging.
         tracing::debug!(job = %job_id, stage = stage.label(), "fetch page");
-    }
-}
-
-/// Persist the checkpoint before surfacing an error — the resume story depends on it.
-fn checkpointed(cp: &mut Checkpoint, err: JobError) -> JobError {
-    if let Err(e) = cp.save() {
-        tracing::warn!(error = %e, "could not save checkpoint while failing");
-    } else {
-        save_import_session(cp);
-    }
-    err
-}
-
-fn save_import_session(cp: &Checkpoint) {
-    let session = super::session::ImportSession::from_checkpoint(cp);
-    if let Err(e) = session.save() {
-        tracing::warn!(error = %e, "could not save import session");
-    }
-}
-
-fn spotify_job_error(e: SpotifyError) -> JobError {
-    let resumable = matches!(
-        e,
-        SpotifyError::RateLimited | SpotifyError::Network(_) | SpotifyError::Auth(_)
-    );
-    JobError {
-        resumable,
-        error: anyhow!("{e}"),
-    }
-}
-
-fn ytm_job_error(e: anyhow::Error) -> JobError {
-    // Mid-job YTM/yt-dlp failures are resumable. Do not blame cookies when the cause is
-    // clearly a public yt-dlp search / YouTube API rejection.
-    let detail = format!("{e:#}");
-    let detail_lc = detail.to_ascii_lowercase();
-    let ytdlp_search = detail_lc.contains("yt-dlp")
-        || detail_lc.contains("unable to download api page")
-        || detail_lc.contains("http error 403")
-        || detail_lc.contains("403 forbidden")
-        || detail_lc.contains("http error 429")
-        || detail_lc.contains("too many requests")
-        || detail_lc.contains("rate-limited")
-        || crate::tools::classify_ytdlp_failure(&detail).is_some();
-    let context = if ytdlp_search {
-        "YouTube/yt-dlp search failed — wait and retry, or run `ytt tools update` / `ytt doctor --verbose`; then resume this job"
-    } else {
-        "YouTube Music request failed — after fixing the cookie you can resume this job"
-    };
-    JobError {
-        resumable: true,
-        error: e.context(context),
     }
 }
 

--- a/src/transfer/engine/album_prefill.rs
+++ b/src/transfer/engine/album_prefill.rs
@@ -1,13 +1,46 @@
-use std::collections::HashMap;
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+
+use futures::{StreamExt, stream};
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::api::ytmusic::{TransferAlbum, TransferAlbumCandidate, TransferAlbumTrack, YtMusicApi};
 use crate::search_source::SearchConfig;
-use crate::transfer::checkpoint::{Checkpoint, MatchStats};
+use crate::transfer::checkpoint::Checkpoint;
 use crate::transfer::match_cache::{CachedAlbum, TransferMatchCache, album_key};
 use crate::transfer::matching::{
-    CandidateSourceKind, MatchCandidate, MatchConfig, MatchOutcome, Pacing, TrackInput,
-    YtmMatchDiagnostics, best_outcome, normalize, normalize_stripped, similarity,
+    CandidateSourceKind, MatchCandidate, MatchConfig, MatchOutcome, MatchScoreBreakdown, Pacing,
+    TrackInput, normalize, normalize_stripped, score_candidate_breakdown_with_config, similarity,
 };
+
+mod stats;
+
+pub(super) use stats::{merge_ytm_diagnostics, record_match_outcome_stats};
+
+/// Album work shares the same 600 ms catalog start pacer as per-track matching. Two in-flight
+/// groups hide network latency without increasing request start rate or creating a second pacer.
+const ALBUM_LIVE_CONCURRENCY: usize = 2;
+const ALBUM_LIVE_MIN_TRACKS: usize = 3;
+const ALBUM_LIVE_GROUP_LIMIT: usize = 12;
+const ALBUM_METADATA_MIN_SCORE: f32 = 0.82;
+const ALBUM_METADATA_CLOSE_MARGIN: f32 = 0.04;
+const ALBUM_DETAIL_SCORE_MARGIN: f32 = 0.02;
+
+struct AlbumGroupWork {
+    order: usize,
+    key: String,
+    indexes: Vec<usize>,
+    inputs: Vec<TrackInput>,
+    query: String,
+}
+
+struct AlbumGroupResolution {
+    order: usize,
+    key: String,
+    indexes: Vec<usize>,
+    album: Option<TransferAlbum>,
+    catalog_searches: u32,
+}
 
 pub(super) fn apply_persistent_cache(cp: &mut Checkpoint, cache: &TransferMatchCache) -> bool {
     let mut changed = false;
@@ -36,17 +69,20 @@ pub(super) async fn prefill_album_matches(
 ) -> anyhow::Result<bool> {
     let mut groups: HashMap<String, Vec<usize>> = HashMap::new();
     for (idx, entry) in cp.tracks.iter().enumerate() {
-        if entry.outcome.is_some() {
-            continue;
-        }
         if let Some(key) = album_key(&entry.input) {
             groups.entry(key).or_default().push(idx);
         }
     }
 
+    // Largest groups have the greatest chance of avoiding per-track probes. Stable source-order
+    // and key tie-breaks keep provider scheduling deterministic despite HashMap iteration order.
+    let mut groups = groups.into_iter().collect::<Vec<_>>();
+    groups.sort_by(compare_album_group_priority);
+
     let mut changed = false;
+    let mut live_groups = Vec::new();
     for (key, indexes) in groups {
-        if indexes.len() < 2 {
+        if indexes.len() < 2 || indexes.iter().all(|idx| cp.tracks[*idx].outcome.is_some()) {
             continue;
         }
         cp.match_stats.album_groups_attempted += 1;
@@ -59,48 +95,157 @@ pub(super) async fn prefill_album_matches(
             continue;
         }
 
-        let Some(query) = album_query(&cp.tracks[indexes[0]].input) else {
+        // Two-track groups still benefit from a cache hit, but a live album lookup costs at
+        // least a paced search plus one paced detail call. Spend that budget only where one
+        // successful album can replace three or more per-track searches, and cap the queue.
+        if !within_live_album_budget(&indexes, live_groups.len()) {
+            continue;
+        }
+
+        let inputs = indexes
+            .iter()
+            .map(|idx| cp.tracks[*idx].input.clone())
+            .collect::<Vec<_>>();
+        let Some(query) = album_query(&inputs) else {
             continue;
         };
-        pace.tick().await;
-        cp.match_stats.catalog_searches += 1;
-        let candidates = match api.search_transfer_albums(&query, search_config).await {
-            Ok(candidates) => candidates,
-            Err(error) => {
-                tracing::debug!(
-                    query = %query,
-                    error = %crate::util::sanitize::sanitize_error_text(format!("{error:#}")),
-                    "transfer album search failed"
-                );
-                continue;
+        live_groups.push(AlbumGroupWork {
+            order: live_groups.len(),
+            key,
+            indexes,
+            inputs,
+            query,
+        });
+    }
+
+    // Cached evidence above stays available in anonymous/degraded runs. Do not create queued
+    // live work, acquire the pacer, or consume a search counter when the provider is unavailable.
+    if live_groups.is_empty() || !api.transfer_catalog_available() {
+        return Ok(changed);
+    }
+
+    let shared_pace = AsyncMutex::new(pace);
+    let mut resolutions = stream::iter(live_groups)
+        .map(|work| {
+            let shared_pace = &shared_pace;
+            async move {
+                resolve_live_album_group(work, api, cfg, search_config, shared_pace).await
             }
-        };
-        let Some(album_candidate) = best_album_candidate(&cp.tracks[indexes[0]].input, &candidates)
-        else {
+        })
+        .buffer_unordered(ALBUM_LIVE_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+    // Completion order depends on provider latency. Apply disjoint groups in launch-priority
+    // order so cache/report state remains deterministic.
+    resolutions.sort_by_key(|resolution| resolution.order);
+    for resolution in resolutions {
+        cp.match_stats.catalog_searches = cp
+            .match_stats
+            .catalog_searches
+            .saturating_add(resolution.catalog_searches);
+        let Some(album) = resolution.album else {
             continue;
         };
-        pace.tick().await;
-        let album = match api.transfer_album_tracks(&album_candidate.album_id).await {
-            Ok(Some(album)) => album,
-            Ok(None) => continue,
-            Err(error) => {
-                tracing::debug!(
-                    album_id = %album_candidate.album_id,
-                    error = %crate::util::sanitize::sanitize_error_text(format!("{error:#}")),
-                    "transfer album detail fetch failed"
-                );
-                continue;
-            }
-        };
-        cache.save_album(key, &album);
+        cache.save_album(resolution.key, &album);
         changed = true;
-        let matched = apply_transfer_album_matches(cp, cfg, cache, &album, &indexes);
+        let matched = apply_transfer_album_matches(cp, cfg, cache, &album, &resolution.indexes);
         if matched > 0 {
             cp.match_stats.album_groups_matched += 1;
-            changed = true;
         }
     }
     Ok(changed)
+}
+
+fn compare_album_group_priority(
+    (key_a, indexes_a): &(String, Vec<usize>),
+    (key_b, indexes_b): &(String, Vec<usize>),
+) -> Ordering {
+    indexes_b
+        .len()
+        .cmp(&indexes_a.len())
+        .then_with(|| indexes_a.first().cmp(&indexes_b.first()))
+        .then_with(|| key_a.cmp(key_b))
+}
+
+fn within_live_album_budget(indexes: &[usize], queued_groups: usize) -> bool {
+    indexes.len() >= ALBUM_LIVE_MIN_TRACKS && queued_groups < ALBUM_LIVE_GROUP_LIMIT
+}
+
+async fn wait_for_album_catalog_slot(api: &YtMusicApi, pace: &AsyncMutex<&mut Pacing>) -> bool {
+    // Check both before queueing and after acquiring the shared pacer. A prior in-flight search
+    // may have opened the global parser cooldown while this group was waiting.
+    if !api.transfer_catalog_available() {
+        return false;
+    }
+    let mut pace = pace.lock().await;
+    if !api.transfer_catalog_available() {
+        return false;
+    }
+    pace.tick().await;
+    api.transfer_catalog_available()
+}
+
+async fn resolve_live_album_group(
+    work: AlbumGroupWork,
+    api: &YtMusicApi,
+    cfg: &MatchConfig,
+    search_config: &SearchConfig,
+    pace: &AsyncMutex<&mut Pacing>,
+) -> AlbumGroupResolution {
+    let mut resolution = AlbumGroupResolution {
+        order: work.order,
+        key: work.key,
+        indexes: work.indexes,
+        album: None,
+        catalog_searches: 0,
+    };
+    if !wait_for_album_catalog_slot(api, pace).await {
+        return resolution;
+    }
+    resolution.catalog_searches = 1;
+    let candidates = match api.search_transfer_albums(&work.query, search_config).await {
+        Ok(candidates) => candidates,
+        Err(error) => {
+            tracing::debug!(
+                query = %work.query,
+                error = %crate::util::sanitize::sanitize_error_text(format!("{error:#}")),
+                "transfer album search failed"
+            );
+            return resolution;
+        }
+    };
+    let shortlist = album_candidate_shortlist(&work.inputs, &candidates);
+    if shortlist.is_empty() {
+        return resolution;
+    }
+
+    let expected_details = shortlist.len();
+    let mut details = Vec::with_capacity(expected_details);
+    for candidate in shortlist {
+        // Search/detail calls use one shared start pacer. Capability is rechecked after every
+        // response so a parser cooldown prevents queued detail work immediately.
+        if !wait_for_album_catalog_slot(api, pace).await {
+            break;
+        }
+        match api.transfer_album_tracks(&candidate.album_id).await {
+            Ok(Some(album)) => details.push(album),
+            Ok(None) => break,
+            Err(error) => {
+                tracing::debug!(
+                    album_id = %candidate.album_id,
+                    error = %crate::util::sanitize::sanitize_error_text(format!("{error:#}")),
+                    "transfer album detail fetch failed"
+                );
+                break;
+            }
+        }
+    }
+    // A close metadata race is intentionally unresolved unless every planned detail was
+    // available; choosing the sole surviving candidate would recreate the old false-positive.
+    if details.len() == expected_details {
+        resolution.album = select_album_detail(&work.inputs, details, cfg);
+    }
+    resolution
 }
 
 fn apply_cached_album_matches(
@@ -120,9 +265,20 @@ fn apply_cached_album_matches(
             album: Some(track.album.clone()),
             duration_secs: track.duration_secs,
             track_number: track.track_number,
+            release_year: album
+                .year
+                .as_deref()
+                .and_then(|year| year.parse::<u16>().ok()),
+            explicit: None,
             source_kind: CandidateSourceKind::YtmAlbumTrack,
             channel: Some(track.artist.clone()),
+            channel_id: None,
+            channel_verified: None,
+            availability: None,
+            has_audio_format: None,
+            max_audio_bitrate_kbps: None,
             isrc: None,
+            metadata_title: None,
             preflighted: false,
             preflight_reject_reason: None,
             preflight_reason_codes: Vec::new(),
@@ -141,7 +297,7 @@ fn apply_transfer_album_matches(
     let candidates = album
         .tracks
         .iter()
-        .map(album_track_candidate)
+        .map(|track| album_track_candidate(track, album.year.as_deref()))
         .collect::<Vec<_>>();
     apply_album_candidates(cp, cfg, cache, &candidates, indexes)
 }
@@ -153,25 +309,304 @@ fn apply_album_candidates(
     candidates: &[MatchCandidate],
     indexes: &[usize],
 ) -> u32 {
+    let candidates = prepare_album_candidates(cp, candidates, indexes);
+    let source_order = source_album_order(cp, indexes);
+    let candidate_indexes = candidates
+        .iter()
+        .enumerate()
+        .map(|(index, candidate)| (candidate.key.as_str(), index))
+        .collect::<HashMap<_, _>>();
+    let mut used = vec![false; candidates.len()];
+    for key in indexes
+        .iter()
+        .filter_map(|idx| match cp.tracks[*idx].outcome.as_ref() {
+            Some(MatchOutcome::Matched { key, .. }) => Some(key.as_str()),
+            _ => None,
+        })
+    {
+        if let Some(index) = candidate_indexes.get(key) {
+            used[*index] = true;
+        }
+    }
+    let mut rows = indexes
+        .iter()
+        .copied()
+        .filter(|idx| cp.tracks[*idx].outcome.is_none())
+        .map(|index| AlbumRowState::new(index, &cp.tracks[index].input, &candidates, cfg, &used))
+        .collect::<Vec<_>>();
     let mut matched = 0;
-    for idx in indexes {
-        if cp.tracks[*idx].outcome.is_some() {
-            continue;
+
+    // Every source×candidate breakdown is computed once in AlbumRowState. Candidate claims only
+    // advance per-row ranked cursors and decrement precomputed viable counts, preserving the
+    // constraints-first one-to-one behavior without rescoring the full matrix after every edge.
+    loop {
+        let mut proposals = rows
+            .iter_mut()
+            .filter(|row| row.active)
+            .filter_map(|row| row.proposal(&candidates, cfg, &source_order, &used))
+            .collect::<Vec<_>>();
+        proposals.sort_by(compare_album_proposals);
+        let Some(proposal) = proposals.into_iter().next() else {
+            break;
+        };
+
+        let input = cp.tracks[proposal.index].input.clone();
+        cp.match_stats.album_tracks_matched += 1;
+        record_match_outcome_stats(&mut cp.match_stats, &proposal.outcome);
+        cache.save_match(&input, &proposal.outcome);
+        cp.tracks[proposal.index].outcome = Some(proposal.outcome);
+        if let Some(row) = rows.iter_mut().find(|row| row.index == proposal.index) {
+            row.active = false;
         }
-        let input = cp.tracks[*idx].input.clone();
-        let outcome = best_outcome(&input, candidates, cfg);
-        if matches!(outcome, MatchOutcome::Matched { .. }) {
-            cp.match_stats.album_tracks_matched += 1;
-            record_match_outcome_stats(&mut cp.match_stats, &outcome);
-            cache.save_match(&input, &outcome);
-            cp.tracks[*idx].outcome = Some(outcome);
-            matched += 1;
+        if !used[proposal.candidate_index] {
+            used[proposal.candidate_index] = true;
+            for row in rows.iter_mut().filter(|row| row.active) {
+                row.mark_candidate_used(proposal.candidate_index);
+            }
         }
+        matched += 1;
     }
     matched
 }
 
-fn album_track_candidate(track: &TransferAlbumTrack) -> MatchCandidate {
+fn prepare_album_candidates(
+    cp: &Checkpoint,
+    candidates: &[MatchCandidate],
+    indexes: &[usize],
+) -> Vec<MatchCandidate> {
+    prepare_album_candidates_for_inputs(
+        candidates,
+        indexes.iter().map(|idx| &cp.tracks[*idx].input),
+    )
+}
+
+fn prepare_album_candidates_for_inputs<'a>(
+    candidates: &[MatchCandidate],
+    inputs: impl IntoIterator<Item = &'a TrackInput>,
+) -> Vec<MatchCandidate> {
+    let mut seen_keys = HashSet::new();
+    let mut candidates = candidates
+        .iter()
+        .filter(|candidate| seen_keys.insert(candidate.key.clone()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut source_track_numbers = HashMap::<u32, usize>::new();
+    for track_number in inputs.into_iter().filter_map(|input| input.track_number) {
+        *source_track_numbers.entry(track_number).or_default() += 1;
+    }
+    let mut candidate_track_numbers = HashMap::<u32, usize>::new();
+    for track_number in candidates
+        .iter()
+        .filter_map(|candidate| candidate.track_number)
+    {
+        *candidate_track_numbers.entry(track_number).or_default() += 1;
+    }
+
+    // Destination album rows currently carry no disc number. Only retain the small track
+    // number tie-break when that number is unique on both sides; a repeated "track 1" from
+    // a multi-disc release is not a globally unique identity signal.
+    for candidate in &mut candidates {
+        if candidate.track_number.is_some_and(|track_number| {
+            source_track_numbers.get(&track_number) != Some(&1)
+                || candidate_track_numbers.get(&track_number) != Some(&1)
+        }) {
+            candidate.track_number = None;
+        }
+    }
+    candidates
+}
+
+fn source_album_order(cp: &Checkpoint, indexes: &[usize]) -> HashMap<usize, usize> {
+    let mut ordered = indexes.iter().copied().enumerate().collect::<Vec<_>>();
+    ordered.sort_by_key(|(fallback_order, idx)| {
+        let input = &cp.tracks[*idx].input;
+        (
+            input.disc_number.unwrap_or(u32::MAX),
+            input.track_number.unwrap_or(u32::MAX),
+            *fallback_order,
+        )
+    });
+    ordered
+        .into_iter()
+        .enumerate()
+        .map(|(album_order, (_, idx))| (idx, album_order))
+        .collect()
+}
+
+fn input_album_order(inputs: &[TrackInput]) -> HashMap<usize, usize> {
+    let mut ordered = inputs.iter().enumerate().collect::<Vec<_>>();
+    ordered.sort_by_key(|(fallback_order, input)| {
+        (
+            input.disc_number.unwrap_or(u32::MAX),
+            input.track_number.unwrap_or(u32::MAX),
+            *fallback_order,
+        )
+    });
+    ordered
+        .into_iter()
+        .enumerate()
+        .map(|(album_order, (input_index, _))| (input_index, album_order))
+        .collect()
+}
+
+struct AlbumMatchProposal {
+    index: usize,
+    candidate_index: usize,
+    outcome: MatchOutcome,
+    viable_candidates: usize,
+    score: f32,
+    title: f32,
+    duration: f32,
+    track_number_bonus: f32,
+    order_distance: usize,
+}
+
+struct AlbumRowScore {
+    candidate_index: usize,
+    cluster_key: String,
+    score: MatchScoreBreakdown,
+}
+
+struct AlbumRowState {
+    index: usize,
+    active: bool,
+    ranked: Vec<AlbumRowScore>,
+    viable: Vec<bool>,
+    viable_remaining: usize,
+    cursor: usize,
+}
+
+impl AlbumRowState {
+    fn new(
+        index: usize,
+        input: &TrackInput,
+        candidates: &[MatchCandidate],
+        cfg: &MatchConfig,
+        used: &[bool],
+    ) -> Self {
+        let mut viable = vec![false; candidates.len()];
+        let mut ranked = candidates
+            .iter()
+            .enumerate()
+            .filter_map(|(candidate_index, candidate)| {
+                let score = score_candidate_breakdown_with_config(input, candidate, cfg);
+                let eligible = score.reject_reason.is_none() && !score.accept_blocked;
+                viable[candidate_index] = eligible && score.total >= cfg.accept;
+                eligible.then(|| AlbumRowScore {
+                    candidate_index,
+                    cluster_key: album_candidate_cluster_key(candidate),
+                    score,
+                })
+            })
+            .collect::<Vec<_>>();
+        ranked.sort_by(|a, b| {
+            b.score
+                .total
+                .total_cmp(&a.score.total)
+                .then_with(|| a.candidate_index.cmp(&b.candidate_index))
+        });
+        let viable_remaining = viable
+            .iter()
+            .enumerate()
+            .filter(|(candidate_index, viable)| **viable && !used[*candidate_index])
+            .count();
+        Self {
+            index,
+            active: true,
+            ranked,
+            viable,
+            viable_remaining,
+            cursor: 0,
+        }
+    }
+
+    fn mark_candidate_used(&mut self, candidate_index: usize) {
+        if self.viable.get(candidate_index) == Some(&true) {
+            self.viable_remaining = self.viable_remaining.saturating_sub(1);
+        }
+    }
+
+    fn proposal(
+        &mut self,
+        candidates: &[MatchCandidate],
+        cfg: &MatchConfig,
+        source_order: &HashMap<usize, usize>,
+        used: &[bool],
+    ) -> Option<AlbumMatchProposal> {
+        while self
+            .ranked
+            .get(self.cursor)
+            .is_some_and(|score| used[score.candidate_index])
+        {
+            self.cursor += 1;
+        }
+        let best = self.ranked.get(self.cursor)?;
+        let second = self.ranked[self.cursor + 1..].iter().find(|candidate| {
+            !used[candidate.candidate_index] && candidate.cluster_key != best.cluster_key
+        });
+        let margin = second.map_or(best.score.total, |second| {
+            best.score.total - second.score.total
+        });
+        if best.score.total < cfg.accept || margin < cfg.accept_margin {
+            return None;
+        }
+
+        let candidate = &candidates[best.candidate_index];
+        let mut score = best.score.clone();
+        let default_cfg = MatchConfig::default();
+        if score.total >= default_cfg.accept
+            && margin >= default_cfg.accept_margin
+            && !score
+                .reason_codes
+                .iter()
+                .any(|code| code == "policy_safe_cache")
+        {
+            score.reason_codes.push("policy_safe_cache".to_owned());
+        }
+        let source_order = source_order.get(&self.index).copied().unwrap_or(self.index);
+        Some(AlbumMatchProposal {
+            index: self.index,
+            candidate_index: best.candidate_index,
+            outcome: MatchOutcome::Matched {
+                key: candidate.key.clone(),
+                score: score.total,
+                display: format!("{} — {}", candidate.artist, candidate.title),
+                title: Some(candidate.title.clone()),
+                artist: Some(candidate.artist.clone()),
+                album: candidate.album.clone(),
+                duration_secs: candidate.duration_secs,
+                score_breakdown: Some(Box::new(score.clone())),
+            },
+            viable_candidates: self.viable_remaining,
+            score: score.total,
+            title: score.title,
+            duration: score.duration,
+            track_number_bonus: score.track_number_bonus,
+            order_distance: source_order.abs_diff(best.candidate_index),
+        })
+    }
+}
+
+fn album_candidate_cluster_key(candidate: &MatchCandidate) -> String {
+    format!(
+        "{}\u{1f}{}",
+        normalize(&candidate.artist),
+        normalize_stripped(&candidate.title)
+    )
+}
+
+fn compare_album_proposals(a: &AlbumMatchProposal, b: &AlbumMatchProposal) -> Ordering {
+    a.viable_candidates
+        .cmp(&b.viable_candidates)
+        .then_with(|| b.score.total_cmp(&a.score))
+        .then_with(|| b.title.total_cmp(&a.title))
+        .then_with(|| b.duration.total_cmp(&a.duration))
+        .then_with(|| b.track_number_bonus.total_cmp(&a.track_number_bonus))
+        .then_with(|| a.order_distance.cmp(&b.order_distance))
+        .then_with(|| a.index.cmp(&b.index))
+}
+
+fn album_track_candidate(track: &TransferAlbumTrack, release_year: Option<&str>) -> MatchCandidate {
     MatchCandidate {
         key: track.video_id.clone(),
         title: track.title.clone(),
@@ -181,137 +616,305 @@ fn album_track_candidate(track: &TransferAlbumTrack) -> MatchCandidate {
             .duration_secs
             .or_else(|| crate::streaming::candidate::parse_duration_secs(track.duration.as_str())),
         track_number: track.track_number,
+        release_year: release_year.and_then(|year| year.parse::<u16>().ok()),
+        explicit: None,
         source_kind: CandidateSourceKind::YtmAlbumTrack,
         channel: Some(track.artist.clone()),
+        channel_id: None,
+        channel_verified: None,
+        availability: None,
+        has_audio_format: None,
+        max_audio_bitrate_kbps: None,
         isrc: None,
+        metadata_title: None,
         preflighted: false,
         preflight_reject_reason: None,
         preflight_reason_codes: Vec::new(),
     }
 }
 
-fn album_query(input: &TrackInput) -> Option<String> {
-    let album = input.album.as_deref()?.trim();
-    if album.is_empty() {
-        return None;
-    }
-    let artist = input
-        .album_artists
-        .first()
-        .or_else(|| input.artists.first())
-        .map(|artist| artist.trim())
-        .filter(|artist| !artist.is_empty())?;
+fn album_query(inputs: &[TrackInput]) -> Option<String> {
+    let album = consensus_value(
+        inputs.iter().filter_map(|input| input.album.clone()),
+        normalize_stripped,
+    )?;
+    let artist = consensus_value(
+        inputs.iter().filter_map(|input| {
+            input
+                .album_artists
+                .first()
+                .or_else(|| input.artists.first())
+                .cloned()
+        }),
+        normalize,
+    )?;
     let mut query = format!("{artist} {album}");
-    if let Some(year) = input
-        .album_release_date
-        .as_deref()
-        .and_then(|date| date.get(0..4))
-        .filter(|year| year.bytes().all(|b| b.is_ascii_digit()))
-    {
+    if let Some(year) = consensus_value(
+        inputs.iter().filter_map(|input| {
+            input
+                .album_release_date
+                .as_deref()
+                .and_then(|date| date.get(0..4))
+                .filter(|year| year.bytes().all(|b| b.is_ascii_digit()))
+                .map(str::to_owned)
+        }),
+        normalize,
+    ) {
         query.push(' ');
-        query.push_str(year);
+        query.push_str(&year);
     }
     Some(query)
 }
 
-fn best_album_candidate(
-    input: &TrackInput,
-    candidates: &[TransferAlbumCandidate],
-) -> Option<TransferAlbumCandidate> {
-    let mut scored = candidates
-        .iter()
-        .map(|candidate| (album_candidate_score(input, candidate), candidate))
-        .collect::<Vec<_>>();
-    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-    let (score, best) = scored.first()?;
-    if *score < 0.82 {
-        return None;
+fn consensus_value(
+    values: impl IntoIterator<Item = String>,
+    normalize_key: fn(&str) -> String,
+) -> Option<String> {
+    let mut counts = HashMap::<String, (usize, usize, String)>::new();
+    for (order, value) in values.into_iter().enumerate() {
+        let value = value.trim();
+        let key = normalize_key(value);
+        if value.is_empty() || key.is_empty() {
+            continue;
+        }
+        let entry = counts
+            .entry(key)
+            .or_insert_with(|| (0, order, value.to_owned()));
+        entry.0 += 1;
     }
-    if let Some((second, _)) = scored.get(1)
-        && score - second < 0.04
-    {
-        return None;
-    }
-    Some((*best).clone())
+    counts
+        .into_values()
+        .max_by(|a, b| a.0.cmp(&b.0).then_with(|| b.1.cmp(&a.1)))
+        .map(|(_, _, value)| value)
 }
 
-fn album_candidate_score(input: &TrackInput, candidate: &TransferAlbumCandidate) -> f32 {
-    let input_album = input.album.as_deref().unwrap_or_default();
-    let title = similarity(
-        &normalize_stripped(input_album),
-        &normalize_stripped(&candidate.title),
-    );
-    let input_artist = input
-        .album_artists
-        .first()
-        .or_else(|| input.artists.first())
-        .map(|artist| normalize(artist))
-        .unwrap_or_default();
-    let candidate_artist = normalize(&candidate.artist);
-    let artist = if !input_artist.is_empty() && !candidate_artist.is_empty() {
-        if input_artist.contains(&candidate_artist) || candidate_artist.contains(&input_artist) {
-            1.0
-        } else {
-            similarity(&input_artist, &candidate_artist)
-        }
+#[cfg(test)]
+fn best_album_candidate(
+    inputs: &[TrackInput],
+    candidates: &[TransferAlbumCandidate],
+) -> Option<TransferAlbumCandidate> {
+    let shortlist = album_candidate_shortlist(inputs, candidates);
+    if shortlist.len() == 1 {
+        shortlist.into_iter().next()
     } else {
-        0.5
+        None
+    }
+}
+
+fn album_candidate_shortlist(
+    inputs: &[TrackInput],
+    candidates: &[TransferAlbumCandidate],
+) -> Vec<TransferAlbumCandidate> {
+    let mut seen = HashSet::new();
+    let mut scored = candidates
+        .iter()
+        .filter(|candidate| seen.insert(candidate.album_id.as_str()))
+        .map(|candidate| (album_candidate_score(inputs, candidate), candidate))
+        .collect::<Vec<_>>();
+    scored.sort_by(|a, b| {
+        b.0.total_cmp(&a.0)
+            .then_with(|| a.1.album_id.cmp(&b.1.album_id))
+    });
+    let Some((score, best)) = scored.first() else {
+        return Vec::new();
     };
-    let year = match (
-        input
+    if *score < ALBUM_METADATA_MIN_SCORE {
+        return Vec::new();
+    }
+    let mut shortlist = vec![(*best).clone()];
+    if let Some((second, _)) = scored.get(1)
+        && score - second < ALBUM_METADATA_CLOSE_MARGIN
+    {
+        shortlist.push((*scored[1].1).clone());
+    }
+    shortlist
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AlbumGroupEvidence {
+    matched: usize,
+    average_score: f32,
+    track_count_distance: Option<u32>,
+}
+
+fn select_album_detail(
+    inputs: &[TrackInput],
+    mut albums: Vec<TransferAlbum>,
+    cfg: &MatchConfig,
+) -> Option<TransferAlbum> {
+    if albums.len() == 1 {
+        return albums.pop();
+    }
+    if albums.len() != 2 {
+        return None;
+    }
+    let evidence = albums
+        .iter()
+        .map(|album| album_group_evidence(inputs, album, cfg))
+        .collect::<Vec<_>>();
+    let selected = compare_album_detail_evidence(evidence[0], evidence[1]);
+    match selected {
+        Ordering::Greater => Some(albums.remove(0)),
+        Ordering::Less => Some(albums.remove(1)),
+        Ordering::Equal => None,
+    }
+}
+
+fn compare_album_detail_evidence(a: AlbumGroupEvidence, b: AlbumGroupEvidence) -> Ordering {
+    let coverage = a.matched.cmp(&b.matched);
+    if coverage != Ordering::Equal {
+        return coverage;
+    }
+    if a.matched == 0 {
+        return Ordering::Equal;
+    }
+    if let (Some(a_distance), Some(b_distance)) = (a.track_count_distance, b.track_count_distance) {
+        let count_fit = b_distance.cmp(&a_distance);
+        if count_fit != Ordering::Equal {
+            return count_fit;
+        }
+    }
+    let score_delta = a.average_score - b.average_score;
+    if score_delta.abs() >= ALBUM_DETAIL_SCORE_MARGIN {
+        score_delta.total_cmp(&0.0)
+    } else {
+        Ordering::Equal
+    }
+}
+
+fn album_group_evidence(
+    inputs: &[TrackInput],
+    album: &TransferAlbum,
+    cfg: &MatchConfig,
+) -> AlbumGroupEvidence {
+    let raw_candidates = album
+        .tracks
+        .iter()
+        .map(|track| album_track_candidate(track, album.year.as_deref()))
+        .collect::<Vec<_>>();
+    let candidates = prepare_album_candidates_for_inputs(&raw_candidates, inputs.iter());
+    let source_order = input_album_order(inputs);
+    let mut used = vec![false; candidates.len()];
+    let mut rows = inputs
+        .iter()
+        .enumerate()
+        .map(|(index, input)| AlbumRowState::new(index, input, &candidates, cfg, &used))
+        .collect::<Vec<_>>();
+    let mut matched = 0usize;
+    let mut score_sum = 0.0f32;
+    loop {
+        let mut proposals = rows
+            .iter_mut()
+            .filter(|row| row.active)
+            .filter_map(|row| row.proposal(&candidates, cfg, &source_order, &used))
+            .collect::<Vec<_>>();
+        proposals.sort_by(compare_album_proposals);
+        let Some(proposal) = proposals.into_iter().next() else {
+            break;
+        };
+        matched += 1;
+        score_sum += proposal.score;
+        if let Some(row) = rows.iter_mut().find(|row| row.index == proposal.index) {
+            row.active = false;
+        }
+        used[proposal.candidate_index] = true;
+        for row in rows.iter_mut().filter(|row| row.active) {
+            row.mark_candidate_used(proposal.candidate_index);
+        }
+    }
+    let expected_tracks = consensus_u32(inputs.iter().filter_map(|input| input.album_total_tracks));
+    AlbumGroupEvidence {
+        matched,
+        average_score: if matched > 0 {
+            score_sum / matched as f32
+        } else {
+            0.0
+        },
+        track_count_distance: expected_tracks.map(|expected| {
+            expected.abs_diff(u32::try_from(album.tracks.len()).unwrap_or(u32::MAX))
+        }),
+    }
+}
+
+fn consensus_u32(values: impl IntoIterator<Item = u32>) -> Option<u32> {
+    let mut counts = HashMap::<u32, (usize, usize)>::new();
+    for (order, value) in values.into_iter().enumerate() {
+        let entry = counts.entry(value).or_insert((0, order));
+        entry.0 += 1;
+    }
+    counts
+        .into_iter()
+        .max_by(|a, b| a.1.0.cmp(&b.1.0).then_with(|| b.1.1.cmp(&a.1.1)))
+        .map(|(value, _)| value)
+}
+
+fn album_candidate_score(inputs: &[TrackInput], candidate: &TransferAlbumCandidate) -> f32 {
+    let candidate_title = normalize_stripped(&candidate.title);
+    let title = median_score(inputs.iter().filter_map(|input| {
+        let input_album = normalize_stripped(input.album.as_deref()?);
+        (!input_album.is_empty()).then(|| similarity(&input_album, &candidate_title))
+    }))
+    .unwrap_or(0.5);
+    let candidate_artist = normalize(&candidate.artist);
+    let artist = median_score(inputs.iter().filter_map(|input| {
+        let artists = if input.album_artists.is_empty() {
+            &input.artists
+        } else {
+            &input.album_artists
+        };
+        artists
+            .iter()
+            .map(|artist| normalize(artist))
+            .filter(|artist| !artist.is_empty() && !candidate_artist.is_empty())
+            .map(|input_artist| {
+                if input_artist.contains(&candidate_artist)
+                    || candidate_artist.contains(&input_artist)
+                {
+                    1.0
+                } else {
+                    similarity(&input_artist, &candidate_artist)
+                }
+            })
+            .max_by(f32::total_cmp)
+    }))
+    .unwrap_or(0.5);
+    let year = median_score(inputs.iter().filter_map(|input| {
+        let input_year = input
             .album_release_date
             .as_deref()
-            .and_then(|date| date.get(0..4)),
-        candidate.year.as_deref(),
-    ) {
-        (Some(a), Some(b)) if a == b => 1.0,
-        (Some(_), Some(_)) => 0.4,
-        _ => 0.6,
-    };
-    let type_bonus = match (input.album_type.as_deref(), candidate.album_type.as_deref()) {
-        (Some(a), Some(b)) if normalize(a) == normalize(b) => 0.03,
-        _ => 0.0,
-    };
+            .and_then(|date| date.get(0..4))?;
+        Some(match candidate.year.as_deref() {
+            Some(candidate_year) if input_year == candidate_year => 1.0,
+            Some(_) => 0.4,
+            None => 0.6,
+        })
+    }))
+    .unwrap_or(0.6);
+    let type_bonus = 0.03
+        * median_score(inputs.iter().filter_map(|input| {
+            let input_type = input.album_type.as_deref()?;
+            let candidate_type = candidate.album_type.as_deref()?;
+            Some(if normalize(input_type) == normalize(candidate_type) {
+                1.0
+            } else {
+                0.0
+            })
+        }))
+        .unwrap_or(0.0);
     0.60 * title + 0.30 * artist + 0.10 * year + type_bonus
 }
 
-pub(super) fn merge_ytm_diagnostics(stats: &mut MatchStats, diagnostics: YtmMatchDiagnostics) {
-    stats.catalog_searches += diagnostics.catalog_searches;
-    stats.video_searches += diagnostics.video_searches;
-    stats.preflight_lookups += diagnostics.preflight_lookups;
-    stats.authenticated_catalog_degraded += diagnostics.authenticated_catalog_degraded;
-    stats.query_cache_hits += diagnostics.query_cache_hits;
-    stats.video_meta_cache_hits += diagnostics.video_meta_cache_hits;
-}
-
-pub(super) fn record_match_outcome_stats(stats: &mut MatchStats, outcome: &MatchOutcome) {
-    match outcome {
-        MatchOutcome::Matched {
-            score_breakdown: Some(score),
-            ..
-        } => record_score_stats(stats, score),
-        MatchOutcome::Ambiguous { candidates } => {
-            for candidate in candidates {
-                if let Some(score) = &candidate.score_breakdown {
-                    record_score_stats(stats, score);
-                }
-            }
-        }
-        _ => {}
+fn median_score(scores: impl IntoIterator<Item = f32>) -> Option<f32> {
+    let mut scores = scores.into_iter().collect::<Vec<_>>();
+    if scores.is_empty() {
+        return None;
     }
-}
-
-fn record_score_stats(
-    stats: &mut MatchStats,
-    score: &crate::transfer::matching::MatchScoreBreakdown,
-) {
-    stats.bump_source_kind(&score.source_kind);
-    stats.bump_quality_tier(&score.quality_tier);
-    for code in &score.reason_codes {
-        stats.bump_reason_code(code);
-    }
-    if let Some(reason) = &score.reject_reason {
-        stats.bump_reason_code(reason);
+    scores.sort_by(f32::total_cmp);
+    let middle = scores.len() / 2;
+    if scores.len() % 2 == 0 {
+        Some((scores[middle - 1] + scores[middle]) / 2.0)
+    } else {
+        Some(scores[middle])
     }
 }
 
@@ -361,6 +964,7 @@ mod tests {
                 quality_tier: "catalog".to_owned(),
                 total: 0.96,
                 raw_total: 0.96,
+                reason_codes: vec!["policy_safe_cache".to_owned()],
                 ..MatchScoreBreakdown::default()
             })),
         }
@@ -379,6 +983,59 @@ mod tests {
             cache_mode: TransferCacheMode::Use,
             rematch: false,
         }
+    }
+
+    fn transfer_album(album_id: &str, titles: &[&str]) -> TransferAlbum {
+        TransferAlbum {
+            album_id: album_id.to_owned(),
+            title: "Album".to_owned(),
+            artist: "Artist".to_owned(),
+            year: Some("2024".to_owned()),
+            tracks: titles
+                .iter()
+                .enumerate()
+                .map(|(index, title)| TransferAlbumTrack {
+                    video_id: format!("{album_id}-{index}"),
+                    title: (*title).to_owned(),
+                    artist: "Artist".to_owned(),
+                    album: "Album".to_owned(),
+                    track_number: u32::try_from(index + 1).ok(),
+                    duration: "3:00".to_owned(),
+                    duration_secs: Some(180),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn live_album_budget_selects_largest_groups_and_stops_at_limit() {
+        let mut groups = (0..14)
+            .map(|order| {
+                (
+                    format!("album-{order:02}"),
+                    vec![order; ALBUM_LIVE_MIN_TRACKS + order],
+                )
+            })
+            .collect::<Vec<_>>();
+        groups.push(("two-track-cache-only".to_owned(), vec![99, 100]));
+        groups.sort_by(compare_album_group_priority);
+
+        let mut selected = Vec::new();
+        for (key, indexes) in groups {
+            if within_live_album_budget(&indexes, selected.len()) {
+                selected.push((key, indexes.len()));
+            }
+        }
+
+        assert_eq!(selected.len(), ALBUM_LIVE_GROUP_LIMIT);
+        assert_eq!(selected.first().map(|(_, size)| *size), Some(16));
+        assert_eq!(selected.last().map(|(_, size)| *size), Some(5));
+        assert!(selected.iter().all(|(_, size)| *size >= 5));
+        assert!(
+            selected
+                .iter()
+                .all(|(key, _)| key != "two-track-cache-only")
+        );
     }
 
     #[test]
@@ -436,7 +1093,8 @@ mod tests {
             album_type: Some("album".to_owned()),
         };
         assert_eq!(
-            best_album_candidate(&input, std::slice::from_ref(&clear)).map(|c| c.album_id),
+            best_album_candidate(std::slice::from_ref(&input), std::slice::from_ref(&clear))
+                .map(|c| c.album_id),
             Some("album-1".to_owned())
         );
 
@@ -447,7 +1105,10 @@ mod tests {
             year: Some("1999".to_owned()),
             album_type: None,
         };
-        assert!(best_album_candidate(&input, std::slice::from_ref(&weak)).is_none());
+        assert!(
+            best_album_candidate(std::slice::from_ref(&input), std::slice::from_ref(&weak))
+                .is_none()
+        );
 
         let twin_a = TransferAlbumCandidate {
             album_id: "album-a".to_owned(),
@@ -463,7 +1124,85 @@ mod tests {
             year: Some("2024".to_owned()),
             album_type: Some("album".to_owned()),
         };
-        assert!(best_album_candidate(&input, &[twin_a, twin_b]).is_none());
+        let twins = [twin_a, twin_b];
+        assert_eq!(
+            album_candidate_shortlist(std::slice::from_ref(&input), &twins)
+                .iter()
+                .map(|candidate| candidate.album_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["album-a", "album-b"]
+        );
+        assert!(best_album_candidate(std::slice::from_ref(&input), &twins).is_none());
+    }
+
+    #[test]
+    fn album_selection_uses_group_consensus_instead_of_first_row() {
+        let mut noisy_first = track_input("Song A", "Wrong Artist", "Wrong Collection", 1);
+        noisy_first.album_artists = vec!["Wrong Artist".to_owned()];
+        noisy_first.album_release_date = Some("1999-01-01".to_owned());
+        noisy_first.album_type = Some("single".to_owned());
+        let inputs = vec![
+            noisy_first,
+            track_input("Song B", "Artist", "Album", 2),
+            track_input("Song C", "Artist", "Album", 3),
+        ];
+        let wrong = TransferAlbumCandidate {
+            album_id: "wrong".to_owned(),
+            title: "Wrong Collection".to_owned(),
+            artist: "Wrong Artist".to_owned(),
+            year: Some("1999".to_owned()),
+            album_type: Some("single".to_owned()),
+        };
+        let consensus = TransferAlbumCandidate {
+            album_id: "consensus".to_owned(),
+            title: "Album".to_owned(),
+            artist: "Artist".to_owned(),
+            year: Some("2024".to_owned()),
+            album_type: Some("album".to_owned()),
+        };
+
+        assert_eq!(album_query(&inputs).as_deref(), Some("Artist Album 2024"));
+        assert_eq!(
+            best_album_candidate(&inputs, &[wrong, consensus]).map(|candidate| candidate.album_id),
+            Some("consensus".to_owned())
+        );
+    }
+
+    #[test]
+    fn close_album_metadata_uses_group_coverage_then_track_count() {
+        let inputs = vec![
+            track_input("Alpha Theme", "Artist", "Album", 1),
+            track_input("Beta Groove", "Artist", "Album", 2),
+        ];
+        let partial = transfer_album("partial", &["Alpha Theme", "Unrelated Noise"]);
+        let complete = transfer_album("complete", &["Alpha Theme", "Beta Groove"]);
+
+        let selected = select_album_detail(
+            &inputs,
+            vec![partial, complete.clone()],
+            &MatchConfig::default(),
+        )
+        .expect("complete track coverage should disambiguate close album metadata");
+        assert_eq!(selected.album_id, "complete");
+
+        let deluxe = transfer_album("deluxe", &["Alpha Theme", "Beta Groove", "Unrelated Bonus"]);
+        let selected = select_album_detail(
+            &inputs,
+            vec![deluxe, complete.clone()],
+            &MatchConfig::default(),
+        )
+        .expect("expected track count should break equal-coverage ties");
+        assert_eq!(selected.album_id, "complete");
+
+        let indistinguishable = transfer_album("same-evidence", &["Alpha Theme", "Beta Groove"]);
+        assert!(
+            select_album_detail(
+                &inputs,
+                vec![complete, indistinguishable],
+                &MatchConfig::default(),
+            )
+            .is_none()
+        );
     }
 
     #[test]
@@ -530,5 +1269,245 @@ mod tests {
             Some(MatchOutcome::Matched { ref key, .. }) if key == "vid-b"
         ));
         assert!(cp.tracks[2].outcome.is_none());
+    }
+
+    #[test]
+    fn album_assignment_never_reuses_one_video_id_for_two_rows() {
+        let mut cache = TransferMatchCache::default();
+        let mut second = track_input("Repeated Song", "Artist", "Album", 1);
+        second.disc_number = Some(2);
+        second.source_key = "spotify:track:repeated-2".to_owned();
+        let mut cp = Checkpoint::new(
+            "job-album-unique".to_owned(),
+            job_spec(),
+            vec![
+                TrackEntry {
+                    input: track_input("Repeated Song", "Artist", "Album", 1),
+                    outcome: None,
+                    review_decision: None,
+                    written: false,
+                },
+                TrackEntry {
+                    input: second,
+                    outcome: None,
+                    review_decision: None,
+                    written: false,
+                },
+            ],
+        );
+        let album = CachedAlbum {
+            ytm_album_id: "ytm-album".to_owned(),
+            title: "Album".to_owned(),
+            artist: "Artist".to_owned(),
+            year: Some("2024".to_owned()),
+            tracks: vec![CachedAlbumTrack {
+                video_id: "only-video".to_owned(),
+                title: "Repeated Song".to_owned(),
+                artist: "Artist".to_owned(),
+                album: "Album".to_owned(),
+                track_number: Some(1),
+                duration_secs: Some(180),
+            }],
+            updated_at: crate::signals::unix_now(),
+        };
+
+        assert_eq!(
+            apply_cached_album_matches(
+                &mut cp,
+                &MatchConfig::default(),
+                &mut cache,
+                &album,
+                &[0, 1]
+            ),
+            1
+        );
+        assert_eq!(
+            cp.tracks
+                .iter()
+                .filter(|entry| matches!(entry.outcome, Some(MatchOutcome::Matched { .. })))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn repeated_track_numbers_across_discs_use_identity_and_duration() {
+        let mut cache = TransferMatchCache::default();
+        let mut disc_two = track_input("Disc Two Finale", "Artist", "Album", 1);
+        disc_two.disc_number = Some(2);
+        disc_two.duration_secs = Some(241);
+        let mut cp = Checkpoint::new(
+            "job-multi-disc".to_owned(),
+            job_spec(),
+            vec![
+                TrackEntry {
+                    input: track_input("Disc One Intro", "Artist", "Album", 1),
+                    outcome: None,
+                    review_decision: None,
+                    written: false,
+                },
+                TrackEntry {
+                    input: disc_two,
+                    outcome: None,
+                    review_decision: None,
+                    written: false,
+                },
+            ],
+        );
+        let album = CachedAlbum {
+            ytm_album_id: "ytm-multi-disc".to_owned(),
+            title: "Album".to_owned(),
+            artist: "Artist".to_owned(),
+            year: Some("2024".to_owned()),
+            tracks: vec![
+                CachedAlbumTrack {
+                    video_id: "disc-one".to_owned(),
+                    title: "Disc One Intro".to_owned(),
+                    artist: "Artist".to_owned(),
+                    album: "Album".to_owned(),
+                    track_number: Some(1),
+                    duration_secs: Some(180),
+                },
+                CachedAlbumTrack {
+                    video_id: "disc-two".to_owned(),
+                    title: "Disc Two Finale".to_owned(),
+                    artist: "Artist".to_owned(),
+                    album: "Album".to_owned(),
+                    track_number: Some(1),
+                    duration_secs: Some(241),
+                },
+            ],
+            updated_at: crate::signals::unix_now(),
+        };
+
+        assert_eq!(
+            apply_cached_album_matches(
+                &mut cp,
+                &MatchConfig::default(),
+                &mut cache,
+                &album,
+                &[0, 1]
+            ),
+            2
+        );
+        assert!(matches!(
+            cp.tracks[0].outcome,
+            Some(MatchOutcome::Matched { ref key, .. }) if key == "disc-one"
+        ));
+        assert!(matches!(
+            cp.tracks[1].outcome,
+            Some(MatchOutcome::Matched { ref key, .. }) if key == "disc-two"
+        ));
+    }
+
+    #[tokio::test]
+    async fn unavailable_catalog_skips_live_album_calls_and_pacing() {
+        let mut cp = Checkpoint::new(
+            "job-anonymous".to_owned(),
+            job_spec(),
+            vec![
+                TrackEntry {
+                    input: track_input("Song A", "Artist", "Album", 1),
+                    outcome: None,
+                    review_decision: None,
+                    written: false,
+                },
+                TrackEntry {
+                    input: track_input("Song B", "Artist", "Album", 2),
+                    outcome: None,
+                    review_decision: None,
+                    written: false,
+                },
+            ],
+        );
+        let mut cache = TransferMatchCache::default();
+        let mut pace = Pacing::new(std::time::Duration::from_secs(60));
+
+        assert!(
+            !prefill_album_matches(
+                &mut cp,
+                &YtMusicApi::Anonymous,
+                &MatchConfig::default(),
+                &SearchConfig::default(),
+                &mut cache,
+                false,
+                &mut pace,
+            )
+            .await
+            .unwrap()
+        );
+        assert_eq!(cp.match_stats.catalog_searches, 0);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), pace.tick())
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn unavailable_catalog_still_applies_cached_album() {
+        let inputs = [
+            track_input("Alpha Theme", "Artist", "Album", 1),
+            track_input("Beta Groove", "Artist", "Album", 2),
+        ];
+        let mut cp = Checkpoint::new(
+            "job-anonymous-cache".to_owned(),
+            job_spec(),
+            inputs
+                .iter()
+                .cloned()
+                .map(|input| TrackEntry {
+                    input,
+                    outcome: None,
+                    review_decision: None,
+                    written: false,
+                })
+                .collect(),
+        );
+        let album = TransferAlbum {
+            album_id: "ytm-album".to_owned(),
+            title: "Album".to_owned(),
+            artist: "Artist".to_owned(),
+            year: Some("2024".to_owned()),
+            tracks: vec![
+                TransferAlbumTrack {
+                    video_id: "video-a".to_owned(),
+                    title: "Alpha Theme".to_owned(),
+                    artist: "Artist".to_owned(),
+                    album: "Album".to_owned(),
+                    track_number: Some(1),
+                    duration: "3:00".to_owned(),
+                    duration_secs: Some(180),
+                },
+                TransferAlbumTrack {
+                    video_id: "video-b".to_owned(),
+                    title: "Beta Groove".to_owned(),
+                    artist: "Artist".to_owned(),
+                    album: "Album".to_owned(),
+                    track_number: Some(2),
+                    duration: "3:00".to_owned(),
+                    duration_secs: Some(180),
+                },
+            ],
+        };
+        let mut cache = TransferMatchCache::default();
+        cache.save_album(album_key(&inputs[0]).unwrap(), &album);
+        let mut pace = Pacing::new(std::time::Duration::from_secs(60));
+
+        assert!(
+            prefill_album_matches(
+                &mut cp,
+                &YtMusicApi::Anonymous,
+                &MatchConfig::default(),
+                &SearchConfig::default(),
+                &mut cache,
+                true,
+                &mut pace,
+            )
+            .await
+            .unwrap()
+        );
+        assert_eq!(cp.match_stats.album_tracks_matched, 2);
+        assert_eq!(cp.match_stats.catalog_searches, 0);
     }
 }

--- a/src/transfer/engine/album_prefill/stats.rs
+++ b/src/transfer/engine/album_prefill/stats.rs
@@ -1,0 +1,93 @@
+use crate::transfer::checkpoint::MatchStats;
+use crate::transfer::matching::{MatchOutcome, MatchScoreBreakdown, YtmMatchDiagnostics};
+
+pub(in crate::transfer::engine) fn merge_ytm_diagnostics(
+    stats: &mut MatchStats,
+    diagnostics: YtmMatchDiagnostics,
+) {
+    stats.catalog_searches += diagnostics.catalog_searches;
+    stats.video_searches += diagnostics.video_searches;
+    stats.ytm_video_catalog_searches += diagnostics.ytm_video_searches;
+    stats.public_video_searches += diagnostics.public_video_searches;
+    stats.retries = stats
+        .retries
+        .saturating_add(diagnostics.public_video_retries)
+        .saturating_add(diagnostics.preflight_retries);
+    stats.preflight_lookups += diagnostics.preflight_lookups;
+    stats.catalog_http_pages += diagnostics.catalog_searches;
+    stats.video_process_spawns += diagnostics.public_video_searches;
+    stats.preflight_process_spawns += diagnostics.preflight_lookups;
+    if diagnostics.preflight_failures > 0 {
+        let failures = stats
+            .provider_errors
+            .entry("metadata_preflight_unavailable".to_owned())
+            .or_default();
+        *failures = failures.saturating_add(diagnostics.preflight_failures);
+    }
+    stats.authenticated_catalog_degraded += diagnostics.authenticated_catalog_degraded;
+    stats.query_cache_hits += diagnostics.query_cache_hits;
+    stats.video_meta_cache_hits += diagnostics.video_meta_cache_hits;
+}
+
+pub(in crate::transfer::engine) fn record_match_outcome_stats(
+    stats: &mut MatchStats,
+    outcome: &MatchOutcome,
+) {
+    match outcome {
+        MatchOutcome::Matched {
+            score_breakdown: Some(score),
+            ..
+        } => record_score_stats(stats, score),
+        MatchOutcome::Ambiguous { candidates } => {
+            for candidate in candidates {
+                if let Some(score) = &candidate.score_breakdown {
+                    record_score_stats(stats, score);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn record_score_stats(stats: &mut MatchStats, score: &MatchScoreBreakdown) {
+    stats.bump_source_kind(&score.source_kind);
+    stats.bump_quality_tier(&score.quality_tier);
+    for code in &score.reason_codes {
+        stats.bump_reason_code(code);
+    }
+    if let Some(reason) = &score.reject_reason {
+        stats.bump_reason_code(reason);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_diagnostics_preserve_process_attempts_and_retries() {
+        let mut stats = MatchStats::default();
+        merge_ytm_diagnostics(
+            &mut stats,
+            YtmMatchDiagnostics {
+                video_searches: 3,
+                public_video_searches: 2,
+                public_video_retries: 1,
+                preflight_lookups: 3,
+                preflight_retries: 1,
+                preflight_failures: 1,
+                ..YtmMatchDiagnostics::default()
+            },
+        );
+
+        assert_eq!(stats.video_searches, 3);
+        assert_eq!(stats.public_video_searches, 2);
+        assert_eq!(stats.video_process_spawns, 2);
+        assert_eq!(stats.retries, 2);
+        assert_eq!(stats.preflight_process_spawns, 3);
+        assert_eq!(
+            stats.provider_errors.get("metadata_preflight_unavailable"),
+            Some(&1)
+        );
+    }
+}

--- a/src/transfer/engine/job_errors.rs
+++ b/src/transfer/engine/job_errors.rs
@@ -1,0 +1,109 @@
+//! Checkpoint-preserving provider error classification for resumable transfers.
+
+use super::*;
+use crate::transfer::checkpoint::JobDeferReason;
+
+/// Persist the checkpoint before surfacing an error — the resume story depends on it.
+pub(super) fn checkpointed(cp: &mut Checkpoint, err: JobError) -> JobError {
+    if let Err(error) = cp.save() {
+        tracing::warn!(error = %error, "could not save checkpoint while failing");
+    } else {
+        save_import_session(cp);
+        if cp.defer_reason.is_some() {
+            let report = build_report(cp, cp.skipped_local);
+            if let Err(error) = report.save() {
+                tracing::warn!(error = %error, "could not save deferred transfer report");
+            }
+        }
+    }
+    err
+}
+
+pub(super) fn save_import_session(cp: &Checkpoint) {
+    let session = super::super::session::ImportSession::from_checkpoint(cp);
+    if let Err(error) = session.save_unlocked() {
+        tracing::warn!(error = %error, "could not save import session");
+    }
+}
+
+pub(super) fn spotify_job_error(error: SpotifyError) -> JobError {
+    let resumable = matches!(
+        error,
+        SpotifyError::RateLimited | SpotifyError::Network(_) | SpotifyError::Auth(_)
+    );
+    JobError {
+        resumable,
+        error: anyhow!("{error}"),
+    }
+}
+
+fn is_youtube_search_failure(detail: &str) -> bool {
+    let detail = detail.to_ascii_lowercase();
+    detail.contains("yt-dlp")
+        || detail.contains("unable to download api page")
+        || detail.contains("http error 403")
+        || detail.contains("403 forbidden")
+        || detail.contains("http error 429")
+        || detail.contains("too many requests")
+        || detail.contains("rate-limited")
+        || crate::tools::classify_ytdlp_failure(&detail).is_some()
+}
+
+pub(super) fn defer_ytm_match_error(
+    cp: &mut Checkpoint,
+    failed_index: Option<usize>,
+    error: anyhow::Error,
+) -> JobError {
+    let detail = format!("{error:#}");
+    let budget_exhausted = detail.contains("provider budget");
+    let (code, backend, message) = if budget_exhausted {
+        (
+            "provider_budget_exhausted",
+            "youtube",
+            "YouTube matching exceeded its bounded provider budget; resume to retry pending tracks",
+        )
+    } else if is_youtube_search_failure(&detail) {
+        (
+            "youtube_search_unavailable",
+            "youtube",
+            "YouTube search is temporarily unavailable; resume this job after retrying",
+        )
+    } else {
+        (
+            "ytm_catalog_unavailable",
+            "youtube_music",
+            "YouTube Music catalog matching is temporarily unavailable; resume this job after restoring access",
+        )
+    };
+
+    cp.defer_reason = Some(JobDeferReason::new(code, Some(backend), message));
+    cp.match_stats.deferred_jobs = cp.match_stats.deferred_jobs.saturating_add(1);
+    cp.match_stats.bump_provider_error(code);
+    cp.match_stats
+        .bump_terminal_reason("deferred_provider_error");
+    if let Some(index) = failed_index {
+        cp.match_traces
+            .entry(index as u32 + 1)
+            .or_default()
+            .terminal_reason = Some(code.to_owned());
+    }
+
+    checkpointed(cp, ytm_job_error(error))
+}
+
+pub(super) fn ytm_job_error(error: anyhow::Error) -> JobError {
+    // Mid-job YTM/yt-dlp failures are resumable. Do not blame cookies when the cause is
+    // clearly a public yt-dlp search / YouTube API rejection.
+    let detail = format!("{error:#}");
+    let context = if detail.contains("provider budget") {
+        "YouTube matching exceeded its bounded provider budget — resume this job to retry pending tracks"
+    } else if is_youtube_search_failure(&detail) {
+        "YouTube/yt-dlp search failed — wait and retry, or run `ytt tools update` / `ytt doctor --verbose`; then resume this job"
+    } else {
+        "YouTube Music request failed — after fixing the cookie you can resume this job"
+    };
+    JobError {
+        resumable: true,
+        error: error.context(context),
+    }
+}

--- a/src/transfer/engine/reporting.rs
+++ b/src/transfer/engine/reporting.rs
@@ -1,0 +1,372 @@
+//! Capacity, outcome accounting, and transfer report construction.
+
+use super::*;
+
+pub(super) fn outcome_counts(tracks: &[TrackEntry]) -> (u32, u32, u32) {
+    let mut matched = 0;
+    let mut ambiguous = 0;
+    let mut not_found = 0;
+    for track in tracks {
+        match &track.outcome {
+            Some(MatchOutcome::Matched { .. }) => matched += 1,
+            Some(MatchOutcome::Ambiguous { .. }) => ambiguous += 1,
+            Some(MatchOutcome::NotFound) => not_found += 1,
+            _ => {}
+        }
+    }
+    (matched, ambiguous, not_found)
+}
+
+pub(super) fn local_destination_keys(cp: &Checkpoint) -> Option<HashSet<String>> {
+    if !matches!(cp.spec.dest, TransferDest::LocalPlaylist { .. }) {
+        return None;
+    }
+    let store = crate::playlists::Playlists::load();
+    Some(
+        find_local_destination(&store, cp)
+            .map(|playlist| {
+                playlist
+                    .songs
+                    .iter()
+                    .map(|song| song.video_id.clone())
+                    .collect()
+            })
+            .unwrap_or_default(),
+    )
+}
+
+pub(super) fn find_local_destination<'a>(
+    store: &'a crate::playlists::Playlists,
+    cp: &Checkpoint,
+) -> Option<&'a crate::playlists::Playlist> {
+    cp.dest_id
+        .as_deref()
+        .and_then(|id| store.find(id))
+        .or_else(|| store.find(cp.dest_name.as_deref().unwrap_or("Imported playlist")))
+}
+
+#[cfg(test)]
+pub(super) fn extend_matched_keys(keys: &mut HashSet<String>, tracks: &[TrackEntry]) {
+    keys.extend(tracks.iter().filter_map(|entry| match &entry.outcome {
+        Some(MatchOutcome::Matched { key, .. }) => Some(key.clone()),
+        _ => None,
+    }));
+}
+
+/// Keep source order deterministic when a local destination has fewer free slots than
+/// already-resolved matches. Existing destination songs and repeated matches do not consume
+/// another slot; excess unique matches become an explicit capacity outcome, never "missing".
+pub(super) fn enforce_matched_capacity(
+    cp: &mut Checkpoint,
+    keys: &mut HashSet<String>,
+) -> Vec<usize> {
+    let mut indexes = Vec::new();
+    let take_best = cp.spec.take_best;
+    for (index, entry) in cp.tracks.iter_mut().enumerate() {
+        let Some(key) = effective_write_key(entry, take_best).map(str::to_owned) else {
+            continue;
+        };
+        if entry.written || keys.contains(&key) {
+            continue;
+        }
+        if keys.len() < crate::playlists::SONGS_PER_PLAYLIST_MAX {
+            keys.insert(key);
+            continue;
+        }
+        entry.outcome = Some(MatchOutcome::SkippedCapacity);
+        entry.review_decision = None;
+        indexes.push(index);
+    }
+    record_capacity_skips(
+        &mut cp.match_stats,
+        u32::try_from(indexes.len()).unwrap_or(u32::MAX),
+    );
+    indexes
+}
+
+pub(super) fn record_capacity_skips(stats: &mut MatchStats, count: u32) {
+    stats.capacity_skipped = stats.capacity_skipped.saturating_add(count);
+    if count > 0 {
+        stats.bump_terminal_reason("destination_capacity");
+    }
+}
+
+pub(super) fn mark_pending_capacity_skipped(cp: &mut Checkpoint) -> Vec<usize> {
+    let mut indexes = Vec::new();
+    for (index, entry) in cp.tracks.iter_mut().enumerate() {
+        if entry.outcome.is_none() {
+            entry.outcome = Some(MatchOutcome::SkippedCapacity);
+            indexes.push(index);
+        }
+    }
+    let count = u32::try_from(indexes.len()).unwrap_or(u32::MAX);
+    record_capacity_skips(&mut cp.match_stats, count);
+    indexes
+}
+
+pub(super) fn increment_outcome_counts(
+    outcome: &MatchOutcome,
+    matched: &mut u32,
+    ambiguous: &mut u32,
+    not_found: &mut u32,
+) {
+    match outcome {
+        MatchOutcome::Matched { .. } => *matched = matched.saturating_add(1),
+        MatchOutcome::Ambiguous { .. } => *ambiguous = ambiguous.saturating_add(1),
+        MatchOutcome::NotFound => *not_found = not_found.saturating_add(1),
+        MatchOutcome::SkippedLocal | MatchOutcome::SkippedCapacity => {}
+    }
+}
+
+pub(super) fn record_match_trace_stats(stats: &mut MatchStats, trace: &MatchTrace) {
+    for probe in &trace.probes {
+        if probe.status == "empty" {
+            stats.successful_empty_probes = stats.successful_empty_probes.saturating_add(1);
+        }
+        // Metadata preflight inspects existing finalists; it does not fetch a new
+        // candidate set and must not inflate retrieval volume.
+        if probe.backend != "youtube_metadata" {
+            stats.candidates_fetched = stats.candidates_fetched.saturating_add(probe.result_count);
+        }
+        stats.add_elapsed_ms(&probe.backend, probe.elapsed_ms);
+    }
+    for candidate in &trace.candidates {
+        let Some(score) = candidate.score_breakdown.as_ref() else {
+            continue;
+        };
+        if score.reject_reason.is_some() {
+            stats.candidates_rejected = stats.candidates_rejected.saturating_add(1);
+        } else if score.accept_blocked {
+            stats.candidates_review_only = stats.candidates_review_only.saturating_add(1);
+        }
+    }
+    if let Some(reason) = trace.terminal_reason.as_deref() {
+        stats.bump_terminal_reason(reason);
+    }
+}
+
+pub(super) fn build_report(cp: &Checkpoint, skipped_local: u32) -> TransferReport {
+    let (matched, _, _) = outcome_counts(&cp.tracks);
+    let mut report = TransferReport {
+        job_id: cp.job_id.clone(),
+        total: cp.tracks.len() as u32,
+        matched,
+        skipped_local,
+        match_stats: cp.match_stats.clone(),
+        defer_reason: cp.defer_reason.clone(),
+        ..TransferReport::default()
+    };
+    for (idx, entry) in cp.tracks.iter().enumerate() {
+        match &entry.outcome {
+            Some(MatchOutcome::Ambiguous { candidates }) => {
+                let report_candidates: Vec<ReportCandidate> = candidates
+                    .iter()
+                    .map(|candidate| ReportCandidate {
+                        key: candidate.key.clone(),
+                        score: candidate.score,
+                        display: candidate.display.clone(),
+                        score_breakdown: candidate.score_breakdown.clone(),
+                    })
+                    .collect();
+                let note = candidates
+                    .iter()
+                    .map(|candidate| format!("{} ({:.2})", candidate.display, candidate.score))
+                    .collect::<Vec<_>>()
+                    .join(" | ");
+                let mut row = report_row_base(entry, idx, note);
+                row.selected_key = report_candidates
+                    .first()
+                    .map(|candidate| candidate.key.clone());
+                row.selected_score = report_candidates.first().map(|candidate| candidate.score);
+                if let Some(score) = report_candidates
+                    .first()
+                    .and_then(|candidate| candidate.score_breakdown.as_ref())
+                {
+                    apply_report_quality(&mut row, score);
+                }
+                row.candidates = report_candidates;
+                if let Some(trace) = cp.match_traces.get(&(idx as u32 + 1)) {
+                    apply_trace_to_report_row(&mut row, trace);
+                }
+                report.ambiguous.push(row);
+            }
+            Some(MatchOutcome::NotFound) => {
+                let trace = cp.match_traces.get(&(idx as u32 + 1));
+                let note = not_found_note(trace);
+                let mut row = report_row_base(entry, idx, note);
+                if let Some(trace) = trace {
+                    apply_trace_to_report_row(&mut row, trace);
+                }
+                report.not_found.push(row);
+            }
+            None if cp.defer_reason.is_some() => {
+                let reason = cp.defer_reason.as_ref().expect("checked above");
+                let mut row = report_row_base(
+                    entry,
+                    idx,
+                    format!("deferred before completion: {}", reason.code),
+                );
+                if let Some(trace) = cp.match_traces.get(&(idx as u32 + 1)) {
+                    apply_trace_to_report_row(&mut row, trace);
+                } else {
+                    row.terminal_reason = Some(reason.code.clone());
+                }
+                report.deferred.push(row);
+            }
+            Some(MatchOutcome::SkippedCapacity) => {
+                let mut row = report_row_base(
+                    entry,
+                    idx,
+                    "destination capacity was already satisfied".to_owned(),
+                );
+                row.terminal_reason = Some("destination_capacity".to_owned());
+                report.capacity_skipped.push(row);
+            }
+            _ => {}
+        }
+    }
+    report
+}
+
+pub(super) fn rebuild_report_after_write(
+    cp: &Checkpoint,
+    skipped_local: u32,
+    report: &mut TransferReport,
+) {
+    let auto_accepted = report.auto_accepted;
+    let duplicates_dropped = report.duplicates_dropped;
+    let elapsed_secs = report.elapsed_secs;
+    let written = report.written;
+    let mut rebuilt = build_report(cp, skipped_local);
+    rebuilt.auto_accepted = auto_accepted;
+    rebuilt.duplicates_dropped = duplicates_dropped;
+    rebuilt.elapsed_secs = elapsed_secs;
+    rebuilt.written = written;
+    *report = rebuilt;
+}
+
+fn apply_trace_to_report_row(row: &mut ReportRow, trace: &MatchTrace) {
+    row.executed_probes = trace.probes.clone();
+    row.terminal_reason = trace.terminal_reason.clone();
+    let mut seen = HashSet::new();
+    row.search_queries = trace
+        .probes
+        .iter()
+        .filter_map(|probe| {
+            let query = probe.query.trim();
+            (!query.is_empty() && seen.insert(query.to_owned())).then(|| query.to_owned())
+        })
+        .collect();
+    if row.candidates.is_empty() {
+        row.candidates = trace.candidates.clone();
+        row.selected_key = row
+            .candidates
+            .first()
+            .map(|candidate| candidate.key.clone());
+        row.selected_score = row.candidates.first().map(|candidate| candidate.score);
+        if let Some(score) = row
+            .candidates
+            .first()
+            .and_then(|candidate| candidate.score_breakdown.as_ref())
+            .cloned()
+        {
+            apply_report_quality(row, &score);
+        }
+    }
+}
+
+fn not_found_note(trace: Option<&MatchTrace>) -> String {
+    let Some(trace) = trace else {
+        return "no match on the destination".to_owned();
+    };
+    if trace.candidates.is_empty() {
+        return "all executed providers completed without a candidate".to_owned();
+    }
+    if trace.candidates.iter().all(|candidate| {
+        candidate
+            .score_breakdown
+            .as_ref()
+            .is_some_and(|score| score.reject_reason.is_some())
+    }) {
+        return "all retrieved candidates were rejected by safety/version gates".to_owned();
+    }
+    "retrieved candidates stayed below the review threshold".to_owned()
+}
+
+fn report_row_base(entry: &TrackEntry, idx: usize, note: String) -> ReportRow {
+    ReportRow {
+        title: entry.input.title.clone(),
+        artists: entry.input.artists.join(", "),
+        note,
+        source_order: Some(idx as u32 + 1),
+        source_key: Some(entry.input.source_key.clone()),
+        source_url: entry.input.source_url.clone(),
+        album: entry.input.album.clone(),
+        album_artists: entry.input.album_artists.clone(),
+        album_id: entry.input.album_id.clone(),
+        album_uri: entry.input.album_uri.clone(),
+        album_release_date: entry.input.album_release_date.clone(),
+        album_release_date_precision: entry.input.album_release_date_precision.clone(),
+        album_total_tracks: entry.input.album_total_tracks,
+        album_type: entry.input.album_type.clone(),
+        album_art_url: entry.input.album_art_url.clone(),
+        disc_number: entry.input.disc_number,
+        track_number: entry.input.track_number,
+        duration_secs: entry.input.duration_secs,
+        isrc: entry.input.isrc.clone(),
+        explicit: entry.input.explicit,
+        candidates: Vec::new(),
+        selected_key: None,
+        selected_score: None,
+        search_queries: Vec::new(),
+        source_kind: None,
+        quality_tier: None,
+        reject_reason: None,
+        reason_codes: Vec::new(),
+        duration_delta_secs: None,
+        executed_probes: Vec::new(),
+        terminal_reason: None,
+    }
+}
+
+fn apply_report_quality(row: &mut ReportRow, score: &super::super::matching::MatchScoreBreakdown) {
+    if !score.source_kind.is_empty() {
+        row.source_kind = Some(score.source_kind.clone());
+    }
+    if !score.quality_tier.is_empty() {
+        row.quality_tier = Some(score.quality_tier.clone());
+    }
+    row.reject_reason = score.reject_reason.clone();
+    row.reason_codes = score.reason_codes.clone();
+    row.duration_delta_secs = score.duration_delta_secs;
+}
+
+pub(super) fn progress_write(
+    cp: &Checkpoint,
+    done: u32,
+    total: u32,
+    idx: usize,
+    auto_accepted: u32,
+    counts: WriteProgressCounts,
+) -> TransferProgress {
+    TransferProgress {
+        job_id: cp.job_id.clone(),
+        stage: Stage::Writing,
+        done,
+        total,
+        matched: counts.matched,
+        auto_accepted,
+        ambiguous: counts.ambiguous,
+        not_found: counts.not_found,
+        written: counts.written,
+        current: cp
+            .tracks
+            .get(idx)
+            .map(|track| track.input.display())
+            .unwrap_or_default(),
+    }
+}
+
+pub(super) fn written_count(tracks: &[TrackEntry]) -> u32 {
+    tracks.iter().filter(|track| track.written).count() as u32
+}

--- a/src/transfer/engine/tests.rs
+++ b/src/transfer/engine/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
-use crate::transfer::checkpoint::ReviewDecision;
+use crate::transfer::checkpoint::{ProbeTrace, ReviewDecision};
 use crate::transfer::matching::{AmbiguousCandidate, MatchScoreBreakdown};
+
+mod capacity;
 
 fn spec(dest: TransferDest) -> JobSpec {
     JobSpec {
@@ -422,6 +424,166 @@ fn provider_errors_are_classified_for_resume_safety() {
 }
 
 #[test]
+fn first_ytm_provider_failure_defers_without_fabricating_missing() {
+    // Underscores deliberately make this an in-memory-only checkpoint id.
+    let mut cp = Checkpoint::new(
+        "job_provider_failure_no_persist".to_owned(),
+        spec(TransferDest::YtmLikes),
+        vec![entry(input("Still Pending", &["Artist"]), None)],
+    );
+    cp.stage = Stage::Matching;
+    cp.match_traces.insert(
+        1,
+        MatchTrace {
+            probes: vec![ProbeTrace {
+                backend: "public_youtube".to_owned(),
+                status: "error".to_owned(),
+                error_kind: Some("http_429".to_owned()),
+                attempt: 2,
+                ..ProbeTrace::default()
+            }],
+            ..MatchTrace::default()
+        },
+    );
+
+    let error = defer_ytm_match_error(
+        &mut cp,
+        Some(0),
+        anyhow!("yt-dlp search failed with HTTP Error 429"),
+    );
+
+    assert!(error.resumable);
+    assert!(cp.tracks[0].outcome.is_none());
+    let reason = cp
+        .defer_reason
+        .as_ref()
+        .expect("job is explicitly deferred");
+    assert_eq!(reason.code, "youtube_search_unavailable");
+    assert_eq!(reason.backend.as_deref(), Some("youtube"));
+    assert_eq!(cp.match_stats.deferred_jobs, 1);
+    assert_eq!(
+        cp.match_stats
+            .provider_errors
+            .get("youtube_search_unavailable"),
+        Some(&1)
+    );
+    assert_eq!(
+        cp.match_stats
+            .terminal_reasons
+            .get("deferred_provider_error"),
+        Some(&1)
+    );
+    assert_eq!(
+        cp.match_traces
+            .get(&1)
+            .and_then(|trace| trace.terminal_reason.as_deref()),
+        Some("youtube_search_unavailable")
+    );
+    let probe = &cp.match_traces.get(&1).expect("failure trace").probes[0];
+    assert_eq!(probe.status, "error");
+    assert_eq!(probe.error_kind.as_deref(), Some("http_429"));
+    assert_eq!(probe.attempt, 2);
+}
+
+#[test]
+fn matching_budget_exhaustion_has_accurate_resume_reason() {
+    let mut cp = Checkpoint::new(
+        "job_provider_budget_no_persist".to_owned(),
+        spec(TransferDest::YtmLikes),
+        vec![entry(input("Still Pending", &["Artist"]), None)],
+    );
+    cp.stage = Stage::Matching;
+
+    let error = defer_ytm_match_error(
+        &mut cp,
+        Some(0),
+        anyhow!("transfer matching exceeded the per-track 60 second provider budget"),
+    );
+
+    assert!(error.resumable);
+    assert!(cp.tracks[0].outcome.is_none());
+    let reason = cp.defer_reason.as_ref().expect("explicit defer reason");
+    assert_eq!(reason.code, "provider_budget_exhausted");
+    assert_eq!(reason.backend.as_deref(), Some("youtube"));
+    assert!(format!("{:#}", error.error).contains("resume this job"));
+}
+
+#[test]
+fn match_journal_cadence_bounds_unsynced_outcomes_by_count_and_time() {
+    let mut cadence = MatchJournalCadence::new();
+    for _ in 1..CHECKPOINT_EVERY {
+        assert!(!cadence.next_is_durable());
+    }
+    assert!(cadence.next_is_durable());
+    assert_eq!(cadence.pending, 0);
+
+    cadence.last_durable = Instant::now() - MATCH_JOURNAL_DURABLE_EVERY;
+    assert!(cadence.next_is_durable());
+    assert_eq!(cadence.pending, 0);
+}
+
+#[test]
+fn match_trace_stats_count_only_retrieval_candidates_and_safe_empty_probes() {
+    let trace = MatchTrace {
+        probes: vec![
+            crate::transfer::checkpoint::ProbeTrace {
+                backend: "ytm_song".to_owned(),
+                status: "empty".to_owned(),
+                elapsed_ms: 11,
+                ..crate::transfer::checkpoint::ProbeTrace::default()
+            },
+            crate::transfer::checkpoint::ProbeTrace {
+                backend: "public_youtube".to_owned(),
+                status: "success".to_owned(),
+                result_count: 4,
+                elapsed_ms: 22,
+                ..crate::transfer::checkpoint::ProbeTrace::default()
+            },
+            crate::transfer::checkpoint::ProbeTrace {
+                backend: "youtube_metadata".to_owned(),
+                status: "success".to_owned(),
+                result_count: 2,
+                elapsed_ms: 7,
+                ..crate::transfer::checkpoint::ProbeTrace::default()
+            },
+        ],
+        candidates: vec![
+            ReportCandidate {
+                key: "rejected".to_owned(),
+                score: 0.1,
+                display: "Rejected".to_owned(),
+                score_breakdown: Some(MatchScoreBreakdown {
+                    reject_reason: Some("version mismatch".to_owned()),
+                    ..MatchScoreBreakdown::default()
+                }),
+            },
+            ReportCandidate {
+                key: "review".to_owned(),
+                score: 0.7,
+                display: "Review".to_owned(),
+                score_breakdown: Some(MatchScoreBreakdown {
+                    accept_blocked: true,
+                    ..MatchScoreBreakdown::default()
+                }),
+            },
+        ],
+        terminal_reason: Some("ambiguous".to_owned()),
+    };
+    let mut stats = MatchStats::default();
+
+    record_match_trace_stats(&mut stats, &trace);
+
+    assert_eq!(stats.successful_empty_probes, 1);
+    assert_eq!(stats.candidates_fetched, 4);
+    assert_eq!(stats.candidates_rejected, 1);
+    assert_eq!(stats.candidates_review_only, 1);
+    assert_eq!(stats.elapsed_ms.get("ytm_song"), Some(&11));
+    assert_eq!(stats.elapsed_ms.get("public_youtube"), Some(&22));
+    assert_eq!(stats.elapsed_ms.get("youtube_metadata"), Some(&7));
+    assert_eq!(stats.terminal_reasons.get("ambiguous"), Some(&1));
+}
+
+#[test]
 fn progress_beat_accepts_fetch_progress_without_surface_state() {
     let mut beat = progress_beat("job-fetch", Stage::Fetching);
     beat(1, 3, "Page 1".to_owned());
@@ -455,7 +617,7 @@ fn report_counts_matched_and_preserves_ambiguous_and_not_found_rows() {
     maybe.isrc = Some("ISRC-B".to_owned());
     maybe.explicit = Some(false);
     maybe.source_url = Some("https://open.spotify.com/track/b".to_owned());
-    let cp = Checkpoint::new(
+    let mut cp = Checkpoint::new(
         "job-report".to_owned(),
         spec(TransferDest::YtmLikes),
         vec![
@@ -489,11 +651,53 @@ fn report_counts_matched_and_preserves_ambiguous_and_not_found_rows() {
             ),
         ],
     );
+    cp.match_traces.insert(
+        2,
+        MatchTrace {
+            probes: vec![
+                ProbeTrace {
+                    backend: "ytm_song".to_owned(),
+                    query: "Artist B Maybe Song".to_owned(),
+                    status: "success".to_owned(),
+                    ..ProbeTrace::default()
+                },
+                ProbeTrace {
+                    backend: "public_youtube".to_owned(),
+                    query: "Artist B Maybe Song official audio".to_owned(),
+                    status: "success".to_owned(),
+                    ..ProbeTrace::default()
+                },
+            ],
+            terminal_reason: Some("ambiguous".to_owned()),
+            ..MatchTrace::default()
+        },
+    );
+    cp.match_traces.insert(
+        3,
+        MatchTrace {
+            probes: vec![
+                ProbeTrace {
+                    backend: "ytm_song".to_owned(),
+                    query: "Artist C Missing Song".to_owned(),
+                    status: "empty".to_owned(),
+                    ..ProbeTrace::default()
+                },
+                ProbeTrace {
+                    backend: "public_youtube".to_owned(),
+                    query: "Artist C Missing Song official audio".to_owned(),
+                    status: "empty".to_owned(),
+                    ..ProbeTrace::default()
+                },
+            ],
+            terminal_reason: Some("successful_exhaustion".to_owned()),
+            ..MatchTrace::default()
+        },
+    );
 
     let report = build_report(&cp, 1);
 
     assert_eq!(report.job_id, "job-report");
-    assert_eq!(report.schema_version, 4);
+    assert_eq!(report.schema_version, 5);
     assert_eq!(report.total, 4);
     assert_eq!(report.matched, 1);
     assert_eq!(report.skipped_local, 1);
@@ -541,13 +745,7 @@ fn report_counts_matched_and_preserves_ambiguous_and_not_found_rows() {
         report.ambiguous[0].search_queries,
         vec![
             "Artist B Maybe Song".to_owned(),
-            "Album Artist B Maybe Song".to_owned(),
-            "Artist B Maybe Song Input Album".to_owned(),
-            "Maybe Song Input Album".to_owned(),
-            "Artist B Maybe Song 2026".to_owned(),
             "Artist B Maybe Song official audio".to_owned(),
-            "Artist B Maybe Song topic".to_owned(),
-            "Maybe Song".to_owned(),
         ]
     );
     assert_eq!(report.ambiguous[0].candidates.len(), 2);
@@ -558,18 +756,16 @@ fn report_counts_matched_and_preserves_ambiguous_and_not_found_rows() {
     );
     assert_eq!(report.not_found.len(), 1);
     assert_eq!(report.not_found[0].artists, "Artist C, Feat D");
-    assert_eq!(report.not_found[0].note, "no match on the destination");
+    assert_eq!(
+        report.not_found[0].note,
+        "all executed providers completed without a candidate"
+    );
     assert_eq!(report.not_found[0].source_order, Some(3));
     assert_eq!(
         report.not_found[0].search_queries,
         vec![
             "Artist C Missing Song".to_owned(),
-            "Artist C Feat D Missing Song".to_owned(),
-            "Artist C Missing Song Input Album".to_owned(),
-            "Missing Song Input Album".to_owned(),
             "Artist C Missing Song official audio".to_owned(),
-            "Artist C Missing Song topic".to_owned(),
-            "Missing Song".to_owned(),
         ]
     );
 }
@@ -688,7 +884,8 @@ fn progress_write_reports_current_track_and_outcome_counts() {
         ],
     );
 
-    let progress = progress_write(&cp, 2, 3, 1, 1);
+    let counts = WriteProgressCounts::from_checkpoint(&cp);
+    let progress = progress_write(&cp, 2, 3, 1, 1, counts);
 
     assert_eq!(progress.job_id, "job-progress");
     assert_eq!(progress.stage, Stage::Writing);
@@ -713,13 +910,49 @@ fn progress_write_handles_missing_index_without_panicking() {
         )],
     );
 
-    let progress = progress_write(&cp, 1, 1, 99, 0);
+    let counts = WriteProgressCounts::from_checkpoint(&cp);
+    let progress = progress_write(&cp, 1, 1, 99, 0, counts);
 
     assert_eq!(progress.job_id, "job-progress-missing");
     assert_eq!(progress.current, "");
     assert_eq!(progress.matched, 1);
     assert_eq!(progress.auto_accepted, 0);
     assert_eq!(progress.written, 0);
+}
+
+#[test]
+fn write_progress_counts_update_without_rescanning_tracks() {
+    let mut already_written = entry(
+        input("Already Written", &["Artist A"]),
+        Some(matched("vid-a")),
+    );
+    already_written.written = true;
+    let cp = Checkpoint::new(
+        "job-progress-incremental".to_owned(),
+        spec(TransferDest::YtmLikes),
+        vec![
+            already_written,
+            entry(input("Pending", &["Artist B"]), Some(matched("vid-b"))),
+        ],
+    );
+
+    let mut counts = WriteProgressCounts::from_checkpoint(&cp);
+    assert_eq!(counts.written, 1);
+    counts.record_written(1);
+
+    let progress = progress_write(&cp, 2, 2, 1, 0, counts);
+    assert_eq!(progress.matched, 2);
+    assert_eq!(progress.written, 2);
+}
+
+#[test]
+fn ytm_playlist_pause_is_only_between_chunks() {
+    assert!(!should_pause_after_chunk(0, 0));
+    assert!(!should_pause_after_chunk(0, 1));
+    assert!(should_pause_after_chunk(0, 2));
+    assert!(!should_pause_after_chunk(1, 2));
+    assert!(should_pause_after_chunk(7, 10));
+    assert!(!should_pause_after_chunk(9, 10));
 }
 
 #[tokio::test]
@@ -849,6 +1082,42 @@ async fn write_stage_dedupes_matches_before_missing_client_error() {
     assert!(cp.tracks.iter().all(|track| !track.written));
 }
 
+#[tokio::test]
+async fn ytm_reconciliation_failure_is_resumable_instead_of_assuming_empty() {
+    // Underscores deliberately make this an in-memory-only checkpoint id.
+    let mut cp = Checkpoint::new(
+        "job_reconcile_failure_no_persist".to_owned(),
+        spec(TransferDest::YtmNewPlaylist {
+            name: Some("Destination".to_owned()),
+        }),
+        vec![entry(
+            input("Still Pending", &["Artist"]),
+            Some(matched("video-id")),
+        )],
+    );
+    cp.stage = Stage::Writing;
+    cp.dest_id = Some("existing-playlist".to_owned());
+    let mut ctx = JobCtx {
+        ytm: Some(YtMusicApi::Anonymous),
+        spotify: None,
+        search_config: SearchConfig::default(),
+        market: None,
+    };
+
+    let error = reconcile_written_ytm(&mut cp, &mut ctx, "existing-playlist")
+        .await
+        .expect_err("destination fetch failure must pause the job");
+
+    assert!(error.resumable);
+    assert!(
+        error
+            .error
+            .to_string()
+            .contains("YouTube Music request failed")
+    );
+    assert!(!cp.tracks[0].written);
+}
+
 #[test]
 fn collect_writes_skips_rejected_review_rows_even_with_take_best() {
     let mut rejected = entry(
@@ -883,7 +1152,7 @@ fn collect_writes_skips_rejected_review_rows_even_with_take_best() {
 }
 
 #[test]
-fn fast_auto_accept_promotes_only_safe_first_candidates_above_threshold() {
+fn fast_auto_accept_promotes_highest_safe_candidates_above_threshold() {
     let mut spec = spec(TransferDest::LocalPlaylist { name: None });
     spec.auto_accept_ambiguous_min_score = Some(0.75);
     let mut already_reviewed = entry(
@@ -914,7 +1183,7 @@ fn fast_auto_accept_promotes_only_safe_first_candidates_above_threshold() {
                 input("Safe first", &["Artist"]),
                 Some(ambiguous(vec![
                     ambiguous_candidate("safe-first", 0.76, false, None),
-                    ambiguous_candidate("safe-second", 0.95, false, None),
+                    ambiguous_candidate("safe-second", 0.75, false, None),
                 ])),
             ),
             entry(
@@ -941,7 +1210,7 @@ fn fast_auto_accept_promotes_only_safe_first_candidates_above_threshold() {
     let accepted = auto_accept_ambiguous_candidates(&mut cp)
         .unwrap_or_else(|err| panic!("auto-accept safe candidates failed: {}", err.error));
 
-    assert_eq!(accepted, 1);
+    assert_eq!(accepted, 2);
     assert!(matches!(
         cp.tracks[0].review_decision,
         Some(ReviewDecision::Accepted { ref key, .. }) if key == "safe-first"
@@ -955,7 +1224,14 @@ fn fast_auto_accept_promotes_only_safe_first_candidates_above_threshold() {
         cp.tracks[1].outcome,
         Some(MatchOutcome::Ambiguous { .. })
     ));
-    assert!(cp.tracks[2].review_decision.is_none());
+    assert!(matches!(
+        cp.tracks[2].review_decision,
+        Some(ReviewDecision::Accepted { ref key, .. }) if key == "high-second"
+    ));
+    assert!(matches!(
+        cp.tracks[2].outcome,
+        Some(MatchOutcome::Matched { ref key, .. }) if key == "high-second"
+    ));
     assert_eq!(cp.tracks[3].review_decision, Some(ReviewDecision::Skipped));
     assert!(cp.tracks[4].review_decision.is_none());
 }
@@ -983,23 +1259,30 @@ fn fast_auto_accept_never_promotes_blocked_or_rejected_candidates() {
                     Some("duration mismatch"),
                 )])),
             ),
+            entry(
+                input("Safe behind blocked", &["Artist"]),
+                Some(ambiguous(vec![
+                    ambiguous_candidate("blocked-first", 0.99, true, None),
+                    ambiguous_candidate("safe-later", 0.80, false, None),
+                ])),
+            ),
         ],
     );
 
     let accepted = auto_accept_ambiguous_candidates(&mut cp)
         .unwrap_or_else(|err| panic!("auto-accept inspection failed: {}", err.error));
 
-    assert_eq!(accepted, 0);
-    assert!(
-        cp.tracks
-            .iter()
-            .all(|track| track.review_decision.is_none())
-    );
-    assert!(
-        cp.tracks
-            .iter()
-            .all(|track| matches!(track.outcome, Some(MatchOutcome::Ambiguous { .. })))
-    );
+    assert_eq!(accepted, 1);
+    assert!(cp.tracks[0].review_decision.is_none());
+    assert!(cp.tracks[1].review_decision.is_none());
+    assert!(matches!(
+        cp.tracks[2].review_decision,
+        Some(ReviewDecision::Accepted { ref key, .. }) if key == "safe-later"
+    ));
+    assert!(matches!(
+        cp.tracks[2].outcome,
+        Some(MatchOutcome::Matched { ref key, .. }) if key == "safe-later"
+    ));
 }
 
 #[tokio::test]

--- a/src/transfer/engine/tests/capacity.rs
+++ b/src/transfer/engine/tests/capacity.rs
@@ -1,0 +1,287 @@
+use super::*;
+
+#[test]
+fn local_capacity_marks_all_pending_rows_after_999_unique_matches() {
+    let mut tracks = (0..crate::playlists::SONGS_PER_PLAYLIST_MAX)
+        .map(|index| {
+            entry(
+                input(&format!("Matched {index}"), &["Artist"]),
+                Some(matched(&format!("video-{index}"))),
+            )
+        })
+        .collect::<Vec<_>>();
+    tracks.push(entry(input("Pending A", &["Artist"]), None));
+    tracks.push(entry(input("Pending B", &["Artist"]), None));
+    let mut cp = Checkpoint::new(
+        "job_capacity_no_persist".to_owned(),
+        spec(TransferDest::LocalPlaylist {
+            name: Some("Capacity".to_owned()),
+        }),
+        tracks,
+    );
+    let mut unique_keys = HashSet::new();
+
+    extend_matched_keys(&mut unique_keys, &cp.tracks);
+    assert_eq!(unique_keys.len(), crate::playlists::SONGS_PER_PLAYLIST_MAX);
+    let skipped = if unique_keys.len() >= crate::playlists::SONGS_PER_PLAYLIST_MAX {
+        mark_pending_capacity_skipped(&mut cp)
+    } else {
+        Vec::new()
+    };
+
+    assert_eq!(
+        skipped,
+        vec![
+            crate::playlists::SONGS_PER_PLAYLIST_MAX,
+            crate::playlists::SONGS_PER_PLAYLIST_MAX + 1,
+        ]
+    );
+    assert!(matches!(
+        cp.tracks[crate::playlists::SONGS_PER_PLAYLIST_MAX].outcome,
+        Some(MatchOutcome::SkippedCapacity)
+    ));
+    assert!(matches!(
+        cp.tracks[crate::playlists::SONGS_PER_PLAYLIST_MAX + 1].outcome,
+        Some(MatchOutcome::SkippedCapacity)
+    ));
+    assert_eq!(cp.match_stats.capacity_skipped, 2);
+    assert_eq!(
+        cp.match_stats.terminal_reasons.get("destination_capacity"),
+        Some(&1)
+    );
+}
+
+#[test]
+fn duplicate_match_keys_do_not_consume_local_playlist_capacity() {
+    let mut tracks = (0..crate::playlists::SONGS_PER_PLAYLIST_MAX)
+        .map(|index| {
+            let key_index = if index + 1 == crate::playlists::SONGS_PER_PLAYLIST_MAX {
+                0
+            } else {
+                index
+            };
+            entry(
+                input(&format!("Matched {index}"), &["Artist"]),
+                Some(matched(&format!("video-{key_index}"))),
+            )
+        })
+        .collect::<Vec<_>>();
+    tracks.push(entry(input("Still Pending", &["Artist"]), None));
+    let mut cp = Checkpoint::new(
+        "job_duplicate_capacity_no_persist".to_owned(),
+        spec(TransferDest::LocalPlaylist {
+            name: Some("Capacity".to_owned()),
+        }),
+        tracks,
+    );
+    let mut unique_keys = HashSet::new();
+
+    extend_matched_keys(&mut unique_keys, &cp.tracks);
+    assert_eq!(
+        unique_keys.len(),
+        crate::playlists::SONGS_PER_PLAYLIST_MAX - 1
+    );
+    if unique_keys.len() >= crate::playlists::SONGS_PER_PLAYLIST_MAX {
+        mark_pending_capacity_skipped(&mut cp);
+    }
+
+    assert!(
+        cp.tracks[crate::playlists::SONGS_PER_PLAYLIST_MAX]
+            .outcome
+            .is_none()
+    );
+    assert_eq!(cp.match_stats.capacity_skipped, 0);
+    assert!(
+        !cp.match_stats
+            .terminal_reasons
+            .contains_key("destination_capacity")
+    );
+}
+
+#[test]
+fn cached_matches_respect_remaining_local_capacity_in_source_order() {
+    let mut existing = (0..crate::playlists::SONGS_PER_PLAYLIST_MAX - 1)
+        .map(|index| format!("existing-{index}"))
+        .collect::<HashSet<_>>();
+    let duplicate_existing = "existing-0";
+    let mut cp = Checkpoint::new(
+        "job_cached_capacity_no_persist".to_owned(),
+        spec(TransferDest::LocalPlaylist {
+            name: Some("Capacity".to_owned()),
+        }),
+        vec![
+            entry(
+                input("Existing duplicate", &["Artist"]),
+                Some(matched(duplicate_existing)),
+            ),
+            entry(
+                input("Last free slot", &["Artist"]),
+                Some(matched("last-free-slot")),
+            ),
+            entry(
+                input("First overflow", &["Artist"]),
+                Some(matched("overflow")),
+            ),
+            entry(
+                input("Duplicate of kept row", &["Artist"]),
+                Some(matched("last-free-slot")),
+            ),
+        ],
+    );
+
+    let skipped = enforce_matched_capacity(&mut cp, &mut existing);
+
+    assert_eq!(skipped, vec![2]);
+    assert_eq!(existing.len(), crate::playlists::SONGS_PER_PLAYLIST_MAX);
+    assert!(matches!(
+        cp.tracks[0].outcome,
+        Some(MatchOutcome::Matched { ref key, .. }) if key == duplicate_existing
+    ));
+    assert!(matches!(
+        cp.tracks[1].outcome,
+        Some(MatchOutcome::Matched { ref key, .. }) if key == "last-free-slot"
+    ));
+    assert!(matches!(
+        cp.tracks[2].outcome,
+        Some(MatchOutcome::SkippedCapacity)
+    ));
+    assert!(matches!(
+        cp.tracks[3].outcome,
+        Some(MatchOutcome::Matched { ref key, .. }) if key == "last-free-slot"
+    ));
+    assert_eq!(cp.match_stats.capacity_skipped, 1);
+
+    // Resume/idempotency: a row already marked at capacity is not counted twice.
+    assert!(enforce_matched_capacity(&mut cp, &mut existing).is_empty());
+    assert_eq!(cp.match_stats.capacity_skipped, 1);
+}
+
+#[test]
+fn take_best_review_rows_use_the_same_local_capacity_accounting_as_writes() {
+    let mut existing = (0..crate::playlists::SONGS_PER_PLAYLIST_MAX - 1)
+        .map(|index| format!("existing-{index}"))
+        .collect::<HashSet<_>>();
+    let mut transfer_spec = spec(TransferDest::LocalPlaylist {
+        name: Some("Capacity".to_owned()),
+    });
+    transfer_spec.take_best = true;
+    let mut cp = Checkpoint::new(
+        "job_take_best_capacity_no_persist".to_owned(),
+        transfer_spec,
+        vec![
+            entry(
+                input("First review row", &["Artist"]),
+                Some(ambiguous(vec![ambiguous_candidate(
+                    "review-first",
+                    0.79,
+                    false,
+                    None,
+                )])),
+            ),
+            entry(
+                input("Second review row", &["Artist"]),
+                Some(ambiguous(vec![ambiguous_candidate(
+                    "review-overflow",
+                    0.78,
+                    false,
+                    None,
+                )])),
+            ),
+        ],
+    );
+
+    let skipped = enforce_matched_capacity(&mut cp, &mut existing);
+
+    assert_eq!(skipped, vec![1]);
+    assert!(matches!(
+        cp.tracks[0].outcome,
+        Some(MatchOutcome::Ambiguous { .. })
+    ));
+    assert!(matches!(
+        cp.tracks[1].outcome,
+        Some(MatchOutcome::SkippedCapacity)
+    ));
+    assert_eq!(
+        collect_writes_without_deduping(&cp),
+        vec![(0, "review-first".to_owned())]
+    );
+}
+
+#[test]
+fn completed_provider_results_are_drained_in_frozen_source_order() {
+    let mut ready = BTreeMap::new();
+    let mut next = 0usize;
+
+    ready.insert(1, "fast-second");
+    assert_eq!(take_ready_in_source_order(&mut ready, &mut next), None);
+    ready.insert(0, "slow-first");
+
+    assert_eq!(
+        take_ready_in_source_order(&mut ready, &mut next),
+        Some("slow-first")
+    );
+    assert_eq!(
+        take_ready_in_source_order(&mut ready, &mut next),
+        Some("fast-second")
+    );
+    assert_eq!(next, 2);
+}
+
+#[test]
+fn local_destination_resolution_reuses_case_insensitive_name_and_prefers_id() {
+    let mut store = crate::playlists::Playlists::default();
+    let mix_id = store.create("Mix").expect("create Mix");
+    let other_id = store.create("Other").expect("create Other");
+    let mut cp = Checkpoint::new(
+        "job_local_destination_resolution".to_owned(),
+        spec(TransferDest::LocalPlaylist {
+            name: Some("mix".to_owned()),
+        }),
+        Vec::new(),
+    );
+    cp.dest_name = Some("mix".to_owned());
+
+    assert_eq!(
+        find_local_destination(&store, &cp).map(|playlist| playlist.id.as_str()),
+        Some(mix_id.as_str())
+    );
+
+    cp.dest_id = Some(other_id.clone());
+    assert_eq!(
+        find_local_destination(&store, &cp).map(|playlist| playlist.id.as_str()),
+        Some(other_id.as_str())
+    );
+}
+
+#[test]
+fn post_write_report_rebuild_keeps_capacity_bucket_exclusive_and_refreshes_stats() {
+    let mut cp = Checkpoint::new(
+        "job_report_rebuild_no_persist".to_owned(),
+        spec(TransferDest::LocalPlaylist { name: None }),
+        vec![entry(
+            input("Review row", &["Artist"]),
+            Some(ambiguous(vec![ambiguous_candidate(
+                "review-candidate",
+                0.78,
+                false,
+                None,
+            )])),
+        )],
+    );
+    let mut report = build_report(&cp, 0);
+    report.auto_accepted = 3;
+    report.duplicates_dropped = 2;
+    assert_eq!(report.ambiguous.len(), 1);
+
+    cp.tracks[0].outcome = Some(MatchOutcome::SkippedCapacity);
+    cp.match_stats.capacity_skipped = 1;
+    cp.match_stats.checkpoint_flushes = 4;
+    rebuild_report_after_write(&cp, 0, &mut report);
+
+    assert!(report.ambiguous.is_empty());
+    assert_eq!(report.capacity_skipped.len(), 1);
+    assert_eq!(report.auto_accepted, 3);
+    assert_eq!(report.duplicates_dropped, 2);
+    assert_eq!(report.match_stats.capacity_skipped, 1);
+    assert_eq!(report.match_stats.checkpoint_flushes, 4);
+}

--- a/src/transfer/engine/tests/capacity.rs
+++ b/src/transfer/engine/tests/capacity.rs
@@ -228,6 +228,66 @@ fn completed_provider_results_are_drained_in_frozen_source_order() {
 }
 
 #[test]
+fn committed_results_after_capacity_preserve_non_writing_outcomes() {
+    let existing = (0..crate::playlists::SONGS_PER_PLAYLIST_MAX - 1)
+        .map(|index| format!("existing-{index}"))
+        .collect::<HashSet<_>>();
+    let mut capacity_keys = Some(existing);
+    let mut capacity_skips = 0u32;
+    let mut cp = Checkpoint::new(
+        "job_committed_capacity_results".to_owned(),
+        spec(TransferDest::LocalPlaylist {
+            name: Some("Capacity".to_owned()),
+        }),
+        vec![
+            entry(input("Last slot", &["Artist"]), Some(matched("last-slot"))),
+            entry(
+                input("Not found", &["Artist"]),
+                Some(MatchOutcome::NotFound),
+            ),
+            entry(input("Overflow", &["Artist"]), Some(matched("overflow"))),
+            entry(input("Duplicate", &["Artist"]), Some(matched("last-slot"))),
+        ],
+    );
+
+    assert!(enforce_local_capacity_for_committed_entry(
+        &mut cp,
+        0,
+        &mut capacity_keys,
+        &mut capacity_skips
+    ));
+    assert!(enforce_local_capacity_for_committed_entry(
+        &mut cp,
+        1,
+        &mut capacity_keys,
+        &mut capacity_skips
+    ));
+    assert!(enforce_local_capacity_for_committed_entry(
+        &mut cp,
+        2,
+        &mut capacity_keys,
+        &mut capacity_skips
+    ));
+    assert!(enforce_local_capacity_for_committed_entry(
+        &mut cp,
+        3,
+        &mut capacity_keys,
+        &mut capacity_skips
+    ));
+
+    assert!(matches!(cp.tracks[1].outcome, Some(MatchOutcome::NotFound)));
+    assert!(matches!(
+        cp.tracks[2].outcome,
+        Some(MatchOutcome::SkippedCapacity)
+    ));
+    assert!(matches!(
+        cp.tracks[3].outcome,
+        Some(MatchOutcome::Matched { ref key, .. }) if key == "last-slot"
+    ));
+    assert_eq!(capacity_skips, 1);
+}
+
+#[test]
 fn local_destination_resolution_reuses_case_insensitive_name_and_prefers_id() {
     let mut store = crate::playlists::Playlists::default();
     let mix_id = store.create("Mix").expect("create Mix");

--- a/src/transfer/match_cache.rs
+++ b/src/transfer/match_cache.rs
@@ -4,19 +4,57 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use super::matching::{
-    MatchOutcome, MatchScoreBreakdown, TrackInput, normalize, normalize_stripped,
+    MatchConfig, MatchOutcome, MatchScoreBreakdown, TrackInput, normalize, normalize_stripped,
 };
 use crate::api::Song;
 use crate::api::ytmusic::{TransferAlbum, YoutubeSearchKind, YtdlpVideoMeta};
 use crate::util::safe_fs;
 
 const CACHE_SCHEMA_VERSION: u32 = 1;
-const MATCHER_VERSION: u32 = 2;
+const MATCHER_VERSION: u32 = 3;
 const CACHE_MAX_BYTES: u64 = 32 * 1024 * 1024;
+const MATCH_CACHE_TTL_SECS: i64 = 365 * 24 * 60 * 60;
+const ALBUM_CACHE_TTL_SECS: i64 = 180 * 24 * 60 * 60;
 const QUERY_CACHE_TTL_SECS: i64 = 30 * 24 * 60 * 60;
+const EMPTY_QUERY_CACHE_TTL_SECS: i64 = 30 * 60;
 const VIDEO_META_CACHE_TTL_SECS: i64 = 90 * 24 * 60 * 60;
+const SOURCE_KEY_CACHE_MAX: usize = 16_384;
+const ISRC_CACHE_MAX: usize = 16_384;
+const NORMALIZED_CACHE_MAX: usize = 16_384;
+const ALBUM_CACHE_MAX: usize = 1_024;
 const QUERY_CACHE_MAX: usize = 512;
 const VIDEO_META_CACHE_MAX: usize = 2048;
+const ALBUM_TRACKS_MAX: usize = 512;
+const QUERY_RESULT_SONGS_MAX: usize = 50;
+/// Keep insertion hot paths O(1) while retaining a strict bound at prune/save time.
+/// Once slack is exhausted, one bulk eviction amortizes the full-map ordering cost.
+const MATCH_CACHE_PRUNE_SLACK: usize = 256;
+const ALBUM_CACHE_PRUNE_SLACK: usize = 32;
+
+/// Counts records removed while making the on-disk cache safe to reuse and bounded.
+///
+/// Successfully empty query results use a short negative TTL. Failed provider/video lookups are
+/// never persisted as empty, so an outage cannot poison future imports.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct CacheMaintenanceStats {
+    pub expired: usize,
+    pub incompatible: usize,
+    pub capacity_evictions: usize,
+    pub size_evictions: usize,
+}
+
+impl CacheMaintenanceStats {
+    fn add(&mut self, other: Self) {
+        self.expired += other.expired;
+        self.incompatible += other.incompatible;
+        self.capacity_evictions += other.capacity_evictions;
+        self.size_evictions += other.size_evictions;
+    }
+
+    pub(crate) fn removed(self) -> usize {
+        self.expired + self.incompatible + self.capacity_evictions + self.size_evictions
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -29,6 +67,8 @@ pub(crate) struct TransferMatchCache {
     pub albums: HashMap<String, CachedAlbum>,
     pub query_results: HashMap<String, CachedQueryResult>,
     pub video_metadata: HashMap<String, CachedVideoMeta>,
+    #[serde(skip)]
+    maintenance: CacheMaintenanceStats,
 }
 
 impl Default for TransferMatchCache {
@@ -42,6 +82,7 @@ impl Default for TransferMatchCache {
             albums: HashMap::new(),
             query_results: HashMap::new(),
             video_metadata: HashMap::new(),
+            maintenance: CacheMaintenanceStats::default(),
         }
     }
 }
@@ -57,6 +98,10 @@ pub(crate) struct CachedMatch {
     pub duration_secs: Option<u32>,
     pub source_kind: Option<String>,
     pub quality_tier: Option<String>,
+    /// True only when selection also satisfied the default Strict provenance and margin.
+    /// Older entries default to false and cannot cross a policy boundary.
+    #[serde(default)]
+    pub policy_safe: bool,
     pub updated_at: i64,
 }
 
@@ -109,29 +154,39 @@ impl TransferMatchCache {
         let Some(path) = cache_path() else {
             return Self::default();
         };
-        let cache = safe_fs::load_json_or_default_limited::<Self>(&path, CACHE_MAX_BYTES);
+        let mut cache = safe_fs::load_json_or_default_limited::<Self>(&path, CACHE_MAX_BYTES);
         if cache.schema_version == CACHE_SCHEMA_VERSION && cache.matcher_version == MATCHER_VERSION
         {
+            let stats = cache.prune();
+            cache.maintenance.add(stats);
+            log_maintenance("load", stats);
             cache
         } else {
             Self::default()
         }
     }
 
-    pub fn save(&self) {
+    /// Persist a compact cache and return the accumulated maintenance. Pruning in place avoids
+    /// cloning a cache that may legitimately approach the 32 MiB disk ceiling.
+    pub fn save(&mut self) -> CacheMaintenanceStats {
+        let mut stats = self.maintenance;
+        stats.add(self.prune());
+        self.maintenance = CacheMaintenanceStats::default();
+        log_maintenance("save", stats);
         let Some(path) = cache_path() else {
-            return;
+            return stats;
         };
-        let mut cache = self.clone();
-        cache.prune();
-        if let Err(error) = safe_fs::write_private_atomic_json(&path, &cache) {
+        if let Err(error) = safe_fs::write_private_atomic_json(&path, self) {
             tracing::warn!(error = %error, "failed to save transfer match cache");
         }
+        stats
     }
 
     pub fn lookup_track(&self, input: &TrackInput) -> Option<CacheLookup> {
+        let now = crate::signals::unix_now();
         if !input.source_key.trim().is_empty()
             && let Some(hit) = self.source_key.get(&input.source_key)
+            && hit.is_fresh_policy_safe(now)
         {
             return Some(CacheLookup {
                 outcome: hit.outcome(),
@@ -140,6 +195,7 @@ impl TransferMatchCache {
         }
         if let Some(key) = isrc_key(input)
             && let Some(hit) = self.isrc.get(&key)
+            && hit.is_fresh_policy_safe(now)
         {
             return Some(CacheLookup {
                 outcome: hit.outcome(),
@@ -148,6 +204,7 @@ impl TransferMatchCache {
         }
         if let Some(key) = normalized_track_key(input)
             && let Some(hit) = self.normalized.get(&key)
+            && hit.is_fresh_policy_safe(now)
         {
             return Some(CacheLookup {
                 outcome: hit.outcome(),
@@ -155,6 +212,22 @@ impl TransferMatchCache {
             });
         }
         None
+    }
+
+    /// Drop accepted outcomes which cannot satisfy the current run's threshold. Match entries
+    /// are already restricted to policy-independent Strict-safe selections on write; this final
+    /// filter prevents a prior lower `min_score` from bypassing the current configuration.
+    pub fn retain_compatible_matches(&mut self, cfg: &MatchConfig) -> bool {
+        let now = crate::signals::unix_now();
+        let before = self.source_key.len() + self.isrc.len() + self.normalized.len();
+        let compatible =
+            |hit: &CachedMatch| hit.is_fresh_policy_safe(now) && hit.score >= cfg.accept;
+        self.source_key.retain(|_, hit| compatible(hit));
+        self.isrc.retain(|_, hit| compatible(hit));
+        self.normalized.retain(|_, hit| compatible(hit));
+        let removed = before - (self.source_key.len() + self.isrc.len() + self.normalized.len());
+        self.maintenance.incompatible += removed;
+        removed > 0
     }
 
     pub fn save_match(&mut self, input: &TrackInput, outcome: &MatchOutcome) {
@@ -165,23 +238,49 @@ impl TransferMatchCache {
         if !input.source_key.trim().is_empty() {
             self.source_key
                 .insert(input.source_key.clone(), cached.clone());
+            self.maintenance.capacity_evictions += prune_map_batched(
+                &mut self.source_key,
+                SOURCE_KEY_CACHE_MAX,
+                MATCH_CACHE_PRUNE_SLACK,
+                |hit| hit.updated_at,
+            );
         }
         if let Some(key) = isrc_key(input) {
             self.isrc.insert(key, cached.clone());
+            self.maintenance.capacity_evictions += prune_map_batched(
+                &mut self.isrc,
+                ISRC_CACHE_MAX,
+                MATCH_CACHE_PRUNE_SLACK,
+                |hit| hit.updated_at,
+            );
         }
         if let Some(key) = normalized_track_key(input) {
             self.normalized.insert(key, cached);
+            self.maintenance.capacity_evictions += prune_map_batched(
+                &mut self.normalized,
+                NORMALIZED_CACHE_MAX,
+                MATCH_CACHE_PRUNE_SLACK,
+                |hit| hit.updated_at,
+            );
         }
     }
 
     pub fn lookup_album(&self, key: &str) -> Option<&CachedAlbum> {
-        self.albums.get(key)
+        let now = crate::signals::unix_now();
+        self.albums
+            .get(key)
+            .filter(|album| !is_expired(album.updated_at, now, ALBUM_CACHE_TTL_SECS))
     }
 
     pub fn save_album(&mut self, key: String, album: &TransferAlbum) {
+        if key.trim().is_empty() || album.album_id.trim().is_empty() || album.tracks.is_empty() {
+            return;
+        }
         let tracks = album
             .tracks
             .iter()
+            .filter(|track| !track.video_id.trim().is_empty() && !track.title.trim().is_empty())
+            .take(ALBUM_TRACKS_MAX)
             .map(|track| CachedAlbumTrack {
                 video_id: track.video_id.clone(),
                 title: track.title.clone(),
@@ -190,7 +289,10 @@ impl TransferMatchCache {
                 track_number: track.track_number,
                 duration_secs: track.duration_secs,
             })
-            .collect();
+            .collect::<Vec<_>>();
+        if tracks.is_empty() {
+            return;
+        }
         self.albums.insert(
             key,
             CachedAlbum {
@@ -202,20 +304,33 @@ impl TransferMatchCache {
                 updated_at: crate::signals::unix_now(),
             },
         );
+        self.maintenance.capacity_evictions += prune_map_batched(
+            &mut self.albums,
+            ALBUM_CACHE_MAX,
+            ALBUM_CACHE_PRUNE_SLACK,
+            |album| album.updated_at,
+        );
     }
 
     pub fn query_cache_entries(&self) -> Vec<(String, Vec<(Song, YoutubeSearchKind)>)> {
         let now = crate::signals::unix_now();
         self.query_results
             .iter()
-            .filter(|(_, cached)| !is_expired(cached.updated_at, now, QUERY_CACHE_TTL_SECS))
-            .filter_map(|(key, cached)| {
+            .filter(|(_, cached)| {
+                let ttl = if cached.songs.is_empty() {
+                    EMPTY_QUERY_CACHE_TTL_SECS
+                } else {
+                    QUERY_CACHE_TTL_SECS
+                };
+                !is_expired(cached.updated_at, now, ttl)
+            })
+            .map(|(key, cached)| {
                 let songs = cached
                     .songs
                     .iter()
                     .map(|entry| (entry.song.clone(), entry.kind))
                     .collect::<Vec<_>>();
-                (!songs.is_empty()).then(|| (key.clone(), songs))
+                (key.clone(), songs)
             })
             .collect()
     }
@@ -237,11 +352,12 @@ impl TransferMatchCache {
         let now = crate::signals::unix_now();
         let mut changed = false;
         for (key, songs) in queries {
-            if key.trim().is_empty() || songs.is_empty() {
+            if key.trim().is_empty() {
                 continue;
             }
             let songs = songs
                 .into_iter()
+                .take(QUERY_RESULT_SONGS_MAX)
                 .map(|(song, kind)| CachedQuerySong { song, kind })
                 .collect::<Vec<_>>();
             self.query_results.insert(
@@ -267,19 +383,78 @@ impl TransferMatchCache {
             changed = true;
         }
         if changed {
-            self.prune();
+            let stats = self.prune();
+            self.maintenance.add(stats);
+            log_maintenance("merge", stats);
         }
         changed
     }
 
-    fn prune(&mut self) {
+    pub(crate) fn prune(&mut self) -> CacheMaintenanceStats {
         let now = crate::signals::unix_now();
-        self.query_results
-            .retain(|_, cached| !is_expired(cached.updated_at, now, QUERY_CACHE_TTL_SECS));
-        self.video_metadata
-            .retain(|_, cached| !is_expired(cached.updated_at, now, VIDEO_META_CACHE_TTL_SECS));
-        prune_query_map(&mut self.query_results, QUERY_CACHE_MAX);
-        prune_video_map(&mut self.video_metadata, VIDEO_META_CACHE_MAX);
+        let mut stats = CacheMaintenanceStats::default();
+        stats.add(prune_match_entries(
+            &mut self.source_key,
+            now,
+            SOURCE_KEY_CACHE_MAX,
+        ));
+        stats.add(prune_match_entries(&mut self.isrc, now, ISRC_CACHE_MAX));
+        stats.add(prune_match_entries(
+            &mut self.normalized,
+            now,
+            NORMALIZED_CACHE_MAX,
+        ));
+        stats.add(prune_album_entries(&mut self.albums, now, ALBUM_CACHE_MAX));
+        stats.add(prune_query_entries(
+            &mut self.query_results,
+            now,
+            QUERY_CACHE_MAX,
+        ));
+        stats.add(prune_video_entries(
+            &mut self.video_metadata,
+            now,
+            VIDEO_META_CACHE_MAX,
+        ));
+        stats.size_evictions += self.prune_to_serialized_size(CACHE_MAX_BYTES as usize);
+        stats
+    }
+
+    fn prune_to_serialized_size(&mut self, max_bytes: usize) -> usize {
+        let mut evicted = 0;
+        loop {
+            let Ok(json) = serde_json::to_vec_pretty(self) else {
+                return evicted;
+            };
+            if json.len() <= max_bytes {
+                return evicted;
+            }
+
+            let mut candidates = eviction_candidates(self);
+            if candidates.is_empty() {
+                return evicted;
+            }
+            candidates.sort_by(|left, right| {
+                (left.updated_at, left.kind, left.key.as_str()).cmp(&(
+                    right.updated_at,
+                    right.kind,
+                    right.key.as_str(),
+                ))
+            });
+
+            // Remove approximately the excess fraction, then measure again. This avoids one
+            // full-cache serialization per record while still evicting strictly oldest-first.
+            let excess = json.len().saturating_sub(max_bytes);
+            let remove_count = candidates
+                .len()
+                .saturating_mul(excess)
+                .div_ceil(json.len())
+                .max(1);
+            for candidate in candidates.into_iter().take(remove_count) {
+                if remove_candidate(self, &candidate) {
+                    evicted += 1;
+                }
+            }
+        }
     }
 }
 
@@ -298,7 +473,16 @@ impl CachedMatch {
         else {
             return None;
         };
-        let breakdown = score_breakdown.as_deref();
+        let breakdown = score_breakdown.as_deref()?;
+        if breakdown.accept_blocked
+            || breakdown.reject_reason.is_some()
+            || !breakdown
+                .reason_codes
+                .iter()
+                .any(|reason| reason == "policy_safe_cache")
+        {
+            return None;
+        }
         Some(Self {
             ytm_video_id: key.clone(),
             score: *score,
@@ -307,10 +491,29 @@ impl CachedMatch {
             artist: artist.clone(),
             album: album.clone(),
             duration_secs: *duration_secs,
-            source_kind: breakdown.map(|score| score.source_kind.clone()),
-            quality_tier: breakdown.map(|score| score.quality_tier.clone()),
+            source_kind: Some(breakdown.source_kind.clone()),
+            quality_tier: Some(breakdown.quality_tier.clone()),
+            policy_safe: true,
             updated_at: crate::signals::unix_now(),
         })
+    }
+
+    fn is_policy_safe(&self) -> bool {
+        if !self.policy_safe || !self.score.is_finite() {
+            return false;
+        }
+        match self.source_kind.as_deref() {
+            Some("ytm_album_track" | "ytm_catalog_song" | "spotify_catalog") => true,
+            Some("ytm_catalog_video" | "youtube_video_search" | "unknown") => matches!(
+                self.quality_tier.as_deref(),
+                Some("trusted_official" | "official_like")
+            ),
+            _ => false,
+        }
+    }
+
+    fn is_fresh_policy_safe(&self, now: i64) -> bool {
+        self.is_policy_safe() && !is_expired(self.updated_at, now, MATCH_CACHE_TTL_SECS)
     }
 
     fn outcome(&self) -> MatchOutcome {
@@ -373,47 +576,246 @@ fn isrc_key(input: &TrackInput) -> Option<String> {
 }
 
 fn normalized_track_key(input: &TrackInput) -> Option<String> {
-    let title = normalize_stripped(&input.title);
-    let artist = input.artists.first().map(|artist| normalize(artist))?;
-    if title.is_empty() || artist.is_empty() {
+    let title = normalize(&input.title);
+    let stripped_title = normalize_stripped(&input.title);
+    let artists = input
+        .artists
+        .iter()
+        .map(|artist| normalize(artist))
+        .collect::<Vec<_>>()
+        .join("\u{1f}");
+    if title.is_empty() || stripped_title.is_empty() || artists.is_empty() {
         return None;
     }
+    let album = input.album.as_deref().map(normalize).unwrap_or_default();
     let duration = input
         .duration_secs
         .map(|duration| duration.to_string())
         .unwrap_or_default();
-    Some(format!("{artist}|{title}|{duration}"))
+    let disc = input
+        .disc_number
+        .map(|disc| disc.to_string())
+        .unwrap_or_default();
+    let track = input
+        .track_number
+        .map(|track| track.to_string())
+        .unwrap_or_default();
+    Some(format!(
+        "artists={artists}|title={title}|stripped={stripped_title}|album={album}|duration={duration}|disc={disc}|track={track}"
+    ))
 }
 
 fn is_expired(updated_at: i64, now: i64, ttl_secs: i64) -> bool {
     updated_at <= 0 || now.saturating_sub(updated_at) > ttl_secs
 }
 
-fn prune_query_map(map: &mut HashMap<String, CachedQueryResult>, max_entries: usize) {
-    if map.len() <= max_entries {
-        return;
+fn prune_oldest<T>(
+    map: &mut HashMap<String, T>,
+    max_entries: usize,
+    updated_at: impl Fn(&T) -> i64,
+) -> usize {
+    let remove_count = map.len().saturating_sub(max_entries);
+    if remove_count == 0 {
+        return 0;
     }
     let mut entries = map
         .iter()
-        .map(|(key, cached)| (cached.updated_at, key.clone()))
+        .map(|(key, cached)| (updated_at(cached), key.clone()))
         .collect::<Vec<_>>();
-    entries.sort_by_key(|(updated_at, _)| *updated_at);
-    for (_, key) in entries.into_iter().take(map.len() - max_entries) {
+    entries.sort();
+    for (_, key) in entries.into_iter().take(remove_count) {
         map.remove(&key);
+    }
+    remove_count
+}
+
+fn prune_map_batched<T>(
+    map: &mut HashMap<String, T>,
+    max_entries: usize,
+    slack: usize,
+    updated_at: impl Fn(&T) -> i64,
+) -> usize {
+    if map.len() <= max_entries.saturating_add(slack) {
+        return 0;
+    }
+    prune_oldest(map, max_entries, updated_at)
+}
+
+fn prune_match_map(map: &mut HashMap<String, CachedMatch>, max_entries: usize) -> usize {
+    prune_oldest(map, max_entries, |cached| cached.updated_at)
+}
+
+fn prune_album_map(map: &mut HashMap<String, CachedAlbum>, max_entries: usize) -> usize {
+    prune_oldest(map, max_entries, |cached| cached.updated_at)
+}
+
+fn prune_match_entries(
+    map: &mut HashMap<String, CachedMatch>,
+    now: i64,
+    max_entries: usize,
+) -> CacheMaintenanceStats {
+    let mut stats = CacheMaintenanceStats::default();
+    map.retain(|key, cached| {
+        if is_expired(cached.updated_at, now, MATCH_CACHE_TTL_SECS) {
+            stats.expired += 1;
+            false
+        } else if key.trim().is_empty()
+            || cached.ytm_video_id.trim().is_empty()
+            || !cached.is_policy_safe()
+        {
+            stats.incompatible += 1;
+            false
+        } else {
+            true
+        }
+    });
+    stats.capacity_evictions += prune_match_map(map, max_entries);
+    stats
+}
+
+fn prune_album_entries(
+    map: &mut HashMap<String, CachedAlbum>,
+    now: i64,
+    max_entries: usize,
+) -> CacheMaintenanceStats {
+    let mut stats = CacheMaintenanceStats::default();
+    map.retain(|key, cached| {
+        if is_expired(cached.updated_at, now, ALBUM_CACHE_TTL_SECS) {
+            stats.expired += 1;
+            return false;
+        }
+        cached.tracks.retain(|track| {
+            let compatible = !track.video_id.trim().is_empty() && !track.title.trim().is_empty();
+            if !compatible {
+                stats.incompatible += 1;
+            }
+            compatible
+        });
+        if cached.tracks.len() > ALBUM_TRACKS_MAX {
+            stats.capacity_evictions += cached.tracks.len() - ALBUM_TRACKS_MAX;
+            cached.tracks.truncate(ALBUM_TRACKS_MAX);
+        }
+        if key.trim().is_empty()
+            || cached.ytm_album_id.trim().is_empty()
+            || cached.tracks.is_empty()
+        {
+            stats.incompatible += 1;
+            false
+        } else {
+            true
+        }
+    });
+    stats.capacity_evictions += prune_album_map(map, max_entries);
+    stats
+}
+
+fn prune_query_entries(
+    map: &mut HashMap<String, CachedQueryResult>,
+    now: i64,
+    max_entries: usize,
+) -> CacheMaintenanceStats {
+    let mut stats = CacheMaintenanceStats::default();
+    map.retain(|key, cached| {
+        let ttl = if cached.songs.is_empty() {
+            EMPTY_QUERY_CACHE_TTL_SECS
+        } else {
+            QUERY_CACHE_TTL_SECS
+        };
+        if is_expired(cached.updated_at, now, ttl) {
+            stats.expired += 1;
+            return false;
+        }
+        if cached.songs.len() > QUERY_RESULT_SONGS_MAX {
+            stats.capacity_evictions += cached.songs.len() - QUERY_RESULT_SONGS_MAX;
+            cached.songs.truncate(QUERY_RESULT_SONGS_MAX);
+        }
+        if key.trim().is_empty() {
+            stats.incompatible += 1;
+            false
+        } else {
+            true
+        }
+    });
+    stats.capacity_evictions += prune_oldest(map, max_entries, |cached| cached.updated_at);
+    stats
+}
+
+fn prune_video_entries(
+    map: &mut HashMap<String, CachedVideoMeta>,
+    now: i64,
+    max_entries: usize,
+) -> CacheMaintenanceStats {
+    let mut stats = CacheMaintenanceStats::default();
+    map.retain(|key, cached| {
+        if is_expired(cached.updated_at, now, VIDEO_META_CACHE_TTL_SECS) {
+            stats.expired += 1;
+            false
+        } else if key.trim().is_empty() {
+            stats.incompatible += 1;
+            false
+        } else {
+            true
+        }
+    });
+    stats.capacity_evictions += prune_oldest(map, max_entries, |cached| cached.updated_at);
+    stats
+}
+
+#[derive(Debug)]
+struct EvictionCandidate {
+    updated_at: i64,
+    kind: u8,
+    key: String,
+}
+
+fn eviction_candidates(cache: &TransferMatchCache) -> Vec<EvictionCandidate> {
+    let total = cache.source_key.len()
+        + cache.isrc.len()
+        + cache.normalized.len()
+        + cache.albums.len()
+        + cache.query_results.len()
+        + cache.video_metadata.len();
+    let mut candidates = Vec::with_capacity(total);
+    macro_rules! extend_candidates {
+        ($map:expr, $kind:expr) => {
+            candidates.extend($map.iter().map(|(key, cached)| EvictionCandidate {
+                updated_at: cached.updated_at,
+                kind: $kind,
+                key: key.clone(),
+            }));
+        };
+    }
+    extend_candidates!(&cache.source_key, 0);
+    extend_candidates!(&cache.isrc, 1);
+    extend_candidates!(&cache.normalized, 2);
+    extend_candidates!(&cache.albums, 3);
+    extend_candidates!(&cache.query_results, 4);
+    extend_candidates!(&cache.video_metadata, 5);
+    candidates
+}
+
+fn remove_candidate(cache: &mut TransferMatchCache, candidate: &EvictionCandidate) -> bool {
+    match candidate.kind {
+        0 => cache.source_key.remove(&candidate.key).is_some(),
+        1 => cache.isrc.remove(&candidate.key).is_some(),
+        2 => cache.normalized.remove(&candidate.key).is_some(),
+        3 => cache.albums.remove(&candidate.key).is_some(),
+        4 => cache.query_results.remove(&candidate.key).is_some(),
+        5 => cache.video_metadata.remove(&candidate.key).is_some(),
+        _ => false,
     }
 }
 
-fn prune_video_map(map: &mut HashMap<String, CachedVideoMeta>, max_entries: usize) {
-    if map.len() <= max_entries {
-        return;
-    }
-    let mut entries = map
-        .iter()
-        .map(|(key, cached)| (cached.updated_at, key.clone()))
-        .collect::<Vec<_>>();
-    entries.sort_by_key(|(updated_at, _)| *updated_at);
-    for (_, key) in entries.into_iter().take(map.len() - max_entries) {
-        map.remove(&key);
+fn log_maintenance(operation: &'static str, stats: CacheMaintenanceStats) {
+    if stats.removed() > 0 {
+        tracing::debug!(
+            operation,
+            expired = stats.expired,
+            incompatible = stats.incompatible,
+            capacity_evictions = stats.capacity_evictions,
+            size_evictions = stats.size_evictions,
+            "maintained transfer match cache"
+        );
     }
 }
 
@@ -465,6 +867,7 @@ mod tests {
                 quality_tier: "catalog".to_owned(),
                 total: 0.96,
                 raw_total: 0.96,
+                reason_codes: vec!["policy_safe_cache".to_owned()],
                 ..MatchScoreBreakdown::default()
             })),
         }
@@ -480,6 +883,7 @@ mod tests {
             was_live: None,
             media_type: None,
             description: None,
+            ..YtdlpVideoMeta::default()
         }
     }
 
@@ -505,6 +909,273 @@ mod tests {
     }
 
     #[test]
+    fn track_cache_refuses_non_policy_safe_or_generic_matches() {
+        let input = input("Song", "Artist");
+        let mut unsafe_outcome = matched();
+        if let MatchOutcome::Matched {
+            score_breakdown: Some(score),
+            ..
+        } = &mut unsafe_outcome
+        {
+            score.reason_codes.clear();
+        } else {
+            panic!("test match should contain a score breakdown");
+        }
+
+        let mut cache = TransferMatchCache::default();
+        cache.save_match(&input, &unsafe_outcome);
+        assert!(cache.lookup_track(&input).is_none());
+
+        if let MatchOutcome::Matched {
+            score_breakdown: Some(score),
+            ..
+        } = &mut unsafe_outcome
+        {
+            score.reason_codes.push("policy_safe_cache".to_owned());
+            score.source_kind = "youtube_video_search".to_owned();
+            score.quality_tier = "unverified_upload".to_owned();
+        }
+        cache.save_match(&input, &unsafe_outcome);
+        assert!(cache.lookup_track(&input).is_none());
+    }
+
+    #[test]
+    fn current_accept_threshold_invalidates_lower_scored_cached_match() {
+        let input = input("Song", "Artist");
+        let mut cache = TransferMatchCache::default();
+        cache.save_match(&input, &matched());
+        assert!(cache.lookup_track(&input).is_some());
+
+        let cfg = MatchConfig {
+            accept: 0.99,
+            ..MatchConfig::default()
+        };
+        assert!(cache.retain_compatible_matches(&cfg));
+        assert!(cache.lookup_track(&input).is_none());
+    }
+
+    #[test]
+    fn successful_mapping_is_long_lived_but_expired_entries_never_hit() {
+        let input = input("Song", "Artist");
+        let mut cache = TransferMatchCache::default();
+        cache.save_match(&input, &matched());
+
+        let stale = crate::signals::unix_now() - MATCH_CACHE_TTL_SECS - 1;
+        for cached in cache.source_key.values_mut() {
+            cached.updated_at = stale;
+        }
+        for cached in cache.isrc.values_mut() {
+            cached.updated_at = stale;
+        }
+        for cached in cache.normalized.values_mut() {
+            cached.updated_at = stale;
+        }
+
+        assert!(cache.lookup_track(&input).is_none());
+        let stats = cache.prune();
+        assert_eq!(stats.expired, 2);
+        assert!(cache.source_key.is_empty());
+        assert!(cache.normalized.is_empty());
+    }
+
+    #[test]
+    fn pruning_all_maps_is_deterministic_for_equal_timestamps() {
+        let now = crate::signals::unix_now();
+        let base = CachedMatch::from_outcome(&matched()).expect("safe match");
+        let mut matches = HashMap::new();
+        for key in ["c", "a", "b"] {
+            matches.insert(
+                key.to_owned(),
+                CachedMatch {
+                    updated_at: now,
+                    ..base.clone()
+                },
+            );
+        }
+        assert_eq!(prune_match_map(&mut matches, 2), 1);
+        assert!(!matches.contains_key("a"));
+
+        let mut albums = HashMap::new();
+        for key in ["c", "a", "b"] {
+            albums.insert(
+                key.to_owned(),
+                CachedAlbum {
+                    ytm_album_id: format!("album-{key}"),
+                    title: "Album".to_owned(),
+                    artist: "Artist".to_owned(),
+                    year: Some("2024".to_owned()),
+                    tracks: vec![CachedAlbumTrack {
+                        video_id: format!("video-{key}"),
+                        title: "Song".to_owned(),
+                        artist: "Artist".to_owned(),
+                        album: "Album".to_owned(),
+                        track_number: Some(1),
+                        duration_secs: Some(180),
+                    }],
+                    updated_at: now,
+                },
+            );
+        }
+        assert_eq!(prune_album_map(&mut albums, 2), 1);
+        assert!(!albums.contains_key("a"));
+    }
+
+    #[test]
+    fn incremental_pruning_uses_bounded_slack_then_evicts_in_bulk() {
+        let mut entries = (0..4)
+            .map(|index| (format!("key-{index}"), index as i64))
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(prune_map_batched(&mut entries, 2, 2, |updated| *updated), 0);
+        assert_eq!(entries.len(), 4);
+
+        entries.insert("key-4".to_owned(), 4);
+        assert_eq!(prune_map_batched(&mut entries, 2, 2, |updated| *updated), 3);
+        assert_eq!(entries.len(), 2);
+        assert!(entries.contains_key("key-3"));
+        assert!(entries.contains_key("key-4"));
+    }
+
+    #[test]
+    fn save_match_uses_bounded_slack_then_bulk_prunes_real_cache_maps() {
+        let mut cache = TransferMatchCache::default();
+        let outcome = matched();
+        for index in 0..SOURCE_KEY_CACHE_MAX + MATCH_CACHE_PRUNE_SLACK {
+            let mut source = input(&format!("Song {index}"), "Artist");
+            source.source_key = format!("spotify:track:{index}");
+            cache.save_match(&source, &outcome);
+        }
+        assert_eq!(
+            cache.source_key.len(),
+            SOURCE_KEY_CACHE_MAX + MATCH_CACHE_PRUNE_SLACK
+        );
+        assert_eq!(
+            cache.normalized.len(),
+            NORMALIZED_CACHE_MAX + MATCH_CACHE_PRUNE_SLACK
+        );
+        assert_eq!(cache.maintenance.capacity_evictions, 0);
+
+        let mut source = input("Song overflow", "Artist");
+        source.source_key = "spotify:track:overflow".to_owned();
+        cache.save_match(&source, &outcome);
+
+        assert_eq!(cache.source_key.len(), SOURCE_KEY_CACHE_MAX);
+        assert_eq!(cache.normalized.len(), NORMALIZED_CACHE_MAX);
+        assert_eq!(
+            cache.maintenance.capacity_evictions,
+            2 * (MATCH_CACHE_PRUNE_SLACK + 1)
+        );
+    }
+
+    #[test]
+    fn prune_removes_incompatible_and_expired_records_from_every_map() {
+        let now = crate::signals::unix_now();
+        let stale_match = now - MATCH_CACHE_TTL_SECS - 1;
+        let stale_album = now - ALBUM_CACHE_TTL_SECS - 1;
+        let mut cache = TransferMatchCache::default();
+        let mut cached_match = CachedMatch::from_outcome(&matched()).expect("safe match");
+        cached_match.updated_at = stale_match;
+        cache.source_key.insert("old".to_owned(), cached_match);
+        cache.albums.insert(
+            "old".to_owned(),
+            CachedAlbum {
+                ytm_album_id: "album".to_owned(),
+                title: "Album".to_owned(),
+                artist: "Artist".to_owned(),
+                year: None,
+                tracks: vec![CachedAlbumTrack {
+                    video_id: "video".to_owned(),
+                    title: "Song".to_owned(),
+                    artist: "Artist".to_owned(),
+                    album: "Album".to_owned(),
+                    track_number: Some(1),
+                    duration_secs: Some(180),
+                }],
+                updated_at: stale_album,
+            },
+        );
+        cache.query_results.insert(
+            " ".to_owned(),
+            CachedQueryResult {
+                songs: Vec::new(),
+                updated_at: now,
+            },
+        );
+        cache.video_metadata.insert(
+            String::new(),
+            CachedVideoMeta {
+                meta: video_meta(),
+                updated_at: now,
+            },
+        );
+
+        let stats = cache.prune();
+
+        assert_eq!(stats.expired, 2);
+        assert_eq!(stats.incompatible, 2);
+        assert_eq!(stats.removed(), 4);
+        assert!(cache.source_key.is_empty());
+        assert!(cache.albums.is_empty());
+        assert!(cache.query_results.is_empty());
+        assert!(cache.video_metadata.is_empty());
+    }
+
+    #[test]
+    fn serialized_size_cap_evicts_oldest_records_until_bounded() {
+        let now = crate::signals::unix_now();
+        let base = CachedMatch::from_outcome(&matched()).expect("safe match");
+        let mut cache = TransferMatchCache::default();
+        for idx in 0..6 {
+            cache.source_key.insert(
+                format!("source-{idx}"),
+                CachedMatch {
+                    display: "x".repeat(2_000),
+                    updated_at: now + idx,
+                    ..base.clone()
+                },
+            );
+        }
+
+        let evicted = cache.prune_to_serialized_size(4_000);
+        let bytes = serde_json::to_vec_pretty(&cache).expect("serialize bounded cache");
+
+        assert!(evicted > 0);
+        assert!(bytes.len() <= 4_000);
+        assert!(!cache.source_key.contains_key("source-0"));
+        assert!(cache.source_key.contains_key("source-5"));
+    }
+
+    #[test]
+    fn top_level_cache_schema_defaults_newer_maps_for_older_json() {
+        let cache: TransferMatchCache = serde_json::from_str(&format!(
+            r#"{{"schema_version":{CACHE_SCHEMA_VERSION},"matcher_version":{MATCHER_VERSION}}}"#
+        ))
+        .expect("deserialize sparse prior cache schema");
+
+        assert!(cache.source_key.is_empty());
+        assert!(cache.albums.is_empty());
+        assert!(cache.query_results.is_empty());
+        assert!(cache.video_metadata.is_empty());
+    }
+
+    #[test]
+    fn normalized_cache_identity_preserves_versions_album_and_artist_order() {
+        let base = input("Song", "Artist");
+
+        let mut version = base.clone();
+        version.title = "Song (Instrumental)".to_owned();
+        assert_ne!(normalized_track_key(&base), normalized_track_key(&version));
+
+        let mut album = base.clone();
+        album.album = Some("Other Album".to_owned());
+        assert_ne!(normalized_track_key(&base), normalized_track_key(&album));
+
+        let mut artists = base.clone();
+        artists.artists = vec!["Guest".to_owned(), "Artist".to_owned()];
+        assert_ne!(normalized_track_key(&base), normalized_track_key(&artists));
+    }
+
+    #[test]
     fn album_key_prefers_spotify_album_id_and_falls_back_to_identity() {
         let mut with_id = input("Song", "Artist");
         with_id.album_id = Some("sp-album".to_owned());
@@ -522,12 +1193,12 @@ mod tests {
     }
 
     #[test]
-    fn query_cache_persists_positive_results_and_ignores_empty_results() {
+    fn query_cache_persists_positive_and_short_lived_empty_results() {
         let mut cache = TransferMatchCache::default();
         let song = Song::from_search("video-id", "Song", "Artist", "3:00", Some("Album".into()));
 
-        assert!(!cache.merge_query_cache(vec![("catalog:empty".to_owned(), Vec::new())], vec![]));
-        assert!(cache.query_cache_entries().is_empty());
+        assert!(cache.merge_query_cache(vec![("catalog:empty".to_owned(), Vec::new())], vec![]));
+        assert_eq!(cache.query_cache_entries().len(), 1);
 
         assert!(cache.merge_query_cache(
             vec![(
@@ -537,14 +1208,22 @@ mod tests {
             vec![],
         ));
         let entries = cache.query_cache_entries();
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].0, "catalog:artist song");
-        assert_eq!(entries[0].1[0].0.video_id, "video-id");
-        assert_eq!(entries[0].1[0].1, YoutubeSearchKind::YtmCatalogSong);
+        assert_eq!(entries.len(), 2);
+        let positive = entries
+            .iter()
+            .find(|(key, _)| key == "catalog:artist song")
+            .expect("positive entry");
+        assert_eq!(positive.1[0].0.video_id, "video-id");
+        assert_eq!(positive.1[0].1, YoutubeSearchKind::YtmCatalogSong);
 
         cache
             .query_results
             .get_mut("catalog:artist song")
+            .unwrap()
+            .updated_at = 1;
+        cache
+            .query_results
+            .get_mut("catalog:empty")
             .unwrap()
             .updated_at = 1;
         assert!(cache.query_cache_entries().is_empty());

--- a/src/transfer/matching.rs
+++ b/src/transfer/matching.rs
@@ -6,11 +6,12 @@
 //! are compared as the max over (full, annotation-stripped) forms, so dual-script names
 //! like `"TT (티티)"` match either half.
 //!
-//! Scoring: title 0.55 + artist 0.30 + duration 0.15, plus a 0.05 album bonus as the
-//! remaster-vs-original tie-breaker. Accept ≥ 0.80; 0.60..0.80 is reported as ambiguous
-//! (top 3 candidates) rather than silently guessed.
+//! Scoring is bounded to 1.0 and combines title, primary-artist identity, featured-artist
+//! coverage, duration, album/release year, requested version, and track position. Policy
+//! gates are symmetric: covers, karaoke/instrumental, live/remix, edit/remaster, language,
+//! and low-quality evidence can force review or rejection even when text similarity is high.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 use unicode_normalization::UnicodeNormalization;
@@ -22,7 +23,9 @@ use crate::streaming::musicgate;
 
 use super::MatchPolicy;
 
+mod identity;
 mod ytm_retrieval;
+use identity::{CandidateDisposition, disposition, parse_version_profile, version_agreement};
 pub(crate) use ytm_retrieval::YtmMatchDiagnostics;
 pub use ytm_retrieval::{
     Pacing, memo_key, ytm_catalog_query_plan, ytm_fallback_query_plan, ytm_query_plan,
@@ -141,6 +144,9 @@ pub enum CandidateSourceKind {
     Unknown,
     YtmAlbumTrack,
     YtmCatalogSong,
+    /// Music-scoped video-filter result. This is better retrieval provenance than a
+    /// generic public search, but is not by itself proof of an official artist upload.
+    YtmCatalogVideo,
     YoutubeVideoSearch,
     SpotifyCatalog,
 }
@@ -149,6 +155,7 @@ impl From<YoutubeSearchKind> for CandidateSourceKind {
     fn from(kind: YoutubeSearchKind) -> Self {
         match kind {
             YoutubeSearchKind::YtmCatalogSong => Self::YtmCatalogSong,
+            YoutubeSearchKind::YtmCatalogVideo => Self::YtmCatalogVideo,
             YoutubeSearchKind::YoutubeVideoSearch => Self::YoutubeVideoSearch,
         }
     }
@@ -164,9 +171,23 @@ pub struct MatchCandidate {
     pub album: Option<String>,
     pub duration_secs: Option<u32>,
     pub track_number: Option<u32>,
+    /// Structured metadata when the destination provider exposes it.  Search surfaces
+    /// that omit these fields leave them unknown rather than inferring them from noise.
+    pub release_year: Option<u16>,
+    pub explicit: Option<bool>,
     pub source_kind: CandidateSourceKind,
     pub channel: Option<String>,
+    pub channel_id: Option<String>,
+    /// Provider verification is corroboration only; it is not OAC/official-upload proof.
+    pub channel_verified: Option<bool>,
+    pub availability: Option<String>,
+    pub has_audio_format: Option<bool>,
+    pub max_audio_bitrate_kbps: Option<f64>,
     pub isrc: Option<String>,
+    /// Canonical title returned by full video metadata. Flat public-search rows can expose
+    /// a translated title while this contains the uploader's native title; scoring keeps
+    /// both independent identity signals instead of overwriting either one.
+    pub(crate) metadata_title: Option<String>,
     pub(crate) preflighted: bool,
     pub(crate) preflight_reject_reason: Option<String>,
     pub(crate) preflight_reason_codes: Vec<String>,
@@ -189,9 +210,17 @@ impl MatchCandidate {
                 .duration_secs
                 .or_else(|| crate::streaming::candidate::parse_duration_secs(&s.duration)),
             track_number: s.track_number,
+            release_year: None,
+            explicit: None,
             source_kind,
             channel: Some(s.artist.clone()).filter(|a| !a.trim().is_empty()),
+            channel_id: None,
+            channel_verified: None,
+            availability: None,
+            has_audio_format: None,
+            max_audio_bitrate_kbps: None,
             isrc: s.isrc.clone(),
+            metadata_title: None,
             preflighted: false,
             preflight_reject_reason: None,
             preflight_reason_codes: Vec::new(),
@@ -208,9 +237,21 @@ impl From<&SpotifyTrack> for MatchCandidate {
             album: Some(t.album.clone()).filter(|a| !a.is_empty()),
             duration_secs: Some(t.duration_ms / 1000).filter(|d| *d > 0),
             track_number: t.track_number,
+            release_year: t
+                .album_release_date
+                .as_deref()
+                .and_then(|date| date.get(0..4))
+                .and_then(|year| year.parse::<u16>().ok()),
+            explicit: Some(t.explicit),
             source_kind: CandidateSourceKind::SpotifyCatalog,
             channel: None,
+            channel_id: None,
+            channel_verified: None,
+            availability: None,
+            has_audio_format: None,
+            max_audio_bitrate_kbps: None,
             isrc: t.isrc.clone(),
+            metadata_title: None,
             preflighted: false,
             preflight_reject_reason: None,
             preflight_reason_codes: Vec::new(),
@@ -243,6 +284,8 @@ pub enum MatchOutcome {
     NotFound,
     /// Spotify local file / episode — never searched.
     SkippedLocal,
+    /// Destination capacity became certain before this row needed matching.
+    SkippedCapacity,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -288,13 +331,25 @@ pub struct MatchScoreBreakdown {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duration_delta_secs: Option<i32>,
     pub title: f32,
+    /// Primary-artist agreement. `artist` is retained for checkpoint/report
+    /// compatibility and carries the same value.
     pub artist: f32,
+    #[serde(default)]
+    pub artist_coverage: f32,
     pub duration: f32,
+    #[serde(default)]
+    pub album_year: f32,
+    #[serde(default)]
+    pub version_agreement: f32,
+    #[serde(default)]
+    pub evidence_completeness: f32,
     pub album_bonus: f32,
     #[serde(default)]
     pub track_number_bonus: f32,
     #[serde(default)]
     pub quality_bonus: f32,
+    #[serde(default)]
+    pub corroboration_bonus: f32,
     #[serde(default)]
     pub identity_penalty: f32,
     #[serde(default)]
@@ -565,12 +620,20 @@ fn token_set_similarity(a: &str, b: &str) -> f32 {
 }
 
 fn title_similarity(input: &TrackInput, cand: &MatchCandidate) -> f32 {
+    let search_title = title_similarity_text(input, &cand.title);
+    cand.metadata_title
+        .as_deref()
+        .map(|title| search_title.max(title_similarity_text(input, title)))
+        .unwrap_or(search_title)
+}
+
+fn title_similarity_text(input: &TrackInput, candidate_title: &str) -> f32 {
     let input_stripped = normalize_stripped(&input.title);
-    let cand_stripped = normalize_stripped(&cand.title);
-    let full = similarity(&normalize(&input.title), &normalize(&cand.title));
+    let cand_stripped = normalize_stripped(candidate_title);
+    let full = similarity(&normalize(&input.title), &normalize(candidate_title));
     let stripped = similarity(&input_stripped, &cand_stripped);
-    let tokens = token_set_similarity(&input.title, &cand.title)
-        .max(token_sort_similarity(&input.title, &cand.title));
+    let tokens = token_set_similarity(&input.title, candidate_title)
+        .max(token_sort_similarity(&input.title, candidate_title));
     let mut best = full.max(stripped).max(tokens);
 
     let mut without_artists = format!(" {cand_stripped} ");
@@ -596,9 +659,25 @@ fn title_similarity(input: &TrackInput, cand: &MatchCandidate) -> f32 {
             0.0
         }
     };
-    let cand_clean = strip_video_noise(&normalize(&strip_annotations(&cand.title)));
-    best.max(contain(&input_stripped, &cand_clean))
-        .max(contain(&cand_stripped, &input_stripped))
+    let cand_clean = strip_video_noise(&normalize(&strip_annotations(candidate_title)));
+    best = best
+        .max(contain(&input_stripped, &cand_clean))
+        .max(contain(&cand_stripped, &input_stripped));
+
+    // Full YouTube metadata commonly uses `native artist - native title`, while Spotify may
+    // spell the artist in another script. Compare the structured suffix directly instead of
+    // requiring the source spelling to be removable from the prefix. The independent artist
+    // gate still decides whether the upload belongs to the requested artist.
+    if let Some(suffix) = title_artist_credit_suffix(candidate_title) {
+        let suffix_stripped = normalize_stripped(suffix);
+        let suffix_clean = strip_video_noise(&normalize(&strip_annotations(suffix)));
+        best = best
+            .max(similarity(&input_stripped, &suffix_stripped))
+            .max(token_sort_similarity(&input.title, suffix))
+            .max(token_set_similarity(&input.title, suffix))
+            .max(contain(&input_stripped, &suffix_clean));
+    }
+    best
 }
 
 fn single_artist_similarity(candidate: &str, artist: &str) -> f32 {
@@ -613,49 +692,107 @@ fn single_artist_similarity(candidate: &str, artist: &str) -> f32 {
     }
 }
 
-fn artist_similarity(input: &TrackInput, cand: &MatchCandidate) -> f32 {
+fn candidate_artist_text(cand: &MatchCandidate) -> String {
     let cand_artist = normalize(&cand.artist);
-    let cand_artist = cand_artist
+    cand_artist
         .strip_suffix(" topic")
         .unwrap_or(&cand_artist)
-        .to_owned();
-    let primary = input
+        .to_owned()
+}
+
+fn title_artist_credit_prefix(title: &str) -> Option<&str> {
+    [" - ", " – ", " — "]
+        .into_iter()
+        .filter_map(|separator| title.find(separator))
+        .min()
+        .map(|index| title[..index].trim())
+        .filter(|prefix| !prefix.is_empty())
+}
+
+fn title_artist_credit_suffix(title: &str) -> Option<&str> {
+    [" - ", " – ", " — "]
+        .into_iter()
+        .filter_map(|separator| title.find(separator).map(|index| (index, separator.len())))
+        .min_by_key(|(index, _)| *index)
+        .map(|(index, separator_len)| title[index + separator_len..].trim())
+        .filter(|suffix| !suffix.is_empty())
+}
+
+/// Some official channels use a native-script channel name while spelling the artist in
+/// the video title (`Aimyon - Marigold` on the `あいみょん` channel). Treat that title
+/// credit as primary-artist evidence only when both halves are independently strong:
+///
+/// - the prefix is an almost-exact, symmetric match (never mere containment), and
+/// - the upload has a strong official signal plus trusted/catalog provenance, or verified
+///   metadata whose native title independently credits its channel.
+///
+/// This deliberately excludes an unverified user merely writing "Official" in a title,
+/// and excludes prefixes such as `Aimyon Fan Channel` which only contain the artist name.
+fn corroborated_title_artist_similarity(input: &TrackInput, cand: &MatchCandidate) -> Option<f32> {
+    if official_signal_score(cand) < 0.7 {
+        return None;
+    }
+
+    let channel = cand.channel.as_deref().unwrap_or(&cand.artist);
+    let trusted_or_catalog = musicgate::is_trusted_music_channel(channel)
+        || matches!(
+            cand.source_kind,
+            CandidateSourceKind::YtmAlbumTrack
+                | CandidateSourceKind::YtmCatalogSong
+                | CandidateSourceKind::SpotifyCatalog
+        );
+    let verified_preflight = cand.preflighted
+        && cand.channel_verified == Some(true)
+        && cand
+            .preflight_reason_codes
+            .iter()
+            .any(|reason| reason == "metadata_title_channel_corroborated");
+    if !trusted_or_catalog && !verified_preflight {
+        return None;
+    }
+
+    let prefix = normalize(title_artist_credit_prefix(&cand.title)?);
+    let primary_artist = normalize(input.artists.first()?);
+    if prefix.is_empty() || primary_artist.is_empty() {
+        return None;
+    }
+    let score =
+        similarity(&prefix, &primary_artist).max(token_sort_similarity(&prefix, &primary_artist));
+    (score >= 0.92).then_some(score)
+}
+
+fn artist_similarities(input: &TrackInput, cand: &MatchCandidate) -> (f32, f32, bool) {
+    let cand_artist = candidate_artist_text(cand);
+    let channel_primary = input
         .artists
         .first()
         .map(|artist| single_artist_similarity(&cand_artist, artist))
         .unwrap_or(0.0);
-    let featured = input
-        .artists
-        .iter()
-        .skip(1)
-        .map(|artist| single_artist_similarity(&cand_artist, artist) * 0.85)
-        .fold(0.0f32, f32::max);
-    let album = input
+    let combined = format!("{cand_artist} {}", normalize(&cand.title));
+    let coverage = if input.artists.is_empty() {
+        0.0
+    } else {
+        input
+            .artists
+            .iter()
+            .map(|artist| single_artist_similarity(&combined, artist))
+            .sum::<f32>()
+            / input.artists.len() as f32
+    };
+    // Compilation metadata occasionally names the album artist instead of the track
+    // artist.  It is useful corroboration but can never fully replace the primary artist.
+    let album_corroboration = input
         .album_artists
         .iter()
-        .map(|artist| single_artist_similarity(&cand_artist, artist) * 0.92)
+        .map(|artist| single_artist_similarity(&cand_artist, artist) * 0.85)
         .fold(0.0f32, f32::max);
-    primary.max(featured).max(album)
-}
-
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
-struct IdentityFlags {
-    instrumental: bool,
-    karaoke: bool,
-    backing_track: bool,
-    cover: bool,
-    remix: bool,
-    live: bool,
-    acoustic: bool,
-    sped_up: bool,
-    slowed: bool,
-    slowed_reverb: bool,
-    nightcore: bool,
-    eight_d: bool,
-    demo: bool,
-    taylor_version: bool,
-    clean: bool,
-    explicit: bool,
+    let baseline = channel_primary.max(album_corroboration);
+    let title_credit = corroborated_title_artist_similarity(input, cand).unwrap_or(0.0);
+    (
+        baseline.max(title_credit),
+        coverage,
+        title_credit > baseline,
+    )
 }
 
 #[derive(Default)]
@@ -666,157 +803,47 @@ struct IdentityGate {
     reasons: Vec<&'static str>,
 }
 
-fn identity_flags(text: &str) -> IdentityFlags {
-    let normalized = normalize(text);
-    let lower = text.to_lowercase();
-    let phrase = |needle: &str| normalized_contains_phrase(&normalized, needle);
-    let raw = |needle: &str| lower.contains(needle);
-    let live_marker = phrase("live")
-        && (raw("(live")
-            || raw("[live")
-            || raw(" live at ")
-            || raw(" live from ")
-            || raw(" live in ")
-            || raw(" live on ")
-            || raw(" live version")
-            || raw("concert")
-            || raw("라이브")
-            || raw("ライブ")
-            || raw("现场")
-            || raw("現場"));
-    IdentityFlags {
-        instrumental: phrase("instrumental")
-            || phrase("inst")
-            || phrase("off vocal")
-            || phrase("no vocal")
-            || raw("instrumental ver")
-            || raw("반주")
-            || raw("伴奏"),
-        karaoke: phrase("karaoke") || raw("노래방") || raw("カラオケ"),
-        backing_track: phrase("backing track")
-            || phrase("accompaniment")
-            || phrase("off vocal")
-            || raw("伴奏")
-            || raw(" mr ")
-            || lower.ends_with(" mr"),
-        cover: phrase("cover")
-            || phrase("covered by")
-            || phrase("cover by")
-            || raw("歌ってみた")
-            || raw("커버"),
-        remix: phrase("remix") || raw(" 리믹스") || raw("リミックス"),
-        live: live_marker,
-        acoustic: phrase("acoustic") || raw("어쿠스틱") || raw("アコースティック"),
-        sped_up: phrase("sped up") || phrase("spedup") || phrase("speed up"),
-        slowed: phrase("slowed") || raw("느리게"),
-        slowed_reverb: phrase("slowed reverb") || raw("slowed + reverb") || raw("slowed+reverb"),
-        nightcore: phrase("nightcore"),
-        eight_d: phrase("8d") || phrase("8d audio") || phrase("8d version"),
-        demo: phrase("demo"),
-        taylor_version: raw("taylor's version") || raw("taylors version"),
-        clean: phrase("clean"),
-        explicit: phrase("explicit"),
-    }
-}
-
-fn normalized_contains_phrase(normalized: &str, phrase: &str) -> bool {
-    let needle = normalize(phrase);
-    if needle.is_empty() {
-        return false;
-    }
-    let hay = format!(" {normalized} ");
-    hay.contains(&format!(" {needle} "))
-}
-
 fn identity_gate(input: &TrackInput, cand: &MatchCandidate) -> IdentityGate {
-    let source_text = format!(
-        "{} {} {}",
-        input.title,
-        input.artists.join(" "),
-        input.album.as_deref().unwrap_or_default()
+    let src = parse_version_profile(
+        &input.title,
+        &input.artists.join(", "),
+        input.album.as_deref(),
+        None,
+        input.explicit,
     );
-    let candidate_text = format!(
-        "{} {} {}",
-        cand.title,
-        cand.artist,
-        cand.channel.as_deref().unwrap_or_default()
+    let dst = parse_version_profile(
+        &cand.title,
+        &cand.artist,
+        cand.album.as_deref(),
+        cand.channel.as_deref(),
+        cand.explicit,
     );
-    let src = identity_flags(&source_text);
-    let dst = identity_flags(&candidate_text);
     let mut gate = IdentityGate::default();
 
-    if !src.karaoke && dst.karaoke {
-        gate.hard_reject = Some("karaoke_mismatch");
-        gate.reasons.push("karaoke_mismatch");
-    }
-    if !src.backing_track && dst.backing_track {
-        gate.hard_reject = Some("backing_track_mismatch");
-        gate.reasons.push("backing_track_mismatch");
-    }
-    if !src.sped_up && dst.sped_up {
-        gate.hard_reject = Some("sped_up_mismatch");
-        gate.reasons.push("sped_up_mismatch");
-    }
-    if !src.nightcore && dst.nightcore {
-        gate.hard_reject = Some("nightcore_mismatch");
-        gate.reasons.push("nightcore_mismatch");
-    }
-    if !src.eight_d && dst.eight_d {
-        gate.hard_reject = Some("8d_mismatch");
-        gate.reasons.push("8d_mismatch");
-    }
-    if !src.slowed_reverb && dst.slowed_reverb {
-        gate.hard_reject = Some("slowed_reverb_mismatch");
-        gate.reasons.push("slowed_reverb_mismatch");
-    }
-
-    let mut block = |condition: bool, reason: &'static str, penalty: f32| {
-        if condition {
+    match disposition(&src, &dst) {
+        CandidateDisposition::AutoEligible => {}
+        CandidateDisposition::ReviewOnly(reason) => {
             gate.accept_blocked = true;
-            gate.penalty += penalty;
+            gate.penalty = identity_penalty_for(reason);
             gate.reasons.push(reason);
         }
-    };
-    block(
-        !src.instrumental && dst.instrumental,
-        "instrumental_mismatch",
-        0.35,
-    );
-    block(
-        src.instrumental && !dst.instrumental,
-        "missing_instrumental_marker",
-        0.25,
-    );
-    block(!src.cover && dst.cover, "cover_mismatch", 0.25);
-    block(!src.live && dst.live, "live_mismatch", 0.20);
-    block(!src.remix && dst.remix, "remix_mismatch", 0.25);
-    block(!src.acoustic && dst.acoustic, "acoustic_mismatch", 0.18);
-    block(!src.demo && dst.demo, "demo_mismatch", 0.18);
-    block(!src.slowed && dst.slowed, "slowed_mismatch", 0.20);
-    block(
-        src.taylor_version && !dst.taylor_version,
-        "missing_taylor_version_marker",
-        0.20,
-    );
-    block(
-        !src.taylor_version && dst.taylor_version,
-        "taylor_version_mismatch",
-        0.20,
-    );
-    block(src.clean && dst.explicit, "explicit_mismatch", 0.10);
-    block(src.explicit && dst.clean, "clean_mismatch", 0.10);
-    block(
-        input.explicit == Some(false) && dst.explicit,
-        "explicit_mismatch",
-        0.10,
-    );
-    block(
-        input.explicit == Some(true) && dst.clean,
-        "clean_mismatch",
-        0.10,
-    );
+        CandidateDisposition::Rejected(reason) => {
+            gate.hard_reject = Some(reason);
+            gate.reasons.push(reason);
+        }
+    }
 
     gate
+}
+
+fn identity_penalty_for(reason: &str) -> f32 {
+    match reason {
+        "instrumental_mismatch" | "vocal_version_mismatch" => 0.30,
+        "cover_mismatch" | "remix_mismatch" | "missing_mix_marker" => 0.24,
+        "live_mismatch" | "missing_performance_marker" => 0.18,
+        "clean_mismatch" | "explicit_mismatch" => 0.08,
+        _ => 0.16,
+    }
 }
 
 fn source_kind_code(kind: CandidateSourceKind) -> &'static str {
@@ -824,6 +851,7 @@ fn source_kind_code(kind: CandidateSourceKind) -> &'static str {
         CandidateSourceKind::Unknown => "unknown",
         CandidateSourceKind::YtmAlbumTrack => "ytm_album_track",
         CandidateSourceKind::YtmCatalogSong => "ytm_catalog_song",
+        CandidateSourceKind::YtmCatalogVideo => "ytm_catalog_video",
         CandidateSourceKind::YoutubeVideoSearch => "youtube_video_search",
         CandidateSourceKind::SpotifyCatalog => "spotify_catalog",
     }
@@ -842,7 +870,12 @@ fn official_signal_score(cand: &MatchCandidate) -> f32 {
     if musicgate::is_trusted_music_channel(channel) {
         return 1.0;
     }
-    let title_tier = musicgate::music_tier_score(&cand.title, channel);
+    let title_tier = cand
+        .metadata_title
+        .as_deref()
+        .map(|title| musicgate::music_tier_score(title, channel))
+        .unwrap_or(0.0)
+        .max(musicgate::music_tier_score(&cand.title, channel));
     if title_tier >= 0.7 {
         return title_tier;
     }
@@ -857,7 +890,9 @@ fn quality_tier(cand: &MatchCandidate) -> &'static str {
     match cand.source_kind {
         CandidateSourceKind::YtmAlbumTrack => "album_track",
         CandidateSourceKind::YtmCatalogSong | CandidateSourceKind::SpotifyCatalog => "catalog",
-        CandidateSourceKind::YoutubeVideoSearch | CandidateSourceKind::Unknown => {
+        CandidateSourceKind::YtmCatalogVideo
+        | CandidateSourceKind::YoutubeVideoSearch
+        | CandidateSourceKind::Unknown => {
             let official = official_signal_score(cand);
             if official >= 1.0 {
                 "trusted_official"
@@ -892,6 +927,120 @@ fn duration_delta_secs(input: &TrackInput, cand: &MatchCandidate) -> Option<i32>
     Some(cand - input)
 }
 
+fn is_official_video_presentation(cand: &MatchCandidate) -> bool {
+    matches!(
+        cand.source_kind,
+        CandidateSourceKind::YtmCatalogVideo | CandidateSourceKind::YoutubeVideoSearch
+    ) && official_signal_score(cand) >= 0.7
+        && cand
+            .metadata_title
+            .as_deref()
+            .into_iter()
+            .chain(std::iter::once(cand.title.as_str()))
+            .any(|title| {
+                let title = title.to_lowercase();
+                [
+                    "official music video",
+                    "official video",
+                    "official mv",
+                    "music video",
+                    " m v",
+                    " mv",
+                    "뮤직비디오",
+                ]
+                .iter()
+                .any(|marker| title.contains(marker))
+            })
+}
+
+fn official_video_runtime_limit(input: &TrackInput) -> u32 {
+    input
+        .duration_secs
+        .map(|duration| ((duration as f32 * 0.16).round() as u32).clamp(20, 45))
+        .unwrap_or(30)
+}
+
+fn duration_component(input: &TrackInput, cand: &MatchCandidate) -> f32 {
+    match duration_delta_secs(input, cand) {
+        Some(delta) if delta.unsigned_abs() <= 3 => 1.0,
+        Some(delta) if delta.unsigned_abs() <= soft_duration_limit(input) => 0.72,
+        Some(delta)
+            if delta > 0
+                && is_official_video_presentation(cand)
+                && delta.unsigned_abs() <= official_video_runtime_limit(input) =>
+        {
+            0.58
+        }
+        Some(delta) if delta.unsigned_abs() <= hard_duration_limit(input) => 0.18,
+        Some(_) => 0.0,
+        None => 0.5,
+    }
+}
+
+fn input_release_year(input: &TrackInput) -> Option<u16> {
+    release_year(input)?.parse().ok()
+}
+
+fn album_year_component(input: &TrackInput, cand: &MatchCandidate) -> f32 {
+    let album = match (&input.album, &cand.album) {
+        (Some(source), Some(candidate)) => {
+            let source = normalize_stripped(source);
+            let candidate = normalize_stripped(candidate);
+            if source.is_empty() || candidate.is_empty() {
+                0.5
+            } else if containment(&source, &candidate) {
+                1.0
+            } else {
+                similarity(&source, &candidate)
+            }
+        }
+        _ => 0.5,
+    };
+    match (input_release_year(input), cand.release_year) {
+        (Some(source), Some(candidate)) => {
+            let year = if source == candidate {
+                1.0
+            } else if source.abs_diff(candidate) <= 1 {
+                0.7
+            } else {
+                0.0
+            };
+            0.75 * album + 0.25 * year
+        }
+        _ => album,
+    }
+}
+
+fn version_component(input: &TrackInput, cand: &MatchCandidate) -> f32 {
+    let source = parse_version_profile(
+        &input.title,
+        &input.artists.join(", "),
+        input.album.as_deref(),
+        None,
+        input.explicit,
+    );
+    let candidate = parse_version_profile(
+        &cand.title,
+        &cand.artist,
+        cand.album.as_deref(),
+        cand.channel.as_deref(),
+        cand.explicit,
+    );
+    version_agreement(&source, &candidate)
+}
+
+fn evidence_completeness(input: &TrackInput, cand: &MatchCandidate) -> f32 {
+    let available = [
+        input.duration_secs.is_some() && cand.duration_secs.is_some(),
+        input.album.is_some() && cand.album.is_some(),
+        input_release_year(input).is_some() && cand.release_year.is_some(),
+        input.track_number.is_some() && cand.track_number.is_some(),
+        input.explicit.is_some() && cand.explicit.is_some(),
+        !matches!(cand.source_kind, CandidateSourceKind::Unknown),
+    ];
+    available.into_iter().filter(|present| *present).count() as f32 / available.len() as f32
+}
+
 fn quality_adjustment(cand: &MatchCandidate) -> (f32, f32, Vec<&'static str>) {
     let mut bonus = 0.0f32;
     let mut penalty = 0.0f32;
@@ -902,26 +1051,40 @@ fn quality_adjustment(cand: &MatchCandidate) -> (f32, f32, Vec<&'static str>) {
         CandidateSourceKind::YtmAlbumTrack
         | CandidateSourceKind::YtmCatalogSong
         | CandidateSourceKind::SpotifyCatalog => {
-            bonus += 0.07;
+            bonus += 0.035;
             reasons.push("catalog_song");
             if cand.source_kind == CandidateSourceKind::YtmAlbumTrack {
-                bonus += 0.03;
+                bonus += 0.015;
                 reasons.push("album_track");
             }
+        }
+        CandidateSourceKind::YtmCatalogVideo => {
+            bonus += 0.01;
+            reasons.push("ytm_video_filter");
         }
         CandidateSourceKind::YoutubeVideoSearch | CandidateSourceKind::Unknown => {}
     }
 
     let tier = musicgate::music_tier_score(&cand.title, channel);
     if tier >= 1.0 {
-        bonus += 0.05;
+        bonus += 0.025;
         reasons.push("trusted_channel");
     } else if tier >= 0.7 {
-        bonus += 0.03;
+        bonus += 0.015;
         reasons.push("official_like");
     } else if tier >= 0.4 {
-        bonus += 0.01;
+        bonus += 0.005;
         reasons.push("music_video_signal");
+    }
+    if cand.channel_verified == Some(true) && cand.channel_id.is_some() {
+        // Weak corroboration only. A verified YouTube channel is not necessarily the
+        // recording artist and must never cross the official threshold by itself.
+        bonus += 0.005;
+        reasons.push("verified_channel_corroboration");
+    }
+    if cand.has_audio_format == Some(true) {
+        bonus += 0.005;
+        reasons.push("playable_audio_format");
     }
 
     let risk = musicgate::non_music_risk_score(&cand.title, channel);
@@ -974,8 +1137,10 @@ fn confidence_tier(
     {
         return "strong";
     }
-    if matches!(cand.source_kind, CandidateSourceKind::YoutubeVideoSearch)
-        && official_signal_score(cand) >= 0.7
+    if matches!(
+        cand.source_kind,
+        CandidateSourceKind::YtmCatalogVideo | CandidateSourceKind::YoutubeVideoSearch
+    ) && official_signal_score(cand) >= 0.7
         && total >= 0.88
     {
         return "strong";
@@ -999,54 +1164,48 @@ pub fn score_candidate_breakdown_with_config(
     cfg: &MatchConfig,
 ) -> MatchScoreBreakdown {
     let title = title_similarity(input, cand);
-    let artist = artist_similarity(input, cand);
-
-    // Duration proximity; neutral when either side is unknown.
-    let duration = match (input.duration_secs, cand.duration_secs) {
-        (Some(a), Some(b)) => {
-            let delta = a.abs_diff(b);
-            if delta <= 3 {
-                1.0
-            } else if delta <= soft_duration_limit(input) {
-                0.6
-            } else if delta <= hard_duration_limit(input) {
-                0.2
-            } else {
-                0.0
-            }
-        }
+    let (artist, artist_coverage, used_title_artist_credit) = artist_similarities(input, cand);
+    let duration = duration_component(input, cand);
+    let album_year = album_year_component(input, cand);
+    let version_agreement = version_component(input, cand);
+    let evidence_completeness = evidence_completeness(input, cand);
+    let track_number = match (input.track_number, cand.track_number) {
+        (Some(a), Some(b)) if a == b => 1.0,
+        (Some(_), Some(_)) => 0.0,
         _ => 0.5,
     };
+    let album_bonus = 0.08 * album_year;
+    let track_number_bonus = 0.02 * track_number;
 
-    let album_bonus = match (&input.album, &cand.album) {
-        (Some(a), Some(b)) => {
-            let (a, b) = (normalize_stripped(a), normalize_stripped(b));
-            if !a.is_empty() && (a == b || containment(&a, &b)) {
-                0.05
-            } else {
-                0.0
-            }
-        }
-        _ => 0.0,
-    };
-    let track_number_bonus = match (input.track_number, cand.track_number) {
-        (Some(a), Some(b)) if a == b => 0.04,
-        _ => 0.0,
-    };
-
-    // Deliberately starts unclamped (max 1.05): clamping would erase the album bonus exactly
-    // where it matters — as the tie-breaker between two otherwise-perfect candidates.
-    let raw_total =
-        0.55 * title + 0.30 * artist + 0.15 * duration + album_bonus + track_number_bonus;
+    // Bounded seed model.  Each term has a distinct semantic role so missing metadata
+    // cannot be mistaken for negative evidence and quality adjustments remain auditable.
+    let raw_total = (0.42 * title
+        + 0.23 * artist
+        + 0.08 * artist_coverage
+        + 0.12 * duration
+        + album_bonus
+        + 0.05 * version_agreement
+        + track_number_bonus)
+        .clamp(0.0, 1.0);
     let mut gate = identity_gate(input, cand);
     let delta_secs = duration_delta_secs(input, cand);
     if let Some(delta) = delta_secs.map(i32::unsigned_abs) {
-        if delta > hard_duration_limit(input) {
+        if delta > hard_duration_limit(input)
+            && !(delta_secs.is_some_and(|signed| signed > 0)
+                && is_official_video_presentation(cand)
+                && delta <= official_video_runtime_limit(input))
+        {
             gate.hard_reject = Some("duration_mismatch");
             gate.reasons.push("duration_mismatch");
-        } else if delta > soft_duration_limit(input) {
+        } else if delta > soft_duration_limit(input)
+            && !(delta_secs.is_some_and(|signed| signed > 0)
+                && is_official_video_presentation(cand)
+                && delta <= official_video_runtime_limit(input))
+        {
             gate.accept_blocked = true;
             gate.reasons.push("duration_mismatch");
+        } else if delta > soft_duration_limit(input) {
+            gate.reasons.push("official_video_runtime");
         }
     }
     if input.duration_secs.is_none()
@@ -1058,24 +1217,62 @@ pub fn score_candidate_breakdown_with_config(
         gate.reasons.push("long_mix_duration");
     }
     let generic_video_allowed = cfg.allow_user_videos || cfg.policy == MatchPolicy::Aggressive;
+    let channel = cand.channel.as_deref().unwrap_or(&cand.artist);
+    let needs_metadata_evidence = match cand.source_kind {
+        CandidateSourceKind::YtmCatalogVideo => true,
+        CandidateSourceKind::YoutubeVideoSearch | CandidateSourceKind::Unknown => {
+            !musicgate::is_trusted_music_channel(channel)
+        }
+        CandidateSourceKind::YtmAlbumTrack
+        | CandidateSourceKind::YtmCatalogSong
+        | CandidateSourceKind::SpotifyCatalog => false,
+    };
     if !generic_video_allowed
         && matches!(
             cand.source_kind,
-            CandidateSourceKind::YoutubeVideoSearch | CandidateSourceKind::Unknown
+            CandidateSourceKind::YtmCatalogVideo
+                | CandidateSourceKind::YoutubeVideoSearch
+                | CandidateSourceKind::Unknown
         )
-        && official_signal_score(cand) < 0.7
+        && (official_signal_score(cand) < 0.7 || (needs_metadata_evidence && !cand.preflighted))
     {
         gate.accept_blocked = true;
         gate.reasons.push("unverified_youtube_upload");
     }
+    // A failed metadata lookup is unknown evidence, never positive evidence. This block is
+    // policy-independent: `--allow-user-videos` may permit a complete generic row, but it must
+    // not turn a finalist whose verification actually failed into an automatic match.
+    if cand
+        .preflight_reason_codes
+        .iter()
+        .any(|reason| reason == "metadata_preflight_failed")
+    {
+        gate.accept_blocked = true;
+        gate.reasons.push("metadata_preflight_failed");
+    }
+    if cand
+        .preflight_reason_codes
+        .iter()
+        .any(|reason| reason == "low_audio_ceiling")
+        && !matches!(
+            cand.source_kind,
+            CandidateSourceKind::YtmAlbumTrack
+                | CandidateSourceKind::YtmCatalogSong
+                | CandidateSourceKind::SpotifyCatalog
+        )
+    {
+        gate.accept_blocked = true;
+        gate.penalty += 0.05;
+        gate.reasons.push("low_audio_ceiling");
+    }
     let (quality_bonus, non_music_penalty, quality_reasons) = quality_adjustment(cand);
     let identity_penalty = gate.penalty.min(0.75);
-    let mut total = (raw_total + quality_bonus - non_music_penalty - identity_penalty).max(0.0);
+    let mut total =
+        (raw_total + quality_bonus - non_music_penalty - identity_penalty).clamp(0.0, 1.0);
     let mut reject_reason = gate.hard_reject.map(str::to_owned);
     if reject_reason.is_none() {
         reject_reason = cand.preflight_reject_reason.clone();
     }
-    let channel = cand.channel.as_deref().unwrap_or(&cand.artist);
     if reject_reason.is_none()
         && let Some(reason) = musicgate::non_music_reason(&cand.title, channel)
     {
@@ -1088,6 +1285,11 @@ pub fn score_candidate_breakdown_with_config(
     let mut reason_codes: Vec<String> = gate.reasons.into_iter().map(str::to_owned).collect();
     reason_codes.extend(quality_reasons.into_iter().map(str::to_owned));
     reason_codes.extend(cand.preflight_reason_codes.iter().cloned());
+    if used_title_artist_credit {
+        reason_codes.push("corroborated_title_artist_credit".to_owned());
+    }
+    let mut seen_reason_codes = HashSet::new();
+    reason_codes.retain(|reason| seen_reason_codes.insert(reason.clone()));
     let confidence_tier = confidence_tier(
         cand,
         total,
@@ -1106,16 +1308,50 @@ pub fn score_candidate_breakdown_with_config(
         duration_delta_secs: delta_secs,
         title,
         artist,
+        artist_coverage,
         duration,
+        album_year,
+        version_agreement,
+        evidence_completeness,
         album_bonus,
         track_number_bonus,
         quality_bonus,
+        corroboration_bonus: 0.0,
         identity_penalty,
         non_music_penalty,
         accept_blocked,
         reject_reason,
         reason_codes,
     }
+}
+
+fn candidate_cluster_key(candidate: &MatchCandidate) -> String {
+    let mut artist = candidate_artist_text(candidate);
+    for suffix in [" official", " official artist", " records", " vevo"] {
+        if let Some(stripped) = artist.strip_suffix(suffix) {
+            artist = stripped.trim().to_owned();
+        }
+    }
+    let mut title = normalize_stripped(&candidate.title);
+    if let Some(stripped) = title.strip_prefix(&format!("{artist} ")) {
+        title = stripped.trim().to_owned();
+    }
+    let version = parse_version_profile(
+        &candidate.title,
+        &candidate.artist,
+        candidate.album.as_deref(),
+        candidate.channel.as_deref(),
+        candidate.explicit,
+    );
+    format!(
+        "{artist}\u{1f}{title}\u{1f}{:?}\u{1f}{:?}\u{1f}{:?}\u{1f}{:?}\u{1f}{:?}\u{1f}{:?}",
+        version.vocal,
+        version.performance,
+        version.mix,
+        version.authorship,
+        version.edition,
+        version.explicit
+    )
 }
 
 /// Rank candidates and classify against the thresholds.
@@ -1128,35 +1364,95 @@ pub fn best_outcome(
         .iter()
         .map(|c| (score_candidate_breakdown_with_config(input, c, cfg), c))
         .collect();
+    let mut cluster_sources: HashMap<String, HashSet<&'static str>> = HashMap::new();
+    for (score, candidate) in &scored {
+        if score.reject_reason.is_none() {
+            cluster_sources
+                .entry(candidate_cluster_key(candidate))
+                .or_default()
+                .insert(source_kind_code(candidate.source_kind));
+        }
+    }
+    for (score, candidate) in &mut scored {
+        let sources = cluster_sources
+            .get(&candidate_cluster_key(candidate))
+            .map_or(0, HashSet::len);
+        if sources >= 2 {
+            let bonus = (0.01 * (sources.saturating_sub(1) as f32)).min(0.025);
+            score.corroboration_bonus = bonus;
+            score.quality_bonus += bonus;
+            score.total = (score.total + bonus).clamp(0.0, 1.0);
+            score.reason_codes.push("evidence_corroborated".to_owned());
+        }
+    }
     scored.sort_by(|a, b| {
         b.0.total
             .partial_cmp(&a.0.total)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
     let review_candidates = || {
+        let mut seen_clusters = HashSet::new();
         scored
             .iter()
-            .filter(|(s, _)| s.reject_reason.is_none() && s.total >= cfg.ambiguous_floor)
+            .filter(|(score, candidate)| {
+                score.reject_reason.is_none()
+                    && score.total >= cfg.ambiguous_floor
+                    && seen_clusters.insert(candidate_cluster_key(candidate))
+            })
             .take(3)
-            .map(|(score, c)| AmbiguousCandidate {
-                key: c.key.clone(),
+            .map(|(score, candidate)| AmbiguousCandidate {
+                key: candidate.key.clone(),
                 score: score.total,
-                display: format!("{} — {}", c.artist, c.title),
+                display: format!("{} — {}", candidate.artist, candidate.title),
                 score_breakdown: Some(score.clone()),
             })
             .collect::<Vec<_>>()
     };
-    match scored.first() {
-        Some((score, best))
-            if score.reject_reason.is_none()
-                && !score.accept_blocked
-                && score.total >= cfg.accept
-                && scored
-                    .iter()
-                    .filter(|(s, _)| s.reject_reason.is_none())
-                    .nth(1)
-                    .is_none_or(|(second, _)| score.total - second.total >= cfg.accept_margin) =>
-        {
+    // Auto-selection is a decision among candidates which are actually eligible under the
+    // current policy. A higher-scoring review-only upload must not hide a safe official result,
+    // and it must not consume the acceptance margin as though it could win automatically.
+    let auto_eligible =
+        |score: &MatchScoreBreakdown| score.reject_reason.is_none() && !score.accept_blocked;
+    let policy_independent = |score: &MatchScoreBreakdown| {
+        auto_eligible(score)
+            && (matches!(
+                score.source_kind.as_str(),
+                "ytm_album_track" | "ytm_catalog_song" | "spotify_catalog"
+            ) || matches!(
+                score.quality_tier.as_str(),
+                "trusted_official" | "official_like"
+            ))
+    };
+    let mut seen_eligible_clusters = HashSet::new();
+    let mut eligible = scored.iter().filter(|(score, candidate)| {
+        auto_eligible(score) && seen_eligible_clusters.insert(candidate_cluster_key(candidate))
+    });
+    if let Some((score, best)) = eligible.next() {
+        let eligible_margin = eligible
+            .next()
+            .map_or(score.total, |(second, _)| score.total - second.total);
+        if score.total >= cfg.accept && eligible_margin >= cfg.accept_margin {
+            let mut score = score.clone();
+            // Persistent matches are policy-independent only when they would also survive the
+            // default Strict gate and margin. Loose-policy generic uploads are deliberately not
+            // marked and therefore never enter the reusable track cache.
+            let mut seen_policy_clusters = HashSet::new();
+            let mut policy_safe = scored.iter().filter(|(candidate_score, candidate)| {
+                policy_independent(candidate_score)
+                    && seen_policy_clusters.insert(candidate_cluster_key(candidate))
+            });
+            if let Some((winner, candidate)) = policy_safe.next() {
+                let policy_safe_margin =
+                    policy_safe.next().map_or(winner.total, |(runner_up, _)| {
+                        winner.total - runner_up.total
+                    });
+                if candidate.key == best.key
+                    && winner.total >= MatchConfig::default().accept
+                    && policy_safe_margin >= MatchConfig::default().accept_margin
+                {
+                    score.reason_codes.push("policy_safe_cache".to_owned());
+                }
+            }
             MatchOutcome::Matched {
                 key: best.key.clone(),
                 score: score.total,
@@ -1165,10 +1461,9 @@ pub fn best_outcome(
                 artist: Some(best.artist.clone()),
                 album: best.album.clone(),
                 duration_secs: best.duration_secs,
-                score_breakdown: Some(Box::new(score.clone())),
+                score_breakdown: Some(Box::new(score)),
             }
-        }
-        Some((score, _)) if score.total >= cfg.ambiguous_floor => {
+        } else {
             let candidates = review_candidates();
             if candidates.is_empty() {
                 MatchOutcome::NotFound
@@ -1176,7 +1471,13 @@ pub fn best_outcome(
                 MatchOutcome::Ambiguous { candidates }
             }
         }
-        _ => MatchOutcome::NotFound,
+    } else {
+        let candidates = review_candidates();
+        if candidates.is_empty() {
+            MatchOutcome::NotFound
+        } else {
+            MatchOutcome::Ambiguous { candidates }
+        }
     }
 }
 

--- a/src/transfer/matching/identity.rs
+++ b/src/transfer/matching/identity.rs
@@ -1,0 +1,726 @@
+//! Structured recording-version evidence for transfer matching.
+//!
+//! This module deliberately keeps presentation words ("official video", "visualizer")
+//! separate from recording identity.  Marker recognition is context-aware: short or
+//! ordinary words such as `live`, `cover`, and `inst` are only strong when they occur in
+//! an annotation/version suffix or in an unambiguous multi-word phrase.
+
+use super::normalize;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) enum VocalKind {
+    #[default]
+    OriginalOrUnknown,
+    Instrumental,
+    Karaoke,
+    BackingTrack,
+    Acapella,
+    VocalRemoved,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) enum PerformanceKind {
+    #[default]
+    StudioOrUnknown,
+    Live,
+    Acoustic,
+    Demo,
+    Rehearsal,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) enum MixKind {
+    #[default]
+    OriginalOrUnknown,
+    Remix,
+    RadioEdit,
+    Extended,
+    SpedUp,
+    Slowed,
+    SlowedReverb,
+    Nightcore,
+    EightD,
+    BassBoosted,
+    Lofi,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) enum AuthorshipKind {
+    #[default]
+    OriginalOrUnknown,
+    Cover,
+    Tribute,
+    AiCover,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) enum StereoKind {
+    #[default]
+    Unknown,
+    Mono,
+    Stereo,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct EditionProfile {
+    pub remastered: bool,
+    pub remaster_year: Option<u16>,
+    pub radio_edit: bool,
+    pub extended: bool,
+    pub taylor_version: bool,
+    pub deluxe_or_reissue: bool,
+    pub stereo: StereoKind,
+    pub language_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum EvidenceField {
+    TitleAnnotation,
+    TitleSuffix,
+    TitlePhrase,
+    Artist,
+    Album,
+    Channel,
+    ExplicitMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct VersionEvidence {
+    pub marker: &'static str,
+    pub field: EvidenceField,
+    /// 100 = explicit structured/annotation evidence, 70 = strong phrase, lower values
+    /// are corroboration only and must not independently reject a candidate.
+    pub confidence: u8,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct VersionProfile {
+    pub vocal: VocalKind,
+    pub performance: PerformanceKind,
+    pub mix: MixKind,
+    pub authorship: AuthorshipKind,
+    pub edition: EditionProfile,
+    pub explicit: Option<bool>,
+    pub evidence: Vec<VersionEvidence>,
+}
+
+impl VersionProfile {
+    #[cfg(test)]
+    pub fn is_plain(&self) -> bool {
+        self.vocal == VocalKind::OriginalOrUnknown
+            && self.performance == PerformanceKind::StudioOrUnknown
+            && self.mix == MixKind::OriginalOrUnknown
+            && self.authorship == AuthorshipKind::OriginalOrUnknown
+            && !self.edition.taylor_version
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CandidateDisposition {
+    AutoEligible,
+    ReviewOnly(&'static str),
+    Rejected(&'static str),
+}
+
+pub(super) fn parse_version_profile(
+    title: &str,
+    artist: &str,
+    album: Option<&str>,
+    channel: Option<&str>,
+    explicit: Option<bool>,
+) -> VersionProfile {
+    let mut profile = VersionProfile {
+        explicit,
+        ..VersionProfile::default()
+    };
+    if explicit.is_some() {
+        profile.evidence.push(VersionEvidence {
+            marker: if explicit == Some(true) {
+                "explicit_metadata"
+            } else {
+                "clean_metadata"
+            },
+            field: EvidenceField::ExplicitMetadata,
+            confidence: 100,
+        });
+    }
+
+    let title_context = TitleContext::new(title);
+    parse_title_markers(&title_context, &mut profile);
+    parse_supporting_markers(artist, EvidenceField::Artist, &mut profile);
+    if let Some(album) = album {
+        parse_supporting_markers(album, EvidenceField::Album, &mut profile);
+    }
+    if let Some(channel) = channel {
+        parse_supporting_markers(channel, EvidenceField::Channel, &mut profile);
+    }
+    profile
+}
+
+#[derive(Debug)]
+struct TitleContext {
+    normalized: String,
+    annotations: Vec<String>,
+    suffix: String,
+    raw_lower: String,
+}
+
+impl TitleContext {
+    fn new(title: &str) -> Self {
+        let raw_lower = title.to_lowercase();
+        let annotations = bracket_segments(title)
+            .into_iter()
+            .map(|value| normalize(&value))
+            .filter(|value| !value.is_empty())
+            .collect();
+        let suffix = title
+            .rfind(" - ")
+            .map(|index| normalize(&title[index + 3..]))
+            .unwrap_or_default();
+        Self {
+            normalized: normalize(title),
+            annotations,
+            suffix,
+            raw_lower,
+        }
+    }
+
+    fn phrase(&self, phrase: &str) -> bool {
+        contains_phrase(&self.normalized, phrase)
+    }
+
+    fn version_context(&self, phrase: &str) -> Option<EvidenceField> {
+        if self
+            .annotations
+            .iter()
+            .any(|annotation| contains_phrase(annotation, phrase))
+        {
+            return Some(EvidenceField::TitleAnnotation);
+        }
+        if contains_phrase(&self.suffix, phrase) {
+            return Some(EvidenceField::TitleSuffix);
+        }
+        None
+    }
+
+    fn unambiguous_phrase(&self, phrase: &str) -> Option<EvidenceField> {
+        self.version_context(phrase)
+            .or_else(|| self.phrase(phrase).then_some(EvidenceField::TitlePhrase))
+    }
+}
+
+fn bracket_segments(value: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut chars = value.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if !matches!(ch, '(' | '[' | '{') {
+            continue;
+        }
+        let close = match ch {
+            '(' => ')',
+            '[' => ']',
+            _ => '}',
+        };
+        let mut depth = 1usize;
+        let mut inner = String::new();
+        for next in chars.by_ref() {
+            if next == ch {
+                depth += 1;
+            } else if next == close {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            inner.push(next);
+        }
+        if !inner.trim().is_empty() {
+            segments.push(inner);
+        }
+    }
+    segments
+}
+
+fn contains_phrase(normalized: &str, phrase: &str) -> bool {
+    let needle = normalize(phrase);
+    !needle.is_empty() && format!(" {normalized} ").contains(&format!(" {needle} "))
+}
+
+fn push_evidence(
+    profile: &mut VersionProfile,
+    marker: &'static str,
+    field: EvidenceField,
+    confidence: u8,
+) {
+    if !profile
+        .evidence
+        .iter()
+        .any(|evidence| evidence.marker == marker && evidence.field == field)
+    {
+        profile.evidence.push(VersionEvidence {
+            marker,
+            field,
+            confidence,
+        });
+    }
+}
+
+fn parse_title_markers(title: &TitleContext, profile: &mut VersionProfile) {
+    let first_context = |phrases: &[&str]| {
+        phrases
+            .iter()
+            .find_map(|phrase| title.unambiguous_phrase(phrase))
+    };
+
+    if let Some(field) = first_context(&[
+        "instrumental",
+        "instrumental version",
+        "off vocal",
+        "no vocal",
+        "반주",
+        "伴奏",
+    ]) {
+        profile.vocal = VocalKind::Instrumental;
+        push_evidence(profile, "instrumental", field, 100);
+    } else if let Some(field) = title.version_context("inst") {
+        // `inst` is intentionally annotation/suffix-only so `Instinct` and artists
+        // containing those letters never trigger it.
+        profile.vocal = VocalKind::Instrumental;
+        push_evidence(profile, "instrumental", field, 100);
+    }
+    if let Some(field) = first_context(&["karaoke", "노래방", "カラオケ"]) {
+        profile.vocal = VocalKind::Karaoke;
+        push_evidence(profile, "karaoke", field, 100);
+    }
+    if let Some(field) = first_context(&["backing track", "accompaniment", "mr version"]) {
+        profile.vocal = VocalKind::BackingTrack;
+        push_evidence(profile, "backing_track", field, 100);
+    }
+    if let Some(field) = first_context(&["acapella", "a cappella"]) {
+        profile.vocal = VocalKind::Acapella;
+        push_evidence(profile, "acapella", field, 100);
+    }
+    if let Some(field) = first_context(&["vocal removed", "vocal remover", "no vocals"]) {
+        profile.vocal = VocalKind::VocalRemoved;
+        push_evidence(profile, "vocal_removed", field, 100);
+    }
+
+    // A lone "live" is only a recording marker in annotation/suffix form. Longer
+    // phrases are unambiguous in the whole title.
+    let live_field = title.version_context("live").or_else(|| {
+        ["live at", "live from", "live in", "live version", "concert"]
+            .iter()
+            .find_map(|phrase| title.phrase(phrase).then_some(EvidenceField::TitlePhrase))
+    });
+    if let Some(field) = live_field {
+        profile.performance = PerformanceKind::Live;
+        push_evidence(profile, "live", field, 100);
+    }
+    if let Some(field) = first_context(&["acoustic", "어쿠스틱", "アコースティック"]) {
+        profile.performance = PerformanceKind::Acoustic;
+        push_evidence(profile, "acoustic", field, 100);
+    }
+    if let Some(field) = title.version_context("demo") {
+        profile.performance = PerformanceKind::Demo;
+        push_evidence(profile, "demo", field, 100);
+    }
+    if let Some(field) = first_context(&["rehearsal", "practice recording"]) {
+        profile.performance = PerformanceKind::Rehearsal;
+        push_evidence(profile, "rehearsal", field, 100);
+    }
+
+    if let Some(field) = first_context(&["slowed reverb", "slowed and reverb"]) {
+        profile.mix = MixKind::SlowedReverb;
+        push_evidence(profile, "slowed_reverb", field, 100);
+    } else if title.raw_lower.contains("slowed + reverb")
+        || title.raw_lower.contains("slowed+reverb")
+    {
+        profile.mix = MixKind::SlowedReverb;
+        push_evidence(profile, "slowed_reverb", EvidenceField::TitlePhrase, 100);
+    } else if let Some(field) = first_context(&["sped up", "speed up", "spedup"]) {
+        profile.mix = MixKind::SpedUp;
+        push_evidence(profile, "sped_up", field, 100);
+    } else if let Some(field) = first_context(&["nightcore"]) {
+        profile.mix = MixKind::Nightcore;
+        push_evidence(profile, "nightcore", field, 100);
+    } else if let Some(field) = first_context(&["8d audio", "8d version"]) {
+        profile.mix = MixKind::EightD;
+        push_evidence(profile, "8d", field, 100);
+    } else if let Some(field) = title.version_context("8d") {
+        profile.mix = MixKind::EightD;
+        push_evidence(profile, "8d", field, 100);
+    } else if let Some(field) = first_context(&["bass boosted", "bass boost"]) {
+        profile.mix = MixKind::BassBoosted;
+        push_evidence(profile, "bass_boosted", field, 100);
+    } else if let Some(field) = title.version_context("lofi") {
+        profile.mix = MixKind::Lofi;
+        push_evidence(profile, "lofi", field, 100);
+    } else if let Some(field) = title.version_context("slowed") {
+        profile.mix = MixKind::Slowed;
+        push_evidence(profile, "slowed", field, 100);
+    } else if let Some(field) = first_context(&["radio edit", "radio version"]) {
+        profile.mix = MixKind::RadioEdit;
+        profile.edition.radio_edit = true;
+        push_evidence(profile, "radio_edit", field, 100);
+    } else if let Some(field) = first_context(&["extended mix", "extended version"]) {
+        profile.mix = MixKind::Extended;
+        profile.edition.extended = true;
+        push_evidence(profile, "extended", field, 100);
+    } else if let Some(field) = first_context(&["remix", "리믹스", "リミックス"]) {
+        profile.mix = MixKind::Remix;
+        push_evidence(profile, "remix", field, 100);
+    }
+
+    let cover_field = ["covered by", "cover by", "tribute to", "ai cover"]
+        .iter()
+        .find_map(|phrase| title.phrase(phrase).then_some(EvidenceField::TitlePhrase))
+        .or_else(|| title.version_context("cover"));
+    if let Some(field) = cover_field {
+        profile.authorship = if title.phrase("ai cover") {
+            AuthorshipKind::AiCover
+        } else if title.phrase("tribute to") {
+            AuthorshipKind::Tribute
+        } else {
+            AuthorshipKind::Cover
+        };
+        push_evidence(profile, "cover", field, 100);
+    } else if title.raw_lower.contains("歌ってみた") || title.raw_lower.contains("커버") {
+        profile.authorship = AuthorshipKind::Cover;
+        push_evidence(profile, "cover", EvidenceField::TitlePhrase, 100);
+    }
+
+    if title.raw_lower.contains("taylor's version") || title.raw_lower.contains("taylors version") {
+        profile.edition.taylor_version = true;
+        push_evidence(profile, "taylor_version", EvidenceField::TitlePhrase, 100);
+    }
+    if let Some(field) = first_context(&["mono"]) {
+        profile.edition.stereo = StereoKind::Mono;
+        push_evidence(profile, "mono", field, 100);
+    } else if let Some(field) = first_context(&["stereo"]) {
+        profile.edition.stereo = StereoKind::Stereo;
+        push_evidence(profile, "stereo", field, 100);
+    }
+    if let Some((year, field)) = remaster_marker(title) {
+        profile.edition.remastered = true;
+        profile.edition.remaster_year = year;
+        push_evidence(profile, "remaster", field, 100);
+    }
+    if first_context(&[
+        "deluxe edition",
+        "anniversary edition",
+        "expanded edition",
+        "reissue",
+    ])
+    .is_some()
+    {
+        profile.edition.deluxe_or_reissue = true;
+    }
+    for (marker, language) in [
+        ("english version", "english"),
+        ("japanese version", "japanese"),
+        ("japanese ver", "japanese"),
+        ("korean version", "korean"),
+        ("chinese version", "chinese"),
+        ("spanish version", "spanish"),
+    ] {
+        if let Some(field) = title.unambiguous_phrase(marker) {
+            profile.edition.language_version = Some(language.to_owned());
+            push_evidence(profile, "language_version", field, 100);
+            break;
+        }
+    }
+    if title.version_context("clean").is_some() || title.phrase("clean version") {
+        profile.explicit = Some(false);
+        push_evidence(profile, "clean_title", EvidenceField::TitlePhrase, 70);
+    } else if title.version_context("explicit").is_some() || title.phrase("explicit version") {
+        profile.explicit = Some(true);
+        push_evidence(profile, "explicit_title", EvidenceField::TitlePhrase, 70);
+    }
+}
+
+fn parse_supporting_markers(text: &str, field: EvidenceField, profile: &mut VersionProfile) {
+    let normalized = normalize(text);
+    // Supporting fields never independently set ambiguous short markers. They can only
+    // corroborate unambiguous authorship/version phrases.
+    if contains_phrase(&normalized, "tribute band") || contains_phrase(&normalized, "cover channel")
+    {
+        if profile.authorship == AuthorshipKind::OriginalOrUnknown {
+            profile.authorship = AuthorshipKind::Cover;
+        }
+        push_evidence(profile, "cover_support", field, 70);
+    }
+    if contains_phrase(&normalized, "karaoke") {
+        profile.vocal = VocalKind::Karaoke;
+        push_evidence(profile, "karaoke_support", field, 80);
+    }
+}
+
+fn remaster_marker(title: &TitleContext) -> Option<(Option<u16>, EvidenceField)> {
+    for (text, field) in title
+        .annotations
+        .iter()
+        .map(|value| (value.as_str(), EvidenceField::TitleAnnotation))
+        .chain(std::iter::once((
+            title.suffix.as_str(),
+            EvidenceField::TitleSuffix,
+        )))
+    {
+        if !contains_phrase(text, "remaster") && !contains_phrase(text, "remastered") {
+            continue;
+        }
+        let year = text.split_whitespace().find_map(|token| {
+            token
+                .parse::<u16>()
+                .ok()
+                .filter(|year| (1900..=2200).contains(year))
+        });
+        return Some((year, field));
+    }
+    None
+}
+
+/// Version compatibility is intentionally asymmetric where uncertainty is common.
+/// Clearly unsafe gimmick/utility recordings are rejected; live/remix/edition
+/// uncertainty remains reviewable so retrieval recall is not converted into a wrong
+/// automatic import.
+pub(super) fn disposition(
+    source: &VersionProfile,
+    candidate: &VersionProfile,
+) -> CandidateDisposition {
+    use CandidateDisposition::{AutoEligible, Rejected, ReviewOnly};
+
+    if source.vocal != candidate.vocal {
+        return match candidate.vocal {
+            VocalKind::Karaoke => Rejected("karaoke_mismatch"),
+            VocalKind::BackingTrack | VocalKind::VocalRemoved => Rejected("backing_track_mismatch"),
+            VocalKind::Instrumental | VocalKind::Acapella => {
+                if source.vocal == VocalKind::OriginalOrUnknown {
+                    ReviewOnly("instrumental_mismatch")
+                } else {
+                    ReviewOnly("vocal_version_mismatch")
+                }
+            }
+            VocalKind::OriginalOrUnknown => ReviewOnly("missing_vocal_version_marker"),
+        };
+    }
+    if source.authorship != candidate.authorship {
+        return match candidate.authorship {
+            AuthorshipKind::Cover | AuthorshipKind::Tribute | AuthorshipKind::AiCover => {
+                ReviewOnly("cover_mismatch")
+            }
+            AuthorshipKind::OriginalOrUnknown => ReviewOnly("missing_cover_marker"),
+        };
+    }
+    if source.mix != candidate.mix {
+        return match candidate.mix {
+            MixKind::SpedUp => Rejected("sped_up_mismatch"),
+            MixKind::SlowedReverb => Rejected("slowed_reverb_mismatch"),
+            MixKind::Nightcore => Rejected("nightcore_mismatch"),
+            MixKind::EightD => Rejected("8d_mismatch"),
+            MixKind::BassBoosted => Rejected("bass_boosted_mismatch"),
+            MixKind::Lofi => Rejected("lofi_mismatch"),
+            MixKind::OriginalOrUnknown => ReviewOnly("missing_mix_marker"),
+            MixKind::Remix => ReviewOnly("remix_mismatch"),
+            MixKind::RadioEdit => ReviewOnly("radio_edit_mismatch"),
+            MixKind::Extended => ReviewOnly("extended_mismatch"),
+            MixKind::Slowed => ReviewOnly("slowed_mismatch"),
+        };
+    }
+    if source.performance != candidate.performance {
+        return match candidate.performance {
+            PerformanceKind::Live => ReviewOnly("live_mismatch"),
+            PerformanceKind::Acoustic => ReviewOnly("acoustic_mismatch"),
+            PerformanceKind::Demo => ReviewOnly("demo_mismatch"),
+            PerformanceKind::Rehearsal => ReviewOnly("rehearsal_mismatch"),
+            PerformanceKind::StudioOrUnknown => ReviewOnly("missing_performance_marker"),
+        };
+    }
+    if source.edition.taylor_version != candidate.edition.taylor_version {
+        return ReviewOnly(if source.edition.taylor_version {
+            "missing_taylor_version_marker"
+        } else {
+            "taylor_version_mismatch"
+        });
+    }
+    if source.edition.remastered != candidate.edition.remastered {
+        return ReviewOnly(if source.edition.remastered {
+            "missing_remaster_marker"
+        } else {
+            "remaster_mismatch"
+        });
+    }
+    if source.edition.remaster_year.is_some()
+        && candidate.edition.remaster_year.is_some()
+        && source.edition.remaster_year != candidate.edition.remaster_year
+    {
+        return ReviewOnly("remaster_year_mismatch");
+    }
+    if source.edition.language_version != candidate.edition.language_version {
+        return ReviewOnly(
+            if source.edition.language_version.is_some()
+                && candidate.edition.language_version.is_none()
+            {
+                "missing_language_version_marker"
+            } else {
+                "language_version_mismatch"
+            },
+        );
+    }
+    if source.edition.radio_edit != candidate.edition.radio_edit {
+        return ReviewOnly("radio_edit_mismatch");
+    }
+    if source.edition.extended != candidate.edition.extended {
+        return ReviewOnly("extended_mismatch");
+    }
+    if source.edition.deluxe_or_reissue != candidate.edition.deluxe_or_reissue {
+        return ReviewOnly(if source.edition.deluxe_or_reissue {
+            "missing_edition_marker"
+        } else {
+            "edition_mismatch"
+        });
+    }
+    if source.edition.stereo != candidate.edition.stereo {
+        return ReviewOnly(
+            if source.edition.stereo != StereoKind::Unknown
+                && candidate.edition.stereo == StereoKind::Unknown
+            {
+                "missing_stereo_marker"
+            } else {
+                "mono_stereo_mismatch"
+            },
+        );
+    }
+    if source.explicit.is_some()
+        && candidate.explicit.is_some()
+        && source.explicit != candidate.explicit
+    {
+        return ReviewOnly(if source.explicit == Some(true) {
+            "clean_mismatch"
+        } else {
+            "explicit_mismatch"
+        });
+    }
+    AutoEligible
+}
+
+pub(super) fn version_agreement(source: &VersionProfile, candidate: &VersionProfile) -> f32 {
+    let mut compared = 0u32;
+    let mut agreed = 0u32;
+    macro_rules! compare {
+        ($left:expr, $right:expr) => {{
+            compared += 1;
+            if $left == $right {
+                agreed += 1;
+            }
+        }};
+    }
+    compare!(source.vocal, candidate.vocal);
+    compare!(source.performance, candidate.performance);
+    compare!(source.mix, candidate.mix);
+    compare!(source.authorship, candidate.authorship);
+    compare!(
+        source.edition.taylor_version,
+        candidate.edition.taylor_version
+    );
+    compare!(source.edition.remastered, candidate.edition.remastered);
+    if source.edition.remaster_year.is_some() || candidate.edition.remaster_year.is_some() {
+        compare!(
+            source.edition.remaster_year,
+            candidate.edition.remaster_year
+        );
+    }
+    if source.edition.deluxe_or_reissue || candidate.edition.deluxe_or_reissue {
+        compare!(
+            source.edition.deluxe_or_reissue,
+            candidate.edition.deluxe_or_reissue
+        );
+    }
+    if source.edition.stereo != StereoKind::Unknown
+        || candidate.edition.stereo != StereoKind::Unknown
+    {
+        compare!(source.edition.stereo, candidate.edition.stereo);
+    }
+    if source.edition.language_version.is_some() || candidate.edition.language_version.is_some() {
+        compare!(
+            source.edition.language_version,
+            candidate.edition.language_version
+        );
+    }
+    if source.explicit.is_some() && candidate.explicit.is_some() {
+        compare!(source.explicit, candidate.explicit);
+    }
+    agreed as f32 / compared.max(1) as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile(title: &str) -> VersionProfile {
+        parse_version_profile(title, "Artist", Some("Album"), Some("Artist"), None)
+    }
+
+    #[test]
+    fn marker_boundaries_avoid_ordinary_names() {
+        assert!(profile("Live Forever").is_plain());
+        assert!(parse_version_profile("Song", "Cover Drive", None, None, None).is_plain());
+        assert!(profile("Instinct").is_plain());
+        assert!(profile("8days").is_plain());
+    }
+
+    #[test]
+    fn annotation_and_suffix_markers_are_structured() {
+        assert_eq!(profile("Song (Live)").performance, PerformanceKind::Live);
+        assert_eq!(
+            profile("Song - Instrumental").vocal,
+            VocalKind::Instrumental
+        );
+        assert_eq!(profile("Song [Radio Edit]").mix, MixKind::RadioEdit);
+        assert_eq!(profile("Song (Slowed + Reverb)").mix, MixKind::SlowedReverb);
+        assert_eq!(
+            profile("Song (AI Cover)").authorship,
+            AuthorshipKind::AiCover
+        );
+    }
+
+    #[test]
+    fn compatibility_is_symmetric_for_requested_versions() {
+        let plain = profile("Song");
+        let live = profile("Song (Live)");
+        assert_eq!(
+            disposition(&plain, &live),
+            CandidateDisposition::ReviewOnly("live_mismatch")
+        );
+        assert_eq!(
+            disposition(&live, &plain),
+            CandidateDisposition::ReviewOnly("missing_performance_marker")
+        );
+        assert_eq!(
+            disposition(&live, &live),
+            CandidateDisposition::AutoEligible
+        );
+    }
+
+    #[test]
+    fn utility_and_gimmick_versions_are_rejected() {
+        let plain = profile("Song");
+        assert!(matches!(
+            disposition(&plain, &profile("Song (Karaoke)")),
+            CandidateDisposition::Rejected("karaoke_mismatch")
+        ));
+        assert!(matches!(
+            disposition(&plain, &profile("Song (Nightcore)")),
+            CandidateDisposition::Rejected("nightcore_mismatch")
+        ));
+    }
+
+    #[test]
+    fn explicit_metadata_is_stronger_than_title_guess() {
+        let explicit = parse_version_profile("Song", "Artist", None, None, Some(true));
+        let clean = parse_version_profile("Song", "Artist", None, None, Some(false));
+        assert_eq!(
+            disposition(&explicit, &clean),
+            CandidateDisposition::ReviewOnly("clean_mismatch")
+        );
+    }
+}

--- a/src/transfer/matching/tests.rs
+++ b/src/transfer/matching/tests.rs
@@ -1,4 +1,4 @@
-use super::ytm_retrieval::{is_noisy_video_fallback_query, video_search_error_is_soft};
+use super::ytm_retrieval::video_search_error_is_soft;
 use super::*;
 
 fn input(title: &str, artists: &[&str], album: Option<&str>, dur: Option<u32>) -> TrackInput {
@@ -33,9 +33,17 @@ fn cand(title: &str, artist: &str, album: Option<&str>, dur: Option<u32>) -> Mat
         album: album.map(str::to_owned),
         duration_secs: dur,
         track_number: None,
+        release_year: None,
+        explicit: None,
         source_kind: CandidateSourceKind::YtmCatalogSong,
         channel: Some(artist.to_owned()),
+        channel_id: None,
+        channel_verified: None,
+        availability: None,
+        has_audio_format: None,
+        max_audio_bitrate_kbps: None,
         isrc: None,
+        metadata_title: None,
         preflighted: false,
         preflight_reject_reason: None,
         preflight_reason_codes: Vec::new(),
@@ -253,38 +261,23 @@ fn ytm_catalog_plan_uses_only_fast_primary_queries_before_fallbacks() {
         ]
     );
     let fallback = ytm_fallback_query_plan(&input);
-    assert!(!fallback.contains(&"Primary Song Title".to_owned()));
-    assert!(fallback.contains(&"Primary Song Title official audio".to_owned()));
-    assert!(
-        !fallback.contains(&"Primary Song Title topic".to_owned()),
-        "bare topic suffix is filtered from video fallback"
-    );
-    assert!(
-        !fallback.iter().any(|q| q.ends_with(" 2024")),
-        "year-suffix variants are filtered from video fallback: {fallback:?}"
+    assert_eq!(
+        fallback,
+        vec![
+            "Primary Song Title".to_owned(),
+            "Primary Song Title official audio".to_owned(),
+            "Song Title official music video".to_owned(),
+        ],
+        "public search is a separate backend, so its primary query must not be suppressed by a catalog attempt"
     );
 }
 
 #[test]
-fn noisy_video_fallback_query_filter_drops_topic_and_year_suffix() {
-    assert!(is_noisy_video_fallback_query("Aimyon Marigold topic"));
-    assert!(is_noisy_video_fallback_query(
-        "21univ. Sticker picture 2022"
-    ));
-    assert!(!is_noisy_video_fallback_query(
-        "Primary Song Title official audio"
-    ));
-    assert!(!is_noisy_video_fallback_query(
-        "Primary Song Title Album Name"
-    ));
-}
-
-#[test]
-fn video_search_errors_are_soft_at_matching_boundary() {
+fn video_search_provider_errors_remain_hard_at_matching_boundary() {
     let err = anyhow::anyhow!(
         "yt-dlp search exited with status exit status: 1 (ERROR: query \"Aimyon Marigold topic\" page 1: Unable to download API page: HTTP Error 403: Forbidden)"
     );
-    assert!(video_search_error_is_soft(&err));
+    assert!(!video_search_error_is_soft(&err));
 }
 
 #[test]
@@ -329,7 +322,7 @@ fn instrumental_source_can_match_instrumental_candidate() {
 }
 
 #[test]
-fn top_gap_sends_close_candidates_to_review() {
+fn duplicate_recording_representations_do_not_consume_cluster_margin() {
     let i = input("Song", &["Artist"], None, Some(180));
     let a = cand("Song", "Artist", None, Some(180));
     let b = cand("Song", "Artist", Some("Other Album"), Some(180));
@@ -337,7 +330,7 @@ fn top_gap_sends_close_candidates_to_review() {
 
     assert!(matches!(
         best_outcome(&i, &[a, b], &cfg),
-        MatchOutcome::Ambiguous { .. }
+        MatchOutcome::Matched { .. }
     ));
 }
 
@@ -355,6 +348,64 @@ fn ytm_catalog_candidate_beats_plain_video_when_close() {
     match best_outcome(&i, &[video, catalog], &MatchConfig::default()) {
         MatchOutcome::Matched { key, .. } => assert_eq!(key, "catalog"),
         other => panic!("expected matched catalog candidate, got {other:?}"),
+    }
+}
+
+#[test]
+fn blocked_top_candidate_does_not_hide_safe_official_match() {
+    let i = input("Song", &["Artist"], Some("Album"), Some(180));
+    let mut blocked = cand("Song", "Artist", Some("Album"), Some(180));
+    blocked.key = "blocked-generic".to_owned();
+    blocked.source_kind = CandidateSourceKind::YoutubeVideoSearch;
+    blocked.channel = Some("Random Uploads".to_owned());
+
+    let mut official = cand("Song", "Artist Official", None, Some(180));
+    official.key = "safe-official".to_owned();
+    official.source_kind = CandidateSourceKind::YoutubeVideoSearch;
+    official.channel = Some("Artist Official".to_owned());
+    official.preflighted = true;
+    official.has_audio_format = Some(true);
+
+    let blocked_score = score_candidate_breakdown(&i, &blocked);
+    let official_score = score_candidate_breakdown(&i, &official);
+    assert!(blocked_score.accept_blocked);
+    assert!(blocked_score.total > official_score.total);
+
+    match best_outcome(&i, &[blocked, official], &MatchConfig::default()) {
+        MatchOutcome::Matched { key, .. } => assert_eq!(key, "safe-official"),
+        other => panic!("expected safe official match, got {other:?}"),
+    }
+}
+
+#[test]
+fn blocked_runner_up_does_not_consume_safe_acceptance_margin() {
+    let i = input("Song", &["Artist"], Some("Album"), Some(180));
+    let mut catalog = cand("Song", "Artist", None, Some(180));
+    catalog.key = "safe-catalog".to_owned();
+    catalog.source_kind = CandidateSourceKind::YtmCatalogSong;
+
+    let mut blocked = cand("Song", "Artist", Some("Album"), Some(180));
+    blocked.key = "blocked-generic".to_owned();
+    blocked.source_kind = CandidateSourceKind::YoutubeVideoSearch;
+    blocked.channel = Some("Random Uploads".to_owned());
+
+    let catalog_score = score_candidate_breakdown(&i, &catalog);
+    let blocked_score = score_candidate_breakdown(&i, &blocked);
+    assert!(blocked_score.accept_blocked);
+    assert!(
+        (catalog_score.total - blocked_score.total).abs() < MatchConfig::default().accept_margin
+    );
+
+    match best_outcome(&i, &[blocked, catalog], &MatchConfig::default()) {
+        MatchOutcome::Matched {
+            key,
+            score_breakdown: Some(score),
+            ..
+        } => {
+            assert_eq!(key, "safe-catalog");
+            assert!(score.reason_codes.contains(&"policy_safe_cache".to_owned()));
+        }
+        other => panic!("expected catalog match with blocked runner-up ignored, got {other:?}"),
     }
 }
 
@@ -419,6 +470,301 @@ fn official_topic_youtube_candidate_can_auto_accept() {
             assert_eq!(score.quality_tier, "trusted_official");
         }
         other => panic!("expected matched Topic candidate, got {other:?}"),
+    }
+}
+
+#[test]
+fn public_official_title_requires_finalist_metadata_before_auto_accept() {
+    let i = input("Song", &["Artist"], Some("Album"), Some(180));
+    let mut video = cand("Song (Official Audio)", "Artist", Some("Album"), Some(180));
+    video.source_kind = CandidateSourceKind::YoutubeVideoSearch;
+    video.channel = Some("Artist".to_owned());
+
+    let before = score_candidate_breakdown(&i, &video);
+    assert!(before.accept_blocked);
+    assert!(
+        before
+            .reason_codes
+            .contains(&"unverified_youtube_upload".to_owned())
+    );
+
+    video.preflighted = true;
+    video.has_audio_format = Some(true);
+    match best_outcome(&i, &[video], &MatchConfig::default()) {
+        MatchOutcome::Matched {
+            score_breakdown: Some(score),
+            ..
+        } => {
+            assert!(!score.accept_blocked);
+            assert!(
+                score
+                    .reason_codes
+                    .contains(&"playable_audio_format".to_owned())
+            );
+        }
+        other => panic!("expected preflighted official audio match, got {other:?}"),
+    }
+}
+
+#[test]
+fn failed_metadata_preflight_never_auto_accepts_even_when_user_videos_are_allowed() {
+    let i = input("Song", &["Artist"], Some("Album"), Some(180));
+    let mut video = cand(
+        "Artist - Song [OFFICIAL MUSIC VIDEO]",
+        "Artist",
+        Some("Album"),
+        Some(180),
+    );
+    video.source_kind = CandidateSourceKind::YoutubeVideoSearch;
+    video.channel = Some("Artist".to_owned());
+    video
+        .preflight_reason_codes
+        .push("metadata_preflight_failed".to_owned());
+    let cfg = MatchConfig {
+        allow_user_videos: true,
+        ..MatchConfig::default()
+    };
+
+    let breakdown = score_candidate_breakdown_with_config(&i, &video, &cfg);
+    assert!(breakdown.accept_blocked);
+    assert!(
+        breakdown
+            .reason_codes
+            .contains(&"metadata_preflight_failed".to_owned())
+    );
+    assert!(!matches!(
+        best_outcome(&i, &[video], &cfg),
+        MatchOutcome::Matched { .. }
+    ));
+}
+
+#[test]
+fn verified_official_title_credit_bridges_cross_script_channel_artist() {
+    let i = input("Marigold", &["Aimyon"], None, Some(306));
+    let mut video = cand(
+        "Aimyon - Marigold [OFFICIAL MUSIC VIDEO]",
+        "あいみょん",
+        None,
+        Some(322),
+    );
+    video.source_kind = CandidateSourceKind::YoutubeVideoSearch;
+    video.channel = Some("あいみょん".to_owned());
+    video.preflighted = true;
+    video.channel_verified = Some(true);
+    video.channel_id = Some("UCQVhrypJhw1HxuRV4gX6hoQ".to_owned());
+    video.has_audio_format = Some(true);
+    video
+        .preflight_reason_codes
+        .push("metadata_title_channel_corroborated".to_owned());
+
+    let breakdown = score_candidate_breakdown(&i, &video);
+    assert_eq!(breakdown.artist, 1.0);
+    assert!(
+        breakdown
+            .reason_codes
+            .contains(&"corroborated_title_artist_credit".to_owned())
+    );
+    assert!(!breakdown.accept_blocked);
+    assert!(matches!(
+        best_outcome(&i, &[video], &MatchConfig::default()),
+        MatchOutcome::Matched { .. }
+    ));
+}
+
+#[test]
+fn unverified_or_spoofed_title_credit_does_not_replace_channel_artist() {
+    let i = input("Marigold", &["Aimyon"], None, Some(306));
+    let user_video_config = MatchConfig {
+        allow_user_videos: true,
+        ..MatchConfig::default()
+    };
+
+    let mut unverified = cand(
+        "Aimyon - Marigold [OFFICIAL MUSIC VIDEO]",
+        "ファン投稿",
+        None,
+        Some(322),
+    );
+    unverified.source_kind = CandidateSourceKind::YoutubeVideoSearch;
+    unverified.channel = Some("ファン投稿".to_owned());
+    unverified.preflighted = true;
+    unverified.channel_verified = Some(false);
+    unverified.has_audio_format = Some(true);
+
+    let unverified_score =
+        score_candidate_breakdown_with_config(&i, &unverified, &user_video_config);
+    assert!(unverified_score.artist < 0.5);
+    assert!(
+        !unverified_score
+            .reason_codes
+            .contains(&"corroborated_title_artist_credit".to_owned())
+    );
+    assert!(!matches!(
+        best_outcome(&i, &[unverified], &user_video_config),
+        MatchOutcome::Matched { .. }
+    ));
+
+    let mut spoof = cand(
+        "Aimyon Fan Channel - Marigold [OFFICIAL MUSIC VIDEO]",
+        "ファン投稿",
+        None,
+        Some(322),
+    );
+    spoof.source_kind = CandidateSourceKind::YoutubeVideoSearch;
+    spoof.channel = Some("ファン投稿".to_owned());
+    spoof.preflighted = true;
+    spoof.channel_verified = Some(true);
+    spoof.channel_id = Some("verified-fan-channel".to_owned());
+    spoof.has_audio_format = Some(true);
+
+    let spoof_score = score_candidate_breakdown_with_config(&i, &spoof, &user_video_config);
+    assert!(spoof_score.artist < 0.5);
+    assert!(
+        !spoof_score
+            .reason_codes
+            .contains(&"corroborated_title_artist_credit".to_owned())
+    );
+    assert!(!matches!(
+        best_outcome(&i, &[spoof], &user_video_config),
+        MatchOutcome::Matched { .. }
+    ));
+}
+
+#[test]
+fn official_title_credit_cannot_override_instrumental_identity_gate() {
+    let i = input("Marigold", &["Aimyon"], None, Some(306));
+    let mut video = cand(
+        "Aimyon - Marigold (Instrumental) [Official Audio]",
+        "あいみょん",
+        None,
+        Some(306),
+    );
+    video.source_kind = CandidateSourceKind::YoutubeVideoSearch;
+    video.channel = Some("あいみょん".to_owned());
+    video.preflighted = true;
+    video.channel_verified = Some(true);
+    video.has_audio_format = Some(true);
+    video
+        .preflight_reason_codes
+        .push("metadata_title_channel_corroborated".to_owned());
+
+    let breakdown = score_candidate_breakdown(&i, &video);
+    assert_eq!(breakdown.artist, 1.0);
+    assert!(breakdown.accept_blocked);
+    assert!(
+        breakdown
+            .reason_codes
+            .contains(&"instrumental_mismatch".to_owned())
+    );
+    assert!(!matches!(
+        best_outcome(&i, &[video], &MatchConfig::default()),
+        MatchOutcome::Matched { .. }
+    ));
+}
+
+#[test]
+fn low_audio_ceiling_stays_review_only_and_reason_codes_are_unique() {
+    let i = input("Song", &["Artist"], Some("Album"), Some(180));
+    let mut video = cand("Song (Official Audio)", "Artist", Some("Album"), Some(180));
+    video.source_kind = CandidateSourceKind::YoutubeVideoSearch;
+    video.channel = Some("Artist".to_owned());
+    video.preflighted = true;
+    video.has_audio_format = Some(true);
+    video.max_audio_bitrate_kbps = Some(32.0);
+    video.preflight_reason_codes = vec![
+        "metadata_preflight".to_owned(),
+        "low_audio_ceiling".to_owned(),
+        "low_audio_ceiling".to_owned(),
+    ];
+
+    match best_outcome(&i, &[video], &MatchConfig::default()) {
+        MatchOutcome::Ambiguous { candidates } => {
+            let score = candidates[0].score_breakdown.as_ref().unwrap();
+            assert!(score.accept_blocked);
+            assert_eq!(
+                score
+                    .reason_codes
+                    .iter()
+                    .filter(|reason| reason.as_str() == "low_audio_ceiling")
+                    .count(),
+                1
+            );
+        }
+        other => panic!("expected low-quality official upload to need review, got {other:?}"),
+    }
+}
+
+#[test]
+fn adversarial_version_matrix_never_silently_auto_accepts_plain_source() {
+    let i = input("Song", &["Artist"], Some("Album"), Some(180));
+    let unsafe_versions = [
+        "Song (Instrumental)",
+        "Song (Karaoke)",
+        "Song (Backing Track)",
+        "Song (Vocal Removed)",
+        "Song (Cover)",
+        "Song (AI Cover)",
+        "Song (Live)",
+        "Song (Acoustic)",
+        "Song (Demo)",
+        "Song (Rehearsal)",
+        "Song (Remix)",
+        "Song (Radio Edit)",
+        "Song (Extended Mix)",
+        "Song (Sped Up)",
+        "Song (Slowed)",
+        "Song (Slowed + Reverb)",
+        "Song (Nightcore)",
+        "Song (8D Audio)",
+        "Song (Bass Boosted)",
+        "Song (Lofi)",
+        "Song (2011 Remaster)",
+        "Song (Taylor's Version)",
+        "Song (Japanese Version)",
+    ];
+
+    for title in unsafe_versions {
+        let outcome = best_outcome(
+            &i,
+            &[cand(title, "Artist", Some("Album"), Some(180))],
+            &MatchConfig::default(),
+        );
+        assert!(
+            !matches!(outcome, MatchOutcome::Matched { .. }),
+            "plain source unexpectedly auto-accepted {title}: {outcome:?}"
+        );
+    }
+}
+
+#[test]
+fn requested_version_matrix_requires_the_same_version_marker() {
+    for source_title in [
+        "Song (Instrumental)",
+        "Song (Live)",
+        "Song (Acoustic)",
+        "Song (Remix)",
+        "Song (Radio Edit)",
+        "Song (2011 Remaster)",
+        "Song (Taylor's Version)",
+    ] {
+        let source = input(source_title, &["Artist"], Some("Album"), Some(180));
+        let plain = cand("Song", "Artist", Some("Album"), Some(180));
+        assert!(
+            !matches!(
+                best_outcome(&source, &[plain], &MatchConfig::default()),
+                MatchOutcome::Matched { .. }
+            ),
+            "requested version {source_title} unexpectedly accepted a plain candidate"
+        );
+
+        let same = cand(source_title, "Artist", Some("Album"), Some(180));
+        assert!(
+            matches!(
+                best_outcome(&source, &[same], &MatchConfig::default()),
+                MatchOutcome::Matched { .. }
+            ),
+            "requested version {source_title} did not accept the same marked version"
+        );
     }
 }
 
@@ -488,7 +834,7 @@ fn score_breakdown_exposes_weighted_components() {
     assert_eq!(breakdown.title, 1.0);
     assert_eq!(breakdown.artist, 1.0);
     assert_eq!(breakdown.duration, 1.0);
-    assert_eq!(breakdown.album_bonus, 0.05);
+    assert_eq!(breakdown.album_bonus, 0.08);
     assert_eq!(breakdown.total, score_candidate(&i, &exact));
 }
 
@@ -503,7 +849,7 @@ fn album_track_candidate_gets_track_number_bonus() {
     let breakdown = score_candidate_breakdown(&i, &exact);
 
     assert_eq!(breakdown.source_kind, "ytm_album_track");
-    assert_eq!(breakdown.track_number_bonus, 0.04);
+    assert_eq!(breakdown.track_number_bonus, 0.02);
     assert_eq!(breakdown.confidence_tier, "exact");
     assert!(breakdown.reason_codes.contains(&"album_track".to_owned()));
 }
@@ -587,6 +933,35 @@ fn memo_key_folds_case_and_annotations() {
     let a = input("Song (feat. X)", &["Artist"], None, None);
     let b = input("SONG (FEAT. X)", &["artist"], None, None);
     assert_eq!(memo_key(&a), memo_key(&b));
+}
+
+#[test]
+fn memo_key_separates_recording_identity_and_source_metadata() {
+    let base = input("Song", &["Artist", "Guest"], Some("Album"), Some(180));
+
+    let mut different_source = base.clone();
+    different_source.source_key = "spotify:track:other".to_owned();
+    assert_ne!(memo_key(&base), memo_key(&different_source));
+
+    let mut different_isrc = base.clone();
+    different_isrc.isrc = Some("USRC00000001".to_owned());
+    assert_ne!(memo_key(&base), memo_key(&different_isrc));
+
+    let mut different_version = base.clone();
+    different_version.title = "Song (Instrumental)".to_owned();
+    assert_ne!(memo_key(&base), memo_key(&different_version));
+
+    let mut different_album = base.clone();
+    different_album.album = Some("Deluxe Album".to_owned());
+    assert_ne!(memo_key(&base), memo_key(&different_album));
+
+    let mut different_duration = base.clone();
+    different_duration.duration_secs = Some(240);
+    assert_ne!(memo_key(&base), memo_key(&different_duration));
+
+    let mut different_artist_order = base.clone();
+    different_artist_order.artists.reverse();
+    assert_ne!(memo_key(&base), memo_key(&different_artist_order));
 }
 
 /// Degraded (yt-dlp video) results: MV-decorated titles, artist-in-title, and

--- a/src/transfer/matching/ytm_retrieval.rs
+++ b/src/transfer/matching/ytm_retrieval.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use tokio::sync::{Mutex as AsyncMutex, Semaphore};
@@ -9,15 +9,29 @@ use crate::api::ytmusic::{YoutubeSearchKind, YtMusicApi, YtdlpVideoMeta};
 use crate::search_source::SearchConfig;
 use crate::streaming::musicgate;
 use crate::transfer::MatchPolicy;
+use crate::transfer::checkpoint::{MatchTrace, ProbeTrace, ReportCandidate};
 
 use super::{
     CandidateSourceKind, MatchCandidate, MatchConfig, MatchOutcome, MatchScoreBreakdown,
     TrackInput, best_outcome, hard_duration_limit, normalize, normalize_stripped,
-    push_query_variant, release_year, score_candidate_breakdown_with_config, soft_duration_limit,
-    strip_annotations,
+    official_signal_score, push_query_variant, release_year, score_candidate_breakdown_with_config,
+    similarity, soft_duration_limit, strip_annotations, title_artist_credit_prefix,
 };
 
 type QueryMemo = HashMap<String, Vec<(Song, YoutubeSearchKind)>>;
+const OUTCOME_MEMO_MAX: usize = 8_192;
+const QUERY_MEMO_MAX: usize = 2_048;
+const VIDEO_MEMO_MAX: usize = 2_048;
+const SINGLE_FLIGHT_LOCK_MAX: usize = 2_048;
+const PUBLIC_QUERY_BUDGET: usize = 3;
+/// This is a deadlock/systemic-stall guard, not a sum of provider timeouts. Four tracks share
+/// paced catalog/public queues, so a 25-second wall-clock cap could expire a healthy track merely
+/// while it waited behind its siblings. Individual video/public/preflight calls keep their much
+/// shorter deadlines; this wider envelope allows the bounded quality stages to finish.
+const TRACK_MATCH_DEADLINE: Duration = Duration::from_secs(60);
+const PUBLIC_SEARCH_RETRY_DELAY: Duration = Duration::from_millis(1_200);
+const PUBLIC_SEARCH_MAX_ATTEMPTS: u16 = 2;
+const METADATA_PREFLIGHT_MAX_ATTEMPTS: u16 = 2;
 
 #[derive(Clone)]
 pub(crate) struct SharedYtmMatchState {
@@ -26,9 +40,10 @@ pub(crate) struct SharedYtmMatchState {
     video_memo: Arc<AsyncMutex<HashMap<String, Option<YtdlpVideoMeta>>>>,
     persistent_query_keys: Arc<AsyncMutex<HashSet<String>>>,
     persistent_video_keys: Arc<AsyncMutex<HashSet<String>>>,
-    query_locks: Arc<AsyncMutex<HashMap<String, Arc<AsyncMutex<()>>>>>,
-    video_locks: Arc<AsyncMutex<HashMap<String, Arc<AsyncMutex<()>>>>>,
-    pace: Arc<AsyncMutex<Pacing>>,
+    query_locks: Arc<AsyncMutex<HashMap<String, Weak<AsyncMutex<()>>>>>,
+    video_locks: Arc<AsyncMutex<HashMap<String, Weak<AsyncMutex<()>>>>>,
+    catalog_pace: Arc<AsyncMutex<Pacing>>,
+    public_pace: Arc<AsyncMutex<Pacing>>,
     diagnostics: Arc<AsyncMutex<YtmMatchDiagnostics>>,
     catalog_gate: Arc<Semaphore>,
     video_gate: Arc<Semaphore>,
@@ -50,7 +65,8 @@ impl SharedYtmMatchState {
             persistent_video_keys: Arc::new(AsyncMutex::new(HashSet::new())),
             query_locks: Arc::new(AsyncMutex::new(HashMap::new())),
             video_locks: Arc::new(AsyncMutex::new(HashMap::new())),
-            pace: Arc::new(AsyncMutex::new(pace)),
+            catalog_pace: Arc::new(AsyncMutex::new(pace)),
+            public_pace: Arc::new(AsyncMutex::new(Pacing::public_default())),
             diagnostics: Arc::new(AsyncMutex::new(YtmMatchDiagnostics::default())),
             catalog_gate: Arc::new(Semaphore::new(catalog_concurrency.max(1))),
             video_gate: Arc::new(Semaphore::new(video_concurrency.max(1))),
@@ -70,10 +86,7 @@ impl SharedYtmMatchState {
         if !queries.is_empty() {
             let mut memo = self.query_memo.lock().await;
             let mut persistent = self.persistent_query_keys.lock().await;
-            for (key, songs) in queries {
-                if songs.is_empty() {
-                    continue;
-                }
+            for (key, songs) in queries.into_iter().take(QUERY_MEMO_MAX) {
                 persistent.insert(key.clone());
                 memo.insert(key, songs);
             }
@@ -81,7 +94,7 @@ impl SharedYtmMatchState {
         if !videos.is_empty() {
             let mut memo = self.video_memo.lock().await;
             let mut persistent = self.persistent_video_keys.lock().await;
-            for (key, meta) in videos {
+            for (key, meta) in videos.into_iter().take(VIDEO_MEMO_MAX) {
                 persistent.insert(key.clone());
                 memo.insert(key, Some(meta));
             }
@@ -94,6 +107,7 @@ impl SharedYtmMatchState {
             .lock()
             .await
             .iter()
+            .take(QUERY_MEMO_MAX)
             .map(|(key, songs)| (key.clone(), songs.clone()))
             .collect();
         let video_metadata = self
@@ -101,11 +115,37 @@ impl SharedYtmMatchState {
             .lock()
             .await
             .iter()
+            .take(VIDEO_MEMO_MAX)
             .filter_map(|(key, meta)| meta.clone().map(|meta| (key.clone(), meta)))
             .collect();
         YtmCacheSnapshot {
             queries,
             video_metadata,
+        }
+    }
+
+    async fn outcome(&self, key: &str) -> Option<MatchOutcome> {
+        self.memo.lock().await.get(key).cloned()
+    }
+
+    async fn remember_outcome(&self, key: String, outcome: MatchOutcome) {
+        let mut memo = self.memo.lock().await;
+        if memo.contains_key(&key) || memo.len() < OUTCOME_MEMO_MAX {
+            memo.insert(key, outcome);
+        }
+    }
+
+    async fn remember_query(&self, key: String, songs: Vec<(Song, YoutubeSearchKind)>) {
+        let mut memo = self.query_memo.lock().await;
+        if memo.contains_key(&key) || memo.len() < QUERY_MEMO_MAX {
+            memo.insert(key, songs);
+        }
+    }
+
+    async fn remember_video(&self, key: String, meta: Option<YtdlpVideoMeta>) {
+        let mut memo = self.video_memo.lock().await;
+        if memo.contains_key(&key) || memo.len() < VIDEO_MEMO_MAX {
+            memo.insert(key, meta);
         }
     }
 }
@@ -114,7 +154,12 @@ impl SharedYtmMatchState {
 pub(crate) struct YtmMatchDiagnostics {
     pub catalog_searches: u32,
     pub video_searches: u32,
+    pub ytm_video_searches: u32,
+    pub public_video_searches: u32,
+    pub public_video_retries: u32,
     pub preflight_lookups: u32,
+    pub preflight_retries: u32,
+    pub preflight_failures: u32,
     pub authenticated_catalog_degraded: u32,
     pub query_cache_hits: u32,
     pub video_meta_cache_hits: u32,
@@ -123,6 +168,28 @@ pub(crate) struct YtmMatchDiagnostics {
 pub(crate) struct YtmCacheSnapshot {
     pub queries: Vec<(String, Vec<(Song, YoutubeSearchKind)>)>,
     pub video_metadata: Vec<(String, YtdlpVideoMeta)>,
+}
+
+pub(crate) struct YtmMatchResult {
+    pub outcome: MatchOutcome,
+    pub trace: MatchTrace,
+}
+
+pub(crate) struct YtmMatchFailure {
+    pub error: anyhow::Error,
+    pub trace: MatchTrace,
+}
+
+impl YtmMatchFailure {
+    fn new(error: anyhow::Error, trace: MatchTrace) -> Self {
+        Self { error, trace }
+    }
+}
+
+impl From<anyhow::Error> for YtmMatchFailure {
+    fn from(error: anyhow::Error) -> Self {
+        Self::new(error, MatchTrace::default())
+    }
 }
 
 /// Self-pacing between catalog searches. YTM default 600 ms (~1.6 rps), overridable via
@@ -148,6 +215,18 @@ impl Pacing {
         Self::new(Duration::from_millis(ms))
     }
 
+    /// Space public yt-dlp process starts independently from first-party YTM requests.
+    /// Two searches may still overlap, but a large import cannot burst several extractor
+    /// processes at YouTube in the same instant. Set `YTM_TRANSFER_PUBLIC_PACE_MS=0` to
+    /// disable this guard for diagnostics.
+    fn public_default() -> Self {
+        let ms = std::env::var("YTM_TRANSFER_PUBLIC_PACE_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(600);
+        Self::new(Duration::from_millis(ms))
+    }
+
     pub async fn tick(&mut self) {
         if let Some(last) = self.last {
             let since = last.elapsed();
@@ -159,12 +238,37 @@ impl Pacing {
     }
 }
 
-/// Memo key: repeated tracks across playlists/runs resolve once per engine run.
+/// Memo key: repeated instances of the same source recording resolve once per engine run,
+/// without aliasing different versions, releases, or source identities.
 pub fn memo_key(input: &TrackInput) -> String {
+    let artists = input
+        .artists
+        .iter()
+        .map(|artist| normalize(artist))
+        .collect::<Vec<_>>()
+        .join("\u{1f}");
     format!(
-        "{}|{}",
-        normalize(&input.artists.join(" ")),
-        normalize_stripped(&input.title)
+        "source={}|isrc={}|artists={artists}|title={}|stripped={}|album={}|duration={}|album_id={}|disc={}|track={}",
+        normalize(&input.source_key),
+        input
+            .isrc
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default()
+            .to_ascii_uppercase(),
+        normalize(&input.title),
+        normalize_stripped(&input.title),
+        input.album.as_deref().map(normalize).unwrap_or_default(),
+        input
+            .duration_secs
+            .map_or_else(String::new, |value| value.to_string()),
+        input.album_id.as_deref().map(normalize).unwrap_or_default(),
+        input
+            .disc_number
+            .map_or_else(String::new, |value| value.to_string()),
+        input
+            .track_number
+            .map_or_else(String::new, |value| value.to_string()),
     )
 }
 
@@ -303,40 +407,149 @@ pub fn ytm_catalog_query_plan(input: &TrackInput) -> Vec<String> {
     out
 }
 
+/// Build the three-query public YouTube rescue plan.
+///
+/// Query deduplication is deliberately scoped to this backend. Even when the YTM song
+/// catalog already tried `artist title`, public YouTube may expose a different (and often
+/// official) result set, so the same text remains the highest-recall first public query.
 pub fn ytm_fallback_query_plan(input: &TrackInput) -> Vec<String> {
-    let fast: HashSet<String> = ytm_catalog_query_plan(input)
-        .into_iter()
-        .map(|query| normalize(&query))
-        .collect();
-    ytm_query_plan(input)
-        .into_iter()
-        .filter(|query| !fast.contains(&normalize(query)))
-        // Under degraded catalog search, every fallback hits yt-dlp. Drop variants that
-        // mostly amplify 403s without unique signal (`… topic`, bare year suffixes).
-        .filter(|query| !is_noisy_video_fallback_query(query))
-        .collect()
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+
+    let stripped_title = strip_annotations(&input.title);
+    let stripped_title = stripped_title.trim();
+    let first_artist = input
+        .artists
+        .first()
+        .map(|artist| artist.trim())
+        .filter(|artist| !artist.is_empty());
+
+    if let Some(artist) = first_artist {
+        let base = format!("{artist} {stripped_title}");
+        push_query_variant(&mut out, &mut seen, base.clone());
+        push_query_variant(&mut out, &mut seen, format!("{base} official audio"));
+        // Drop the source artist spelling for the final official-video probe. Official
+        // channels and titles often use a native-script name while Spotify exposes a Latin
+        // transliteration (for example Aimyon vs. あいみょん); repeating the Latin artist in
+        // every query can hide the real official upload. Ranking still requires independent
+        // artist/provenance evidence, so this raises recall without relaxing acceptance.
+        push_query_variant(
+            &mut out,
+            &mut seen,
+            format!("{stripped_title} official music video"),
+        );
+    } else {
+        let base = input
+            .album
+            .as_deref()
+            .map(str::trim)
+            .filter(|album| !album.is_empty())
+            .map_or_else(
+                || stripped_title.to_owned(),
+                |album| format!("{stripped_title} {album}"),
+            );
+        push_query_variant(&mut out, &mut seen, base);
+        push_query_variant(
+            &mut out,
+            &mut seen,
+            format!("{stripped_title} official audio"),
+        );
+        push_query_variant(
+            &mut out,
+            &mut seen,
+            format!("{stripped_title} official music video"),
+        );
+    }
+    out
 }
 
-/// Video-fallback queries that add little unique signal and inflate yt-dlp call volume.
-pub(crate) fn is_noisy_video_fallback_query(query: &str) -> bool {
-    let query = query.trim_end();
-    if query.ends_with(" topic") {
-        return true;
-    }
-    if let Some((_, year)) = query.rsplit_once(' ')
-        && year.len() == 4
-        && year.chars().all(|c| c.is_ascii_digit())
-    {
-        return true;
-    }
+/// Whether a failed public-video query is equivalent to a successful empty result.
+///
+/// yt-dlp already returns `Ok([])` for a valid search with no rows. Process failures,
+/// timeouts, HTTP rejection, and malformed output are provider failures and must remain
+/// errors so the engine's consecutive-failure circuit can stop an unhealthy import.
+pub(crate) fn video_search_error_is_soft(_err: &anyhow::Error) -> bool {
     false
 }
 
-/// Transfer matching soft-fails yt-dlp video-search errors so one bad query cannot abort
-/// a whole playlist job. Video search is the noisy path; catalog already soft-fails the
-/// same way. Engine consecutive-failure abort still covers systemic Err from other paths.
-pub(crate) fn video_search_error_is_soft(_err: &anyhow::Error) -> bool {
-    true
+fn public_video_search_error_kind(error: &anyhow::Error) -> &'static str {
+    let detail = format!("{error:#}").to_ascii_lowercase();
+    if detail.contains("http error 403") || detail.contains("403 forbidden") {
+        "http_403"
+    } else if detail.contains("http error 429")
+        || detail.contains("too many requests")
+        || detail.contains("rate-limited")
+    {
+        "http_429"
+    } else if detail.contains("timed out") || detail.contains("timeout") {
+        "timeout"
+    } else if detail.contains("unable to download api page")
+        || detail.contains("connection reset")
+        || detail.contains("connection refused")
+        || detail.contains("temporary failure")
+    {
+        "network"
+    } else if detail.contains("invalid json") || detail.contains("malformed") {
+        "invalid_response"
+    } else if detail.contains("not found") && detail.contains("yt-dlp") {
+        "tool_missing"
+    } else {
+        "provider_error"
+    }
+}
+
+fn public_video_search_is_retryable(error: &anyhow::Error) -> bool {
+    matches!(
+        public_video_search_error_kind(error),
+        "http_403" | "http_429" | "network"
+    )
+}
+
+struct SharedPublicVideos {
+    songs: Vec<(Song, YoutubeSearchKind)>,
+    attempts: u16,
+}
+
+struct PublicSearchFailure {
+    error: anyhow::Error,
+    attempts: u16,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct PreflightSummary {
+    attempts: u32,
+    successes: u32,
+    failures: u32,
+    first_error_kind: Option<String>,
+}
+
+impl PreflightSummary {
+    fn status(&self) -> &'static str {
+        if self.failures == 0 {
+            "success"
+        } else if self.successes > 0 {
+            "partial"
+        } else {
+            "error"
+        }
+    }
+}
+
+enum SharedCatalogSongs {
+    Complete(Vec<(Song, YoutubeSearchKind)>),
+    Unavailable,
+}
+
+enum SharedCatalogVideos {
+    Complete(Vec<(Song, YoutubeSearchKind)>),
+    Unavailable,
+}
+
+fn provider_scope(api: &YtMusicApi) -> &'static str {
+    match api {
+        YtMusicApi::Browser(_) => "browser",
+        YtMusicApi::Anonymous => "anonymous",
+    }
 }
 
 pub(crate) async fn match_track_ytm_shared(
@@ -345,9 +558,47 @@ pub(crate) async fn match_track_ytm_shared(
     cfg: &MatchConfig,
     search_config: &SearchConfig,
     state: &SharedYtmMatchState,
-) -> anyhow::Result<MatchOutcome> {
+) -> Result<YtmMatchResult, YtmMatchFailure> {
+    let mut trace = MatchTrace::default();
+    match tokio::time::timeout(
+        TRACK_MATCH_DEADLINE,
+        match_track_ytm_shared_inner(api, input, cfg, search_config, state, &mut trace),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            trace.push_probe(ProbeTrace {
+                backend: "matching_budget".to_owned(),
+                intent: "bounded_track_match".to_owned(),
+                status: "error".to_owned(),
+                elapsed_ms: TRACK_MATCH_DEADLINE.as_millis() as u64,
+                attempt: 1,
+                error_kind: Some("deadline_exceeded".to_owned()),
+                ..ProbeTrace::default()
+            });
+            trace.terminal_reason = Some("provider_budget_exhausted".to_owned());
+            Err(YtmMatchFailure::new(
+                anyhow::anyhow!(
+                    "transfer matching exceeded the per-track {} second provider budget",
+                    TRACK_MATCH_DEADLINE.as_secs()
+                ),
+                trace,
+            ))
+        }
+    }
+}
+
+async fn match_track_ytm_shared_inner(
+    api: &YtMusicApi,
+    input: &TrackInput,
+    cfg: &MatchConfig,
+    search_config: &SearchConfig,
+    state: &SharedYtmMatchState,
+    trace: &mut MatchTrace,
+) -> Result<YtmMatchResult, YtmMatchFailure> {
     if let Some(id) = &input.known_video_id {
-        return Ok(MatchOutcome::Matched {
+        let outcome = MatchOutcome::Matched {
             key: id.clone(),
             score: 1.0,
             display: input.display(),
@@ -356,19 +607,59 @@ pub(crate) async fn match_track_ytm_shared(
             album: input.album.clone(),
             duration_secs: input.duration_secs,
             score_breakdown: None,
+        };
+        trace.terminal_reason = Some("known_video_id".to_owned());
+        return Ok(YtmMatchResult {
+            outcome,
+            trace: trace.clone(),
         });
     }
     let key = memo_key(input);
-    if let Some(hit) = state.memo.lock().await.get(&key).cloned() {
-        return Ok(hit);
+    if let Some(hit) = state.outcome(&key).await {
+        trace.terminal_reason = Some("in_run_memo_hit".to_owned());
+        return Ok(YtmMatchResult {
+            outcome: hit,
+            trace: trace.clone(),
+        });
     }
 
     let mut candidates = Vec::<MatchCandidate>::new();
+    let mut candidate_keys = HashSet::new();
     let mut outcome = MatchOutcome::NotFound;
     for query in ytm_catalog_query_plan(input) {
-        let songs = shared_catalog_songs(api, &query, search_config, state).await?;
+        let started = Instant::now();
+        let songs = match shared_catalog_songs(api, &query, search_config, state)
+            .await
+            .map_err(|error| YtmMatchFailure::new(error, trace.clone()))?
+        {
+            SharedCatalogSongs::Complete(songs) => {
+                trace.push_probe(ProbeTrace {
+                    backend: "ytm_song".to_owned(),
+                    intent: "primary_or_targeted".to_owned(),
+                    query: query.clone(),
+                    status: if songs.is_empty() { "empty" } else { "success" }.to_owned(),
+                    result_count: songs.len() as u32,
+                    elapsed_ms: started.elapsed().as_millis() as u64,
+                    attempt: 1,
+                    ..ProbeTrace::default()
+                });
+                songs
+            }
+            SharedCatalogSongs::Unavailable => {
+                trace.push_probe(ProbeTrace {
+                    backend: "ytm_song".to_owned(),
+                    intent: "primary_or_targeted".to_owned(),
+                    query,
+                    status: "unavailable".to_owned(),
+                    elapsed_ms: started.elapsed().as_millis() as u64,
+                    attempt: 1,
+                    ..ProbeTrace::default()
+                });
+                break;
+            }
+        };
         for (song, kind) in &songs {
-            if !candidates.iter().any(|c| c.key == song.video_id) {
+            if candidate_keys.insert(song.video_id.clone()) {
                 candidates.push(MatchCandidate::from_song_with_kind(song, (*kind).into()));
             }
         }
@@ -378,44 +669,204 @@ pub(crate) async fn match_track_ytm_shared(
         }
     }
 
+    // Music-scoped video rescue precedes generic public search. A VideosFilter row is
+    // deliberately review-only until finalist metadata confirms authority/playability.
     if !matches!(outcome, MatchOutcome::Matched { .. }) {
-        // Soft-continue on video-search errors: one yt-dlp 403 must not promote to a
-        // whole-track Err (engine consecutive-failure abort). Keep candidates already found.
-        for query in ytm_fallback_query_plan(input) {
-            let songs = match shared_video_songs(api, &query, search_config, state).await {
-                Ok(songs) => songs,
-                Err(error) => {
-                    tracing::warn!(
-                        query = %query,
-                        error = %crate::util::sanitize::sanitize_error_text(format!("{error:#}")),
-                        "transfer video search failed; continuing with remaining fallback queries"
-                    );
-                    continue;
+        for query in ytm_catalog_query_plan(input).into_iter().take(2) {
+            let started = Instant::now();
+            let songs = match shared_ytm_video_songs(api, &query, search_config, state)
+                .await
+                .map_err(|error| YtmMatchFailure::new(error, trace.clone()))?
+            {
+                SharedCatalogVideos::Complete(songs) => {
+                    trace.push_probe(ProbeTrace {
+                        backend: "ytm_video".to_owned(),
+                        intent: "music_scoped_rescue".to_owned(),
+                        query: query.clone(),
+                        status: if songs.is_empty() { "empty" } else { "success" }.to_owned(),
+                        result_count: songs.len() as u32,
+                        elapsed_ms: started.elapsed().as_millis() as u64,
+                        attempt: 1,
+                        ..ProbeTrace::default()
+                    });
+                    songs
+                }
+                SharedCatalogVideos::Unavailable => {
+                    trace.push_probe(ProbeTrace {
+                        backend: "ytm_video".to_owned(),
+                        intent: "music_scoped_rescue".to_owned(),
+                        query,
+                        status: "unavailable".to_owned(),
+                        elapsed_ms: started.elapsed().as_millis() as u64,
+                        attempt: 1,
+                        ..ProbeTrace::default()
+                    });
+                    break;
                 }
             };
             for (song, kind) in &songs {
-                if !candidates.iter().any(|c| c.key == song.video_id) {
+                if candidate_keys.insert(song.video_id.clone()) {
                     candidates.push(MatchCandidate::from_song_with_kind(song, (*kind).into()));
                 }
             }
+            outcome = best_outcome(input, &candidates, cfg);
+            if songs.is_empty() {
+                continue;
+            }
+            let preflight_started = Instant::now();
+            let preflight =
+                preflight_ytm_candidates_shared(api, input, cfg, &mut candidates, state, None)
+                    .await;
+            push_preflight_probe(trace, "ytm_video_finalist", preflight_started, &preflight);
             outcome = best_outcome(input, &candidates, cfg);
             if should_stop_ytm_search(&outcome, cfg) {
                 break;
             }
         }
-        // Early-stop can produce Matched inside the loop above. Do NOT still run
-        // yt-dlp metadata preflight in that case — it re-spawns slow/403-prone
-        // lookups and keeps the CLI stuck at 0/N with no progress.
-        if !matches!(outcome, MatchOutcome::Matched { .. }) {
-            let preflighted =
-                preflight_ytm_candidates_shared(api, input, cfg, &mut candidates, state).await;
-            state.diagnostics.lock().await.preflight_lookups += preflighted;
+    }
+
+    if !matches!(outcome, MatchOutcome::Matched { .. }) {
+        for query in ytm_fallback_query_plan(input)
+            .into_iter()
+            .take(PUBLIC_QUERY_BUDGET)
+        {
+            let started = Instant::now();
+            let search = match shared_video_songs(api, &query, search_config, state).await {
+                Ok(search) => search,
+                Err(failure) => {
+                    let error_kind = public_video_search_error_kind(&failure.error);
+                    trace.push_probe(ProbeTrace {
+                        backend: "public_youtube".to_owned(),
+                        intent: "bounded_rescue".to_owned(),
+                        query: query.clone(),
+                        status: "error".to_owned(),
+                        elapsed_ms: started.elapsed().as_millis() as u64,
+                        attempt: failure.attempts,
+                        error_kind: Some(error_kind.to_owned()),
+                        ..ProbeTrace::default()
+                    });
+                    if video_search_error_is_soft(&failure.error) {
+                        tracing::warn!(
+                            query = %query,
+                            error = %crate::util::sanitize::sanitize_error_text(format!("{:#}", failure.error)),
+                            "transfer video query was rejected; continuing with remaining fallback queries"
+                        );
+                        continue;
+                    }
+                    trace.set_candidates(trace_candidates(input, cfg, &candidates));
+                    trace.terminal_reason = Some("public_youtube_provider_error".to_owned());
+                    let error = failure.error.context(format!(
+                        "public YouTube transfer search failed for query {query:?}"
+                    ));
+                    return Err(YtmMatchFailure::new(error, trace.clone()));
+                }
+            };
+            let songs = search.songs;
+            trace.push_probe(ProbeTrace {
+                backend: "public_youtube".to_owned(),
+                intent: "bounded_rescue".to_owned(),
+                query: query.clone(),
+                status: if songs.is_empty() { "empty" } else { "success" }.to_owned(),
+                result_count: songs.len() as u32,
+                elapsed_ms: started.elapsed().as_millis() as u64,
+                attempt: search.attempts,
+                ..ProbeTrace::default()
+            });
+            for (song, kind) in &songs {
+                if candidate_keys.insert(song.video_id.clone()) {
+                    candidates.push(MatchCandidate::from_song_with_kind(song, (*kind).into()));
+                }
+            }
+            let provider_first = songs.first().and_then(|(song, _)| {
+                candidates
+                    .iter()
+                    .position(|candidate| candidate.key == song.video_id)
+                    .filter(|idx| official_signal_score(&candidates[*idx]) >= 0.7)
+            });
+            // `--allow-user-videos` relaxes provenance, not hard safety. Always preflight the
+            // best auto-eligible public finalist before accepting it so full metadata can still
+            // reject live/private/no-audio/description-only cover and low-quality uploads.
+            let preflight_started = Instant::now();
+            let preflight = preflight_ytm_candidates_shared(
+                api,
+                input,
+                cfg,
+                &mut candidates,
+                state,
+                provider_first,
+            )
+            .await;
+            push_preflight_probe(
+                trace,
+                "public_video_finalist",
+                preflight_started,
+                &preflight,
+            );
             outcome = best_outcome(input, &candidates, cfg);
+            if should_stop_ytm_search(&outcome, cfg) {
+                break;
+            }
         }
     }
 
-    state.memo.lock().await.insert(key, outcome.clone());
-    Ok(outcome)
+    trace.set_candidates(trace_candidates(input, cfg, &candidates));
+    trace.terminal_reason = Some(
+        match &outcome {
+            MatchOutcome::Matched { .. } => "matched",
+            MatchOutcome::Ambiguous { .. } => "ambiguous",
+            MatchOutcome::NotFound => "successful_exhaustion",
+            MatchOutcome::SkippedLocal => "skipped_local",
+            MatchOutcome::SkippedCapacity => "destination_capacity",
+        }
+        .to_owned(),
+    );
+    state.remember_outcome(key, outcome.clone()).await;
+    Ok(YtmMatchResult {
+        outcome,
+        trace: trace.clone(),
+    })
+}
+
+fn push_preflight_probe(
+    trace: &mut MatchTrace,
+    intent: &str,
+    started: Instant,
+    summary: &PreflightSummary,
+) {
+    if summary.attempts == 0 {
+        return;
+    }
+    trace.push_probe(ProbeTrace {
+        backend: "youtube_metadata".to_owned(),
+        intent: intent.to_owned(),
+        status: summary.status().to_owned(),
+        result_count: summary.successes,
+        elapsed_ms: started.elapsed().as_millis() as u64,
+        attempt: u16::try_from(summary.attempts).unwrap_or(u16::MAX),
+        error_kind: summary.first_error_kind.clone(),
+        ..ProbeTrace::default()
+    });
+}
+
+fn trace_candidates(
+    input: &TrackInput,
+    cfg: &MatchConfig,
+    candidates: &[MatchCandidate],
+) -> Vec<ReportCandidate> {
+    let mut candidates = candidates
+        .iter()
+        .map(|candidate| {
+            let score = score_candidate_breakdown_with_config(input, candidate, cfg);
+            ReportCandidate {
+                key: candidate.key.clone(),
+                score: score.total,
+                display: format!("{} — {}", candidate.artist, candidate.title),
+                score_breakdown: Some(score),
+            }
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| right.score.total_cmp(&left.score));
+    candidates
 }
 
 async fn shared_catalog_songs(
@@ -423,24 +874,34 @@ async fn shared_catalog_songs(
     query: &str,
     search_config: &SearchConfig,
     state: &SharedYtmMatchState,
-) -> anyhow::Result<Vec<(Song, YoutubeSearchKind)>> {
-    let memo_key = format!("catalog:{query}");
-    if let Some(hit) = state.query_memo.lock().await.get(&memo_key).cloned() {
+) -> anyhow::Result<SharedCatalogSongs> {
+    let memo_key = format!("v3:{}:ytm-song:{}", provider_scope(api), normalize(query));
+    if let Some(hit) = cached_query(state, &memo_key).await {
         count_persistent_query_hit(state, &memo_key).await;
-        return Ok(hit);
+        return Ok(SharedCatalogSongs::Complete(hit));
     }
     let lock = query_lock(state, &memo_key).await;
     let _guard = lock.lock().await;
-    if let Some(hit) = state.query_memo.lock().await.get(&memo_key).cloned() {
+    if let Some(hit) = cached_query(state, &memo_key).await {
         count_persistent_query_hit(state, &memo_key).await;
-        return Ok(hit);
+        return Ok(SharedCatalogSongs::Complete(hit));
+    }
+    // Keep persistent catalog hits usable in anonymous/degraded runs, but do not take a
+    // semaphore slot or the shared pacing delay when a live catalog request is impossible.
+    if !api.transfer_catalog_available() {
+        return Ok(SharedCatalogSongs::Unavailable);
     }
     let _permit = state
         .catalog_gate
         .acquire()
         .await
         .expect("catalog semaphore should not close");
-    state.pace.lock().await.tick().await;
+    // Another concurrent query may have opened the authenticated-parser cooldown while
+    // this one waited for the gate.
+    if !api.transfer_catalog_available() {
+        return Ok(SharedCatalogSongs::Unavailable);
+    }
+    state.catalog_pace.lock().await.tick().await;
     let (songs, degraded) = api.search_transfer_catalog(query, search_config).await?;
     {
         let mut diagnostics = state.diagnostics.lock().await;
@@ -449,16 +910,17 @@ async fn shared_catalog_songs(
             diagnostics.authenticated_catalog_degraded += 1;
         }
     }
+    if degraded {
+        // A parser/provider failure is not a successful negative lookup. Do not memoize it,
+        // and let the same primary query cross the provider boundary into public fallback.
+        return Ok(SharedCatalogSongs::Unavailable);
+    }
     let songs = songs
         .into_iter()
         .map(|song| (song, YoutubeSearchKind::YtmCatalogSong))
         .collect::<Vec<_>>();
-    state
-        .query_memo
-        .lock()
-        .await
-        .insert(memo_key, songs.clone());
-    Ok(songs)
+    state.remember_query(memo_key, songs.clone()).await;
+    Ok(SharedCatalogSongs::Complete(songs))
 }
 
 async fn shared_video_songs(
@@ -466,68 +928,155 @@ async fn shared_video_songs(
     query: &str,
     search_config: &SearchConfig,
     state: &SharedYtmMatchState,
-) -> anyhow::Result<Vec<(Song, YoutubeSearchKind)>> {
-    let memo_key = format!("video:{query}");
-    if let Some(hit) = state.query_memo.lock().await.get(&memo_key).cloned() {
+) -> Result<SharedPublicVideos, PublicSearchFailure> {
+    let memo_key = format!("v3:public:youtube-video:{}", normalize(query));
+    if let Some(hit) = cached_query(state, &memo_key).await {
         count_persistent_query_hit(state, &memo_key).await;
-        return Ok(hit);
+        return Ok(SharedPublicVideos {
+            songs: hit,
+            attempts: 1,
+        });
     }
     let lock = query_lock(state, &memo_key).await;
     let _guard = lock.lock().await;
-    if let Some(hit) = state.query_memo.lock().await.get(&memo_key).cloned() {
+    if let Some(hit) = cached_query(state, &memo_key).await {
         count_persistent_query_hit(state, &memo_key).await;
-        return Ok(hit);
+        return Ok(SharedPublicVideos {
+            songs: hit,
+            attempts: 1,
+        });
     }
-    let _permit = state
-        .video_gate
-        .acquire()
-        .await
-        .expect("video semaphore should not close");
-    state.pace.lock().await.tick().await;
-    // Soft-fail like catalog/album: yt-dlp 403/exit-1 must become Ok([]) so matching
-    // records NotFound instead of a track-level Err that trips the engine streak abort.
-    let songs = match api.search_transfer_video(query, search_config).await {
-        Ok(songs) => songs,
-        Err(error) => {
-            debug_assert!(
-                video_search_error_is_soft(&error),
-                "video search errors are soft-failed at the matching boundary"
-            );
-            tracing::warn!(
-                query = %query,
-                error = %crate::util::sanitize::sanitize_error_text(format!("{error:#}")),
-                "transfer video search soft-failed; treating as no results"
-            );
-            Vec::new()
+    let mut attempt = 1_u16;
+    let songs = loop {
+        let permit = state
+            .video_gate
+            .acquire()
+            .await
+            .expect("video semaphore should not close");
+        state.public_pace.lock().await.tick().await;
+        let result = api.search_transfer_video(query, search_config).await;
+        // A retry must not occupy scarce public-search capacity during its backoff.
+        drop(permit);
+        {
+            let mut diagnostics = state.diagnostics.lock().await;
+            diagnostics.video_searches = diagnostics.video_searches.saturating_add(1);
+            diagnostics.public_video_searches = diagnostics.public_video_searches.saturating_add(1);
+        }
+        match result {
+            Ok(songs) => break songs,
+            Err(error)
+                if attempt < PUBLIC_SEARCH_MAX_ATTEMPTS
+                    && public_video_search_is_retryable(&error) =>
+            {
+                let mut diagnostics = state.diagnostics.lock().await;
+                diagnostics.public_video_retries =
+                    diagnostics.public_video_retries.saturating_add(1);
+                drop(diagnostics);
+                tracing::warn!(
+                    query = %query,
+                    attempt,
+                    error_kind = public_video_search_error_kind(&error),
+                    error = %crate::util::sanitize::sanitize_error_text(format!("{error:#}")),
+                    retry_after_ms = PUBLIC_SEARCH_RETRY_DELAY.as_millis(),
+                    "transient public YouTube search failure; retrying once"
+                );
+                tokio::time::sleep(PUBLIC_SEARCH_RETRY_DELAY).await;
+                attempt = attempt.saturating_add(1);
+            }
+            Err(error) => {
+                return Err(PublicSearchFailure {
+                    error,
+                    attempts: attempt,
+                });
+            }
         }
     };
-    state.diagnostics.lock().await.video_searches += 1;
+    // Cache successful empty searches, but never cache a process/network/provider failure
+    // as an empty result. The latter must remain retryable and visible to the engine circuit.
     let songs = songs
         .into_iter()
         .map(|song| (song, YoutubeSearchKind::YoutubeVideoSearch))
         .collect::<Vec<_>>();
-    state
-        .query_memo
-        .lock()
+    state.remember_query(memo_key, songs.clone()).await;
+    Ok(SharedPublicVideos {
+        songs,
+        attempts: attempt,
+    })
+}
+
+async fn shared_ytm_video_songs(
+    api: &YtMusicApi,
+    query: &str,
+    search_config: &SearchConfig,
+    state: &SharedYtmMatchState,
+) -> anyhow::Result<SharedCatalogVideos> {
+    let memo_key = format!("v3:{}:ytm-video:{}", provider_scope(api), normalize(query));
+    if let Some(hit) = cached_query(state, &memo_key).await {
+        count_persistent_query_hit(state, &memo_key).await;
+        return Ok(SharedCatalogVideos::Complete(hit));
+    }
+    let lock = query_lock(state, &memo_key).await;
+    let _guard = lock.lock().await;
+    if let Some(hit) = cached_query(state, &memo_key).await {
+        count_persistent_query_hit(state, &memo_key).await;
+        return Ok(SharedCatalogVideos::Complete(hit));
+    }
+    if !api.transfer_video_catalog_available() {
+        return Ok(SharedCatalogVideos::Unavailable);
+    }
+    let _permit = state
+        .catalog_gate
+        .acquire()
         .await
-        .insert(memo_key, songs.clone());
-    Ok(songs)
+        .expect("catalog semaphore should not close");
+    if !api.transfer_video_catalog_available() {
+        return Ok(SharedCatalogVideos::Unavailable);
+    }
+    state.catalog_pace.lock().await.tick().await;
+    let (songs, degraded) = api
+        .search_transfer_video_catalog(query, search_config)
+        .await?;
+    {
+        let mut diagnostics = state.diagnostics.lock().await;
+        diagnostics.video_searches += 1;
+        diagnostics.ytm_video_searches += 1;
+    }
+    if degraded {
+        return Ok(SharedCatalogVideos::Unavailable);
+    }
+    let songs = songs
+        .into_iter()
+        .map(|song| (song, YoutubeSearchKind::YtmCatalogVideo))
+        .collect::<Vec<_>>();
+    state.remember_query(memo_key, songs.clone()).await;
+    Ok(SharedCatalogVideos::Complete(songs))
 }
 
 async fn query_lock(state: &SharedYtmMatchState, key: &str) -> Arc<AsyncMutex<()>> {
     let mut locks = state.query_locks.lock().await;
-    locks
-        .entry(key.to_owned())
-        .or_insert_with(|| Arc::new(AsyncMutex::new(())))
-        .clone()
+    single_flight_lock(&mut locks, key)
 }
 
 async fn video_lock(state: &SharedYtmMatchState, key: &str) -> Arc<AsyncMutex<()>> {
     let mut locks = state.video_locks.lock().await;
-    locks
-        .entry(key.to_owned())
-        .or_insert_with(|| Arc::new(AsyncMutex::new(())))
-        .clone()
+    single_flight_lock(&mut locks, key)
+}
+
+fn single_flight_lock(
+    locks: &mut HashMap<String, Weak<AsyncMutex<()>>>,
+    key: &str,
+) -> Arc<AsyncMutex<()>> {
+    if let Some(lock) = locks.get(key).and_then(Weak::upgrade) {
+        return lock;
+    }
+    if locks.len() >= SINGLE_FLIGHT_LOCK_MAX {
+        locks.retain(|_, lock| lock.strong_count() > 0);
+    }
+    let lock = Arc::new(AsyncMutex::new(()));
+    if locks.len() < SINGLE_FLIGHT_LOCK_MAX {
+        locks.insert(key.to_owned(), Arc::downgrade(&lock));
+    }
+    lock
 }
 
 async fn count_persistent_query_hit(state: &SharedYtmMatchState, key: &str) {
@@ -536,14 +1085,43 @@ async fn count_persistent_query_hit(state: &SharedYtmMatchState, key: &str) {
     }
 }
 
+/// Clone a query-cache entry behind a short lexical guard. Awaiting diagnostics while a
+/// temporary `query_memo` guard is still alive can otherwise retain the cache lock longer than
+/// intended and makes a cache hit vulnerable to future lock-order changes.
+async fn cached_query(
+    state: &SharedYtmMatchState,
+    key: &str,
+) -> Option<Vec<(Song, YoutubeSearchKind)>> {
+    let memo = state.query_memo.lock().await;
+    memo.get(key).cloned()
+}
+
 async fn count_persistent_video_hit(state: &SharedYtmMatchState, key: &str) {
     if state.persistent_video_keys.lock().await.remove(key) {
         state.diagnostics.lock().await.video_meta_cache_hits += 1;
     }
 }
 
-const TRANSFER_PREFLIGHT_TOP_N: usize = 2;
-const TRANSFER_EXHAUSTIVE_PREFLIGHT_TOP_N: usize = 5;
+/// Clone a metadata-cache entry behind a short lexical guard. Keeping this lookup separate is
+/// important: matching directly on `video_memo.lock().await.get(...)` extends the temporary
+/// guard through the entire `match` arm, and the cache-miss arm then deadlocks when it checks the
+/// same mutex again after acquiring its single-flight lock.
+async fn cached_video_metadata(state: &SharedYtmMatchState, key: &str) -> Option<YtdlpVideoMeta> {
+    let mut memo = state.video_memo.lock().await;
+    match memo.get(key).cloned() {
+        Some(Some(meta)) if usable_transfer_preflight(&meta) => Some(meta),
+        // Old/partial cache rows must not be treated as verified metadata. Remove them so a
+        // fresh provider lookup can repair the evidence instead of silently auto-accepting it.
+        Some(_) => {
+            memo.remove(key);
+            None
+        }
+        None => None,
+    }
+}
+
+const TRANSFER_PREFLIGHT_TOP_N: usize = 1;
+const TRANSFER_EXHAUSTIVE_PREFLIGHT_TOP_N: usize = 3;
 
 async fn preflight_ytm_candidates_shared(
     api: &YtMusicApi,
@@ -551,89 +1129,177 @@ async fn preflight_ytm_candidates_shared(
     cfg: &MatchConfig,
     candidates: &mut [MatchCandidate],
     state: &SharedYtmMatchState,
-) -> u32 {
-    let mut ranked: Vec<(f32, usize)> = candidates
+    provider_first: Option<usize>,
+) -> PreflightSummary {
+    let mut ranked: Vec<(bool, f32, usize)> = candidates
         .iter()
         .enumerate()
-        .filter(|(_, candidate)| needs_transfer_preflight(candidate))
-        .map(|(idx, candidate)| {
-            (
-                score_candidate_breakdown_with_config(input, candidate, cfg).total,
-                idx,
-            )
+        .filter_map(|(idx, candidate)| {
+            transfer_preflight_rank(input, candidate, cfg)
+                .map(|score| (provider_first == Some(idx), score, idx))
         })
-        .filter(|(score, _)| *score >= cfg.ambiguous_floor)
         .collect();
-    ranked.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    ranked.sort_by(|a, b| {
+        b.0.cmp(&a.0)
+            .then_with(|| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal))
+    });
 
-    let mut lookups = 0;
+    let mut summary = PreflightSummary::default();
     let preflight_top_n = match cfg.policy {
         MatchPolicy::Exhaustive => TRANSFER_EXHAUSTIVE_PREFLIGHT_TOP_N,
         _ => TRANSFER_PREFLIGHT_TOP_N,
     };
-    for (_, idx) in ranked.into_iter().take(preflight_top_n) {
+    for (_, _, idx) in ranked.into_iter().take(preflight_top_n) {
         let key = candidates[idx].key.clone();
-        let meta = match state.video_memo.lock().await.get(&key).cloned() {
+        let meta = match cached_video_metadata(state, &key).await {
             Some(hit) => {
                 count_persistent_video_hit(state, &key).await;
-                hit
+                Some(hit)
             }
             None => {
                 let lock = video_lock(state, &key).await;
                 let _guard = lock.lock().await;
-                if let Some(hit) = state.video_memo.lock().await.get(&key).cloned() {
+                if let Some(hit) = cached_video_metadata(state, &key).await {
                     count_persistent_video_hit(state, &key).await;
-                    hit
+                    Some(hit)
                 } else {
-                    let _permit = state
-                        .preflight_gate
-                        .acquire()
-                        .await
-                        .expect("preflight semaphore should not close");
-                    lookups += 1;
-                    let hit = match api.youtube_video_metadata(&key).await {
-                        Ok(meta) => Some(meta),
+                    match fetch_transfer_preflight(api, &key, state, &mut summary).await {
+                        Ok(meta) => {
+                            state.remember_video(key.clone(), Some(meta.clone())).await;
+                            summary.successes = summary.successes.saturating_add(1);
+                            Some(meta)
+                        }
                         Err(error) => {
-                            tracing::debug!(
+                            let error_kind = public_video_search_error_kind(&error);
+                            summary.failures = summary.failures.saturating_add(1);
+                            summary
+                                .first_error_kind
+                                .get_or_insert_with(|| error_kind.to_owned());
+                            {
+                                let mut diagnostics = state.diagnostics.lock().await;
+                                diagnostics.preflight_failures =
+                                    diagnostics.preflight_failures.saturating_add(1);
+                            }
+                            push_preflight_reason(
+                                &mut candidates[idx],
+                                "metadata_preflight_failed",
+                            );
+                            tracing::warn!(
                                 video_id = %key,
+                                error_kind,
                                 error = %crate::util::sanitize::sanitize_error_text(format!("{error:#}")),
-                                "transfer metadata preflight failed"
+                                "transfer metadata preflight unavailable; keeping candidate review-only"
                             );
                             None
                         }
-                    };
-                    state
-                        .video_memo
-                        .lock()
-                        .await
-                        .insert(key.clone(), hit.clone());
-                    hit
+                    }
                 }
             }
         };
-        candidates[idx].preflighted = true;
         if let Some(meta) = meta {
+            candidates[idx].preflighted = true;
             apply_transfer_preflight(input, &mut candidates[idx], &meta);
         }
     }
-    lookups
+    summary
 }
 
-fn needs_transfer_preflight(candidate: &MatchCandidate) -> bool {
-    // Flat yt-dlp search already carries duration/channel for most rows. Full
-    // `--dump-single-json` metadata enrichment is the hang we saw under 403
-    // pressure (preflight_before with no preflight_after for 75s+). Skip when
-    // the flat row is already rich enough for scoring.
+fn transfer_preflight_rank(
+    input: &TrackInput,
+    candidate: &MatchCandidate,
+    cfg: &MatchConfig,
+) -> Option<f32> {
+    if !needs_transfer_preflight(candidate, cfg) {
+        return None;
+    }
+    let score = score_candidate_breakdown_with_config(input, candidate, cfg).total;
+    // A localized flat-search title can make a real official upload appear weak until full
+    // metadata reveals its native title/channel. Let one official-like finalist through that
+    // bootstrap boundary; acceptance still happens only after metadata is reapplied and scored.
+    (score >= cfg.ambiguous_floor || official_signal_score(candidate) >= 0.7).then_some(score)
+}
+
+async fn fetch_transfer_preflight(
+    api: &YtMusicApi,
+    key: &str,
+    state: &SharedYtmMatchState,
+    summary: &mut PreflightSummary,
+) -> anyhow::Result<YtdlpVideoMeta> {
+    let mut attempt = 1_u16;
+    loop {
+        let permit = state
+            .preflight_gate
+            .acquire()
+            .await
+            .expect("preflight semaphore should not close");
+        // Public search and metadata extraction share a start-rate budget; otherwise their
+        // independent concurrency limits can still burst five yt-dlp processes at once.
+        state.public_pace.lock().await.tick().await;
+        summary.attempts = summary.attempts.saturating_add(1);
+        {
+            let mut diagnostics = state.diagnostics.lock().await;
+            diagnostics.preflight_lookups = diagnostics.preflight_lookups.saturating_add(1);
+        }
+        let result = api.youtube_video_metadata(key).await.and_then(|meta| {
+            usable_transfer_preflight(&meta)
+                .then_some(meta)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("YouTube metadata response lacked usable audio evidence")
+                })
+        });
+        // Neither the provider permit nor the start-rate mutex may be held during backoff.
+        drop(permit);
+        match result {
+            Ok(meta) => return Ok(meta),
+            Err(error)
+                if attempt < METADATA_PREFLIGHT_MAX_ATTEMPTS
+                    && public_video_search_is_retryable(&error) =>
+            {
+                {
+                    let mut diagnostics = state.diagnostics.lock().await;
+                    diagnostics.preflight_retries = diagnostics.preflight_retries.saturating_add(1);
+                }
+                tokio::time::sleep(PUBLIC_SEARCH_RETRY_DELAY).await;
+                attempt = attempt.saturating_add(1);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn usable_transfer_preflight(meta: &YtdlpVideoMeta) -> bool {
+    let has_audio_evidence = meta.audio.available_audio_formats.is_some()
+        || meta.audio.available_audio_only_formats.is_some()
+        || meta
+            .audio
+            .selected_audio_codec
+            .as_ref()
+            .is_some_and(|codec| !codec.trim().is_empty());
+    !meta.title.trim().is_empty() && !meta.channel.trim().is_empty() && has_audio_evidence
+}
+
+fn needs_transfer_preflight(candidate: &MatchCandidate, cfg: &MatchConfig) -> bool {
+    let missing_core_metadata = candidate.duration_secs.is_none()
+        || candidate
+            .channel
+            .as_ref()
+            .is_none_or(|channel| channel.trim().is_empty());
     !candidate.preflighted
+        && !candidate
+            .preflight_reason_codes
+            .iter()
+            .any(|reason| reason == "metadata_preflight_failed")
         && matches!(
             candidate.source_kind,
-            CandidateSourceKind::YoutubeVideoSearch | CandidateSourceKind::Unknown
+            CandidateSourceKind::YtmCatalogVideo
+                | CandidateSourceKind::YoutubeVideoSearch
+                | CandidateSourceKind::Unknown
         )
-        && (candidate.duration_secs.is_none()
-            || candidate
-                .channel
-                .as_ref()
-                .is_none_or(|c| c.trim().is_empty()))
+        && (candidate.source_kind == CandidateSourceKind::YtmCatalogVideo
+            || cfg.allow_user_videos
+            || cfg.policy == MatchPolicy::Aggressive
+            || official_signal_score(candidate) >= 0.7
+            || missing_core_metadata)
 }
 
 fn apply_transfer_preflight(
@@ -641,8 +1307,14 @@ fn apply_transfer_preflight(
     candidate: &mut MatchCandidate,
     meta: &YtdlpVideoMeta,
 ) {
-    if !meta.title.trim().is_empty() && candidate.title.trim().is_empty() {
-        candidate.title = meta.title.clone();
+    if metadata_title_credits_channel(meta) {
+        push_preflight_reason(candidate, "metadata_title_channel_corroborated");
+    }
+    if !meta.title.trim().is_empty() {
+        candidate.metadata_title = Some(meta.title.clone());
+        if candidate.title.trim().is_empty() {
+            candidate.title = meta.title.clone();
+        }
     }
     if !meta.channel.trim().is_empty() {
         candidate.channel = Some(meta.channel.clone());
@@ -650,6 +1322,18 @@ fn apply_transfer_preflight(
             candidate.artist = meta.channel.clone();
         }
     }
+    candidate.channel_id = meta.channel_id.clone().or_else(|| meta.uploader_id.clone());
+    candidate.channel_verified = meta.channel_is_verified;
+    candidate.availability = meta.availability.clone();
+    candidate.has_audio_format = meta
+        .audio
+        .available_audio_formats
+        .map(|count| count > 0)
+        .or_else(|| meta.audio.selected_audio_codec.as_ref().map(|_| true));
+    candidate.max_audio_bitrate_kbps = meta
+        .audio
+        .max_audio_bitrate_kbps
+        .or(meta.audio.selected_audio_bitrate_kbps);
     if candidate.duration_secs.is_none() {
         candidate.duration_secs = meta.duration_secs;
     }
@@ -667,6 +1351,24 @@ fn apply_transfer_preflight(
     }
     if matches!(meta.media_type.as_deref(), Some("playlist" | "multi_video")) {
         reject_preflight(candidate, "non_track_media");
+    }
+    if matches!(
+        meta.availability.as_deref(),
+        Some("private" | "needs_auth" | "premium_only" | "subscriber_only")
+    ) {
+        reject_preflight(candidate, "unavailable_video");
+    }
+    if candidate.has_audio_format == Some(false) {
+        reject_preflight(candidate, "no_audio_format");
+    } else if candidate
+        .max_audio_bitrate_kbps
+        .is_some_and(|bitrate| bitrate < 48.0)
+        && !musicgate::is_trusted_music_channel(&meta.channel)
+    {
+        push_preflight_reason(candidate, "low_audio_ceiling");
+    }
+    if meta.channel_is_verified == Some(true) {
+        push_preflight_reason(candidate, "verified_channel_corroboration");
     }
     if let Some(duration) = meta.duration_secs {
         if let Some(source_duration) = input.duration_secs {
@@ -688,6 +1390,17 @@ fn apply_transfer_preflight(
     if let Some(reason) = musicgate::non_music_reason(&rich_title, channel) {
         reject_preflight(candidate, reason);
     }
+}
+
+fn metadata_title_credits_channel(meta: &YtdlpVideoMeta) -> bool {
+    let Some(prefix) = title_artist_credit_prefix(&meta.title) else {
+        return false;
+    };
+    let prefix = normalize(prefix);
+    let channel = normalize(&meta.channel);
+    !prefix.is_empty()
+        && !channel.is_empty()
+        && (prefix == channel || similarity(&prefix, &channel) >= 0.92)
 }
 
 fn push_preflight_reason(candidate: &mut MatchCandidate, reason: &str) {
@@ -744,3 +1457,6 @@ fn should_stop_ytm_search(outcome: &MatchOutcome, cfg: &MatchConfig) -> bool {
 fn score_breakdown_has(score: &MatchScoreBreakdown, reason: &str) -> bool {
     score.reason_codes.iter().any(|r| r == reason)
 }
+
+#[cfg(test)]
+mod retrieval_tests;

--- a/src/transfer/matching/ytm_retrieval/retrieval_tests.rs
+++ b/src/transfer/matching/ytm_retrieval/retrieval_tests.rs
@@ -1,0 +1,280 @@
+use super::*;
+
+fn input() -> TrackInput {
+    TrackInput {
+        title: "Song Title (feat. Guest)".to_owned(),
+        artists: vec!["Primary".to_owned(), "Featured".to_owned()],
+        album_artists: Vec::new(),
+        album: Some("Album Name".to_owned()),
+        album_id: None,
+        album_uri: None,
+        album_release_date: Some("2024-05-01".to_owned()),
+        album_release_date_precision: None,
+        album_total_tracks: None,
+        album_type: None,
+        album_art_url: None,
+        disc_number: None,
+        track_number: None,
+        duration_secs: Some(180),
+        isrc: None,
+        explicit: None,
+        source_url: None,
+        source_key: "spotify:track:test".to_owned(),
+        known_video_id: None,
+    }
+}
+
+#[test]
+fn public_fallback_is_backend_scoped_and_quality_ordered() {
+    let input = input();
+    assert_eq!(
+        ytm_fallback_query_plan(&input),
+        vec![
+            "Primary Song Title".to_owned(),
+            "Primary Song Title official audio".to_owned(),
+            "Song Title official music video".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn public_fallback_uses_album_context_without_an_artist() {
+    let mut input = input();
+    input.artists.clear();
+
+    assert_eq!(
+        ytm_fallback_query_plan(&input),
+        vec![
+            "Song Title Album Name".to_owned(),
+            "Song Title official audio".to_owned(),
+            "Song Title official music video".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn public_fallback_without_artist_or_album_still_uses_three_distinct_intents() {
+    let mut input = input();
+    input.artists.clear();
+    input.album = None;
+
+    assert_eq!(
+        ytm_fallback_query_plan(&input),
+        vec![
+            "Song Title".to_owned(),
+            "Song Title official audio".to_owned(),
+            "Song Title official music video".to_owned(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn anonymous_catalog_miss_skips_pacing_and_provider_work() {
+    let state = SharedYtmMatchState::new(Pacing::new(Duration::ZERO), 1, 1, 1);
+    let result = shared_catalog_songs(
+        &YtMusicApi::Anonymous,
+        "Primary Song Title",
+        &SearchConfig::default(),
+        &state,
+    )
+    .await
+    .expect("anonymous catalog capability check");
+
+    assert!(matches!(result, SharedCatalogSongs::Unavailable));
+    assert_eq!(state.diagnostics().await.catalog_searches, 0);
+}
+
+#[tokio::test]
+async fn metadata_cache_miss_releases_guard_before_single_flight_recheck() {
+    let state = SharedYtmMatchState::new(Pacing::new(Duration::ZERO), 1, 1, 1);
+    let key = "missing-video";
+
+    assert!(cached_video_metadata(&state, key).await.is_none());
+    let lock = video_lock(&state, key).await;
+    let _single_flight = lock.lock().await;
+    let second_lookup = tokio::time::timeout(
+        Duration::from_millis(50),
+        cached_video_metadata(&state, key),
+    )
+    .await
+    .expect("cache miss must not retain video_memo across the miss arm");
+    assert!(second_lookup.is_none());
+}
+
+#[test]
+fn metadata_preflight_requires_identity_and_audio_evidence() {
+    let mut meta = YtdlpVideoMeta {
+        title: "Song Title".to_owned(),
+        channel: "Artist".to_owned(),
+        ..YtdlpVideoMeta::default()
+    };
+    assert!(!usable_transfer_preflight(&meta));
+
+    meta.audio.available_audio_formats = Some(0);
+    assert!(
+        usable_transfer_preflight(&meta),
+        "a known zero audio count is usable evidence and is rejected by the scoring gate"
+    );
+    meta.channel.clear();
+    assert!(!usable_transfer_preflight(&meta));
+}
+
+#[test]
+fn failed_metadata_preflight_is_not_retried_in_the_same_track() {
+    let song = Song::remote("video", "Song Title", "Artist", "3:00");
+    let mut candidate =
+        MatchCandidate::from_song_with_kind(&song, CandidateSourceKind::YoutubeVideoSearch);
+    candidate
+        .preflight_reason_codes
+        .push("metadata_preflight_failed".to_owned());
+
+    assert!(!needs_transfer_preflight(
+        &candidate,
+        &MatchConfig::default()
+    ));
+}
+
+#[test]
+fn allow_user_videos_still_requires_finalist_safety_preflight() {
+    let song = Song::remote("video", "Song Title", "Artist", "3:00");
+    let candidate =
+        MatchCandidate::from_song_with_kind(&song, CandidateSourceKind::YoutubeVideoSearch);
+    assert!(!needs_transfer_preflight(
+        &candidate,
+        &MatchConfig::default()
+    ));
+    assert!(needs_transfer_preflight(
+        &candidate,
+        &MatchConfig {
+            allow_user_videos: true,
+            ..MatchConfig::default()
+        }
+    ));
+}
+
+#[test]
+fn metadata_native_title_must_credit_the_verified_channel() {
+    let mut meta = YtdlpVideoMeta {
+        title: "あいみょん - マリーゴールド【OFFICIAL MUSIC VIDEO】".to_owned(),
+        channel: "あいみょん".to_owned(),
+        ..YtdlpVideoMeta::default()
+    };
+    assert!(metadata_title_credits_channel(&meta));
+
+    meta.channel = "Verified Broadcaster".to_owned();
+    assert!(!metadata_title_credits_channel(&meta));
+}
+
+#[test]
+fn translated_search_title_and_native_metadata_title_both_contribute_identity() {
+    let mut input = input();
+    input.title = "満月の夜なら".to_owned();
+    input.artists = vec!["Aimyon".to_owned()];
+    input.duration_secs = Some(205);
+
+    let song = Song::remote(
+        "OVKKtwDReEA",
+        "Aimyon - Only Under the Full Moon [OFFICIAL MUSIC VIDEO]",
+        "あいみょん",
+        "3:42",
+    );
+    let mut candidate =
+        MatchCandidate::from_song_with_kind(&song, CandidateSourceKind::YoutubeVideoSearch);
+    let cfg = MatchConfig {
+        allow_user_videos: true,
+        ..MatchConfig::default()
+    };
+    let flat_score = score_candidate_breakdown_with_config(&input, &candidate, &cfg).total;
+    assert!(flat_score < cfg.ambiguous_floor);
+    assert_eq!(
+        transfer_preflight_rank(&input, &candidate, &cfg),
+        Some(flat_score),
+        "official-like localized rows must reach canonical metadata"
+    );
+    candidate.preflighted = true;
+    let mut meta = YtdlpVideoMeta {
+        title: "あいみょん - 満月の夜なら 【OFFICIAL MUSIC VIDEO】".to_owned(),
+        channel: "あいみょん".to_owned(),
+        channel_is_verified: Some(true),
+        duration_secs: Some(222),
+        availability: Some("public".to_owned()),
+        live_status: Some("not_live".to_owned()),
+        ..YtdlpVideoMeta::default()
+    };
+    meta.audio.available_audio_formats = Some(5);
+
+    apply_transfer_preflight(&input, &mut candidate, &meta);
+    let breakdown = score_candidate_breakdown_with_config(&input, &candidate, &cfg);
+
+    assert_eq!(
+        candidate.metadata_title.as_deref(),
+        Some(meta.title.as_str())
+    );
+    assert!(breakdown.title >= 0.98, "native title: {breakdown:?}");
+    assert!(
+        breakdown.artist >= 0.95,
+        "translated artist credit: {breakdown:?}"
+    );
+    assert!(
+        !breakdown.accept_blocked,
+        "verified official video: {breakdown:?}"
+    );
+    assert!(matches!(
+        best_outcome(&input, &[candidate], &cfg),
+        MatchOutcome::Matched { .. }
+    ));
+}
+
+#[test]
+fn preflight_summary_distinguishes_partial_and_terminal_failure() {
+    assert_eq!(PreflightSummary::default().status(), "success");
+    assert_eq!(
+        PreflightSummary {
+            attempts: 2,
+            successes: 1,
+            failures: 1,
+            first_error_kind: Some("http_403".to_owned()),
+        }
+        .status(),
+        "partial"
+    );
+    assert_eq!(
+        PreflightSummary {
+            attempts: 1,
+            failures: 1,
+            first_error_kind: Some("timeout".to_owned()),
+            ..PreflightSummary::default()
+        }
+        .status(),
+        "error"
+    );
+}
+
+#[test]
+fn provider_failures_are_not_successful_empty_searches() {
+    let error = anyhow::anyhow!("yt-dlp search exited with status 1 (HTTP Error 403: Forbidden)");
+    assert!(!video_search_error_is_soft(&error));
+}
+
+#[test]
+fn public_search_retries_only_transient_provider_rejections() {
+    for (detail, kind) in [
+        ("HTTP Error 403: Forbidden", "http_403"),
+        ("HTTP Error 429: Too Many Requests", "http_429"),
+        ("Unable to download API page: connection reset", "network"),
+    ] {
+        let error = anyhow::anyhow!(detail);
+        assert_eq!(public_video_search_error_kind(&error), kind);
+        assert!(public_video_search_is_retryable(&error));
+    }
+
+    for (detail, kind) in [
+        ("yt-dlp search timed out", "timeout"),
+        ("yt-dlp returned invalid JSON", "invalid_response"),
+        ("yt-dlp executable not found", "tool_missing"),
+    ] {
+        let error = anyhow::anyhow!(detail);
+        assert_eq!(public_video_search_error_kind(&error), kind);
+        assert!(!public_video_search_is_retryable(&error));
+    }
+}

--- a/src/transfer/organize_plan.rs
+++ b/src/transfer/organize_plan.rs
@@ -110,6 +110,20 @@ pub fn build_import_organize_plan(
 pub fn apply_import_organize_plan(
     plan: &ImportOrganizePlan,
 ) -> anyhow::Result<ImportOrganizeApplyReport> {
+    let _guard = super::session::ImportRecordGuard::try_acquire(&plan.session_id)?;
+    for row in &plan.rows {
+        if matches!(row.decision, ImportOrganizeDecision::Move)
+            && let Some(target) = row.target_path.as_ref().filter(|path| path.exists())
+        {
+            anyhow::bail!("organize target already exists: {}", target.display());
+        }
+    }
+    ImportSession::load(&plan.session_id).with_context(|| {
+        format!(
+            "reload import session {} before organizing",
+            plan.session_id
+        )
+    })?;
     let mut moved_count = 0u32;
     let mut already_count = 0u32;
     let mut skipped_count = 0u32;
@@ -125,7 +139,7 @@ pub fn apply_import_organize_plan(
                     .as_ref()
                     .context("move row missing target path")?;
                 move_audio_and_sidecar(from, to, &plan.root)?;
-                super::session::record_download_done(
+                super::session::record_download_done_unlocked(
                     &plan.session_id,
                     row.source_order,
                     to.clone(),
@@ -627,6 +641,33 @@ mod tests {
         assert!(err.to_string().contains("already exists"));
         assert!(audio.exists());
         assert_eq!(std::fs::read(&target).unwrap(), b"existing");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn apply_does_not_move_files_after_import_record_was_deleted() {
+        let root = temp_root("apply-deleted-record");
+        let inbox = root
+            .join(".yututui-inbox")
+            .join("sp2yt-organize-deleted-record");
+        std::fs::create_dir_all(&inbox).unwrap();
+        let audio = inbox.join("Song.m4a");
+        std::fs::write(&audio, b"audio").unwrap();
+        let session = ImportSession {
+            session_id: "sp2yt-organize-deleted-record".to_owned(),
+            rows: vec![row(1, "Song", &audio.to_string_lossy())],
+            ..ImportSession::default()
+        };
+        let plan = build_import_organize_plan(&session, &ImportOrganizeOptions::new(root.clone()))
+            .unwrap();
+        let target = plan.rows[0].target_path.clone().unwrap();
+
+        let error = apply_import_organize_plan(&plan)
+            .expect_err("an already-deleted import record must abort before moving audio");
+
+        assert!(error.to_string().contains("reload import session"));
+        assert!(audio.exists());
+        assert!(!target.exists());
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src/transfer/report_cli.rs
+++ b/src/transfer/report_cli.rs
@@ -77,7 +77,25 @@ fn load_report(job_id: &str) -> anyhow::Result<TransferReport> {
 
 fn format_text_report(report: &TransferReport) -> String {
     let mut out = format!("Report: {}\n{}\n", report.job_id, report.render_text());
+    if let Some(defer) = &report.defer_reason {
+        out.push_str(&format!(
+            "Deferred: {}{} — {}\n",
+            defer.code,
+            defer
+                .backend
+                .as_deref()
+                .map(|backend| format!(" ({backend})"))
+                .unwrap_or_default(),
+            defer.message
+        ));
+    }
     append_match_stats(&mut out, &report.match_stats);
+    append_rows(&mut out, "Deferred", &report.deferred);
+    append_rows(
+        &mut out,
+        "Skipped at destination capacity",
+        &report.capacity_skipped,
+    );
     append_rows(&mut out, "Ambiguous", &report.ambiguous);
     append_rows(&mut out, "Not found", &report.not_found);
     out
@@ -112,6 +130,16 @@ fn append_match_stats(out: &mut String, stats: &MatchStats) {
             stats.video_searches
         ));
     }
+    append_nonzero(
+        out,
+        "YTM video catalog searches",
+        stats.ytm_video_catalog_searches.into(),
+    );
+    append_nonzero(
+        out,
+        "public video searches",
+        stats.public_video_searches.into(),
+    );
     if stats.preflight_lookups > 0 {
         out.push_str(&format!(
             "        metadata preflight lookups: {}\n",
@@ -124,9 +152,49 @@ fn append_match_stats(out: &mut String, stats: &MatchStats) {
             stats.authenticated_catalog_degraded
         ));
     }
+    append_nonzero(out, "catalog HTTP pages", stats.catalog_http_pages.into());
+    append_nonzero(
+        out,
+        "video process spawns",
+        stats.video_process_spawns.into(),
+    );
+    append_nonzero(
+        out,
+        "preflight process spawns",
+        stats.preflight_process_spawns.into(),
+    );
+    append_nonzero(
+        out,
+        "successful empty probes",
+        stats.successful_empty_probes.into(),
+    );
+    append_nonzero(out, "retries", stats.retries.into());
+    append_nonzero(out, "circuit opens", stats.circuit_opens.into());
+    append_nonzero(out, "deferred jobs", stats.deferred_jobs.into());
+    append_nonzero(out, "capacity-skipped rows", stats.capacity_skipped.into());
+    append_nonzero(out, "candidates fetched", stats.candidates_fetched.into());
+    append_nonzero(out, "candidates deduped", stats.candidates_deduped.into());
+    append_nonzero(out, "candidates rejected", stats.candidates_rejected.into());
+    append_nonzero(
+        out,
+        "candidates review-only",
+        stats.candidates_review_only.into(),
+    );
+    append_nonzero(out, "cache evictions", stats.cache_evictions.into());
+    append_nonzero(out, "checkpoint bytes", stats.checkpoint_bytes);
+    append_nonzero(out, "checkpoint flushes", stats.checkpoint_flushes.into());
+    append_counter_map(out, "provider errors", &stats.provider_errors);
+    append_counter_map(out, "terminal reasons", &stats.terminal_reasons);
     append_counter_map(out, "source kinds", &stats.source_kinds);
     append_counter_map(out, "quality tiers", &stats.quality_tiers);
     append_counter_map(out, "reason codes", &stats.reason_codes);
+    append_duration_map(out, "elapsed", &stats.elapsed_ms);
+}
+
+fn append_nonzero(out: &mut String, label: &str, value: u64) {
+    if value > 0 {
+        out.push_str(&format!("        {label}: {value}\n"));
+    }
 }
 
 fn append_counter_map(
@@ -140,6 +208,22 @@ fn append_counter_map(
     let rendered = values
         .iter()
         .map(|(key, count)| format!("{key}={count}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    out.push_str(&format!("        {label}: {rendered}\n"));
+}
+
+fn append_duration_map(
+    out: &mut String,
+    label: &str,
+    values: &std::collections::BTreeMap<String, u64>,
+) {
+    if values.is_empty() {
+        return;
+    }
+    let rendered = values
+        .iter()
+        .map(|(key, millis)| format!("{key}={millis}ms"))
         .collect::<Vec<_>>()
         .join(", ");
     out.push_str(&format!("        {label}: {rendered}\n"));
@@ -186,6 +270,20 @@ fn append_rows(out: &mut String, label: &str, rows: &[ReportRow]) {
             out.push_str(&format!(
                 "        reasons: {}\n",
                 row.reason_codes.join(", ")
+            ));
+        }
+        if let Some(reason) = &row.terminal_reason {
+            out.push_str(&format!("        terminal: {reason}\n"));
+        }
+        for probe in &row.executed_probes {
+            out.push_str(&format!(
+                "        probe [{}:{}] {} -> {} ({} results, {}ms)\n",
+                probe.backend,
+                probe.intent,
+                probe.query,
+                probe.status,
+                probe.result_count,
+                probe.elapsed_ms
             ));
         }
         for (idx, candidate) in row.candidates.iter().enumerate() {
@@ -271,7 +369,7 @@ mod tests {
         let output = run_inner(&[job_id, "--format", "json"]).expect("json report");
 
         assert!(output.contains(r#""job_id": "sp2yt-report-json""#));
-        assert!(output.contains(r#""schema_version": 4"#));
+        assert!(output.contains(r#""schema_version": 5"#));
         assert!(output.contains(r#""source_key": "spotify:track:maybe""#));
     }
 

--- a/src/transfer/review_action.rs
+++ b/src/transfer/review_action.rs
@@ -4,7 +4,7 @@ use anyhow::{Context as _, anyhow, bail};
 
 use super::checkpoint::{Checkpoint, ReviewDecision};
 use super::matching::{MatchOutcome, MatchScoreBreakdown};
-use super::session::ImportSession;
+use super::session::{ImportRecordGuard, ImportSession};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReviewActionSummary {
@@ -34,6 +34,7 @@ pub fn accept_first_candidate(
     job_id: &str,
     source_order: u32,
 ) -> anyhow::Result<ReviewActionSummary> {
+    let _guard = ImportRecordGuard::try_acquire(job_id)?;
     let mut cp = Checkpoint::load(job_id)?;
     let index = row_order_to_index(&cp, source_order)?;
     ensure_not_written(&cp, index)?;
@@ -48,6 +49,7 @@ pub fn choose_next_candidate(
     job_id: &str,
     source_order: u32,
 ) -> anyhow::Result<ReviewActionSummary> {
+    let _guard = ImportRecordGuard::try_acquire(job_id)?;
     let mut cp = Checkpoint::load(job_id)?;
     let index = row_order_to_index(&cp, source_order)?;
     ensure_not_written(&cp, index)?;
@@ -78,6 +80,7 @@ pub fn skip_row(job_id: &str, source_order: u32) -> anyhow::Result<ReviewActionS
 }
 
 pub fn accept_all_candidates(job_id: &str) -> anyhow::Result<ReviewBatchSummary> {
+    let _guard = ImportRecordGuard::try_acquire(job_id)?;
     let mut cp = Checkpoint::load(job_id)?;
     let mut rows = Vec::new();
     for index in 0..cp.tracks.len() {
@@ -149,6 +152,7 @@ fn apply_terminal_decision(
     decision: ReviewDecision,
     label: &'static str,
 ) -> anyhow::Result<ReviewActionSummary> {
+    let _guard = ImportRecordGuard::try_acquire(job_id)?;
     let mut cp = Checkpoint::load(job_id)?;
     let index = row_order_to_index(&cp, source_order)?;
     ensure_not_written(&cp, index)?;
@@ -166,7 +170,7 @@ fn apply_terminal_decision(
 fn save_checkpoint_and_session(cp: &mut Checkpoint) -> anyhow::Result<()> {
     cp.save().context("save checkpoint")?;
     ImportSession::from_checkpoint(cp)
-        .save()
+        .save_unlocked()
         .context("save import session")?;
     Ok(())
 }

--- a/src/transfer/review_cli.rs
+++ b/src/transfer/review_cli.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, bail};
 use super::checkpoint::{Checkpoint, ReviewDecision};
 use super::cli::{EXIT_FAILED, EXIT_OK, EXIT_USAGE};
 use super::matching::{MatchOutcome, MatchScoreBreakdown};
-use super::session::{ImportSession, ImportSessionRow, ImportSessionRowStatus};
+use super::session::{ImportRecordGuard, ImportSession, ImportSessionRow, ImportSessionRowStatus};
 
 const USAGE: &str = "\
 Usage:
@@ -65,6 +65,8 @@ fn run_inner(args: &[&str]) -> Result<String, ReviewError> {
         return Err(ReviewError::Usage("too many review arguments".to_owned()));
     }
 
+    let _guard = ImportRecordGuard::try_acquire(job_id)
+        .map_err(|error| ReviewError::Failed(error.into()))?;
     let mut cp = Checkpoint::load(job_id).map_err(ReviewError::Failed)?;
     let index = resolve_row_index(&cp, row_ref).map_err(ReviewError::Usage)?;
     let message = match action {
@@ -103,7 +105,7 @@ fn run_inner(args: &[&str]) -> Result<String, ReviewError> {
     };
     cp.save().map_err(|e| ReviewError::Failed(e.into()))?;
     ImportSession::from_checkpoint(&cp)
-        .save()
+        .save_unlocked()
         .map_err(|e| ReviewError::Failed(e.into()))?;
     Ok(format!("{message}\n"))
 }
@@ -315,6 +317,7 @@ fn row_status_label(status: ImportSessionRowStatus) -> &'static str {
         ImportSessionRowStatus::Ambiguous => "review",
         ImportSessionRowStatus::NotFound => "not_found",
         ImportSessionRowStatus::SkippedLocal => "skipped",
+        ImportSessionRowStatus::SkippedCapacity => "capacity",
     }
 }
 

--- a/src/transfer/session.rs
+++ b/src/transfer/session.rs
@@ -5,11 +5,16 @@
 //! follow-up, and Local Deck inbox organization without making UI code reverse-engineer
 //! checkpoint internals.
 
-use std::path::PathBuf;
+use std::collections::BTreeMap;
+use std::fs::{File, OpenOptions, TryLockError};
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
 
 use serde::{Deserialize, Serialize};
 
-use super::checkpoint::{Checkpoint, ReportCandidate, ReviewDecision};
+use super::checkpoint::{
+    Checkpoint, JobDeferReason, MatchTrace, ProbeTrace, ReportCandidate, ReviewDecision,
+};
 use super::matching::{MatchOutcome, TrackInput};
 use super::{Stage, TransferDest, TransferSource};
 use crate::util::safe_fs;
@@ -31,6 +36,8 @@ pub struct ImportSession {
     pub source: SessionEndpoint,
     pub destination: SessionEndpoint,
     pub counts: ImportSessionCounts,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub defer_reason: Option<JobDeferReason>,
     pub rows: Vec<ImportSessionRow>,
 }
 
@@ -42,6 +49,23 @@ pub struct ImportSessionSummary {
     pub source: SessionEndpoint,
     pub destination: SessionEndpoint,
     pub counts: ImportSessionCounts,
+}
+
+/// One persisted import-history record, including incomplete/orphaned records that no
+/// longer have a readable session document. Local Deck uses this lightweight index to keep
+/// every checkpoint/report/journal/summary cleanup target visible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportRecordEntry {
+    pub session_id: String,
+    pub updated_at: i64,
+}
+
+/// Exclusive per-job guard shared by every import-history writer and record deletion.
+///
+/// The lock file is deliberately permanent: unlinking a locked inode would let a new caller
+/// create and lock a different inode for the same job while the first guard is still alive.
+pub(crate) struct ImportRecordGuard {
+    _file: File,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -128,6 +152,7 @@ impl Default for ImportSession {
             source: SessionEndpoint::default(),
             destination: SessionEndpoint::default(),
             counts: ImportSessionCounts::default(),
+            defer_reason: None,
             rows: Vec::new(),
         }
     }
@@ -161,6 +186,7 @@ pub struct ImportSessionCounts {
     pub ambiguous: u32,
     pub not_found: u32,
     pub skipped_local: u32,
+    pub capacity_skipped: u32,
     pub written: u32,
 }
 
@@ -233,6 +259,10 @@ pub struct ImportSessionRow {
     pub reason_codes: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duration_delta_secs: Option<i32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub executed_probes: Vec<ProbeTrace>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_reason: Option<String>,
 }
 
 impl Default for ImportSessionRow {
@@ -274,6 +304,8 @@ impl Default for ImportSessionRow {
             reject_reason: None,
             reason_codes: Vec::new(),
             duration_delta_secs: None,
+            executed_probes: Vec::new(),
+            terminal_reason: None,
         }
     }
 }
@@ -287,6 +319,7 @@ pub enum ImportSessionRowStatus {
     Ambiguous,
     NotFound,
     SkippedLocal,
+    SkippedCapacity,
 }
 
 impl ImportSession {
@@ -304,6 +337,7 @@ impl ImportSession {
                     entry.review_decision.clone(),
                     entry.written,
                     searched_ytm,
+                    cp.match_traces.get(&(idx as u32 + 1)),
                 )
             })
             .collect();
@@ -322,11 +356,23 @@ impl ImportSession {
             source: endpoint_from_source(&cp.spec.source, cp.source_name.clone()),
             destination,
             counts,
+            defer_reason: cp.defer_reason.clone(),
             rows,
         }
     }
 
     pub fn save(&self) -> std::io::Result<()> {
+        if session_path(&self.session_id).is_none() {
+            return Ok(());
+        }
+        let _guard = ImportRecordGuard::try_acquire(&self.session_id)?;
+        self.save_unlocked()
+    }
+
+    /// Save while the caller already holds this session's [`ImportRecordGuard`].
+    /// Keeping this separate avoids platform-dependent recursive file-lock behavior in
+    /// long-running import/review operations.
+    pub(crate) fn save_unlocked(&self) -> std::io::Result<()> {
         let Some(path) = session_path(&self.session_id) else {
             return Ok(());
         };
@@ -385,9 +431,74 @@ impl ImportSession {
         out.sort_by_key(|summary| std::cmp::Reverse(summary.updated_at));
         out
     }
+
+    /// List every persisted import-history id, even when only an orphan checkpoint, report,
+    /// journal, or summary remains. Imported Local Deck tracks are merged by the UI separately.
+    pub fn list_record_entries() -> Vec<ImportRecordEntry> {
+        let Some(transfers) = transfers_dir() else {
+            return Vec::new();
+        };
+        let sessions = transfers.join("sessions");
+        let mut records = BTreeMap::<String, i64>::new();
+        collect_record_artifacts(&transfers, RecordArtifactDir::Transfers, &mut records);
+        collect_record_artifacts(&sessions, RecordArtifactDir::Sessions, &mut records);
+        let mut out: Vec<_> = records
+            .into_iter()
+            .map(|(session_id, updated_at)| ImportRecordEntry {
+                session_id,
+                updated_at,
+            })
+            .collect();
+        out.sort_by(|a, b| {
+            b.updated_at
+                .cmp(&a.updated_at)
+                .then_with(|| a.session_id.cmp(&b.session_id))
+        });
+        out
+    }
+
+    /// Delete the persisted history for one import job without touching any imported audio,
+    /// Local Deck index row, download sidecar, or destination playlist. The session document is
+    /// removed last so an interrupted cleanup remains visible and can be retried.
+    pub fn delete_record(session_id: &str) -> std::io::Result<usize> {
+        let Some(paths) = import_record_paths(session_id) else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "invalid import session id",
+            ));
+        };
+        reject_symlinked_record_parents()?;
+        let _guard = ImportRecordGuard::try_acquire(session_id)?;
+        let mut removed = 0;
+        for path in paths {
+            match std::fs::remove_file(path) {
+                Ok(()) => removed += 1,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(removed)
+    }
+
+    pub fn record_exists(session_id: &str) -> bool {
+        import_record_paths(session_id).is_some_and(|paths| {
+            paths
+                .iter()
+                .any(|path| std::fs::symlink_metadata(path).is_ok())
+        })
+    }
 }
 
 pub fn record_download_done(
+    session_id: &str,
+    source_order: u32,
+    local_path: PathBuf,
+) -> anyhow::Result<()> {
+    let _guard = ImportRecordGuard::try_acquire(session_id)?;
+    record_download_done_unlocked(session_id, source_order, local_path)
+}
+
+pub(crate) fn record_download_done_unlocked(
     session_id: &str,
     source_order: u32,
     local_path: PathBuf,
@@ -401,6 +512,15 @@ pub fn record_download_done(
 }
 
 pub fn record_download_error(
+    session_id: &str,
+    source_order: u32,
+    error: &str,
+) -> anyhow::Result<()> {
+    let _guard = ImportRecordGuard::try_acquire(session_id)?;
+    record_download_error_unlocked(session_id, source_order, error)
+}
+
+fn record_download_error_unlocked(
     session_id: &str,
     source_order: u32,
     error: &str,
@@ -435,7 +555,7 @@ fn row_by_source_order_mut(
 fn save_updated_session(mut session: ImportSession) -> anyhow::Result<()> {
     session.updated_at = crate::signals::unix_now();
     session.counts = ImportSessionCounts::from_rows(&session.rows);
-    session.save().map_err(Into::into)
+    session.save_unlocked().map_err(Into::into)
 }
 
 impl ImportSessionCounts {
@@ -451,6 +571,7 @@ impl ImportSessionCounts {
                 ImportSessionRowStatus::Ambiguous => counts.ambiguous += 1,
                 ImportSessionRowStatus::NotFound => counts.not_found += 1,
                 ImportSessionRowStatus::SkippedLocal => counts.skipped_local += 1,
+                ImportSessionRowStatus::SkippedCapacity => counts.capacity_skipped += 1,
             }
             if row.written {
                 counts.written += 1;
@@ -467,6 +588,7 @@ fn row_from_input(
     review_decision: Option<ReviewDecision>,
     written: bool,
     searched_ytm: bool,
+    trace: Option<&MatchTrace>,
 ) -> ImportSessionRow {
     let mut row = ImportSessionRow {
         row_id: format!("row-{:05}", idx + 1),
@@ -545,12 +667,29 @@ fn row_from_input(
             row.warnings
                 .push("spotify local file or episode skipped".to_owned());
         }
+        Some(MatchOutcome::SkippedCapacity) => {
+            row.status = ImportSessionRowStatus::SkippedCapacity;
+            row.warnings
+                .push("destination playlist capacity reached".to_owned());
+        }
         None => {
             row.status = ImportSessionRowStatus::Pending;
         }
     }
-    if searched_ytm && input.known_video_id.is_none() {
-        row.search_queries = super::matching::ytm_query_plan(input);
+    if let Some(trace) = trace {
+        row.executed_probes = trace.probes.clone();
+        row.terminal_reason = trace.terminal_reason.clone();
+        row.search_queries = trace
+            .probes
+            .iter()
+            .map(|probe| probe.query.clone())
+            .filter(|query| !query.is_empty())
+            .collect();
+        if row.candidates.is_empty() {
+            row.candidates = trace.candidates.clone();
+        }
+    } else if !searched_ytm || input.known_video_id.is_some() {
+        row.search_queries.clear();
     }
     row
 }
@@ -686,7 +825,11 @@ fn write_session_summary(session: &ImportSession) -> std::io::Result<()> {
 }
 
 fn sessions_dir() -> Option<PathBuf> {
-    crate::paths::data_dir().map(|d| d.join("transfers").join("sessions"))
+    Some(transfers_dir()?.join("sessions"))
+}
+
+fn transfers_dir() -> Option<PathBuf> {
+    crate::paths::data_dir().map(|d| d.join("transfers"))
 }
 
 fn safe_session_id(session_id: &str) -> Option<&str> {
@@ -695,6 +838,159 @@ fn safe_session_id(session_id: &str) -> Option<&str> {
             .bytes()
             .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-'))
     .then_some(session_id)
+}
+
+fn import_record_paths(session_id: &str) -> Option<[PathBuf; 5]> {
+    let safe_id = safe_session_id(session_id)?;
+    let transfers = transfers_dir()?;
+    let sessions = transfers.join("sessions");
+    Some([
+        transfers.join(format!("{safe_id}.json")),
+        transfers.join(format!("{safe_id}.report.json")),
+        transfers.join(format!("{safe_id}.journal.jsonl")),
+        sessions.join(format!("{safe_id}.summary.json")),
+        sessions.join(format!("{safe_id}.json")),
+    ])
+}
+
+impl ImportRecordGuard {
+    pub(crate) fn try_acquire_if_persistable(session_id: &str) -> std::io::Result<Option<Self>> {
+        if safe_session_id(session_id).is_none() || transfers_dir().is_none() {
+            return Ok(None);
+        }
+        Self::try_acquire(session_id).map(Some)
+    }
+
+    pub(crate) fn try_acquire(session_id: &str) -> std::io::Result<Self> {
+        let file = open_record_lock(session_id)?;
+        match file.try_lock() {
+            Ok(()) => Ok(Self { _file: file }),
+            Err(TryLockError::WouldBlock) => Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                format!("import job `{session_id}` is still active"),
+            )),
+            Err(TryLockError::Error(error)) => Err(error),
+        }
+    }
+}
+
+fn open_record_lock(session_id: &str) -> std::io::Result<File> {
+    let safe_id = safe_session_id(session_id).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "invalid import session id",
+        )
+    })?;
+    let transfers = transfers_dir().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no data directory on this platform",
+        )
+    })?;
+    reject_existing_symlink_or_non_directory(&transfers)?;
+    let lock_dir = transfers.join("record-locks");
+    safe_fs::ensure_private_dir(&lock_dir)?;
+    let lock_path = lock_dir.join(format!("{safe_id}.lock"));
+    if std::fs::symlink_metadata(&lock_path).is_ok_and(|meta| meta.file_type().is_symlink()) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!("refusing symlink lock file {}", lock_path.display()),
+        ));
+    }
+
+    let mut options = OpenOptions::new();
+    options.read(true).write(true).create(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    options.open(lock_path)
+}
+
+fn reject_symlinked_record_parents() -> std::io::Result<()> {
+    let transfers = transfers_dir().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no data directory on this platform",
+        )
+    })?;
+    reject_symlinked_record_parents_at(&transfers)
+}
+
+fn reject_symlinked_record_parents_at(transfers: &Path) -> std::io::Result<()> {
+    reject_existing_symlink_or_non_directory(transfers)?;
+    reject_existing_symlink_or_non_directory(&transfers.join("sessions"))
+}
+
+fn reject_existing_symlink_or_non_directory(path: &Path) -> std::io::Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing symlink import-record directory {}",
+                path.display()
+            ),
+        )),
+        Ok(metadata) if !metadata.is_dir() => Err(std::io::Error::new(
+            std::io::ErrorKind::NotADirectory,
+            format!(
+                "import-record parent is not a directory: {}",
+                path.display()
+            ),
+        )),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RecordArtifactDir {
+    Transfers,
+    Sessions,
+}
+
+fn collect_record_artifacts(
+    dir: &Path,
+    kind: RecordArtifactDir,
+    records: &mut BTreeMap<String, i64>,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        let session_id = match kind {
+            RecordArtifactDir::Transfers => name
+                .strip_suffix(".journal.jsonl")
+                .or_else(|| name.strip_suffix(".report.json"))
+                .or_else(|| name.strip_suffix(".json")),
+            RecordArtifactDir::Sessions => name
+                .strip_suffix(".summary.json")
+                .or_else(|| name.strip_suffix(".json")),
+        };
+        let Some(session_id) = session_id.and_then(safe_session_id) else {
+            continue;
+        };
+        let updated_at = artifact_modified_unix(&path);
+        records
+            .entry(session_id.to_owned())
+            .and_modify(|previous| *previous = (*previous).max(updated_at))
+            .or_insert(updated_at);
+    }
+}
+
+fn artifact_modified_unix(path: &Path) -> i64 {
+    std::fs::symlink_metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .and_then(|duration| i64::try_from(duration.as_secs()).ok())
+        .unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -837,6 +1133,7 @@ mod tests {
                 ambiguous: 1,
                 not_found: 1,
                 skipped_local: 1,
+                capacity_skipped: 0,
                 written: 1,
             }
         );
@@ -860,6 +1157,12 @@ mod tests {
         assert!(session_path("UPPER").is_none());
         assert!(session_path("").is_none());
         assert!(session_path("sp2yt-20260708-abcd").is_some());
+        assert_eq!(
+            ImportSession::delete_record("../escape")
+                .expect_err("hostile id must be rejected")
+                .kind(),
+            std::io::ErrorKind::InvalidInput
+        );
     }
 
     #[test]
@@ -971,5 +1274,163 @@ mod tests {
         assert_eq!(failed.rows[0].local_path, None);
         assert_eq!(failed.rows[0].errors, vec!["network failed"]);
         assert_eq!(failed.counts.written, 0);
+    }
+
+    #[test]
+    fn delete_record_removes_history_artifacts_but_keeps_imported_audio() {
+        let job_id = "sp2yt-session-delete-record";
+        let mut cp = Checkpoint::new(
+            job_id.to_owned(),
+            spec(TransferDest::LocalPlaylist {
+                name: Some("Imported".to_owned()),
+            }),
+            vec![entry(input("Keep Me", &["Artist"]), None, false)],
+        );
+        cp.save().expect("save checkpoint");
+        cp.append_track_journal(0, false)
+            .expect("append checkpoint journal");
+        super::super::checkpoint::TransferReport {
+            job_id: job_id.to_owned(),
+            ..super::super::checkpoint::TransferReport::default()
+        }
+        .save()
+        .expect("save report");
+
+        let data_dir = crate::paths::data_dir().expect("test data dir");
+        std::fs::create_dir_all(&data_dir).expect("create test data dir");
+        let audio = data_dir.join("kept-import-after-record-delete.m4a");
+        std::fs::write(&audio, b"audio remains").expect("write imported audio fixture");
+        let mut session = ImportSession::from_checkpoint(&cp);
+        session.rows[0].local_path = Some(audio.clone());
+        session.save().expect("save import session");
+
+        let transfers = data_dir.join("transfers");
+        let artifacts = [
+            super::super::checkpoint::checkpoint_path(job_id).expect("checkpoint path"),
+            super::super::checkpoint::report_path(job_id).expect("report path"),
+            transfers.join(format!("{job_id}.journal.jsonl")),
+            session_summary_path(job_id).expect("summary path"),
+            session_path(job_id).expect("session path"),
+        ];
+        assert!(artifacts.iter().all(|path| path.exists()));
+
+        assert_eq!(
+            ImportSession::delete_record(job_id).unwrap(),
+            artifacts.len()
+        );
+        assert!(artifacts.iter().all(|path| !path.exists()));
+        assert!(
+            audio.exists(),
+            "record deletion must not delete imported audio"
+        );
+        assert!(
+            ImportSession::list_all()
+                .into_iter()
+                .all(|summary| summary.session_id != job_id)
+        );
+        let _ = std::fs::remove_file(audio);
+    }
+
+    #[test]
+    fn active_import_record_lock_blocks_delete_until_writer_finishes() {
+        let job_id = "sp2yt-session-delete-active-lock";
+        let session = ImportSession {
+            session_id: job_id.to_owned(),
+            job_id: job_id.to_owned(),
+            ..ImportSession::default()
+        };
+        session.save().expect("save locked deletion fixture");
+
+        let guard = ImportRecordGuard::try_acquire(job_id).expect("hold active writer lock");
+        let error = ImportSession::delete_record(job_id)
+            .expect_err("active writer must prevent record deletion");
+        assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
+        assert!(ImportSession::record_exists(job_id));
+
+        let lock_path = transfers_dir()
+            .expect("transfers dir")
+            .join("record-locks")
+            .join(format!("{job_id}.lock"));
+        assert!(lock_path.exists());
+        drop(guard);
+
+        assert_eq!(ImportSession::delete_record(job_id).unwrap(), 2);
+        assert!(!ImportSession::record_exists(job_id));
+        assert!(
+            lock_path.exists(),
+            "the permanent lock inode must never be deleted"
+        );
+    }
+
+    #[test]
+    fn record_entry_index_includes_orphan_history_artifacts() {
+        let transfers = transfers_dir().expect("transfers dir");
+        let sessions = transfers.join("sessions");
+        std::fs::create_dir_all(&sessions).expect("create sessions dir");
+        let fixtures = [
+            (
+                "sp2yt-orphan-checkpoint-only",
+                transfers.join("sp2yt-orphan-checkpoint-only.json"),
+            ),
+            (
+                "sp2yt-orphan-report-only",
+                transfers.join("sp2yt-orphan-report-only.report.json"),
+            ),
+            (
+                "sp2yt-orphan-journal-only",
+                transfers.join("sp2yt-orphan-journal-only.journal.jsonl"),
+            ),
+            (
+                "sp2yt-orphan-summary-only",
+                sessions.join("sp2yt-orphan-summary-only.summary.json"),
+            ),
+        ];
+        for (_, path) in &fixtures {
+            std::fs::write(path, b"orphan").expect("write orphan artifact");
+        }
+
+        let entries = ImportSession::list_record_entries();
+        for (session_id, _) in &fixtures {
+            assert!(
+                entries.iter().any(|entry| entry.session_id == *session_id),
+                "missing orphan record {session_id}"
+            );
+        }
+
+        for (session_id, _) in fixtures {
+            ImportSession::delete_record(session_id).expect("clean orphan fixture");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deletion_rejects_symlinked_transfer_or_session_parent() {
+        use std::os::unix::fs::symlink;
+
+        let root = crate::paths::data_dir()
+            .expect("test data dir")
+            .join("record-delete-symlink-parent-test");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("real")).expect("create symlink target");
+
+        let transfers_link = root.join("transfers-link");
+        symlink(root.join("real"), &transfers_link).expect("link transfers parent");
+        assert_eq!(
+            reject_symlinked_record_parents_at(&transfers_link)
+                .expect_err("symlinked transfers parent must be rejected")
+                .kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+
+        let transfers = root.join("transfers");
+        std::fs::create_dir_all(&transfers).expect("create transfers parent");
+        symlink(root.join("real"), transfers.join("sessions")).expect("link sessions parent");
+        assert_eq!(
+            reject_symlinked_record_parents_at(&transfers)
+                .expect_err("symlinked sessions parent must be rejected")
+                .kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src/ui/buttons.rs
+++ b/src/ui/buttons.rs
@@ -164,7 +164,7 @@ fn render_segments_inner(
 
     let mut spans = Vec::with_capacity(segments.len());
     for (seg, width) in segments.iter().zip(widths) {
-        let style = if let Some(target) = seg.target {
+        let style = if let Some(target) = seg.target.clone() {
             // The rect hugs the text, plus any `hit_pad` cells of flanking air —
             // clamped to `area` so padding never escapes the strip's row.
             let x0 = x.saturating_sub(seg.hit_pad).max(area.x);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -81,6 +81,9 @@ pub fn render(frame: &mut Frame, app: &App) {
     if let Some(confirm) = &app.local_mode.pending_accept_all_confirm {
         views::local::render_local_accept_all_confirm(frame, app, area, confirm);
     }
+    if let Some(session_id) = &app.local_mode.pending_import_record_delete {
+        views::local::render_local_import_delete_confirm(frame, app, area, session_id);
+    }
     // A keybinding-conflict warning (Keys tab) is modal — it sits above everything else.
     if let Some(conflict) = &app.overlays.key_conflict {
         views::settings::render_conflict(frame, app, area, conflict);

--- a/src/ui/views/local.rs
+++ b/src/ui/views/local.rs
@@ -348,7 +348,7 @@ fn render_rows(frame: &mut Frame, app: &App, area: Rect) {
         app.bridges
             .library_scroll
             .resolve(cursor, area.height, len, crate::ui::scroll::SCROLLOFF);
-    let body_w = area.width.saturating_sub(1) as usize;
+    let row_width = area.width.saturating_sub(1);
 
     for (vis, (i, song)) in rows
         .iter()
@@ -359,6 +359,9 @@ fn render_rows(frame: &mut Frame, app: &App, area: Rect) {
     {
         let y = area.y + vis as u16;
         let selected = i == cursor;
+        let deletable = app.local_import_record_deletable(song);
+        let delete_width = if deletable { 2 } else { 0 };
+        let body_w = row_width.saturating_sub(delete_width) as usize;
         let marker = if selected { "> " } else { "  " };
         let text = app.local_row_text(song);
         let text = if selected {
@@ -390,11 +393,36 @@ fn render_rows(frame: &mut Frame, app: &App, area: Rect) {
         let row = Rect {
             x: area.x,
             y,
-            width: area.width.saturating_sub(1),
+            width: row_width,
             height: 1,
         };
         frame.render_widget(Paragraph::new(Line::from(body).style(style)), row);
-        app.register_mouse_button(row, MouseTarget::LocalRow(i));
+        let body_rect = Rect {
+            width: row.width.saturating_sub(delete_width),
+            ..row
+        };
+        app.register_mouse_button(body_rect, MouseTarget::LocalRow(i));
+        if deletable {
+            let delete_rect = Rect {
+                x: row.right().saturating_sub(delete_width),
+                width: delete_width,
+                ..row
+            };
+            let mut delete_style = app.theme.style(R::Error);
+            if selected {
+                delete_style = delete_style.bg(app.theme.color(R::SelectionBg));
+            }
+            frame.render_widget(
+                Paragraph::new(Line::from("✗").style(delete_style)),
+                delete_rect,
+            );
+            if let crate::local::LocalRowId::ImportSession(session_id) = song {
+                app.register_mouse_button(
+                    delete_rect,
+                    MouseTarget::LocalImportDel(session_id.clone()),
+                );
+            }
+        }
     }
 
     buttons::render_list_scrollbar(
@@ -653,6 +681,78 @@ pub fn render_local_accept_all_confirm(
         &segs,
         crate::ui::confirm_button_style(app),
         crate::ui::confirm_gap_style(app),
+        Alignment::Center,
+    );
+    crate::ui::seal_popup_background(frame, app, popup);
+    crate::ui::mark_art_rows_for_popup(frame, app, popup);
+}
+
+/// Confirm removal of transfer/session history only. Imported tracks and destination playlists
+/// are deliberately outside this operation and remain available after the record disappears.
+pub fn render_local_import_delete_confirm(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    session_id: &str,
+) {
+    let popup = centered_fixed(area, 72, 9);
+    crate::ui::render_popup_background(frame, app, popup);
+    let block = Block::default()
+        .title(t!(" ⚠ Delete import record ", " ⚠ 임포트 기록 삭제 "))
+        .borders(Borders::ALL)
+        .border_style(crate::ui::popup_style(app, R::Error).add_modifier(Modifier::BOLD))
+        .style(crate::ui::popup_style(app, R::TextPrimary));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+    let rows = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Min(1),
+    ])
+    .split(inner);
+    let prompt = if crate::i18n::is_korean() {
+        format!("임포트 세션 {session_id}의 기록을 삭제할까요?")
+    } else {
+        format!("Delete the saved record for import session {session_id}?")
+    };
+    frame.render_widget(
+        Paragraph::new(crate::ui::text::truncate_owned_to_width(
+            prompt,
+            inner.width as usize,
+        ))
+        .alignment(Alignment::Center)
+        .style(crate::ui::popup_style(app, R::TextPrimary)),
+        rows[1],
+    );
+    frame.render_widget(
+        Paragraph::new(t!(
+            "Imported songs, audio files, and playlists are not deleted.",
+            "임포트한 곡, 오디오 파일, 플레이리스트는 삭제하지 않습니다."
+        ))
+        .alignment(Alignment::Center)
+        .style(crate::ui::popup_style(app, R::TextMuted)),
+        rows[2],
+    );
+    let segs = [
+        buttons::Seg::button(
+            MouseTarget::ConfirmLocalImportDelete,
+            t!(" Delete record (Enter) ", " 기록 삭제 (Enter) "),
+        ),
+        buttons::Seg::label("    "),
+        buttons::Seg::button(
+            MouseTarget::CancelLocalImportDelete,
+            t!(" Cancel (Esc) ", " 취소 (Esc) "),
+        ),
+    ];
+    buttons::render_segments(
+        frame,
+        app,
+        rows[4],
+        &segs,
+        crate::ui::popup_style(app, R::Error).add_modifier(Modifier::BOLD),
+        crate::ui::popup_style(app, R::Accent).add_modifier(Modifier::BOLD),
         Alignment::Center,
     );
     crate::ui::seal_popup_background(frame, app, popup);

--- a/src/ui/views/player.rs
+++ b/src/ui/views/player.rs
@@ -320,9 +320,9 @@ fn render_status_line(frame: &mut Frame, app: &App, area: Rect) {
         .iter()
         .map(|(target, text)| match target {
             Some(t @ MouseTarget::Player(Action::IdentifyNowPlaying)) => {
-                Seg::padded_button(*t, text.as_ref(), id_pad)
+                Seg::padded_button(t.clone(), text.as_ref(), id_pad)
             }
-            Some(t) => Seg::button(*t, text.as_ref()),
+            Some(t) => Seg::button(t.clone(), text.as_ref()),
             None => Seg::label(text.as_ref()),
         })
         .collect();
@@ -746,7 +746,7 @@ fn render_dropdown(
             app.theme.style(R::TextPrimary)
         };
         frame.render_widget(Paragraph::new(Line::from(text).style(style)), row);
-        app.register_mouse_button(row, *target);
+        app.register_mouse_button(row, target.clone());
     }
     crate::ui::seal_popup_background(frame, app, popup);
     crate::ui::mark_art_rows_for_popup(frame, app, popup);

--- a/src/ui/views/search.rs
+++ b/src/ui/views/search.rs
@@ -492,7 +492,7 @@ fn render_dropdown(
             app.theme.style(R::TextPrimary)
         };
         frame.render_widget(Paragraph::new(Line::from(text).style(style)), row);
-        app.register_mouse_button(row, *target);
+        app.register_mouse_button(row, target.clone());
     }
     crate::ui::seal_popup_background(frame, app, popup);
     crate::ui::mark_art_rows_for_popup(frame, app, popup);


### PR DESCRIPTION
Release TUI and tray companion only; full GUI remains excluded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches external Spotify/YouTube APIs, transfer checkpoint durability, and destructive import-record deletion, but behavior is heavily bounded with cooldowns, timeouts, and tests.
> 
> **Overview**
> **Release 1.6.25** bumps `Cargo.toml` / Nix package versions (including aligning `yututray` with the TUI).
> 
> **YouTube Music / matching:** Authenticated search now needs **two consecutive failures** before the yt-dlp fallback cooldown; successes reset the streak. Transfer matching adds **bounded, timed** YTM song/album lookups, an optional **YTM Videos** catalog pass (separate per-mode cooldown) before public yt-dlp, a **cached anonymous** YTM client, and **`--retry-sleep extractor:1`** on yt-dlp searches. **`YtdlpVideoMeta`** moves to `video_metadata.rs` with richer channel/audio fields for ranking and preflight.
> 
> **Transfer durability:** Checkpoints gain a **checksum JSONL journal** (generation-aware replay), **`defer_reason`** / **`match_traces`**, **`SkippedCapacity`** when destination playlists hit the cap, richer **`MatchStats`**, and report schema **v5** (`deferred`, `capacity_skipped`). Spotify fetching gets **stricter pagination**, capped preallocation, **transfer-bounded** playlist/liked fetches, and safer **429/transient** retries. Playlists expose **`add_many`** for bulk import writes.
> 
> **Local Deck:** Users can **delete import session records** (Del / ✗) behind a modal—artifacts only, not imported audio. **`MouseTarget`** carries session ids for stable delete clicks after re-sort; import list includes orphan report entries; session recovery uses an **`ImportRecordGuard`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6ece68b2ff0fddb28287c887b5f516aa84bc789. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->