### PR TITLE
Release 1.6.27

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     name: Quality gates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -99,8 +99,8 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@v5
+      - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
 
@@ -137,7 +137,7 @@ jobs:
             bin: ytt
             archive: yututui-linux-arm64.tar.gz
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # native-tls links against the system OpenSSL on Linux, so the runner needs the headers
       # plus pkg-config to locate them. (macOS/Windows use Security.framework/SChannel —
@@ -536,7 +536,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Verify tag matches Cargo version
         run: |
           tag="${GITHUB_REF_NAME#v}"
@@ -628,7 +628,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
         with:
           name: checksums
@@ -666,7 +666,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
         with:
           name: checksums
@@ -700,7 +700,7 @@ jobs:
     env:
       AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Render PKGBUILD
         run: |
           sed "s/__VERSION__/${GITHUB_REF_NAME#v}/g" packaging/aur/PKGBUILD.tmpl > PKGBUILD

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       # The full GUI app is not published in this release. These still run so the protocol and
       # future frontend do not drift while the shipped surface remains TUI + tray.
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: GUI frontend (typecheck, test, build)
@@ -518,7 +518,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.archive }}
           path: |
@@ -546,7 +546,7 @@ jobs:
             echo "::error::release tag v$tag does not match Cargo.toml version $version"
             exit 1
           fi
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           merge-multiple: true
       - name: Verify release artifact scope
@@ -595,13 +595,13 @@ jobs:
         # awk extractors in the publish jobs match the Windows line too.
         run: cat *.sha256 | sed 's/ \*/  /' | sort -k2 > checksums.txt
       - name: Attest release artifacts
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v3
         with:
           subject-path: |
             yututui-*.tar.gz
             yututui-*.zip
             checksums.txt
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
@@ -612,7 +612,7 @@ jobs:
             checksums.txt
       # Hand checksums.txt to the packaging jobs as an artifact, so they don't round-trip the
       # Releases API right after publish (avoids an asset-propagation race).
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: checksums
           path: checksums.txt
@@ -629,7 +629,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: checksums
       - name: Render formula
@@ -667,7 +667,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: checksums
       - name: Render manifest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "yututui"
-version = "1.6.26"
+version = "1.6.27"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui"
-version = "1.6.26"
+version = "1.6.27"
 edition = "2024"
 description = "A fast terminal UI for YouTube Music — search, radio, synced lyrics, album art, and downloads, driven by mpv and yt-dlp."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,8 @@ tray-icon = { version = "0.24.1", optional = true }
 # ts-rs generates the TypeScript protocol types the GUI is typed against, honoring the
 # serde attributes the wire already relies on (rename_all, internally-tagged enums).
 # Optional + gated behind `ts-export`: build/test-time only, never in a release binary.
-ts-rs = { version = "10", optional = true }
+# The wire tests cover `skip_serializing_if`, which ts-rs ignores; suppress only those diagnostics.
+ts-rs = { version = "10", optional = true, features = ["no-serde-warnings"] }
 tracing-appender = "0.2.5"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 # The transport strip lays out wide media glyphs (⏮ ⏯ ⏭) and registers click rects by

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           lib = pkgs.lib;
           yututui = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui";
-            version = "1.6.26"; # keep in sync with Cargo.toml
+            version = "1.6.27"; # keep in sync with Cargo.toml
 
             # Drop build artifacts and flake results from the copied source so the store path
             # stays small and rebuilds aren't invalidated by a local `target/`.
@@ -84,7 +84,7 @@
           };
           yututui-desktop = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui-desktop";
-            version = "1.6.26"; # keep the yututray binary version in sync with Cargo.toml
+            version = "1.6.27"; # keep the yututray binary version in sync with Cargo.toml
             src = desktopSrc;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = [ pkgs.makeWrapper pkgs.pkg-config ];


### PR DESCRIPTION
## Summary

- bump the application, lockfile, and Nix package versions to 1.6.27
- keep every commit already merged to main, including the authenticated YouTube search fallback hotfix
- suppress only unsupported ts-rs serde diagnostics while retaining wire-contract tests
- move all JavaScript actions executed by the release workflow to Node.js 24-compatible majors

## Validation

- canonical gate passed at `dd5ea048af6a0af911fd98db563b4811609926f7`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (1,885 library tests and 8 CLI smoke tests)
- architecture, file-size, doc-honesty, ratatui-image, and unsafe-inventory checks
- GUI type check with generated files unchanged
- GitHub Quality gates, Dependency review, and Linux checks passed with zero annotations
- total warnings: 0