### PR TITLE
Expand local remote CLI and add read-only watch

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -329,9 +329,19 @@ ytt -r seek-to 90          # 1:30 へジャンプ
 ytt -r streaming on        # 無限ストリーミング: on / off / toggle
 ytt -r play "lofi"         # デーモン: 検索して最初の結果を再生
 ytt -r status              # 一行の「再生中」(--json はスクリプト用)
+ytt -r info                # owner 種別、プロトコル、capability（トークンは非表示）
+ytt -r queue-list          # 番号付きキュー; 現在の曲は > で表示
+ytt -r queue-play 2        # 2番目を再生（キュー番号は1から）
+ytt -r settings-show       # 秘密情報を含まない簡潔な設定一覧
+ytt -r watch --json        # 既定の player/queue/system イベントを NDJSON で購読
+ytt -r watch all           # 現在提供中の全て: player, queue, settings, system
 ```
 
 i3 / sway のメディアキー割り当て: `bindsym XF86AudioPlay exec ytt -r pp`。
+
+リモート操作は同じマシン上の現在の OS ユーザーだけが使える非公開 Unix ソケットまたは
+Windows named pipe に限定されます。LAN/HTTP リモートではないため、runtime ディレクトリを
+共有・公開しないでください。`queue-list` のキュー番号は1から始まります。
 
 ターミナルなしの再生は headless デーモンで:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -329,9 +329,19 @@ ytt -r seek-to 90          # 1:30 지점으로 점프
 ytt -r streaming on        # 무한 스트리밍: on / off / toggle
 ytt -r play "lofi"         # 데몬: 검색해서 첫 결과 재생
 ytt -r status              # 한 줄 "지금 재생 중" (--json 스크립트용)
+ytt -r info                # owner 종류, 프로토콜, capability (토큰은 표시 안 함)
+ytt -r queue-list          # 번호가 붙은 큐; 현재 곡은 >로 표시
+ytt -r queue-play 2        # 2번 곡 재생 (큐 번호는 1부터)
+ytt -r settings-show       # 비밀값 없는 간단한 설정 요약
+ytt -r watch --json        # 기본 player/queue/system 이벤트를 NDJSON으로 구독
+ytt -r watch all           # 제공 중인 전체: player, queue, settings, system
 ```
 
 i3 / sway 미디어 키 연결: `bindsym XF86AudioPlay exec ytt -r pp`.
+
+원격 제어는 같은 컴퓨터의 현재 OS 사용자에게만 열리는 비공개 Unix 소켓 또는 Windows
+named pipe를 사용합니다. LAN/HTTP remote가 아니므로 runtime 디렉터리를 공유하거나 외부에
+노출하지 마세요. `queue-list`에 표시되는 큐 번호는 1부터 시작합니다.
 
 터미널 없는 재생은 headless 데몬으로:
 

--- a/README.md
+++ b/README.md
@@ -329,9 +329,19 @@ ytt -r seek-to 90          # jump to 1:30
 ytt -r streaming on        # endless streaming: on / off / toggle
 ytt -r play "lofi"         # daemon: search and play the first result
 ytt -r status              # one-line "now playing" (--json for scripts)
+ytt -r info                # owner mode, protocol and capabilities (never the token)
+ytt -r queue-list          # numbered queue; the current row starts with >
+ytt -r queue-play 2        # play queue row 2 (queue numbers start at 1)
+ytt -r settings-show       # compact, non-secret settings summary
+ytt -r watch --json        # live player/queue/system events as NDJSON (the default topics)
+ytt -r watch all           # all published topics: player, queue, settings, system
 ```
 
 Media keys on i3 / sway: `bindsym XF86AudioPlay exec ytt -r pp`.
+
+Remote control stays on the same machine and is scoped to the current OS user through a private
+Unix socket or Windows named pipe. It is not a LAN/HTTP remote: never share or expose its runtime
+directory. Queue numbers shown by `queue-list` are 1-based.
 
 For terminal-free playback, run the headless daemon:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1286,6 +1286,11 @@ $ ytt</span>
       <div class="r"><code>ytt -r seek-to 90</code><span class="desc" data-i18n="rem.seek">Jump to a timestamp</span></div>
       <div class="r"><code>ytt -r streaming on</code><span class="desc" data-i18n="rem.streaming">Switch endless streaming on</span></div>
       <div class="r"><code>ytt -r status --json</code><span class="desc" data-i18n="rem.status">Now-playing snapshot, script-ready</span></div>
+      <div class="r"><code>ytt -r info</code><span class="desc" data-i18n="rem.info">Owner mode, protocol and safe capabilities</span></div>
+      <div class="r"><code>ytt -r queue-list</code><span class="desc" data-i18n="rem.queue">Numbered queue (1-based)</span></div>
+      <div class="r"><code>ytt -r queue-play 2</code><span class="desc" data-i18n="rem.queueplay">Play the second queue row</span></div>
+      <div class="r"><code>ytt -r settings-show</code><span class="desc" data-i18n="rem.settings">Compact, non-secret settings summary</span></div>
+      <div class="r"><code>ytt -r watch --json</code><span class="desc" data-i18n="rem.watch">Player/queue/system events; all adds settings</span></div>
       <div class="r"><code>ytt daemon start --resume</code><span class="desc" data-i18n="rem.daemon">Headless: restore the saved queue and play</span></div>
       <div class="r"><code>ytt -r play "lofi"</code><span class="desc" data-i18n="rem.play">Daemon: search and play the first hit</span></div>
       <div class="r"><code>ytt daemon stop</code><span class="desc" data-i18n="rem.stopdaemon">Stop the daemon and reap mpv</span></div>
@@ -1302,6 +1307,7 @@ $ ytt</span>
         <div style="color:var(--foam)">bindsym XF86AudioNext exec ytt -r next</div>
       </div>
       <p style="color:var(--subtle);font-size:.85rem" data-i18n-html="rem.single">Launching <code>ytt</code> twice never starts a second player — it just hands you the controls. The daemon restores queue, cursor, shuffle/repeat and streaming state, and keeps scrobbling.</p>
+      <p style="color:var(--subtle);font-size:.85rem" data-i18n-html="rem.local">Remote control is same-machine, same-OS-user IPC only — never expose its runtime directory as a LAN or HTTP remote.</p>
     </div>
   </div>
 
@@ -1565,9 +1571,11 @@ var KO = {
   "rem.sub": "<code>ytt</code> 가 재생 중이면 — 터미널 없는 headless 데몬이어도 — 아무 셸, 미디어 키, Control Center, 트레이에서 부릴 수 있어요. 명령 하나, 깔끔한 한 줄 응답.",
   "rem.pp": "재생 / 일시정지", "rem.next": "다음 곡으로", "rem.vol": "볼륨을 바로 지정",
   "rem.seek": "원하는 시점으로 점프", "rem.streaming": "무한 스트리밍 켜기", "rem.status": "지금 재생 정보, 스크립트에 바로",
+  "rem.info": "owner 종류, 프로토콜, 안전한 capability", "rem.queue": "번호가 붙은 큐 (1부터)", "rem.queueplay": "큐의 두 번째 곡 재생", "rem.settings": "비밀값 없는 간단한 설정 요약", "rem.watch": "player/queue/system 이벤트; all은 settings도 포함",
   "rem.daemon": "headless: 저장된 큐를 복원해 재생", "rem.play": "데몬: 검색해서 첫 곡 재생", "rem.stopdaemon": "데몬 중지 및 mpv 정리",
   "rem.wire": "# 미디어 키에 연결 (i3 / sway)",
   "rem.single": "<code>ytt</code> 를 두 번 실행해도 두 번째 플레이어는 생기지 않아요 — 조종간만 넘겨줄 뿐. 데몬은 큐·커서·셔플/반복·스트리밍 상태를 복원하고, 그동안 스크로블도 계속합니다.",
+  "rem.local": "원격 제어는 같은 컴퓨터·같은 OS 사용자의 IPC 전용입니다. runtime 디렉터리를 LAN 또는 HTTP remote로 노출하지 마세요.",
 
   "os.mac": "진짜 Now Playing 카드: 앨범 아트, 실제로 움직이는 시크바, 좋아요 버튼까지 — 같은 미니 플레이어가 메뉴 바에도, macOS 빌드에 동봉된 <code>yututray</code> 로.",
   "os.win.tray": "트레이 미니 플레이어",
@@ -1730,9 +1738,11 @@ var JA = {
   "rem.sub": "<code>ytt</code> が再生中なら — ターミナルなしの headless デーモンでも — どのシェルからでも、メディアキーでも、コントロールセンターでも、トレイからでも。コマンド一つ、返事は一行。",
   "rem.pp": "再生 / 一時停止", "rem.next": "次の曲へ", "rem.vol": "音量を直接指定",
   "rem.seek": "好きな時点へジャンプ", "rem.streaming": "無限ストリーミングをオン", "rem.status": "再生情報をスクリプトへそのまま",
+  "rem.info": "owner 種別、プロトコル、安全な capability", "rem.queue": "番号付きキュー（1から）", "rem.queueplay": "キューの2番目を再生", "rem.settings": "秘密値を含まない簡潔な設定概要", "rem.watch": "player/queue/system イベント; all は settings も含む",
   "rem.daemon": "headless: 保存したキューを復元して再生", "rem.play": "デーモン: 検索して最初の一曲を再生", "rem.stopdaemon": "デーモン停止と mpv の後始末",
   "rem.wire": "# メディアキーに割り当て (i3 / sway)",
   "rem.single": "<code>ytt</code> を二度起動しても二つ目のプレイヤーは生まれません — 操作を渡すだけ。デーモンはキュー・カーソル・シャッフル/リピート・ストリーミング状態を復元し、その間もスクロブルを続けます。",
+  "rem.local": "リモート操作は同じマシン・同じ OS ユーザーの IPC 専用です。runtime ディレクトリを LAN や HTTP remote として公開しないでください。",
 
   "os.mac": "本物の Now Playing カード: アートワーク、ちゃんと動くシークバー、Like ボタンまで — 同じミニプレイヤーはメニューバーにも、macOS ビルド同梱の <code>yututray</code> で。",
   "os.win.tray": "トレイ・ミニプレイヤー",

--- a/src/app/remote_reducer.rs
+++ b/src/app/remote_reducer.rs
@@ -106,8 +106,18 @@ impl App {
             RemoteCommand::CycleRepeat => {
                 // Music-mode invariant: refuse turning repeat on while autoplay is on (mirrors
                 // the daemon engine so parity holds). Off→All is the only enabling transition.
-                if self.queue.repeat == crate::queue::Repeat::Off && self.autoplay_streaming {
-                    return (RemoteResponse::status(self.status_snapshot()), Vec::new());
+                if self
+                    .queue
+                    .repeat
+                    .cycle_blocked_by_streaming(self.autoplay_streaming)
+                {
+                    self.status.text = t!(
+                        "Can't use repeat while autoplay is on",
+                        "자동재생 중에는 반복을 켤 수 없어요"
+                    )
+                    .to_owned();
+                    self.dirty = true;
+                    return (RemoteResponse::err("repeat_streaming_conflict"), Vec::new());
                 }
                 self.queue.cycle_repeat();
                 self.dirty = true;
@@ -165,12 +175,17 @@ impl App {
     /// Set/toggle autoplay streaming, mirroring the `ToggleStreaming` key handler (status toast +
     /// an immediate top-up when enabling, so a low queue doesn't gap before the next track).
     fn remote_set_streaming(&mut self, state: ToggleState) -> (RemoteResponse, Vec<Cmd>) {
-        let mut on = state.resolve(self.autoplay_streaming);
-        // Music-mode invariant: never enable autoplay while repeat is on. Clamping to `false`
-        // keeps the response shape identical to a normal "off" so app↔daemon parity holds
-        // (mirror of the daemon engine's `set_streaming`).
+        let on = state.resolve(self.autoplay_streaming);
+        // Music-mode invariant: reject the enable without changing playback/config state or
+        // emitting effects. The TUI still surfaces the same localized notice as its key path.
         if on && self.queue.repeat.is_on() {
-            on = false;
+            self.status.text = t!(
+                "Can't use autoplay while repeat is on",
+                "반복 재생 중에는 자동재생을 켤 수 없어요"
+            )
+            .to_owned();
+            self.dirty = true;
+            return (RemoteResponse::err("repeat_streaming_conflict"), Vec::new());
         }
         self.set_autoplay_streaming(on);
         self.status.text = format!(
@@ -539,30 +554,107 @@ mod tests {
     }
 
     #[test]
-    fn remote_streaming_refused_while_repeat_on() {
-        let mut app = App::new(50);
-        app.queue.repeat = crate::queue::Repeat::One;
-        let (resp, _) = app.apply_remote(RemoteCommand::Streaming {
-            state: ToggleState::On,
-        });
-        // Clamped to off so the response still reads as a normal "off" (keeps app↔daemon parity).
-        assert!(resp.ok);
-        assert!(
-            !app.autoplay_streaming,
-            "streaming stays off while repeat is on"
-        );
+    fn remote_streaming_enables_reject_without_state_or_effects() {
+        for command in [
+            RemoteCommand::Streaming {
+                state: ToggleState::On,
+            },
+            RemoteCommand::Streaming {
+                state: ToggleState::Toggle,
+            },
+            RemoteCommand::SetSetting {
+                change: RemoteSettingChange::AutoplayStreaming { value: true },
+            },
+        ] {
+            let mut app = App::new(50);
+            app.queue.repeat = crate::queue::Repeat::One;
+            app.config.repeat = crate::queue::Repeat::One;
+            app.config.autoplay_streaming = Some(false);
+            app.streaming.consecutive_failures = 2;
+            app.status.text = "before".to_owned();
+            app.dirty = false;
+
+            let (resp, cmds) = app.apply_remote(command);
+
+            assert!(!resp.ok);
+            assert_eq!(resp.reason.as_deref(), Some("repeat_streaming_conflict"));
+            assert!(cmds.is_empty(), "a rejection must emit no effects");
+            assert!(!app.autoplay_streaming);
+            assert_eq!(app.queue.repeat, crate::queue::Repeat::One);
+            assert_eq!(app.config.autoplay_streaming, Some(false));
+            assert_eq!(app.config.repeat, crate::queue::Repeat::One);
+            assert_eq!(app.streaming.consecutive_failures, 2);
+            assert!(matches!(
+                app.status.text.as_str(),
+                "Can't use autoplay while repeat is on"
+                    | "반복 재생 중에는 자동재생을 켤 수 없어요"
+            ));
+            assert!(app.dirty, "the localized rejection notice must redraw");
+        }
     }
 
     #[test]
-    fn remote_cycle_repeat_refused_while_streaming_on() {
+    fn remote_cycle_repeat_rejects_without_state_or_effects() {
         let mut app = App::new(50);
         app.autoplay_streaming = true;
-        app.apply_remote(RemoteCommand::CycleRepeat);
-        assert_eq!(
-            app.queue.repeat,
-            crate::queue::Repeat::Off,
-            "repeat stays off while streaming is on"
-        );
+        app.config.autoplay_streaming = Some(true);
+        app.streaming.consecutive_failures = 2;
+        app.status.text = "before".to_owned();
+        app.dirty = false;
+
+        let (resp, cmds) = app.apply_remote(RemoteCommand::CycleRepeat);
+
+        assert!(!resp.ok);
+        assert_eq!(resp.reason.as_deref(), Some("repeat_streaming_conflict"));
+        assert!(cmds.is_empty(), "a rejection must emit no effects");
+        assert_eq!(app.queue.repeat, crate::queue::Repeat::Off);
+        assert_eq!(app.config.repeat, crate::queue::Repeat::Off);
+        assert_eq!(app.config.autoplay_streaming, Some(true));
+        assert_eq!(app.streaming.consecutive_failures, 2);
+        assert!(matches!(
+            app.status.text.as_str(),
+            "Can't use repeat while autoplay is on" | "자동재생 중에는 반복을 켤 수 없어요"
+        ));
+        assert!(app.dirty, "the localized rejection notice must redraw");
+    }
+
+    #[test]
+    fn repeat_streaming_disables_remain_allowed() {
+        for command in [
+            RemoteCommand::Streaming {
+                state: ToggleState::Off,
+            },
+            RemoteCommand::Streaming {
+                state: ToggleState::Toggle,
+            },
+            RemoteCommand::SetSetting {
+                change: RemoteSettingChange::AutoplayStreaming { value: false },
+            },
+        ] {
+            let mut app = App::new(50);
+            app.autoplay_streaming = true;
+            app.queue.repeat = crate::queue::Repeat::One;
+
+            let (resp, cmds) = app.apply_remote(command);
+
+            assert!(resp.ok);
+            assert!(!app.autoplay_streaming);
+            assert_eq!(app.queue.repeat, crate::queue::Repeat::One);
+            assert!(cmds.iter().any(|cmd| matches!(
+                cmd,
+                Cmd::Persist(PersistCmd::Config(config))
+                    if config.autoplay_streaming == Some(false)
+            )));
+        }
+
+        let mut app = App::new(50);
+        app.autoplay_streaming = true;
+        app.queue.repeat = crate::queue::Repeat::One;
+        let (resp, cmds) = app.apply_remote(RemoteCommand::CycleRepeat);
+        assert!(resp.ok);
+        assert_eq!(app.queue.repeat, crate::queue::Repeat::Off);
+        assert!(app.autoplay_streaming);
+        assert!(!cmds.is_empty(), "the allowed repeat change is persisted");
     }
 
     #[test]

--- a/src/daemon/engine.rs
+++ b/src/daemon/engine.rs
@@ -354,7 +354,7 @@ impl DaemonEngine {
                 // Music-mode invariant (mirrors the App reducer for parity): refuse turning
                 // repeat on while autoplay streaming is on. Off→All is the only enabling step.
                 if self.queue.repeat.cycle_blocked_by_streaming(self.streaming) {
-                    RemoteResponse::status(self.status())
+                    RemoteResponse::err("repeat_streaming_conflict")
                 } else {
                     self.queue.cycle_repeat();
                     self.config.repeat = self.queue.repeat;
@@ -538,7 +538,9 @@ impl DaemonEngine {
             ("playback", "repeat") => {
                 match serde_json::from_value::<crate::queue::Repeat>(value.clone()) {
                     // Music-mode invariant: can't enable repeat while autoplay streaming is on.
-                    Ok(repeat) if repeat.set_blocked_by_streaming(self.streaming) => ok(self),
+                    Ok(repeat) if repeat.set_blocked_by_streaming(self.streaming) => {
+                        (RemoteResponse::err("repeat_streaming_conflict"), Vec::new())
+                    }
                     Ok(repeat) => {
                         self.queue.repeat = repeat;
                         self.config.repeat = repeat;
@@ -1727,11 +1729,11 @@ impl DaemonEngine {
     }
 
     fn set_streaming(&mut self, state: ToggleState) -> (RemoteResponse, Vec<EngineEffect>) {
-        let mut on = state.resolve(self.streaming);
-        // Music-mode invariant (mirrors the App reducer for parity): never enable autoplay while
-        // repeat is on. Clamping to `false` keeps the response identical to a normal "off".
+        let on = state.resolve(self.streaming);
+        // Music-mode invariant (mirrors the App reducer for parity): reject the enable before
+        // changing or persisting state, and without emitting any engine/player effects.
         if on && self.queue.repeat.is_on() {
-            on = false;
+            return (RemoteResponse::err("repeat_streaming_conflict"), Vec::new());
         }
         self.streaming = on;
         self.config.autoplay_streaming = Some(self.streaming);
@@ -3037,32 +3039,6 @@ mod tests {
         assert!(shutdown);
         assert!(effects.is_empty());
         assert!(engine.loaded_video_id.is_none());
-    }
-
-    #[tokio::test]
-    async fn remote_repeat_and_streaming_guards_preserve_music_mode_invariant() {
-        let mut engine = engine_with_queue(&["seed"]);
-        engine.streaming = true;
-        engine.queue.repeat = crate::queue::Repeat::Off;
-
-        let (response, _, effects) = engine.handle_remote(RemoteCommand::CycleRepeat).await;
-
-        assert!(response.ok);
-        assert!(effects.is_empty());
-        assert_eq!(engine.queue.repeat, crate::queue::Repeat::Off);
-
-        engine.streaming = false;
-        engine.queue.repeat = crate::queue::Repeat::All;
-        let (response, _, effects) = engine
-            .handle_remote(RemoteCommand::Streaming {
-                state: ToggleState::On,
-            })
-            .await;
-
-        assert!(response.ok);
-        assert!(effects.is_empty());
-        assert!(!engine.streaming);
-        assert_eq!(engine.config.autoplay_streaming, Some(false));
     }
 
     #[tokio::test]

--- a/src/daemon/parity_tests.rs
+++ b/src/daemon/parity_tests.rs
@@ -22,19 +22,21 @@ use std::sync::Arc;
 use tokio::sync::oneshot;
 
 use crate::api::Song;
-use crate::app::{App, Msg};
+use crate::app::{App, Cmd, Msg};
 use crate::config::Config;
 use crate::library::Library;
-use crate::queue::{Queue, QueueSnapshot};
+use crate::queue::{Queue, QueueSnapshot, Repeat};
 use crate::remote::proto::{
-    InstanceMode, PlayerModel, QueueModel, RemoteCommand, RemoteResponse, RemoteSettingChange,
-    ToggleState,
+    GuiSettingChange, InstanceMode, PlayerModel, QueueModel, RemoteCommand, RemoteResponse,
+    RemoteSettingChange, ToggleState,
 };
 use crate::remote::publish;
 use crate::signals::Signals;
 use crate::station::StationStore;
 
 use super::engine::{DaemonEngine, EngineState};
+
+const RNG_SEED: u64 = 20260703;
 
 fn song(id: &str) -> Song {
     Song::remote(id, format!("title-{id}"), format!("artist-{id}"), "3:45")
@@ -60,7 +62,6 @@ fn hermetic_pair() -> (App, DaemonEngine) {
         },
         Arc::new(|_event| {}),
     );
-    const RNG_SEED: u64 = 20260703;
     engine.restore_queue_snapshot(snap.clone(), RNG_SEED);
 
     let mut app = App::new(Config::default().volume);
@@ -78,11 +79,16 @@ fn hermetic_pair() -> (App, DaemonEngine) {
 
 /// Apply one command to the App through its real path (`Msg::Remote` → `apply_remote`).
 fn app_apply(app: &mut App, cmd: RemoteCommand) -> RemoteResponse {
+    app_apply_with_cmds(app, cmd).0
+}
+
+fn app_apply_with_cmds(app: &mut App, cmd: RemoteCommand) -> (RemoteResponse, Vec<Cmd>) {
     let (tx, mut rx) = oneshot::channel();
-    // Side-effect Cmds are deliberately dropped: parity compares state projections;
-    // effect parity (which PlayerCmds each owner emits) is an S1 extension.
-    let _cmds = app.update(Msg::Remote(cmd, tx));
-    rx.try_recv().expect("apply_remote replies synchronously")
+    let cmds = app.update(Msg::Remote(cmd, tx));
+    (
+        rx.try_recv().expect("apply_remote replies synchronously"),
+        cmds,
+    )
 }
 
 fn models_of(view: &publish::CoreView<'_>) -> (PlayerModel, QueueModel) {
@@ -106,6 +112,32 @@ fn assert_parity(step: &str, app: &App, engine: &DaemonEngine) {
     normalize(&mut eng_player, &mut eng_queue);
     assert_eq!(app_player, eng_player, "PlayerModel diverged after {step}");
     assert_eq!(app_queue, eng_queue, "QueueModel diverged after {step}");
+}
+
+async fn engine_with_modes(repeat: Repeat, streaming: bool) -> DaemonEngine {
+    let (_, mut engine) = hermetic_pair();
+    if streaming {
+        let (response, shutdown, _) = engine
+            .handle_remote(RemoteCommand::Streaming {
+                state: ToggleState::On,
+            })
+            .await;
+        assert!(response.ok && !shutdown, "test setup must enable streaming");
+    }
+    let mut snapshot = seed_snapshot();
+    snapshot.repeat = repeat;
+    engine.restore_queue_snapshot(snapshot, RNG_SEED);
+    engine
+}
+
+fn gui_repeat(repeat: Repeat) -> RemoteCommand {
+    RemoteCommand::Apply {
+        change: GuiSettingChange {
+            group: "playback".to_owned(),
+            field: "repeat".to_owned(),
+            value: serde_json::to_value(repeat).unwrap(),
+        },
+    }
 }
 
 /// The B0 shared command script: settings, toggles, and queue membership — everything
@@ -134,11 +166,19 @@ fn b0_script() -> Vec<RemoteCommand> {
         RemoteCommand::Streaming {
             state: ToggleState::On,
         },
+        RemoteCommand::SetSetting {
+            change: RemoteSettingChange::AutoplayStreaming { value: true },
+        },
+        RemoteCommand::CycleRepeat, // One → Off: disabling repeat remains allowed
         RemoteCommand::Streaming {
-            state: ToggleState::Toggle,
+            state: ToggleState::On,
+        },
+        RemoteCommand::CycleRepeat, // rejected while streaming is on
+        RemoteCommand::Streaming {
+            state: ToggleState::Toggle, // On → Off: disabling streaming remains allowed
         },
         RemoteCommand::ToggleShuffle, // back to natural order
-        RemoteCommand::CycleRepeat,   // Off → All → One → Off completes
+        RemoteCommand::CycleRepeat,   // Off → All remains allowed after streaming is off
     ]
 }
 
@@ -150,8 +190,8 @@ async fn shared_script_keeps_app_and_engine_projections_equal() {
     for (index, cmd) in b0_script().into_iter().enumerate() {
         let step = format!("step {index}: {cmd:?}");
 
-        let app_resp = app_apply(&mut app, cmd.clone());
-        let (engine_resp, shutdown, _effects) = engine.handle_remote(cmd).await;
+        let (app_resp, app_cmds) = app_apply_with_cmds(&mut app, cmd.clone());
+        let (engine_resp, shutdown, engine_effects) = engine.handle_remote(cmd).await;
         assert!(!shutdown, "{step}: script must not shut the engine down");
 
         assert_eq!(
@@ -162,8 +202,90 @@ async fn shared_script_keeps_app_and_engine_projections_equal() {
             app_resp.reason, engine_resp.reason,
             "{step}: owners disagree on the machine reason code"
         );
+        if app_resp.reason.as_deref() == Some("repeat_streaming_conflict") {
+            assert!(app_cmds.is_empty(), "{step}: App rejection emitted effects");
+            assert!(
+                engine_effects.is_empty(),
+                "{step}: daemon rejection emitted effects"
+            );
+        }
 
         assert_parity(&step, &app, &engine);
+    }
+}
+
+#[tokio::test]
+async fn daemon_conflicts_reject_without_state_or_effects() {
+    for command in [
+        RemoteCommand::Streaming {
+            state: ToggleState::On,
+        },
+        RemoteCommand::Streaming {
+            state: ToggleState::Toggle,
+        },
+        RemoteCommand::SetSetting {
+            change: RemoteSettingChange::AutoplayStreaming { value: true },
+        },
+    ] {
+        let mut engine = engine_with_modes(Repeat::All, false).await;
+        let before = engine.status();
+        let (response, shutdown, effects) = engine.handle_remote(command).await;
+        assert!(!response.ok && !shutdown);
+        assert_eq!(
+            response.reason.as_deref(),
+            Some("repeat_streaming_conflict")
+        );
+        assert!(effects.is_empty());
+        assert_eq!(engine.status(), before, "rejection mutated daemon state");
+    }
+
+    for (repeat, streaming, command) in [
+        (Repeat::Off, true, RemoteCommand::CycleRepeat),
+        (Repeat::Off, true, gui_repeat(Repeat::All)),
+    ] {
+        let mut engine = engine_with_modes(repeat, streaming).await;
+        let before = engine.status();
+        let (response, shutdown, effects) = engine.handle_remote(command).await;
+        assert!(!response.ok && !shutdown);
+        assert_eq!(
+            response.reason.as_deref(),
+            Some("repeat_streaming_conflict")
+        );
+        assert!(effects.is_empty());
+        assert_eq!(engine.status(), before, "rejection mutated daemon state");
+    }
+}
+
+#[tokio::test]
+async fn daemon_conflict_disables_remain_allowed() {
+    for command in [
+        RemoteCommand::Streaming {
+            state: ToggleState::Off,
+        },
+        RemoteCommand::Streaming {
+            state: ToggleState::Toggle,
+        },
+        RemoteCommand::SetSetting {
+            change: RemoteSettingChange::AutoplayStreaming { value: false },
+        },
+    ] {
+        let mut engine = engine_with_modes(Repeat::One, true).await;
+        let (response, shutdown, effects) = engine.handle_remote(command).await;
+        let status = engine.status();
+        assert!(response.ok && !shutdown);
+        assert!(effects.is_empty());
+        assert!(!status.streaming);
+        assert_eq!(status.repeat, Repeat::One);
+    }
+
+    for command in [RemoteCommand::CycleRepeat, gui_repeat(Repeat::Off)] {
+        let mut engine = engine_with_modes(Repeat::One, true).await;
+        let (response, shutdown, effects) = engine.handle_remote(command).await;
+        let status = engine.status();
+        assert!(response.ok && !shutdown);
+        assert!(effects.is_empty());
+        assert!(status.streaming);
+        assert_eq!(status.repeat, Repeat::Off);
     }
 }
 

--- a/src/remote/args.rs
+++ b/src/remote/args.rs
@@ -1,14 +1,30 @@
 //! Hand-rolled parser for `ytt -r <command> [args] [flags]`.
 //!
 //! The project ships no `clap`; this mirrors the existing `--version`/`--help` style in
-//! `main`. The verb (with short aliases) maps to a [`RemoteCommand`]; `-q`/`--json` are
+//! `main`. The verb (with short aliases) maps to an [`Invocation`]; `-q`/`--json` are
 //! client-side display flags.
 
-use super::proto::{RemoteCommand, ToggleState};
+use super::proto::{RemoteCommand, ToggleState, Topic};
+
+/// Work requested by a parsed `ytt -r` command line.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Invocation {
+    /// A frozen one-shot protocol command.
+    Command(RemoteCommand),
+    /// Show non-secret metadata for the current owner after proving it is reachable.
+    Info,
+    /// Fetch status and render its queue projection.
+    QueueList,
+    /// Fetch status and render its settings projection.
+    SettingsShow,
+    /// Follow the selected read-only v8 event topics.
+    Watch { topics: Vec<Topic> },
+}
 
 /// A successfully parsed `ytt -r` invocation.
+#[derive(Debug, Clone, PartialEq)]
 pub struct Parsed {
-    pub command: RemoteCommand,
+    pub invocation: Invocation,
     /// Suppress the success line (errors still print).
     pub quiet: bool,
     /// Print the raw JSON response instead of the human line.
@@ -44,6 +60,11 @@ Commands:
                           Toggle (or set) autoplay streaming
   resume-session          Load and play the saved session
   status, st              Print the current track / state
+  info                    Print non-secret owner metadata
+  queue-list              List the queue (current item is marked with >)
+  queue-play <N>          Play the one-based queue item N
+  settings-show           Print the remote settings summary
+  watch [topics|all]      Follow player, queue, settings, and system events
   quit                    Quit the running instance
 
 Flags:
@@ -54,6 +75,8 @@ Flags:
 Examples:
   ytt -r pp               # play / pause
   ytt -r streaming off    # turn autoplay streaming off
+  ytt -r queue-play 2     # jump to the second queue item
+  ytt -r watch player,queue
   bindsym XF86AudioNext exec ytt -r next   # i3 / sway media key
 ";
 
@@ -78,32 +101,34 @@ pub fn parse(args: &[String]) -> Result<Parsed, ParseError> {
         return Err(ParseError::Usage(USAGE.to_string()));
     };
 
-    let command = match verb {
-        "next" | "n" => RemoteCommand::Next,
-        "prev" | "p" | "previous" => RemoteCommand::Prev,
-        "play" if !rest.is_empty() => RemoteCommand::Play {
+    let invocation = match verb {
+        "next" | "n" => Invocation::Command(RemoteCommand::Next),
+        "prev" | "p" | "previous" => Invocation::Command(RemoteCommand::Prev),
+        "play" if !rest.is_empty() => Invocation::Command(RemoteCommand::Play {
             query: rest.join(" "),
-        },
+        }),
         "enqueue" | "queue" | "add" => {
             if rest.is_empty() {
                 return Err(ParseError::Invalid(format!(
                     "{verb}: expected a search query"
                 )));
             }
-            RemoteCommand::Enqueue {
+            Invocation::Command(RemoteCommand::Enqueue {
                 query: rest.join(" "),
-            }
+            })
         }
-        "play-pause" | "pp" | "toggle" | "play" | "pause" => RemoteCommand::TogglePause,
-        "up" | "vol-up" | "volup" => RemoteCommand::VolumeUp,
-        "down" | "vol-down" | "voldown" => RemoteCommand::VolumeDown,
+        "play-pause" | "pp" | "toggle" | "play" | "pause" => {
+            Invocation::Command(RemoteCommand::TogglePause)
+        }
+        "up" | "vol-up" | "volup" => Invocation::Command(RemoteCommand::VolumeUp),
+        "down" | "vol-down" | "voldown" => Invocation::Command(RemoteCommand::VolumeDown),
         "volume" | "vol" => {
             let percent = rest
                 .first()
                 .and_then(|value| value.parse::<i64>().ok())
                 .filter(|value| (0..=100).contains(value));
             match percent {
-                Some(percent) => RemoteCommand::SetVolume { percent },
+                Some(percent) => Invocation::Command(RemoteCommand::SetVolume { percent }),
                 None => {
                     return Err(ParseError::Invalid(format!(
                         "{verb}: expected a percent between 0 and 100"
@@ -111,14 +136,16 @@ pub fn parse(args: &[String]) -> Result<Parsed, ParseError> {
                 }
             }
         }
-        "back" | "rewind" => RemoteCommand::SeekBack,
-        "fwd" | "forward" | "ff" => RemoteCommand::SeekForward,
+        "back" | "rewind" => Invocation::Command(RemoteCommand::SeekBack),
+        "fwd" | "forward" | "ff" => Invocation::Command(RemoteCommand::SeekForward),
         "seek-to" | "seekto" => {
             let seconds = rest.first().and_then(|value| value.parse::<f64>().ok());
             match seconds {
-                Some(seconds) if seconds >= 0.0 && seconds.is_finite() => RemoteCommand::SeekTo {
-                    ms: (seconds * 1000.0).round() as u64,
-                },
+                Some(seconds) if seconds >= 0.0 && seconds.is_finite() => {
+                    Invocation::Command(RemoteCommand::SeekTo {
+                        ms: (seconds * 1000.0).round() as u64,
+                    })
+                }
                 _ => {
                     return Err(ParseError::Invalid(format!(
                         "{verb}: expected a non-negative position in seconds"
@@ -138,11 +165,38 @@ pub fn parse(args: &[String]) -> Result<Parsed, ParseError> {
                     )));
                 }
             };
-            RemoteCommand::Streaming { state }
+            Invocation::Command(RemoteCommand::Streaming { state })
         }
-        "resume-session" | "load-session" => RemoteCommand::ResumeSession,
-        "status" | "st" => RemoteCommand::Status,
-        "quit" | "exit" => RemoteCommand::Quit,
+        "resume-session" | "load-session" => Invocation::Command(RemoteCommand::ResumeSession),
+        "status" | "st" => Invocation::Command(RemoteCommand::Status),
+        "info" => {
+            require_no_args(verb, &rest)?;
+            Invocation::Info
+        }
+        "queue-list" => {
+            require_no_args(verb, &rest)?;
+            Invocation::QueueList
+        }
+        "settings-show" => {
+            require_no_args(verb, &rest)?;
+            Invocation::SettingsShow
+        }
+        "queue-play" => {
+            let position = match rest.as_slice() {
+                [value] => value.parse::<usize>().ok().and_then(|n| n.checked_sub(1)),
+                _ => None,
+            };
+            let Some(position) = position else {
+                return Err(ParseError::Invalid(format!(
+                    "{verb}: expected exactly one queue position (N >= 1)"
+                )));
+            };
+            Invocation::Command(RemoteCommand::QueuePlay { position })
+        }
+        "watch" => Invocation::Watch {
+            topics: parse_watch_topics(verb, &rest)?,
+        },
+        "quit" | "exit" => Invocation::Command(RemoteCommand::Quit),
         other => {
             return Err(ParseError::Invalid(format!(
                 "unknown command `{other}` (try `ytt -r --help`)"
@@ -151,22 +205,79 @@ pub fn parse(args: &[String]) -> Result<Parsed, ParseError> {
     };
 
     Ok(Parsed {
-        command,
+        invocation,
         quiet,
         json,
     })
+}
+
+fn require_no_args(verb: &str, rest: &[&str]) -> Result<(), ParseError> {
+    if rest.is_empty() {
+        Ok(())
+    } else {
+        Err(ParseError::Invalid(format!(
+            "{verb}: expected no arguments"
+        )))
+    }
+}
+
+fn parse_watch_topics(verb: &str, rest: &[&str]) -> Result<Vec<Topic>, ParseError> {
+    let raw = match rest {
+        [] => return Ok(vec![Topic::Player, Topic::Queue, Topic::System]),
+        [raw] => raw,
+        _ => {
+            return Err(ParseError::Invalid(format!(
+                "{verb}: expected at most one comma-separated topic list"
+            )));
+        }
+    };
+
+    if *raw == "all" {
+        return Ok(vec![
+            Topic::Player,
+            Topic::Queue,
+            Topic::Settings,
+            Topic::System,
+        ]);
+    }
+
+    let mut topics = Vec::new();
+    for name in raw.split(',') {
+        let topic = match name.trim() {
+            "player" => Topic::Player,
+            "queue" => Topic::Queue,
+            "settings" => Topic::Settings,
+            "system" => Topic::System,
+            other => {
+                return Err(ParseError::Invalid(format!(
+                    "{verb}: unsupported topic `{other}` (expected player,queue,settings,system|all)"
+                )));
+            }
+        };
+        if !topics.contains(&topic) {
+            topics.push(topic);
+        }
+    }
+    Ok(topics)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn cmd(args: &[&str]) -> RemoteCommand {
+    fn invocation(args: &[&str]) -> Invocation {
         let owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
         match parse(&owned) {
-            Ok(p) => p.command,
+            Ok(p) => p.invocation,
             Err(ParseError::Invalid(m)) => panic!("unexpected invalid: {m}"),
             Err(ParseError::Usage(_)) => panic!("unexpected usage"),
+        }
+    }
+
+    fn cmd(args: &[&str]) -> RemoteCommand {
+        match invocation(args) {
+            Invocation::Command(command) => command,
+            other => panic!("expected command, got {other:?}"),
         }
     }
 
@@ -185,6 +296,12 @@ mod tests {
         );
         assert_eq!(
             cmd(&["enqueue", "new", "song"]),
+            RemoteCommand::Enqueue {
+                query: "new song".to_string()
+            }
+        );
+        assert_eq!(
+            cmd(&["queue", "new", "song"]),
             RemoteCommand::Enqueue {
                 query: "new song".to_string()
             }
@@ -269,6 +386,93 @@ mod tests {
     }
 
     #[test]
+    fn new_read_only_invocations_require_exact_arity() {
+        assert_eq!(invocation(&["info"]), Invocation::Info);
+        assert_eq!(invocation(&["queue-list"]), Invocation::QueueList);
+        assert_eq!(invocation(&["settings-show"]), Invocation::SettingsShow);
+
+        for args in [
+            &["info", "extra"][..],
+            &["queue-list", "extra"][..],
+            &["settings-show", "extra"][..],
+        ] {
+            let owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+            assert!(
+                matches!(parse(&owned), Err(ParseError::Invalid(_))),
+                "{args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn queue_play_converts_one_based_position() {
+        assert_eq!(
+            cmd(&["queue-play", "1"]),
+            RemoteCommand::QueuePlay { position: 0 }
+        );
+        assert_eq!(
+            cmd(&["queue-play", "42"]),
+            RemoteCommand::QueuePlay { position: 41 }
+        );
+    }
+
+    #[test]
+    fn queue_play_rejects_bad_position_and_extra_args() {
+        for args in [
+            &["queue-play"][..],
+            &["queue-play", "0"][..],
+            &["queue-play", "-1"][..],
+            &["queue-play", "nope"][..],
+            &["queue-play", "1", "extra"][..],
+            &["queue-play", "184467440737095516160"][..],
+        ] {
+            let owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+            assert!(
+                matches!(parse(&owned), Err(ParseError::Invalid(_))),
+                "{args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn watch_topics_default_all_and_subset() {
+        assert_eq!(
+            invocation(&["watch"]),
+            Invocation::Watch {
+                topics: vec![Topic::Player, Topic::Queue, Topic::System]
+            }
+        );
+        assert_eq!(
+            invocation(&["watch", "all"]),
+            Invocation::Watch {
+                topics: vec![Topic::Player, Topic::Queue, Topic::Settings, Topic::System]
+            }
+        );
+        assert_eq!(
+            invocation(&["watch", "settings,player,settings"]),
+            Invocation::Watch {
+                topics: vec![Topic::Settings, Topic::Player]
+            }
+        );
+    }
+
+    #[test]
+    fn watch_rejects_unsupported_empty_and_extra_topics() {
+        for args in [
+            &["watch", "lyrics"][..],
+            &["watch", "player,"][..],
+            &["watch", "all,player"][..],
+            &["watch", "player", "queue"][..],
+        ] {
+            let owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+            assert!(
+                matches!(parse(&owned), Err(ParseError::Invalid(_))),
+                "{args:?}"
+            );
+        }
+    }
+
+    #[test]
     fn unknown_verb_is_invalid() {
         let owned = vec!["frobnicate".to_string()];
         assert!(matches!(parse(&owned), Err(ParseError::Invalid(_))));
@@ -290,7 +494,7 @@ mod tests {
             .map(|s| s.to_string())
             .collect();
         let p = parse(&owned).unwrap_or_else(|_| panic!("should parse"));
-        assert_eq!(p.command, RemoteCommand::Next);
+        assert_eq!(p.invocation, Invocation::Command(RemoteCommand::Next));
         assert!(p.quiet);
         assert!(p.json);
     }

--- a/src/remote/client.rs
+++ b/src/remote/client.rs
@@ -13,15 +13,18 @@ use std::time::Duration;
 use interprocess::local_socket::GenericFilePath;
 use interprocess::local_socket::tokio::Stream;
 use interprocess::local_socket::tokio::prelude::*;
+use serde::Serialize;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::time::timeout;
 
-use super::args::{self, ParseError, Parsed};
+use super::args::{self, Invocation, ParseError, Parsed};
 use super::endpoint;
 use super::proto::{
-    InstanceFile, MAX_ONESHOT_REPLY_BYTES, PROTOCOL_VERSION, RemoteCommand, RemoteRequest,
-    RemoteResponse,
+    InstanceFile, InstanceMode, MAX_ONESHOT_REPLY_BYTES, PROTOCOL_VERSION, PROTOCOL_VERSION_V7,
+    RemoteCommand, RemoteRequest, RemoteResponse, StatusSnapshot,
 };
+use crate::search_source::SearchSource;
+use crate::streaming::StreamingMode;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
 
@@ -34,7 +37,9 @@ const EXIT_USAGE: i32 = 2;
 #[derive(Debug, PartialEq, Eq)]
 pub enum ClientError {
     NoRunningInstance,
+    CurrentDescriptor(endpoint::CurrentInstanceError),
     MalformedEndpoint,
+    UnsupportedProtocol,
     ConnectFailed,
     EncodeFailed(String),
     WriteFailed(String),
@@ -49,8 +54,12 @@ impl ClientError {
             ClientError::NoRunningInstance => {
                 "no running ytt instance found — start one with `ytt`.".to_string()
             }
+            ClientError::CurrentDescriptor(error) => error.to_string(),
             ClientError::MalformedEndpoint => {
                 "malformed endpoint in the instance descriptor.".to_string()
+            }
+            ClientError::UnsupportedProtocol => {
+                "the running ytt instance does not support remote protocol v7 or v8.".to_string()
             }
             ClientError::ConnectFailed => {
                 "could not reach ytt (it may have exited) — start one with `ytt`.".to_string()
@@ -105,10 +114,16 @@ pub async fn send(command: RemoteCommand) -> Result<RemoteResponse, ClientError>
     send_to_instance(instance, command).await
 }
 
+async fn send_current(command: RemoteCommand) -> Result<RemoteResponse, ClientError> {
+    let instance = endpoint::read_current_instance().map_err(ClientError::CurrentDescriptor)?;
+    send_to_instance(instance, command).await
+}
+
 async fn send_to_instance(
     instance: InstanceFile,
     command: RemoteCommand,
 ) -> Result<RemoteResponse, ClientError> {
+    let version = negotiated_oneshot_version(instance.protocol_version)?;
     let Ok(name) = instance.endpoint.as_str().to_fs_name::<GenericFilePath>() else {
         return Err(ClientError::MalformedEndpoint);
     };
@@ -121,7 +136,7 @@ async fn send_to_instance(
 
     let reply_timeout = super::reply_timeout_for(&command);
     let req = RemoteRequest {
-        version: PROTOCOL_VERSION,
+        version,
         token: instance.token,
         command,
     };
@@ -152,7 +167,34 @@ async fn send_to_instance(
 }
 
 async fn exchange_for_cli(parsed: Parsed) -> i32 {
-    let resp = match send(parsed.command).await {
+    let Parsed {
+        invocation,
+        quiet,
+        json,
+    } = parsed;
+    match invocation {
+        Invocation::Command(command) => {
+            let current_only = matches!(command, RemoteCommand::QueuePlay { .. });
+            let response = if current_only {
+                send_current(command).await
+            } else {
+                send(command).await
+            };
+            exchange_default_response(response, json, quiet)
+        }
+        Invocation::Info => exchange_info(json, quiet).await,
+        Invocation::QueueList => exchange_status_projection(json, quiet, queue_human).await,
+        Invocation::SettingsShow => exchange_status_projection(json, quiet, settings_human).await,
+        Invocation::Watch { topics } => super::watch::run(topics, json, quiet).await,
+    }
+}
+
+fn exchange_default_response(
+    response: Result<RemoteResponse, ClientError>,
+    json: bool,
+    quiet: bool,
+) -> i32 {
+    let resp = match response {
         Ok(r) => r,
         Err(e) => {
             eprintln!("ytt -r: {}", e.human_message());
@@ -161,17 +203,10 @@ async fn exchange_for_cli(parsed: Parsed) -> i32 {
     };
 
     if resp.ok {
-        if parsed.json {
-            match serde_json::to_string(&resp) {
-                Ok(line) => println!("{line}"),
-                Err(e) => {
-                    eprintln!("ytt -r: could not encode response: {e}");
-                    return EXIT_TRANSPORT;
-                }
-            }
-        } else if !parsed.quiet
-            && let Some(msg) = &resp.message
-        {
+        if json {
+            return print_json(&resp);
+        }
+        if !quiet && let Some(msg) = &resp.message {
             println!("{msg}");
         }
         EXIT_OK
@@ -180,6 +215,278 @@ async fn exchange_for_cli(parsed: Parsed) -> i32 {
         let reason = resp.reason.as_deref().unwrap_or("rejected");
         eprintln!("ytt -r: {reason}");
         EXIT_USAGE
+    }
+}
+
+async fn exchange_info(json: bool, quiet: bool) -> i32 {
+    let instance = match endpoint::read_current_instance() {
+        Ok(instance) => instance,
+        Err(error) => {
+            eprintln!("ytt -r: {error}");
+            return EXIT_TRANSPORT;
+        }
+    };
+    // A descriptor can be stale. Authenticate a harmless status request before claiming that
+    // its owner is alive, then render only the explicitly allow-listed descriptor fields.
+    let response = match send_to_instance(instance.clone(), RemoteCommand::Status).await {
+        Ok(response) => response,
+        Err(error) => {
+            eprintln!("ytt -r: {}", error.human_message());
+            return EXIT_TRANSPORT;
+        }
+    };
+    if !response.ok {
+        eprintln!("ytt -r: {}", info_rejection_message(&response));
+        return EXIT_USAGE;
+    }
+    if response.status.is_none() {
+        eprintln!("ytt -r: {}", ClientError::MalformedResponse.human_message());
+        return EXIT_TRANSPORT;
+    }
+
+    let info = SanitizedInfo::from(instance);
+    if json {
+        print_json(&info)
+    } else {
+        if !quiet {
+            println!("{}", info.human_line());
+        }
+        EXIT_OK
+    }
+}
+
+async fn exchange_status_projection(
+    json: bool,
+    quiet: bool,
+    formatter: fn(&StatusSnapshot) -> String,
+) -> i32 {
+    let response = match send_current(RemoteCommand::Status).await {
+        Ok(response) => response,
+        Err(error) => {
+            eprintln!("ytt -r: {}", error.human_message());
+            return EXIT_TRANSPORT;
+        }
+    };
+    if !response.ok {
+        return print_rejection(&response);
+    }
+    let Some(status) = response.status.as_ref() else {
+        eprintln!("ytt -r: {}", ClientError::MalformedResponse.human_message());
+        return EXIT_TRANSPORT;
+    };
+    if json {
+        return print_json(&response);
+    }
+    if !quiet {
+        println!("{}", formatter(status));
+    }
+    EXIT_OK
+}
+
+fn print_json<T: Serialize>(value: &T) -> i32 {
+    match serde_json::to_string(value) {
+        Ok(line) => {
+            println!("{line}");
+            EXIT_OK
+        }
+        Err(error) => {
+            eprintln!("ytt -r: could not encode response: {error}");
+            EXIT_TRANSPORT
+        }
+    }
+}
+
+fn print_rejection(response: &RemoteResponse) -> i32 {
+    let reason = response.reason.as_deref().unwrap_or("rejected");
+    eprintln!("ytt -r: {reason}");
+    EXIT_USAGE
+}
+
+fn negotiated_oneshot_version(owner_version: u8) -> Result<u8, ClientError> {
+    if owner_version < PROTOCOL_VERSION_V7 {
+        Err(ClientError::UnsupportedProtocol)
+    } else {
+        Ok(owner_version.min(PROTOCOL_VERSION))
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SanitizedInfo {
+    app_pid: u32,
+    created_unix: u64,
+    mode: InstanceMode,
+    protocol_version: u8,
+    capabilities: Vec<String>,
+}
+
+impl From<InstanceFile> for SanitizedInfo {
+    fn from(instance: InstanceFile) -> Self {
+        let InstanceFile {
+            app_pid,
+            endpoint,
+            token,
+            created_unix,
+            mode,
+            protocol_version,
+            mut capabilities,
+        } = instance;
+        capabilities
+            .retain(|capability| !reflects_descriptor_secret(capability, &endpoint, &token));
+        capabilities.sort_unstable();
+        Self {
+            app_pid,
+            created_unix,
+            mode,
+            protocol_version,
+            capabilities,
+        }
+    }
+}
+
+fn reflects_descriptor_secret(capability: &str, endpoint: &str, token: &str) -> bool {
+    [endpoint, token]
+        .into_iter()
+        .any(|secret| contains_ascii_case_insensitive(capability, secret))
+}
+
+fn contains_ascii_case_insensitive(value: &str, secret: &str) -> bool {
+    !secret.is_empty()
+        && value
+            .as_bytes()
+            .windows(secret.len())
+            .any(|window| window.eq_ignore_ascii_case(secret.as_bytes()))
+}
+
+fn info_rejection_message(response: &RemoteResponse) -> &'static str {
+    debug_assert!(!response.ok);
+    "info_status_rejected"
+}
+
+impl SanitizedInfo {
+    fn human_line(&self) -> String {
+        let capabilities = if self.capabilities.is_empty() {
+            "none".to_string()
+        } else {
+            self.capabilities
+                .iter()
+                .map(|capability| sanitize_human_text(capability))
+                .collect::<Vec<_>>()
+                .join(",")
+        };
+        format!(
+            "pid {}  •  mode {}  •  protocol {}  •  capabilities {}",
+            self.app_pid,
+            instance_mode_name(self.mode),
+            self.protocol_version,
+            capabilities
+        )
+    }
+}
+
+fn queue_human(status: &StatusSnapshot) -> String {
+    if status.queue.is_empty() {
+        return "queue empty".to_string();
+    }
+
+    status
+        .queue
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            let marker = if item.current { '>' } else { ' ' };
+            let title = sanitize_human_text(&item.title);
+            let artist = sanitize_human_text(&item.artist);
+            let duration = sanitize_human_text(&item.duration);
+            let mut track = if title.is_empty() {
+                "(untitled)".to_string()
+            } else {
+                title
+            };
+            if !artist.is_empty() {
+                track.push_str(" — ");
+                track.push_str(&artist);
+            }
+            if !duration.is_empty() {
+                track.push_str("  [");
+                track.push_str(&duration);
+                track.push(']');
+            }
+            format!("{marker} {}. {track}", index + 1)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn settings_human(status: &StatusSnapshot) -> String {
+    let settings = &status.settings;
+    format!(
+        "autoplay={}  •  source={}  •  mode={}  •  speed={}.{}x  •  seek={}s  •  normalize={}  •  gapless={}  •  ai={}  •  radio-mode={}",
+        on_off(settings.autoplay_streaming),
+        search_source_name(settings.streaming_source),
+        streaming_mode_name(settings.streaming_mode),
+        settings.speed_tenths / 10,
+        settings.speed_tenths % 10,
+        settings.seek_seconds,
+        on_off(settings.normalize),
+        on_off(settings.gapless),
+        on_off(settings.ai_enabled),
+        on_off(settings.radio_mode),
+    )
+}
+
+fn sanitize_human_text(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut pending_space = false;
+    for ch in input.chars() {
+        let unsafe_format = ch.is_control()
+            || matches!(
+                ch,
+                '\u{200e}'
+                    | '\u{200f}'
+                    | '\u{2028}'..='\u{202e}'
+                    | '\u{2066}'..='\u{2069}'
+            );
+        if unsafe_format || ch.is_whitespace() {
+            pending_space = !output.is_empty();
+        } else {
+            if pending_space {
+                output.push(' ');
+                pending_space = false;
+            }
+            output.push(ch);
+        }
+    }
+    output
+}
+
+fn on_off(value: bool) -> &'static str {
+    if value { "on" } else { "off" }
+}
+
+fn instance_mode_name(mode: InstanceMode) -> &'static str {
+    match mode {
+        InstanceMode::StandaloneTui => "standalone_tui",
+        InstanceMode::Daemon => "daemon",
+    }
+}
+
+fn streaming_mode_name(mode: StreamingMode) -> &'static str {
+    match mode {
+        StreamingMode::Focused => "focused",
+        StreamingMode::Balanced => "balanced",
+        StreamingMode::Discovery => "discovery",
+    }
+}
+
+fn search_source_name(source: SearchSource) -> &'static str {
+    match source {
+        SearchSource::Youtube => "youtube",
+        SearchSource::SoundCloud => "soundcloud",
+        SearchSource::Audius => "audius",
+        SearchSource::Jamendo => "jamendo",
+        SearchSource::InternetArchive => "internet_archive",
+        SearchSource::RadioBrowser => "radio_browser",
+        SearchSource::All => "all",
     }
 }
 
@@ -220,14 +527,15 @@ mod tests {
             .unwrap()
     }
 
-    async fn serve_one_response(listener: Listener, response_line: String) {
+    async fn serve_one_response(listener: Listener, response_line: String, expected_version: u8) {
         let conn = listener.accept().await.unwrap();
         {
             let mut reader = BufReader::new(&conn);
             let mut request = String::new();
             reader.read_line(&mut request).await.unwrap();
-            assert!(request.contains("\"version\""));
-            assert!(request.contains("\"secret\""));
+            let request: RemoteRequest = serde_json::from_str(request.trim()).unwrap();
+            assert_eq!(request.version, expected_version);
+            assert_eq!(request.token, "secret");
         }
         let mut writer = &conn;
         writer.write_all(response_line.as_bytes()).await.unwrap();
@@ -257,7 +565,7 @@ mod tests {
             artwork: None,
         };
         let response = serde_json::to_string(&RemoteResponse::status(snapshot.clone())).unwrap();
-        let server = tokio::spawn(serve_one_response(listener, response));
+        let server = tokio::spawn(serve_one_response(listener, response, PROTOCOL_VERSION));
 
         let resp = send_to_instance(test_instance(endpoint.clone()), RemoteCommand::Status)
             .await
@@ -274,7 +582,7 @@ mod tests {
         let endpoint = test_endpoint("rejected");
         let listener = bind_test_listener(&endpoint);
         let response = serde_json::to_string(&RemoteResponse::err("queue_empty")).unwrap();
-        let server = tokio::spawn(serve_one_response(listener, response));
+        let server = tokio::spawn(serve_one_response(listener, response, PROTOCOL_VERSION));
 
         let resp = send_to_instance(test_instance(endpoint.clone()), RemoteCommand::Next)
             .await
@@ -290,7 +598,11 @@ mod tests {
     async fn send_to_instance_rejects_malformed_response() {
         let endpoint = test_endpoint("malformed");
         let listener = bind_test_listener(&endpoint);
-        let server = tokio::spawn(serve_one_response(listener, "{not json}".to_string()));
+        let server = tokio::spawn(serve_one_response(
+            listener,
+            "{not json}".to_string(),
+            PROTOCOL_VERSION,
+        ));
 
         let err = send_to_instance(test_instance(endpoint.clone()), RemoteCommand::Status)
             .await
@@ -299,6 +611,202 @@ mod tests {
         let _ = std::fs::remove_file(endpoint);
 
         assert_eq!(err, ClientError::MalformedResponse);
+    }
+
+    #[tokio::test]
+    async fn send_to_instance_uses_v7_for_v7_owner() {
+        let endpoint = test_endpoint("v7");
+        let listener = bind_test_listener(&endpoint);
+        let response = serde_json::to_string(&RemoteResponse::ok("ok".to_string())).unwrap();
+        let server = tokio::spawn(serve_one_response(listener, response, PROTOCOL_VERSION_V7));
+        let mut instance = test_instance(endpoint.clone());
+        instance.protocol_version = PROTOCOL_VERSION_V7;
+
+        let response = send_to_instance(instance, RemoteCommand::Next)
+            .await
+            .unwrap();
+        server.await.unwrap();
+        let _ = std::fs::remove_file(endpoint);
+
+        assert!(response.ok);
+    }
+
+    #[test]
+    fn one_shot_version_negotiates_v7_v8_and_future() {
+        assert_eq!(
+            negotiated_oneshot_version(PROTOCOL_VERSION_V7),
+            Ok(PROTOCOL_VERSION_V7)
+        );
+        assert_eq!(
+            negotiated_oneshot_version(PROTOCOL_VERSION),
+            Ok(PROTOCOL_VERSION)
+        );
+        assert_eq!(negotiated_oneshot_version(u8::MAX), Ok(PROTOCOL_VERSION));
+        assert_eq!(
+            negotiated_oneshot_version(PROTOCOL_VERSION_V7 - 1),
+            Err(ClientError::UnsupportedProtocol)
+        );
+    }
+
+    fn snapshot(queue: Vec<crate::remote::proto::QueueItemSnapshot>) -> StatusSnapshot {
+        StatusSnapshot {
+            title: None,
+            artist: None,
+            paused: true,
+            volume: 50,
+            position: usize::from(!queue.is_empty()),
+            total: queue.len(),
+            streaming: false,
+            owner_mode: InstanceMode::Daemon,
+            settings: crate::remote::proto::SettingsSnapshot::default(),
+            queue,
+            shuffle: false,
+            repeat: Default::default(),
+            elapsed_ms: None,
+            duration_ms: None,
+            artwork: None,
+        }
+    }
+
+    #[test]
+    fn queue_formatter_is_one_based_marks_current_and_sanitizes_controls() {
+        let status = snapshot(vec![
+            crate::remote::proto::QueueItemSnapshot {
+                title: "첫 곡\n\u{1b}[31m".to_string(),
+                artist: "가수\r이름".to_string(),
+                duration: "3:14\t".to_string(),
+                current: true,
+            },
+            crate::remote::proto::QueueItemSnapshot {
+                title: "Second".to_string(),
+                artist: String::new(),
+                duration: String::new(),
+                current: false,
+            },
+        ]);
+
+        let line = queue_human(&status);
+        assert_eq!(line, "> 1. 첫 곡 [31m — 가수 이름  [3:14]\n  2. Second");
+        assert!(!line.contains('\u{1b}'));
+        assert_eq!(line.lines().count(), 2);
+    }
+
+    #[test]
+    fn queue_formatter_has_stable_empty_message() {
+        assert_eq!(queue_human(&snapshot(Vec::new())), "queue empty");
+    }
+
+    #[test]
+    fn settings_formatter_includes_only_summary_fields() {
+        let mut status = snapshot(Vec::new());
+        status.settings = crate::remote::proto::SettingsSnapshot {
+            autoplay_streaming: true,
+            streaming_mode: StreamingMode::Discovery,
+            streaming_source: SearchSource::InternetArchive,
+            speed_tenths: 15,
+            seek_seconds: 12,
+            normalize: true,
+            gapless: false,
+            ai_enabled: true,
+            radio_mode: false,
+        };
+
+        assert_eq!(
+            settings_human(&status),
+            "autoplay=on  •  source=internet_archive  •  mode=discovery  •  speed=1.5x  •  seek=12s  •  normalize=on  •  gapless=off  •  ai=on  •  radio-mode=off"
+        );
+    }
+
+    #[test]
+    fn queue_and_settings_projection_json_retains_full_remote_response() {
+        let mut status = snapshot(vec![crate::remote::proto::QueueItemSnapshot {
+            title: "곡".to_string(),
+            artist: "가수".to_string(),
+            duration: "2:34".to_string(),
+            current: true,
+        }]);
+        status.settings.autoplay_streaming = true;
+        let response = RemoteResponse::status(status.clone());
+
+        // Both projection branches pass this whole response to `print_json`; they do not
+        // serialize only the selected human projection.
+        let value = serde_json::to_value(&response).unwrap();
+        assert_eq!(value["ok"], true);
+        assert_eq!(value["reason"], "ok");
+        assert!(value.get("message").is_some());
+        assert_eq!(value["status"]["queue"][0]["title"], "곡");
+        assert_eq!(value["status"]["settings"]["autoplay_streaming"], true);
+        assert_eq!(response.status, Some(status));
+    }
+
+    #[test]
+    fn info_output_is_sorted_and_structurally_omits_credentials() {
+        let mut instance = test_instance("/private/secret-endpoint".to_string());
+        instance.token = "super-secret-token".to_string();
+        instance.created_unix = 99;
+        instance.mode = InstanceMode::Daemon;
+        instance.capabilities = vec![
+            "status".to_string(),
+            "events-v8".to_string(),
+            "remote-control".to_string(),
+            "socket=/PRIVATE/SECRET-ENDPOINT".to_string(),
+            "token=SUPER-SECRET-TOKEN".to_string(),
+        ];
+
+        let info = SanitizedInfo::from(instance);
+        let value = serde_json::to_value(&info).unwrap();
+        let object = value.as_object().unwrap();
+        assert_eq!(object.len(), 5);
+        assert_eq!(
+            object["capabilities"],
+            serde_json::json!(["events-v8", "remote-control", "status"])
+        );
+        let line = serde_json::to_string(&info).unwrap();
+        let human = info.human_line();
+        assert!(!line.contains("secret-endpoint"));
+        assert!(!line.contains("super-secret-token"));
+        assert!(!human.to_ascii_lowercase().contains("secret-endpoint"));
+        assert!(!human.to_ascii_lowercase().contains("super-secret-token"));
+        assert!(human.contains("events-v8,remote-control,status"));
+        assert!(!object.contains_key("endpoint"));
+        assert!(!object.contains_key("token"));
+    }
+
+    #[test]
+    fn info_rejection_never_reflects_owner_text() {
+        let response = RemoteResponse {
+            ok: false,
+            reason: Some(
+                "0123456789abcdef0123456789abcdef\n\u{1b}[31m/private/secret-endpoint".to_string(),
+            ),
+            message: Some("another owner-controlled field".to_string()),
+            status: None,
+        };
+
+        let message = info_rejection_message(&response);
+        assert_eq!(message, "info_status_rejected");
+        assert!(!message.contains("0123456789abcdef0123456789abcdef"));
+        assert!(!message.contains("secret-endpoint"));
+        assert!(!message.chars().any(char::is_control));
+    }
+
+    #[test]
+    fn info_human_line_sanitizes_capability_controls() {
+        let info = SanitizedInfo {
+            app_pid: 7,
+            created_unix: 1,
+            mode: InstanceMode::StandaloneTui,
+            protocol_version: PROTOCOL_VERSION,
+            capabilities: vec!["events\n\u{1b}[31m-v8".to_string()],
+        };
+        let line = info.human_line();
+        assert!(!line.contains('\n'));
+        assert!(!line.contains('\u{1b}'));
+        assert!(!line.contains("created_unix"));
+        assert!(line.contains("pid 7"));
+        assert!(line.contains("mode standalone_tui"));
+        assert!(line.contains("protocol 8"));
+        assert!(line.contains("events [31m-v8"));
     }
 }
 

--- a/src/remote/endpoint.rs
+++ b/src/remote/endpoint.rs
@@ -11,11 +11,57 @@
 //! form): on Linux the abstract namespace bypasses filesystem permissions, which would
 //! let any local user connect — the `0700` dir is exactly the boundary we want.
 
+use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
 
+#[cfg(all(test, unix))]
+use std::os::unix::fs::PermissionsExt;
+
 use super::proto::InstanceFile;
 use crate::util::{runtime, safe_fs};
+
+const MAX_INSTANCE_BYTES: u64 = 8 * 1024;
+
+/// Fail-closed errors from the current (non-legacy) instance descriptor.
+///
+/// Messages deliberately omit paths, endpoint names, and tokens so callers can safely print
+/// them without disclosing control-channel credentials.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CurrentInstanceError {
+    NotFound,
+    Unreadable,
+    UnsafePermissions,
+    Malformed,
+    UnexpectedEndpoint,
+    InvalidToken,
+}
+
+impl fmt::Display for CurrentInstanceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            CurrentInstanceError::NotFound => {
+                "no running ytt instance found — start one with `ytt`."
+            }
+            CurrentInstanceError::Unreadable => {
+                "could not safely read the current ytt instance descriptor."
+            }
+            CurrentInstanceError::UnsafePermissions => {
+                "refusing a current ytt instance descriptor that is not private."
+            }
+            CurrentInstanceError::Malformed => "malformed current ytt instance descriptor.",
+            CurrentInstanceError::UnexpectedEndpoint => {
+                "current ytt instance descriptor names an unexpected endpoint."
+            }
+            CurrentInstanceError::InvalidToken => {
+                "current ytt instance descriptor contains an invalid token."
+            }
+        };
+        f.write_str(message)
+    }
+}
+
+impl std::error::Error for CurrentInstanceError {}
 
 fn user_tag() -> String {
     runtime::filesystem_user_tag()
@@ -55,6 +101,24 @@ pub fn alt_socket_endpoint(pid: u32) -> io::Result<String> {
 /// Path to the instance descriptor (endpoint + token), beside the socket.
 pub fn instance_path() -> io::Result<PathBuf> {
     Ok(runtime::app_runtime_dir()?.join(format!("yututui-remote-{}.json", user_tag())))
+}
+
+fn current_socket_endpoint_path() -> String {
+    #[cfg(windows)]
+    {
+        windows_socket_endpoint(&user_tag())
+    }
+    #[cfg(unix)]
+    {
+        runtime::app_runtime_dir_path()
+            .join(format!("yututui-remote-{}.sock", user_tag()))
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+fn current_instance_path() -> PathBuf {
+    runtime::app_runtime_dir_path().join(format!("yututui-remote-{}.json", user_tag()))
 }
 
 fn legacy_socket_endpoint() -> String {
@@ -103,8 +167,65 @@ pub fn read_instance() -> Option<InstanceFile> {
     serde_json::from_slice(&data).ok()
 }
 
+/// Read only the current private descriptor and validate its local trust boundary.
+///
+/// Unlike [`read_instance`], this never falls back to the legacy shared-runtime path. The
+/// endpoint must be the exact canonical primary endpoint produced by this build, the token must
+/// retain its generated 128-bit hex shape, and Unix reads require a current-user `0700` parent
+/// plus a current-user `0600` regular descriptor. New remote surfaces use this stricter reader;
+/// legacy one-shot commands keep their compatibility fallback.
+pub fn read_current_instance() -> Result<InstanceFile, CurrentInstanceError> {
+    // Resolve only: unlike the server/write path, a strict read must not create the runtime
+    // directory or repair unsafe modes before validating them.
+    let path = current_instance_path();
+    let expected_endpoint = current_socket_endpoint_path();
+    read_current_instance_at(&path, &expected_endpoint)
+}
+
+fn read_current_instance_at(
+    path: &Path,
+    expected_endpoint: &str,
+) -> Result<InstanceFile, CurrentInstanceError> {
+    let data = read_private_current_bytes(path)?;
+    let instance: InstanceFile =
+        serde_json::from_slice(&data).map_err(|_| CurrentInstanceError::Malformed)?;
+    validate_current_instance(instance, expected_endpoint)
+}
+
+fn validate_current_instance(
+    instance: InstanceFile,
+    expected_endpoint: &str,
+) -> Result<InstanceFile, CurrentInstanceError> {
+    if instance.endpoint != expected_endpoint {
+        return Err(CurrentInstanceError::UnexpectedEndpoint);
+    }
+    if instance.token.len() != 32 || !instance.token.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(CurrentInstanceError::InvalidToken);
+    }
+    Ok(instance)
+}
+
+fn read_private_current_bytes(path: &Path) -> Result<Vec<u8>, CurrentInstanceError> {
+    safe_fs::read_private_file_limited(path, MAX_INSTANCE_BYTES).map_err(map_current_read_error)
+}
+
+fn map_current_read_error(error: io::Error) -> CurrentInstanceError {
+    #[cfg(unix)]
+    let symlink_loop = error.raw_os_error() == Some(libc::ELOOP);
+    #[cfg(not(unix))]
+    let symlink_loop = false;
+
+    if error.kind() == io::ErrorKind::NotFound {
+        CurrentInstanceError::NotFound
+    } else if error.kind() == io::ErrorKind::PermissionDenied || symlink_loop {
+        CurrentInstanceError::UnsafePermissions
+    } else {
+        CurrentInstanceError::Unreadable
+    }
+}
+
 fn read_instance_bytes(path: &Path) -> Option<Vec<u8>> {
-    safe_fs::read_no_symlink_limited(path, 8 * 1024).ok()
+    safe_fs::read_no_symlink_limited(path, MAX_INSTANCE_BYTES).ok()
 }
 
 /// Best-effort removal of the descriptor on shutdown.
@@ -135,6 +256,7 @@ pub fn legacy_primary_endpoint_for_probe() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::remote::proto::{InstanceMode, PROTOCOL_VERSION};
 
     #[test]
     fn token_is_32_hex_chars() {
@@ -180,5 +302,123 @@ mod tests {
         let tag = user_tag();
         assert!(!tag.is_empty());
         assert!(tag.chars().all(|c| c.is_ascii_alphanumeric()));
+    }
+
+    fn instance_for(endpoint: &str, token: &str) -> InstanceFile {
+        InstanceFile {
+            app_pid: 7,
+            endpoint: endpoint.to_string(),
+            token: token.to_string(),
+            created_unix: 1,
+            mode: InstanceMode::Daemon,
+            protocol_version: PROTOCOL_VERSION,
+            capabilities: vec!["status".to_string()],
+        }
+    }
+
+    #[test]
+    fn current_descriptor_requires_canonical_endpoint_and_hex_token() {
+        let endpoint = socket_endpoint().unwrap();
+        let valid = instance_for(&endpoint, "0123456789abcdef0123456789ABCDEF");
+        assert!(validate_current_instance(valid, &endpoint).is_ok());
+
+        let redirected = instance_for("unexpected", "0123456789abcdef0123456789abcdef");
+        assert_eq!(
+            validate_current_instance(redirected, &endpoint).unwrap_err(),
+            CurrentInstanceError::UnexpectedEndpoint
+        );
+
+        for token in [
+            "short",
+            "0123456789abcdef0123456789abcdeg",
+            "0123456789abcdef0123456789abcdef0",
+        ] {
+            let invalid = instance_for(&endpoint, token);
+            assert_eq!(
+                validate_current_instance(invalid, &endpoint).unwrap_err(),
+                CurrentInstanceError::InvalidToken
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    fn private_test_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "yututui-current-instance-{label}-{}-{}",
+            std::process::id(),
+            gen_token().unwrap()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        dir
+    }
+
+    #[cfg(unix)]
+    fn write_test_descriptor(path: &Path, instance: &InstanceFile) {
+        std::fs::write(path, serde_json::to_vec(instance).unwrap()).unwrap();
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn current_descriptor_read_enforces_private_unix_modes() {
+        let dir = private_test_dir("modes");
+        let path = dir.join("instance.json");
+        let endpoint = dir.join("remote.sock").to_string_lossy().into_owned();
+        let instance = instance_for(&endpoint, "0123456789abcdef0123456789abcdef");
+        write_test_descriptor(&path, &instance);
+
+        let read = read_current_instance_at(&path, &endpoint).unwrap();
+        assert_eq!(read.app_pid, 7);
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(
+            read_current_instance_at(&path, &endpoint).unwrap_err(),
+            CurrentInstanceError::UnsafePermissions
+        );
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert_eq!(
+            read_current_instance_at(&path, &endpoint).unwrap_err(),
+            CurrentInstanceError::UnsafePermissions
+        );
+        assert_eq!(
+            std::fs::metadata(&dir).unwrap().permissions().mode() & 0o7777,
+            0o755,
+            "strict reads must not repair an unsafe runtime directory"
+        );
+
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn current_descriptor_read_rejects_symlink_and_malformed_file() {
+        use std::os::unix::fs::symlink;
+
+        let dir = private_test_dir("shape");
+        let target = dir.join("target.json");
+        let link = dir.join("instance.json");
+        let endpoint = dir.join("remote.sock").to_string_lossy().into_owned();
+        let instance = instance_for(&endpoint, "0123456789abcdef0123456789abcdef");
+        write_test_descriptor(&target, &instance);
+        symlink(&target, &link).unwrap();
+
+        assert_eq!(
+            read_current_instance_at(&link, &endpoint).unwrap_err(),
+            CurrentInstanceError::UnsafePermissions
+        );
+
+        std::fs::remove_file(&link).unwrap();
+        std::fs::write(&link, b"{not json}").unwrap();
+        std::fs::set_permissions(&link, std::fs::Permissions::from_mode(0o600)).unwrap();
+        assert_eq!(
+            read_current_instance_at(&link, &endpoint).unwrap_err(),
+            CurrentInstanceError::Malformed
+        );
+
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -20,6 +20,7 @@ pub mod proto;
 pub mod publish;
 pub mod server;
 mod sessions;
+pub mod watch;
 
 pub use sessions::{RemoteSessionHub, RemoteSessionRef};
 

--- a/src/remote/watch.rs
+++ b/src/remote/watch.rs
@@ -1,0 +1,1641 @@
+//! Read-only `ytt -r watch` client for protocol-v8 push sessions.
+//!
+//! This deliberately does not reuse the desktop gateway: the CLI opens one authenticated
+//! local-socket session, subscribes to the small read-only topic surface, and exits when that
+//! connection ends. There is no reconnect or replay path.
+
+use std::future::Future;
+use std::io::{self, Write};
+use std::time::Duration;
+
+use interprocess::local_socket::GenericFilePath;
+use interprocess::local_socket::tokio::Stream;
+use interprocess::local_socket::tokio::prelude::*;
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::time::{Instant, interval_at, timeout};
+
+use super::endpoint;
+use super::proto::{
+    ClientFrame, ClientOp, HelloAck, HelloBody, HelloRequest, MAX_ONESHOT_REPLY_BYTES,
+    PROTOCOL_VERSION, PushEvent, ServerFrame, Topic,
+};
+
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
+const IO_TIMEOUT: Duration = Duration::from_secs(2);
+const PING_INTERVAL: Duration = Duration::from_secs(15);
+const MAX_FRAME_BYTES: usize = MAX_ONESHOT_REPLY_BYTES;
+const OUTPUT_QUEUE_CAPACITY: usize = 16;
+const OUTPUT_FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
+
+const EXIT_OK: i32 = 0;
+const EXIT_TRANSPORT: i32 = 1;
+const EXIT_USAGE: i32 = 2;
+const SUBSCRIBE_ID: u64 = 1;
+
+/// Run a read-only protocol-v8 watch session against the current, validated owner.
+pub async fn run(topics: Vec<crate::remote::proto::Topic>, json: bool, quiet: bool) -> i32 {
+    race_operation_with_cancel(run_operation(topics, json, quiet), tokio::signal::ctrl_c()).await
+}
+
+/// Poll cancellation first so Tokio installs its signal handler before descriptor I/O,
+/// connect, or either handshake write can run. Once installed, SIGINT remains captured even
+/// while a synchronous descriptor check is in progress, and every Ctrl-C path exits cleanly.
+async fn race_operation_with_cancel<O, C>(operation: O, cancel: C) -> i32
+where
+    O: Future<Output = i32>,
+    C: Future<Output = io::Result<()>>,
+{
+    tokio::pin!(operation);
+    tokio::pin!(cancel);
+    tokio::select! {
+        biased;
+        cancel_result = &mut cancel => match cancel_result {
+            Ok(()) => EXIT_OK,
+            Err(error) => {
+                eprintln!("ytt -r: could not listen for Ctrl-C: {error}");
+                EXIT_TRANSPORT
+            }
+        },
+        exit_code = &mut operation => exit_code,
+    }
+}
+
+async fn run_operation(topics: Vec<Topic>, json: bool, quiet: bool) -> i32 {
+    let topics = match normalize_topics(topics) {
+        Ok(topics) => topics,
+        Err(error) => {
+            eprintln!("ytt -r: {}", error.message);
+            return error.exit_code();
+        }
+    };
+
+    let instance = match endpoint::read_current_instance() {
+        Ok(instance) => instance,
+        Err(error) => {
+            eprintln!("ytt -r: {error}");
+            return EXIT_TRANSPORT;
+        }
+    };
+    if instance.protocol_version < PROTOCOL_VERSION {
+        eprintln!(
+            "ytt -r: watch requires protocol {PROTOCOL_VERSION} or newer (owner advertises {}).",
+            instance.protocol_version
+        );
+        return EXIT_USAGE;
+    }
+    if !has_events_capability(&instance.capabilities) {
+        eprintln!("ytt -r: the running ytt instance does not support watch events.");
+        return EXIT_USAGE;
+    }
+
+    let Ok(name) = instance.endpoint.as_str().to_fs_name::<GenericFilePath>() else {
+        eprintln!("ytt -r: malformed endpoint in the instance descriptor.");
+        return EXIT_TRANSPORT;
+    };
+    let stream = match timeout(CONNECT_TIMEOUT, Stream::connect(name)).await {
+        Ok(Ok(stream)) => stream,
+        _ => {
+            eprintln!("ytt -r: could not reach ytt (it may have exited).");
+            return EXIT_TRANSPORT;
+        }
+    };
+
+    let config = SessionConfig {
+        token: instance.token,
+        topics,
+        json,
+        quiet,
+        io_timeout: IO_TIMEOUT,
+        ping_interval: PING_INTERVAL,
+    };
+    match run_session_with_output(
+        stream,
+        config,
+        std::future::pending::<Result<(), WatchError>>(),
+        io::stdout(),
+        OUTPUT_QUEUE_CAPACITY,
+        OUTPUT_FLUSH_TIMEOUT,
+    )
+    .await
+    {
+        Ok(()) => EXIT_OK,
+        Err(error) => {
+            eprintln!("ytt -r: {}", error.message);
+            error.exit_code()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ErrorKind {
+    Transport,
+    Unsupported,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct WatchError {
+    kind: ErrorKind,
+    message: String,
+}
+
+impl WatchError {
+    fn transport(message: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::Transport,
+            message: message.into(),
+        }
+    }
+
+    fn unsupported(message: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::Unsupported,
+            message: message.into(),
+        }
+    }
+
+    fn exit_code(&self) -> i32 {
+        match self.kind {
+            ErrorKind::Transport => EXIT_TRANSPORT,
+            ErrorKind::Unsupported => EXIT_USAGE,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SessionConfig {
+    token: String,
+    topics: Vec<Topic>,
+    json: bool,
+    quiet: bool,
+    io_timeout: Duration,
+    ping_interval: Duration,
+}
+
+fn normalize_topics(topics: Vec<Topic>) -> Result<Vec<Topic>, WatchError> {
+    if topics.is_empty() {
+        return Err(WatchError::unsupported(
+            "watch requires at least one topic.",
+        ));
+    }
+
+    let mut normalized = Vec::with_capacity(topics.len());
+    for topic in topics {
+        if !matches!(
+            topic,
+            Topic::Player | Topic::Queue | Topic::Settings | Topic::System
+        ) {
+            return Err(WatchError::unsupported(format!(
+                "unsupported watch topic `{}`.",
+                topic.wire_str()
+            )));
+        }
+        if !normalized.contains(&topic) {
+            normalized.push(topic);
+        }
+    }
+    Ok(normalized)
+}
+
+fn has_events_capability(capabilities: &[String]) -> bool {
+    capabilities
+        .iter()
+        .any(|capability| capability == "events-v8")
+}
+
+fn spawn_output_writer<W>(
+    mut writer: W,
+    capacity: usize,
+) -> Result<
+    (
+        std::sync::mpsc::SyncSender<String>,
+        tokio::sync::oneshot::Receiver<io::Result<()>>,
+    ),
+    WatchError,
+>
+where
+    W: Write + Send + 'static,
+{
+    let (line_tx, line_rx) = std::sync::mpsc::sync_channel::<String>(capacity);
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+    std::thread::Builder::new()
+        .name("ytt-watch-output".to_string())
+        .spawn(move || {
+            let result = (|| {
+                while let Ok(mut line) = line_rx.recv() {
+                    line.push('\n');
+                    writer.write_all(line.as_bytes())?;
+                    writer.flush()?;
+                }
+                writer.flush()
+            })();
+            let _ = done_tx.send(result);
+        })
+        .map_err(|_| WatchError::transport("could not start the watch output writer."))?;
+    Ok((line_tx, done_rx))
+}
+
+fn output_completion(
+    result: Result<io::Result<()>, tokio::sync::oneshot::error::RecvError>,
+) -> Result<(), WatchError> {
+    match result {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(_)) => Err(WatchError::transport("watch output failed.")),
+        Err(_) => Err(WatchError::transport(
+            "watch output writer stopped unexpectedly.",
+        )),
+    }
+}
+
+fn enqueue_output_line(
+    line_tx: &std::sync::mpsc::SyncSender<String>,
+    line: &str,
+) -> io::Result<()> {
+    line_tx.try_send(line.to_string()).map_err(|error| {
+        let (kind, message) = match error {
+            std::sync::mpsc::TrySendError::Full(_) => (
+                io::ErrorKind::WouldBlock,
+                "watch output consumer is too slow.",
+            ),
+            std::sync::mpsc::TrySendError::Disconnected(_) => {
+                (io::ErrorKind::BrokenPipe, "watch output writer stopped.")
+            }
+        };
+        io::Error::new(kind, message)
+    })
+}
+
+async fn run_session_with_output<S, C, W>(
+    stream: S,
+    config: SessionConfig,
+    cancel: C,
+    writer: W,
+    output_capacity: usize,
+    output_timeout: Duration,
+) -> Result<(), WatchError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+    C: Future<Output = Result<(), WatchError>>,
+    W: Write + Send + 'static,
+{
+    let (line_tx, mut output_done) = spawn_output_writer(writer, output_capacity)?;
+    let session_result = {
+        let mut emit = move |line: &str| enqueue_output_line(&line_tx, line);
+        let session = run_session(stream, config, cancel, &mut emit);
+        tokio::pin!(session);
+        tokio::select! {
+            biased;
+            writer_result = &mut output_done => {
+                output_completion(writer_result)?;
+                return Err(WatchError::transport(
+                    "watch output writer stopped unexpectedly.",
+                ));
+            }
+            result = &mut session => result,
+        }
+    };
+
+    let writer_result = timeout(output_timeout, &mut output_done)
+        .await
+        .map_err(|_| WatchError::transport("timed out flushing watch output."))?;
+    output_completion(writer_result)?;
+    session_result
+}
+
+async fn run_session<S, C, E>(
+    stream: S,
+    config: SessionConfig,
+    cancel: C,
+    emit: &mut E,
+) -> Result<(), WatchError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+    C: Future<Output = Result<(), WatchError>>,
+    E: FnMut(&str) -> io::Result<()>,
+{
+    let (read_half, mut write_half) = tokio::io::split(stream);
+    let mut reader = BufReader::new(read_half);
+
+    let hello = HelloRequest {
+        version: PROTOCOL_VERSION,
+        token: config.token,
+        hello: HelloBody {
+            client: "ytt-cli-watch".to_string(),
+            min_version: PROTOCOL_VERSION,
+        },
+    };
+    write_json_line(&mut write_half, &hello, config.io_timeout, "Hello").await?;
+
+    let ack: HelloAck = timeout(
+        config.io_timeout,
+        read_json_line(&mut reader, MAX_FRAME_BYTES),
+    )
+    .await
+    .map_err(|_| WatchError::transport("timed out waiting for the watch handshake."))??;
+    validate_ack(&ack)?;
+
+    let subscribe = ClientFrame {
+        id: SUBSCRIBE_ID,
+        op: ClientOp::Subscribe {
+            topics: config.topics.clone(),
+        },
+    };
+    write_json_line(
+        &mut write_half,
+        &subscribe,
+        config.io_timeout,
+        "subscription",
+    )
+    .await?;
+
+    let first_tick = Instant::now() + config.ping_interval;
+    let mut ping_timer = interval_at(first_tick, config.ping_interval);
+    ping_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let subscribe_deadline = tokio::time::sleep(config.io_timeout);
+    tokio::pin!(subscribe_deadline);
+    tokio::pin!(cancel);
+
+    let mut line = Vec::new();
+    let mut subscribed = false;
+    let mut last_seq = None;
+    let mut next_id = SUBSCRIBE_ID + 1;
+    let mut pending_ping = None;
+    let mut pong_deadline = None;
+    let mut shutting_down = false;
+
+    loop {
+        // `select!` constructs disabled branch futures too, so give the no-ping case a
+        // harmless distant instant instead of unwrapping the optional deadline.
+        let next_pong_deadline =
+            pong_deadline.unwrap_or_else(|| Instant::now() + Duration::from_secs(24 * 60 * 60));
+        tokio::select! {
+            biased;
+            cancel_result = &mut cancel => return cancel_result,
+            _ = &mut subscribe_deadline, if !subscribed => {
+                return Err(WatchError::transport(
+                    "timed out waiting for the watch subscription reply.",
+                ));
+            }
+            _ = tokio::time::sleep_until(next_pong_deadline), if pong_deadline.is_some() => {
+                return Err(WatchError::transport("watch owner stopped answering pings."));
+            }
+            _ = ping_timer.tick() => {
+                if pending_ping.is_some() {
+                    continue;
+                }
+                let id = next_id;
+                next_id = next_id.checked_add(1).ok_or_else(|| {
+                    WatchError::transport("watch frame id overflowed.")
+                })?;
+                let ping = ClientFrame { id, op: ClientOp::Ping };
+                write_json_line(&mut write_half, &ping, config.io_timeout, "ping").await?;
+                pending_ping = Some(id);
+                pong_deadline = Some(Instant::now() + config.io_timeout);
+            }
+            read_result = crate::util::io::read_bounded_line(
+                &mut reader,
+                &mut line,
+                MAX_FRAME_BYTES,
+            ) => {
+                use crate::util::io::BoundedLine;
+
+                let outcome = read_result.map_err(|error| {
+                    WatchError::transport(format!("watch connection read failed: {error}"))
+                })?;
+                match outcome {
+                    BoundedLine::TooLarge => {
+                        return Err(WatchError::transport("watch owner sent an oversized frame."));
+                    }
+                    BoundedLine::Eof if shutting_down && line.is_empty() => return Ok(()),
+                    BoundedLine::Eof if !line.is_empty() => {
+                        return Err(WatchError::transport(
+                            "watch owner closed with a malformed partial frame.",
+                        ));
+                    }
+                    BoundedLine::Eof => {
+                        return Err(WatchError::transport("watch connection closed unexpectedly."));
+                    }
+                    BoundedLine::Line => {}
+                }
+
+                let frame: ServerFrame = serde_json::from_slice(&line).map_err(|_| {
+                    WatchError::transport("watch owner sent a malformed frame.")
+                })?;
+                line.clear();
+
+                match &frame {
+                    ServerFrame::Reply { id, resp } => {
+                        if *id != SUBSCRIBE_ID || subscribed {
+                            return Err(WatchError::transport(
+                                "watch owner sent an unexpected reply.",
+                            ));
+                        }
+                        if !resp.ok {
+                            let reason = sanitize(resp.reason.as_deref().unwrap_or("rejected"), 64);
+                            return Err(WatchError::transport(format!(
+                                "watch subscription was rejected: {reason}."
+                            )));
+                        }
+                        subscribed = true;
+                    }
+                    ServerFrame::Event { seq, topic, event } => {
+                        validate_event(*seq, *topic, event, &config.topics, &mut last_seq)?;
+                        emit_frame(&frame, config.json, config.quiet, emit)?;
+                        if matches!(event, PushEvent::ShuttingDown) {
+                            shutting_down = true;
+                        }
+                    }
+                    ServerFrame::Pong { id } => {
+                        if pending_ping != Some(*id) {
+                            return Err(WatchError::transport(
+                                "watch owner sent an unexpected pong.",
+                            ));
+                        }
+                        pending_ping = None;
+                        pong_deadline = None;
+                    }
+                    ServerFrame::Goodbye { reason } => {
+                        emit_frame(&frame, config.json, config.quiet, emit)?;
+                        if reason == "shutting_down" {
+                            return Ok(());
+                        }
+                        return Err(WatchError::transport(format!(
+                            "watch session ended: {}.",
+                            sanitize(reason, 64)
+                        )));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn validate_ack(ack: &HelloAck) -> Result<(), WatchError> {
+    if !ack.ok {
+        let raw_reason = ack.reason.as_deref().unwrap_or("rejected");
+        let reason = sanitize(raw_reason, 64);
+        let message = format!("watch handshake was rejected: {reason}.");
+        return if raw_reason == "bad_version" {
+            Err(WatchError::unsupported(message))
+        } else {
+            Err(WatchError::transport(message))
+        };
+    }
+    if ack.version != PROTOCOL_VERSION {
+        return Err(WatchError::unsupported(format!(
+            "watch handshake selected unsupported protocol {}.",
+            ack.version
+        )));
+    }
+    if ack.session_id == 0 || ack.reason.is_some() {
+        return Err(WatchError::transport(
+            "watch owner returned an invalid successful handshake.",
+        ));
+    }
+    if !has_events_capability(&ack.capabilities) {
+        return Err(WatchError::unsupported(
+            "watch owner did not negotiate events-v8.",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_event(
+    seq: u64,
+    topic: Topic,
+    event: &PushEvent,
+    subscribed_topics: &[Topic],
+    last_seq: &mut Option<u64>,
+) -> Result<(), WatchError> {
+    if !subscribed_topics.contains(&topic) || !event_matches_topic(topic, event) {
+        return Err(WatchError::transport(
+            "watch owner sent an event outside the subscription.",
+        ));
+    }
+
+    let valid_seq = match *last_seq {
+        None => seq == 1,
+        Some(previous) => previous.checked_add(1) == Some(seq),
+    };
+    if !valid_seq {
+        return Err(WatchError::transport(format!(
+            "watch event sequence gap (last {}, received {seq}).",
+            last_seq
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "none".to_string())
+        )));
+    }
+    *last_seq = Some(seq);
+    Ok(())
+}
+
+fn event_matches_topic(topic: Topic, event: &PushEvent) -> bool {
+    matches!(
+        (topic, event),
+        (Topic::Player, PushEvent::PlayerSnapshot { .. })
+            | (Topic::Queue, PushEvent::QueueSnapshot { .. })
+            | (Topic::Settings, PushEvent::SettingsSnapshot { .. })
+            | (
+                Topic::System,
+                PushEvent::OwnerChanged { .. } | PushEvent::ShuttingDown
+            )
+    )
+}
+
+async fn write_json_line<W, T>(
+    writer: &mut W,
+    value: &T,
+    write_timeout: Duration,
+    label: &'static str,
+) -> Result<(), WatchError>
+where
+    W: AsyncWrite + Unpin,
+    T: serde::Serialize,
+{
+    let mut bytes = serde_json::to_vec(value).map_err(|error| {
+        WatchError::transport(format!("could not encode watch {label}: {error}"))
+    })?;
+    bytes.push(b'\n');
+
+    timeout(write_timeout, async {
+        writer.write_all(&bytes).await?;
+        writer.flush().await
+    })
+    .await
+    .map_err(|_| WatchError::transport(format!("timed out writing watch {label}.")))?
+    .map_err(|error| WatchError::transport(format!("could not write watch {label}: {error}")))
+}
+
+async fn read_json_line<R, T>(reader: &mut R, max_bytes: usize) -> Result<T, WatchError>
+where
+    R: AsyncRead + Unpin,
+    T: serde::de::DeserializeOwned,
+{
+    use crate::util::io::BoundedLine;
+
+    let mut line = Vec::new();
+    match crate::util::io::read_bounded_line(reader, &mut line, max_bytes)
+        .await
+        .map_err(|error| WatchError::transport(format!("watch handshake read failed: {error}")))?
+    {
+        BoundedLine::Line => serde_json::from_slice(&line)
+            .map_err(|_| WatchError::transport("watch owner sent a malformed handshake.")),
+        BoundedLine::TooLarge => Err(WatchError::transport(
+            "watch owner sent an oversized handshake.",
+        )),
+        BoundedLine::Eof => Err(WatchError::transport(
+            "watch connection closed during the handshake.",
+        )),
+    }
+}
+
+fn emit_frame<E>(
+    frame: &ServerFrame,
+    json: bool,
+    quiet: bool,
+    emit: &mut E,
+) -> Result<(), WatchError>
+where
+    E: FnMut(&str) -> io::Result<()>,
+{
+    let line = if json {
+        serde_json::to_string(frame)
+            .map_err(|error| WatchError::transport(format!("could not encode event: {error}")))?
+    } else if quiet {
+        return Ok(());
+    } else {
+        human_line(frame).ok_or_else(|| WatchError::transport("could not render watch event."))?
+    };
+    emit(&line).map_err(|error| WatchError::transport(format!("could not write output: {error}")))
+}
+
+fn human_line(frame: &ServerFrame) -> Option<String> {
+    match frame {
+        ServerFrame::Event { event, .. } => match event {
+            PushEvent::PlayerSnapshot { model } => {
+                let state = if model.paused { "paused" } else { "playing" };
+                let track = model.track.as_ref().map_or_else(
+                    || "nothing playing".to_string(),
+                    |track| {
+                        let title = track
+                            .display_title
+                            .as_deref()
+                            .unwrap_or(track.title.as_str());
+                        let artist = track
+                            .display_artist
+                            .as_deref()
+                            .unwrap_or(track.artist.as_str());
+                        format!("{} — {}", sanitize(title, 80), sanitize(artist, 60))
+                    },
+                );
+                let queue = if model.queue_len == 0 {
+                    "queue empty".to_string()
+                } else {
+                    format!(
+                        "queue {}/{}",
+                        model.queue_pos.saturating_add(1),
+                        model.queue_len
+                    )
+                };
+                Some(format!(
+                    "[player] {state} · {track} · vol {}% · {queue}",
+                    model.volume
+                ))
+            }
+            PushEvent::QueueSnapshot { model } => Some(format!(
+                "[queue] {} {} · rev {}",
+                model.items.len(),
+                if model.items.len() == 1 {
+                    "track"
+                } else {
+                    "tracks"
+                },
+                model.rev
+            )),
+            PushEvent::SettingsSnapshot { model } => Some(format!(
+                "[settings] rev {} · speed {:.1}x · autoplay {} · source {} · mode {}",
+                model.rev,
+                f32::from(model.playback.speed_tenths) / 10.0,
+                on_off(model.streaming.autoplay),
+                model.search.default_source.label(),
+                sanitize(&model.streaming.mode, 32)
+            )),
+            PushEvent::OwnerChanged { mode } => Some(format!(
+                "[system] owner {}",
+                match mode {
+                    super::proto::InstanceMode::StandaloneTui => "standalone_tui",
+                    super::proto::InstanceMode::Daemon => "daemon",
+                }
+            )),
+            PushEvent::ShuttingDown => Some("[system] shutting down".to_string()),
+            _ => None,
+        },
+        ServerFrame::Goodbye { reason } => {
+            Some(format!("[system] goodbye · {}", sanitize(reason, 64)))
+        }
+        ServerFrame::Reply { .. } | ServerFrame::Pong { .. } => None,
+    }
+}
+
+fn on_off(value: bool) -> &'static str {
+    if value { "on" } else { "off" }
+}
+
+fn sanitize(value: &str, max_chars: usize) -> String {
+    let cleaned: String = value
+        .chars()
+        .map(|character| {
+            let unsafe_format = character.is_control()
+                || matches!(
+                    character,
+                    '\u{200e}'
+                        | '\u{200f}'
+                        | '\u{2028}'..='\u{202e}'
+                        | '\u{2066}'..='\u{2069}'
+                );
+            if unsafe_format { ' ' } else { character }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let mut chars = cleaned.chars();
+    let truncated: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        format!("{truncated}…")
+    } else {
+        truncated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+    use super::*;
+    use crate::remote::proto::{InstanceMode, RemoteResponse};
+
+    struct StallingWriter {
+        started: Option<tokio::sync::oneshot::Sender<()>>,
+        release: std::sync::mpsc::Receiver<()>,
+    }
+
+    impl Write for StallingWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            if let Some(started) = self.started.take() {
+                let _ = started.send(());
+                self.release.recv().map_err(io::Error::other)?;
+            }
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct BrokenWriter;
+
+    impl Write for BrokenWriter {
+        fn write(&mut self, _buffer: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct RecordingWriter {
+        bytes: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    }
+
+    impl Write for RecordingWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            self.bytes.lock().unwrap().extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn config(topics: Vec<Topic>) -> SessionConfig {
+        SessionConfig {
+            token: "0123456789abcdef0123456789abcdef".to_string(),
+            topics,
+            json: true,
+            quiet: false,
+            io_timeout: Duration::from_secs(1),
+            ping_interval: Duration::from_secs(30),
+        }
+    }
+
+    fn ack() -> HelloAck {
+        HelloAck {
+            ok: true,
+            version: PROTOCOL_VERSION,
+            session_id: 7,
+            capabilities: vec!["events-v8".to_string()],
+            owner_mode: InstanceMode::Daemon,
+            reason: None,
+        }
+    }
+
+    async fn server_handshake<S>(
+        stream: S,
+        expected_topics: &[Topic],
+    ) -> (BufReader<tokio::io::ReadHalf<S>>, tokio::io::WriteHalf<S>)
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let (read_half, mut write_half) = tokio::io::split(stream);
+        let mut reader = BufReader::new(read_half);
+
+        let mut line = String::new();
+        reader.read_line(&mut line).await.unwrap();
+        let hello: HelloRequest = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(hello.version, PROTOCOL_VERSION);
+        assert_eq!(hello.token, "0123456789abcdef0123456789abcdef");
+        assert_eq!(hello.hello.client, "ytt-cli-watch");
+        assert_eq!(hello.hello.min_version, PROTOCOL_VERSION);
+        write_test_line(&mut write_half, &ack()).await;
+
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        let subscribe: ClientFrame = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(subscribe.id, SUBSCRIBE_ID);
+        assert_eq!(
+            subscribe.op,
+            ClientOp::Subscribe {
+                topics: expected_topics.to_vec()
+            }
+        );
+        (reader, write_half)
+    }
+
+    async fn write_test_line<W: AsyncWrite + Unpin, T: serde::Serialize>(
+        writer: &mut W,
+        value: &T,
+    ) {
+        let mut bytes = serde_json::to_vec(value).unwrap();
+        bytes.push(b'\n');
+        writer.write_all(&bytes).await.unwrap();
+        writer.flush().await.unwrap();
+    }
+
+    fn system_event(seq: u64, event: PushEvent) -> ServerFrame {
+        ServerFrame::Event {
+            seq,
+            topic: Topic::System,
+            event,
+        }
+    }
+
+    #[tokio::test]
+    async fn immediate_cancel_wins_before_operation_is_polled() {
+        let operation_polled = std::cell::Cell::new(false);
+        let operation = std::future::poll_fn(|_| {
+            operation_polled.set(true);
+            std::task::Poll::Ready(EXIT_TRANSPORT)
+        });
+        let cancel = std::future::ready(Ok::<(), io::Error>(()));
+
+        assert_eq!(race_operation_with_cancel(operation, cancel).await, EXIT_OK);
+        assert!(!operation_polled.get());
+    }
+
+    #[tokio::test]
+    async fn cancel_during_pre_ack_handshake_exits_successfully() {
+        let (client, server) = tokio::io::duplex(4096);
+        let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
+        let operation = async move {
+            let mut emit = |_line: &str| Ok(());
+            match run_session(
+                client,
+                config(vec![Topic::System]),
+                pending::<Result<(), WatchError>>(),
+                &mut emit,
+            )
+            .await
+            {
+                Ok(()) => EXIT_OK,
+                Err(error) => error.exit_code(),
+            }
+        };
+        let cancel = async move {
+            cancel_rx.await.map_err(io::Error::other)?;
+            Ok(())
+        };
+        let server_fut = async move {
+            let (read_half, _write_half) = tokio::io::split(server);
+            let mut reader = BufReader::new(read_half);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            serde_json::from_str::<HelloRequest>(line.trim()).unwrap();
+            cancel_tx.send(()).unwrap();
+
+            line.clear();
+            assert_eq!(reader.read_line(&mut line).await.unwrap(), 0);
+        };
+
+        let (exit_code, ()) =
+            tokio::join!(race_operation_with_cancel(operation, cancel), server_fut);
+        assert_eq!(exit_code, EXIT_OK);
+    }
+
+    #[tokio::test]
+    async fn outer_cancel_interrupts_stalled_output_drain() {
+        let (client, server) = tokio::io::duplex(4096);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let writer = StallingWriter {
+            started: Some(started_tx),
+            release: release_rx,
+        };
+        let operation = async move {
+            let _ = run_session_with_output(
+                client,
+                config(vec![Topic::System]),
+                pending::<Result<(), WatchError>>(),
+                writer,
+                4,
+                Duration::from_secs(5),
+            )
+            .await;
+            EXIT_TRANSPORT
+        };
+        let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
+        let cancel = async move {
+            cancel_rx.await.map_err(io::Error::other)?;
+            Ok(())
+        };
+        let server_fut = async move {
+            let (_reader, mut socket_writer) = server_handshake(server, &[Topic::System]).await;
+            write_test_line(
+                &mut socket_writer,
+                &system_event(
+                    1,
+                    PushEvent::OwnerChanged {
+                        mode: InstanceMode::Daemon,
+                    },
+                ),
+            )
+            .await;
+            write_test_line(
+                &mut socket_writer,
+                &ServerFrame::Reply {
+                    id: SUBSCRIBE_ID,
+                    resp: RemoteResponse::ok("subscribed".to_string()),
+                },
+            )
+            .await;
+            write_test_line(
+                &mut socket_writer,
+                &ServerFrame::Goodbye {
+                    reason: "shutting_down".to_string(),
+                },
+            )
+            .await;
+
+            started_rx.await.unwrap();
+            cancel_tx.send(()).unwrap();
+            tokio::task::yield_now().await;
+            release_tx.send(()).unwrap();
+        };
+
+        let (exit_code, ()) =
+            tokio::join!(race_operation_with_cancel(operation, cancel), server_fut);
+        assert_eq!(exit_code, EXIT_OK);
+    }
+
+    #[tokio::test]
+    async fn stalled_output_flush_times_out_as_transport_error() {
+        let (client, server) = tokio::io::duplex(4096);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let writer = StallingWriter {
+            started: Some(started_tx),
+            release: release_rx,
+        };
+        let client_fut = run_session_with_output(
+            client,
+            config(vec![Topic::System]),
+            pending::<Result<(), WatchError>>(),
+            writer,
+            4,
+            Duration::from_millis(50),
+        );
+        let server_fut = async move {
+            let (_reader, mut socket_writer) = server_handshake(server, &[Topic::System]).await;
+            write_test_line(
+                &mut socket_writer,
+                &system_event(
+                    1,
+                    PushEvent::OwnerChanged {
+                        mode: InstanceMode::Daemon,
+                    },
+                ),
+            )
+            .await;
+            write_test_line(
+                &mut socket_writer,
+                &ServerFrame::Reply {
+                    id: SUBSCRIBE_ID,
+                    resp: RemoteResponse::ok("subscribed".to_string()),
+                },
+            )
+            .await;
+            write_test_line(
+                &mut socket_writer,
+                &ServerFrame::Goodbye {
+                    reason: "shutting_down".to_string(),
+                },
+            )
+            .await;
+            started_rx.await.unwrap();
+        };
+
+        let (result, ()) = tokio::join!(client_fut, server_fut);
+        release_tx.send(()).unwrap();
+        let error = result.unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Transport);
+        assert!(error.message.contains("timed out flushing"));
+    }
+
+    #[tokio::test]
+    async fn full_output_lane_is_nonblocking_and_reports_slow_consumer() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let writer = StallingWriter {
+            started: Some(started_tx),
+            release: release_rx,
+        };
+        let (line_tx, mut done_rx) = spawn_output_writer(writer, 1).unwrap();
+
+        enqueue_output_line(&line_tx, "first").unwrap();
+        started_rx.await.unwrap();
+        enqueue_output_line(&line_tx, "second").unwrap();
+        let error = enqueue_output_line(&line_tx, "third").unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+
+        drop(line_tx);
+        release_tx.send(()).unwrap();
+        let completion = timeout(Duration::from_secs(1), &mut done_rx).await.unwrap();
+        assert_eq!(output_completion(completion), Ok(()));
+    }
+
+    #[tokio::test]
+    async fn broken_output_writer_is_transport_error() {
+        let (client, server) = tokio::io::duplex(4096);
+        let client_fut = run_session_with_output(
+            client,
+            config(vec![Topic::System]),
+            pending::<Result<(), WatchError>>(),
+            BrokenWriter,
+            4,
+            Duration::from_secs(1),
+        );
+        let server_fut = async move {
+            let (_reader, mut socket_writer) = server_handshake(server, &[Topic::System]).await;
+            write_test_line(
+                &mut socket_writer,
+                &system_event(
+                    1,
+                    PushEvent::OwnerChanged {
+                        mode: InstanceMode::Daemon,
+                    },
+                ),
+            )
+            .await;
+            write_test_line(
+                &mut socket_writer,
+                &ServerFrame::Reply {
+                    id: SUBSCRIBE_ID,
+                    resp: RemoteResponse::ok("subscribed".to_string()),
+                },
+            )
+            .await;
+        };
+
+        let (result, ()) = tokio::join!(client_fut, server_fut);
+        let error = result.unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Transport);
+        assert!(error.message.contains("output"));
+    }
+
+    #[tokio::test]
+    async fn abnormal_goodbye_drains_accepted_output_in_order() {
+        let (client, server) = tokio::io::duplex(4096);
+        let bytes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let writer = RecordingWriter {
+            bytes: std::sync::Arc::clone(&bytes),
+        };
+        let client_fut = run_session_with_output(
+            client,
+            config(vec![Topic::System]),
+            pending::<Result<(), WatchError>>(),
+            writer,
+            4,
+            Duration::from_secs(1),
+        );
+        let event = system_event(
+            1,
+            PushEvent::OwnerChanged {
+                mode: InstanceMode::Daemon,
+            },
+        );
+        let goodbye = ServerFrame::Goodbye {
+            reason: "slow_consumer".to_string(),
+        };
+        let expected = format!(
+            "{}\n{}\n",
+            serde_json::to_string(&event).unwrap(),
+            serde_json::to_string(&goodbye).unwrap()
+        );
+        let server_fut = async move {
+            let (_reader, mut socket_writer) = server_handshake(server, &[Topic::System]).await;
+            write_test_line(&mut socket_writer, &event).await;
+            write_test_line(
+                &mut socket_writer,
+                &ServerFrame::Reply {
+                    id: SUBSCRIBE_ID,
+                    resp: RemoteResponse::ok("subscribed".to_string()),
+                },
+            )
+            .await;
+            write_test_line(&mut socket_writer, &goodbye).await;
+        };
+
+        let (result, ()) = tokio::join!(client_fut, server_fut);
+        let error = result.unwrap_err();
+        assert!(error.message.contains("slow_consumer"));
+        let recorded = bytes.lock().unwrap().clone();
+        assert_eq!(std::str::from_utf8(&recorded).unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn accepts_snapshot_before_subscribe_reply_and_json_filters_frames() {
+        let (client, server) = tokio::io::duplex(16 * 1024);
+        let mut lines = Vec::new();
+        let mut emit = |line: &str| -> io::Result<()> {
+            lines.push(line.to_string());
+            Ok(())
+        };
+        let client_fut = run_session(
+            client,
+            config(vec![Topic::System]),
+            pending::<Result<(), WatchError>>(),
+            &mut emit,
+        );
+        let server_fut = async move {
+            let (_reader, mut writer) = server_handshake(server, &[Topic::System]).await;
+            write_test_line(
+                &mut writer,
+                &system_event(
+                    1,
+                    PushEvent::OwnerChanged {
+                        mode: InstanceMode::Daemon,
+                    },
+                ),
+            )
+            .await;
+            write_test_line(
+                &mut writer,
+                &ServerFrame::Reply {
+                    id: SUBSCRIBE_ID,
+                    resp: RemoteResponse::ok("subscribed".to_string()),
+                },
+            )
+            .await;
+            write_test_line(&mut writer, &system_event(2, PushEvent::ShuttingDown)).await;
+            write_test_line(
+                &mut writer,
+                &ServerFrame::Goodbye {
+                    reason: "shutting_down".to_string(),
+                },
+            )
+            .await;
+        };
+
+        let (result, ()) = tokio::join!(client_fut, server_fut);
+        assert_eq!(result, Ok(()));
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].contains(r#""seq":1"#));
+        assert!(lines[1].contains(r#""kind":"shutting_down""#));
+        assert_eq!(lines[2], r#"{"frame":"goodbye","reason":"shutting_down"}"#);
+        assert!(
+            lines
+                .iter()
+                .all(|line| !line.contains(r#""frame":"reply""#))
+        );
+    }
+
+    #[tokio::test]
+    async fn sends_ping_and_suppresses_pong() {
+        let (client, server) = tokio::io::duplex(16 * 1024);
+        let mut test_config = config(vec![Topic::System]);
+        test_config.ping_interval = Duration::from_millis(10);
+        let mut lines = Vec::new();
+        let mut emit = |line: &str| -> io::Result<()> {
+            lines.push(line.to_string());
+            Ok(())
+        };
+        let client_fut = run_session(
+            client,
+            test_config,
+            pending::<Result<(), WatchError>>(),
+            &mut emit,
+        );
+        let server_fut = async move {
+            let (mut reader, mut writer) = server_handshake(server, &[Topic::System]).await;
+            write_test_line(
+                &mut writer,
+                &ServerFrame::Reply {
+                    id: SUBSCRIBE_ID,
+                    resp: RemoteResponse::ok("subscribed".to_string()),
+                },
+            )
+            .await;
+
+            let mut line = String::new();
+            timeout(Duration::from_secs(1), reader.read_line(&mut line))
+                .await
+                .expect("client should ping")
+                .unwrap();
+            let ping: ClientFrame = serde_json::from_str(line.trim()).unwrap();
+            assert_eq!(ping.id, SUBSCRIBE_ID + 1);
+            assert_eq!(ping.op, ClientOp::Ping);
+            write_test_line(&mut writer, &ServerFrame::Pong { id: ping.id }).await;
+            write_test_line(
+                &mut writer,
+                &ServerFrame::Goodbye {
+                    reason: "shutting_down".to_string(),
+                },
+            )
+            .await;
+        };
+
+        let (result, ()) = tokio::join!(client_fut, server_fut);
+        assert_eq!(result, Ok(()));
+        assert_eq!(
+            lines,
+            vec![r#"{"frame":"goodbye","reason":"shutting_down"}"#]
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_event_sequence_gap() {
+        let (client, server) = tokio::io::duplex(16 * 1024);
+        let mut emit = |_line: &str| Ok(());
+        let client_fut = run_session(
+            client,
+            config(vec![Topic::System]),
+            pending::<Result<(), WatchError>>(),
+            &mut emit,
+        );
+        let server_fut = async move {
+            let (_reader, mut writer) = server_handshake(server, &[Topic::System]).await;
+            write_test_line(
+                &mut writer,
+                &system_event(
+                    1,
+                    PushEvent::OwnerChanged {
+                        mode: InstanceMode::Daemon,
+                    },
+                ),
+            )
+            .await;
+            write_test_line(
+                &mut writer,
+                &ServerFrame::Reply {
+                    id: SUBSCRIBE_ID,
+                    resp: RemoteResponse::ok("subscribed".to_string()),
+                },
+            )
+            .await;
+            write_test_line(&mut writer, &system_event(3, PushEvent::ShuttingDown)).await;
+        };
+
+        let (result, ()) = tokio::join!(client_fut, server_fut);
+        let error = result.unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Transport);
+        assert!(error.message.contains("sequence gap"));
+    }
+
+    #[tokio::test]
+    async fn rejects_duplicate_event_sequence() {
+        let (client, server) = tokio::io::duplex(16 * 1024);
+        let mut emit = |_line: &str| Ok(());
+        let client_fut = run_session(
+            client,
+            config(vec![Topic::System]),
+            pending::<Result<(), WatchError>>(),
+            &mut emit,
+        );
+        let server_fut = async move {
+            let (_reader, mut writer) = server_handshake(server, &[Topic::System]).await;
+            write_test_line(
+                &mut writer,
+                &system_event(
+                    1,
+                    PushEvent::OwnerChanged {
+                        mode: InstanceMode::Daemon,
+                    },
+                ),
+            )
+            .await;
+            write_test_line(
+                &mut writer,
+                &ServerFrame::Reply {
+                    id: SUBSCRIBE_ID,
+                    resp: RemoteResponse::ok("subscribed".to_string()),
+                },
+            )
+            .await;
+            write_test_line(&mut writer, &system_event(1, PushEvent::ShuttingDown)).await;
+        };
+
+        let (result, ()) = tokio::join!(client_fut, server_fut);
+        let error = result.unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Transport);
+        assert!(error.message.contains("sequence gap"));
+    }
+
+    #[tokio::test]
+    async fn malformed_regular_frame_is_transport_error() {
+        let (client, server) = tokio::io::duplex(4096);
+        let mut emit = |_line: &str| Ok(());
+        let client_fut = run_session(
+            client,
+            config(vec![Topic::System]),
+            pending::<Result<(), WatchError>>(),
+            &mut emit,
+        );
+        let server_fut = async move {
+            let (_reader, mut writer) = server_handshake(server, &[Topic::System]).await;
+            write_test_line(
+                &mut writer,
+                &ServerFrame::Reply {
+                    id: SUBSCRIBE_ID,
+                    resp: RemoteResponse::ok("subscribed".to_string()),
+                },
+            )
+            .await;
+            writer.write_all(b"{not-json}\n").await.unwrap();
+            writer.flush().await.unwrap();
+        };
+
+        let (result, ()) = tokio::join!(client_fut, server_fut);
+        let error = result.unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Transport);
+        assert!(error.message.contains("malformed frame"));
+    }
+
+    #[tokio::test]
+    async fn partial_eof_after_shutting_down_is_transport_error() {
+        let (client, server) = tokio::io::duplex(4096);
+        let mut emit = |_line: &str| Ok(());
+        let client_fut = run_session(
+            client,
+            config(vec![Topic::System]),
+            pending::<Result<(), WatchError>>(),
+            &mut emit,
+        );
+        let server_fut = async move {
+            let (_reader, mut writer) = server_handshake(server, &[Topic::System]).await;
+            write_test_line(
+                &mut writer,
+                &system_event(
+                    1,
+                    PushEvent::OwnerChanged {
+                        mode: InstanceMode::Daemon,
+                    },
+                ),
+            )
+            .await;
+            write_test_line(
+                &mut writer,
+                &ServerFrame::Reply {
+                    id: SUBSCRIBE_ID,
+                    resp: RemoteResponse::ok("subscribed".to_string()),
+                },
+            )
+            .await;
+            write_test_line(&mut writer, &system_event(2, PushEvent::ShuttingDown)).await;
+            writer.write_all(b"{\"frame\":\"goodbye\"").await.unwrap();
+            writer.flush().await.unwrap();
+        };
+
+        let (result, ()) = tokio::join!(client_fut, server_fut);
+        let error = result.unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Transport);
+        assert!(error.message.contains("malformed partial frame"));
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_frame_without_waiting_for_newline() {
+        let (client, server) = tokio::io::duplex(16 * 1024);
+        let mut emit = |_line: &str| Ok(());
+        let client_fut = run_session(
+            client,
+            config(vec![Topic::System]),
+            pending::<Result<(), WatchError>>(),
+            &mut emit,
+        );
+        let server_fut = async move {
+            let (_reader, mut writer) = server_handshake(server, &[Topic::System]).await;
+            let oversized = vec![b'x'; MAX_FRAME_BYTES + 1];
+            let _ = writer.write_all(&oversized).await;
+        };
+
+        let (result, ()) = tokio::join!(client_fut, server_fut);
+        let error = result.unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Transport);
+        assert!(error.message.contains("oversized"));
+    }
+
+    #[tokio::test]
+    async fn capacity_handshake_rejection_is_transport_error() {
+        let (client, server) = tokio::io::duplex(4096);
+        let mut emit = |_line: &str| Ok(());
+        let client_fut = run_session(
+            client,
+            config(vec![Topic::System]),
+            pending::<Result<(), WatchError>>(),
+            &mut emit,
+        );
+        let server_fut = async move {
+            let (read_half, mut write_half) = tokio::io::split(server);
+            let mut reader = BufReader::new(read_half);
+            let mut hello = String::new();
+            reader.read_line(&mut hello).await.unwrap();
+            let rejected = HelloAck {
+                ok: false,
+                version: PROTOCOL_VERSION,
+                session_id: 0,
+                capabilities: Vec::new(),
+                owner_mode: InstanceMode::Daemon,
+                reason: Some("sessions_full".to_string()),
+            };
+            write_test_line(&mut write_half, &rejected).await;
+        };
+
+        let (result, ()) = tokio::join!(client_fut, server_fut);
+        let error = result.unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Transport);
+        assert!(error.message.contains("sessions_full"));
+    }
+
+    #[test]
+    fn handshake_rejection_reason_is_sanitized_and_bounded() {
+        let rejected = HelloAck {
+            ok: false,
+            version: PROTOCOL_VERSION,
+            session_id: 0,
+            capabilities: Vec::new(),
+            owner_mode: InstanceMode::Daemon,
+            reason: Some(format!(
+                "sessions_full\n\u{1b}]0;watch-owned-{}\u{7}",
+                "x".repeat(100)
+            )),
+        };
+
+        let error = validate_ack(&rejected).unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Transport);
+        assert!(!error.message.chars().any(char::is_control));
+        assert!(error.message.contains('…'));
+    }
+
+    #[tokio::test]
+    async fn subscription_rejection_reason_is_sanitized_and_bounded() {
+        let (client, server) = tokio::io::duplex(4096);
+        let mut emit = |_line: &str| Ok(());
+        let client_fut = run_session(
+            client,
+            config(vec![Topic::System]),
+            pending::<Result<(), WatchError>>(),
+            &mut emit,
+        );
+        let server_fut = async move {
+            let (_reader, mut writer) = server_handshake(server, &[Topic::System]).await;
+            let reason = format!("rejected\r\n\u{1b}]0;watch-owned-{}\u{7}", "y".repeat(100));
+            write_test_line(
+                &mut writer,
+                &ServerFrame::Reply {
+                    id: SUBSCRIBE_ID,
+                    resp: RemoteResponse::err(&reason),
+                },
+            )
+            .await;
+        };
+
+        let (result, ()) = tokio::join!(client_fut, server_fut);
+        let error = result.unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Transport);
+        assert!(!error.message.chars().any(char::is_control));
+        assert!(error.message.contains('…'));
+    }
+
+    #[test]
+    fn protocol_handshake_rejection_is_usage_error() {
+        let rejected = HelloAck {
+            ok: false,
+            version: PROTOCOL_VERSION,
+            session_id: 0,
+            capabilities: Vec::new(),
+            owner_mode: InstanceMode::Daemon,
+            reason: Some("bad_version".to_string()),
+        };
+        let error = validate_ack(&rejected).unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Unsupported);
+        assert!(error.message.contains("bad_version"));
+    }
+
+    #[tokio::test]
+    async fn unanswered_ping_fails_on_io_deadline() {
+        let (client, server) = tokio::io::duplex(4096);
+        let mut test_config = config(vec![Topic::System]);
+        test_config.io_timeout = Duration::from_millis(100);
+        test_config.ping_interval = Duration::from_millis(10);
+        let mut emit = |_line: &str| Ok(());
+        let client_fut = run_session(
+            client,
+            test_config,
+            pending::<Result<(), WatchError>>(),
+            &mut emit,
+        );
+        let server_fut = async move {
+            let (mut reader, mut writer) = server_handshake(server, &[Topic::System]).await;
+            write_test_line(
+                &mut writer,
+                &ServerFrame::Reply {
+                    id: SUBSCRIBE_ID,
+                    resp: RemoteResponse::ok("subscribed".to_string()),
+                },
+            )
+            .await;
+
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            let ping: ClientFrame = serde_json::from_str(line.trim()).unwrap();
+            assert_eq!(ping.op, ClientOp::Ping);
+            line.clear();
+            assert_eq!(reader.read_line(&mut line).await.unwrap(), 0);
+        };
+
+        let (result, ()) = tokio::join!(client_fut, server_fut);
+        let error = result.unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Transport);
+        assert!(error.message.contains("answering pings"));
+    }
+
+    #[tokio::test]
+    async fn slow_consumer_and_idle_goodbyes_are_transport_errors() {
+        for reason in ["slow_consumer", "idle_timeout"] {
+            let (client, server) = tokio::io::duplex(4096);
+            let mut lines = Vec::new();
+            let mut emit = |line: &str| -> io::Result<()> {
+                lines.push(line.to_string());
+                Ok(())
+            };
+            let client_fut = run_session(
+                client,
+                config(vec![Topic::System]),
+                pending::<Result<(), WatchError>>(),
+                &mut emit,
+            );
+            let server_fut = async move {
+                let (_reader, mut writer) = server_handshake(server, &[Topic::System]).await;
+                write_test_line(
+                    &mut writer,
+                    &ServerFrame::Reply {
+                        id: SUBSCRIBE_ID,
+                        resp: RemoteResponse::ok("subscribed".to_string()),
+                    },
+                )
+                .await;
+                write_test_line(
+                    &mut writer,
+                    &ServerFrame::Goodbye {
+                        reason: reason.to_string(),
+                    },
+                )
+                .await;
+            };
+
+            let (result, ()) = tokio::join!(client_fut, server_fut);
+            let error = result.unwrap_err();
+            assert_eq!(error.kind, ErrorKind::Transport);
+            assert!(error.message.contains(reason));
+            assert_eq!(lines.len(), 1, "JSON should retain the Goodbye frame");
+            assert!(lines[0].contains(reason));
+        }
+    }
+
+    #[test]
+    fn topic_validation_deduplicates_and_rejects_non_watch_topics() {
+        assert_eq!(
+            normalize_topics(vec![Topic::Player, Topic::Player, Topic::System]).unwrap(),
+            vec![Topic::Player, Topic::System]
+        );
+        let error = normalize_topics(vec![Topic::Lyrics]).unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Unsupported);
+    }
+
+    #[test]
+    fn first_event_sequence_must_start_at_one() {
+        let mut last_seq = None;
+        let error = validate_event(
+            2,
+            Topic::System,
+            &PushEvent::OwnerChanged {
+                mode: InstanceMode::Daemon,
+            },
+            &[Topic::System],
+            &mut last_seq,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind, ErrorKind::Transport);
+        assert!(error.message.contains("sequence gap"));
+        assert_eq!(last_seq, None);
+    }
+
+    #[test]
+    fn sanitizer_removes_terminal_controls_and_bounds_fields() {
+        assert_eq!(sanitize("song\n\u{1b}[31m  title", 80), "song [31m title");
+        assert_eq!(sanitize("left\u{202e}right", 80), "left right");
+        assert_eq!(sanitize("abcdef", 3), "abc…");
+    }
+
+    #[test]
+    fn quiet_suppresses_human_output_but_json_wins() {
+        let frame = system_event(
+            1,
+            PushEvent::OwnerChanged {
+                mode: InstanceMode::Daemon,
+            },
+        );
+        let mut lines = Vec::new();
+        {
+            let mut emit = |line: &str| -> io::Result<()> {
+                lines.push(line.to_string());
+                Ok(())
+            };
+            emit_frame(&frame, false, true, &mut emit).unwrap();
+        }
+        assert!(lines.is_empty());
+        {
+            let mut emit = |line: &str| -> io::Result<()> {
+                lines.push(line.to_string());
+                Ok(())
+            };
+            emit_frame(&frame, true, true, &mut emit).unwrap();
+        }
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains(r#""frame":"event""#));
+    }
+}

--- a/src/util/runtime.rs
+++ b/src/util/runtime.rs
@@ -70,9 +70,17 @@ fn runtime_base() -> PathBuf {
 
 /// Private app runtime directory. Unix callers get a `0700` directory.
 pub fn app_runtime_dir() -> io::Result<PathBuf> {
-    let dir = runtime_base().join(format!("yututui-{}", uid_tag()));
+    let dir = app_runtime_dir_path();
     safe_fs::ensure_private_dir(&dir)?;
     Ok(dir)
+}
+
+/// Resolve the app runtime directory without creating it or repairing its permissions.
+///
+/// Strict readers use this to validate the directory exactly as it exists. Writers and normal
+/// runtime setup should keep using [`app_runtime_dir`], which establishes the private directory.
+pub(crate) fn app_runtime_dir_path() -> PathBuf {
+    runtime_base().join(format!("yututui-{}", uid_tag()))
 }
 
 /// Legacy base used before the private runtime dir migration.

--- a/src/util/safe_fs.rs
+++ b/src/util/safe_fs.rs
@@ -328,7 +328,18 @@ pub fn read_to_string_no_symlink(path: &Path) -> io::Result<String> {
 pub fn read_no_symlink_limited(path: &Path, max_bytes: u64) -> io::Result<Vec<u8>> {
     let file = open_no_symlink(path)?;
     let meta = file.metadata()?;
-    if !meta.is_file() {
+    if !meta.is_file()
+        || cfg!(windows) && {
+            #[cfg(windows)]
+            {
+                is_windows_reparse_point(&meta)
+            }
+            #[cfg(not(windows))]
+            {
+                false
+            }
+        }
+    {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             format!("not a regular file: {}", path.display()),
@@ -341,6 +352,97 @@ pub fn read_no_symlink_limited(path: &Path, max_bytes: u64) -> io::Result<Vec<u8
         ));
     }
     let mut out = Vec::new();
+    file.take(max_bytes.saturating_add(1))
+        .read_to_end(&mut out)?;
+    if out.len() as u64 > max_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("file too large: {}", path.display()),
+        ));
+    }
+    Ok(out)
+}
+
+/// Read a bounded private file without repairing or creating any part of its path.
+///
+/// On Unix the already-existing parent must be a current-user `0700` directory and the opened
+/// final inode must be a current-user `0600` regular file. The final open uses `O_NOFOLLOW`, and
+/// ownership/mode/size checks are made against that opened inode. Windows applies the equivalent
+/// no-reparse-point and regular-file checks available to this module. This is intentionally a
+/// validator only: unlike [`ensure_private_dir`], it never changes permissions.
+pub(crate) fn read_private_file_limited(path: &Path, max_bytes: u64) -> io::Result<Vec<u8>> {
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("private file has no parent: {}", path.display()),
+        )
+    })?;
+    let parent_meta = fs::symlink_metadata(parent)?;
+
+    #[cfg(unix)]
+    if !parent_meta.is_dir()
+        || parent_meta.file_type().is_symlink()
+        || !is_owned_by_current_user(&parent_meta)
+        || parent_meta.permissions().mode() & 0o7777 != private_dir_mode()
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "private parent is not current-user 0700: {}",
+                parent.display()
+            ),
+        ));
+    }
+
+    #[cfg(windows)]
+    if !parent_meta.is_dir() || is_windows_reparse_point(&parent_meta) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("refusing non-private parent: {}", parent.display()),
+        ));
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    if !parent_meta.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("refusing non-directory parent: {}", parent.display()),
+        ));
+    }
+
+    let file = open_no_symlink(path)?;
+    let meta = file.metadata()?;
+    if !meta.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("not a private regular file: {}", path.display()),
+        ));
+    }
+
+    #[cfg(windows)]
+    if is_windows_reparse_point(&meta) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("refusing private file reparse point: {}", path.display()),
+        ));
+    }
+
+    #[cfg(unix)]
+    if !is_owned_by_current_user(&meta) || meta.permissions().mode() & 0o7777 != private_file_mode()
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("private file is not current-user 0600: {}", path.display()),
+        ));
+    }
+
+    if meta.len() > max_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("file too large: {}", path.display()),
+        ));
+    }
+    let mut out = Vec::with_capacity(meta.len() as usize);
     file.take(max_bytes.saturating_add(1))
         .read_to_end(&mut out)?;
     if out.len() as u64 > max_bytes {
@@ -847,6 +949,26 @@ mod tests {
             fs::metadata(&path).unwrap().permissions().mode() & 0o777,
             private_file_mode()
         );
+        assert_eq!(read_private_file_limited(&path, 16).unwrap(), b"{}");
+
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o640)).unwrap();
+        assert_eq!(
+            read_private_file_limited(&path, 16).unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        fs::set_permissions(&path, fs::Permissions::from_mode(private_file_mode())).unwrap();
+
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o750)).unwrap();
+        assert_eq!(
+            read_private_file_limited(&path, 16).unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o1700)).unwrap();
+        assert_eq!(
+            read_private_file_limited(&path, 16).unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        fs::set_permissions(&dir, fs::Permissions::from_mode(private_dir_mode())).unwrap();
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -1,5 +1,14 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use yututui::remote::proto::{InstanceFile, InstanceMode, PROTOCOL_VERSION};
+
+const CHILD_TIMEOUT: Duration = Duration::from_secs(10);
+const DESCRIPTOR_TOKEN: &str = "0123456789abcdef0123456789abcdef";
 
 fn run(args: &[&str]) -> std::process::Output {
     Command::new(env!("CARGO_BIN_EXE_ytt"))
@@ -22,6 +31,7 @@ fn isolated_command(root: &Path, args: &[&str]) -> Command {
             .expect("isolated runtime dir should be private");
     }
 
+    let user_tag = isolated_user_tag(root);
     let mut command = Command::new(env!("CARGO_BIN_EXE_ytt"));
     command
         .args(args)
@@ -35,11 +45,134 @@ fn isolated_command(root: &Path, args: &[&str]) -> Command {
         .env("XDG_CACHE_HOME", root.join("cache"))
         .env("XDG_RUNTIME_DIR", runtime)
         .env("YTM_TOOLS_DIR", root.join("tools"))
+        .env("USER", &user_tag)
+        .env("USERNAME", user_tag)
         .env("LANG", "C")
         .env("LC_ALL", "C")
         .env_remove("YTM_YTDLP")
         .env_remove("YTM_MPV");
     command
+}
+
+fn isolated_user_tag(root: &Path) -> String {
+    let mut hasher = DefaultHasher::new();
+    root.hash(&mut hasher);
+    format!("smoke{:x}", hasher.finish())
+        .chars()
+        .take(16)
+        .collect()
+}
+
+#[cfg(unix)]
+fn remote_app_dir(root: &Path) -> PathBuf {
+    use std::os::unix::fs::MetadataExt;
+
+    let runtime = root.join("runtime");
+    std::fs::create_dir_all(&runtime).expect("isolated runtime dir should be creatable");
+    let uid = std::fs::metadata(&runtime)
+        .expect("isolated runtime metadata should be readable")
+        .uid();
+    runtime.join(format!("yututui-{uid}"))
+}
+
+#[cfg(not(unix))]
+fn remote_app_dir(root: &Path) -> PathBuf {
+    std::env::temp_dir().join(format!("yututui-{}", isolated_user_tag(root)))
+}
+
+#[cfg(unix)]
+fn canonical_remote_endpoint(root: &Path) -> String {
+    remote_app_dir(root)
+        .join(format!("yututui-remote-{}.sock", isolated_user_tag(root)))
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(not(unix))]
+fn canonical_remote_endpoint(root: &Path) -> String {
+    format!(r"\\.\pipe\yututui-remote-{}", isolated_user_tag(root))
+}
+
+fn current_descriptor_path(root: &Path) -> PathBuf {
+    remote_app_dir(root).join(format!("yututui-remote-{}.json", isolated_user_tag(root)))
+}
+
+fn write_current_descriptor(root: &Path, instance: &InstanceFile) {
+    assert_eq!(instance.endpoint, canonical_remote_endpoint(root));
+    let runtime = root.join("runtime");
+    std::fs::create_dir_all(&runtime).expect("isolated runtime dir should be creatable");
+    let app_dir = remote_app_dir(root);
+    std::fs::create_dir_all(&app_dir).expect("private remote app dir should be creatable");
+    let path = current_descriptor_path(root);
+    std::fs::write(&path, serde_json::to_vec(instance).unwrap())
+        .expect("current descriptor should be writable");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&runtime, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::set_permissions(&app_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
+}
+
+fn isolated_instance(root: &Path, protocol_version: u8, capabilities: Vec<String>) -> InstanceFile {
+    InstanceFile {
+        app_pid: 4_242,
+        endpoint: canonical_remote_endpoint(root),
+        token: DESCRIPTOR_TOKEN.to_owned(),
+        created_unix: 123,
+        mode: InstanceMode::Daemon,
+        protocol_version,
+        capabilities,
+    }
+}
+
+fn clean_isolated_remote(root: &Path) {
+    let _ = std::fs::remove_dir_all(remote_app_dir(root));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+fn run_isolated_with_timeout(root: &Path, args: &[&str]) -> std::process::Output {
+    output_with_timeout(isolated_command(root, args), CHILD_TIMEOUT)
+}
+
+fn output_with_timeout(mut command: Command, timeout: Duration) -> std::process::Output {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command.spawn().expect("ytt command should spawn");
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child
+            .try_wait()
+            .expect("ytt child status should be readable")
+        {
+            Some(status) => break status,
+            None if Instant::now() < deadline => std::thread::sleep(Duration::from_millis(10)),
+            None => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("ytt command exceeded {timeout:?}");
+            }
+        }
+    };
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    child
+        .stdout
+        .take()
+        .expect("ytt stdout should be captured")
+        .read_to_end(&mut stdout)
+        .unwrap();
+    child
+        .stderr
+        .take()
+        .expect("ytt stderr should be captured")
+        .read_to_end(&mut stderr)
+        .unwrap();
+    std::process::Output {
+        status,
+        stdout,
+        stderr,
+    }
 }
 
 fn stdout(output: &std::process::Output) -> String {
@@ -434,4 +567,617 @@ fn transfer_and_auth_one_shots_report_setup_failures_without_tui_startup() {
         "stdout={}",
         stdout(&spotify_logout)
     );
+}
+
+#[test]
+fn new_remote_commands_fail_cleanly_without_an_owner() {
+    let root = isolated_root("remote-no-instance");
+    clean_isolated_remote(&root);
+
+    for args in [
+        &["-r", "info"][..],
+        &["-r", "queue-list"][..],
+        &["-r", "settings-show"][..],
+        &["-r", "queue-play", "1"][..],
+        &["-r", "watch"][..],
+    ] {
+        let output = run_isolated_with_timeout(&root, args);
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "{args:?}: stdout={}, stderr={}",
+            stdout(&output),
+            stderr(&output)
+        );
+        assert!(stdout(&output).is_empty(), "{args:?}: unexpected stdout");
+        assert!(
+            stderr(&output).contains("ytt -r:"),
+            "{args:?}: stderr={}",
+            stderr(&output)
+        );
+    }
+
+    clean_isolated_remote(&root);
+}
+
+#[test]
+fn new_remote_parser_rejects_bad_arity_before_connecting() {
+    let root = isolated_root("remote-bad-arity");
+    clean_isolated_remote(&root);
+
+    for args in [
+        &["-r", "info", "extra"][..],
+        &["-r", "queue-list", "extra"][..],
+        &["-r", "settings-show", "extra"][..],
+        &["-r", "queue-play"][..],
+        &["-r", "queue-play", "0"][..],
+        &["-r", "queue-play", "-1"][..],
+        &["-r", "queue-play", "1", "extra"][..],
+        &["-r", "queue-play", "184467440737095516160"][..],
+        &["-r", "watch", "player", "queue"][..],
+    ] {
+        let output = run_isolated_with_timeout(&root, args);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "{args:?}: stdout={}, stderr={}",
+            stdout(&output),
+            stderr(&output)
+        );
+        assert!(stdout(&output).is_empty(), "{args:?}: unexpected stdout");
+        assert!(
+            stderr(&output).contains("ytt -r:"),
+            "{args:?}: stderr={}",
+            stderr(&output)
+        );
+    }
+
+    clean_isolated_remote(&root);
+}
+
+#[test]
+fn watch_rejects_unsupported_descriptor_protocol_and_capability() {
+    let root = isolated_root("remote-watch-unsupported");
+    clean_isolated_remote(&root);
+
+    let protocol_instance =
+        isolated_instance(&root, PROTOCOL_VERSION - 1, vec!["events-v8".to_owned()]);
+    write_current_descriptor(&root, &protocol_instance);
+    let protocol = run_isolated_with_timeout(&root, &["-r", "watch"]);
+    assert_eq!(protocol.status.code(), Some(2), "{}", stderr(&protocol));
+    assert!(stderr(&protocol).contains("requires protocol 8"));
+    assert!(!stderr(&protocol).contains(DESCRIPTOR_TOKEN));
+    assert!(!stderr(&protocol).contains(&protocol_instance.endpoint));
+
+    let capability_instance = isolated_instance(
+        &root,
+        PROTOCOL_VERSION,
+        vec!["remote-control".to_owned(), "status".to_owned()],
+    );
+    write_current_descriptor(&root, &capability_instance);
+    let capability = run_isolated_with_timeout(&root, &["-r", "watch"]);
+    assert_eq!(capability.status.code(), Some(2), "{}", stderr(&capability));
+    assert!(stderr(&capability).contains("does not support watch events"));
+    assert!(!stderr(&capability).contains(DESCRIPTOR_TOKEN));
+    assert!(!stderr(&capability).contains(&capability_instance.endpoint));
+
+    clean_isolated_remote(&root);
+}
+
+#[cfg(any(unix, windows))]
+mod remote_owner {
+    use super::*;
+    use std::sync::mpsc;
+
+    use interprocess::local_socket::tokio::prelude::*;
+    use interprocess::local_socket::{GenericFilePath, ListenerOptions};
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use yututui::remote::proto::{
+        ClientFrame, ClientOp, HelloAck, HelloRequest, PushEvent, QueueItemSnapshot, RemoteCommand,
+        RemoteRequest, RemoteResponse, ServerFrame, SettingsSnapshot, StatusSnapshot, Topic,
+    };
+    use yututui::search_source::SearchSource;
+    use yututui::streaming::StreamingMode;
+
+    const OWNER_IO_TIMEOUT: Duration = Duration::from_secs(10);
+
+    struct Exchange {
+        command: RemoteCommand,
+        response: RemoteResponse,
+    }
+
+    #[cfg(unix)]
+    fn short_root(label: &str) -> PathBuf {
+        PathBuf::from("/tmp").join(format!("ytt-r-{label}-{}", std::process::id()))
+    }
+
+    #[cfg(windows)]
+    fn short_root(label: &str) -> PathBuf {
+        isolated_root(label)
+    }
+
+    fn spawn_fake_owner(endpoint: String, exchanges: Vec<Exchange>) -> std::thread::JoinHandle<()> {
+        let (ready_tx, ready_rx) = mpsc::sync_channel::<Result<(), String>>(1);
+        let handle = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("fake owner runtime should build");
+            runtime.block_on(async move {
+                let _ = std::fs::remove_file(&endpoint);
+                let name = endpoint
+                    .as_str()
+                    .to_fs_name::<GenericFilePath>()
+                    .expect("canonical endpoint should be a filesystem socket name");
+                let listener = match ListenerOptions::new()
+                    .name(name)
+                    .reclaim_name(false)
+                    .create_tokio()
+                {
+                    Ok(listener) => listener,
+                    Err(error) => {
+                        let _ = ready_tx.send(Err(error.to_string()));
+                        return;
+                    }
+                };
+                ready_tx.send(Ok(())).unwrap();
+
+                for exchange in exchanges {
+                    let conn = tokio::time::timeout(OWNER_IO_TIMEOUT, listener.accept())
+                        .await
+                        .expect("timed out waiting for ytt remote connection")
+                        .expect("fake owner should accept ytt connection");
+                    let mut request_line = String::new();
+                    {
+                        let mut reader = BufReader::new(&conn);
+                        tokio::time::timeout(OWNER_IO_TIMEOUT, reader.read_line(&mut request_line))
+                            .await
+                            .expect("timed out reading ytt request")
+                            .expect("fake owner should read ytt request");
+                    }
+                    let request: RemoteRequest = serde_json::from_str(request_line.trim())
+                        .expect("ytt should send a valid one-shot request");
+                    assert_eq!(request.version, PROTOCOL_VERSION);
+                    assert_eq!(request.token, DESCRIPTOR_TOKEN);
+                    assert_eq!(request.command, exchange.command);
+
+                    let mut response = serde_json::to_vec(&exchange.response).unwrap();
+                    response.push(b'\n');
+                    let mut writer = &conn;
+                    tokio::time::timeout(OWNER_IO_TIMEOUT, writer.write_all(&response))
+                        .await
+                        .expect("timed out writing fake-owner response")
+                        .expect("fake owner should write response");
+                    tokio::time::timeout(OWNER_IO_TIMEOUT, writer.flush())
+                        .await
+                        .expect("timed out flushing fake-owner response")
+                        .expect("fake owner should flush response");
+                }
+            });
+        });
+
+        match ready_rx.recv_timeout(CHILD_TIMEOUT) {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => panic!("fake owner could not bind: {error}"),
+            Err(error) => panic!("fake owner did not become ready: {error}"),
+        }
+        handle
+    }
+
+    fn spawn_watch_owner(endpoint: String) -> std::thread::JoinHandle<()> {
+        let (ready_tx, ready_rx) = mpsc::sync_channel::<Result<(), String>>(1);
+        let handle = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("fake watch owner runtime should build");
+            runtime.block_on(async move {
+                let _ = std::fs::remove_file(&endpoint);
+                let name = endpoint
+                    .as_str()
+                    .to_fs_name::<GenericFilePath>()
+                    .expect("canonical endpoint should be a local socket name");
+                let listener = match ListenerOptions::new()
+                    .name(name)
+                    .reclaim_name(false)
+                    .create_tokio()
+                {
+                    Ok(listener) => listener,
+                    Err(error) => {
+                        let _ = ready_tx.send(Err(error.to_string()));
+                        return;
+                    }
+                };
+                ready_tx.send(Ok(())).unwrap();
+
+                let conn = tokio::time::timeout(OWNER_IO_TIMEOUT, listener.accept())
+                    .await
+                    .expect("timed out waiting for ytt watch connection")
+                    .expect("fake watch owner should accept ytt connection");
+                let mut reader = BufReader::new(&conn);
+                let mut writer = &conn;
+
+                let mut line = String::new();
+                tokio::time::timeout(OWNER_IO_TIMEOUT, reader.read_line(&mut line))
+                    .await
+                    .expect("timed out reading watch Hello")
+                    .expect("fake watch owner should read Hello");
+                let hello: HelloRequest =
+                    serde_json::from_str(line.trim()).expect("ytt watch should send a valid Hello");
+                assert_eq!(hello.version, PROTOCOL_VERSION);
+                assert_eq!(hello.token, DESCRIPTOR_TOKEN);
+                assert_eq!(hello.hello.client, "ytt-cli-watch");
+                assert_eq!(hello.hello.min_version, PROTOCOL_VERSION);
+
+                write_owner_line(
+                    &mut writer,
+                    &HelloAck {
+                        ok: true,
+                        version: PROTOCOL_VERSION,
+                        session_id: 99,
+                        capabilities: vec!["events-v8".to_owned()],
+                        owner_mode: InstanceMode::Daemon,
+                        reason: None,
+                    },
+                )
+                .await;
+
+                line.clear();
+                tokio::time::timeout(OWNER_IO_TIMEOUT, reader.read_line(&mut line))
+                    .await
+                    .expect("timed out reading watch subscription")
+                    .expect("fake watch owner should read subscription");
+                let subscribe: ClientFrame = serde_json::from_str(line.trim())
+                    .expect("ytt watch should send a valid subscription");
+                assert_eq!(subscribe.id, 1);
+                assert_eq!(
+                    subscribe.op,
+                    ClientOp::Subscribe {
+                        topics: vec![Topic::System]
+                    }
+                );
+
+                write_owner_line(
+                    &mut writer,
+                    &ServerFrame::Event {
+                        seq: 1,
+                        topic: Topic::System,
+                        event: PushEvent::OwnerChanged {
+                            mode: InstanceMode::Daemon,
+                        },
+                    },
+                )
+                .await;
+                write_owner_line(
+                    &mut writer,
+                    &ServerFrame::Reply {
+                        id: 1,
+                        resp: RemoteResponse::ok("subscribed".to_owned()),
+                    },
+                )
+                .await;
+                write_owner_line(
+                    &mut writer,
+                    &ServerFrame::Goodbye {
+                        reason: "shutting_down".to_owned(),
+                    },
+                )
+                .await;
+            });
+        });
+
+        match ready_rx.recv_timeout(CHILD_TIMEOUT) {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => panic!("fake watch owner could not bind: {error}"),
+            Err(error) => panic!("fake watch owner did not become ready: {error}"),
+        }
+        handle
+    }
+
+    async fn write_owner_line<W, T>(writer: &mut W, value: &T)
+    where
+        W: tokio::io::AsyncWrite + Unpin,
+        T: serde::Serialize,
+    {
+        let mut bytes = serde_json::to_vec(value).expect("fake owner frame should serialize");
+        bytes.push(b'\n');
+        tokio::time::timeout(OWNER_IO_TIMEOUT, writer.write_all(&bytes))
+            .await
+            .expect("timed out writing fake-owner frame")
+            .expect("fake owner should write frame");
+        tokio::time::timeout(OWNER_IO_TIMEOUT, writer.flush())
+            .await
+            .expect("timed out flushing fake-owner frame")
+            .expect("fake owner should flush frame");
+    }
+
+    fn snapshot(queue: Vec<QueueItemSnapshot>, settings: SettingsSnapshot) -> StatusSnapshot {
+        let position = queue
+            .iter()
+            .position(|item| item.current)
+            .map_or(0, |index| index + 1);
+        StatusSnapshot {
+            title: None,
+            artist: None,
+            paused: true,
+            volume: 50,
+            position,
+            total: queue.len(),
+            streaming: settings.autoplay_streaming,
+            owner_mode: InstanceMode::Daemon,
+            settings,
+            queue,
+            shuffle: false,
+            repeat: Default::default(),
+            elapsed_ms: None,
+            duration_ms: None,
+            artwork: None,
+        }
+    }
+
+    fn assert_credentials_hidden(output: &std::process::Output, endpoint: &str) {
+        for text in [stdout(output), stderr(output)] {
+            assert!(
+                !text.contains(DESCRIPTOR_TOKEN),
+                "credential leaked: {text}"
+            );
+            assert!(!text.contains(endpoint), "endpoint leaked: {text}");
+        }
+    }
+
+    #[test]
+    fn actual_ytt_remote_cli_projects_owner_status_and_converts_queue_index() {
+        let root = short_root("ok");
+        clean_isolated_remote(&root);
+        let instance = isolated_instance(
+            &root,
+            PROTOCOL_VERSION,
+            vec![
+                "status".to_owned(),
+                "events-v8".to_owned(),
+                "remote-control".to_owned(),
+            ],
+        );
+        #[cfg(unix)]
+        assert!(
+            instance.endpoint.len() < 100,
+            "Unix socket path is too long for macOS sun_path: {}",
+            instance.endpoint
+        );
+        write_current_descriptor(&root, &instance);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(remote_app_dir(&root))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+            assert_eq!(
+                std::fs::metadata(current_descriptor_path(&root))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+
+        let info_response = RemoteResponse::status(snapshot(Vec::new(), Default::default()));
+        let empty_response = RemoteResponse::status(snapshot(Vec::new(), Default::default()));
+        let queue_response = RemoteResponse::status(snapshot(
+            vec![
+                QueueItemSnapshot {
+                    title: "첫 곡\n\u{1b}[31m".to_owned(),
+                    artist: "가수\r이름".to_owned(),
+                    duration: "3:14\t".to_owned(),
+                    current: true,
+                },
+                QueueItemSnapshot {
+                    title: "第二曲\u{202e}".to_owned(),
+                    artist: "Artist".to_owned(),
+                    duration: "4:00".to_owned(),
+                    current: false,
+                },
+            ],
+            Default::default(),
+        ));
+        let settings_response = RemoteResponse::status(snapshot(
+            Vec::new(),
+            SettingsSnapshot {
+                autoplay_streaming: true,
+                streaming_mode: StreamingMode::Discovery,
+                streaming_source: SearchSource::InternetArchive,
+                speed_tenths: 15,
+                seek_seconds: 12,
+                normalize: true,
+                gapless: false,
+                ai_enabled: true,
+                radio_mode: false,
+            },
+        ));
+        let queue_json_expected = serde_json::to_value(&queue_response).unwrap();
+        let settings_json_expected = serde_json::to_value(&settings_response).unwrap();
+        let owner = spawn_fake_owner(
+            instance.endpoint.clone(),
+            vec![
+                Exchange {
+                    command: RemoteCommand::Status,
+                    response: info_response.clone(),
+                },
+                Exchange {
+                    command: RemoteCommand::Status,
+                    response: info_response,
+                },
+                Exchange {
+                    command: RemoteCommand::Status,
+                    response: empty_response,
+                },
+                Exchange {
+                    command: RemoteCommand::Status,
+                    response: queue_response.clone(),
+                },
+                Exchange {
+                    command: RemoteCommand::Status,
+                    response: queue_response,
+                },
+                Exchange {
+                    command: RemoteCommand::Status,
+                    response: settings_response.clone(),
+                },
+                Exchange {
+                    command: RemoteCommand::Status,
+                    response: settings_response,
+                },
+                Exchange {
+                    command: RemoteCommand::QueuePlay { position: 0 },
+                    response: RemoteResponse::ok("played queue item 1".to_owned()),
+                },
+            ],
+        );
+
+        let info = run_isolated_with_timeout(&root, &["-r", "info"]);
+        assert!(info.status.success(), "{}", stderr(&info));
+        let info_text = stdout(&info);
+        assert!(info_text.contains("pid 4242"), "{info_text}");
+        assert!(info_text.contains("mode daemon"), "{info_text}");
+        assert!(info_text.contains("protocol 8"), "{info_text}");
+        assert!(
+            info_text.contains("events-v8,remote-control,status"),
+            "{info_text}"
+        );
+        assert_credentials_hidden(&info, &instance.endpoint);
+
+        let info_json = run_isolated_with_timeout(&root, &["-r", "info", "--json"]);
+        assert!(info_json.status.success(), "{}", stderr(&info_json));
+        let info_value: serde_json::Value = serde_json::from_slice(&info_json.stdout).unwrap();
+        let info_object = info_value.as_object().unwrap();
+        assert_eq!(info_object.len(), 5);
+        assert_eq!(info_object["app_pid"], 4_242);
+        assert_eq!(info_object["created_unix"], 123);
+        assert_eq!(info_object["mode"], "daemon");
+        assert_eq!(info_object["protocol_version"], PROTOCOL_VERSION);
+        assert_eq!(
+            info_object["capabilities"],
+            serde_json::json!(["events-v8", "remote-control", "status"])
+        );
+        assert!(!info_object.contains_key("endpoint"));
+        assert!(!info_object.contains_key("token"));
+        assert_credentials_hidden(&info_json, &instance.endpoint);
+
+        let empty = run_isolated_with_timeout(&root, &["-r", "queue-list"]);
+        assert!(empty.status.success(), "{}", stderr(&empty));
+        assert_eq!(stdout(&empty), "queue empty\n");
+        assert_credentials_hidden(&empty, &instance.endpoint);
+
+        let queue = run_isolated_with_timeout(&root, &["-r", "queue-list"]);
+        assert!(queue.status.success(), "{}", stderr(&queue));
+        let queue_text = stdout(&queue);
+        assert!(queue_text.starts_with("> 1. 첫 곡 [31m — 가수 이름  [3:14]"));
+        assert!(queue_text.contains("  2. 第二曲 — Artist  [4:00]"));
+        assert_eq!(queue_text.lines().count(), 2);
+        assert!(!queue_text.contains('\u{1b}'));
+        assert!(!queue_text.contains('\r'));
+        assert!(!queue_text.contains('\u{202e}'));
+        assert_credentials_hidden(&queue, &instance.endpoint);
+
+        let queue_json = run_isolated_with_timeout(&root, &["-r", "queue-list", "--json"]);
+        assert!(queue_json.status.success(), "{}", stderr(&queue_json));
+        let queue_value: serde_json::Value = serde_json::from_slice(&queue_json.stdout).unwrap();
+        assert_eq!(queue_value, queue_json_expected);
+        assert!(queue_value.get("ok").is_some());
+        assert!(queue_value.get("reason").is_some());
+        assert!(queue_value.get("message").is_some());
+        assert!(queue_value.get("status").is_some());
+        assert_credentials_hidden(&queue_json, &instance.endpoint);
+
+        let settings = run_isolated_with_timeout(&root, &["-r", "settings-show"]);
+        assert!(settings.status.success(), "{}", stderr(&settings));
+        assert_eq!(
+            stdout(&settings).trim(),
+            "autoplay=on  •  source=internet_archive  •  mode=discovery  •  speed=1.5x  •  seek=12s  •  normalize=on  •  gapless=off  •  ai=on  •  radio-mode=off"
+        );
+        assert_credentials_hidden(&settings, &instance.endpoint);
+
+        let settings_json = run_isolated_with_timeout(&root, &["-r", "settings-show", "--json"]);
+        assert!(settings_json.status.success(), "{}", stderr(&settings_json));
+        let settings_value: serde_json::Value =
+            serde_json::from_slice(&settings_json.stdout).unwrap();
+        assert_eq!(settings_value, settings_json_expected);
+        assert!(settings_value.get("ok").is_some());
+        assert!(settings_value.get("reason").is_some());
+        assert!(settings_value.get("message").is_some());
+        assert!(settings_value.get("status").is_some());
+        assert_credentials_hidden(&settings_json, &instance.endpoint);
+
+        let queue_play = run_isolated_with_timeout(&root, &["-r", "queue-play", "1"]);
+        assert!(queue_play.status.success(), "{}", stderr(&queue_play));
+        assert_eq!(stdout(&queue_play), "played queue item 1\n");
+        assert_credentials_hidden(&queue_play, &instance.endpoint);
+
+        owner.join().expect("fake owner thread should complete");
+        clean_isolated_remote(&root);
+    }
+
+    #[test]
+    fn actual_ytt_watch_json_accepts_initial_event_before_reply_and_exits_on_goodbye() {
+        let root = short_root("watch");
+        clean_isolated_remote(&root);
+        let instance = isolated_instance(
+            &root,
+            PROTOCOL_VERSION,
+            vec!["events-v8".to_owned(), "status".to_owned()],
+        );
+        #[cfg(unix)]
+        assert!(
+            instance.endpoint.len() < 100,
+            "Unix socket path is too long for macOS sun_path: {}",
+            instance.endpoint
+        );
+        write_current_descriptor(&root, &instance);
+        let owner = spawn_watch_owner(instance.endpoint.clone());
+
+        let output = run_isolated_with_timeout(&root, &["-r", "watch", "system", "--json"]);
+        assert!(output.status.success(), "stderr={}", stderr(&output));
+        assert!(stderr(&output).is_empty(), "stderr={}", stderr(&output));
+        assert_credentials_hidden(&output, &instance.endpoint);
+
+        let output_text = stdout(&output);
+        let lines: Vec<_> = output_text.lines().collect();
+        assert_eq!(lines.len(), 2, "stdout={output_text}");
+        assert!(
+            lines
+                .iter()
+                .all(|line| !line.contains(r#"\"frame\":\"reply\""#)),
+            "subscribe Reply must stay hidden: {output_text}"
+        );
+        let frames: Vec<ServerFrame> = lines
+            .iter()
+            .map(|line| serde_json::from_str(line).expect("watch stdout should be NDJSON frames"))
+            .collect();
+        assert_eq!(
+            frames[0],
+            ServerFrame::Event {
+                seq: 1,
+                topic: Topic::System,
+                event: PushEvent::OwnerChanged {
+                    mode: InstanceMode::Daemon
+                }
+            }
+        );
+        assert_eq!(
+            frames[1],
+            ServerFrame::Goodbye {
+                reason: "shutting_down".to_owned()
+            }
+        );
+
+        owner
+            .join()
+            .expect("fake watch owner thread should complete");
+        clean_isolated_remote(&root);
+    }
 }


### PR DESCRIPTION
## Summary

- Add local-only `ytt -r info`, `queue-list`, one-based `queue-play <N>`, and `settings-show` commands while preserving the existing v7 wire, aliases, JSON response shape, and exit-code contract.
- Add an independent read-only protocol-v8 watch client for player, queue, settings, and system events over the existing same-user Unix socket or Windows named pipe.
- Validate current descriptors fail-closed without exposing endpoint or token data, and negotiate v7/v8 one-shot request versions.
- Enforce the repeat/autoplay-streaming invariant consistently across the App, daemon, and GUI Apply path.
- Document the local-only trust boundary and new commands in English, Korean, Japanese, and the web reference.

## Why

The remote surface needed richer local automation and observation without adding TCP, LAN, HTTP, or mobile exposure. The existing repeat/streaming conflict paths also returned silent success even though the requested transition was not applied, which made the playback invariant ambiguous across owners.

Conflicting enables now return `repeat_streaming_conflict` without changing playback state, persisted settings, or player effects. This is the only intentional semantic change.

## Impact

- Watch requires protocol v8 plus the `events-v8` capability and never reconnects or replays.
- Human output sanitizes control characters; `info` never prints descriptor credentials.
- Existing commands retain legacy descriptor fallback, while new surfaces require the private current descriptor.
- No protocol bump, new `RemoteCommand` variant, config key, persistence-format change, or network listener is introduced.

## Validation

- `~/.fable-harness/bin/run-gates .`: fmt, Clippy with warnings denied, workspace tests, and architecture checks passed.
- Remote tests: 109 passed.
- CLI smoke tests: 13 passed.
- App/daemon parity tests: 5 passed.
- Isolated TUI verification confirmed `info`, empty `queue-list`, `settings-show`, Ctrl-C watch exit 0, a volume event, and ordered `ShuttingDown` / `Goodbye` frames without starting playback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local IPC trust boundaries and changes remote/GUI semantics for repeat vs autoplay conflicts, though scope stays same-user sockets with broad tests and no network listeners.
> 
> **Overview**
> **Local remote CLI** grows with `info`, `queue-list`, one-based `queue-play`, `settings-show`, and read-only **`watch`** (protocol v8 / `events-v8`). Parsing routes through an `Invocation` layer; new surfaces use **`read_current_instance`** (canonical endpoint, hex token, private Unix modes) and negotiate **v7/v8** one-shot versions, while legacy commands keep the old descriptor fallback. Human output sanitizes controls; **`info` never leaks** socket/token data.
> 
> **`watch`** is a standalone NDJSON client (handshake, subscribe, pings, ordered events) with no reconnect/replay. Docs and the site i18n blocks document the same-machine-only boundary and new verbs.
> 
> **Playback invariant change:** enabling **repeat while autoplay streaming is on** (or the reverse) now returns **`repeat_streaming_conflict`** with **no state, persistence, or effects**—replacing prior silent “success but unchanged” behavior. App remote paths set localized status toasts; daemon/GUI Apply paths match; **parity tests** assert agreement and that disables still work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af2a946ae1d492187a2aeb166e2646d00f1b8d05. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->