### PR TITLE
Run PR actions on Node.js 24

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -34,7 +34,7 @@ jobs:
     # Match debian-ts custom labels; OS/arch come from the runner automatically.
     runs-on: [self-hosted, debian, yututui]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Persist cargo target dir
         run: |
@@ -116,8 +116,8 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@v5
+      - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
 
@@ -127,7 +127,7 @@ jobs:
     # Match debian-ts custom labels; OS/arch come from the runner automatically.
     runs-on: [self-hosted, debian, yututui]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Persist cargo target dir
         run: |
@@ -169,7 +169,7 @@ jobs:
     runs-on: [self-hosted, windows, x64, yututui]
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -195,7 +195,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, yututui]
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Persist cargo target dir
         run: |


### PR DESCRIPTION
## What changed

- Upgrade `actions/checkout` from v4 to v5 in every PR CI job.
- Upgrade `actions/dependency-review-action` from v4 to v5.

## Why

GitHub now emits warning annotations because both v4 actions target the deprecated Node.js 20 runtime and are forcibly run on Node.js 24. This project treats warnings as gate failures, so release candidates cannot be considered warning-free while the PR workflow keeps the old major versions.

Both v5 actions declare the Node.js 24 runtime. The existing self-hosted runners already execute the forced Node.js 24 fallback successfully.

## Impact

No project build or test behavior changes. The PR gate keeps the same jobs, permissions, inputs, and required check names while removing the runtime-deprecation warnings.

## Validation

- `git diff --check`
- Verified all `checkout` and `dependency-review-action` references in `.github/workflows/ci-pr.yml` use v5.
- GitHub PR checks will validate the workflow on the real runners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency bumps with no application or test logic changes; release `build.yml` still uses v4 actions outside this PR.
> 
> **Overview**
> Updates **`.github/workflows/ci-pr.yml`** so every job uses **`actions/checkout@v5`** instead of v4, and the **`dependency-review`** job also moves **`actions/dependency-review-action`** from v4 to v5.
> 
> Job layout, permissions, `fail-on-severity`, and self-hosted runner labels are unchanged. The bump targets GitHub’s Node.js 24 action runtime and clears deprecation warnings that this repo treats as CI gate failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4b8e7faba3b35860c961a626eb16ba7adac5baf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->