### PR TITLE
Stabilize v1.6.27 release preflight

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
       - name: Format
         run: cargo fmt --check
       - name: Architecture invariants
@@ -111,7 +110,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-15
             name: macOS (arm64)
             target: aarch64-apple-darwin
             bin: ytt
@@ -151,15 +150,19 @@ jobs:
 
       - name: Install macOS smoke dependencies
         if: runner.os == 'macOS'
-        run: brew install mpv
+        run: |
+          # Hosted images currently leave an unrelated, untrusted aws/tap behind. Remove it
+          # rather than granting broad trust so Homebrew 6 can resolve official mpv cleanly.
+          if brew tap | grep -Fxq 'aws/tap'; then
+            brew untap aws/tap
+          fi
+          brew install mpv
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
           components: clippy
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Clippy (warnings = errors)
         run: cargo clippy --all-targets --target ${{ matrix.target }} -- -D warnings
@@ -172,7 +175,9 @@ jobs:
           cargo clippy --features desktop --target ${{ matrix.target }} --bin yututray -- -D warnings
 
       - name: Test
-        run: cargo test --target ${{ matrix.target }}
+        # Unit tests intentionally share one process-scoped persistence sandbox. Run the
+        # release matrix serially so filesystem fixtures cannot observe each other's writes.
+        run: cargo test --target ${{ matrix.target }} -- --test-threads=1
 
       - name: Test tray helper
         if: runner.os != 'Linux'

--- a/src/transfer/session.rs
+++ b/src/transfer/session.rs
@@ -424,9 +424,10 @@ impl ImportSession {
                             safe_fs::read_no_symlink_limited(&path, IMPORT_SESSION_MAX_BYTES)
                                 .ok()?;
                         let session: ImportSession = serde_json::from_slice(&bytes).ok()?;
-                        let summary = ImportSessionSummary::from(&session);
-                        let _ = write_session_summary(&session);
-                        Some(summary)
+                        // Keep discovery read-only. Recreating a missing sidecar here can race
+                        // with `delete_record`: a reader that loaded the session just before
+                        // deletion could otherwise resurrect an orphan summary afterwards.
+                        Some(ImportSessionSummary::from(&session))
                     })
                     .or_else(|| read_session_summary(session_id))
             })
@@ -823,13 +824,6 @@ fn summary_is_older_than_session(
         return false;
     };
     summary_modified < session_modified
-}
-
-fn write_session_summary(session: &ImportSession) -> std::io::Result<()> {
-    let Some(path) = session_summary_path(&session.session_id) else {
-        return Ok(());
-    };
-    safe_fs::write_private_atomic_json(&path, &ImportSessionSummaryFile::from(session))
 }
 
 fn sessions_dir() -> Option<PathBuf> {
@@ -1239,6 +1233,32 @@ mod tests {
             .expect("summary from list_all");
         assert_eq!(summary.session_id, session.session_id);
         assert_eq!(summary.counts.total, 1);
+    }
+
+    #[test]
+    fn list_all_does_not_recreate_a_missing_summary_sidecar() {
+        let cp = Checkpoint::new(
+            "sp2yt-session-read-only-list".to_owned(),
+            spec(TransferDest::LocalPlaylist {
+                name: Some("Imported".to_owned()),
+            }),
+            vec![entry(input("Matched", &["A"]), None, false)],
+        );
+        let session = ImportSession::from_checkpoint(&cp);
+        session.save().expect("save import session");
+        let summary_path = session_summary_path(&session.session_id).expect("summary path");
+        std::fs::remove_file(&summary_path).expect("remove summary sidecar");
+
+        assert!(
+            ImportSession::list_all()
+                .iter()
+                .any(|summary| summary.session_id == session.session_id),
+            "the full session remains discoverable without its sidecar"
+        );
+        assert!(
+            !summary_path.exists(),
+            "read-only discovery must not resurrect a removed sidecar"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep import-session discovery read-only so deletion cannot resurrect orphan summaries
- serialize the release matrix test runner because unit tests intentionally share one process-scoped persistence sandbox
- remove release-workflow Node deprecation warnings and pin the macOS arm64 image

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace (1,886 lib + 8 CLI)
- architecture/file-size/docs/ratatui/unsafe gates
- YAML parse and git diff --check

Release preflight for v1.6.27; no version or search behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch persisted import-history discovery semantics (deletion races); CI-only changes are low risk but serial tests may hide latent parallelism bugs locally.
> 
> **Overview**
> Release **build** workflow tweaks for v1.6.27: drops **Swatinem/rust-cache** from quality and matrix build jobs, pins **macOS arm64** to `macos-15`, and on macOS smoke setup **untaps `aws/tap`** before `brew install mpv` so Homebrew can resolve mpv without trusting that tap. Matrix **`cargo test`** now runs with **`--test-threads=1`** so parallel jobs do not stomp the shared process-scoped persistence sandbox used by unit tests.
> 
> **Import session listing** is now **read-only** when falling back from a missing summary sidecar: `ImportSession::list_all` no longer writes a `.summary.json` while discovering from the full session JSON, avoiding a race where a reader could resurrect an orphan summary after `delete_record`. The standalone `write_session_summary` helper is removed; sidecars still come from **`save` / `save_unlocked`**. A new test asserts listing stays discoverable without recreating a deleted sidecar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d7e8bf8efbb70254c93b46e4e003c4baedb974d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->