### PR TITLE
Release 1.6.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "yututui"
-version = "1.6.25"
+version = "1.6.26"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui"
-version = "1.6.25"
+version = "1.6.26"
 edition = "2024"
 description = "A fast terminal UI for YouTube Music — search, radio, synced lyrics, album art, and downloads, driven by mpv and yt-dlp."
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           lib = pkgs.lib;
           yututui = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui";
-            version = "1.6.25"; # keep in sync with Cargo.toml
+            version = "1.6.26"; # keep in sync with Cargo.toml
 
             # Drop build artifacts and flake results from the copied source so the store path
             # stays small and rebuilds aren't invalidated by a local `target/`.
@@ -84,7 +84,7 @@
           };
           yututui-desktop = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui-desktop";
-            version = "1.6.25"; # keep the yututray binary version in sync with Cargo.toml
+            version = "1.6.26"; # keep the yututray binary version in sync with Cargo.toml
             src = desktopSrc;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = [ pkgs.makeWrapper pkgs.pkg-config ];


### PR DESCRIPTION
## Summary
- bump yututui and yututray to 1.6.26
- keep Cargo.lock and flake package versions in sync

## Validation
- `~/.fable-harness/bin/run-gates .`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or logic changes; only version metadata and lockfile package entry updates.
> 
> **Overview**
> **Release 1.6.26** — version-only bump for `yututui` / `ytt` and the `yututray` Nix desktop package.
> 
> `Cargo.toml`, `Cargo.lock`, and `flake.nix` are updated so the crate version and both `yututui` / `yututui-desktop` `buildRustPackage` versions stay aligned (comments in the flake still call out syncing with `Cargo.toml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 230bbb7ca79fb581fc56363e5bfc584672e22339. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->