### PR TITLE
Reduce TUI CPU and memory hot-path work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /target
 /dist
+__pycache__/
+*.py[cod]
 
 # Frontend workspace: deps and build output are never vendored (package-lock.json is
 # the reproducibility stance; gui/src/generated/ IS committed and drift-gated).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ windows = { version = "0.62", default-features = false, features = ["Media", "St
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Security",
+    "Win32_Storage_FileSystem",
     "Win32_System_JobObjects",
     "Win32_System_Console",
     "Win32_System_Registry",

--- a/crates/ratatui-image/src/picker.rs
+++ b/crates/ratatui-image/src/picker.rs
@@ -3,6 +3,7 @@
 use std::{
     env,
     io::{self, Read, Write},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -275,7 +276,12 @@ impl Picker {
 
     /// Returns a new *stateful* protocol for [`crate::StatefulImage`] widgets.
     pub fn new_resize_protocol(&self, image: DynamicImage) -> StatefulProtocol {
-        self.new_resize_protocol_with_kitty_z_index(image, None)
+        self.new_resize_protocol_shared(Arc::new(image))
+    }
+
+    /// Returns a new stateful protocol sharing its immutable decoded source pixels.
+    pub fn new_resize_protocol_shared(&self, image: Arc<DynamicImage>) -> StatefulProtocol {
+        self.new_resize_protocol_shared_with_kitty_z_index(image, None)
     }
 
     /// Returns a new *stateful* protocol, overriding Kitty's z-index when Kitty is selected.
@@ -285,6 +291,15 @@ impl Picker {
     pub fn new_resize_protocol_with_kitty_z_index(
         &self,
         image: DynamicImage,
+        kitty_z_index: Option<i32>,
+    ) -> StatefulProtocol {
+        self.new_resize_protocol_shared_with_kitty_z_index(Arc::new(image), kitty_z_index)
+    }
+
+    /// Shared-source variant of [`Self::new_resize_protocol_with_kitty_z_index`].
+    pub fn new_resize_protocol_shared_with_kitty_z_index(
+        &self,
+        image: Arc<DynamicImage>,
         kitty_z_index: Option<i32>,
     ) -> StatefulProtocol {
         let protocol_type = match self.protocol_type {
@@ -302,7 +317,7 @@ impl Picker {
                 ..Iterm2::default()
             }),
         };
-        StatefulProtocol::new(image, self.font_size, self.background_color, protocol_type)
+        StatefulProtocol::new_shared(image, self.font_size, self.background_color, protocol_type)
     }
 }
 

--- a/crates/ratatui-image/src/protocol.rs
+++ b/crates/ratatui-image/src/protocol.rs
@@ -1,10 +1,9 @@
 //! Protocol backends for the widgets
 
 use std::{
-    collections::hash_map::DefaultHasher,
     fmt::Write,
-    hash::{Hash, Hasher},
     num::NonZeroU16,
+    sync::Arc,
     sync::atomic::{AtomicU32, Ordering},
 };
 
@@ -176,7 +175,19 @@ impl StatefulProtocol {
         background_color: Option<Rgba<u8>>,
         protocol_type: StatefulProtocolType,
     ) -> Self {
-        let source = ImageSource::new(image, font_size, background_color);
+        Self::new_shared(Arc::new(image), font_size, background_color, protocol_type)
+    }
+
+    /// Construct a protocol that shares its immutable decoded source pixels with its owner.
+    /// Resized protocol buffers remain independently owned; only the full-resolution source is
+    /// shared, avoiding a multi-megabyte deep clone for every held album cover.
+    pub fn new_shared(
+        image: Arc<DynamicImage>,
+        font_size: FontSize,
+        background_color: Option<Rgba<u8>>,
+        protocol_type: StatefulProtocolType,
+    ) -> Self {
+        let source = ImageSource::new_shared(image, font_size, background_color);
         Self {
             source,
             font_size,
@@ -280,7 +291,7 @@ impl ResizeEncodeRender for StatefulProtocol {
 ///
 struct ImageSource {
     /// The original image without resizing.
-    pub image: DynamicImage,
+    pub image: Arc<DynamicImage>,
     /// The area that the [`ImageSource::image`] covers, but not necessarily fills.
     pub desired: Size,
     /// TODO: document this; when image changes but it doesn't need a resize, force a render.
@@ -290,34 +301,129 @@ struct ImageSource {
 }
 
 impl ImageSource {
-    /// Create a new image source
-    pub fn new(
-        mut image: DynamicImage,
+    /// Create an image source from shared decoded pixels. A non-transparent background requires
+    /// a composited copy (the source pixels would otherwise be mutated); the usual transparent
+    /// album-art path keeps the exact same allocation.
+    pub fn new_shared(
+        image: Arc<DynamicImage>,
         font_size: FontSize,
         background_color: Option<Rgba<u8>>,
     ) -> ImageSource {
         let desired = Resize::round_pixel_size_to_cells(image.width(), image.height(), font_size);
 
-        let mut state = DefaultHasher::new();
-        image.as_bytes().hash(&mut state);
-        let hash = state.finish();
-
         // We only need to underlay the background color here if it's not completely transparent.
-        if let Some(background_color) = background_color
+        let image = if let Some(background_color) = background_color
             && background_color.0[3] != 0
         {
             let mut bg: DynamicImage =
                 ImageBuffer::from_pixel(image.width(), image.height(), background_color).into();
-            imageops::overlay(&mut bg, &image, 0, 0);
-            image = bg;
-        }
+            imageops::overlay(&mut bg, image.as_ref(), 0, 0);
+            Arc::new(bg)
+        } else {
+            image
+        };
 
         ImageSource {
             image,
             desired,
-            hash,
+            // The source is immutable for the lifetime of a StatefulProtocol. A nonzero marker
+            // is sufficient to force the first encode, after which `self.hash` matches it.
+            hash: 1,
             background_color,
         }
+    }
+}
+
+#[cfg(test)]
+mod shared_source_tests {
+    use super::*;
+
+    fn patterned_image() -> DynamicImage {
+        let mut image = ImageBuffer::new(7, 5);
+        for (x, y, pixel) in image.enumerate_pixels_mut() {
+            *pixel = Rgba([
+                (x * 31 + y * 7) as u8,
+                (x * 11 + y * 37) as u8,
+                (x * 19 + y * 13) as u8,
+                if (x + y).is_multiple_of(3) { 96 } else { 255 },
+            ]);
+        }
+        DynamicImage::ImageRgba8(image)
+    }
+
+    fn halfblocks() -> StatefulProtocolType {
+        StatefulProtocolType::Halfblocks(Halfblocks::default())
+    }
+
+    #[test]
+    fn transparent_shared_source_reuses_the_exact_pixel_allocation() {
+        let image = Arc::new(DynamicImage::new_rgba8(64, 64));
+        let protocol = StatefulProtocol::new_shared(
+            Arc::clone(&image),
+            FontSize::new(10, 20),
+            None,
+            StatefulProtocolType::Halfblocks(Halfblocks::default()),
+        );
+
+        assert!(Arc::ptr_eq(&image, &protocol.source.image));
+        assert_eq!(Arc::strong_count(&image), 2);
+    }
+
+    #[test]
+    fn opaque_background_keeps_compositing_semantics_without_mutating_shared_input() {
+        let image = Arc::new(DynamicImage::new_rgba8(2, 2));
+        let protocol = StatefulProtocol::new_shared(
+            Arc::clone(&image),
+            FontSize::new(10, 20),
+            Some(Rgba([20, 30, 40, 255])),
+            StatefulProtocolType::Halfblocks(Halfblocks::default()),
+        );
+
+        assert!(!Arc::ptr_eq(&image, &protocol.source.image));
+        assert_eq!(image.to_rgba8().get_pixel(0, 0).0, [0, 0, 0, 0]);
+        assert_eq!(
+            protocol.source.image.to_rgba8().get_pixel(0, 0).0,
+            [20, 30, 40, 255]
+        );
+    }
+
+    #[test]
+    fn owned_and_shared_constructors_encode_identical_pixels_at_multiple_sizes() {
+        let image = patterned_image();
+        for background in [None, Some(Rgba([20, 30, 40, 255]))] {
+            for area in [Rect::new(0, 0, 5, 3), Rect::new(0, 0, 9, 4)] {
+                let mut owned = StatefulProtocol::new(
+                    image.clone(),
+                    FontSize::new(10, 20),
+                    background,
+                    halfblocks(),
+                );
+                let mut shared = StatefulProtocol::new_shared(
+                    Arc::new(image.clone()),
+                    FontSize::new(10, 20),
+                    background,
+                    halfblocks(),
+                );
+                let mut owned_buffer = Buffer::empty(area);
+                let mut shared_buffer = Buffer::empty(area);
+
+                owned.resize_encode_render(&Resize::Fit(None), area, &mut owned_buffer);
+                shared.resize_encode_render(&Resize::Fit(None), area, &mut shared_buffer);
+
+                assert_eq!(owned_buffer, shared_buffer);
+                assert_eq!(owned.last_encoding_area(), shared.last_encoding_area());
+                assert!(owned.last_encoding_result().unwrap().is_ok());
+                assert!(shared.last_encoding_result().unwrap().is_ok());
+            }
+        }
+    }
+
+    #[test]
+    fn shared_source_and_protocol_remain_send_sync_for_resize_worker_handoff() {
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<Arc<DynamicImage>>();
+        assert_send_sync::<StatefulProtocol>();
     }
 }
 

--- a/examples/tui_perf_control.rs
+++ b/examples/tui_perf_control.rs
@@ -6,7 +6,7 @@
 
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use interprocess::local_socket::GenericFilePath;
@@ -14,8 +14,9 @@ use interprocess::local_socket::tokio::Stream;
 use interprocess::local_socket::tokio::prelude::*;
 use serde::Serialize;
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
-use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::io::{AsyncRead, AsyncWriteExt, BufReader};
 use tokio::sync::mpsc;
 use tokio::time::{sleep, timeout};
 use yututui::remote::proto::{RemoteCommand, StatusSnapshot};
@@ -34,6 +35,7 @@ enum LoadAction {
 #[derive(Debug)]
 struct Args {
     output: PathBuf,
+    ready_file: PathBuf,
     wait: Duration,
     observe: Duration,
     close_grace: Duration,
@@ -45,6 +47,7 @@ struct Args {
 impl Args {
     fn parse() -> Result<Self, String> {
         let mut output = None;
+        let mut ready_file = None;
         let mut wait_secs = 30.0;
         let mut observe_secs = 0.0;
         let mut close_grace_secs = 0.0;
@@ -58,6 +61,7 @@ impl Args {
             };
             match arg.as_str() {
                 "--output" => output = Some(PathBuf::from(next("--output", &mut raw)?)),
+                "--ready-file" => ready_file = Some(PathBuf::from(next("--ready-file", &mut raw)?)),
                 "--wait-secs" => {
                     wait_secs = next("--wait-secs", &mut raw)?
                         .parse::<f64>()
@@ -111,6 +115,7 @@ impl Args {
         }
         Ok(Self {
             output: output.ok_or_else(|| "--output is required".to_string())?,
+            ready_file: ready_file.ok_or_else(|| "--ready-file is required".to_string())?,
             wait: Duration::from_secs_f64(wait_secs),
             observe: Duration::from_secs_f64(observe_secs),
             close_grace: Duration::from_secs_f64(close_grace_secs),
@@ -122,9 +127,10 @@ impl Args {
 }
 
 fn usage() -> &'static str {
-    "Usage: tui_perf_control --output FILE [options]\n\
+    "Usage: tui_perf_control --output FILE --ready-file FILE [options]\n\
      Options:\n\
        --wait-secs N                 Per-operation timeout (default 30)\n\
+       --ready-file FILE             Atomic sampler subscription barrier\n\
        --observe-secs N              Drain mpv telemetry for the full run (default 0)\n\
        --close-grace-secs N          Extra final wait for sampler-owned mpv close (default 0)\n\
        --load none|resume-session    Optional deterministic session load\n\
@@ -167,69 +173,139 @@ struct IpcEvent {
     value: Value,
 }
 
+#[derive(Debug)]
+enum IpcMessage {
+    Event(IpcEvent),
+    CleanEof {
+        observed_at: Instant,
+    },
+    TooLarge {
+        observed_at: Instant,
+    },
+    ParseError {
+        observed_at: Instant,
+        message: String,
+    },
+    IoError {
+        observed_at: Instant,
+        message: String,
+    },
+}
+
+#[derive(Clone, Debug)]
+struct ProcessIdentity {
+    pid: u32,
+    start_time_unix_s: u64,
+    executable: PathBuf,
+    executable_bytes: u64,
+    executable_sha256: String,
+}
+
+#[derive(Clone, Debug)]
+struct MpvBinding {
+    process: ProcessIdentity,
+    endpoint: String,
+}
+
 struct Telemetry {
     origin: Instant,
+    buffering_cutoff: Instant,
     buffering_since: Option<Instant>,
     buffering_events: u64,
     buffering_total: Duration,
     last_time_pos_s: Option<f64>,
+    cutoff_first_time_pos: Option<(Instant, f64)>,
+    cutoff_last_time_pos: Option<(Instant, f64)>,
+    first_event_ns: Option<u128>,
+    last_event_ns: Option<u128>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DrainEnd {
     Deadline,
-    ObserverClosed,
+    CleanEof(Instant),
 }
 
 impl DrainEnd {
     fn as_str(self) -> &'static str {
         match self {
             Self::Deadline => "deadline",
-            Self::ObserverClosed => "mpv_ipc_closed",
+            Self::CleanEof(_) => "mpv_ipc_closed",
         }
     }
 }
 
 impl Telemetry {
-    fn new(origin: Instant) -> Self {
+    fn new(origin: Instant, buffering_cutoff: Instant) -> Self {
         Self {
             origin,
+            buffering_cutoff,
             buffering_since: None,
             buffering_events: 0,
             buffering_total: Duration::ZERO,
             last_time_pos_s: None,
+            cutoff_first_time_pos: None,
+            cutoff_last_time_pos: None,
+            first_event_ns: None,
+            last_event_ns: None,
         }
     }
 
     fn record(&mut self, event: &IpcEvent, out: &mut BufWriter<File>) -> Result<(), String> {
+        let elapsed_ns = event
+            .observed_at
+            .saturating_duration_since(self.origin)
+            .as_nanos();
+        self.first_event_ns.get_or_insert(elapsed_ns);
+        self.last_event_ns = Some(elapsed_ns);
         if let Some(position) = time_pos_seconds(&event.value) {
-            self.last_time_pos_s = Some(position);
+            self.record_time_pos(event.observed_at, position);
         }
-        if event.value.get("event").and_then(Value::as_str) == Some("property-change")
-            && event.value.get("name").and_then(Value::as_str) == Some("paused-for-cache")
-            && let Some(paused) = event.value.get("data").and_then(Value::as_bool)
-        {
-            if paused && self.buffering_since.is_none() {
-                self.buffering_since = Some(event.observed_at);
-                self.buffering_events += 1;
-            } else if !paused && let Some(started) = self.buffering_since.take() {
-                self.buffering_total += event.observed_at.saturating_duration_since(started);
-            }
-        }
+        self.record_buffering(event.observed_at, &event.value);
         write_ndjson(
             out,
             &json!({
                 "schema": SCHEMA,
                 "kind": "mpv_event",
                 "elapsed_ms": event.observed_at.saturating_duration_since(self.origin).as_millis(),
+                "elapsed_ns": elapsed_ns,
                 "event": event.value,
             }),
         )
     }
 
+    fn record_buffering(&mut self, observed_at: Instant, value: &Value) {
+        if observed_at >= self.buffering_cutoff {
+            self.finish_buffering(self.buffering_cutoff);
+        } else if value.get("event").and_then(Value::as_str) == Some("property-change")
+            && value.get("name").and_then(Value::as_str) == Some("paused-for-cache")
+            && let Some(paused) = value.get("data").and_then(Value::as_bool)
+        {
+            if paused && self.buffering_since.is_none() {
+                self.buffering_since = Some(observed_at);
+                self.buffering_events += 1;
+            } else if !paused && let Some(started) = self.buffering_since.take() {
+                self.buffering_total += observed_at.saturating_duration_since(started);
+            }
+        }
+    }
+
+    fn record_time_pos(&mut self, observed_at: Instant, position: f64) {
+        self.last_time_pos_s = Some(position);
+        if observed_at <= self.buffering_cutoff {
+            self.cutoff_first_time_pos
+                .get_or_insert((observed_at, position));
+            self.cutoff_last_time_pos = Some((observed_at, position));
+        }
+    }
+
     fn finish(&mut self, now: Instant) {
+        self.finish_buffering(now.min(self.buffering_cutoff));
+    }
+
+    fn finish_buffering(&mut self, end: Instant) {
         if let Some(started) = self.buffering_since.take() {
-            self.buffering_total += now.saturating_duration_since(started);
+            self.buffering_total += end.saturating_duration_since(started);
         }
     }
 }
@@ -247,12 +323,15 @@ fn proves_resume_progress(value: &Value, paused_time_pos_s: f64) -> bool {
 }
 
 fn drain_pending_mpv(
-    rx: &mut mpsc::UnboundedReceiver<IpcEvent>,
+    rx: &mut mpsc::UnboundedReceiver<IpcMessage>,
     telemetry: &mut Telemetry,
     out: &mut BufWriter<File>,
 ) -> Result<(), String> {
-    while let Ok(event) = rx.try_recv() {
-        telemetry.record(&event, out)?;
+    while let Ok(message) = rx.try_recv() {
+        match message {
+            IpcMessage::Event(event) => telemetry.record(&event, out)?,
+            terminal => return Err(ipc_terminal_error(terminal)),
+        }
     }
     Ok(())
 }
@@ -276,6 +355,8 @@ async fn main() {
 }
 
 async fn run(args: Args) -> Result<(), String> {
+    let run_id =
+        std::env::var("TUI_PERF_RUN_ID").map_err(|_| "TUI_PERF_RUN_ID is required".to_string())?;
     if let Some(parent) = args.output.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("create output directory {}: {e}", parent.display()))?;
@@ -283,41 +364,53 @@ async fn run(args: Args) -> Result<(), String> {
     let mut out = BufWriter::new(
         File::create(&args.output).map_err(|e| format!("create {}: {e}", args.output.display()))?,
     );
-    let origin = Instant::now();
+    let producer_binary_hash = producer_binary_sha256()?;
     let instance = wait_for_instance(args.wait).await?;
-    let (mpv_pid, mpv_endpoint) = discover_mpv(instance.app_pid, args.wait).await?;
-    let stream = connect_mpv(&mpv_endpoint, args.wait).await?;
-    subscribe(&stream).await?;
+    let (owner, mpv) = discover_mpv(instance.app_pid, args.wait).await?;
+    let stream = connect_mpv(&mpv.endpoint, args.wait).await?;
+    let reader = subscribe_and_confirm(stream, args.wait).await?;
+    let observation_started_unix_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| format!("system clock before Unix epoch: {e}"))?
+        .as_nanos();
+    let origin = Instant::now();
+    publish_ready(
+        &args.ready_file,
+        &owner,
+        &mpv,
+        &run_id,
+        observation_started_unix_ns,
+    )?;
     let (tx, mut rx) = mpsc::unbounded_channel();
-    tokio::spawn(read_mpv(stream, tx));
-    let mut telemetry = Telemetry::new(origin);
+    tokio::spawn(read_mpv(reader, tx));
+    let mut telemetry = Telemetry::new(origin, origin + args.observe);
 
     write_ndjson(
         &mut out,
-        &json!({
-            "schema": SCHEMA,
-            "kind": "header",
-            "owner_pid": instance.app_pid,
-            "owner_mode": instance.mode,
-            "mpv_pid": mpv_pid,
-            "mpv_endpoint": mpv_endpoint,
-            "scenario_sha256": std::env::var("TUI_PERF_SCENARIO_SHA256").ok(),
-            "os": std::env::consts::OS,
-            "arch": std::env::consts::ARCH,
-            "pause_policy": if args.pause_hold.is_some() { "pause-resume" } else { "none" },
-            "pause_hold_ms": args.pause_hold.map(|hold| hold.as_millis()),
-        }),
+        &header_record(
+            &args,
+            &owner,
+            instance.mode,
+            &mpv,
+            &producer_binary_hash,
+            &run_id,
+            observation_started_unix_ns,
+        ),
     )?;
 
-    match args.load {
+    match &args.load {
         LoadAction::None => {
             let started = Instant::now();
             let status = wait_for_status(args.wait, |status| status.title.is_some()).await?;
+            let completed = Instant::now();
             operation(
                 &mut out,
+                origin,
                 "ready",
-                started.elapsed(),
-                json!({"title": status.title}),
+                started..completed,
+                "status",
+                None,
+                json!({"title": status.title, "status_field": "title", "status_present": true}),
             )?;
         }
         LoadAction::ResumeSession => {
@@ -333,7 +426,9 @@ async fn run(args: Args) -> Result<(), String> {
         }
         LoadAction::Play(query) => {
             perform_load(
-                RemoteCommand::Play { query },
+                RemoteCommand::Play {
+                    query: query.clone(),
+                },
                 "play_query",
                 args.wait,
                 &mut rx,
@@ -346,25 +441,42 @@ async fn run(args: Args) -> Result<(), String> {
 
     // Seek through the app's public control lane so position_epoch and all owner invariants run.
     let scheduled_actions = scheduled_action_count(args.seeks.len(), args.pause_hold);
-    for (index, target_s) in args.seeks.into_iter().enumerate() {
+    for (index, target_s) in args.seeks.iter().copied().enumerate() {
         if scheduled_actions > 0 && !args.observe.is_zero() {
             let offset = scheduled_offset(args.observe, index + 1, scheduled_actions);
             drain_to_action(origin + offset, &mut rx, &mut telemetry, &mut out).await?;
         }
+        drain_pending_mpv(&mut rx, &mut telemetry, &mut out)?;
         let started = Instant::now();
         send_remote(RemoteCommand::SeekTo {
             ms: (target_s * 1_000.0).round() as u64,
         })
         .await?;
-        wait_for_mpv(args.wait, &mut rx, &mut telemetry, &mut out, |value| {
-            value.get("event").and_then(Value::as_str) == Some("playback-restart")
-        })
+        let (restart, completed, observed_target_s) = wait_for_seek(
+            args.wait,
+            &mut rx,
+            &mut telemetry,
+            &mut out,
+            started,
+            target_s,
+        )
         .await?;
         operation(
             &mut out,
+            origin,
             "seek",
-            started.elapsed(),
-            json!({"target_s": target_s}),
+            started..completed.observed_at,
+            "mpv_event",
+            Some(&completed),
+            json!({
+                "target_s": target_s,
+                "observed_target_s": observed_target_s,
+                "playback_restart_elapsed_ns": restart
+                    .observed_at
+                    .saturating_duration_since(origin)
+                    .as_nanos(),
+                "target_tolerance_s": 2.0,
+            }),
         )?;
     }
 
@@ -374,10 +486,20 @@ async fn run(args: Args) -> Result<(), String> {
             drain_to_action(origin + offset, &mut rx, &mut telemetry, &mut out).await?;
         }
         ensure_playing(args.wait).await?;
+        drain_pending_mpv(&mut rx, &mut telemetry, &mut out)?;
         let pause_started = Instant::now();
         send_remote(RemoteCommand::TogglePause).await?;
         wait_for_status(args.wait, |status| status.paused).await?;
-        operation(&mut out, "pause", pause_started.elapsed(), json!({}))?;
+        let pause_completed = Instant::now();
+        operation(
+            &mut out,
+            origin,
+            "pause",
+            pause_started..pause_completed,
+            "status",
+            None,
+            json!({"status_field": "paused", "status_value": true}),
+        )?;
         sleep(hold).await;
 
         // mpv 0.40 does not emit playback-restart for a plain unpause. Drain every event already
@@ -390,14 +512,22 @@ async fn run(args: Args) -> Result<(), String> {
         let resume_started = Instant::now();
         send_remote(RemoteCommand::TogglePause).await?;
         wait_for_status(args.wait, |status| !status.paused).await?;
-        wait_for_mpv(args.wait, &mut rx, &mut telemetry, &mut out, |value| {
-            proves_resume_progress(value, paused_time_pos_s)
-        })
+        let resume_completed = wait_for_mpv(
+            args.wait,
+            &mut rx,
+            &mut telemetry,
+            &mut out,
+            resume_started,
+            |value| proves_resume_progress(value, paused_time_pos_s),
+        )
         .await?;
         operation(
             &mut out,
+            origin,
             "resume",
-            resume_started.elapsed(),
+            resume_started..resume_completed.observed_at,
+            "mpv_event",
+            Some(&resume_completed),
             json!({
                 "pause_hold_ms": hold.as_millis(),
                 "paused_time_pos_s": paused_time_pos_s,
@@ -410,32 +540,44 @@ async fn run(args: Args) -> Result<(), String> {
     // cannot disappear from the no-added-rebuffer gate merely because the last seek finished.
     let observation_end = drain_until(
         origin + args.observe + args.close_grace,
+        origin + args.observe,
         &mut rx,
         &mut telemetry,
         &mut out,
     )
     .await?;
 
-    while let Ok(event) = rx.try_recv() {
-        telemetry.record(&event, &mut out)?;
+    while let Ok(message) = rx.try_recv() {
+        match message {
+            IpcMessage::Event(event) => telemetry.record(&event, &mut out)?,
+            IpcMessage::CleanEof { .. } if matches!(observation_end, DrainEnd::CleanEof(_)) => {}
+            terminal => return Err(ipc_terminal_error(terminal)),
+        }
     }
-    telemetry.finish(Instant::now());
+    let summary_at = Instant::now();
+    telemetry.finish(summary_at);
     write_ndjson(
         &mut out,
-        &json!({
-            "schema": SCHEMA,
-            "kind": "summary",
-            "buffering_events": telemetry.buffering_events,
-            "buffering_ms": telemetry.buffering_total.as_millis(),
-            "observation_end": observation_end.as_str(),
-        }),
+        &summary_record(
+            &telemetry,
+            &args,
+            origin,
+            summary_at,
+            observation_end,
+            &run_id,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|e| format!("system clock before Unix epoch: {e}"))?
+                .as_nanos(),
+        ),
     )?;
     out.flush().map_err(|e| format!("flush output: {e}"))
 }
 
 async fn drain_until(
     deadline: Instant,
-    rx: &mut mpsc::UnboundedReceiver<IpcEvent>,
+    minimum_clean_eof: Instant,
+    rx: &mut mpsc::UnboundedReceiver<IpcMessage>,
     telemetry: &mut Telemetry,
     out: &mut BufWriter<File>,
 ) -> Result<DrainEnd, String> {
@@ -445,8 +587,19 @@ async fn drain_until(
             return Ok(DrainEnd::Deadline);
         }
         match timeout(remaining, rx.recv()).await {
-            Ok(Some(event)) => telemetry.record(&event, out)?,
-            Ok(None) => return Ok(DrainEnd::ObserverClosed),
+            Ok(Some(IpcMessage::Event(event))) => telemetry.record(&event, out)?,
+            Ok(Some(IpcMessage::CleanEof { observed_at })) => {
+                if observed_at < minimum_clean_eof {
+                    return Err("mpv IPC closed before the declared observation window".to_string());
+                }
+                return Ok(DrainEnd::CleanEof(observed_at));
+            }
+            Ok(Some(terminal)) => return Err(ipc_terminal_error(terminal)),
+            Ok(None) => {
+                return Err(
+                    "mpv IPC observer task disappeared without a terminal record".to_string(),
+                );
+            }
             Err(_) => return Ok(DrainEnd::Deadline),
         }
     }
@@ -454,14 +607,36 @@ async fn drain_until(
 
 async fn drain_to_action(
     deadline: Instant,
-    rx: &mut mpsc::UnboundedReceiver<IpcEvent>,
+    rx: &mut mpsc::UnboundedReceiver<IpcMessage>,
     telemetry: &mut Telemetry,
     out: &mut BufWriter<File>,
 ) -> Result<(), String> {
-    match drain_until(deadline, rx, telemetry, out).await? {
+    match drain_until(deadline, deadline, rx, telemetry, out).await? {
         DrainEnd::Deadline => Ok(()),
-        DrainEnd::ObserverClosed => {
+        DrainEnd::CleanEof(_) => {
             Err("mpv IPC observer closed before a scheduled action".to_string())
+        }
+    }
+}
+
+fn ipc_terminal_error(message: IpcMessage) -> String {
+    match message {
+        IpcMessage::Event(_) => "internal IPC event classification error".to_string(),
+        IpcMessage::CleanEof { .. } => "mpv IPC closed unexpectedly".to_string(),
+        IpcMessage::TooLarge { observed_at } => {
+            format!("mpv IPC emitted an oversized line at {observed_at:?}")
+        }
+        IpcMessage::ParseError {
+            observed_at,
+            message,
+        } => {
+            format!("mpv IPC JSON parse error at {observed_at:?}: {message}")
+        }
+        IpcMessage::IoError {
+            observed_at,
+            message,
+        } => {
+            format!("mpv IPC I/O error at {observed_at:?}: {message}")
         }
     }
 }
@@ -479,7 +654,10 @@ async fn wait_for_instance(wait: Duration) -> Result<yututui::remote::proto::Ins
     }
 }
 
-async fn discover_mpv(app_pid: u32, wait: Duration) -> Result<(u32, String), String> {
+async fn discover_mpv(
+    app_pid: u32,
+    wait: Duration,
+) -> Result<(ProcessIdentity, MpvBinding), String> {
     let deadline = Instant::now() + wait;
     let mut system = System::new();
     let refresh = ProcessRefreshKind::nothing()
@@ -488,6 +666,14 @@ async fn discover_mpv(app_pid: u32, wait: Duration) -> Result<(u32, String), Str
         .without_tasks();
     loop {
         system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+        let Some(owner_process) = system.process(sysinfo::Pid::from_u32(app_pid)) else {
+            if Instant::now() >= deadline {
+                return Err(format!("timed out resolving ytt owner PID {app_pid}"));
+            }
+            sleep(Duration::from_millis(25)).await;
+            continue;
+        };
+        let owner = process_identity(app_pid, owner_process)?;
         let mut descendants = std::collections::HashSet::from([app_pid]);
         loop {
             let before = descendants.len();
@@ -524,7 +710,13 @@ async fn discover_mpv(app_pid: u32, wait: Duration) -> Result<(u32, String), Str
                     .map(str::to_owned)
             });
             if let Some(endpoint) = endpoint {
-                return Ok((pid, endpoint));
+                return Ok((
+                    owner,
+                    MpvBinding {
+                        process: process_identity(pid, process)?,
+                        endpoint,
+                    },
+                ));
             }
             return Err(format!(
                 "mpv PID {pid} was found but its command line did not expose --input-ipc-server"
@@ -537,6 +729,31 @@ async fn discover_mpv(app_pid: u32, wait: Duration) -> Result<(u32, String), Str
         }
         sleep(Duration::from_millis(25)).await;
     }
+}
+
+fn process_identity(pid: u32, process: &sysinfo::Process) -> Result<ProcessIdentity, String> {
+    let executable = process
+        .exe()
+        .ok_or_else(|| format!("PID {pid} has no executable path"))?
+        .canonicalize()
+        .map_err(|e| format!("canonicalize executable for PID {pid}: {e}"))?;
+    let executable_bytes = executable
+        .metadata()
+        .map_err(|e| {
+            format!(
+                "stat executable for PID {pid} {}: {e}",
+                executable.display()
+            )
+        })?
+        .len();
+    let executable_sha256 = sha256_file(&executable)?;
+    Ok(ProcessIdentity {
+        pid,
+        start_time_unix_s: process.start_time(),
+        executable,
+        executable_bytes,
+        executable_sha256,
+    })
 }
 
 async fn connect_mpv(endpoint: &str, wait: Duration) -> Result<Stream, String> {
@@ -556,48 +773,130 @@ async fn connect_mpv(endpoint: &str, wait: Duration) -> Result<Stream, String> {
     }
 }
 
-async fn subscribe(stream: &Stream) -> Result<(), String> {
+async fn subscribe_and_confirm(
+    mut stream: Stream,
+    wait: Duration,
+) -> Result<BufReader<Stream>, String> {
     for (id, property) in [(9_001u64, "paused-for-cache"), (9_002, "time-pos")] {
-        let mut writer = stream;
         let mut payload = serde_json::to_vec(&json!({
             "command": ["observe_property", id, property],
             "request_id": id,
         }))
         .map_err(|e| format!("encode mpv subscription: {e}"))?;
         payload.push(b'\n');
-        writer
+        stream
             .write_all(&payload)
             .await
             .map_err(|e| format!("write mpv subscription: {e}"))?;
-        writer
+        stream
             .flush()
             .await
             .map_err(|e| format!("flush mpv subscription: {e}"))?;
     }
-    Ok(())
+    let mut reader = BufReader::new(stream);
+    let deadline = Instant::now() + wait;
+    let mut confirmed = std::collections::HashSet::new();
+    let mut line = Vec::new();
+    while confirmed.len() < 2 {
+        line.clear();
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err("timed out confirming mpv property subscriptions".to_string());
+        }
+        let bounded = timeout(
+            remaining,
+            yututui::util::io::read_bounded_line(&mut reader, &mut line, IPC_LINE_CAP),
+        )
+        .await
+        .map_err(|_| "timed out confirming mpv property subscriptions".to_string())?
+        .map_err(|e| format!("read mpv subscription response: {e}"))?;
+        match bounded {
+            yututui::util::io::BoundedLine::Line => {
+                let value: Value = serde_json::from_slice(&line)
+                    .map_err(|e| format!("parse mpv subscription response: {e}"))?;
+                let Some(request_id) = value.get("request_id").and_then(Value::as_u64) else {
+                    continue;
+                };
+                if !matches!(request_id, 9_001 | 9_002) {
+                    continue;
+                }
+                if value.get("error").and_then(Value::as_str) != Some("success") {
+                    return Err(format!(
+                        "mpv subscription {request_id} failed: {}",
+                        value.get("error").unwrap_or(&Value::Null)
+                    ));
+                }
+                confirmed.insert(request_id);
+            }
+            yututui::util::io::BoundedLine::Eof => {
+                return Err("mpv IPC closed before subscription confirmation".to_string());
+            }
+            yututui::util::io::BoundedLine::TooLarge => {
+                return Err("oversized mpv subscription response".to_string());
+            }
+        }
+    }
+    Ok(reader)
 }
 
-async fn read_mpv(stream: Stream, tx: mpsc::UnboundedSender<IpcEvent>) {
-    let mut reader = BufReader::new(&stream);
+async fn read_mpv<R>(mut reader: BufReader<R>, tx: mpsc::UnboundedSender<IpcMessage>)
+where
+    R: AsyncRead + Unpin,
+{
     let mut line = Vec::new();
     loop {
         line.clear();
         match yututui::util::io::read_bounded_line(&mut reader, &mut line, IPC_LINE_CAP).await {
             Ok(yututui::util::io::BoundedLine::Line) => {
-                if let Ok(value) = serde_json::from_slice::<Value>(&line)
-                    && tx
-                        .send(IpcEvent {
+                match serde_json::from_slice::<Value>(&line) {
+                    Ok(value) => {
+                        if tx
+                            .send(IpcMessage::Event(IpcEvent {
+                                observed_at: Instant::now(),
+                                value,
+                            }))
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                    Err(error) => {
+                        let _ = tx.send(IpcMessage::ParseError {
                             observed_at: Instant::now(),
-                            value,
-                        })
-                        .is_err()
-                {
-                    return;
+                            message: error.to_string(),
+                        });
+                        return;
+                    }
                 }
             }
-            Ok(yututui::util::io::BoundedLine::Eof)
-            | Ok(yututui::util::io::BoundedLine::TooLarge)
-            | Err(_) => return,
+            Ok(yututui::util::io::BoundedLine::Eof) => {
+                let observed_at = Instant::now();
+                if line.is_empty() {
+                    let _ = tx.send(IpcMessage::CleanEof { observed_at });
+                } else {
+                    let _ = tx.send(IpcMessage::ParseError {
+                        observed_at,
+                        message: format!(
+                            "mpv IPC closed with a truncated JSON frame ({} bytes)",
+                            line.len()
+                        ),
+                    });
+                }
+                return;
+            }
+            Ok(yututui::util::io::BoundedLine::TooLarge) => {
+                let _ = tx.send(IpcMessage::TooLarge {
+                    observed_at: Instant::now(),
+                });
+                return;
+            }
+            Err(error) => {
+                let _ = tx.send(IpcMessage::IoError {
+                    observed_at: Instant::now(),
+                    message: error.to_string(),
+                });
+                return;
+            }
         }
     }
 }
@@ -606,37 +905,90 @@ async fn perform_load(
     command: RemoteCommand,
     name: &str,
     wait: Duration,
-    rx: &mut mpsc::UnboundedReceiver<IpcEvent>,
+    rx: &mut mpsc::UnboundedReceiver<IpcMessage>,
     telemetry: &mut Telemetry,
     out: &mut BufWriter<File>,
 ) -> Result<(), String> {
+    drain_pending_mpv(rx, telemetry, out)?;
     let started = Instant::now();
     send_remote(command).await?;
-    wait_for_mpv(wait, rx, telemetry, out, |value| {
+    let completed = wait_for_mpv(wait, rx, telemetry, out, started, |value| {
         value.get("event").and_then(Value::as_str) == Some("playback-restart")
     })
     .await?;
-    operation(out, name, started.elapsed(), json!({}))
+    operation(
+        out,
+        telemetry.origin,
+        name,
+        started..completed.observed_at,
+        "mpv_event",
+        Some(&completed),
+        json!({}),
+    )
 }
 
 async fn wait_for_mpv(
     wait: Duration,
-    rx: &mut mpsc::UnboundedReceiver<IpcEvent>,
+    rx: &mut mpsc::UnboundedReceiver<IpcMessage>,
     telemetry: &mut Telemetry,
     out: &mut BufWriter<File>,
+    operation_started: Instant,
     predicate: impl Fn(&Value) -> bool,
-) -> Result<(), String> {
+) -> Result<IpcEvent, String> {
     let deadline = Instant::now() + wait;
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
-        let event = timeout(remaining, rx.recv())
+        let message = timeout(remaining, rx.recv())
             .await
             .map_err(|_| "timed out waiting for mpv playback telemetry".to_string())?
             .ok_or_else(|| "mpv IPC observer closed unexpectedly".to_string())?;
+        let event = match message {
+            IpcMessage::Event(event) => event,
+            terminal => return Err(ipc_terminal_error(terminal)),
+        };
         let matched = predicate(&event.value);
         telemetry.record(&event, out)?;
-        if matched {
-            return Ok(());
+        if matched && event.observed_at >= operation_started {
+            return Ok(event);
+        }
+    }
+}
+
+async fn wait_for_seek(
+    wait: Duration,
+    rx: &mut mpsc::UnboundedReceiver<IpcMessage>,
+    telemetry: &mut Telemetry,
+    out: &mut BufWriter<File>,
+    operation_started: Instant,
+    target_s: f64,
+) -> Result<(IpcEvent, IpcEvent, f64), String> {
+    let deadline = Instant::now() + wait;
+    let mut restart = None;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let message = timeout(remaining, rx.recv())
+            .await
+            .map_err(|_| "timed out waiting for seek completion telemetry".to_string())?
+            .ok_or_else(|| "mpv IPC observer closed unexpectedly".to_string())?;
+        let event = match message {
+            IpcMessage::Event(event) => event,
+            terminal => return Err(ipc_terminal_error(terminal)),
+        };
+        let is_post_command = event.observed_at >= operation_started;
+        let is_restart =
+            event.value.get("event").and_then(Value::as_str) == Some("playback-restart");
+        let position = time_pos_seconds(&event.value);
+        telemetry.record(&event, out)?;
+        if is_post_command && is_restart && restart.is_none() {
+            restart = Some(event);
+            continue;
+        }
+        if is_post_command
+            && restart.is_some()
+            && let Some(position) = position
+            && (position - target_s).abs() <= 2.0
+        {
+            return Ok((restart.expect("checked above"), event, position));
         }
     }
 }
@@ -693,20 +1045,200 @@ async fn ensure_playing(wait: Duration) -> Result<(), String> {
 
 fn operation(
     out: &mut BufWriter<File>,
+    origin: Instant,
     operation: &str,
-    latency: Duration,
+    interval: std::ops::Range<Instant>,
+    completion_source: &str,
+    completion_event: Option<&IpcEvent>,
     detail: Value,
 ) -> Result<(), String> {
+    let started = interval.start;
+    let completed = interval.end;
+    let started_ns = started.saturating_duration_since(origin).as_nanos();
+    let completed_ns = completed.saturating_duration_since(origin).as_nanos();
+    let completion_event_elapsed_ns = completion_event.map(|event| {
+        event
+            .observed_at
+            .saturating_duration_since(origin)
+            .as_nanos()
+    });
+    let completion_event_type = completion_event.and_then(|event| {
+        event
+            .value
+            .get("event")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+    });
+    let completion_property = completion_event.and_then(|event| {
+        event
+            .value
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+    });
     write_ndjson(
         out,
         &json!({
             "schema": SCHEMA,
             "kind": "operation",
             "operation": operation,
-            "latency_ms": latency.as_secs_f64() * 1_000.0,
+            "operation_started_ns": started_ns,
+            "operation_completed_ns": completed_ns,
+            "latency_ms": (completed_ns - started_ns) as f64 / 1_000_000.0,
+            "completion_source": completion_source,
+            "completion_event_elapsed_ns": completion_event_elapsed_ns,
+            "completion_event_type": completion_event_type,
+            "completion_property": completion_property,
             "detail": detail,
         }),
     )
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let bytes = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    Ok(format!("{:x}", Sha256::digest(bytes)))
+}
+
+fn producer_binary_sha256() -> Result<String, String> {
+    let executable = std::env::current_exe()
+        .map_err(|e| format!("resolve current controller executable: {e}"))?;
+    sha256_file(&executable)
+}
+
+fn header_record(
+    args: &Args,
+    owner: &ProcessIdentity,
+    owner_mode: yututui::remote::proto::InstanceMode,
+    mpv: &MpvBinding,
+    producer_binary_hash: &str,
+    run_id: &str,
+    observation_started_unix_ns: u128,
+) -> Value {
+    json!({
+        "schema": SCHEMA,
+        "kind": "header",
+        "owner_pid": owner.pid,
+        "owner_start_time_unix_s": owner.start_time_unix_s,
+        "owner_executable": owner.executable,
+        "owner_executable_bytes": owner.executable_bytes,
+        "owner_executable_sha256": owner.executable_sha256,
+        "owner_mode": owner_mode,
+        "mpv_pid": mpv.process.pid,
+        "mpv_start_time_unix_s": mpv.process.start_time_unix_s,
+        "mpv_executable": mpv.process.executable,
+        "mpv_executable_bytes": mpv.process.executable_bytes,
+        "mpv_executable_sha256": mpv.process.executable_sha256,
+        "mpv_endpoint": mpv.endpoint,
+        "producer_binary_sha256": producer_binary_hash,
+        "run_id": run_id,
+        "observation_started_unix_ns": observation_started_unix_ns,
+        "observe_ns": args.observe.as_nanos(),
+        "buffering_cutoff_ns": args.observe.as_nanos(),
+        "close_grace_ns": args.close_grace.as_nanos(),
+        "subscriptions_confirmed": true,
+        "scenario_sha256": std::env::var("TUI_PERF_SCENARIO_SHA256").ok(),
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "pause_policy": if args.pause_hold.is_some() { "pause-resume" } else { "none" },
+        "pause_hold_ms": args.pause_hold.map(|hold| hold.as_millis()),
+    })
+}
+
+fn summary_record(
+    telemetry: &Telemetry,
+    args: &Args,
+    origin: Instant,
+    summary_at: Instant,
+    observation_end: DrainEnd,
+    run_id: &str,
+    observation_finished_unix_ns: u128,
+) -> Value {
+    let elapsed_ns = summary_at.saturating_duration_since(origin).as_nanos();
+    let terminal_observed_ns = match observation_end {
+        DrainEnd::Deadline => None,
+        DrainEnd::CleanEof(observed_at) => {
+            Some(observed_at.saturating_duration_since(origin).as_nanos())
+        }
+    };
+    let (cutoff_first_time_pos_ns, cutoff_first_time_pos_s) = telemetry
+        .cutoff_first_time_pos
+        .map(|(observed_at, position)| {
+            (
+                observed_at.saturating_duration_since(origin).as_nanos(),
+                position,
+            )
+        })
+        .unzip();
+    let (cutoff_last_time_pos_ns, cutoff_last_time_pos_s) = telemetry
+        .cutoff_last_time_pos
+        .map(|(observed_at, position)| {
+            (
+                observed_at.saturating_duration_since(origin).as_nanos(),
+                position,
+            )
+        })
+        .unzip();
+    json!({
+        "schema": SCHEMA,
+        "kind": "summary",
+        "run_id": run_id,
+        "observation_finished_unix_ns": observation_finished_unix_ns,
+        "elapsed_ns": elapsed_ns,
+        "expected_observation_ns": args.observe.as_nanos(),
+        "buffering_cutoff_ns": args.observe.as_nanos(),
+        "actual_coverage_ns": elapsed_ns.min(args.observe.as_nanos()),
+        "first_event_ns": telemetry.first_event_ns,
+        "last_event_ns": telemetry.last_event_ns,
+        "terminal_observed_ns": terminal_observed_ns,
+        "terminal_kind": match observation_end {
+            DrainEnd::Deadline => "deadline",
+            DrainEnd::CleanEof(_) => "clean_eof",
+        },
+        "buffering_events": telemetry.buffering_events,
+        "buffering_ms": telemetry.buffering_total.as_millis(),
+        "cutoff_first_time_pos_ns": cutoff_first_time_pos_ns,
+        "cutoff_first_time_pos_s": cutoff_first_time_pos_s,
+        "cutoff_last_time_pos_ns": cutoff_last_time_pos_ns,
+        "cutoff_last_time_pos_s": cutoff_last_time_pos_s,
+        "observation_end": observation_end.as_str(),
+    })
+}
+
+fn publish_ready(
+    path: &Path,
+    owner: &ProcessIdentity,
+    mpv: &MpvBinding,
+    run_id: &str,
+    observation_started_unix_ns: u128,
+) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create ready directory {}: {e}", parent.display()))?;
+    }
+    if path.exists() {
+        return Err(format!(
+            "controller ready path already exists: {}",
+            path.display()
+        ));
+    }
+    let temporary = path.with_extension("tmp");
+    let bytes = serde_json::to_vec_pretty(&json!({
+        "schema": "ytt.tui-perf.controller-ready.v1",
+        "run_id": run_id,
+        "owner_pid": owner.pid,
+        "owner_start_time_unix_s": owner.start_time_unix_s,
+        "mpv_pid": mpv.process.pid,
+        "mpv_start_time_unix_s": mpv.process.start_time_unix_s,
+        "mpv_endpoint": mpv.endpoint,
+        "subscriptions_confirmed": true,
+        "observation_started_unix_ns": observation_started_unix_ns,
+        "scenario_sha256": std::env::var("TUI_PERF_SCENARIO_SHA256").ok(),
+    }))
+    .map_err(|e| format!("encode controller ready file: {e}"))?;
+    std::fs::write(&temporary, bytes)
+        .map_err(|e| format!("write controller ready file {}: {e}", temporary.display()))?;
+    std::fs::rename(&temporary, path)
+        .map_err(|e| format!("publish controller ready file {}: {e}", path.display()))
 }
 
 fn write_ndjson(out: &mut BufWriter<File>, value: &impl Serialize) -> Result<(), String> {
@@ -721,11 +1253,152 @@ mod tests {
     use super::*;
 
     #[test]
+    fn header_records_the_current_controller_binary_sha256() {
+        let executable = std::env::current_exe().expect("resolve current test executable");
+        let expected = sha256_file(&executable).expect("hash current test executable");
+        let producer_hash = producer_binary_sha256().expect("hash current controller executable");
+        let args = Args {
+            output: PathBuf::from("control.ndjson"),
+            ready_file: PathBuf::from("controller-ready.json"),
+            wait: Duration::from_secs(1),
+            observe: Duration::from_secs(2),
+            close_grace: Duration::ZERO,
+            load: LoadAction::None,
+            seeks: Vec::new(),
+            pause_hold: None,
+        };
+        let identity = ProcessIdentity {
+            pid: 42,
+            start_time_unix_s: 1,
+            executable: executable.clone(),
+            executable_bytes: executable.metadata().expect("stat test executable").len(),
+            executable_sha256: expected.clone(),
+        };
+        let mpv = MpvBinding {
+            process: ProcessIdentity {
+                pid: 43,
+                ..identity.clone()
+            },
+            endpoint: "mpv.sock".to_string(),
+        };
+        let header = header_record(
+            &args,
+            &identity,
+            yututui::remote::proto::InstanceMode::StandaloneTui,
+            &mpv,
+            &producer_hash,
+            "self-test-run",
+            123,
+        );
+
+        assert_eq!(producer_hash, expected);
+        assert_eq!(producer_hash.len(), 64);
+        assert_eq!(header["kind"], "header");
+        assert_eq!(header["producer_binary_sha256"], producer_hash);
+        assert_eq!(header["run_id"], "self-test-run");
+    }
+
+    #[test]
+    fn summary_records_the_monotonic_finish_boundary() {
+        let origin = Instant::now();
+        let summary_at = origin + Duration::from_millis(7);
+        let mut telemetry = Telemetry::new(origin, origin + Duration::from_millis(5));
+        telemetry.buffering_since = Some(origin + Duration::from_millis(2));
+        telemetry.buffering_events = 1;
+        telemetry.finish(summary_at);
+
+        let args = Args {
+            output: PathBuf::from("control.ndjson"),
+            ready_file: PathBuf::from("controller-ready.json"),
+            wait: Duration::from_secs(1),
+            observe: Duration::from_millis(5),
+            close_grace: Duration::from_millis(5),
+            load: LoadAction::None,
+            seeks: Vec::new(),
+            pause_hold: None,
+        };
+        let summary = summary_record(
+            &telemetry,
+            &args,
+            origin,
+            summary_at,
+            DrainEnd::CleanEof(summary_at),
+            "self-test-run",
+            456,
+        );
+
+        assert_eq!(summary["elapsed_ns"], 7_000_000u64);
+        assert_eq!(summary["buffering_events"], 1);
+        assert_eq!(summary["buffering_ms"], 3);
+        assert_eq!(summary["buffering_cutoff_ns"], 5_000_000u64);
+        assert_eq!(summary["observation_end"], "mpv_ipc_closed");
+        assert_eq!(summary["run_id"], "self-test-run");
+        assert_eq!(summary["observation_finished_unix_ns"], 456);
+    }
+
+    #[test]
     fn scheduled_actions_are_spread_across_the_observation_window() {
         let window = Duration::from_secs(70);
         assert_eq!(scheduled_offset(window, 1, 6), Duration::from_secs(10));
         assert_eq!(scheduled_offset(window, 3, 6), Duration::from_secs(30));
         assert_eq!(scheduled_offset(window, 6, 6), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn buffering_after_the_metric_cutoff_is_ignored() {
+        let origin = Instant::now();
+        let mut telemetry = Telemetry::new(origin, origin + Duration::from_millis(5));
+        for (elapsed_ms, paused) in [(6, true), (7, false)] {
+            telemetry.record_buffering(
+                origin + Duration::from_millis(elapsed_ms),
+                &json!({
+                    "event": "property-change",
+                    "name": "paused-for-cache",
+                    "data": paused,
+                }),
+            );
+        }
+
+        assert_eq!(telemetry.buffering_events, 0);
+        assert_eq!(telemetry.buffering_total, Duration::ZERO);
+    }
+
+    #[test]
+    fn buffering_interval_crossing_the_metric_cutoff_is_clipped() {
+        let origin = Instant::now();
+        let mut telemetry = Telemetry::new(origin, origin + Duration::from_millis(5));
+        for (elapsed_ms, paused) in [(2, true), (7, false)] {
+            telemetry.record_buffering(
+                origin + Duration::from_millis(elapsed_ms),
+                &json!({
+                    "event": "property-change",
+                    "name": "paused-for-cache",
+                    "data": paused,
+                }),
+            );
+        }
+
+        assert_eq!(telemetry.buffering_events, 1);
+        assert_eq!(telemetry.buffering_total, Duration::from_millis(3));
+    }
+
+    #[test]
+    fn time_pos_summary_tail_is_bound_to_the_metric_cutoff() {
+        let origin = Instant::now();
+        let mut telemetry = Telemetry::new(origin, origin + Duration::from_millis(5));
+        telemetry.record_time_pos(origin + Duration::from_millis(1), 10.0);
+        telemetry.record_time_pos(origin + Duration::from_millis(4), 13.0);
+        telemetry.record_time_pos(origin + Duration::from_millis(7), 99.0);
+
+        assert_eq!(telemetry.last_time_pos_s, Some(99.0));
+        assert_eq!(
+            telemetry.cutoff_first_time_pos,
+            Some((origin + Duration::from_millis(1), 10.0))
+        );
+        assert_eq!(
+            telemetry.cutoff_last_time_pos,
+            Some((origin + Duration::from_millis(4), 13.0))
+        );
     }
 
     #[test]
@@ -768,29 +1441,30 @@ mod tests {
         ));
         let mut out = BufWriter::new(File::create(&path).expect("create test output"));
         let origin = Instant::now();
-        let mut telemetry = Telemetry::new(origin);
+        let mut telemetry = Telemetry::new(origin, origin + Duration::from_millis(40));
         let (tx, mut rx) = mpsc::unbounded_channel();
-        tx.send(IpcEvent {
+        tx.send(IpcMessage::Event(IpcEvent {
             observed_at: origin + Duration::from_millis(2),
             value: json!({
                 "event": "property-change",
                 "name": "paused-for-cache",
                 "data": true,
             }),
-        })
+        }))
         .expect("send buffering start");
-        tx.send(IpcEvent {
+        tx.send(IpcMessage::Event(IpcEvent {
             observed_at: origin + Duration::from_millis(7),
             value: json!({
                 "event": "property-change",
                 "name": "paused-for-cache",
                 "data": false,
             }),
-        })
+        }))
         .expect("send buffering end");
 
         let drain_started = Instant::now();
         let end = drain_until(
+            drain_started + Duration::from_millis(40),
             drain_started + Duration::from_millis(40),
             &mut rx,
             &mut telemetry,
@@ -820,23 +1494,29 @@ mod tests {
         ));
         let mut out = BufWriter::new(File::create(&path).expect("create test output"));
         let origin = Instant::now();
-        let mut telemetry = Telemetry::new(origin);
+        let mut telemetry = Telemetry::new(origin, origin + Duration::from_millis(10));
         let (tx, mut rx) = mpsc::unbounded_channel();
         for (elapsed_ms, paused) in [(2, true), (9, false)] {
-            tx.send(IpcEvent {
+            tx.send(IpcMessage::Event(IpcEvent {
                 observed_at: origin + Duration::from_millis(elapsed_ms),
                 value: json!({
                     "event": "property-change",
                     "name": "paused-for-cache",
                     "data": paused,
                 }),
-            })
+            }))
             .expect("queue telemetry before close");
         }
+        let clean_eof_at = origin + Duration::from_millis(10);
+        tx.send(IpcMessage::CleanEof {
+            observed_at: clean_eof_at,
+        })
+        .expect("queue clean EOF");
         drop(tx);
 
         let end = drain_until(
             Instant::now() + Duration::from_secs(1),
+            origin + Duration::from_millis(10),
             &mut rx,
             &mut telemetry,
             &mut out,
@@ -844,10 +1524,53 @@ mod tests {
         .await
         .expect("clean observer close is a valid final boundary");
 
-        assert_eq!(end, DrainEnd::ObserverClosed);
+        assert_eq!(end, DrainEnd::CleanEof(clean_eof_at));
         assert_eq!(telemetry.buffering_events, 1);
         assert_eq!(telemetry.buffering_total, Duration::from_millis(7));
         drop(out);
         std::fs::remove_file(path).expect("remove test output");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mpv_reader_distinguishes_clean_eof_from_a_truncated_json_frame() {
+        let (mut truncated_writer, truncated_reader) = tokio::io::duplex(256);
+        truncated_writer
+            .write_all(b"{\"event\":\"playback-restart\"}\n{\"event\"")
+            .await
+            .expect("write valid line and truncated frame");
+        truncated_writer
+            .shutdown()
+            .await
+            .expect("close truncated stream");
+        let (truncated_tx, mut truncated_rx) = mpsc::unbounded_channel();
+        read_mpv(BufReader::new(truncated_reader), truncated_tx).await;
+
+        assert!(matches!(
+            truncated_rx.recv().await,
+            Some(IpcMessage::Event(_))
+        ));
+        match truncated_rx.recv().await {
+            Some(IpcMessage::ParseError { message, .. }) => {
+                assert!(message.contains("truncated JSON frame"));
+            }
+            other => panic!("truncated frame must be a parse error, got {other:?}"),
+        }
+        assert!(truncated_rx.recv().await.is_none());
+
+        let (mut clean_writer, clean_reader) = tokio::io::duplex(256);
+        clean_writer
+            .write_all(b"{\"event\":\"playback-restart\"}\n")
+            .await
+            .expect("write complete frame");
+        clean_writer.shutdown().await.expect("close clean stream");
+        let (clean_tx, mut clean_rx) = mpsc::unbounded_channel();
+        read_mpv(BufReader::new(clean_reader), clean_tx).await;
+
+        assert!(matches!(clean_rx.recv().await, Some(IpcMessage::Event(_))));
+        assert!(matches!(
+            clean_rx.recv().await,
+            Some(IpcMessage::CleanEof { .. })
+        ));
+        assert!(clean_rx.recv().await.is_none());
     }
 }

--- a/examples/tui_perf_control.rs
+++ b/examples/tui_perf_control.rs
@@ -1,0 +1,853 @@
+//! Out-of-band playback controller for the TUI performance harness.
+//!
+//! User actions go through the existing authenticated remote protocol. A second,
+//! read-only mpv IPC connection observes `playback-restart`, `paused-for-cache`, and
+//! `time-pos` so latency and buffering are measured without injecting terminal keys.
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use interprocess::local_socket::GenericFilePath;
+use interprocess::local_socket::tokio::Stream;
+use interprocess::local_socket::tokio::prelude::*;
+use serde::Serialize;
+use serde_json::{Value, json};
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::sync::mpsc;
+use tokio::time::{sleep, timeout};
+use yututui::remote::proto::{RemoteCommand, StatusSnapshot};
+
+const SCHEMA: &str = "ytt.tui-perf.control.v1";
+const IPC_LINE_CAP: usize = 1024 * 1024;
+const MIN_RESUME_PROGRESS_S: f64 = 0.01;
+
+#[derive(Debug)]
+enum LoadAction {
+    None,
+    ResumeSession,
+    Play(String),
+}
+
+#[derive(Debug)]
+struct Args {
+    output: PathBuf,
+    wait: Duration,
+    observe: Duration,
+    close_grace: Duration,
+    load: LoadAction,
+    seeks: Vec<f64>,
+    pause_hold: Option<Duration>,
+}
+
+impl Args {
+    fn parse() -> Result<Self, String> {
+        let mut output = None;
+        let mut wait_secs = 30.0;
+        let mut observe_secs = 0.0;
+        let mut close_grace_secs = 0.0;
+        let mut load = LoadAction::None;
+        let mut seeks = Vec::new();
+        let mut pause_hold = None;
+        let mut raw = std::env::args().skip(1);
+        while let Some(arg) = raw.next() {
+            let next = |name: &str, it: &mut std::iter::Skip<std::env::Args>| {
+                it.next().ok_or_else(|| format!("{name} requires a value"))
+            };
+            match arg.as_str() {
+                "--output" => output = Some(PathBuf::from(next("--output", &mut raw)?)),
+                "--wait-secs" => {
+                    wait_secs = next("--wait-secs", &mut raw)?
+                        .parse::<f64>()
+                        .ok()
+                        .filter(|v| v.is_finite() && *v > 0.0)
+                        .ok_or_else(|| "--wait-secs must be a positive number".to_string())?;
+                }
+                "--observe-secs" => {
+                    observe_secs = next("--observe-secs", &mut raw)?
+                        .parse::<f64>()
+                        .ok()
+                        .filter(|v| v.is_finite() && *v >= 0.0)
+                        .ok_or_else(|| {
+                            "--observe-secs must be a non-negative number".to_string()
+                        })?;
+                }
+                "--close-grace-secs" => {
+                    close_grace_secs = next("--close-grace-secs", &mut raw)?
+                        .parse::<f64>()
+                        .ok()
+                        .filter(|v| v.is_finite() && *v >= 0.0)
+                        .ok_or_else(|| {
+                            "--close-grace-secs must be a non-negative number".to_string()
+                        })?;
+                }
+                "--load" => {
+                    load = match next("--load", &mut raw)?.as_str() {
+                        "none" => LoadAction::None,
+                        "resume-session" => LoadAction::ResumeSession,
+                        other => {
+                            return Err(format!(
+                                "unsupported --load value `{other}` (expected none|resume-session)"
+                            ));
+                        }
+                    };
+                }
+                "--play-query" => load = LoadAction::Play(next("--play-query", &mut raw)?),
+                "--seeks" => {
+                    seeks = parse_seeks(&next("--seeks", &mut raw)?)?;
+                }
+                "--pause-hold-ms" => {
+                    let millis = next("--pause-hold-ms", &mut raw)?
+                        .parse::<u64>()
+                        .map_err(|_| "--pause-hold-ms must be an integer".to_string())?;
+                    pause_hold = Some(Duration::from_millis(millis));
+                }
+                "--no-pause" => pause_hold = None,
+                "-h" | "--help" => return Err(usage().to_string()),
+                other => return Err(format!("unknown argument `{other}`\n\n{}", usage())),
+            }
+        }
+        Ok(Self {
+            output: output.ok_or_else(|| "--output is required".to_string())?,
+            wait: Duration::from_secs_f64(wait_secs),
+            observe: Duration::from_secs_f64(observe_secs),
+            close_grace: Duration::from_secs_f64(close_grace_secs),
+            load,
+            seeks,
+            pause_hold,
+        })
+    }
+}
+
+fn usage() -> &'static str {
+    "Usage: tui_perf_control --output FILE [options]\n\
+     Options:\n\
+       --wait-secs N                 Per-operation timeout (default 30)\n\
+       --observe-secs N              Drain mpv telemetry for the full run (default 0)\n\
+       --close-grace-secs N          Extra final wait for sampler-owned mpv close (default 0)\n\
+       --load none|resume-session    Optional deterministic session load\n\
+       --play-query QUERY            Ask the owner to search and play QUERY\n\
+       --seeks S1,S2,...             Absolute seek targets in seconds\n\
+       --pause-hold-ms N             Explicit pause duration before resume\n\
+       --no-pause                    Explicitly keep playback steady (default)"
+}
+
+fn parse_seeks(raw: &str) -> Result<Vec<f64>, String> {
+    if raw.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    raw.split(',')
+        .map(|part| {
+            part.trim()
+                .parse::<f64>()
+                .ok()
+                .filter(|v| v.is_finite() && *v >= 0.0)
+                .ok_or_else(|| format!("invalid seek target `{part}`"))
+        })
+        .collect()
+}
+
+fn scheduled_offset(window: Duration, ordinal: usize, total_actions: usize) -> Duration {
+    if window.is_zero() || ordinal == 0 || total_actions == 0 {
+        return Duration::ZERO;
+    }
+    debug_assert!(ordinal <= total_actions);
+    window.mul_f64(ordinal as f64 / (total_actions + 1) as f64)
+}
+
+fn scheduled_action_count(seeks: usize, pause_hold: Option<Duration>) -> usize {
+    seeks + usize::from(pause_hold.is_some())
+}
+
+#[derive(Debug)]
+struct IpcEvent {
+    observed_at: Instant,
+    value: Value,
+}
+
+struct Telemetry {
+    origin: Instant,
+    buffering_since: Option<Instant>,
+    buffering_events: u64,
+    buffering_total: Duration,
+    last_time_pos_s: Option<f64>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DrainEnd {
+    Deadline,
+    ObserverClosed,
+}
+
+impl DrainEnd {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Deadline => "deadline",
+            Self::ObserverClosed => "mpv_ipc_closed",
+        }
+    }
+}
+
+impl Telemetry {
+    fn new(origin: Instant) -> Self {
+        Self {
+            origin,
+            buffering_since: None,
+            buffering_events: 0,
+            buffering_total: Duration::ZERO,
+            last_time_pos_s: None,
+        }
+    }
+
+    fn record(&mut self, event: &IpcEvent, out: &mut BufWriter<File>) -> Result<(), String> {
+        if let Some(position) = time_pos_seconds(&event.value) {
+            self.last_time_pos_s = Some(position);
+        }
+        if event.value.get("event").and_then(Value::as_str) == Some("property-change")
+            && event.value.get("name").and_then(Value::as_str) == Some("paused-for-cache")
+            && let Some(paused) = event.value.get("data").and_then(Value::as_bool)
+        {
+            if paused && self.buffering_since.is_none() {
+                self.buffering_since = Some(event.observed_at);
+                self.buffering_events += 1;
+            } else if !paused && let Some(started) = self.buffering_since.take() {
+                self.buffering_total += event.observed_at.saturating_duration_since(started);
+            }
+        }
+        write_ndjson(
+            out,
+            &json!({
+                "schema": SCHEMA,
+                "kind": "mpv_event",
+                "elapsed_ms": event.observed_at.saturating_duration_since(self.origin).as_millis(),
+                "event": event.value,
+            }),
+        )
+    }
+
+    fn finish(&mut self, now: Instant) {
+        if let Some(started) = self.buffering_since.take() {
+            self.buffering_total += now.saturating_duration_since(started);
+        }
+    }
+}
+
+fn time_pos_seconds(value: &Value) -> Option<f64> {
+    (value.get("event").and_then(Value::as_str) == Some("property-change")
+        && value.get("name").and_then(Value::as_str) == Some("time-pos"))
+    .then(|| value.get("data").and_then(Value::as_f64))
+    .flatten()
+}
+
+fn proves_resume_progress(value: &Value, paused_time_pos_s: f64) -> bool {
+    time_pos_seconds(value)
+        .is_some_and(|position| position >= paused_time_pos_s + MIN_RESUME_PROGRESS_S)
+}
+
+fn drain_pending_mpv(
+    rx: &mut mpsc::UnboundedReceiver<IpcEvent>,
+    telemetry: &mut Telemetry,
+    out: &mut BufWriter<File>,
+) -> Result<(), String> {
+    while let Ok(event) = rx.try_recv() {
+        telemetry.record(&event, out)?;
+    }
+    Ok(())
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let code = match Args::parse() {
+        Ok(args) => match run(args).await {
+            Ok(()) => 0,
+            Err(message) => {
+                eprintln!("tui_perf_control: {message}");
+                2
+            }
+        },
+        Err(message) => {
+            eprintln!("tui_perf_control: {message}");
+            2
+        }
+    };
+    std::process::exit(code);
+}
+
+async fn run(args: Args) -> Result<(), String> {
+    if let Some(parent) = args.output.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create output directory {}: {e}", parent.display()))?;
+    }
+    let mut out = BufWriter::new(
+        File::create(&args.output).map_err(|e| format!("create {}: {e}", args.output.display()))?,
+    );
+    let origin = Instant::now();
+    let instance = wait_for_instance(args.wait).await?;
+    let (mpv_pid, mpv_endpoint) = discover_mpv(instance.app_pid, args.wait).await?;
+    let stream = connect_mpv(&mpv_endpoint, args.wait).await?;
+    subscribe(&stream).await?;
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    tokio::spawn(read_mpv(stream, tx));
+    let mut telemetry = Telemetry::new(origin);
+
+    write_ndjson(
+        &mut out,
+        &json!({
+            "schema": SCHEMA,
+            "kind": "header",
+            "owner_pid": instance.app_pid,
+            "owner_mode": instance.mode,
+            "mpv_pid": mpv_pid,
+            "mpv_endpoint": mpv_endpoint,
+            "scenario_sha256": std::env::var("TUI_PERF_SCENARIO_SHA256").ok(),
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "pause_policy": if args.pause_hold.is_some() { "pause-resume" } else { "none" },
+            "pause_hold_ms": args.pause_hold.map(|hold| hold.as_millis()),
+        }),
+    )?;
+
+    match args.load {
+        LoadAction::None => {
+            let started = Instant::now();
+            let status = wait_for_status(args.wait, |status| status.title.is_some()).await?;
+            operation(
+                &mut out,
+                "ready",
+                started.elapsed(),
+                json!({"title": status.title}),
+            )?;
+        }
+        LoadAction::ResumeSession => {
+            perform_load(
+                RemoteCommand::ResumeSession,
+                "resume_session",
+                args.wait,
+                &mut rx,
+                &mut telemetry,
+                &mut out,
+            )
+            .await?;
+        }
+        LoadAction::Play(query) => {
+            perform_load(
+                RemoteCommand::Play { query },
+                "play_query",
+                args.wait,
+                &mut rx,
+                &mut telemetry,
+                &mut out,
+            )
+            .await?;
+        }
+    }
+
+    // Seek through the app's public control lane so position_epoch and all owner invariants run.
+    let scheduled_actions = scheduled_action_count(args.seeks.len(), args.pause_hold);
+    for (index, target_s) in args.seeks.into_iter().enumerate() {
+        if scheduled_actions > 0 && !args.observe.is_zero() {
+            let offset = scheduled_offset(args.observe, index + 1, scheduled_actions);
+            drain_to_action(origin + offset, &mut rx, &mut telemetry, &mut out).await?;
+        }
+        let started = Instant::now();
+        send_remote(RemoteCommand::SeekTo {
+            ms: (target_s * 1_000.0).round() as u64,
+        })
+        .await?;
+        wait_for_mpv(args.wait, &mut rx, &mut telemetry, &mut out, |value| {
+            value.get("event").and_then(Value::as_str) == Some("playback-restart")
+        })
+        .await?;
+        operation(
+            &mut out,
+            "seek",
+            started.elapsed(),
+            json!({"target_s": target_s}),
+        )?;
+    }
+
+    if let Some(hold) = args.pause_hold {
+        if scheduled_actions > 0 && !args.observe.is_zero() {
+            let offset = scheduled_offset(args.observe, scheduled_actions, scheduled_actions);
+            drain_to_action(origin + offset, &mut rx, &mut telemetry, &mut out).await?;
+        }
+        ensure_playing(args.wait).await?;
+        let pause_started = Instant::now();
+        send_remote(RemoteCommand::TogglePause).await?;
+        wait_for_status(args.wait, |status| status.paused).await?;
+        operation(&mut out, "pause", pause_started.elapsed(), json!({}))?;
+        sleep(hold).await;
+
+        // mpv 0.40 does not emit playback-restart for a plain unpause. Drain every event already
+        // observed while paused, then require decoder time to move beyond the paused boundary.
+        // The small threshold rejects sub-millisecond property jitter around that boundary.
+        drain_pending_mpv(&mut rx, &mut telemetry, &mut out)?;
+        let paused_time_pos_s = telemetry
+            .last_time_pos_s
+            .ok_or_else(|| "mpv did not publish time-pos before resume".to_string())?;
+        let resume_started = Instant::now();
+        send_remote(RemoteCommand::TogglePause).await?;
+        wait_for_status(args.wait, |status| !status.paused).await?;
+        wait_for_mpv(args.wait, &mut rx, &mut telemetry, &mut out, |value| {
+            proves_resume_progress(value, paused_time_pos_s)
+        })
+        .await?;
+        operation(
+            &mut out,
+            "resume",
+            resume_started.elapsed(),
+            json!({
+                "pause_hold_ms": hold.as_millis(),
+                "paused_time_pos_s": paused_time_pos_s,
+            }),
+        )?;
+    }
+
+    // Operations deliberately occupy only deterministic points in the observation window.
+    // Continue draining until the full warmup+sample duration has elapsed so a late cache stall
+    // cannot disappear from the no-added-rebuffer gate merely because the last seek finished.
+    let observation_end = drain_until(
+        origin + args.observe + args.close_grace,
+        &mut rx,
+        &mut telemetry,
+        &mut out,
+    )
+    .await?;
+
+    while let Ok(event) = rx.try_recv() {
+        telemetry.record(&event, &mut out)?;
+    }
+    telemetry.finish(Instant::now());
+    write_ndjson(
+        &mut out,
+        &json!({
+            "schema": SCHEMA,
+            "kind": "summary",
+            "buffering_events": telemetry.buffering_events,
+            "buffering_ms": telemetry.buffering_total.as_millis(),
+            "observation_end": observation_end.as_str(),
+        }),
+    )?;
+    out.flush().map_err(|e| format!("flush output: {e}"))
+}
+
+async fn drain_until(
+    deadline: Instant,
+    rx: &mut mpsc::UnboundedReceiver<IpcEvent>,
+    telemetry: &mut Telemetry,
+    out: &mut BufWriter<File>,
+) -> Result<DrainEnd, String> {
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Ok(DrainEnd::Deadline);
+        }
+        match timeout(remaining, rx.recv()).await {
+            Ok(Some(event)) => telemetry.record(&event, out)?,
+            Ok(None) => return Ok(DrainEnd::ObserverClosed),
+            Err(_) => return Ok(DrainEnd::Deadline),
+        }
+    }
+}
+
+async fn drain_to_action(
+    deadline: Instant,
+    rx: &mut mpsc::UnboundedReceiver<IpcEvent>,
+    telemetry: &mut Telemetry,
+    out: &mut BufWriter<File>,
+) -> Result<(), String> {
+    match drain_until(deadline, rx, telemetry, out).await? {
+        DrainEnd::Deadline => Ok(()),
+        DrainEnd::ObserverClosed => {
+            Err("mpv IPC observer closed before a scheduled action".to_string())
+        }
+    }
+}
+
+async fn wait_for_instance(wait: Duration) -> Result<yututui::remote::proto::InstanceFile, String> {
+    let deadline = Instant::now() + wait;
+    loop {
+        if let Some(instance) = yututui::remote::endpoint::read_instance() {
+            return Ok(instance);
+        }
+        if Instant::now() >= deadline {
+            return Err("timed out waiting for the isolated ytt remote descriptor".to_string());
+        }
+        sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn discover_mpv(app_pid: u32, wait: Duration) -> Result<(u32, String), String> {
+    let deadline = Instant::now() + wait;
+    let mut system = System::new();
+    let refresh = ProcessRefreshKind::nothing()
+        .with_cmd(UpdateKind::OnlyIfNotSet)
+        .with_exe(UpdateKind::OnlyIfNotSet)
+        .without_tasks();
+    loop {
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+        let mut descendants = std::collections::HashSet::from([app_pid]);
+        loop {
+            let before = descendants.len();
+            for (pid, process) in system.processes() {
+                if process
+                    .parent()
+                    .is_some_and(|parent| descendants.contains(&parent.as_u32()))
+                {
+                    descendants.insert(pid.as_u32());
+                }
+            }
+            if descendants.len() == before {
+                break;
+            }
+        }
+        for pid in descendants {
+            if pid == app_pid {
+                continue;
+            }
+            let Some(process) = system.process(sysinfo::Pid::from_u32(pid)) else {
+                continue;
+            };
+            let is_mpv = process
+                .name()
+                .to_string_lossy()
+                .to_ascii_lowercase()
+                .starts_with("mpv");
+            if !is_mpv {
+                continue;
+            }
+            let endpoint = process.cmd().iter().find_map(|arg| {
+                arg.to_string_lossy()
+                    .strip_prefix("--input-ipc-server=")
+                    .map(str::to_owned)
+            });
+            if let Some(endpoint) = endpoint {
+                return Ok((pid, endpoint));
+            }
+            return Err(format!(
+                "mpv PID {pid} was found but its command line did not expose --input-ipc-server"
+            ));
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "timed out waiting for an mpv descendant of ytt PID {app_pid}"
+            ));
+        }
+        sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn connect_mpv(endpoint: &str, wait: Duration) -> Result<Stream, String> {
+    let deadline = Instant::now() + wait;
+    loop {
+        let name = endpoint
+            .to_fs_name::<GenericFilePath>()
+            .map_err(|e| format!("invalid mpv IPC endpoint: {e}"))?;
+        match Stream::connect(name).await {
+            Ok(stream) => return Ok(stream),
+            Err(error) if Instant::now() < deadline => {
+                let _ = error;
+                sleep(Duration::from_millis(25)).await;
+            }
+            Err(error) => return Err(format!("connect to mpv IPC: {error}")),
+        }
+    }
+}
+
+async fn subscribe(stream: &Stream) -> Result<(), String> {
+    for (id, property) in [(9_001u64, "paused-for-cache"), (9_002, "time-pos")] {
+        let mut writer = stream;
+        let mut payload = serde_json::to_vec(&json!({
+            "command": ["observe_property", id, property],
+            "request_id": id,
+        }))
+        .map_err(|e| format!("encode mpv subscription: {e}"))?;
+        payload.push(b'\n');
+        writer
+            .write_all(&payload)
+            .await
+            .map_err(|e| format!("write mpv subscription: {e}"))?;
+        writer
+            .flush()
+            .await
+            .map_err(|e| format!("flush mpv subscription: {e}"))?;
+    }
+    Ok(())
+}
+
+async fn read_mpv(stream: Stream, tx: mpsc::UnboundedSender<IpcEvent>) {
+    let mut reader = BufReader::new(&stream);
+    let mut line = Vec::new();
+    loop {
+        line.clear();
+        match yututui::util::io::read_bounded_line(&mut reader, &mut line, IPC_LINE_CAP).await {
+            Ok(yututui::util::io::BoundedLine::Line) => {
+                if let Ok(value) = serde_json::from_slice::<Value>(&line)
+                    && tx
+                        .send(IpcEvent {
+                            observed_at: Instant::now(),
+                            value,
+                        })
+                        .is_err()
+                {
+                    return;
+                }
+            }
+            Ok(yututui::util::io::BoundedLine::Eof)
+            | Ok(yututui::util::io::BoundedLine::TooLarge)
+            | Err(_) => return,
+        }
+    }
+}
+
+async fn perform_load(
+    command: RemoteCommand,
+    name: &str,
+    wait: Duration,
+    rx: &mut mpsc::UnboundedReceiver<IpcEvent>,
+    telemetry: &mut Telemetry,
+    out: &mut BufWriter<File>,
+) -> Result<(), String> {
+    let started = Instant::now();
+    send_remote(command).await?;
+    wait_for_mpv(wait, rx, telemetry, out, |value| {
+        value.get("event").and_then(Value::as_str) == Some("playback-restart")
+    })
+    .await?;
+    operation(out, name, started.elapsed(), json!({}))
+}
+
+async fn wait_for_mpv(
+    wait: Duration,
+    rx: &mut mpsc::UnboundedReceiver<IpcEvent>,
+    telemetry: &mut Telemetry,
+    out: &mut BufWriter<File>,
+    predicate: impl Fn(&Value) -> bool,
+) -> Result<(), String> {
+    let deadline = Instant::now() + wait;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let event = timeout(remaining, rx.recv())
+            .await
+            .map_err(|_| "timed out waiting for mpv playback telemetry".to_string())?
+            .ok_or_else(|| "mpv IPC observer closed unexpectedly".to_string())?;
+        let matched = predicate(&event.value);
+        telemetry.record(&event, out)?;
+        if matched {
+            return Ok(());
+        }
+    }
+}
+
+async fn send_remote(command: RemoteCommand) -> Result<(), String> {
+    let response = yututui::remote::client::send(command)
+        .await
+        .map_err(|e| format!("remote transport: {}", e.human_message()))?;
+    if response.ok {
+        Ok(())
+    } else {
+        Err(format!(
+            "remote command rejected: {}",
+            response.reason.as_deref().unwrap_or("rejected")
+        ))
+    }
+}
+
+async fn status() -> Result<StatusSnapshot, String> {
+    let response = yututui::remote::client::send(RemoteCommand::Status)
+        .await
+        .map_err(|e| format!("status transport: {}", e.human_message()))?;
+    response
+        .status
+        .ok_or_else(|| "status response did not contain a snapshot".to_string())
+}
+
+async fn wait_for_status(
+    wait: Duration,
+    predicate: impl Fn(&StatusSnapshot) -> bool,
+) -> Result<StatusSnapshot, String> {
+    let deadline = Instant::now() + wait;
+    loop {
+        if let Ok(snapshot) = status().await
+            && predicate(&snapshot)
+        {
+            return Ok(snapshot);
+        }
+        if Instant::now() >= deadline {
+            return Err("timed out waiting for remote playback state".to_string());
+        }
+        sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn ensure_playing(wait: Duration) -> Result<(), String> {
+    let snapshot = status().await?;
+    if snapshot.paused {
+        send_remote(RemoteCommand::TogglePause).await?;
+        wait_for_status(wait, |state| !state.paused).await?;
+    }
+    Ok(())
+}
+
+fn operation(
+    out: &mut BufWriter<File>,
+    operation: &str,
+    latency: Duration,
+    detail: Value,
+) -> Result<(), String> {
+    write_ndjson(
+        out,
+        &json!({
+            "schema": SCHEMA,
+            "kind": "operation",
+            "operation": operation,
+            "latency_ms": latency.as_secs_f64() * 1_000.0,
+            "detail": detail,
+        }),
+    )
+}
+
+fn write_ndjson(out: &mut BufWriter<File>, value: &impl Serialize) -> Result<(), String> {
+    serde_json::to_writer(&mut *out, value).map_err(|e| format!("encode NDJSON: {e}"))?;
+    out.write_all(b"\n")
+        .map_err(|e| format!("write NDJSON: {e}"))?;
+    out.flush().map_err(|e| format!("flush NDJSON: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scheduled_actions_are_spread_across_the_observation_window() {
+        let window = Duration::from_secs(70);
+        assert_eq!(scheduled_offset(window, 1, 6), Duration::from_secs(10));
+        assert_eq!(scheduled_offset(window, 3, 6), Duration::from_secs(30));
+        assert_eq!(scheduled_offset(window, 6, 6), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn explicit_no_pause_keeps_steady_soak_free_of_pause_actions() {
+        assert_eq!(scheduled_action_count(0, None), 0);
+        assert_eq!(
+            scheduled_action_count(5, Some(Duration::from_millis(500))),
+            6
+        );
+    }
+
+    #[test]
+    fn resume_progress_rejects_pause_boundary_jitter() {
+        let paused = 66.429_486;
+        let time_pos = |position| {
+            json!({
+                "event": "property-change",
+                "name": "time-pos",
+                "data": position,
+            })
+        };
+
+        assert!(!proves_resume_progress(&time_pos(66.429_563), paused));
+        assert!(proves_resume_progress(&time_pos(66.526_510), paused));
+        assert!(!proves_resume_progress(
+            &json!({"event": "playback-restart"}),
+            paused
+        ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn drain_until_keeps_collecting_buffering_for_the_full_window() {
+        let path = std::env::temp_dir().join(format!(
+            "ytt-tui-perf-control-{}-{}.ndjson",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock must be after epoch")
+                .as_nanos()
+        ));
+        let mut out = BufWriter::new(File::create(&path).expect("create test output"));
+        let origin = Instant::now();
+        let mut telemetry = Telemetry::new(origin);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        tx.send(IpcEvent {
+            observed_at: origin + Duration::from_millis(2),
+            value: json!({
+                "event": "property-change",
+                "name": "paused-for-cache",
+                "data": true,
+            }),
+        })
+        .expect("send buffering start");
+        tx.send(IpcEvent {
+            observed_at: origin + Duration::from_millis(7),
+            value: json!({
+                "event": "property-change",
+                "name": "paused-for-cache",
+                "data": false,
+            }),
+        })
+        .expect("send buffering end");
+
+        let drain_started = Instant::now();
+        let end = drain_until(
+            drain_started + Duration::from_millis(40),
+            &mut rx,
+            &mut telemetry,
+            &mut out,
+        )
+        .await
+        .expect("drain observation window");
+
+        assert_eq!(end, DrainEnd::Deadline);
+        assert!(drain_started.elapsed() >= Duration::from_millis(30));
+        assert_eq!(telemetry.buffering_events, 1);
+        assert_eq!(telemetry.buffering_total, Duration::from_millis(5));
+        drop(tx);
+        drop(out);
+        std::fs::remove_file(path).expect("remove test output");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn clean_mpv_close_finishes_after_queued_telemetry_is_recorded() {
+        let path = std::env::temp_dir().join(format!(
+            "ytt-tui-perf-control-close-{}-{}.ndjson",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock must be after epoch")
+                .as_nanos()
+        ));
+        let mut out = BufWriter::new(File::create(&path).expect("create test output"));
+        let origin = Instant::now();
+        let mut telemetry = Telemetry::new(origin);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        for (elapsed_ms, paused) in [(2, true), (9, false)] {
+            tx.send(IpcEvent {
+                observed_at: origin + Duration::from_millis(elapsed_ms),
+                value: json!({
+                    "event": "property-change",
+                    "name": "paused-for-cache",
+                    "data": paused,
+                }),
+            })
+            .expect("queue telemetry before close");
+        }
+        drop(tx);
+
+        let end = drain_until(
+            Instant::now() + Duration::from_secs(1),
+            &mut rx,
+            &mut telemetry,
+            &mut out,
+        )
+        .await
+        .expect("clean observer close is a valid final boundary");
+
+        assert_eq!(end, DrainEnd::ObserverClosed);
+        assert_eq!(telemetry.buffering_events, 1);
+        assert_eq!(telemetry.buffering_total, Duration::from_millis(7));
+        drop(out);
+        std::fs::remove_file(path).expect("remove test output");
+    }
+}

--- a/examples/tui_perf_sampler.rs
+++ b/examples/tui_perf_sampler.rs
@@ -8,6 +8,8 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufWriter, Write};
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::thread;
@@ -18,30 +20,33 @@ use sha2::{Digest, Sha256};
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, Signal, System, UpdateKind};
 
 const SCHEMA: &str = "ytt.tui-perf.samples.v1";
+const CLEANUP_SCOPE: &str = "dedicated_owner_process_group_and_observed_exact_descendants";
 
 #[derive(Debug)]
 struct Args {
     output: PathBuf,
     pid_file: Option<PathBuf>,
+    identity_file: PathBuf,
+    controller_ready_file: Option<PathBuf>,
     binary: PathBuf,
     child_args: Vec<String>,
     warmup: Duration,
     duration: Duration,
     interval: Duration,
     require_silent_mpv: bool,
-    keep_running: bool,
 }
 
 impl Args {
     fn parse() -> Result<Self, String> {
         let mut output = None;
         let mut pid_file = None;
+        let mut identity_file = None;
+        let mut controller_ready_file = None;
         let mut binary = None;
         let mut warmup_secs = 0.0;
         let mut duration_secs = 60.0;
         let mut interval_ms = 1_000u64;
         let mut require_silent_mpv = false;
-        let mut keep_running = false;
         let mut child_args = Vec::new();
         let mut raw = std::env::args().skip(1).peekable();
 
@@ -58,6 +63,13 @@ impl Args {
             match arg.as_str() {
                 "--output" => output = Some(PathBuf::from(value("--output", &mut raw)?)),
                 "--pid-file" => pid_file = Some(PathBuf::from(value("--pid-file", &mut raw)?)),
+                "--identity-file" => {
+                    identity_file = Some(PathBuf::from(value("--identity-file", &mut raw)?))
+                }
+                "--controller-ready-file" => {
+                    controller_ready_file =
+                        Some(PathBuf::from(value("--controller-ready-file", &mut raw)?))
+                }
                 "--binary" => binary = Some(PathBuf::from(value("--binary", &mut raw)?)),
                 "--warmup-secs" => {
                     warmup_secs =
@@ -77,7 +89,6 @@ impl Args {
                         .ok_or_else(|| "--interval-ms must be an integer >= 100".to_string())?;
                 }
                 "--require-silent-mpv" => require_silent_mpv = true,
-                "--keep-running" => keep_running = true,
                 "-h" | "--help" => return Err(usage().to_string()),
                 other => return Err(format!("unknown argument `{other}`\n\n{}", usage())),
             }
@@ -86,13 +97,15 @@ impl Args {
         Ok(Self {
             output: output.ok_or_else(|| "--output is required".to_string())?,
             pid_file,
+            identity_file: identity_file
+                .ok_or_else(|| "--identity-file is required".to_string())?,
+            controller_ready_file,
             binary: binary.ok_or_else(|| "--binary is required".to_string())?,
             child_args,
             warmup: Duration::from_secs_f64(warmup_secs),
             duration: Duration::from_secs_f64(duration_secs),
             interval: Duration::from_millis(interval_ms),
             require_silent_mpv,
-            keep_running,
         })
     }
 }
@@ -101,11 +114,13 @@ fn usage() -> &'static str {
     "Usage: tui_perf_sampler --output FILE --binary YTT [options] [-- YTT_ARGS...]\n\
      Options:\n\
        --pid-file FILE          Write the launched ytt PID atomically\n\
+       --identity-file FILE     Atomically maintain exact owner/mpv cleanup identity\n\
+       --controller-ready-file FILE\n\
+                                Wait for confirmed mpv subscriptions before sampling\n\
        --warmup-secs N          Warm-up samples excluded from the summary (default 0)\n\
        --duration-secs N        Measured duration (default 60)\n\
        --interval-ms N          Sampling interval, at least 100 ms (default 1000)\n\
-       --require-silent-mpv     Fail unless effective mpv argv has ao=null and volume=0\n\
-       --keep-running           Do not remote-quit/terminate ytt after sampling"
+       --require-silent-mpv     Fail unless effective mpv argv has ao=null and volume=0"
 }
 
 fn parse_nonnegative_f64(name: &str, raw: &str) -> Result<f64, String> {
@@ -129,7 +144,7 @@ struct RoleSample {
     rss_bytes: u64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 struct ProcessSample {
     pid: u32,
     parent_pid: Option<u32>,
@@ -140,6 +155,20 @@ struct ProcessSample {
     cpu_percent: f64,
     rss_bytes: u64,
     command: Vec<String>,
+    executable: Option<PathBuf>,
+    executable_bytes: Option<u64>,
+    executable_sha256: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct DescendantIdentity {
+    pid: u32,
+    start_time_unix_s: u64,
+    executable: PathBuf,
+    executable_bytes: u64,
+    executable_sha256: String,
+    role: &'static str,
+    command: Vec<String>,
 }
 
 /// The exact mpv descendant identity retained for cleanup after ytt exits. `start_time_unix_s`
@@ -149,8 +178,30 @@ struct ProcessSample {
 struct MpvIdentity {
     pid: u32,
     start_time_unix_s: u64,
+    executable: PathBuf,
+    executable_bytes: u64,
+    executable_sha256: String,
     input_ipc_server_argv: Vec<String>,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct LiveProcessIdentity {
+    pid: u32,
+    start_time_unix_s: u64,
+    process_group_id: Option<u32>,
+    executable: PathBuf,
+    executable_bytes: u64,
+    executable_sha256: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct PartialProcessIdentity {
+    pid: u32,
+    start_time_unix_s: u64,
+    process_group_id: Option<u32>,
+}
+
+type ProcessInventory = (Vec<DescendantIdentity>, Vec<MpvIdentity>);
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
 struct MeasuredMpvProof {
@@ -195,28 +246,42 @@ struct CpuPoint {
 #[derive(Clone, Copy, Default)]
 struct Aggregate {
     samples: u64,
-    cpu_sum: f64,
+    cpu_weighted_percent_seconds: f64,
     rss_sum: u128,
     rss_peak: u64,
 }
 
 impl Aggregate {
-    fn push(&mut self, value: RoleSample) {
+    fn push(&mut self, value: RoleSample, cpu_interval_overlap: Duration) {
         self.samples += 1;
-        self.cpu_sum += value.cpu_percent;
+        self.cpu_weighted_percent_seconds += value.cpu_percent * cpu_interval_overlap.as_secs_f64();
         self.rss_sum += u128::from(value.rss_bytes);
         self.rss_peak = self.rss_peak.max(value.rss_bytes);
     }
 
-    fn json(&self) -> serde_json::Value {
-        let divisor = self.samples.max(1) as f64;
+    fn json(&self, cpu_window: Duration) -> serde_json::Value {
+        let rss_divisor = self.samples.max(1);
         serde_json::json!({
             "samples": self.samples,
-            "mean_cpu_percent": self.cpu_sum / divisor,
-            "mean_rss_bytes": (self.rss_sum / u128::from(self.samples.max(1))) as u64,
+            "mean_cpu_percent": self.cpu_weighted_percent_seconds / cpu_window.as_secs_f64(),
+            "mean_rss_bytes": (self.rss_sum / u128::from(rss_divisor)) as u64,
             "peak_rss_bytes": self.rss_peak,
         })
     }
+}
+
+fn cpu_interval_overlap(
+    previous: Option<Duration>,
+    observed: Duration,
+    window_start: Duration,
+    window_end: Duration,
+) -> Duration {
+    let Some(previous) = previous else {
+        return Duration::ZERO;
+    };
+    let overlap_start = previous.max(window_start);
+    let overlap_end = observed.min(window_end);
+    overlap_end.saturating_sub(overlap_start)
 }
 
 fn main() {
@@ -231,6 +296,8 @@ fn main() {
 }
 
 fn run(args: Args) -> Result<(), String> {
+    let run_id =
+        std::env::var("TUI_PERF_RUN_ID").map_err(|_| "TUI_PERF_RUN_ID is required".to_string())?;
     if let Some(parent) = args.output.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("create output directory {}: {e}", parent.display()))?;
@@ -240,44 +307,190 @@ fn run(args: Args) -> Result<(), String> {
     let mut out = BufWriter::new(file);
 
     let binary_hash = sha256_file(&args.binary)?;
-    let mut child = Command::new(&args.binary)
+    let producer_binary_hash = producer_binary_sha256()?;
+    let producer_identity = current_process_identity()?;
+    let mut last_mpv_identities = Vec::new();
+    let mut last_descendant_identities = Vec::new();
+    write_live_identity(
+        &args.identity_file,
+        "startup",
+        &producer_identity,
+        None,
+        None,
+        &last_mpv_identities,
+        &last_descendant_identities,
+        false,
+    )?;
+    let mut owner_command = Command::new(&args.binary);
+    owner_command
         .args(&args.child_args)
+        .env_remove("YTM_PERF")
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    #[cfg(unix)]
+    owner_command.process_group(0);
+    let mut child = owner_command
         .spawn()
         .map_err(|e| format!("launch {}: {e}", args.binary.display()))?;
     let root_pid = child.id();
-
-    if let Some(path) = &args.pid_file {
-        write_pid_file(path, root_pid)?;
+    let partial_owner = match wait_for_partial_process_identity(root_pid, &mut child) {
+        Ok(identity) => identity,
+        Err(error) => {
+            return Err(cleanup_after_startup_error(
+                &args,
+                &producer_identity,
+                None,
+                &mut child,
+                error,
+            ));
+        }
+    };
+    if let Err(error) = write_live_identity(
+        &args.identity_file,
+        "owner_starting",
+        &producer_identity,
+        None,
+        Some(&partial_owner),
+        &last_mpv_identities,
+        &last_descendant_identities,
+        false,
+    ) {
+        return Err(cleanup_after_startup_error(
+            &args,
+            &producer_identity,
+            Some(&partial_owner),
+            &mut child,
+            error,
+        ));
+    }
+    let owner_identity = match wait_for_process_identity(root_pid, &binary_hash, &mut child) {
+        Ok(identity) => identity,
+        Err(error) => {
+            return Err(cleanup_after_startup_error(
+                &args,
+                &producer_identity,
+                Some(&partial_owner),
+                &mut child,
+                error,
+            ));
+        }
+    };
+    if let Err(error) = write_live_identity(
+        &args.identity_file,
+        "running",
+        &producer_identity,
+        Some(&owner_identity),
+        Some(&partial_owner),
+        &last_mpv_identities,
+        &last_descendant_identities,
+        false,
+    ) {
+        return Err(cleanup_after_startup_error(
+            &args,
+            &producer_identity,
+            Some(&partial_owner),
+            &mut child,
+            error,
+        ));
     }
 
-    let mut last_mpv_identities = Vec::new();
-    let sample_result = sample_process_tree(
-        &args,
-        root_pid,
-        binary_hash,
-        &mut child,
-        &mut out,
-        &mut last_mpv_identities,
-    );
-    let cleanup_result = if args.keep_running {
-        Ok(())
-    } else {
-        shutdown_child(
-            &args.binary,
+    if let Some(path) = &args.pid_file
+        && let Err(error) = write_pid_file(path, root_pid)
+    {
+        return Err(cleanup_after_startup_error(
+            &args,
+            &producer_identity,
+            Some(&partial_owner),
             &mut child,
-            &last_mpv_identities,
-            args.require_silent_mpv,
+            error,
+        ));
+    }
+    let barrier_result = if let Some(path) = &args.controller_ready_file {
+        wait_for_controller_ready(
+            path,
+            root_pid,
+            &mut child,
+            &args.identity_file,
+            &producer_identity,
+            &owner_identity,
+            &run_id,
+            &mut last_mpv_identities,
+            &mut last_descendant_identities,
+        )
+    } else {
+        // Close the smaller non-controller startup window before the first timed sample.
+        capture_live_descendant_identities(
+            root_pid,
+            &args.identity_file,
+            &producer_identity,
+            &owner_identity,
+            &mut last_mpv_identities,
+            &mut last_descendant_identities,
         )
     };
-    let result = match (sample_result, cleanup_result) {
+    let sample_result = barrier_result.and_then(|()| {
+        sample_process_tree(
+            &args,
+            root_pid,
+            binary_hash,
+            producer_binary_hash,
+            &run_id,
+            &mut child,
+            &mut out,
+            &mut last_mpv_identities,
+            &mut last_descendant_identities,
+            &producer_identity,
+            &owner_identity,
+        )
+    });
+    let cleanup_result = shutdown_measured_tree(
+        &args.binary,
+        &mut child,
+        &producer_identity,
+        &owner_identity,
+        &mut last_mpv_identities,
+        &mut last_descendant_identities,
+        args.require_silent_mpv,
+        |mpv, descendants| {
+            write_live_identity(
+                &args.identity_file,
+                "cleanup_requested",
+                &producer_identity,
+                Some(&owner_identity),
+                Some(&partial_owner),
+                mpv,
+                descendants,
+                false,
+            )
+        },
+    );
+    let cleanup_succeeded = cleanup_result.is_ok();
+    let mut result = match (sample_result, cleanup_result) {
         (Err(sample), Err(cleanup)) => Err(format!("{sample}; cleanup also failed: {cleanup}")),
         (Err(sample), Ok(())) => Err(sample),
         (Ok(()), Err(cleanup)) => Err(cleanup),
         (Ok(()), Ok(())) => Ok(()),
     };
+    if cleanup_succeeded
+        && let Err(cleanup_proof_error) = write_live_identity(
+            &args.identity_file,
+            "cleaned",
+            &producer_identity,
+            Some(&owner_identity),
+            Some(&partial_owner),
+            &last_mpv_identities,
+            &last_descendant_identities,
+            true,
+        )
+    {
+        result = Err(match result {
+            Ok(()) => cleanup_proof_error,
+            Err(error) => format!(
+                "{error}; publishing completed cleanup proof also failed: {cleanup_proof_error}"
+            ),
+        });
+    }
     if let Err(message) = &result {
         let _ = write_ndjson(
             &mut out,
@@ -293,15 +506,27 @@ fn run(args: Args) -> Result<(), String> {
     result
 }
 
+#[allow(clippy::too_many_arguments)]
 fn sample_process_tree(
     args: &Args,
     root_pid: u32,
     binary_hash: String,
+    producer_binary_hash: String,
+    run_id: &str,
     child: &mut Child,
     out: &mut BufWriter<File>,
     last_mpv_identities: &mut Vec<MpvIdentity>,
+    last_descendant_identities: &mut Vec<DescendantIdentity>,
+    producer_identity: &LiveProcessIdentity,
+    owner_identity: &LiveProcessIdentity,
 ) -> Result<(), String> {
     let started = Instant::now();
+    let terminal_geometry = crossterm::terminal::size()
+        .map_err(|error| format!("query measured PTY geometry: {error}"))?;
+    let observation_started_unix_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| format!("system clock before Unix epoch: {e}"))?
+        .as_nanos();
     let deadline = args.warmup + args.duration;
     let mut system = System::new();
     let refresh = ProcessRefreshKind::nothing()
@@ -312,30 +537,25 @@ fn sample_process_tree(
         .without_tasks();
     let mut identities: HashMap<u32, u64> = HashMap::new();
     let mut cpu_points: HashMap<u32, CpuPoint> = HashMap::new();
+    let mut executable_identities: HashMap<(u32, u64), (PathBuf, u64, String)> = HashMap::new();
     let mut measured: BTreeMap<&'static str, Aggregate> = BTreeMap::new();
     let mut measured_mpv_proof = MeasuredMpvProof::default();
-    let mut first = true;
+    let mut previous_observed_elapsed = None;
 
     write_ndjson(
         out,
-        &serde_json::json!({
-            "schema": SCHEMA,
-            "kind": "header",
-            "root_pid": root_pid,
-            "binary": args.binary,
-            "binary_sha256": binary_hash,
-            "scenario_sha256": std::env::var("TUI_PERF_SCENARIO_SHA256").ok(),
-            "os": std::env::consts::OS,
-            "arch": std::env::consts::ARCH,
-            "warmup_ms": args.warmup.as_millis(),
-            "duration_ms": args.duration.as_millis(),
-            "interval_ms": args.interval.as_millis(),
-            "require_silent_mpv": args.require_silent_mpv,
-        }),
+        &header_record(
+            args,
+            root_pid,
+            &binary_hash,
+            &producer_binary_hash,
+            run_id,
+            observation_started_unix_ns,
+            terminal_geometry,
+        ),
     )?;
 
-    while first || started.elapsed() < deadline {
-        first = false;
+    loop {
         if let Some(status) = child
             .try_wait()
             .map_err(|e| format!("query ytt child status: {e}"))?
@@ -360,6 +580,13 @@ fn sample_process_tree(
 
         let tree = descendant_pids(&system, root_pid);
         let observed_at = Instant::now();
+        let observed_elapsed = observed_at.saturating_duration_since(started);
+        let cpu_overlap = cpu_interval_overlap(
+            previous_observed_elapsed,
+            observed_elapsed,
+            args.warmup,
+            deadline,
+        );
         let mut process_samples = Vec::with_capacity(tree.len());
         let mut roles: BTreeMap<&'static str, RoleSample> = BTreeMap::new();
         let mut observed_mpv_identities = Vec::new();
@@ -406,12 +633,55 @@ fn sample_process_tree(
                 .map(|part| part.to_string_lossy().into_owned())
                 .collect::<Vec<_>>();
             let role = process_role(root_pid, pid, &process.name().to_string_lossy(), &command);
+            let executable_identity =
+                if let Some(identity) = executable_identities.get(&(pid, start_time)) {
+                    Some(identity.clone())
+                } else if let Some(executable) = process.exe() {
+                    let canonical = executable.canonicalize().map_err(|e| {
+                        format!(
+                            "canonicalize executable for PID {pid} {}: {e}",
+                            executable.display()
+                        )
+                    })?;
+                    let bytes = canonical
+                        .metadata()
+                        .map_err(|e| {
+                            format!("stat executable for PID {pid} {}: {e}", canonical.display())
+                        })?
+                        .len();
+                    let sha256 = sha256_file(&canonical)?;
+                    let identity = (canonical, bytes, sha256);
+                    executable_identities.insert((pid, start_time), identity.clone());
+                    Some(identity)
+                } else {
+                    None
+                };
+            if executable_identity.is_none() {
+                return Err(format!(
+                    "measured {role} PID {pid} has no executable identity; exact recursive cleanup cannot be proven"
+                ));
+            }
+            if pid == root_pid
+                && executable_identity
+                    .as_ref()
+                    .is_some_and(|(_, _, sha256)| sha256 != &binary_hash)
+            {
+                return Err(
+                    "root executable hash differs from the requested ytt binary".to_string()
+                );
+            }
             if role == "mpv" {
                 mpv_silence.push(silent_mpv_args(&command));
                 if let Some(input_ipc_server_argv) = input_ipc_server_argv(&command) {
+                    let (executable, executable_bytes, executable_sha256) = executable_identity
+                        .as_ref()
+                        .expect("mpv executable identity is required");
                     observed_mpv_identities.push(MpvIdentity {
                         pid,
                         start_time_unix_s: start_time,
+                        executable: executable.clone(),
+                        executable_bytes: *executable_bytes,
+                        executable_sha256: executable_sha256.clone(),
                         input_ipc_server_argv,
                     });
                 }
@@ -430,6 +700,11 @@ fn sample_process_tree(
                 cpu_percent,
                 rss_bytes: process.memory(),
                 command,
+                executable: executable_identity
+                    .as_ref()
+                    .map(|(path, _, _)| path.clone()),
+                executable_bytes: executable_identity.as_ref().map(|(_, bytes, _)| *bytes),
+                executable_sha256: executable_identity.map(|(_, _, sha256)| sha256),
             });
         }
 
@@ -443,24 +718,67 @@ fn sample_process_tree(
                 sum
             });
         roles.insert("tree", total);
-        let phase = if started.elapsed() < args.warmup {
+        let phase = if observed_elapsed < args.warmup {
             "warmup"
         } else {
             measured_mpv_proof.observe(&mpv_silence, observed_mpv_identities.len());
             for (role, sample) in &roles {
-                measured.entry(role).or_default().push(*sample);
+                measured.entry(role).or_default().push(*sample, cpu_overlap);
             }
             "measure"
         };
-        if !observed_mpv_identities.is_empty() {
-            *last_mpv_identities = observed_mpv_identities;
+        let observed_descendant_identities = process_samples
+            .iter()
+            .filter(|process| process.pid != root_pid)
+            .map(|process| DescendantIdentity {
+                pid: process.pid,
+                start_time_unix_s: process.start_time_unix_s,
+                executable: process
+                    .executable
+                    .clone()
+                    .expect("every measured descendant has an executable identity"),
+                executable_bytes: process
+                    .executable_bytes
+                    .expect("every measured descendant has executable bytes"),
+                executable_sha256: process
+                    .executable_sha256
+                    .clone()
+                    .expect("every measured descendant has an executable hash"),
+                role: process.role,
+                command: process.command.clone(),
+            })
+            .collect::<Vec<_>>();
+        let observed_descendant_identities = merge_live_descendants(
+            &system,
+            last_descendant_identities,
+            observed_descendant_identities,
+        );
+        let observed_mpv_identities =
+            merge_live_mpv(&system, last_mpv_identities, observed_mpv_identities);
+        let identity_changed = *last_descendant_identities != observed_descendant_identities
+            || *last_mpv_identities != observed_mpv_identities;
+        *last_descendant_identities = observed_descendant_identities;
+        *last_mpv_identities = observed_mpv_identities;
+        if identity_changed {
+            write_live_identity(
+                &args.identity_file,
+                "running",
+                producer_identity,
+                Some(owner_identity),
+                None,
+                last_mpv_identities,
+                last_descendant_identities,
+                false,
+            )?;
         }
         write_ndjson(
             out,
             &serde_json::json!({
                 "schema": SCHEMA,
                 "kind": "sample",
-                "elapsed_ms": started.elapsed().as_millis(),
+                "elapsed_ms": observed_elapsed.as_millis(),
+                "observed_elapsed_ns": observed_elapsed.as_nanos(),
+                "cpu_interval_overlap_ns": cpu_overlap.as_nanos(),
                 "phase": phase,
                 "mpv_present": !mpv_silence.is_empty(),
                 "mpv_all_silent_this_sample": !mpv_silence.is_empty()
@@ -470,6 +788,11 @@ fn sample_process_tree(
             }),
         )?;
         out.flush().map_err(|e| format!("flush samples: {e}"))?;
+        previous_observed_elapsed = Some(observed_elapsed);
+
+        if observed_elapsed >= deadline {
+            break;
+        }
 
         let next_index =
             (started.elapsed().as_secs_f64() / args.interval.as_secs_f64()).floor() as u32 + 1;
@@ -498,17 +821,26 @@ fn sample_process_tree(
     }
     let summary = measured
         .iter()
-        .map(|(role, aggregate)| ((*role).to_string(), aggregate.json()))
+        .map(|(role, aggregate)| ((*role).to_string(), aggregate.json(args.duration)))
         .collect::<serde_json::Map<_, _>>();
     write_ndjson(
         out,
         &serde_json::json!({
             "schema": SCHEMA,
             "kind": "summary",
+            "run_id": run_id,
+            "cpu_accounting": "time_weighted_counter_deltas_clamped_to_measure_window",
+            "cpu_window_start_ns": args.warmup.as_nanos(),
+            "cpu_window_end_ns": deadline.as_nanos(),
+            "terminal_geometry": [terminal_geometry.0, terminal_geometry.1],
             "root_pid": root_pid,
             "silent_mpv_proven": silent_mpv_proven,
             "measured_mpv_proof": measured_mpv_proof,
             "last_observed_mpv": last_mpv_identities,
+            "observation_finished_unix_ns": std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|e| format!("system clock before Unix epoch: {e}"))?
+                .as_nanos(),
             "roles": summary,
         }),
     )?;
@@ -615,6 +947,457 @@ fn exact_mpv_identity_matches(
         && input_ipc_server_argv(command).as_ref() == Some(&identity.input_ipc_server_argv)
 }
 
+fn mpv_executable_matches(identity: &MpvIdentity, process: &sysinfo::Process) -> bool {
+    process
+        .exe()
+        .and_then(|path| path.canonicalize().ok())
+        .is_some_and(|path| path == identity.executable)
+        && identity
+            .executable
+            .metadata()
+            .ok()
+            .is_some_and(|metadata| metadata.len() == identity.executable_bytes)
+        && sha256_file(&identity.executable).ok().as_deref()
+            == Some(identity.executable_sha256.as_str())
+}
+
+fn exact_descendant_matches(identity: &DescendantIdentity, process: &sysinfo::Process) -> bool {
+    if process.start_time() != identity.start_time_unix_s {
+        return false;
+    }
+    let command = process
+        .cmd()
+        .iter()
+        .map(|part| part.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    command == identity.command
+        && process
+            .exe()
+            .and_then(|path| path.canonicalize().ok())
+            .is_some_and(|path| path == identity.executable)
+        && identity
+            .executable
+            .metadata()
+            .ok()
+            .is_some_and(|metadata| metadata.len() == identity.executable_bytes)
+        && sha256_file(&identity.executable).ok().as_deref()
+            == Some(identity.executable_sha256.as_str())
+}
+
+fn merge_live_descendants(
+    system: &System,
+    previous: &[DescendantIdentity],
+    current: Vec<DescendantIdentity>,
+) -> Vec<DescendantIdentity> {
+    let mut merged = current
+        .into_iter()
+        .map(|identity| ((identity.pid, identity.start_time_unix_s), identity))
+        .collect::<BTreeMap<_, _>>();
+    for identity in previous {
+        let key = (identity.pid, identity.start_time_unix_s);
+        if !merged.contains_key(&key)
+            && system
+                .process(sysinfo::Pid::from_u32(identity.pid))
+                .is_some_and(|process| exact_descendant_matches(identity, process))
+        {
+            merged.insert(key, identity.clone());
+        }
+    }
+    merged.into_values().collect()
+}
+
+fn merge_live_mpv(
+    system: &System,
+    previous: &[MpvIdentity],
+    current: Vec<MpvIdentity>,
+) -> Vec<MpvIdentity> {
+    let mut merged = current
+        .into_iter()
+        .map(|identity| ((identity.pid, identity.start_time_unix_s), identity))
+        .collect::<BTreeMap<_, _>>();
+    for identity in previous {
+        let key = (identity.pid, identity.start_time_unix_s);
+        if !merged.contains_key(&key)
+            && system
+                .process(sysinfo::Pid::from_u32(identity.pid))
+                .is_some_and(|process| {
+                    let command = process
+                        .cmd()
+                        .iter()
+                        .map(|part| part.to_string_lossy().into_owned())
+                        .collect::<Vec<_>>();
+                    mpv_executable_matches(identity, process)
+                        && exact_mpv_identity_matches(
+                            identity,
+                            identity.pid,
+                            process.start_time(),
+                            &command,
+                        )
+                })
+        {
+            merged.insert(key, identity.clone());
+        }
+    }
+    merged.into_values().collect()
+}
+
+fn wait_for_partial_process_identity(
+    pid: u32,
+    child: &mut Child,
+) -> Result<PartialProcessIdentity, String> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let refresh = ProcessRefreshKind::nothing().without_tasks();
+    let mut system = System::new();
+    loop {
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+        if let Some(process) = system.process(sysinfo::Pid::from_u32(pid)) {
+            return Ok(PartialProcessIdentity {
+                pid,
+                start_time_unix_s: process.start_time(),
+                process_group_id: process_group_id(pid)?,
+            });
+        }
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| format!("query owner while capturing startup identity: {e}"))?
+        {
+            return Err(format!(
+                "ytt exited before startup identity capture: {status}"
+            ));
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "timed out capturing startup identity for owner PID {pid}"
+            ));
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_for_process_identity(
+    pid: u32,
+    expected_sha256: &str,
+    child: &mut Child,
+) -> Result<LiveProcessIdentity, String> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let refresh = ProcessRefreshKind::nothing()
+        .with_exe(UpdateKind::Always)
+        .without_tasks();
+    let mut system = System::new();
+    loop {
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+        if let Some(process) = system.process(sysinfo::Pid::from_u32(pid))
+            && let Some(executable) = process.exe()
+        {
+            let executable = executable
+                .canonicalize()
+                .map_err(|e| format!("canonicalize owner executable: {e}"))?;
+            let executable_bytes = executable
+                .metadata()
+                .map_err(|e| format!("stat owner executable: {e}"))?
+                .len();
+            let executable_sha256 = sha256_file(&executable)?;
+            if executable_sha256 != expected_sha256 {
+                return Err("spawned owner executable hash differs from --binary".to_string());
+            }
+            return Ok(LiveProcessIdentity {
+                pid,
+                start_time_unix_s: process.start_time(),
+                process_group_id: process_group_id(pid)?,
+                executable,
+                executable_bytes,
+                executable_sha256,
+            });
+        }
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| format!("query owner while capturing identity: {e}"))?
+        {
+            return Err(format!("ytt exited before identity capture: {status}"));
+        }
+        if Instant::now() >= deadline {
+            return Err(format!("timed out capturing identity for owner PID {pid}"));
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn current_process_identity() -> Result<LiveProcessIdentity, String> {
+    let pid = std::process::id();
+    let refresh = ProcessRefreshKind::nothing()
+        .with_exe(UpdateKind::Always)
+        .without_tasks();
+    let mut system = System::new();
+    system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+    let process = system
+        .process(sysinfo::Pid::from_u32(pid))
+        .ok_or_else(|| format!("sampler PID {pid} is not observable"))?;
+    let executable = process
+        .exe()
+        .ok_or_else(|| format!("sampler PID {pid} has no executable path"))?
+        .canonicalize()
+        .map_err(|e| format!("canonicalize sampler executable: {e}"))?;
+    let executable_bytes = executable
+        .metadata()
+        .map_err(|e| format!("stat sampler executable: {e}"))?
+        .len();
+    Ok(LiveProcessIdentity {
+        pid,
+        start_time_unix_s: process.start_time(),
+        process_group_id: process_group_id(pid)?,
+        executable_sha256: sha256_file(&executable)?,
+        executable,
+        executable_bytes,
+    })
+}
+
+#[cfg(unix)]
+fn process_group_id(pid: u32) -> Result<Option<u32>, String> {
+    observed_process_group_id(pid)
+        .map(Some)
+        .ok_or_else(|| format!("getpgid({pid}) failed: {}", std::io::Error::last_os_error()))
+}
+
+#[cfg(not(unix))]
+fn process_group_id(_pid: u32) -> Result<Option<u32>, String> {
+    Ok(None)
+}
+
+#[cfg(unix)]
+fn observed_process_group_id(pid: u32) -> Option<u32> {
+    let pid = i32::try_from(pid).ok()?;
+    // SAFETY: getpgid only reads kernel process metadata for the supplied numeric PID.
+    let group = unsafe { libc::getpgid(pid) };
+    (group >= 0).then_some(group as u32)
+}
+
+#[cfg(not(unix))]
+fn observed_process_group_id(_pid: u32) -> Option<u32> {
+    None
+}
+
+fn discover_descendant_identities(
+    system: &mut System,
+    executable_identities: &mut HashMap<(u32, u64), (PathBuf, u64, String)>,
+    root_pid: u32,
+    include_process_group: Option<u32>,
+    protected_pid: Option<u32>,
+) -> Result<Option<ProcessInventory>, String> {
+    let refresh = ProcessRefreshKind::nothing()
+        .with_cmd(UpdateKind::Always)
+        .with_exe(UpdateKind::Always)
+        .without_tasks();
+    system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+    if system.process(sysinfo::Pid::from_u32(root_pid)).is_none() {
+        return Ok(None);
+    }
+    let mut candidate_pids = descendant_pids(system, root_pid)
+        .into_iter()
+        .filter(|pid| *pid != root_pid)
+        .collect::<HashSet<_>>();
+    if let Some(group) = include_process_group {
+        candidate_pids.extend(system.processes().keys().filter_map(|pid| {
+            let pid = pid.as_u32();
+            (pid != root_pid
+                && Some(pid) != protected_pid
+                && observed_process_group_id(pid) == Some(group))
+            .then_some(pid)
+        }));
+    }
+    let mut candidate_pids = candidate_pids.into_iter().collect::<Vec<_>>();
+    candidate_pids.sort_unstable();
+    let mut descendants = Vec::new();
+    let mut mpv = Vec::new();
+    for pid in candidate_pids {
+        let Some(process) = system.process(sysinfo::Pid::from_u32(pid)) else {
+            return Ok(None);
+        };
+        let start_time = process.start_time();
+        let command = process
+            .cmd()
+            .iter()
+            .map(|part| part.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        let role = process_role(root_pid, pid, &process.name().to_string_lossy(), &command);
+        let executable_identity =
+            if let Some(identity) = executable_identities.get(&(pid, start_time)) {
+                identity.clone()
+            } else {
+                let Some(path) = process.exe() else {
+                    // A just-forked process may not have completed exec. Retrying is safer than
+                    // publishing an incomplete recursive-tree claim.
+                    return Ok(None);
+                };
+                let executable = path.canonicalize().map_err(|e| {
+                    format!(
+                        "canonicalize startup descendant executable for PID {pid} {}: {e}",
+                        path.display()
+                    )
+                })?;
+                let executable_bytes = executable
+                    .metadata()
+                    .map_err(|e| {
+                        format!(
+                            "stat startup descendant executable for PID {pid} {}: {e}",
+                            executable.display()
+                        )
+                    })?
+                    .len();
+                let identity = (
+                    executable.clone(),
+                    executable_bytes,
+                    sha256_file(&executable)?,
+                );
+                executable_identities.insert((pid, start_time), identity.clone());
+                identity
+            };
+        let identity = DescendantIdentity {
+            pid,
+            start_time_unix_s: start_time,
+            executable: executable_identity.0.clone(),
+            executable_bytes: executable_identity.1,
+            executable_sha256: executable_identity.2.clone(),
+            role,
+            command: command.clone(),
+        };
+        if role == "mpv"
+            && let Some(input_ipc_server_argv) = input_ipc_server_argv(&command)
+        {
+            mpv.push(MpvIdentity {
+                pid,
+                start_time_unix_s: start_time,
+                executable: executable_identity.0,
+                executable_bytes: executable_identity.1,
+                executable_sha256: executable_identity.2,
+                input_ipc_server_argv,
+            });
+        }
+        descendants.push(identity);
+    }
+    descendants.sort_by_key(|identity| identity.pid);
+    mpv.sort_by_key(|identity| identity.pid);
+    Ok(Some((descendants, mpv)))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn capture_live_descendant_identities_with_system(
+    root_pid: u32,
+    identity_file: &Path,
+    producer: &LiveProcessIdentity,
+    owner: &LiveProcessIdentity,
+    last_mpv: &mut Vec<MpvIdentity>,
+    last_descendants: &mut Vec<DescendantIdentity>,
+    system: &mut System,
+    executable_identities: &mut HashMap<(u32, u64), (PathBuf, u64, String)>,
+) -> Result<(), String> {
+    let Some((descendants, mpv)) =
+        discover_descendant_identities(system, executable_identities, root_pid, None, None)?
+    else {
+        return Ok(());
+    };
+    let descendants = merge_live_descendants(system, last_descendants, descendants);
+    let mpv = merge_live_mpv(system, last_mpv, mpv);
+    if descendants != *last_descendants || mpv != *last_mpv {
+        *last_descendants = descendants;
+        *last_mpv = mpv;
+        write_live_identity(
+            identity_file,
+            "running",
+            producer,
+            Some(owner),
+            None,
+            last_mpv,
+            last_descendants,
+            false,
+        )?;
+    }
+    Ok(())
+}
+
+fn capture_live_descendant_identities(
+    root_pid: u32,
+    identity_file: &Path,
+    producer: &LiveProcessIdentity,
+    owner: &LiveProcessIdentity,
+    last_mpv: &mut Vec<MpvIdentity>,
+    last_descendants: &mut Vec<DescendantIdentity>,
+) -> Result<(), String> {
+    let mut system = System::new();
+    let mut executable_identities = HashMap::new();
+    capture_live_descendant_identities_with_system(
+        root_pid,
+        identity_file,
+        producer,
+        owner,
+        last_mpv,
+        last_descendants,
+        &mut system,
+        &mut executable_identities,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_live_identity(
+    path: &Path,
+    state: &str,
+    producer: &LiveProcessIdentity,
+    owner: Option<&LiveProcessIdentity>,
+    partial_owner: Option<&PartialProcessIdentity>,
+    mpv: &[MpvIdentity],
+    descendants: &[DescendantIdentity],
+    cleanup_proven: bool,
+) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create identity directory {}: {e}", parent.display()))?;
+    }
+    let temporary = path.with_extension("tmp");
+    let updated_unix_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| format!("system clock before Unix epoch: {e}"))?
+        .as_nanos();
+    if std::fs::read(path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+        .and_then(|document| {
+            document
+                .get("state")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        })
+        .is_some_and(|existing| live_identity_update_is_stale(state, &existing))
+    {
+        // The external cleanup orchestrator has frozen this producer and published
+        // cleanup_requested. Once resumed, it must never be overwritten by stale startup data.
+        return Ok(());
+    }
+    let run_id = std::env::var("TUI_PERF_RUN_ID")
+        .map_err(|_| "TUI_PERF_RUN_ID is required for live identity".to_string())?;
+    let bytes = serde_json::to_vec_pretty(&serde_json::json!({
+        "schema": "ytt.tui-perf.live-identity.v1",
+        "run_id": run_id,
+        "state": state,
+        "producer": producer,
+        "owner": owner,
+        "partial_owner": partial_owner,
+        "mpv": mpv,
+        "descendants": descendants,
+        "cleanup_scope": CLEANUP_SCOPE,
+        "cleanup_proven": cleanup_proven,
+        "updated_unix_ns": updated_unix_ns,
+    }))
+    .map_err(|e| format!("encode live identity: {e}"))?;
+    std::fs::write(&temporary, bytes)
+        .map_err(|e| format!("write live identity {}: {e}", temporary.display()))?;
+    std::fs::rename(&temporary, path)
+        .map_err(|e| format!("publish live identity {}: {e}", path.display()))
+}
+
+fn live_identity_update_is_stale(requested: &str, existing: &str) -> bool {
+    matches!(requested, "owner_starting" | "running")
+        && !matches!(existing, "startup" | "owner_starting" | "running")
+}
+
 fn write_pid_file(path: &Path, pid: u32) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
@@ -626,9 +1409,107 @@ fn write_pid_file(path: &Path, pid: u32) -> Result<(), String> {
     std::fs::rename(&tmp, path).map_err(|e| format!("publish {}: {e}", path.display()))
 }
 
+#[allow(clippy::too_many_arguments)]
+fn wait_for_controller_ready(
+    path: &Path,
+    root_pid: u32,
+    child: &mut Child,
+    identity_file: &Path,
+    producer: &LiveProcessIdentity,
+    owner: &LiveProcessIdentity,
+    run_id: &str,
+    last_mpv: &mut Vec<MpvIdentity>,
+    last_descendants: &mut Vec<DescendantIdentity>,
+) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let mut system = System::new();
+    let mut executable_identities = HashMap::new();
+    loop {
+        capture_live_descendant_identities_with_system(
+            root_pid,
+            identity_file,
+            producer,
+            owner,
+            last_mpv,
+            last_descendants,
+            &mut system,
+            &mut executable_identities,
+        )?;
+        if let Ok(bytes) = std::fs::read(path)
+            && let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes)
+            && value.get("schema").and_then(serde_json::Value::as_str)
+                == Some("ytt.tui-perf.controller-ready.v1")
+            && value.get("owner_pid").and_then(serde_json::Value::as_u64)
+                == Some(u64::from(root_pid))
+            && value.get("run_id").and_then(serde_json::Value::as_str) == Some(run_id)
+            && value
+                .get("subscriptions_confirmed")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+        {
+            return Ok(());
+        }
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| format!("query ytt while waiting for controller ready: {e}"))?
+        {
+            return Err(format!(
+                "ytt exited before controller subscription barrier: {status}"
+            ));
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "timed out waiting for controller subscription barrier {}",
+                path.display()
+            ));
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
 fn sha256_file(path: &Path) -> Result<String, String> {
     let bytes = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
     Ok(format!("{:x}", Sha256::digest(bytes)))
+}
+
+fn producer_binary_sha256() -> Result<String, String> {
+    let executable =
+        std::env::current_exe().map_err(|e| format!("resolve current sampler executable: {e}"))?;
+    sha256_file(&executable)
+}
+
+fn header_record(
+    args: &Args,
+    root_pid: u32,
+    binary_hash: &str,
+    producer_binary_hash: &str,
+    run_id: &str,
+    observation_started_unix_ns: u128,
+    terminal_geometry: (u16, u16),
+) -> serde_json::Value {
+    serde_json::json!({
+        "schema": SCHEMA,
+        "kind": "header",
+        "root_pid": root_pid,
+        "binary": args.binary,
+        "binary_sha256": binary_hash,
+        "producer_binary_sha256": producer_binary_hash,
+        "run_id": run_id,
+        "observation_started_unix_ns": observation_started_unix_ns,
+        "terminal_geometry": [terminal_geometry.0, terminal_geometry.1],
+        "controller_barrier_required": args.controller_ready_file.is_some(),
+        "child_ytm_perf_enabled": false,
+        "scenario_sha256": std::env::var("TUI_PERF_SCENARIO_SHA256").ok(),
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "warmup_ms": args.warmup.as_millis(),
+        "duration_ms": args.duration.as_millis(),
+        "cpu_accounting": "time_weighted_counter_deltas_clamped_to_measure_window",
+        "cpu_window_start_ns": args.warmup.as_nanos(),
+        "cpu_window_end_ns": (args.warmup + args.duration).as_nanos(),
+        "interval_ms": args.interval.as_millis(),
+        "require_silent_mpv": args.require_silent_mpv,
+    })
 }
 
 fn write_ndjson(out: &mut BufWriter<File>, value: &impl Serialize) -> Result<(), String> {
@@ -637,25 +1518,636 @@ fn write_ndjson(out: &mut BufWriter<File>, value: &impl Serialize) -> Result<(),
         .map_err(|e| format!("write NDJSON: {e}"))
 }
 
+#[cfg(unix)]
+fn live_process_identity_matches(
+    identity: &LiveProcessIdentity,
+    process: &sysinfo::Process,
+) -> bool {
+    process.start_time() == identity.start_time_unix_s
+        && process
+            .exe()
+            .and_then(|path| path.canonicalize().ok())
+            .is_some_and(|path| path == identity.executable)
+        && identity
+            .executable
+            .metadata()
+            .ok()
+            .is_some_and(|metadata| metadata.len() == identity.executable_bytes)
+        && sha256_file(&identity.executable).ok().as_deref()
+            == Some(identity.executable_sha256.as_str())
+}
+
+#[cfg(unix)]
+fn exact_owner_process_group(
+    owner: &LiveProcessIdentity,
+    producer: &LiveProcessIdentity,
+) -> Result<u32, String> {
+    let group = owner.process_group_id.ok_or_else(|| {
+        format!(
+            "owner PID {} has no process-group identity on Unix",
+            owner.pid
+        )
+    })?;
+    if group != owner.pid {
+        return Err(format!(
+            "owner PID {} is not leader of its dedicated process group {group}",
+            owner.pid
+        ));
+    }
+    if Some(group) == producer.process_group_id {
+        return Err("owner process group is not isolated from the sampler".to_string());
+    }
+    let refresh = ProcessRefreshKind::nothing()
+        .with_exe(UpdateKind::Always)
+        .without_tasks();
+    let mut system = System::new();
+    system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+    let process = system
+        .process(sysinfo::Pid::from_u32(owner.pid))
+        .ok_or_else(|| format!("exact owner PID {} is no longer present", owner.pid))?;
+    if !live_process_identity_matches(owner, process) {
+        return Err(format!(
+            "owner PID {} changed exact identity before process-group signal",
+            owner.pid
+        ));
+    }
+    if observed_process_group_id(owner.pid) != Some(group) {
+        return Err(format!(
+            "owner PID {} changed process group before process-group signal",
+            owner.pid
+        ));
+    }
+    Ok(group)
+}
+
+#[cfg(unix)]
+fn signal_dedicated_owner_group(
+    group: u32,
+    producer: &LiveProcessIdentity,
+    requested_signal: i32,
+) -> Result<(), String> {
+    if Some(group) == producer.process_group_id {
+        return Err("owner process group is not isolated from the sampler".to_string());
+    }
+    let group = i32::try_from(group).map_err(|_| "owner PGID does not fit pid_t".to_string())?;
+    // SAFETY: a negative PID addresses the already-verified dedicated owner process group.
+    if unsafe { libc::kill(-group, requested_signal) } != 0 {
+        return Err(format!(
+            "signal dedicated owner process group {group}: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn wait_for_dedicated_group_stop(group: u32) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(1);
+    let mut system = System::new();
+    while Instant::now() < deadline {
+        system.refresh_processes(ProcessesToUpdate::All, true);
+        let members = system
+            .processes()
+            .iter()
+            .filter(|(pid, _process)| observed_process_group_id(pid.as_u32()) == Some(group))
+            .map(|(_pid, process)| process)
+            .collect::<Vec<_>>();
+        if !members.is_empty()
+            && members
+                .iter()
+                .all(|process| process.status() == sysinfo::ProcessStatus::Stop)
+        {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    Err(format!(
+        "dedicated owner process group {group} did not become fully stopped"
+    ))
+}
+
+#[cfg(unix)]
+fn freeze_final_process_inventory<S>(
+    producer: &LiveProcessIdentity,
+    owner: &LiveProcessIdentity,
+    last_mpv: &mut Vec<MpvIdentity>,
+    last_descendants: &mut Vec<DescendantIdentity>,
+    signal_group: &mut S,
+) -> Result<(), String>
+where
+    S: FnMut(u32, i32) -> Result<(), String>,
+{
+    let owner_group = exact_owner_process_group(owner, producer)?;
+    signal_group(owner_group, libc::SIGSTOP)?;
+    wait_for_dedicated_group_stop(owner_group)?;
+    let mut system = System::new();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut executable_identities = HashMap::new();
+    let mut previous_inventory: Option<Vec<(u32, u64)>> = None;
+    let mut stable_count = 0;
+    while Instant::now() < deadline && stable_count < 3 {
+        let Some((descendants, mpv)) = discover_descendant_identities(
+            &mut system,
+            &mut executable_identities,
+            owner.pid,
+            Some(owner_group),
+            Some(producer.pid),
+        )?
+        else {
+            return Err(format!(
+                "owner PID {} disappeared while freezing final inventory",
+                owner.pid
+            ));
+        };
+        let descendants = merge_live_descendants(&system, last_descendants, descendants);
+        let mpv = merge_live_mpv(&system, last_mpv, mpv);
+        for identity in &descendants {
+            if let Some(process) = system.process(sysinfo::Pid::from_u32(identity.pid))
+                && exact_descendant_matches(identity, process)
+                && !process.kill_with(Signal::Stop).unwrap_or(false)
+            {
+                return Err(format!(
+                    "failed to freeze exact descendant PID {} before final inventory",
+                    identity.pid
+                ));
+            }
+        }
+        let inventory = descendants
+            .iter()
+            .map(|identity| (identity.pid, identity.start_time_unix_s))
+            .collect::<Vec<_>>();
+        if previous_inventory.as_ref() == Some(&inventory) {
+            stable_count += 1;
+        } else {
+            previous_inventory = Some(inventory);
+            stable_count = 1;
+        }
+        *last_descendants = descendants;
+        *last_mpv = mpv;
+        thread::sleep(Duration::from_millis(20));
+    }
+    if stable_count < 3 {
+        return Err("final frozen process inventory did not stabilize".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn hard_kill_frozen_descendant(identity: &DescendantIdentity) -> Result<(), String> {
+    let refresh = ProcessRefreshKind::nothing()
+        .with_cmd(UpdateKind::Always)
+        .with_exe(UpdateKind::Always)
+        .without_tasks();
+    let mut system = System::new();
+    let pid = sysinfo::Pid::from_u32(identity.pid);
+    system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+    let Some(process) = system.process(pid) else {
+        return Ok(());
+    };
+    if !exact_descendant_matches(identity, process) {
+        return Ok(());
+    }
+    if !process.kill() {
+        return Err(format!(
+            "failed to hard-kill frozen exact descendant PID {}",
+            identity.pid
+        ));
+    }
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+        if !system
+            .process(pid)
+            .is_some_and(|process| exact_descendant_matches(identity, process))
+        {
+            return Ok(());
+        }
+    }
+    Err(format!(
+        "frozen exact descendant PID {} survived hard cleanup",
+        identity.pid
+    ))
+}
+
+#[cfg(unix)]
+fn capture_stopped_owner_identity(
+    child: &mut Child,
+    partial: Option<&PartialProcessIdentity>,
+) -> Result<LiveProcessIdentity, String> {
+    let pid = child.id();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let refresh = ProcessRefreshKind::nothing()
+        .with_exe(UpdateKind::Always)
+        .without_tasks();
+    let mut system = System::new();
+    loop {
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+        if let Some(process) = system.process(sysinfo::Pid::from_u32(pid))
+            && let Some(path) = process.exe()
+        {
+            let process_group_id = process_group_id(pid)?;
+            if let Some(partial) = partial
+                && (partial.pid != pid
+                    || partial.start_time_unix_s != process.start_time()
+                    || partial.process_group_id != process_group_id)
+            {
+                return Err("stopped emergency owner differs from partial startup identity".into());
+            }
+            let executable = path
+                .canonicalize()
+                .map_err(|error| format!("canonicalize stopped emergency owner: {error}"))?;
+            let executable_bytes = executable
+                .metadata()
+                .map_err(|error| format!("stat stopped emergency owner: {error}"))?
+                .len();
+            return Ok(LiveProcessIdentity {
+                pid,
+                start_time_unix_s: process.start_time(),
+                process_group_id,
+                executable_sha256: sha256_file(&executable)?,
+                executable,
+                executable_bytes,
+            });
+        }
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|error| format!("query stopped emergency owner: {error}"))?
+        {
+            return Err(format!(
+                "startup owner exited before emergency identity capture: {status}"
+            ));
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "timed out capturing stopped emergency owner PID {pid}"
+            ));
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
+fn validate_owned_child_before_group_signal(
+    child: &mut Child,
+    partial: Option<&PartialProcessIdentity>,
+) -> Result<PartialProcessIdentity, String> {
+    if let Some(status) = child
+        .try_wait()
+        .map_err(|error| format!("query startup owner before process-group freeze: {error}"))?
+    {
+        return Err(format!(
+            "startup owner PID {} already exited before process-group freeze: {status}",
+            child.id()
+        ));
+    }
+    let pid = child.id();
+    let refresh = ProcessRefreshKind::nothing().without_tasks();
+    let mut system = System::new();
+    system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+    let process = system.process(sysinfo::Pid::from_u32(pid)).ok_or_else(|| {
+        format!("owned startup owner PID {pid} is not observable before process-group freeze")
+    })?;
+    let current = PartialProcessIdentity {
+        pid,
+        start_time_unix_s: process.start_time(),
+        process_group_id: process_group_id(pid)?,
+    };
+    let group = current.process_group_id.ok_or_else(|| {
+        format!("owned startup owner PID {pid} has no Unix process-group identity")
+    })?;
+    if group != pid {
+        return Err(format!(
+            "startup owner PID {pid} is not leader of dedicated group {group}"
+        ));
+    }
+    if partial.is_some_and(|expected| expected != &current) {
+        return Err(format!(
+            "current startup owner PID/start/PGID differs from partial identity: \
+             expected {partial:?}, observed {current:?}"
+        ));
+    }
+    Ok(current)
+}
+
+#[cfg(unix)]
+fn emergency_shutdown_spawned_tree<F>(
+    binary: &Path,
+    child: &mut Child,
+    producer: &LiveProcessIdentity,
+    partial: Option<&PartialProcessIdentity>,
+    last_mpv: &mut Vec<MpvIdentity>,
+    last_descendants: &mut Vec<DescendantIdentity>,
+    publish_frozen: F,
+) -> Result<LiveProcessIdentity, String>
+where
+    F: FnOnce(&LiveProcessIdentity, &[MpvIdentity], &[DescendantIdentity]) -> Result<(), String>,
+{
+    emergency_shutdown_spawned_tree_with_group_signal(
+        binary,
+        child,
+        producer,
+        partial,
+        last_mpv,
+        last_descendants,
+        publish_frozen,
+        |group, requested_signal| signal_dedicated_owner_group(group, producer, requested_signal),
+    )
+}
+
+#[cfg(unix)]
+#[allow(clippy::too_many_arguments)]
+fn emergency_shutdown_spawned_tree_with_group_signal<F, S>(
+    binary: &Path,
+    child: &mut Child,
+    producer: &LiveProcessIdentity,
+    partial: Option<&PartialProcessIdentity>,
+    last_mpv: &mut Vec<MpvIdentity>,
+    last_descendants: &mut Vec<DescendantIdentity>,
+    publish_frozen: F,
+    mut signal_group: S,
+) -> Result<LiveProcessIdentity, String>
+where
+    F: FnOnce(&LiveProcessIdentity, &[MpvIdentity], &[DescendantIdentity]) -> Result<(), String>,
+    S: FnMut(u32, i32) -> Result<(), String>,
+{
+    let observed = validate_owned_child_before_group_signal(child, partial)?;
+    let group = observed
+        .process_group_id
+        .expect("validated Unix startup owner has a process group");
+    signal_group(group, libc::SIGSTOP)?;
+    wait_for_dedicated_group_stop(group)?;
+    let owner = capture_stopped_owner_identity(child, Some(&observed))?;
+    shutdown_measured_tree_with_group_signal(
+        binary,
+        child,
+        producer,
+        &owner,
+        last_mpv,
+        last_descendants,
+        false,
+        |mpv, descendants| publish_frozen(&owner, mpv, descendants),
+        &mut signal_group,
+    )?;
+    Ok(owner)
+}
+
+#[cfg(unix)]
+fn cleanup_after_startup_error(
+    args: &Args,
+    producer: &LiveProcessIdentity,
+    partial: Option<&PartialProcessIdentity>,
+    child: &mut Child,
+    original_error: String,
+) -> String {
+    let mut mpv = Vec::new();
+    let mut descendants = Vec::new();
+    let cleanup = emergency_shutdown_spawned_tree(
+        &args.binary,
+        child,
+        producer,
+        partial,
+        &mut mpv,
+        &mut descendants,
+        |owner, mpv, descendants| {
+            write_live_identity(
+                &args.identity_file,
+                "cleanup_requested",
+                producer,
+                Some(owner),
+                partial,
+                mpv,
+                descendants,
+                false,
+            )
+        },
+    );
+    match cleanup {
+        Ok(owner) => match write_live_identity(
+            &args.identity_file,
+            "cleaned",
+            producer,
+            Some(&owner),
+            partial,
+            &mpv,
+            &descendants,
+            true,
+        ) {
+            Ok(()) => original_error,
+            Err(cleanup_error) => {
+                format!("{original_error}; emergency cleanup proof failed: {cleanup_error}")
+            }
+        },
+        Err(cleanup_error) => {
+            let mut fallback_errors = Vec::new();
+            match child.try_wait() {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    if let Err(error) = child.kill() {
+                        fallback_errors.push(format!(
+                            "hard-kill still-owned startup child PID {}: {error}",
+                            child.id()
+                        ));
+                    }
+                    if let Err(error) = child.wait() {
+                        fallback_errors.push(format!(
+                            "wait for still-owned startup child PID {}: {error}",
+                            child.id()
+                        ));
+                    }
+                }
+                Err(error) => fallback_errors.push(format!(
+                    "query still-owned startup child PID {}: {error}",
+                    child.id()
+                )),
+            }
+            for identity in descendants.iter().rev() {
+                if let Err(error) = hard_kill_frozen_descendant(identity) {
+                    fallback_errors.push(error);
+                }
+            }
+            let fallback = if fallback_errors.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "; exact-PID fallback errors: {}",
+                    fallback_errors.join("; ")
+                )
+            };
+            format!(
+                "{original_error}; emergency startup cleanup failed without process-group kill: \
+                 {cleanup_error}{fallback}"
+            )
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn cleanup_after_startup_error(
+    _args: &Args,
+    _producer: &LiveProcessIdentity,
+    _partial: Option<&PartialProcessIdentity>,
+    child: &mut Child,
+    original_error: String,
+) -> String {
+    let _ = child.kill();
+    let _ = child.wait();
+    original_error
+}
+
+#[allow(clippy::too_many_arguments)]
+#[cfg(unix)]
+fn shutdown_measured_tree<F>(
+    binary: &Path,
+    child: &mut Child,
+    producer: &LiveProcessIdentity,
+    owner: &LiveProcessIdentity,
+    last_mpv: &mut Vec<MpvIdentity>,
+    last_descendants: &mut Vec<DescendantIdentity>,
+    require_mpv_identity: bool,
+    publish_frozen: F,
+) -> Result<(), String>
+where
+    F: FnOnce(&[MpvIdentity], &[DescendantIdentity]) -> Result<(), String>,
+{
+    shutdown_measured_tree_with_group_signal(
+        binary,
+        child,
+        producer,
+        owner,
+        last_mpv,
+        last_descendants,
+        require_mpv_identity,
+        publish_frozen,
+        |group, requested_signal| signal_dedicated_owner_group(group, producer, requested_signal),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+#[cfg(not(unix))]
+fn shutdown_measured_tree<F>(
+    binary: &Path,
+    child: &mut Child,
+    _producer: &LiveProcessIdentity,
+    _owner: &LiveProcessIdentity,
+    last_mpv: &mut [MpvIdentity],
+    last_descendants: &mut [DescendantIdentity],
+    require_mpv_identity: bool,
+    publish_frozen: F,
+) -> Result<(), String>
+where
+    F: FnOnce(&[MpvIdentity], &[DescendantIdentity]) -> Result<(), String>,
+{
+    publish_frozen(last_mpv, last_descendants)?;
+    shutdown_child(
+        binary,
+        child,
+        last_mpv,
+        last_descendants,
+        require_mpv_identity,
+    )
+}
+
+#[cfg(unix)]
+#[allow(clippy::too_many_arguments)]
+fn shutdown_measured_tree_with_group_signal<F, S>(
+    _binary: &Path,
+    child: &mut Child,
+    producer: &LiveProcessIdentity,
+    owner: &LiveProcessIdentity,
+    last_mpv: &mut Vec<MpvIdentity>,
+    last_descendants: &mut Vec<DescendantIdentity>,
+    require_mpv_identity: bool,
+    publish_frozen: F,
+    mut signal_group: S,
+) -> Result<(), String>
+where
+    F: FnOnce(&[MpvIdentity], &[DescendantIdentity]) -> Result<(), String>,
+    S: FnMut(u32, i32) -> Result<(), String>,
+{
+    let mut errors = Vec::new();
+    let group_frozen = match freeze_final_process_inventory(
+        producer,
+        owner,
+        last_mpv,
+        last_descendants,
+        &mut signal_group,
+    ) {
+        Ok(()) => true,
+        Err(error) => {
+            errors.push(error);
+            false
+        }
+    };
+    if require_mpv_identity && last_mpv.is_empty() {
+        errors.push(
+            "final frozen inventory had no exact mpv PID/start-time/IPC argv identity".to_string(),
+        );
+    }
+    if let Err(error) = publish_frozen(last_mpv, last_descendants) {
+        errors.push(error);
+    }
+    if group_frozen {
+        match exact_owner_process_group(owner, producer) {
+            Ok(group) => {
+                if let Err(error) = signal_group(group, libc::SIGKILL) {
+                    errors.push(error);
+                }
+            }
+            Err(error) => errors.push(format!(
+                "refused dedicated process-group kill after exact owner revalidation: {error}"
+            )),
+        }
+    }
+    match child.try_wait() {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            let _ = child.kill();
+            if let Err(error) = child.wait() {
+                errors.push(format!(
+                    "wait for frozen exact ytt child PID {}: {error}",
+                    child.id()
+                ));
+            }
+        }
+        Err(error) => errors.push(format!("query frozen ytt child: {error}")),
+    }
+    for identity in last_descendants.iter().rev() {
+        if let Err(error) = hard_kill_frozen_descendant(identity) {
+            errors.push(error);
+        }
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
+    }
+}
+
+#[cfg(not(unix))]
 fn shutdown_child(
     binary: &Path,
     child: &mut Child,
     last_mpv_identities: &[MpvIdentity],
+    last_descendant_identities: &[DescendantIdentity],
     require_mpv_identity: bool,
 ) -> Result<(), String> {
     shutdown_child_with_grace(
         binary,
         child,
         last_mpv_identities,
+        last_descendant_identities,
         require_mpv_identity,
         Duration::from_secs(5),
     )
 }
 
+#[cfg(any(test, not(unix)))]
 fn shutdown_child_with_grace(
     binary: &Path,
     child: &mut Child,
     last_mpv_identities: &[MpvIdentity],
+    last_descendant_identities: &[DescendantIdentity],
     require_mpv_identity: bool,
     clean_grace: Duration,
 ) -> Result<(), String> {
@@ -709,12 +2201,23 @@ fn shutdown_child_with_grace(
     for identity in last_mpv_identities {
         stop_exact_mpv(identity, hard_fallback)?;
     }
+    let mpv_pids = last_mpv_identities
+        .iter()
+        .map(|identity| identity.pid)
+        .collect::<HashSet<_>>();
+    for identity in last_descendant_identities {
+        if !mpv_pids.contains(&identity.pid) {
+            stop_exact_descendant(identity, hard_fallback)?;
+        }
+    }
     Ok(())
 }
 
+#[cfg(any(test, not(unix)))]
 fn stop_exact_mpv(identity: &MpvIdentity, hard_fallback: bool) -> Result<(), String> {
     let refresh = ProcessRefreshKind::nothing()
         .with_cmd(UpdateKind::Always)
+        .with_exe(UpdateKind::Always)
         .without_tasks();
     let mut system = System::new();
 
@@ -736,7 +2239,13 @@ fn stop_exact_mpv(identity: &MpvIdentity, hard_fallback: bool) -> Result<(), Str
                     .iter()
                     .map(|part| part.to_string_lossy().into_owned())
                     .collect::<Vec<_>>();
-                exact_mpv_identity_matches(identity, identity.pid, process.start_time(), &command)
+                mpv_executable_matches(identity, process)
+                    && exact_mpv_identity_matches(
+                        identity,
+                        identity.pid,
+                        process.start_time(),
+                        &command,
+                    )
             })
         {
             return Ok(());
@@ -769,7 +2278,13 @@ fn stop_exact_mpv(identity: &MpvIdentity, hard_fallback: bool) -> Result<(), Str
                 .iter()
                 .map(|part| part.to_string_lossy().into_owned())
                 .collect::<Vec<_>>();
-            exact_mpv_identity_matches(identity, identity.pid, process.start_time(), &command)
+            mpv_executable_matches(identity, process)
+                && exact_mpv_identity_matches(
+                    identity,
+                    identity.pid,
+                    process.start_time(),
+                    &command,
+                )
         });
         if !still_exact {
             return Ok(());
@@ -786,7 +2301,9 @@ fn stop_exact_mpv(identity: &MpvIdentity, hard_fallback: bool) -> Result<(), Str
         .iter()
         .map(|part| part.to_string_lossy().into_owned())
         .collect::<Vec<_>>();
-    if !exact_mpv_identity_matches(identity, identity.pid, process.start_time(), &command) {
+    if !mpv_executable_matches(identity, process)
+        || !exact_mpv_identity_matches(identity, identity.pid, process.start_time(), &command)
+    {
         return Ok(());
     }
     if !process.kill() {
@@ -806,7 +2323,13 @@ fn stop_exact_mpv(identity: &MpvIdentity, hard_fallback: bool) -> Result<(), Str
                 .iter()
                 .map(|part| part.to_string_lossy().into_owned())
                 .collect::<Vec<_>>();
-            exact_mpv_identity_matches(identity, identity.pid, process.start_time(), &command)
+            mpv_executable_matches(identity, process)
+                && exact_mpv_identity_matches(
+                    identity,
+                    identity.pid,
+                    process.start_time(),
+                    &command,
+                )
         });
         if !still_exact {
             return Ok(());
@@ -818,16 +2341,394 @@ fn stop_exact_mpv(identity: &MpvIdentity, hard_fallback: bool) -> Result<(), Str
     ))
 }
 
+#[cfg(any(test, not(unix)))]
+fn stop_exact_descendant(identity: &DescendantIdentity, hard_fallback: bool) -> Result<(), String> {
+    let refresh = ProcessRefreshKind::nothing()
+        .with_cmd(UpdateKind::Always)
+        .with_exe(UpdateKind::Always)
+        .without_tasks();
+    let mut system = System::new();
+    let pid = sysinfo::Pid::from_u32(identity.pid);
+    let natural_deadline = Instant::now()
+        + if hard_fallback {
+            Duration::ZERO
+        } else {
+            Duration::from_secs(2)
+        };
+    loop {
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+        if !system
+            .process(pid)
+            .is_some_and(|process| exact_descendant_matches(identity, process))
+        {
+            return Ok(());
+        }
+        if Instant::now() >= natural_deadline {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    let process = system.process(pid).ok_or_else(|| {
+        format!(
+            "exact descendant PID {} disappeared during cleanup",
+            identity.pid
+        )
+    })?;
+    if !process.kill_with(Signal::Term).unwrap_or(false) && !process.kill() {
+        return Err(format!(
+            "failed to terminate exact descendant PID {} after identity verification",
+            identity.pid
+        ));
+    }
+    let term_deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < term_deadline {
+        thread::sleep(Duration::from_millis(50));
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+        if !system
+            .process(pid)
+            .is_some_and(|process| exact_descendant_matches(identity, process))
+        {
+            return Ok(());
+        }
+    }
+    let Some(process) = system.process(pid) else {
+        return Ok(());
+    };
+    if !exact_descendant_matches(identity, process) {
+        return Ok(());
+    }
+    if !process.kill() {
+        return Err(format!(
+            "failed to hard-kill exact descendant PID {} after TERM grace",
+            identity.pid
+        ));
+    }
+    let kill_deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < kill_deadline {
+        thread::sleep(Duration::from_millis(50));
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+        if !system
+            .process(pid)
+            .is_some_and(|process| exact_descendant_matches(identity, process))
+        {
+            return Ok(());
+        }
+    }
+    Err(format!(
+        "exact descendant PID {} remained after verified cleanup and wait",
+        identity.pid
+    ))
+}
+
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::os::unix::process::CommandExt;
     use std::path::PathBuf;
+    use std::process::Child;
+    use std::sync::mpsc;
 
     use super::{
-        MeasuredMpvProof, MpvIdentity, exact_mpv_identity_matches, input_ipc_server_argv,
-        shutdown_child_with_grace, silent_mpv_args, stop_exact_mpv,
+        Aggregate, Args, LiveProcessIdentity, MeasuredMpvProof, MpvIdentity, RoleSample,
+        cpu_interval_overlap, emergency_shutdown_spawned_tree,
+        emergency_shutdown_spawned_tree_with_group_signal, exact_mpv_identity_matches,
+        header_record, input_ipc_server_argv, live_identity_update_is_stale,
+        producer_binary_sha256, sha256_file, shutdown_child_with_grace, shutdown_measured_tree,
+        shutdown_measured_tree_with_group_signal, silent_mpv_args, stop_exact_mpv,
+        wait_for_partial_process_identity, wait_for_process_identity,
     };
     use yututui::api::{Song, validate_playable_url, validate_playback_target_for_handoff};
     use yututui::search_source::SearchSource;
+
+    struct TestChildGuard(Option<Child>);
+
+    impl TestChildGuard {
+        fn new(child: Child) -> Self {
+            Self(Some(child))
+        }
+
+        fn child_mut(&mut self) -> &mut Child {
+            self.0.as_mut().expect("test child is present")
+        }
+
+        fn take(&mut self) -> Child {
+            self.0.take().expect("test child is present")
+        }
+    }
+
+    impl Drop for TestChildGuard {
+        fn drop(&mut self) {
+            if let Some(mut child) = self.0.take() {
+                if child.try_wait().ok().flatten().is_none() {
+                    let _ = child.kill();
+                }
+                let _ = child.wait();
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn spawn_group_signal_sentinel() -> TestChildGuard {
+        let current_exe = std::env::current_exe().expect("test executable");
+        let mut command = std::process::Command::new(current_exe);
+        command
+            .args(["--ignored", "--exact", "tests::cleanup_wait_helper_process"])
+            .env("TUI_PERF_CLEANUP_HELPER", "1")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .process_group(0);
+        TestChildGuard::new(
+            command
+                .spawn()
+                .expect("spawn dedicated group-signal sentinel"),
+        )
+    }
+
+    struct TestWaiterGuard {
+        stop: mpsc::Sender<()>,
+        waiter: Option<std::thread::JoinHandle<std::io::Result<std::process::ExitStatus>>>,
+    }
+
+    impl TestWaiterGuard {
+        fn new(mut child: Child) -> Self {
+            let (stop, requests) = mpsc::channel();
+            let waiter = std::thread::spawn(move || {
+                loop {
+                    if let Some(status) = child.try_wait()? {
+                        return Ok(status);
+                    }
+                    if requests.try_recv().is_ok() {
+                        let _ = child.kill();
+                        return child.wait();
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+            });
+            Self {
+                stop,
+                waiter: Some(waiter),
+            }
+        }
+
+        fn join(mut self) -> std::io::Result<std::process::ExitStatus> {
+            self.waiter
+                .take()
+                .expect("test waiter is present")
+                .join()
+                .expect("test waiter thread")
+        }
+    }
+
+    impl Drop for TestWaiterGuard {
+        fn drop(&mut self) {
+            if let Some(waiter) = self.waiter.take() {
+                let _ = self.stop.send(());
+                let _ = waiter.join();
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    struct LateProcessGuard(PathBuf);
+
+    #[cfg(unix)]
+    impl Drop for LateProcessGuard {
+        fn drop(&mut self) {
+            let Ok(pid) = std::fs::read_to_string(&self.0)
+                .ok()
+                .and_then(|value| value.trim().parse::<u32>().ok())
+                .ok_or(())
+            else {
+                return;
+            };
+            let refresh = sysinfo::ProcessRefreshKind::nothing()
+                .with_cmd(sysinfo::UpdateKind::Always)
+                .without_tasks();
+            let mut system = sysinfo::System::new();
+            system.refresh_processes_specifics(sysinfo::ProcessesToUpdate::All, true, refresh);
+            if let Some(process) = system.process(sysinfo::Pid::from_u32(pid)) {
+                let command = process
+                    .cmd()
+                    .iter()
+                    .map(|part| part.to_string_lossy().into_owned())
+                    .collect::<Vec<_>>();
+                if command.iter().any(|part| part == &self.0.to_string_lossy()) {
+                    let _ = process.kill();
+                }
+            }
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    fn capture_test_mpv_identity(child: &mut Child) -> Result<MpvIdentity, String> {
+        let pid = child.id();
+        let expected_executable =
+            std::env::current_exe().map_err(|error| format!("resolve test executable: {error}"))?;
+        let expected_sha256 = sha256_file(&expected_executable)?;
+        let live_identity = wait_for_process_identity(pid, &expected_sha256, child)?;
+        let refresh = sysinfo::ProcessRefreshKind::nothing()
+            .with_cmd(sysinfo::UpdateKind::Always)
+            .with_exe(sysinfo::UpdateKind::Always)
+            .without_tasks();
+        let mut system = sysinfo::System::new();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            system.refresh_processes_specifics(sysinfo::ProcessesToUpdate::All, true, refresh);
+            if let Some(process) = system.process(sysinfo::Pid::from_u32(pid)) {
+                let command = process
+                    .cmd()
+                    .iter()
+                    .map(|part| part.to_string_lossy().into_owned())
+                    .collect::<Vec<_>>();
+                if let (Some(input_ipc_server_argv), Some(executable)) = (
+                    input_ipc_server_argv(&command),
+                    process.exe().and_then(|path| path.canonicalize().ok()),
+                ) && process.start_time() == live_identity.start_time_unix_s
+                    && executable == live_identity.executable
+                {
+                    return Ok(MpvIdentity {
+                        pid,
+                        start_time_unix_s: live_identity.start_time_unix_s,
+                        executable: live_identity.executable,
+                        executable_bytes: live_identity.executable_bytes,
+                        executable_sha256: live_identity.executable_sha256,
+                        input_ipc_server_argv,
+                    });
+                }
+            }
+            if let Some(status) = child
+                .try_wait()
+                .map_err(|error| format!("query test helper while capturing identity: {error}"))?
+            {
+                return Err(format!(
+                    "test helper exited before publishing its exact identity: {status}"
+                ));
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(format!(
+                    "timed out capturing exact IPC/executable identity for test helper PID {pid}"
+                ));
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn header_records_the_current_sampler_binary_sha256() {
+        let executable = std::env::current_exe().expect("resolve current test executable");
+        let expected = sha256_file(&executable).expect("hash current test executable");
+        let producer_hash = producer_binary_sha256().expect("hash current sampler executable");
+        let args = Args {
+            output: PathBuf::from("samples.ndjson"),
+            pid_file: None,
+            identity_file: PathBuf::from("process-identity.json"),
+            controller_ready_file: None,
+            binary: PathBuf::from("ytt"),
+            child_args: Vec::new(),
+            warmup: std::time::Duration::from_secs(1),
+            duration: std::time::Duration::from_secs(2),
+            interval: std::time::Duration::from_millis(500),
+            require_silent_mpv: false,
+        };
+        let header = header_record(
+            &args,
+            42,
+            "measured-hash",
+            &producer_hash,
+            "self-test-run",
+            123,
+            (100, 30),
+        );
+
+        assert_eq!(producer_hash, expected);
+        assert_eq!(producer_hash.len(), 64);
+        assert_eq!(header["kind"], "header");
+        assert_eq!(header["binary_sha256"], "measured-hash");
+        assert_eq!(header["producer_binary_sha256"], producer_hash);
+        assert_eq!(header["run_id"], "self-test-run");
+        assert_eq!(header["terminal_geometry"], serde_json::json!([100, 30]));
+    }
+
+    #[test]
+    fn cpu_summary_clamps_and_time_weights_raw_intervals() {
+        let window_start = std::time::Duration::from_secs(1);
+        let window_end = std::time::Duration::from_secs(3);
+        assert_eq!(
+            cpu_interval_overlap(
+                Some(std::time::Duration::from_millis(200)),
+                std::time::Duration::from_millis(1_200),
+                window_start,
+                window_end,
+            ),
+            std::time::Duration::from_millis(200),
+            "the warmup portion of a crossing interval must be excluded"
+        );
+        assert_eq!(
+            cpu_interval_overlap(
+                Some(std::time::Duration::from_millis(2_100)),
+                std::time::Duration::from_millis(3_400),
+                window_start,
+                window_end,
+            ),
+            std::time::Duration::from_millis(900),
+            "the post-window portion of the final interval must be excluded"
+        );
+        assert_eq!(
+            cpu_interval_overlap(
+                Some(std::time::Duration::from_millis(3_400)),
+                std::time::Duration::from_millis(4_000),
+                window_start,
+                window_end,
+            ),
+            std::time::Duration::ZERO
+        );
+        assert_eq!(
+            cpu_interval_overlap(
+                None,
+                std::time::Duration::from_millis(500),
+                window_start,
+                window_end,
+            ),
+            std::time::Duration::ZERO
+        );
+
+        let mut aggregate = Aggregate::default();
+        for (cpu_percent, overlap_ms) in [(10.0, 200), (20.0, 800), (30.0, 1_000)] {
+            aggregate.push(
+                RoleSample {
+                    processes: 1,
+                    cpu_percent,
+                    rss_bytes: 100,
+                },
+                std::time::Duration::from_millis(overlap_ms),
+            );
+        }
+        let summary = aggregate.json(std::time::Duration::from_secs(2));
+        assert_eq!(summary["samples"], 3);
+        assert_eq!(summary["mean_rss_bytes"], 100);
+        assert_eq!(summary["peak_rss_bytes"], 100);
+        let mean_cpu = summary["mean_cpu_percent"]
+            .as_f64()
+            .expect("mean CPU is numeric");
+        assert!((mean_cpu - 24.0).abs() < 1e-12);
+        assert_ne!(
+            mean_cpu, 20.0,
+            "jittered intervals must not be equally weighted"
+        );
+    }
+
+    #[test]
+    fn stale_startup_updates_cannot_overwrite_external_cleanup_state() {
+        assert!(!live_identity_update_is_stale("owner_starting", "startup"));
+        assert!(!live_identity_update_is_stale("running", "owner_starting"));
+        assert!(live_identity_update_is_stale(
+            "owner_starting",
+            "cleanup_requested"
+        ));
+        assert!(live_identity_update_is_stale("running", "cleaned"));
+    }
 
     #[test]
     fn silence_check_honors_last_option_wins() {
@@ -895,6 +2796,9 @@ mod tests {
         let identity = MpvIdentity {
             pid: 4_242,
             start_time_unix_s: 99,
+            executable: PathBuf::from("mpv"),
+            executable_bytes: 1,
+            executable_sha256: "00".repeat(32),
             input_ipc_server_argv: input_ipc_server_argv(&equals).expect("extract IPC argv"),
         };
         assert!(exact_mpv_identity_matches(&identity, 4_242, 99, &equals));
@@ -938,7 +2842,7 @@ mod tests {
                 .expect("clock after epoch")
                 .as_nanos(),
         );
-        let mut child = std::process::Command::new(std::env::current_exe().expect("test exe"))
+        let child = std::process::Command::new(std::env::current_exe().expect("test exe"))
             .args([
                 "--ignored",
                 "--exact",
@@ -952,43 +2856,15 @@ mod tests {
             .stderr(std::process::Stdio::null())
             .spawn()
             .expect("spawn cleanup helper");
-        let pid = child.id();
-        let refresh = sysinfo::ProcessRefreshKind::nothing()
-            .with_cmd(sysinfo::UpdateKind::Always)
-            .without_tasks();
-        let mut system = sysinfo::System::new();
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        let identity = loop {
-            system.refresh_processes_specifics(sysinfo::ProcessesToUpdate::All, true, refresh);
-            if let Some(process) = system.process(sysinfo::Pid::from_u32(pid)) {
-                let command = process
-                    .cmd()
-                    .iter()
-                    .map(|part| part.to_string_lossy().into_owned())
-                    .collect::<Vec<_>>();
-                if let Some(input_ipc_server_argv) = input_ipc_server_argv(&command) {
-                    break MpvIdentity {
-                        pid,
-                        start_time_unix_s: process.start_time(),
-                        input_ipc_server_argv,
-                    };
-                }
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "cleanup helper never published its argv"
-            );
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        };
+        let mut child = TestChildGuard::new(child);
+        let identity = capture_test_mpv_identity(child.child_mut())
+            .expect("cleanup helper publishes its exact identity");
 
         // Reap the direct test child concurrently. In production mpv is ytt's descendant and
         // is reaped by the OS after ytt is gone; this preserves the same observable lifecycle.
-        let waiter = std::thread::spawn(move || child.wait());
+        let waiter = TestWaiterGuard::new(child.take());
         stop_exact_mpv(&identity, true).expect("verified cleanup succeeds");
-        let status = waiter
-            .join()
-            .expect("waiter thread")
-            .expect("wait cleanup helper");
+        let status = waiter.join().expect("wait cleanup helper");
         assert!(!status.success(), "helper must have been terminated");
     }
 
@@ -1001,7 +2877,7 @@ mod tests {
             "tests::cleanup_wait_helper_process",
             "--",
         ];
-        let mut ytt = std::process::Command::new(&current_exe)
+        let ytt = std::process::Command::new(&current_exe)
             .args(helper_args)
             .arg("ytt-owner-helper")
             .env("TUI_PERF_CLEANUP_HELPER", "1")
@@ -1010,6 +2886,7 @@ mod tests {
             .stderr(std::process::Stdio::null())
             .spawn()
             .expect("spawn ytt owner helper");
+        let mut ytt = TestChildGuard::new(ytt);
         let ipc_arg = format!(
             "--input-ipc-server={}/ytt-perf-fallback-{}-{}.sock",
             std::env::temp_dir().display(),
@@ -1019,7 +2896,7 @@ mod tests {
                 .expect("clock after epoch")
                 .as_nanos(),
         );
-        let mut mpv = std::process::Command::new(&current_exe)
+        let mpv = std::process::Command::new(&current_exe)
             .args(helper_args)
             .arg(&ipc_arg)
             .env("TUI_PERF_CLEANUP_HELPER", "1")
@@ -1028,59 +2905,394 @@ mod tests {
             .stderr(std::process::Stdio::null())
             .spawn()
             .expect("spawn mpv helper");
-        let mpv_pid = mpv.id();
-        let refresh = sysinfo::ProcessRefreshKind::nothing()
-            .with_cmd(sysinfo::UpdateKind::Always)
-            .without_tasks();
-        let mut system = sysinfo::System::new();
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        let identity = loop {
-            system.refresh_processes_specifics(sysinfo::ProcessesToUpdate::All, true, refresh);
-            if let Some(process) = system.process(sysinfo::Pid::from_u32(mpv_pid)) {
-                let command = process
-                    .cmd()
-                    .iter()
-                    .map(|part| part.to_string_lossy().into_owned())
-                    .collect::<Vec<_>>();
-                if let Some(input_ipc_server_argv) = input_ipc_server_argv(&command) {
-                    break MpvIdentity {
-                        pid: mpv_pid,
-                        start_time_unix_s: process.start_time(),
-                        input_ipc_server_argv,
-                    };
-                }
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "mpv helper never published its argv"
-            );
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        };
-        let mpv_waiter = std::thread::spawn(move || mpv.wait());
+        let mut mpv = TestChildGuard::new(mpv);
+        let identity = capture_test_mpv_identity(mpv.child_mut())
+            .expect("mpv helper publishes its exact identity");
+        let mpv_waiter = TestWaiterGuard::new(mpv.take());
 
         shutdown_child_with_grace(
             &current_exe,
-            &mut ytt,
+            ytt.child_mut(),
             &[identity],
+            &[],
             true,
             std::time::Duration::from_millis(20),
         )
         .expect("hard fallback cleans exact child and mpv");
         assert!(
-            ytt.try_wait().expect("query ytt helper").is_some(),
+            ytt.child_mut()
+                .try_wait()
+                .expect("query ytt helper")
+                .is_some(),
             "exact ytt child must have been reaped"
         );
-        let mpv_status = mpv_waiter
-            .join()
-            .expect("mpv waiter thread")
-            .expect("wait mpv helper");
+        let mpv_status = mpv_waiter.join().expect("wait mpv helper");
         assert!(!mpv_status.success(), "exact mpv helper must be terminated");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn final_frozen_inventory_cleans_a_late_setsid_term_ignoring_child() {
+        let current_exe = std::env::current_exe().expect("test exe");
+        let late_pid_file = std::env::temp_dir().join(format!(
+            "ytt-perf-late-child-{}-{}.pid",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ));
+        let late_guard = LateProcessGuard(late_pid_file.clone());
+        let mut command = std::process::Command::new(&current_exe);
+        command
+            .args([
+                "--ignored",
+                "--exact",
+                "tests::cleanup_wait_helper_process",
+                "--",
+                "late-owner",
+            ])
+            .env("TUI_PERF_CLEANUP_HELPER", "1")
+            .env("TUI_PERF_LATE_CHILD_PID_FILE", &late_pid_file)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .process_group(0);
+        let owner = command.spawn().expect("spawn late-child owner helper");
+        let mut owner = TestChildGuard::new(owner);
+        let expected_hash = sha256_file(&current_exe).expect("hash owner helper");
+        let owner_identity =
+            wait_for_process_identity(owner.child_mut().id(), &expected_hash, owner.child_mut())
+                .expect("capture owner identity");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !std::fs::read_to_string(&late_pid_file)
+            .is_ok_and(|contents| !contents.trim().is_empty())
+        {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "late setsid child did not publish its PID"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        let late_pid = std::fs::read_to_string(&late_pid_file)
+            .expect("read late PID")
+            .trim()
+            .parse::<u32>()
+            .expect("parse late PID");
+        let producer_identity = super::current_process_identity().expect("producer identity");
+        let mut mpv = Vec::new();
+        let mut descendants = Vec::new();
+        shutdown_measured_tree(
+            &current_exe,
+            owner.child_mut(),
+            &producer_identity,
+            &owner_identity,
+            &mut mpv,
+            &mut descendants,
+            false,
+            |_mpv, _descendants| Ok(()),
+        )
+        .expect("frozen final inventory cleans the full late tree");
+        assert!(
+            descendants.iter().any(|identity| identity.pid == late_pid),
+            "late setsid child must be captured in the exact final inventory"
+        );
+        let mut system = sysinfo::System::new();
+        system.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+        assert!(
+            system.process(sysinfo::Pid::from_u32(late_pid)).is_none(),
+            "late setsid child survived frozen exact cleanup"
+        );
+        drop(late_guard);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn missing_exact_owner_never_reuses_recorded_process_group_for_cleanup() {
+        let current_exe = std::env::current_exe()
+            .expect("test executable")
+            .canonicalize()
+            .expect("canonical test executable");
+        let mut command = std::process::Command::new(&current_exe);
+        command
+            .args(["--ignored", "--exact", "tests::cleanup_wait_helper_process"])
+            .env("TUI_PERF_CLEANUP_HELPER", "1")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        let child = command.spawn().expect("spawn sentinel cleanup child");
+        let mut child = TestChildGuard::new(child);
+        let producer = super::current_process_identity().expect("producer identity");
+        let missing_pid = u32::MAX;
+        let missing_owner = LiveProcessIdentity {
+            pid: missing_pid,
+            start_time_unix_s: 1,
+            process_group_id: Some(missing_pid),
+            executable_bytes: current_exe.metadata().expect("test metadata").len(),
+            executable_sha256: sha256_file(&current_exe).expect("test executable hash"),
+            executable: current_exe.clone(),
+        };
+        let mut mpv = Vec::new();
+        let mut descendants = Vec::new();
+        let mut group_signals = Vec::new();
+        let error = shutdown_measured_tree_with_group_signal(
+            &current_exe,
+            child.child_mut(),
+            &producer,
+            &missing_owner,
+            &mut mpv,
+            &mut descendants,
+            false,
+            |_mpv, _descendants| Ok(()),
+            |group, requested_signal| {
+                group_signals.push((group, requested_signal));
+                Ok(())
+            },
+        )
+        .expect_err("missing exact owner must fail closed");
+        assert!(
+            error.contains("exact owner PID") && error.contains("no longer present"),
+            "unexpected fail-closed error: {error}"
+        );
+        assert!(
+            group_signals.is_empty(),
+            "missing owner must not signal a reusable numeric process group: {group_signals:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reaped_startup_child_never_signals_derived_process_group() {
+        let current_exe = std::env::current_exe().expect("test executable");
+        let mut command = std::process::Command::new(&current_exe);
+        command
+            .args(["--ignored", "--exact", "tests::cleanup_wait_helper_process"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .process_group(0);
+        let mut reaped_child = command.spawn().expect("spawn fast startup child");
+        assert!(
+            reaped_child
+                .wait()
+                .expect("reap fast startup child")
+                .success(),
+            "fast startup child must exit cleanly"
+        );
+        let mut sentinel = spawn_group_signal_sentinel();
+        let sentinel_group = sentinel.child_mut().id();
+        let sentinel_group_i32 = i32::try_from(sentinel_group).expect("sentinel PGID fits pid_t");
+        let producer = super::current_process_identity().expect("producer identity");
+        let mut mpv = Vec::new();
+        let mut descendants = Vec::new();
+        let mut group_signals = Vec::new();
+        let error = emergency_shutdown_spawned_tree_with_group_signal(
+            &current_exe,
+            &mut reaped_child,
+            &producer,
+            None,
+            &mut mpv,
+            &mut descendants,
+            |_owner, _mpv, _descendants| Ok(()),
+            |group, requested_signal| {
+                group_signals.push((group, requested_signal));
+                // SAFETY: this PGID belongs to the dedicated sentinel spawned by this test.
+                let _ = unsafe { libc::kill(-sentinel_group_i32, libc::SIGKILL) };
+                Ok(())
+            },
+        )
+        .expect_err("already-reaped startup child must fail closed");
+        let sentinel_status = sentinel
+            .child_mut()
+            .try_wait()
+            .expect("query group-signal sentinel");
+        assert!(
+            error.contains("already exited before process-group freeze"),
+            "unexpected fail-closed error: {error}"
+        );
+        assert!(
+            group_signals.is_empty(),
+            "reaped child must not trigger a numeric group signal: {group_signals:?}"
+        );
+        assert!(
+            sentinel_status.is_none(),
+            "unrelated group-signal sentinel was terminated"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stale_partial_startup_identity_never_signals_process_group() {
+        let current_exe = std::env::current_exe().expect("test executable");
+        let mut owner_command = std::process::Command::new(&current_exe);
+        owner_command
+            .args(["--ignored", "--exact", "tests::cleanup_wait_helper_process"])
+            .env("TUI_PERF_CLEANUP_HELPER", "1")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .process_group(0);
+        let owner = owner_command.spawn().expect("spawn startup owner sentinel");
+        let mut owner = TestChildGuard::new(owner);
+        let mut stale_partial =
+            wait_for_partial_process_identity(owner.child_mut().id(), owner.child_mut())
+                .expect("capture startup owner partial identity");
+        stale_partial.start_time_unix_s = stale_partial.start_time_unix_s.saturating_add(1);
+        let mut sentinel = spawn_group_signal_sentinel();
+        let sentinel_group = sentinel.child_mut().id();
+        let sentinel_group_i32 = i32::try_from(sentinel_group).expect("sentinel PGID fits pid_t");
+        let producer = super::current_process_identity().expect("producer identity");
+        let mut mpv = Vec::new();
+        let mut descendants = Vec::new();
+        let mut group_signals = Vec::new();
+        let error = emergency_shutdown_spawned_tree_with_group_signal(
+            &current_exe,
+            owner.child_mut(),
+            &producer,
+            Some(&stale_partial),
+            &mut mpv,
+            &mut descendants,
+            |_owner, _mpv, _descendants| Ok(()),
+            |group, requested_signal| {
+                group_signals.push((group, requested_signal));
+                // SAFETY: this PGID belongs to the dedicated sentinel spawned by this test.
+                let _ = unsafe { libc::kill(-sentinel_group_i32, libc::SIGKILL) };
+                Ok(())
+            },
+        )
+        .expect_err("stale partial startup identity must fail closed");
+        let sentinel_status = sentinel
+            .child_mut()
+            .try_wait()
+            .expect("query group-signal sentinel");
+        assert!(
+            error.contains("differs from partial identity"),
+            "unexpected fail-closed error: {error}"
+        );
+        assert!(
+            group_signals.is_empty(),
+            "stale partial identity must not trigger a group signal: {group_signals:?}"
+        );
+        assert!(
+            sentinel_status.is_none(),
+            "unrelated group-signal sentinel was terminated"
+        );
+        assert!(
+            owner
+                .child_mut()
+                .try_wait()
+                .expect("query still-owned startup child")
+                .is_none(),
+            "stale partial validation must not terminate the still-owned child"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn startup_error_emergency_cleanup_captures_late_setsid_child() {
+        let current_exe = std::env::current_exe().expect("test exe");
+        let late_pid_file = std::env::temp_dir().join(format!(
+            "ytt-perf-startup-error-child-{}-{}.pid",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ));
+        let late_guard = LateProcessGuard(late_pid_file.clone());
+        let mut command = std::process::Command::new(&current_exe);
+        command
+            .args([
+                "--ignored",
+                "--exact",
+                "tests::cleanup_wait_helper_process",
+                "--",
+                "startup-error-owner",
+            ])
+            .env("TUI_PERF_CLEANUP_HELPER", "1")
+            .env("TUI_PERF_LATE_CHILD_PID_FILE", &late_pid_file)
+            .env("TUI_PERF_LATE_CHILD_DELAY_MS", "0")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .process_group(0);
+        let owner = command.spawn().expect("spawn startup-error owner helper");
+        let mut owner = TestChildGuard::new(owner);
+        let partial = wait_for_partial_process_identity(owner.child_mut().id(), owner.child_mut())
+            .expect("capture partial startup owner");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !std::fs::read_to_string(&late_pid_file)
+            .is_ok_and(|contents| !contents.trim().is_empty())
+        {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "startup-error setsid child did not publish its PID"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        let late_pid = std::fs::read_to_string(&late_pid_file)
+            .expect("read startup-error late PID")
+            .trim()
+            .parse::<u32>()
+            .expect("parse startup-error late PID");
+        let producer_identity = super::current_process_identity().expect("producer identity");
+        let mut mpv = Vec::new();
+        let mut descendants = Vec::new();
+        let _owner_identity = emergency_shutdown_spawned_tree(
+            &current_exe,
+            owner.child_mut(),
+            &producer_identity,
+            Some(&partial),
+            &mut mpv,
+            &mut descendants,
+            |_owner, _mpv, frozen_descendants| {
+                if !frozen_descendants
+                    .iter()
+                    .any(|identity| identity.pid == late_pid)
+                {
+                    return Err("forced startup error missed late setsid child".to_string());
+                }
+                Ok(())
+            },
+        )
+        .expect("forced startup error uses emergency frozen cleanup");
+        let mut system = sysinfo::System::new();
+        system.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+        assert!(
+            system.process(sysinfo::Pid::from_u32(late_pid)).is_none(),
+            "startup-error setsid child survived emergency cleanup"
+        );
+        drop(late_guard);
     }
 
     #[test]
     #[ignore]
     fn cleanup_wait_helper_process() {
         if std::env::var_os("TUI_PERF_CLEANUP_HELPER").is_some() {
+            if let Some(path) = std::env::var_os("TUI_PERF_LATE_CHILD_PID_FILE") {
+                let delay_ms = std::env::var("TUI_PERF_LATE_CHILD_DELAY_MS")
+                    .ok()
+                    .and_then(|value| value.parse::<u64>().ok())
+                    .unwrap_or(100);
+                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                let script = r#"import os,signal,sys,time
+os.setsid()
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+with open(sys.argv[1], 'w', encoding='ascii') as stream:
+    stream.write(str(os.getpid()))
+    stream.flush()
+while True:
+    time.sleep(1)
+"#;
+                let _late_child = std::process::Command::new("python3")
+                    .args(["-c", script])
+                    .arg(path)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn()
+                    .expect("spawn late setsid child");
+            }
             std::thread::sleep(std::time::Duration::from_secs(30));
         }
     }

--- a/examples/tui_perf_sampler.rs
+++ b/examples/tui_perf_sampler.rs
@@ -1,0 +1,1115 @@
+//! Cross-platform process-tree sampler used by `scripts/tui-perf.{sh,ps1}`.
+//!
+//! The sampler must itself run in an interactive terminal (tmux on Unix, a local
+//! ConPTY/console on Windows). It launches exactly one `ytt`, follows only that PID's
+//! descendants, and writes NDJSON outside the measured terminal. No process-name-wide
+//! cleanup is ever performed.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, Signal, System, UpdateKind};
+
+const SCHEMA: &str = "ytt.tui-perf.samples.v1";
+
+#[derive(Debug)]
+struct Args {
+    output: PathBuf,
+    pid_file: Option<PathBuf>,
+    binary: PathBuf,
+    child_args: Vec<String>,
+    warmup: Duration,
+    duration: Duration,
+    interval: Duration,
+    require_silent_mpv: bool,
+    keep_running: bool,
+}
+
+impl Args {
+    fn parse() -> Result<Self, String> {
+        let mut output = None;
+        let mut pid_file = None;
+        let mut binary = None;
+        let mut warmup_secs = 0.0;
+        let mut duration_secs = 60.0;
+        let mut interval_ms = 1_000u64;
+        let mut require_silent_mpv = false;
+        let mut keep_running = false;
+        let mut child_args = Vec::new();
+        let mut raw = std::env::args().skip(1).peekable();
+
+        while let Some(arg) = raw.next() {
+            if arg == "--" {
+                child_args.extend(raw);
+                break;
+            }
+            let value = |name: &str,
+                         it: &mut std::iter::Peekable<std::iter::Skip<std::env::Args>>|
+             -> Result<String, String> {
+                it.next().ok_or_else(|| format!("{name} requires a value"))
+            };
+            match arg.as_str() {
+                "--output" => output = Some(PathBuf::from(value("--output", &mut raw)?)),
+                "--pid-file" => pid_file = Some(PathBuf::from(value("--pid-file", &mut raw)?)),
+                "--binary" => binary = Some(PathBuf::from(value("--binary", &mut raw)?)),
+                "--warmup-secs" => {
+                    warmup_secs =
+                        parse_nonnegative_f64("--warmup-secs", &value("--warmup-secs", &mut raw)?)?;
+                }
+                "--duration-secs" => {
+                    duration_secs = parse_positive_f64(
+                        "--duration-secs",
+                        &value("--duration-secs", &mut raw)?,
+                    )?;
+                }
+                "--interval-ms" => {
+                    interval_ms = value("--interval-ms", &mut raw)?
+                        .parse::<u64>()
+                        .ok()
+                        .filter(|v| *v >= 100)
+                        .ok_or_else(|| "--interval-ms must be an integer >= 100".to_string())?;
+                }
+                "--require-silent-mpv" => require_silent_mpv = true,
+                "--keep-running" => keep_running = true,
+                "-h" | "--help" => return Err(usage().to_string()),
+                other => return Err(format!("unknown argument `{other}`\n\n{}", usage())),
+            }
+        }
+
+        Ok(Self {
+            output: output.ok_or_else(|| "--output is required".to_string())?,
+            pid_file,
+            binary: binary.ok_or_else(|| "--binary is required".to_string())?,
+            child_args,
+            warmup: Duration::from_secs_f64(warmup_secs),
+            duration: Duration::from_secs_f64(duration_secs),
+            interval: Duration::from_millis(interval_ms),
+            require_silent_mpv,
+            keep_running,
+        })
+    }
+}
+
+fn usage() -> &'static str {
+    "Usage: tui_perf_sampler --output FILE --binary YTT [options] [-- YTT_ARGS...]\n\
+     Options:\n\
+       --pid-file FILE          Write the launched ytt PID atomically\n\
+       --warmup-secs N          Warm-up samples excluded from the summary (default 0)\n\
+       --duration-secs N        Measured duration (default 60)\n\
+       --interval-ms N          Sampling interval, at least 100 ms (default 1000)\n\
+       --require-silent-mpv     Fail unless effective mpv argv has ao=null and volume=0\n\
+       --keep-running           Do not remote-quit/terminate ytt after sampling"
+}
+
+fn parse_nonnegative_f64(name: &str, raw: &str) -> Result<f64, String> {
+    raw.parse::<f64>()
+        .ok()
+        .filter(|v| v.is_finite() && *v >= 0.0)
+        .ok_or_else(|| format!("{name} must be a finite non-negative number"))
+}
+
+fn parse_positive_f64(name: &str, raw: &str) -> Result<f64, String> {
+    raw.parse::<f64>()
+        .ok()
+        .filter(|v| v.is_finite() && *v > 0.0)
+        .ok_or_else(|| format!("{name} must be a finite positive number"))
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+struct RoleSample {
+    processes: usize,
+    cpu_percent: f64,
+    rss_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct ProcessSample {
+    pid: u32,
+    parent_pid: Option<u32>,
+    role: &'static str,
+    name: String,
+    start_time_unix_s: u64,
+    accumulated_cpu_ms: u64,
+    cpu_percent: f64,
+    rss_bytes: u64,
+    command: Vec<String>,
+}
+
+/// The exact mpv descendant identity retained for cleanup after ytt exits. `start_time_unix_s`
+/// protects against ordinary PID reuse, while the run-unique IPC argv protects platforms whose
+/// process start time is only reported at second resolution. Cleanup never falls back to a name.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct MpvIdentity {
+    pid: u32,
+    start_time_unix_s: u64,
+    input_ipc_server_argv: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+struct MeasuredMpvProof {
+    samples: u64,
+    samples_with_mpv: u64,
+    samples_all_silent: u64,
+    samples_all_cleanup_identified: u64,
+}
+
+impl MeasuredMpvProof {
+    fn observe(&mut self, mpv_silence: &[bool], cleanup_identities: usize) {
+        self.samples += 1;
+        if !mpv_silence.is_empty() {
+            self.samples_with_mpv += 1;
+            if mpv_silence.iter().all(|silent| *silent) {
+                self.samples_all_silent += 1;
+            }
+            if cleanup_identities == mpv_silence.len() {
+                self.samples_all_cleanup_identified += 1;
+            }
+        }
+    }
+
+    fn proven(self) -> bool {
+        self.samples > 0
+            && self.samples_with_mpv == self.samples
+            && self.samples_all_silent == self.samples
+    }
+
+    fn cleanup_identities_proven(self) -> bool {
+        self.samples > 0 && self.samples_all_cleanup_identified == self.samples
+    }
+}
+
+#[derive(Clone, Copy)]
+struct CpuPoint {
+    start_time: u64,
+    accumulated_ms: u64,
+    observed_at: Instant,
+}
+
+#[derive(Clone, Copy, Default)]
+struct Aggregate {
+    samples: u64,
+    cpu_sum: f64,
+    rss_sum: u128,
+    rss_peak: u64,
+}
+
+impl Aggregate {
+    fn push(&mut self, value: RoleSample) {
+        self.samples += 1;
+        self.cpu_sum += value.cpu_percent;
+        self.rss_sum += u128::from(value.rss_bytes);
+        self.rss_peak = self.rss_peak.max(value.rss_bytes);
+    }
+
+    fn json(&self) -> serde_json::Value {
+        let divisor = self.samples.max(1) as f64;
+        serde_json::json!({
+            "samples": self.samples,
+            "mean_cpu_percent": self.cpu_sum / divisor,
+            "mean_rss_bytes": (self.rss_sum / u128::from(self.samples.max(1))) as u64,
+            "peak_rss_bytes": self.rss_peak,
+        })
+    }
+}
+
+fn main() {
+    let code = match Args::parse().and_then(run) {
+        Ok(()) => 0,
+        Err(message) => {
+            eprintln!("tui_perf_sampler: {message}");
+            2
+        }
+    };
+    std::process::exit(code);
+}
+
+fn run(args: Args) -> Result<(), String> {
+    if let Some(parent) = args.output.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create output directory {}: {e}", parent.display()))?;
+    }
+    let file =
+        File::create(&args.output).map_err(|e| format!("create {}: {e}", args.output.display()))?;
+    let mut out = BufWriter::new(file);
+
+    let binary_hash = sha256_file(&args.binary)?;
+    let mut child = Command::new(&args.binary)
+        .args(&args.child_args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .map_err(|e| format!("launch {}: {e}", args.binary.display()))?;
+    let root_pid = child.id();
+
+    if let Some(path) = &args.pid_file {
+        write_pid_file(path, root_pid)?;
+    }
+
+    let mut last_mpv_identities = Vec::new();
+    let sample_result = sample_process_tree(
+        &args,
+        root_pid,
+        binary_hash,
+        &mut child,
+        &mut out,
+        &mut last_mpv_identities,
+    );
+    let cleanup_result = if args.keep_running {
+        Ok(())
+    } else {
+        shutdown_child(
+            &args.binary,
+            &mut child,
+            &last_mpv_identities,
+            args.require_silent_mpv,
+        )
+    };
+    let result = match (sample_result, cleanup_result) {
+        (Err(sample), Err(cleanup)) => Err(format!("{sample}; cleanup also failed: {cleanup}")),
+        (Err(sample), Ok(())) => Err(sample),
+        (Ok(()), Err(cleanup)) => Err(cleanup),
+        (Ok(()), Ok(())) => Ok(()),
+    };
+    if let Err(message) = &result {
+        let _ = write_ndjson(
+            &mut out,
+            &serde_json::json!({
+                "schema": SCHEMA,
+                "kind": "error",
+                "root_pid": root_pid,
+                "message": message,
+            }),
+        );
+    }
+    let _ = out.flush();
+    result
+}
+
+fn sample_process_tree(
+    args: &Args,
+    root_pid: u32,
+    binary_hash: String,
+    child: &mut Child,
+    out: &mut BufWriter<File>,
+    last_mpv_identities: &mut Vec<MpvIdentity>,
+) -> Result<(), String> {
+    let started = Instant::now();
+    let deadline = args.warmup + args.duration;
+    let mut system = System::new();
+    let refresh = ProcessRefreshKind::nothing()
+        .with_memory()
+        .with_cpu()
+        .with_cmd(UpdateKind::OnlyIfNotSet)
+        .with_exe(UpdateKind::OnlyIfNotSet)
+        .without_tasks();
+    let mut identities: HashMap<u32, u64> = HashMap::new();
+    let mut cpu_points: HashMap<u32, CpuPoint> = HashMap::new();
+    let mut measured: BTreeMap<&'static str, Aggregate> = BTreeMap::new();
+    let mut measured_mpv_proof = MeasuredMpvProof::default();
+    let mut first = true;
+
+    write_ndjson(
+        out,
+        &serde_json::json!({
+            "schema": SCHEMA,
+            "kind": "header",
+            "root_pid": root_pid,
+            "binary": args.binary,
+            "binary_sha256": binary_hash,
+            "scenario_sha256": std::env::var("TUI_PERF_SCENARIO_SHA256").ok(),
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "warmup_ms": args.warmup.as_millis(),
+            "duration_ms": args.duration.as_millis(),
+            "interval_ms": args.interval.as_millis(),
+            "require_silent_mpv": args.require_silent_mpv,
+        }),
+    )?;
+
+    while first || started.elapsed() < deadline {
+        first = false;
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| format!("query ytt child status: {e}"))?
+        {
+            return Err(format!(
+                "ytt exited unexpectedly before sampling completed: {status}"
+            ));
+        }
+
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+        let root_sys = sysinfo::Pid::from_u32(root_pid);
+        let root = system
+            .process(root_sys)
+            .ok_or_else(|| format!("root PID {root_pid} disappeared"))?;
+        let root_start = root.start_time();
+        match identities.insert(root_pid, root_start) {
+            Some(previous) if previous != root_start => {
+                return Err(format!("root PID {root_pid} was reused"));
+            }
+            _ => {}
+        }
+
+        let tree = descendant_pids(&system, root_pid);
+        let observed_at = Instant::now();
+        let mut process_samples = Vec::with_capacity(tree.len());
+        let mut roles: BTreeMap<&'static str, RoleSample> = BTreeMap::new();
+        let mut observed_mpv_identities = Vec::new();
+        let mut mpv_silence = Vec::new();
+
+        for pid in tree {
+            let Some(process) = system.process(sysinfo::Pid::from_u32(pid)) else {
+                continue;
+            };
+            let start_time = process.start_time();
+            if let Some(previous) = identities.insert(pid, start_time)
+                && previous != start_time
+            {
+                return Err(format!(
+                    "PID reuse detected for {pid}: start time changed from {previous} to {start_time}"
+                ));
+            }
+
+            let accumulated_ms = process.accumulated_cpu_time();
+            let cpu_percent = cpu_points
+                .insert(
+                    pid,
+                    CpuPoint {
+                        start_time,
+                        accumulated_ms,
+                        observed_at,
+                    },
+                )
+                .filter(|previous| previous.start_time == start_time)
+                .and_then(|previous| {
+                    let wall_ms = observed_at
+                        .duration_since(previous.observed_at)
+                        .as_secs_f64()
+                        * 1_000.0;
+                    (wall_ms > 0.0).then(|| {
+                        accumulated_ms.saturating_sub(previous.accumulated_ms) as f64 / wall_ms
+                            * 100.0
+                    })
+                })
+                .unwrap_or(0.0);
+            let command = process
+                .cmd()
+                .iter()
+                .map(|part| part.to_string_lossy().into_owned())
+                .collect::<Vec<_>>();
+            let role = process_role(root_pid, pid, &process.name().to_string_lossy(), &command);
+            if role == "mpv" {
+                mpv_silence.push(silent_mpv_args(&command));
+                if let Some(input_ipc_server_argv) = input_ipc_server_argv(&command) {
+                    observed_mpv_identities.push(MpvIdentity {
+                        pid,
+                        start_time_unix_s: start_time,
+                        input_ipc_server_argv,
+                    });
+                }
+            }
+            let sample = roles.entry(role).or_default();
+            sample.processes += 1;
+            sample.cpu_percent += cpu_percent;
+            sample.rss_bytes = sample.rss_bytes.saturating_add(process.memory());
+            process_samples.push(ProcessSample {
+                pid,
+                parent_pid: process.parent().map(sysinfo::Pid::as_u32),
+                role,
+                name: process.name().to_string_lossy().into_owned(),
+                start_time_unix_s: start_time,
+                accumulated_cpu_ms: accumulated_ms,
+                cpu_percent,
+                rss_bytes: process.memory(),
+                command,
+            });
+        }
+
+        let total = roles
+            .values()
+            .copied()
+            .fold(RoleSample::default(), |mut sum, item| {
+                sum.processes += item.processes;
+                sum.cpu_percent += item.cpu_percent;
+                sum.rss_bytes = sum.rss_bytes.saturating_add(item.rss_bytes);
+                sum
+            });
+        roles.insert("tree", total);
+        let phase = if started.elapsed() < args.warmup {
+            "warmup"
+        } else {
+            measured_mpv_proof.observe(&mpv_silence, observed_mpv_identities.len());
+            for (role, sample) in &roles {
+                measured.entry(role).or_default().push(*sample);
+            }
+            "measure"
+        };
+        if !observed_mpv_identities.is_empty() {
+            *last_mpv_identities = observed_mpv_identities;
+        }
+        write_ndjson(
+            out,
+            &serde_json::json!({
+                "schema": SCHEMA,
+                "kind": "sample",
+                "elapsed_ms": started.elapsed().as_millis(),
+                "phase": phase,
+                "mpv_present": !mpv_silence.is_empty(),
+                "mpv_all_silent_this_sample": !mpv_silence.is_empty()
+                    && mpv_silence.iter().all(|silent| *silent),
+                "roles": roles,
+                "processes": process_samples,
+            }),
+        )?;
+        out.flush().map_err(|e| format!("flush samples: {e}"))?;
+
+        let next_index =
+            (started.elapsed().as_secs_f64() / args.interval.as_secs_f64()).floor() as u32 + 1;
+        let next = args.interval.saturating_mul(next_index);
+        if next > started.elapsed() {
+            thread::sleep(next - started.elapsed());
+        }
+    }
+
+    let silent_mpv_proven = measured_mpv_proof.proven();
+    if args.require_silent_mpv && !silent_mpv_proven {
+        return Err(format!(
+            "measured phase requires mpv in every sample with effective last-option-wins \
+             --ao=null and --volume=0 (samples={}, with_mpv={}, all_silent={})",
+            measured_mpv_proof.samples,
+            measured_mpv_proof.samples_with_mpv,
+            measured_mpv_proof.samples_all_silent,
+        ));
+    }
+    if args.require_silent_mpv && !measured_mpv_proof.cleanup_identities_proven() {
+        return Err(format!(
+            "every measured mpv must expose an exact --input-ipc-server argv identity for \
+             cleanup (samples={}, all_identified={})",
+            measured_mpv_proof.samples, measured_mpv_proof.samples_all_cleanup_identified,
+        ));
+    }
+    let summary = measured
+        .iter()
+        .map(|(role, aggregate)| ((*role).to_string(), aggregate.json()))
+        .collect::<serde_json::Map<_, _>>();
+    write_ndjson(
+        out,
+        &serde_json::json!({
+            "schema": SCHEMA,
+            "kind": "summary",
+            "root_pid": root_pid,
+            "silent_mpv_proven": silent_mpv_proven,
+            "measured_mpv_proof": measured_mpv_proof,
+            "last_observed_mpv": last_mpv_identities,
+            "roles": summary,
+        }),
+    )?;
+    Ok(())
+}
+
+fn descendant_pids(system: &System, root: u32) -> Vec<u32> {
+    let mut included = HashSet::from([root]);
+    loop {
+        let before = included.len();
+        for (pid, process) in system.processes() {
+            if process
+                .parent()
+                .is_some_and(|parent| included.contains(&parent.as_u32()))
+            {
+                included.insert(pid.as_u32());
+            }
+        }
+        if included.len() == before {
+            break;
+        }
+    }
+    let mut pids = included.into_iter().collect::<Vec<_>>();
+    pids.sort_unstable();
+    pids
+}
+
+fn process_role(root_pid: u32, pid: u32, name: &str, command: &[String]) -> &'static str {
+    if pid == root_pid {
+        return "ytt";
+    }
+    let name = name.to_ascii_lowercase();
+    let argv0 = command
+        .first()
+        .and_then(|value| Path::new(value).file_stem())
+        .map(|value| value.to_string_lossy().to_ascii_lowercase())
+        .unwrap_or_default();
+    if name == "mpv" || name == "mpv.exe" || argv0 == "mpv" {
+        "mpv"
+    } else {
+        "other"
+    }
+}
+
+/// mpv is last-option-wins. Merely finding the two safety flags is insufficient because a
+/// later argument could re-enable sound, so this parser records the final value of each option.
+fn silent_mpv_args(command: &[String]) -> bool {
+    let mut ao = None;
+    let mut volume = None;
+    let mut index = 0;
+    while index < command.len() {
+        let arg = &command[index];
+        if let Some(value) = arg.strip_prefix("--ao=") {
+            ao = Some(value.to_ascii_lowercase());
+        } else if arg == "--ao" && index + 1 < command.len() {
+            index += 1;
+            ao = Some(command[index].to_ascii_lowercase());
+        } else if let Some(value) = arg.strip_prefix("--volume=") {
+            volume = Some(value.to_string());
+        } else if arg == "--volume" && index + 1 < command.len() {
+            index += 1;
+            volume = Some(command[index].clone());
+        }
+        index += 1;
+    }
+    ao.as_deref() == Some("null")
+        && volume
+            .as_deref()
+            .and_then(|value| value.parse::<f64>().ok())
+            .is_some_and(|value| value == 0.0)
+}
+
+/// Preserve the exact argv spelling for every IPC-server occurrence. Both `--key=value` and
+/// split `--key value` forms are supported; a malformed split option is not an identity.
+fn input_ipc_server_argv(command: &[String]) -> Option<Vec<String>> {
+    let mut identity = Vec::new();
+    let mut saw_nonempty_value = false;
+    let mut index = 0;
+    while index < command.len() {
+        let arg = &command[index];
+        if let Some(value) = arg.strip_prefix("--input-ipc-server=") {
+            saw_nonempty_value |= !value.is_empty();
+            identity.push(arg.clone());
+        } else if arg == "--input-ipc-server" {
+            let value = command.get(index + 1)?;
+            saw_nonempty_value |= !value.is_empty();
+            identity.push(arg.clone());
+            identity.push(value.clone());
+            index += 1;
+        }
+        index += 1;
+    }
+    saw_nonempty_value.then_some(identity)
+}
+
+fn exact_mpv_identity_matches(
+    identity: &MpvIdentity,
+    pid: u32,
+    start_time_unix_s: u64,
+    command: &[String],
+) -> bool {
+    identity.pid == pid
+        && identity.start_time_unix_s == start_time_unix_s
+        && input_ipc_server_argv(command).as_ref() == Some(&identity.input_ipc_server_argv)
+}
+
+fn write_pid_file(path: &Path, pid: u32) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create pid directory {}: {e}", parent.display()))?;
+    }
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, format!("{pid}\n"))
+        .map_err(|e| format!("write {}: {e}", tmp.display()))?;
+    std::fs::rename(&tmp, path).map_err(|e| format!("publish {}: {e}", path.display()))
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let bytes = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    Ok(format!("{:x}", Sha256::digest(bytes)))
+}
+
+fn write_ndjson(out: &mut BufWriter<File>, value: &impl Serialize) -> Result<(), String> {
+    serde_json::to_writer(&mut *out, value).map_err(|e| format!("encode NDJSON: {e}"))?;
+    out.write_all(b"\n")
+        .map_err(|e| format!("write NDJSON: {e}"))
+}
+
+fn shutdown_child(
+    binary: &Path,
+    child: &mut Child,
+    last_mpv_identities: &[MpvIdentity],
+    require_mpv_identity: bool,
+) -> Result<(), String> {
+    shutdown_child_with_grace(
+        binary,
+        child,
+        last_mpv_identities,
+        require_mpv_identity,
+        Duration::from_secs(5),
+    )
+}
+
+fn shutdown_child_with_grace(
+    binary: &Path,
+    child: &mut Child,
+    last_mpv_identities: &[MpvIdentity],
+    require_mpv_identity: bool,
+    clean_grace: Duration,
+) -> Result<(), String> {
+    let mut hard_fallback = false;
+    if child
+        .try_wait()
+        .map_err(|e| format!("query ytt status before shutdown: {e}"))?
+        .is_none()
+    {
+        let _ = Command::new(binary)
+            .args(["-r", "quit", "-q"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        let deadline = Instant::now() + clean_grace;
+        while Instant::now() < deadline {
+            if child
+                .try_wait()
+                .map_err(|e| format!("wait for clean ytt shutdown: {e}"))?
+                .is_some()
+            {
+                break;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        if child
+            .try_wait()
+            .map_err(|e| format!("query ytt after clean-shutdown grace: {e}"))?
+            .is_none()
+        {
+            hard_fallback = true;
+            // This is the exact Child handle launched above, never a process-name lookup. On
+            // Unix it is a hard signal and can bypass ytt Drop hooks, so the recorded exact mpv
+            // descendants are verified and reaped below.
+            child
+                .kill()
+                .map_err(|e| format!("hard-kill exact ytt child PID {}: {e}", child.id()))?;
+            child
+                .wait()
+                .map_err(|e| format!("wait for exact ytt child PID {}: {e}", child.id()))?;
+        }
+    }
+
+    if hard_fallback && require_mpv_identity && last_mpv_identities.is_empty() {
+        return Err(
+            "hard ytt fallback had no recorded exact mpv PID/start-time/IPC argv identity"
+                .to_string(),
+        );
+    }
+    for identity in last_mpv_identities {
+        stop_exact_mpv(identity, hard_fallback)?;
+    }
+    Ok(())
+}
+
+fn stop_exact_mpv(identity: &MpvIdentity, hard_fallback: bool) -> Result<(), String> {
+    let refresh = ProcessRefreshKind::nothing()
+        .with_cmd(UpdateKind::Always)
+        .without_tasks();
+    let mut system = System::new();
+
+    // Give the normal ytt Drop/Windows Job Object path a short opportunity to finish. After a
+    // hard ytt kill we refresh immediately; the descendant may already have been reparented.
+    let natural_deadline = Instant::now()
+        + if hard_fallback {
+            Duration::ZERO
+        } else {
+            Duration::from_secs(2)
+        };
+    loop {
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+        if !system
+            .process(sysinfo::Pid::from_u32(identity.pid))
+            .is_some_and(|process| {
+                let command = process
+                    .cmd()
+                    .iter()
+                    .map(|part| part.to_string_lossy().into_owned())
+                    .collect::<Vec<_>>();
+                exact_mpv_identity_matches(identity, identity.pid, process.start_time(), &command)
+            })
+        {
+            return Ok(());
+        }
+        if Instant::now() >= natural_deadline {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    let pid = sysinfo::Pid::from_u32(identity.pid);
+    let process = system
+        .process(pid)
+        .ok_or_else(|| format!("exact mpv PID {} disappeared during cleanup", identity.pid))?;
+    let term_sent = process.kill_with(Signal::Term).unwrap_or(false);
+    if !term_sent && !process.kill() {
+        return Err(format!(
+            "failed to terminate exact mpv PID {} after identity verification",
+            identity.pid
+        ));
+    }
+
+    let term_deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < term_deadline {
+        thread::sleep(Duration::from_millis(50));
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+        let still_exact = system.process(pid).is_some_and(|process| {
+            let command = process
+                .cmd()
+                .iter()
+                .map(|part| part.to_string_lossy().into_owned())
+                .collect::<Vec<_>>();
+            exact_mpv_identity_matches(identity, identity.pid, process.start_time(), &command)
+        });
+        if !still_exact {
+            return Ok(());
+        }
+    }
+
+    // TERM can be ignored on Unix and is unavailable on some Windows builds. Re-verify all
+    // identity components immediately before the final hard signal.
+    let Some(process) = system.process(pid) else {
+        return Ok(());
+    };
+    let command = process
+        .cmd()
+        .iter()
+        .map(|part| part.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    if !exact_mpv_identity_matches(identity, identity.pid, process.start_time(), &command) {
+        return Ok(());
+    }
+    if !process.kill() {
+        return Err(format!(
+            "failed to hard-kill exact mpv PID {} after TERM grace",
+            identity.pid
+        ));
+    }
+
+    let kill_deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < kill_deadline {
+        thread::sleep(Duration::from_millis(50));
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
+        let still_exact = system.process(pid).is_some_and(|process| {
+            let command = process
+                .cmd()
+                .iter()
+                .map(|part| part.to_string_lossy().into_owned())
+                .collect::<Vec<_>>();
+            exact_mpv_identity_matches(identity, identity.pid, process.start_time(), &command)
+        });
+        if !still_exact {
+            return Ok(());
+        }
+    }
+    Err(format!(
+        "exact mpv PID {} remained after verified cleanup and wait",
+        identity.pid
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{
+        MeasuredMpvProof, MpvIdentity, exact_mpv_identity_matches, input_ipc_server_argv,
+        shutdown_child_with_grace, silent_mpv_args, stop_exact_mpv,
+    };
+    use yututui::api::{Song, validate_playable_url, validate_playback_target_for_handoff};
+    use yututui::search_source::SearchSource;
+
+    #[test]
+    fn silence_check_honors_last_option_wins() {
+        let safe = vec!["mpv", "--ao=null", "--volume=0"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        assert!(silent_mpv_args(&safe));
+
+        let unsafe_ao = vec!["mpv", "--ao=null", "--volume=0", "--ao=coreaudio"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        assert!(!silent_mpv_args(&unsafe_ao));
+
+        let split = vec!["mpv", "--ao", "null", "--volume", "0.0"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        assert!(silent_mpv_args(&split));
+    }
+
+    #[test]
+    fn silent_mpv_proof_requires_every_measured_sample_not_warmup_evidence() {
+        let mut warmup_only = MeasuredMpvProof::default();
+        assert!(
+            !warmup_only.proven(),
+            "warmup observations are never recorded here"
+        );
+
+        warmup_only.observe(&[], 0);
+        warmup_only.observe(&[true], 1);
+        assert!(
+            !warmup_only.proven(),
+            "a missing measured mpv sample must invalidate the proof"
+        );
+
+        let mut unsafe_later = MeasuredMpvProof::default();
+        unsafe_later.observe(&[true], 1);
+        unsafe_later.observe(&[false], 1);
+        assert!(
+            !unsafe_later.proven(),
+            "a later last-option-wins sound override must invalidate the proof"
+        );
+
+        let mut measured_safe = MeasuredMpvProof::default();
+        measured_safe.observe(&[true], 1);
+        measured_safe.observe(&[true], 1);
+        assert!(measured_safe.proven());
+        assert!(measured_safe.cleanup_identities_proven());
+
+        let mut missing_identity = MeasuredMpvProof::default();
+        missing_identity.observe(&[true], 0);
+        assert!(missing_identity.proven());
+        assert!(!missing_identity.cleanup_identities_proven());
+    }
+
+    #[test]
+    fn hard_fallback_cleanup_requires_pid_start_time_and_exact_ipc_argv() {
+        let equals = vec![
+            "mpv".to_string(),
+            "--input-ipc-server=/tmp/ytt-run-7/mpv.sock".to_string(),
+            "--ao=null".to_string(),
+        ];
+        let identity = MpvIdentity {
+            pid: 4_242,
+            start_time_unix_s: 99,
+            input_ipc_server_argv: input_ipc_server_argv(&equals).expect("extract IPC argv"),
+        };
+        assert!(exact_mpv_identity_matches(&identity, 4_242, 99, &equals));
+        assert!(!exact_mpv_identity_matches(&identity, 4_243, 99, &equals));
+        assert!(!exact_mpv_identity_matches(&identity, 4_242, 100, &equals));
+
+        let reused_endpoint = vec![
+            "mpv".to_string(),
+            "--input-ipc-server=/tmp/another-run/mpv.sock".to_string(),
+            "--ao=null".to_string(),
+        ];
+        assert!(!exact_mpv_identity_matches(
+            &identity,
+            4_242,
+            99,
+            &reused_endpoint,
+        ));
+
+        let split = vec![
+            "mpv".to_string(),
+            "--input-ipc-server".to_string(),
+            r"C:\ytt-perf\run\mpv.sock".to_string(),
+        ];
+        assert_eq!(
+            input_ipc_server_argv(&split),
+            Some(vec![
+                "--input-ipc-server".to_string(),
+                r"C:\ytt-perf\run\mpv.sock".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn verified_hard_fallback_terminates_and_waits_for_the_exact_process() {
+        let ipc_arg = format!(
+            "--input-ipc-server={}/ytt-perf-cleanup-{}-{}.sock",
+            std::env::temp_dir().display(),
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos(),
+        );
+        let mut child = std::process::Command::new(std::env::current_exe().expect("test exe"))
+            .args([
+                "--ignored",
+                "--exact",
+                "tests::cleanup_wait_helper_process",
+                "--",
+                &ipc_arg,
+            ])
+            .env("TUI_PERF_CLEANUP_HELPER", "1")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn cleanup helper");
+        let pid = child.id();
+        let refresh = sysinfo::ProcessRefreshKind::nothing()
+            .with_cmd(sysinfo::UpdateKind::Always)
+            .without_tasks();
+        let mut system = sysinfo::System::new();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let identity = loop {
+            system.refresh_processes_specifics(sysinfo::ProcessesToUpdate::All, true, refresh);
+            if let Some(process) = system.process(sysinfo::Pid::from_u32(pid)) {
+                let command = process
+                    .cmd()
+                    .iter()
+                    .map(|part| part.to_string_lossy().into_owned())
+                    .collect::<Vec<_>>();
+                if let Some(input_ipc_server_argv) = input_ipc_server_argv(&command) {
+                    break MpvIdentity {
+                        pid,
+                        start_time_unix_s: process.start_time(),
+                        input_ipc_server_argv,
+                    };
+                }
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "cleanup helper never published its argv"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        };
+
+        // Reap the direct test child concurrently. In production mpv is ytt's descendant and
+        // is reaped by the OS after ytt is gone; this preserves the same observable lifecycle.
+        let waiter = std::thread::spawn(move || child.wait());
+        stop_exact_mpv(&identity, true).expect("verified cleanup succeeds");
+        let status = waiter
+            .join()
+            .expect("waiter thread")
+            .expect("wait cleanup helper");
+        assert!(!status.success(), "helper must have been terminated");
+    }
+
+    #[test]
+    fn child_hard_fallback_also_cleans_the_recorded_exact_mpv() {
+        let current_exe = std::env::current_exe().expect("test exe");
+        let helper_args = [
+            "--ignored",
+            "--exact",
+            "tests::cleanup_wait_helper_process",
+            "--",
+        ];
+        let mut ytt = std::process::Command::new(&current_exe)
+            .args(helper_args)
+            .arg("ytt-owner-helper")
+            .env("TUI_PERF_CLEANUP_HELPER", "1")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn ytt owner helper");
+        let ipc_arg = format!(
+            "--input-ipc-server={}/ytt-perf-fallback-{}-{}.sock",
+            std::env::temp_dir().display(),
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos(),
+        );
+        let mut mpv = std::process::Command::new(&current_exe)
+            .args(helper_args)
+            .arg(&ipc_arg)
+            .env("TUI_PERF_CLEANUP_HELPER", "1")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn mpv helper");
+        let mpv_pid = mpv.id();
+        let refresh = sysinfo::ProcessRefreshKind::nothing()
+            .with_cmd(sysinfo::UpdateKind::Always)
+            .without_tasks();
+        let mut system = sysinfo::System::new();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let identity = loop {
+            system.refresh_processes_specifics(sysinfo::ProcessesToUpdate::All, true, refresh);
+            if let Some(process) = system.process(sysinfo::Pid::from_u32(mpv_pid)) {
+                let command = process
+                    .cmd()
+                    .iter()
+                    .map(|part| part.to_string_lossy().into_owned())
+                    .collect::<Vec<_>>();
+                if let Some(input_ipc_server_argv) = input_ipc_server_argv(&command) {
+                    break MpvIdentity {
+                        pid: mpv_pid,
+                        start_time_unix_s: process.start_time(),
+                        input_ipc_server_argv,
+                    };
+                }
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "mpv helper never published its argv"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        };
+        let mpv_waiter = std::thread::spawn(move || mpv.wait());
+
+        shutdown_child_with_grace(
+            &current_exe,
+            &mut ytt,
+            &[identity],
+            true,
+            std::time::Duration::from_millis(20),
+        )
+        .expect("hard fallback cleans exact child and mpv");
+        assert!(
+            ytt.try_wait().expect("query ytt helper").is_some(),
+            "exact ytt child must have been reaped"
+        );
+        let mpv_status = mpv_waiter
+            .join()
+            .expect("mpv waiter thread")
+            .expect("wait mpv helper");
+        assert!(!mpv_status.success(), "exact mpv helper must be terminated");
+    }
+
+    #[test]
+    #[ignore]
+    fn cleanup_wait_helper_process() {
+        if std::env::var_os("TUI_PERF_CLEANUP_HELPER").is_some() {
+            std::thread::sleep(std::time::Duration::from_secs(30));
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn local_m3u_indirection_passes_both_playback_url_guards() {
+        assert!(
+            validate_playable_url(
+                SearchSource::RadioBrowser,
+                "http://127.0.0.1:12345/fixture.wav",
+            )
+            .is_err(),
+            "a seeded direct loopback URL must remain forbidden",
+        );
+
+        let playlist = if cfg!(windows) {
+            PathBuf::from(r"C:\ytt-perf\home\fixture\tui-perf-stream.m3u")
+        } else {
+            PathBuf::from("/ytt-perf/home/fixture/tui-perf-stream.m3u")
+        };
+        let target = Song::local_file(playlist.clone())
+            .playback_target_checked()
+            .expect("a local playlist path is a valid Song playback target");
+        assert_eq!(target, playlist.to_string_lossy());
+        assert_eq!(
+            validate_playback_target_for_handoff(&target)
+                .await
+                .expect("player handoff accepts local paths"),
+            target,
+        );
+    }
+}

--- a/examples/tui_render_perf.rs
+++ b/examples/tui_render_perf.rs
@@ -1,0 +1,858 @@
+//! Deterministic in-process render/allocation benchmark.
+//!
+//! This is intentionally an `example`, not a criterion benchmark: the exact same source can
+//! be copied onto the frozen baseline tree, it needs no new dependency, and it emits one stable
+//! JSON schema that `scripts/tui-perf.py compare` can pair across revisions.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::hash_map::DefaultHasher;
+use std::fs::File;
+use std::hash::{Hash, Hasher};
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use yututui::api::Song;
+use yututui::app::{AiMessage, AiRole, App, LibraryTab, LocalSection, Mode, Msg, SearchFocus};
+use yututui::i18n::Language;
+use yututui::local::{LocalIndex, LocalTrack};
+
+const SCHEMA: &str = "ytt.tui-perf.render.v1";
+const LOCAL_SCROLL_TRACKS: usize = 180;
+const LOCAL_LARGE_TRACKS: usize = 999;
+const LOCAL_FILTER_STRIDE: usize = 17;
+
+struct CountingAllocator;
+
+static ALLOCS: AtomicU64 = AtomicU64::new(0);
+static REALLOCS: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED: AtomicU64 = AtomicU64::new(0);
+static DEALLOCATED: AtomicU64 = AtomicU64::new(0);
+static LIVE: AtomicU64 = AtomicU64::new(0);
+static WINDOW_PEAK: AtomicU64 = AtomicU64::new(0);
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+// SAFETY: every operation is delegated unchanged to the process System allocator. The atomics
+// only observe sizes and never influence the pointer, layout, or allocation result.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: forwarding the caller-provided layout to System is the GlobalAlloc contract.
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED.fetch_add(layout.size() as u64, Ordering::Relaxed);
+            let live =
+                LIVE.fetch_add(layout.size() as u64, Ordering::Relaxed) + layout.size() as u64;
+            update_peak(live);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        DEALLOCATED.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        LIVE.fetch_sub(layout.size() as u64, Ordering::Relaxed);
+        // SAFETY: pointer/layout are the exact pair supplied by the GlobalAlloc caller.
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: forwarding the caller-provided allocation and size to System.
+        let new_pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        if !new_pointer.is_null() {
+            REALLOCS.fetch_add(1, Ordering::Relaxed);
+            if new_size >= layout.size() {
+                let growth = (new_size - layout.size()) as u64;
+                ALLOCATED.fetch_add(growth, Ordering::Relaxed);
+                let live = LIVE.fetch_add(growth, Ordering::Relaxed) + growth;
+                update_peak(live);
+            } else {
+                let shrink = (layout.size() - new_size) as u64;
+                DEALLOCATED.fetch_add(shrink, Ordering::Relaxed);
+                LIVE.fetch_sub(shrink, Ordering::Relaxed);
+            }
+        }
+        new_pointer
+    }
+}
+
+fn update_peak(live: u64) {
+    let mut peak = WINDOW_PEAK.load(Ordering::Relaxed);
+    while live > peak {
+        match WINDOW_PEAK.compare_exchange_weak(peak, live, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => return,
+            Err(current) => peak = current,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct AllocSnapshot {
+    allocs: u64,
+    reallocs: u64,
+    allocated: u64,
+    deallocated: u64,
+    live: u64,
+}
+
+impl AllocSnapshot {
+    fn now() -> Self {
+        Self {
+            allocs: ALLOCS.load(Ordering::Relaxed),
+            reallocs: REALLOCS.load(Ordering::Relaxed),
+            allocated: ALLOCATED.load(Ordering::Relaxed),
+            deallocated: DEALLOCATED.load(Ordering::Relaxed),
+            live: LIVE.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Args {
+    output: Option<PathBuf>,
+    case: Option<String>,
+    warmup: usize,
+    batches: usize,
+    draws: usize,
+}
+
+impl Args {
+    fn parse() -> Result<Self, String> {
+        let mut output = None;
+        let mut case = None;
+        let mut warmup = 20;
+        let mut batches = 20;
+        let mut draws = 200;
+        let mut raw = std::env::args().skip(1);
+        while let Some(arg) = raw.next() {
+            let next = |name: &str, it: &mut std::iter::Skip<std::env::Args>| {
+                it.next().ok_or_else(|| format!("{name} requires a value"))
+            };
+            match arg.as_str() {
+                "--output" => output = Some(PathBuf::from(next("--output", &mut raw)?)),
+                "--case" => case = Some(next("--case", &mut raw)?),
+                "--warmup" => warmup = positive_usize("--warmup", &next("--warmup", &mut raw)?)?,
+                "--batches" => {
+                    batches = positive_usize("--batches", &next("--batches", &mut raw)?)?
+                }
+                "--draws" => draws = positive_usize("--draws", &next("--draws", &mut raw)?)?,
+                "-h" | "--help" => return Err(usage().to_string()),
+                other => return Err(format!("unknown argument `{other}`\n\n{}", usage())),
+            }
+        }
+        Ok(Self {
+            output,
+            case,
+            warmup,
+            batches,
+            draws,
+        })
+    }
+}
+
+fn positive_usize(name: &str, raw: &str) -> Result<usize, String> {
+    raw.parse::<usize>()
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or_else(|| format!("{name} must be a positive integer"))
+}
+
+fn usage() -> &'static str {
+    "Usage: tui_render_perf [--output FILE] [--case NAME] [--warmup N] [--batches N] [--draws N]\n\
+     Cases: player, search50, library999, ai_long, reducer_input, retro160x50, normal80x24, \
+     local_empty60x16, local_scroll72x18, local_max120x30, local_filter_ko90x24"
+}
+
+#[derive(Serialize)]
+struct BatchReport {
+    batch: usize,
+    draws: usize,
+    total_ns: u128,
+    mean_draw_ns: f64,
+    p50_draw_ns: u128,
+    p95_draw_ns: u128,
+    max_draw_ns: u128,
+    allocations: u64,
+    reallocations: u64,
+    allocated_bytes: u64,
+    deallocated_bytes: u64,
+    retained_bytes_delta: i64,
+    peak_live_bytes_delta: u64,
+}
+
+#[derive(Serialize)]
+struct CaseReport {
+    name: String,
+    update_path: &'static str,
+    width: u16,
+    height: u16,
+    warmup_draws: usize,
+    measured_draws: usize,
+    p95_draw_ns: u128,
+    batches: Vec<BatchReport>,
+    buffer_style_digest: String,
+    hit_map_digest: String,
+}
+
+#[derive(Serialize)]
+struct Report {
+    schema: &'static str,
+    kind: &'static str,
+    binary: PathBuf,
+    binary_sha256: String,
+    scenario_sha256: Option<String>,
+    os: &'static str,
+    arch: &'static str,
+    batches_per_case: usize,
+    draws_per_batch: usize,
+    cases: Vec<CaseReport>,
+}
+
+fn main() {
+    let args = match Args::parse() {
+        Ok(args) => args,
+        Err(message) => {
+            eprintln!("tui_render_perf: {message}");
+            std::process::exit(2);
+        }
+    };
+    let binary = std::env::current_exe().unwrap_or_else(|error| {
+        eprintln!("tui_render_perf: locate current executable: {error}");
+        std::process::exit(2);
+    });
+    let binary_sha256 = sha256_file(&binary).unwrap_or_else(|message| {
+        eprintln!("tui_render_perf: {message}");
+        std::process::exit(2);
+    });
+    let selected = args.case.as_deref();
+    let specs = case_specs();
+    if let Some(case) = selected
+        && !specs.iter().any(|spec| spec.name == case)
+    {
+        eprintln!("tui_render_perf: unknown case `{case}`\n\n{}", usage());
+        std::process::exit(2);
+    }
+
+    let cases = specs
+        .into_iter()
+        .filter(|spec| selected.is_none_or(|case| spec.name == case))
+        .map(|spec| run_case(spec, args.warmup, args.batches, args.draws))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap_or_else(|message| {
+            eprintln!("tui_render_perf: {message}");
+            std::process::exit(2);
+        });
+    let report = Report {
+        schema: SCHEMA,
+        kind: "render_summary",
+        binary,
+        binary_sha256,
+        scenario_sha256: std::env::var("TUI_PERF_SCENARIO_SHA256").ok(),
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+        batches_per_case: args.batches,
+        draws_per_batch: args.draws,
+        cases,
+    };
+    let encoded = serde_json::to_vec_pretty(&report).expect("serialize render report");
+    match args.output {
+        Some(path) => {
+            if let Some(parent) = path.parent()
+                && let Err(error) = std::fs::create_dir_all(parent)
+            {
+                eprintln!("tui_render_perf: create {}: {error}", parent.display());
+                std::process::exit(2);
+            }
+            let mut out = BufWriter::new(File::create(&path).unwrap_or_else(|error| {
+                eprintln!("tui_render_perf: create {}: {error}", path.display());
+                std::process::exit(2);
+            }));
+            out.write_all(&encoded).expect("write render report");
+            out.write_all(b"\n").expect("terminate render report");
+        }
+        None => {
+            std::io::stdout()
+                .write_all(&encoded)
+                .expect("write render report");
+            println!();
+        }
+    }
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let file = File::open(path).map_err(|error| format!("open {}: {error}", path.display()))?;
+    let mut reader = BufReader::new(file);
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|error| format!("read {}: {error}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+#[derive(Clone, Copy)]
+struct CaseSpec {
+    name: &'static str,
+    update_path: &'static str,
+    width: u16,
+    height: u16,
+    language: Language,
+    build: fn() -> App,
+    update: fn(&mut App, usize),
+}
+
+fn case_specs() -> Vec<CaseSpec> {
+    vec![
+        CaseSpec {
+            name: "player",
+            update_path: "direct_fixture_state",
+            width: 100,
+            height: 30,
+            language: Language::English,
+            build: player_app,
+            update: mutate_for_interaction,
+        },
+        CaseSpec {
+            name: "search50",
+            update_path: "direct_fixture_state",
+            width: 100,
+            height: 30,
+            language: Language::English,
+            build: search_app,
+            update: mutate_for_interaction,
+        },
+        CaseSpec {
+            name: "library999",
+            update_path: "direct_fixture_state",
+            width: 100,
+            height: 30,
+            language: Language::English,
+            build: library_app,
+            update: mutate_for_interaction,
+        },
+        CaseSpec {
+            name: "ai_long",
+            update_path: "direct_fixture_state",
+            width: 100,
+            height: 30,
+            language: Language::English,
+            build: ai_app,
+            update: mutate_for_interaction,
+        },
+        CaseSpec {
+            name: "reducer_input",
+            update_path: "app_update_msg_key",
+            width: 100,
+            height: 30,
+            language: Language::English,
+            build: search_app,
+            update: reducer_input,
+        },
+        CaseSpec {
+            name: "retro160x50",
+            update_path: "direct_fixture_state",
+            width: 160,
+            height: 50,
+            language: Language::English,
+            build: retro_app,
+            update: mutate_for_interaction,
+        },
+        CaseSpec {
+            name: "normal80x24",
+            update_path: "direct_fixture_state",
+            width: 80,
+            height: 24,
+            language: Language::English,
+            build: player_app,
+            update: mutate_for_interaction,
+        },
+        CaseSpec {
+            name: "local_empty60x16",
+            update_path: "direct_fixture_state",
+            width: 60,
+            height: 16,
+            language: Language::English,
+            build: local_empty_app,
+            update: no_interaction,
+        },
+        CaseSpec {
+            name: "local_scroll72x18",
+            update_path: "direct_fixture_state",
+            width: 72,
+            height: 18,
+            language: Language::English,
+            build: local_scroll_app,
+            update: local_scroll_interaction,
+        },
+        CaseSpec {
+            name: "local_max120x30",
+            update_path: "direct_fixture_state",
+            width: 120,
+            height: 30,
+            language: Language::English,
+            build: local_max_app,
+            update: local_max_interaction,
+        },
+        CaseSpec {
+            name: "local_filter_ko90x24",
+            update_path: "direct_fixture_state",
+            width: 90,
+            height: 24,
+            language: Language::Korean,
+            build: local_filter_korean_app,
+            update: local_filter_interaction,
+        },
+    ]
+}
+
+fn run_case(
+    spec: CaseSpec,
+    warmup: usize,
+    batch_count: usize,
+    draws_per_batch: usize,
+) -> Result<CaseReport, String> {
+    yututui::i18n::set_language(spec.language);
+    let mut app = (spec.build)();
+    let backend = TestBackend::new(spec.width, spec.height);
+    let mut terminal = Terminal::new(backend).map_err(|e| format!("create backend: {e}"))?;
+    for step in 0..warmup {
+        (spec.update)(&mut app, step);
+        terminal
+            .draw(|frame| yututui::ui::render(frame, &app))
+            .map_err(|e| format!("warm-up draw: {e}"))?;
+    }
+
+    let mut batches = Vec::with_capacity(batch_count);
+    let mut case_latencies = Vec::with_capacity(batch_count.saturating_mul(draws_per_batch));
+    for batch in 0..batch_count {
+        let before = AllocSnapshot::now();
+        WINDOW_PEAK.store(before.live, Ordering::Relaxed);
+        let batch_started = Instant::now();
+        let mut latencies = Vec::with_capacity(draws_per_batch);
+        for draw in 0..draws_per_batch {
+            let latency = measure_update_to_draw(|| {
+                (spec.update)(&mut app, batch * draws_per_batch + draw);
+                terminal
+                    .draw(|frame| yututui::ui::render(frame, &app))
+                    .map(|_| ())
+                    .map_err(|e| format!("measured draw: {e}"))
+            })?;
+            latencies.push(latency);
+        }
+        let total_ns = batch_started.elapsed().as_nanos();
+        let after = AllocSnapshot::now();
+        case_latencies.extend_from_slice(&latencies);
+        latencies.sort_unstable();
+        batches.push(BatchReport {
+            batch,
+            draws: draws_per_batch,
+            total_ns,
+            mean_draw_ns: total_ns as f64 / draws_per_batch as f64,
+            p50_draw_ns: percentile(&latencies, 0.50),
+            p95_draw_ns: percentile(&latencies, 0.95),
+            max_draw_ns: *latencies.last().unwrap_or(&0),
+            allocations: after.allocs.saturating_sub(before.allocs),
+            reallocations: after.reallocs.saturating_sub(before.reallocs),
+            allocated_bytes: after.allocated.saturating_sub(before.allocated),
+            deallocated_bytes: after.deallocated.saturating_sub(before.deallocated),
+            retained_bytes_delta: signed_delta(after.live, before.live),
+            peak_live_bytes_delta: WINDOW_PEAK
+                .load(Ordering::Relaxed)
+                .saturating_sub(before.live),
+        });
+    }
+
+    let buffer_style_digest = digest(terminal.backend().buffer());
+    let hit_map_digest = digest_hit_map(&app, spec.width, spec.height);
+    case_latencies.sort_unstable();
+    Ok(CaseReport {
+        name: spec.name.to_string(),
+        update_path: spec.update_path,
+        width: spec.width,
+        height: spec.height,
+        warmup_draws: warmup,
+        measured_draws: case_latencies.len(),
+        p95_draw_ns: percentile(&case_latencies, 0.95),
+        batches,
+        buffer_style_digest,
+        hit_map_digest,
+    })
+}
+
+fn percentile(sorted: &[u128], quantile: f64) -> u128 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let index = ((sorted.len() - 1) as f64 * quantile).ceil() as usize;
+    sorted[index.min(sorted.len() - 1)]
+}
+
+fn measure_update_to_draw<E>(action: impl FnOnce() -> Result<(), E>) -> Result<u128, E> {
+    measure_update_to_draw_with_clock(action, Instant::now)
+}
+
+fn measure_update_to_draw_with_clock<E>(
+    action: impl FnOnce() -> Result<(), E>,
+    mut now: impl FnMut() -> Instant,
+) -> Result<u128, E> {
+    let started = now();
+    action()?;
+    Ok(now().saturating_duration_since(started).as_nanos())
+}
+
+fn signed_delta(after: u64, before: u64) -> i64 {
+    let delta = i128::from(after) - i128::from(before);
+    delta.clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64
+}
+
+fn digest(value: &impl Hash) -> String {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn digest_hit_map(app: &App, width: u16, height: u16) -> String {
+    let mut hasher = DefaultHasher::new();
+    app.hits.seekbar_rect().hash(&mut hasher);
+    for y in 0..height {
+        for x in 0..width {
+            // MouseTarget deliberately has no Hash implementation; Debug is stable enough for
+            // same-toolchain baseline/candidate equivalence and covers payload indices/actions.
+            format!("{:?}", app.hits.target_at(x, y)).hash(&mut hasher);
+        }
+    }
+    format!("{:016x}", hasher.finish())
+}
+
+fn songs(count: usize) -> Vec<Song> {
+    (0..count)
+        .map(|index| {
+            Song::remote(
+                format!("perf-{index:04}"),
+                format!("Performance fixture track {index:04} 한글 제목"),
+                format!("Fixture artist {:03}", index % 37),
+                format!("{}:{:02}", 2 + index % 5, index % 60),
+            )
+        })
+        .collect()
+}
+
+fn player_app() -> App {
+    let mut app = App::new(100);
+    app.queue.set(songs(20), 7);
+    app.mode = Mode::Player;
+    app.playback.duration = Some(245.0);
+    app.playback.time_pos = Some(73.0);
+    app.playback.volume = 67;
+    app
+}
+
+fn search_app() -> App {
+    let mut app = player_app();
+    app.mode = Mode::Search;
+    app.search.input = "performance fixture".to_string();
+    app.search.results = songs(50);
+    app.search.selected = 25;
+    app.search.focus = SearchFocus::Results;
+    app
+}
+
+fn library_app() -> App {
+    let mut app = player_app();
+    app.mode = Mode::Library;
+    app.library.favorites = songs(999);
+    app.library_ui.tab = LibraryTab::Favorites;
+    app.library_ui.selected = 500;
+    app.library_ui.anchor = 500;
+    app
+}
+
+fn ai_app() -> App {
+    let mut app = player_app();
+    app.mode = Mode::Ai;
+    app.ai.available = true;
+    for index in 0..220 {
+        app.ai.messages.push(AiMessage {
+            role: if index % 2 == 0 {
+                AiRole::User
+            } else {
+                AiRole::Ai
+            },
+            text: format!(
+                "## Turn {index}\nThis is a **deterministic** long transcript line with `code`, \
+                 Korean text 한글, and a list item:\n- recommendation {}\n- reason {}",
+                index % 17,
+                index % 11
+            ),
+        });
+    }
+    app.ai.suggestions = songs(12);
+    app.ai.suggestions_selected = 5;
+    app
+}
+
+fn retro_app() -> App {
+    let mut app = player_app();
+    app.config.retro_mode = true;
+    app.queue.set(
+        vec![Song::remote(
+            "retro-fixture",
+            "한글 제목 日本語 ✨ very long metadata",
+            "가수 简体 ♥",
+            "4:01",
+        )],
+        0,
+    );
+    app
+}
+
+fn local_tracks(count: usize) -> Vec<LocalTrack> {
+    (0..count)
+        .map(|index| {
+            let mut track = LocalTrack::untagged(
+                PathBuf::from(format!("/perf/local/track-{index:04}.flac")),
+                4_000_000 + index as u64 * 1_337,
+                1_700_000_000 + index as i64,
+            );
+            track.title = if index.is_multiple_of(LOCAL_FILTER_STRIDE) {
+                format!("한글 바늘 트랙 {index:04}")
+            } else {
+                format!("Local performance track {index:04}")
+            };
+            track.artist = vec![format!("Fixture artist {:03}", index % 37)];
+            track.album = Some(format!("Fixture album {:03}", index % 53));
+            track.album_artist = Some(format!("Fixture artist {:03}", index % 37));
+            track.genre = vec![if index.is_multiple_of(2) {
+                "Electronic".to_owned()
+            } else {
+                "한국 인디".to_owned()
+            }];
+            track.year = Some(1990 + (index % 35) as i32);
+            track.disc_no = Some(1 + (index % 2) as u32);
+            track.track_no = Some(1 + (index % 20) as u32);
+            track.duration_ms = Some(120_000 + (index % 240) as u64 * 1_000);
+            track.bitrate = Some(900_000 + (index % 7) as u32 * 32_000);
+            track.sample_rate = Some(if index.is_multiple_of(3) {
+                96_000
+            } else {
+                48_000
+            });
+            if index.is_multiple_of(5) {
+                track.embedded_art_key = Some(format!("fixture-art-{index:04}"));
+            }
+            track
+        })
+        .collect()
+}
+
+fn local_app(count: usize) -> App {
+    let mut app = App::new(100);
+    app.mode = Mode::Library;
+    app.local_dedicated_mode = true;
+    app.local_mode.index.index = LocalIndex {
+        tracks: local_tracks(count),
+        updated_at: 1_700_000_000,
+        ..LocalIndex::default()
+    };
+    app.local_mode.index.loaded = true;
+    app.local_mode.ui.section = LocalSection::Tracks;
+    app
+}
+
+fn local_empty_app() -> App {
+    local_app(0)
+}
+
+fn local_scroll_app() -> App {
+    let mut app = local_app(LOCAL_SCROLL_TRACKS);
+    app.local_mode.ui.selected = 140;
+    app.local_mode.ui.anchor = 140;
+    app
+}
+
+fn local_max_app() -> App {
+    let mut app = local_app(LOCAL_LARGE_TRACKS);
+    app.local_mode.ui.selected = usize::MAX;
+    app.local_mode.ui.anchor = usize::MAX;
+    app
+}
+
+fn local_filter_korean_app() -> App {
+    let mut app = local_app(LOCAL_SCROLL_TRACKS);
+    app.local_mode.ui.filter_query = "한글 바늘".to_owned();
+    app.local_mode.ui.filter_editing = true;
+    app.local_mode.ui.selected = 5;
+    app.local_mode.ui.anchor = 5;
+    app
+}
+
+/// Deterministic real input path: key event -> `App::update(Msg::Key)` -> reducer -> render.
+/// Home/End avoid wall-clock key-repeat acceleration while still exercising keymap lookup,
+/// reducer dispatch, selection state, dirty tracking, overlay synchronization, and hit-map output.
+fn reducer_input(app: &mut App, step: usize) {
+    let code = if step.is_multiple_of(2) {
+        KeyCode::End
+    } else {
+        KeyCode::Home
+    };
+    let _ = app.update(Msg::Key(KeyEvent {
+        code,
+        modifiers: KeyModifiers::NONE,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    }));
+}
+
+fn no_interaction(_app: &mut App, _step: usize) {}
+
+fn local_scroll_interaction(app: &mut App, step: usize) {
+    app.local_mode.ui.selected = 140 + step % (LOCAL_SCROLL_TRACKS - 140);
+    app.local_mode.ui.anchor = app.local_mode.ui.selected;
+}
+
+fn local_max_interaction(app: &mut App, _step: usize) {
+    app.local_mode.ui.selected = usize::MAX;
+    app.local_mode.ui.anchor = usize::MAX;
+}
+
+fn local_filter_interaction(app: &mut App, step: usize) {
+    let matching_rows = LOCAL_SCROLL_TRACKS.div_ceil(LOCAL_FILTER_STRIDE);
+    app.local_mode.ui.selected = step % matching_rows;
+    app.local_mode.ui.anchor = app.local_mode.ui.selected;
+}
+
+fn mutate_for_interaction(app: &mut App, step: usize) {
+    match app.mode {
+        Mode::Player => {
+            app.playback.time_pos = Some((step % 244) as f64);
+        }
+        Mode::Search => {
+            if !app.search.results.is_empty() {
+                app.search.selected = step % app.search.results.len();
+            }
+        }
+        Mode::Library => {
+            if !app.library.favorites.is_empty() {
+                app.library_ui.selected = step % app.library.favorites.len();
+                app.library_ui.anchor = app.library_ui.selected;
+            }
+        }
+        Mode::Ai => {
+            if !app.ai.suggestions.is_empty() {
+                app.ai.suggestions_selected = step % app.ai.suggestions.len();
+            }
+        }
+        Mode::Settings => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+    use std::time::{Duration, Instant};
+
+    use super::{
+        LOCAL_FILTER_STRIDE, LOCAL_LARGE_TRACKS, LOCAL_SCROLL_TRACKS, local_empty_app,
+        local_filter_korean_app, local_max_app, local_scroll_app,
+        measure_update_to_draw_with_clock, percentile, reducer_input, search_app,
+    };
+
+    #[test]
+    fn percentile_uses_nearest_rank_upward() {
+        assert_eq!(percentile(&[1, 2, 3, 4, 5], 0.50), 3);
+        assert_eq!(percentile(&[1, 2, 3, 4, 5], 0.95), 5);
+        assert_eq!(percentile(&[], 0.95), 0);
+    }
+
+    #[test]
+    fn pooled_case_p95_is_not_the_mean_of_batch_p95s() {
+        let mut first = vec![0; 95];
+        first.extend([100; 5]);
+        let second = vec![0; 100];
+        let batch_mean = (percentile(&first, 0.95) + percentile(&second, 0.95)) / 2;
+        let mut pooled = first;
+        pooled.extend(second);
+        pooled.sort_unstable();
+
+        assert_eq!(batch_mean, 50);
+        assert_eq!(percentile(&pooled, 0.95), 0);
+    }
+
+    #[test]
+    fn update_to_draw_timer_starts_before_the_update() {
+        let origin = Instant::now();
+        let action_seen = Cell::new(false);
+        let clock_calls = Cell::new(0usize);
+        let measured = measure_update_to_draw_with_clock(
+            || {
+                action_seen.set(true);
+                Ok::<(), ()>(())
+            },
+            || {
+                let call = clock_calls.get();
+                clock_calls.set(call + 1);
+                match call {
+                    0 => {
+                        assert!(!action_seen.get());
+                        origin
+                    }
+                    1 => {
+                        assert!(action_seen.get());
+                        origin + Duration::from_millis(7)
+                    }
+                    _ => panic!("timer sampled the clock more than twice"),
+                }
+            },
+        )
+        .expect("synthetic interaction succeeds");
+
+        assert_eq!(measured, Duration::from_millis(7).as_nanos());
+    }
+
+    #[test]
+    fn reducer_input_case_dispatches_real_key_messages_deterministically() {
+        let mut app = search_app();
+        assert_eq!(app.search.selected, 25);
+
+        reducer_input(&mut app, 0);
+        assert_eq!(app.search.selected, app.search.results.len() - 1);
+
+        reducer_input(&mut app, 1);
+        assert_eq!(app.search.selected, 0);
+    }
+
+    #[test]
+    fn local_deck_fixtures_cover_empty_scroll_max_and_unicode_filter_states() {
+        let empty = local_empty_app();
+        assert_eq!(empty.local_rows_len(), 0);
+
+        let scrolled = local_scroll_app();
+        assert_eq!(scrolled.local_rows_len(), LOCAL_SCROLL_TRACKS);
+        assert_eq!(scrolled.local_mode.ui.selected, 140);
+
+        let max = local_max_app();
+        assert_eq!(max.local_rows_len(), LOCAL_LARGE_TRACKS);
+        assert_eq!(max.local_mode.ui.selected, usize::MAX);
+
+        let filtered = local_filter_korean_app();
+        assert_eq!(
+            filtered.local_rows_len(),
+            LOCAL_SCROLL_TRACKS.div_ceil(LOCAL_FILTER_STRIDE)
+        );
+        assert_eq!(filtered.local_mode.ui.filter_query, "한글 바늘");
+        assert!(filtered.local_mode.ui.filter_editing);
+    }
+}

--- a/examples/tui_render_perf.rs
+++ b/examples/tui_render_perf.rs
@@ -171,6 +171,12 @@ fn usage() -> &'static str {
 }
 
 #[derive(Serialize)]
+struct LatencyBucket {
+    ns: u128,
+    count: usize,
+}
+
+#[derive(Serialize)]
 struct BatchReport {
     batch: usize,
     draws: usize,
@@ -179,6 +185,7 @@ struct BatchReport {
     p50_draw_ns: u128,
     p95_draw_ns: u128,
     max_draw_ns: u128,
+    latency_histogram: Vec<LatencyBucket>,
     allocations: u64,
     reallocations: u64,
     allocated_bytes: u64,
@@ -195,7 +202,12 @@ struct CaseReport {
     height: u16,
     warmup_draws: usize,
     measured_draws: usize,
+    total_draw_ns: u128,
+    mean_draw_ns: f64,
+    p50_draw_ns: u128,
     p95_draw_ns: u128,
+    max_draw_ns: u128,
+    latency_histogram: Vec<LatencyBucket>,
     batches: Vec<BatchReport>,
     buffer_style_digest: String,
     hit_map_digest: String,
@@ -208,6 +220,9 @@ struct Report {
     binary: PathBuf,
     binary_sha256: String,
     scenario_sha256: Option<String>,
+    run_id: String,
+    started_unix_ns: u128,
+    finished_unix_ns: u128,
     os: &'static str,
     arch: &'static str,
     batches_per_case: usize,
@@ -232,6 +247,11 @@ fn main() {
         std::process::exit(2);
     });
     let selected = args.case.as_deref();
+    let run_id = std::env::var("TUI_PERF_RUN_ID").unwrap_or_else(|_| {
+        eprintln!("tui_render_perf: TUI_PERF_RUN_ID is required");
+        std::process::exit(2);
+    });
+    let started_unix_ns = unix_time_ns();
     let specs = case_specs();
     if let Some(case) = selected
         && !specs.iter().any(|spec| spec.name == case)
@@ -255,6 +275,9 @@ fn main() {
         binary,
         binary_sha256,
         scenario_sha256: std::env::var("TUI_PERF_SCENARIO_SHA256").ok(),
+        run_id,
+        started_unix_ns,
+        finished_unix_ns: unix_time_ns(),
         os: std::env::consts::OS,
         arch: std::env::consts::ARCH,
         batches_per_case: args.batches,
@@ -284,6 +307,16 @@ fn main() {
             println!();
         }
     }
+}
+
+fn unix_time_ns() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_else(|error| {
+            eprintln!("tui_render_perf: system clock before Unix epoch: {error}");
+            std::process::exit(2);
+        })
+        .as_nanos()
 }
 
 fn sha256_file(path: &Path) -> Result<String, String> {
@@ -438,10 +471,9 @@ fn run_case(
     let mut batches = Vec::with_capacity(batch_count);
     let mut case_latencies = Vec::with_capacity(batch_count.saturating_mul(draws_per_batch));
     for batch in 0..batch_count {
+        let mut latencies = Vec::with_capacity(draws_per_batch);
         let before = AllocSnapshot::now();
         WINDOW_PEAK.store(before.live, Ordering::Relaxed);
-        let batch_started = Instant::now();
-        let mut latencies = Vec::with_capacity(draws_per_batch);
         for draw in 0..draws_per_batch {
             let latency = measure_update_to_draw(|| {
                 (spec.update)(&mut app, batch * draws_per_batch + draw);
@@ -452,7 +484,7 @@ fn run_case(
             })?;
             latencies.push(latency);
         }
-        let total_ns = batch_started.elapsed().as_nanos();
+        let total_ns = latencies.iter().sum::<u128>();
         let after = AllocSnapshot::now();
         case_latencies.extend_from_slice(&latencies);
         latencies.sort_unstable();
@@ -464,6 +496,7 @@ fn run_case(
             p50_draw_ns: percentile(&latencies, 0.50),
             p95_draw_ns: percentile(&latencies, 0.95),
             max_draw_ns: *latencies.last().unwrap_or(&0),
+            latency_histogram: latency_histogram(&latencies),
             allocations: after.allocs.saturating_sub(before.allocs),
             reallocations: after.reallocs.saturating_sub(before.reallocs),
             allocated_bytes: after.allocated.saturating_sub(before.allocated),
@@ -478,6 +511,7 @@ fn run_case(
     let buffer_style_digest = digest(terminal.backend().buffer());
     let hit_map_digest = digest_hit_map(&app, spec.width, spec.height);
     case_latencies.sort_unstable();
+    let total_draw_ns = case_latencies.iter().sum::<u128>();
     Ok(CaseReport {
         name: spec.name.to_string(),
         update_path: spec.update_path,
@@ -485,11 +519,30 @@ fn run_case(
         height: spec.height,
         warmup_draws: warmup,
         measured_draws: case_latencies.len(),
+        total_draw_ns,
+        mean_draw_ns: total_draw_ns as f64 / case_latencies.len().max(1) as f64,
+        p50_draw_ns: percentile(&case_latencies, 0.50),
         p95_draw_ns: percentile(&case_latencies, 0.95),
+        max_draw_ns: *case_latencies.last().unwrap_or(&0),
+        latency_histogram: latency_histogram(&case_latencies),
         batches,
         buffer_style_digest,
         hit_map_digest,
     })
+}
+
+fn latency_histogram(sorted: &[u128]) -> Vec<LatencyBucket> {
+    let mut histogram: Vec<LatencyBucket> = Vec::new();
+    for &ns in sorted {
+        if let Some(last) = histogram.last_mut()
+            && last.ns == ns
+        {
+            last.count += 1;
+            continue;
+        }
+        histogram.push(LatencyBucket { ns, count: 1 });
+    }
+    histogram
 }
 
 fn percentile(sorted: &[u128], quantile: f64) -> u128 {

--- a/scripts/check-app-boundaries.sh
+++ b/scripts/check-app-boundaries.sh
@@ -24,12 +24,20 @@ BAD
 fi
 
 # INVARIANT(PLAY-EPOCH-001): position discontinuities must go through named helpers.
+# The exact media helper below only copies a core-authored epoch into retained
+# backend state; it never creates a discontinuity or increments the token.
+grep -qE 'fn copy_delivery_clock_from_core\(&mut self, core_position_epoch: u64\)' \
+  src/media/mod.rs \
+  || fail "media delivery epoch-copy helper is missing"
+[ "$(grep -cE '^[[:space:]]*self\.position_epoch = core_position_epoch;$' src/media/mod.rs)" -eq 1 ] \
+  || fail "media delivery epoch copy must have exactly one reviewed assignment"
 position_hits=$(grep -RInE 'position_epoch[[:space:]]*=|position_epoch\.wrapping_add\(1\)' src/app src/daemon src/media \
   | grep -Ev 'src/app/mod.rs:[0-9]+:.*fn bump_position_epoch' \
   | grep -Ev 'src/app/mod.rs:[0-9]+:.*self\.playback\.position_epoch = self\.playback\.position_epoch\.wrapping_add\(1\)' \
   | grep -Ev 'src/daemon/engine.rs:[0-9]+:.*fn bump_position_epoch' \
   | grep -Ev 'src/daemon/engine.rs:[0-9]+:.*self\.playback\.position_epoch = self\.playback\.position_epoch\.wrapping_add\(1\)' \
   | grep -Ev 'src/daemon/parity_tests.rs:[0-9]+:.*position_epoch = 0' \
+  | grep -Ev 'src/media/mod.rs:[0-9]+:[[:space:]]*self\.position_epoch = core_position_epoch;$' \
   | grep -Ev 'src/media/mod.rs:[0-9]+:.*position_epoch \+=' \
   || true)
 if [ -n "$position_hits" ]; then

--- a/scripts/tui-perf-scenarios.json
+++ b/scripts/tui-perf-scenarios.json
@@ -11,7 +11,11 @@
     "interval_ms": 1000,
     "cpu_unit": "percent_of_one_logical_core",
     "resident_memory_unit": "bytes",
-    "process_scope": "ytt_and_recursive_descendants"
+    "process_scope": "ytt_and_recursive_descendants",
+    "measurement_kind": "sampled_process_tree",
+    "limitations": [
+      "sampled process tree; sub-interval descendants may be missed"
+    ]
   },
   "fixture": {
     "duration_s": 1080,
@@ -90,6 +94,20 @@
       "geometry": [[80, 24]],
       "traffic_profile": "normal",
       "requires_mpv": true,
+      "expected_effective_mpv_cache_args": {
+        "--demuxer-max-bytes": "32MiB",
+        "--demuxer-max-back-bytes": "8MiB"
+      },
+      "seed_contract": {
+        "require_identical_tree": true,
+        "require_identical_cache_policy": true,
+        "expected_cache_policy": {
+          "config_present": true,
+          "cache_forward": { "present": true, "value": "32MiB" },
+          "cache_back": { "present": true, "value": "8MiB" },
+          "_cache_defaults_revision": { "present": false, "value": null }
+        }
+      },
       "controller": true,
       "controller_load": "resume-session",
       "pause_policy": "pause-resume",
@@ -137,6 +155,20 @@
       "geometry": [[80, 24]],
       "traffic_profile": "normal",
       "requires_mpv": true,
+      "expected_effective_mpv_cache_args": {
+        "--demuxer-max-bytes": "32MiB",
+        "--demuxer-max-back-bytes": "8MiB"
+      },
+      "seed_contract": {
+        "require_identical_tree": true,
+        "require_identical_cache_policy": true,
+        "expected_cache_policy": {
+          "config_present": true,
+          "cache_forward": { "present": false, "value": null },
+          "cache_back": { "present": false, "value": null },
+          "_cache_defaults_revision": { "present": false, "value": null }
+        }
+      },
       "controller": true,
       "controller_load": "resume-session",
       "pause_policy": "pause-resume",
@@ -172,6 +204,15 @@
       "geometry": [[80, 24]],
       "traffic_profile": "outage",
       "requires_mpv": true,
+      "expected_effective_mpv_cache_args": {
+        "--demuxer-max-bytes": "32MiB",
+        "--demuxer-max-back-bytes": "8MiB"
+      },
+      "seed_contract": {
+        "require_identical_tree": true,
+        "require_identical_cache_policy": true,
+        "expected_cache_policy": null
+      },
       "controller": true,
       "controller_load": "resume-session",
       "pause_policy": "none",
@@ -305,8 +346,8 @@
     },
     {
       "id": "memory_soak",
-      "description": "One 15-minute steady playback soak per binary and OS",
-      "pairs": 1,
+      "description": "Three alternating 15-minute steady playback pairs per OS",
+      "pairs": 3,
       "candidate_repeats": 0,
       "min_improved_pairs": 0,
       "warmup_s": 90,
@@ -314,11 +355,22 @@
       "geometry": [[80, 24]],
       "traffic_profile": "normal",
       "requires_mpv": true,
+      "expected_effective_mpv_cache_args": {
+        "--demuxer-max-bytes": "32MiB",
+        "--demuxer-max-back-bytes": "8MiB"
+      },
+      "seed_contract": {
+        "require_identical_tree": true,
+        "require_identical_cache_policy": true,
+        "expected_cache_policy": null
+      },
       "controller": true,
       "controller_load": "resume-session",
       "pause_policy": "none",
       "pause_hold_ms": 0,
       "seeks_s": [],
+      "minimum_playback_progress_fraction": 0.8,
+      "time_pos_tail_tolerance_s": 2.0,
       "metrics": {
         "tree.peak_rss_bytes": {
           "comparison": "ratio",
@@ -342,11 +394,22 @@
       "geometry": [[100, 30], [160, 50]],
       "traffic_profile": "normal",
       "requires_mpv": true,
+      "expected_effective_mpv_cache_args": {
+        "--demuxer-max-bytes": "32MiB",
+        "--demuxer-max-back-bytes": "8MiB"
+      },
+      "seed_contract": {
+        "require_identical_tree": true,
+        "require_identical_cache_policy": true,
+        "expected_cache_policy": null
+      },
       "controller": true,
       "controller_load": "resume-session",
       "pause_policy": "none",
       "pause_hold_ms": 0,
       "seeks_s": [],
+      "minimum_playback_progress_fraction": 0.8,
+      "time_pos_tail_tolerance_s": 2.0,
       "metrics": {
         "tree.mean_cpu_percent": {
           "comparison": "ratio",

--- a/scripts/tui-perf-scenarios.json
+++ b/scripts/tui-perf-scenarios.json
@@ -1,0 +1,364 @@
+{
+  "schema": "ytt.tui-perf.scenarios.v1",
+  "version": 1,
+  "statistics": {
+    "bootstrap_resamples": 50000,
+    "seed": 20260711,
+    "one_sided_confidence": 0.95,
+    "baseline_cv_max": 0.1
+  },
+  "sampling": {
+    "interval_ms": 1000,
+    "cpu_unit": "percent_of_one_logical_core",
+    "resident_memory_unit": "bytes",
+    "process_scope": "ytt_and_recursive_descendants"
+  },
+  "fixture": {
+    "duration_s": 1080,
+    "sample_rate_hz": 8000,
+    "margin_s": 60
+  },
+  "required_runtime_checklist": [
+    "album art off and on with Halfblocks plus every natively available protocol",
+    "synced lyrics visible and scrolling",
+    "long selected-row marquee at narrow and wide widths",
+    "every animation family at configured FPS bounds",
+    "radio live-sync metadata updates",
+    "80x24, 30x30, 100x30, and 160x50 resize/focus passes"
+  ],
+  "cache_candidates": [
+    { "forward": "8MiB", "back": "2MiB" },
+    { "forward": "16MiB", "back": "4MiB" },
+    { "forward": "24MiB", "back": "6MiB" },
+    { "forward": "32MiB", "back": "8MiB" }
+  ],
+  "traffic_profiles": {
+    "normal": {
+      "throttle_bps": 0,
+      "outage_every_bytes": 0,
+      "outage_ms": 0,
+      "disconnect_every_bytes": 0
+    },
+    "constrained": {
+      "throttle_bps": 24000,
+      "outage_every_bytes": 0,
+      "outage_ms": 0,
+      "disconnect_every_bytes": 0
+    },
+    "outage": {
+      "throttle_bps": 24000,
+      "outage_every_bytes": 524288,
+      "outage_ms": 1500,
+      "disconnect_every_bytes": 2097152
+    }
+  },
+  "scenarios": [
+    {
+      "id": "idle_default",
+      "description": "Empty queue, album art and animations disabled",
+      "pairs": 7,
+      "candidate_repeats": 0,
+      "min_improved_pairs": 6,
+      "warmup_s": 20,
+      "sample_s": 60,
+      "geometry": [[80, 24]],
+      "traffic_profile": "normal",
+      "requires_mpv": false,
+      "controller": false,
+      "pause_policy": "none",
+      "pause_hold_ms": 0,
+      "metrics": {
+        "tree.mean_cpu_percent": {
+          "comparison": "ratio",
+          "max_ratio": 0.2
+        },
+        "tree.mean_rss_bytes": {
+          "comparison": "ratio",
+          "max_ratio": 1.05,
+          "min_improved_pairs": 0
+        }
+      }
+    },
+    {
+      "id": "playback_legacy_cache",
+      "description": "Exact unmarked 32MiB/8MiB pair for diagnostic steady playback comparison; migration is not asserted while the defaults revision is dormant",
+      "pairs": 7,
+      "candidate_repeats": 0,
+      "min_improved_pairs": 6,
+      "warmup_s": 60,
+      "sample_s": 90,
+      "geometry": [[80, 24]],
+      "traffic_profile": "normal",
+      "requires_mpv": true,
+      "controller": true,
+      "controller_load": "resume-session",
+      "pause_policy": "pause-resume",
+      "pause_hold_ms": 500,
+      "seeks_s": [15, 90, 30, 120, 45],
+      "metrics": {
+        "tree.mean_cpu_percent": {
+          "comparison": "ratio",
+          "max_ratio": 0.5
+        },
+        "tree.mean_rss_bytes": {
+          "comparison": "ratio",
+          "max_ratio": 0.7
+        },
+        "operation.resume_session.p95_ms": {
+          "comparison": "latency",
+          "max_ratio": 1.05,
+          "max_delta": 100.0,
+          "min_improved_pairs": 0
+        },
+        "operation.seek.p95_ms": {
+          "comparison": "latency",
+          "max_ratio": 1.05,
+          "max_delta": 100.0,
+          "min_improved_pairs": 0
+        },
+        "buffering_events": {
+          "comparison": "no_increase",
+          "max_delta": 0
+        },
+        "buffering_ms": {
+          "comparison": "no_increase",
+          "max_delta": 0
+        }
+      }
+    },
+    {
+      "id": "playback_fresh_default",
+      "description": "Cache fields omitted; must converge to the selected migrated default",
+      "pairs": 3,
+      "candidate_repeats": 0,
+      "min_improved_pairs": 2,
+      "warmup_s": 60,
+      "sample_s": 90,
+      "geometry": [[80, 24]],
+      "traffic_profile": "normal",
+      "requires_mpv": true,
+      "controller": true,
+      "controller_load": "resume-session",
+      "pause_policy": "pause-resume",
+      "pause_hold_ms": 500,
+      "seeks_s": [20, 80, 35, 110, 50],
+      "metrics": {
+        "tree.mean_cpu_percent": {
+          "comparison": "ratio",
+          "max_ratio": 0.5
+        },
+        "tree.mean_rss_bytes": {
+          "comparison": "ratio",
+          "max_ratio": 0.7
+        },
+        "buffering_events": {
+          "comparison": "no_increase",
+          "max_delta": 0
+        },
+        "buffering_ms": {
+          "comparison": "no_increase",
+          "max_delta": 0
+        }
+      }
+    },
+    {
+      "id": "network_resilience",
+      "description": "18-minute Range fixture under constrained bandwidth, outages, and backward seeks",
+      "pairs": 3,
+      "min_improved_pairs": 2,
+      "candidate_repeats": 1,
+      "warmup_s": 60,
+      "sample_s": 180,
+      "geometry": [[80, 24]],
+      "traffic_profile": "outage",
+      "requires_mpv": true,
+      "controller": true,
+      "controller_load": "resume-session",
+      "pause_policy": "none",
+      "pause_hold_ms": 0,
+      "seeks_s": [240, 30, 300, 60, 360],
+      "metrics": {
+        "operation.seek.p95_ms": {
+          "comparison": "latency",
+          "max_ratio": 1.05,
+          "max_delta": 100.0,
+          "min_improved_pairs": 0
+        },
+        "buffering_events": {
+          "comparison": "no_increase",
+          "max_delta": 0
+        },
+        "buffering_ms": {
+          "comparison": "no_increase",
+          "max_delta": 0
+        }
+      }
+    },
+    {
+      "id": "render_and_interaction",
+      "description": "20 warmups, then 20 by 200 updates plus draws, including deterministic App::update(Msg::Key) reducer input",
+      "pairs": 7,
+      "candidate_repeats": 0,
+      "min_improved_pairs": 6,
+      "warmup_s": 0,
+      "sample_s": 0,
+      "warmup_draws": 20,
+      "batches": 20,
+      "draws_per_batch": 200,
+      "geometry": [[80, 24], [100, 30], [160, 50]],
+      "traffic_profile": "normal",
+      "requires_mpv": false,
+      "controller": false,
+      "pause_policy": "none",
+      "pause_hold_ms": 0,
+      "metrics": {
+        "render.player.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.search50.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.library999.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.ai_long.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.reducer_input.p95_reducer_input_to_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.retro160x50.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.normal80x24.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.local_empty60x16.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.local_scroll72x18.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.local_max120x30.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.local_filter_ko90x24.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.player.buffer_style_digest": { "comparison": "exact" },
+        "render.player.hit_map_digest": { "comparison": "exact" },
+        "render.search50.buffer_style_digest": { "comparison": "exact" },
+        "render.search50.hit_map_digest": { "comparison": "exact" },
+        "render.library999.buffer_style_digest": { "comparison": "exact" },
+        "render.library999.hit_map_digest": { "comparison": "exact" },
+        "render.ai_long.buffer_style_digest": { "comparison": "exact" },
+        "render.ai_long.hit_map_digest": { "comparison": "exact" },
+        "render.reducer_input.buffer_style_digest": { "comparison": "exact" },
+        "render.reducer_input.hit_map_digest": { "comparison": "exact" },
+        "render.reducer_input.update_path": { "comparison": "exact" },
+        "render.retro160x50.buffer_style_digest": { "comparison": "exact" },
+        "render.retro160x50.hit_map_digest": { "comparison": "exact" },
+        "render.normal80x24.buffer_style_digest": { "comparison": "exact" },
+        "render.normal80x24.hit_map_digest": { "comparison": "exact" },
+        "render.local_empty60x16.buffer_style_digest": { "comparison": "exact" },
+        "render.local_empty60x16.hit_map_digest": { "comparison": "exact" },
+        "render.local_scroll72x18.buffer_style_digest": { "comparison": "exact" },
+        "render.local_scroll72x18.hit_map_digest": { "comparison": "exact" },
+        "render.local_max120x30.buffer_style_digest": { "comparison": "exact" },
+        "render.local_max120x30.hit_map_digest": { "comparison": "exact" },
+        "render.local_filter_ko90x24.buffer_style_digest": { "comparison": "exact" },
+        "render.local_filter_ko90x24.hit_map_digest": { "comparison": "exact" }
+      }
+    },
+    {
+      "id": "memory_soak",
+      "description": "One 15-minute steady playback soak per binary and OS",
+      "pairs": 1,
+      "candidate_repeats": 0,
+      "min_improved_pairs": 0,
+      "warmup_s": 90,
+      "sample_s": 900,
+      "geometry": [[80, 24]],
+      "traffic_profile": "normal",
+      "requires_mpv": true,
+      "controller": true,
+      "controller_load": "resume-session",
+      "pause_policy": "none",
+      "pause_hold_ms": 0,
+      "seeks_s": [],
+      "metrics": {
+        "tree.peak_rss_bytes": {
+          "comparison": "ratio",
+          "max_ratio": 1.05,
+          "min_improved_pairs": 0
+        },
+        "tree.rss_slope_bytes_per_s": {
+          "comparison": "no_increase",
+          "max_delta": 0
+        }
+      }
+    },
+    {
+      "id": "feature_regressions",
+      "description": "Geometry-only process no-regression at 100x30 and 160x50; visual feature families remain a separate required runtime checklist",
+      "pairs": 7,
+      "candidate_repeats": 0,
+      "min_improved_pairs": 0,
+      "warmup_s": 20,
+      "sample_s": 60,
+      "geometry": [[100, 30], [160, 50]],
+      "traffic_profile": "normal",
+      "requires_mpv": true,
+      "controller": true,
+      "controller_load": "resume-session",
+      "pause_policy": "none",
+      "pause_hold_ms": 0,
+      "seeks_s": [],
+      "metrics": {
+        "tree.mean_cpu_percent": {
+          "comparison": "ratio",
+          "max_ratio": 1.05,
+          "min_improved_pairs": 0
+        },
+        "tree.mean_rss_bytes": {
+          "comparison": "ratio",
+          "max_ratio": 1.05,
+          "min_improved_pairs": 0
+        }
+      }
+    }
+  ]
+}

--- a/scripts/tui-perf.ps1
+++ b/scripts/tui-perf.ps1
@@ -1,47 +1,31 @@
 <#
 .SYNOPSIS
-Runs paired ytt TUI performance scenarios in isolated per-run profiles.
+Runs paired ytt render-performance scenarios from fresh source-bound builds.
 
-.PARAMETER SeedHome
-Playback seed template. Persisted ytt state must be stored under
-stores\config, stores\data, and stores\cache; the whole template is copied per run.
-The resumed Song.local_path must be the literal {{TUI_PERF_PLAYLIST}} placeholder.
-BaselineSeedHome and CandidateSeedHome override this template per role, enabling explicit
-32MiB/8MiB reference vs candidate cache-pair exploration without mutating either seed.
+.DESCRIPTION
+Render scenarios are supported on Windows. Process scenarios fail closed before creating output
+until this wrapper can provide a run-unique off-screen ConPTY with controlled empty input and
+exact geometry, without inheriting or resizing the parent console.
+
+Seed parameters remain accepted so an existing cross-platform invocation reaches the explicit
+isolation error instead of failing during parameter binding. They are never read on Windows.
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)] [string] $Scenario,
     [Parameter(Mandatory = $true)] [string] $Output,
-    [string] $BaselineBinary,
-    [string] $CandidateBinary,
-    [string] $BaselineRender,
-    [string] $CandidateRender,
-    [string] $BaselineSourceRoot,
+    [Parameter(Mandatory = $true)] [string] $BaselineSourceRoot,
     [string] $CandidateSourceRoot,
-    [Parameter(Mandatory = $true)] [string] $BaselineBuildCommand,
-    [Parameter(Mandatory = $true)] [string] $CandidateBuildCommand,
     [string] $SeedHome,
     [string] $BaselineSeedHome,
     [string] $CandidateSeedHome,
-    [string] $Sampler,
-    [string] $Controller,
-    [string] $Scenarios,
-    [switch] $NoBuild
+    [string] $Scenarios
 )
 
 $ErrorActionPreference = "Stop"
 $Repo = Split-Path -Parent $PSScriptRoot
 $PythonTool = Join-Path $PSScriptRoot "tui-perf.py"
 if (-not $Scenarios) { $Scenarios = Join-Path $PSScriptRoot "tui-perf-scenarios.json" }
-if (-not $Sampler) { $Sampler = Join-Path $Repo "target\release\examples\tui_perf_sampler.exe" }
-if (-not $Controller) { $Controller = Join-Path $Repo "target\release\examples\tui_perf_control.exe" }
-
-function Invoke-Python {
-    param([Parameter(ValueFromRemainingArguments = $true)] [string[]] $Arguments)
-    & python $PythonTool @Arguments
-    if ($LASTEXITCODE -ne 0) { throw "tui-perf.py failed with exit code $LASTEXITCODE" }
-}
 
 function Get-ScenarioField([string] $Name) {
     $value = & python $PythonTool scenario --scenarios $Scenarios --id $Scenario --field $Name
@@ -49,280 +33,30 @@ function Get-ScenarioField([string] $Name) {
     return ($value | Out-String).Trim()
 }
 
-function Get-TrafficField([string] $Name) {
-    $value = & python $PythonTool traffic --scenarios $Scenarios --name $script:TrafficProfile --field $Name
-    if ($LASTEXITCODE -ne 0) { throw "cannot read traffic field $Name" }
-    return ($value | Out-String).Trim()
+function Assert-WindowsProcessIsolation {
+    throw "Windows process scenarios are unsupported: this PowerShell 5.1 wrapper cannot provide a run-unique off-screen ConPTY with controlled empty input and exact geometry without mutating or inheriting the parent console. No process measurement was started and no output was created."
 }
 
-function Get-SettingField([string] $Name) {
-    $value = & python $PythonTool setting --scenarios $Scenarios --field $Name
-    if ($LASTEXITCODE -ne 0) { throw "cannot read top-level scenario setting $Name" }
-    return ($value | Out-String).Trim()
-}
-
-function ConvertTo-WindowsArgument([string] $Value) {
-    if ($Value -notmatch '[\s"]') { return $Value }
-    $builder = New-Object System.Text.StringBuilder
-    [void] $builder.Append('"')
-    $slashes = 0
-    foreach ($character in $Value.ToCharArray()) {
-        if ($character -eq '\') {
-            $slashes++
-        } elseif ($character -eq '"') {
-            [void] $builder.Append((('\' * ($slashes * 2 + 1)) -join ''))
-            [void] $builder.Append('"')
-            $slashes = 0
-        } else {
-            if ($slashes) { [void] $builder.Append((('\' * $slashes) -join '')); $slashes = 0 }
-            [void] $builder.Append($character)
-        }
-    }
-    if ($slashes) { [void] $builder.Append((('\' * ($slashes * 2)) -join '')) }
-    [void] $builder.Append('"')
-    return $builder.ToString()
-}
-
-function Start-ExactProcess([string] $FilePath, [string[]] $Arguments) {
-    $info = New-Object System.Diagnostics.ProcessStartInfo
-    $info.FileName = $FilePath
-    $info.UseShellExecute = $false
-    $info.CreateNoWindow = $false
-    if ($info.PSObject.Properties.Name -contains "ArgumentList") {
-        foreach ($argument in $Arguments) { [void] $info.ArgumentList.Add($argument) }
-    } else {
-        $info.Arguments = (($Arguments | ForEach-Object { ConvertTo-WindowsArgument $_ }) -join ' ')
-    }
-    $process = New-Object System.Diagnostics.Process
-    $process.StartInfo = $info
-    if (-not $process.Start()) { throw "failed to launch $FilePath" }
-    return $process
-}
-
-function Set-IsolatedEnvironment([string] $RunDir, [string] $Home) {
-    $runtime = Join-Path $RunDir "runtime"
-    $temp = Join-Path $RunDir "tmp"
-    $roaming = Join-Path $Home "AppData\Roaming"
-    $local = Join-Path $Home "AppData\Local"
-    $configStore = Join-Path $Home "stores\config"
-    $dataStore = Join-Path $Home "stores\data"
-    $cacheStore = Join-Path $Home "stores\cache"
-    foreach ($directory in @($runtime, $temp, $roaming, $local, $configStore, $dataStore, $cacheStore)) {
-        New-Item -ItemType Directory -Force -Path $directory | Out-Null
-    }
-    $values = @{
-        HOME = $Home
-        USERPROFILE = $Home
-        APPDATA = $roaming
-        LOCALAPPDATA = $local
-        XDG_CONFIG_HOME = (Join-Path $Home ".config")
-        XDG_DATA_HOME = (Join-Path $Home ".local\share")
-        XDG_CACHE_HOME = (Join-Path $Home ".cache")
-        XDG_STATE_HOME = (Join-Path $Home ".local\state")
-        XDG_RUNTIME_DIR = $runtime
-        YTM_CONFIG_DIR = $configStore
-        YTM_DATA_DIR = $dataStore
-        YTM_CACHE_DIR = $cacheStore
-        TEMP = $temp
-        TMP = $temp
-        TERM = "xterm-256color"
-        YTM_MPV_EXTRA = "--ao=null --volume=0 --audio-display=no"
-        YTM_PERF = "1"
-        TUI_PERF_SCENARIO_SHA256 = $script:ScenarioHash
-    }
-    $prior = @{}
-    foreach ($name in $values.Keys) {
-        $prior[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
-        [Environment]::SetEnvironmentVariable($name, $values[$name], "Process")
-    }
-    return $prior
-}
-
-function Restore-Environment([hashtable] $Prior) {
-    foreach ($name in $Prior.Keys) {
-        [Environment]::SetEnvironmentVariable($name, $Prior[$name], "Process")
-    }
-}
-
-function Stop-RecordedYtt([string] $PidFile) {
-    if (-not (Test-Path -LiteralPath $PidFile)) { return }
-    $recorded = 0
-    if (-not [int]::TryParse((Get-Content -LiteralPath $PidFile -Raw).Trim(), [ref] $recorded)) { return }
-    $process = Get-Process -Id $recorded -ErrorAction SilentlyContinue
-    if ($process) {
-        # Exact sampler-recorded PID only. ytt's Windows Job Object owns its mpv descendants.
-        Stop-Process -Id $recorded -Force -ErrorAction SilentlyContinue
-    }
-}
-
-function Run-Render([string] $Role, [string] $Binary, [string] $RunDir) {
-    $runDir = $RunDir
-    New-Item -ItemType Directory -Force -Path $runDir | Out-Null
-    $oldHash = $env:TUI_PERF_SCENARIO_SHA256
+function Run-Render([string] $Role, [string] $Binary, [string] $RunDir, [string] $RunId) {
+    New-Item -ItemType Directory -Force -Path $RunDir | Out-Null
+    $oldHash = [Environment]::GetEnvironmentVariable("TUI_PERF_SCENARIO_SHA256", "Process")
+    $oldYtmPerf = [Environment]::GetEnvironmentVariable("YTM_PERF", "Process")
+    $oldRunId = [Environment]::GetEnvironmentVariable("TUI_PERF_RUN_ID", "Process")
     try {
-        $env:TUI_PERF_SCENARIO_SHA256 = $script:ScenarioHash
-        & $Binary --output (Join-Path $runDir "render.json") `
+        [Environment]::SetEnvironmentVariable("TUI_PERF_SCENARIO_SHA256", $script:ScenarioHash, "Process")
+        [Environment]::SetEnvironmentVariable("TUI_PERF_RUN_ID", $RunId, "Process")
+        # Render evidence also stays on the normal product path. No Windows wrapper path may
+        # silently opt into the optional hot-path instrumentation switch.
+        [Environment]::SetEnvironmentVariable("YTM_PERF", $null, "Process")
+        & $Binary --output (Join-Path $RunDir "render.json") `
             --warmup (Get-ScenarioField "warmup_draws") `
             --batches (Get-ScenarioField "batches") `
             --draws (Get-ScenarioField "draws_per_batch")
         if ($LASTEXITCODE -ne 0) { throw "$Role render harness failed" }
     } finally {
-        $env:TUI_PERF_SCENARIO_SHA256 = $oldHash
-    }
-}
-
-function Run-Process(
-    [string] $Role,
-    [string] $Binary,
-    [string] $RunRoot,
-    [int] $Width,
-    [int] $Height,
-    [string] $Label
-) {
-    $runDir = $RunRoot
-    if ($script:GeometryCount -gt 1) {
-        $runDir = Join-Path $RunRoot ("geometry-{0}x{1}" -f $Width, $Height)
-    }
-    $roleSeedHome = if ($Role -eq "baseline") { $BaselineSeedHome } else { $CandidateSeedHome }
-    $home = Join-Path $runDir "home"
-    $samples = Join-Path $runDir "samples.ndjson"
-    $control = Join-Path $runDir "control.ndjson"
-    $pidFile = Join-Path $runDir "ytt.pid"
-    $readyFile = Join-Path $runDir "http-ready.json"
-    New-Item -ItemType Directory -Force -Path $home | Out-Null
-    if ($roleSeedHome) {
-        Get-ChildItem -LiteralPath $roleSeedHome -Force |
-            Copy-Item -Destination $home -Recurse -Force
-    }
-    $serverProcess = $null
-    $samplerProcess = $null
-    $prior = $null
-    try {
-        if ($script:RequiresMpv) {
-            Remove-Item -LiteralPath $readyFile -Force -ErrorAction SilentlyContinue
-            $serverArgs = @(
-                $PythonTool, "serve",
-                "--file", $script:FixtureFile,
-                "--ready-file", $readyFile,
-                "--throttle-bps", (Get-TrafficField "throttle_bps"),
-                "--outage-every-bytes", (Get-TrafficField "outage_every_bytes"),
-                "--outage-ms", (Get-TrafficField "outage_ms"),
-                "--disconnect-every-bytes", (Get-TrafficField "disconnect_every_bytes")
-            )
-            $serverProcess = Start-ExactProcess "python" $serverArgs
-            $serverDeadline = [DateTime]::UtcNow.AddSeconds(10)
-            while (-not (Test-Path -LiteralPath $readyFile)) {
-                if ($serverProcess.HasExited) { throw "fixture server exited before publishing its URL" }
-                if ([DateTime]::UtcNow -ge $serverDeadline) { throw "fixture server startup timed out" }
-                Start-Sleep -Milliseconds 50
-            }
-            $fixtureUrl = (Get-Content -LiteralPath $readyFile -Raw | ConvertFrom-Json).url
-            & python $PythonTool materialize `
-                --root $home `
-                --home $home `
-                --fixture-url $fixtureUrl `
-                --seed-label $Role `
-                --manifest (Join-Path $runDir "materialize.json") | Out-Null
-            if ($LASTEXITCODE -ne 0) { throw "failed to materialize isolated seed home" }
-        }
-        $prior = Set-IsolatedEnvironment $runDir $home
-        try {
-            $buffer = $Host.UI.RawUI.BufferSize
-            if ($buffer.Width -lt $Width -or $buffer.Height -lt $Height) {
-                $Host.UI.RawUI.BufferSize = [System.Management.Automation.Host.Size]::new(
-                    [Math]::Max($buffer.Width, $Width),
-                    [Math]::Max($buffer.Height, $Height)
-                )
-            }
-            $Host.UI.RawUI.WindowSize = [System.Management.Automation.Host.Size]::new($Width, $Height)
-        } catch {
-            throw "cannot establish the required ${Width}x${Height} interactive console for ${Label}: $_"
-        }
-        $samplerArgs = @(
-            "--output", $samples,
-            "--pid-file", $pidFile,
-            "--binary", $Binary,
-            "--warmup-secs", (Get-ScenarioField "warmup_s"),
-            "--duration-secs", (Get-ScenarioField "sample_s"),
-            "--interval-ms", "1000"
-        )
-        if ($script:RequiresMpv) { $samplerArgs += "--require-silent-mpv" }
-        $controllerEnabled = (Get-ScenarioField "controller") -eq "true"
-        # Controller runs need ytt to publish its primary descriptor inside this run's isolated
-        # runtime directory. Non-controller runs retain the private new-instance endpoint.
-        if (-not $controllerEnabled) { $samplerArgs += @("--", "--new-instance") }
-        Remove-Item -LiteralPath $pidFile -Force -ErrorAction SilentlyContinue
-        $samplerProcess = Start-ExactProcess $Sampler $samplerArgs
-
-        $readyAt = [DateTime]::UtcNow.AddSeconds(30)
-        while (-not (Test-Path -LiteralPath $pidFile)) {
-            if ($samplerProcess.HasExited) { throw "$Role sampler exited before publishing ytt PID" }
-            if ([DateTime]::UtcNow -ge $readyAt) { throw "$Role sampler timed out before publishing ytt PID" }
-            Start-Sleep -Milliseconds 100
-        }
-
-        if ($controllerEnabled) {
-            $controllerArgs = @(
-                "--output", $control,
-                "--wait-secs", "45",
-                "--observe-secs", ([double](Get-ScenarioField "warmup_s") + [double](Get-ScenarioField "sample_s")),
-                "--close-grace-secs", "15",
-                "--load", (Get-ScenarioField "controller_load")
-            )
-            $seekValues = (Get-ScenarioField "seeks_s") | ConvertFrom-Json
-            if ($seekValues.Count -gt 0) { $controllerArgs += @("--seeks", ($seekValues -join ',')) }
-            $pausePolicy = Get-ScenarioField "pause_policy"
-            $pauseHoldMs = Get-ScenarioField "pause_hold_ms"
-            if ($pausePolicy -eq "pause-resume") {
-                $controllerArgs += @("--pause-hold-ms", $pauseHoldMs)
-            } else {
-                $controllerArgs += "--no-pause"
-            }
-            & $Controller @controllerArgs
-            if ($LASTEXITCODE -ne 0) { throw "$Role controller failed" }
-        }
-
-        $timeoutSeconds = [Math]::Ceiling(
-            [double](Get-ScenarioField "warmup_s") + [double](Get-ScenarioField "sample_s") + 90
-        )
-        $deadline = [DateTime]::UtcNow.AddSeconds($timeoutSeconds)
-        while (-not $samplerProcess.HasExited) {
-            if ([DateTime]::UtcNow -ge $deadline) { throw "$Role sampler timed out" }
-            Start-Sleep -Seconds 1
-        }
-        if ($samplerProcess.ExitCode -ne 0) { throw "$Role sampler exited $($samplerProcess.ExitCode)" }
-
-        $checkArgs = @("check", "--samples", $samples, "--scenario-sha256", $script:ScenarioHash)
-        if ($script:RequiresMpv) { $checkArgs += "--require-silent-mpv" }
-        if ($controllerEnabled) {
-            $checkArgs += @("--control", $control, "--require-observer-close")
-        }
-        & python $PythonTool @checkArgs | Out-Null
-        if ($LASTEXITCODE -ne 0) { throw "$Role artifacts failed validation" }
-    } finally {
-        if ($samplerProcess -and -not $samplerProcess.HasExited) {
-            Stop-RecordedYtt $pidFile
-            try { $samplerProcess.Kill() } catch { }
-        }
-        if ($serverProcess -and -not $serverProcess.HasExited) {
-            try { $serverProcess.Kill() } catch { }
-            try { $serverProcess.WaitForExit() } catch { }
-        }
-        if ($prior) { Restore-Environment $prior }
-    }
-}
-
-function Run-ProcessGeometries(
-    [string] $Role,
-    [string] $Binary,
-    [string] $RunRoot,
-    [string] $Label
-) {
-    for ($geometryIndex = 0; $geometryIndex -lt $script:GeometryCount; $geometryIndex++) {
-        $width = [int](Get-ScenarioField ("geometry.{0}.0" -f $geometryIndex))
-        $height = [int](Get-ScenarioField ("geometry.{0}.1" -f $geometryIndex))
-        Run-Process $Role $Binary $RunRoot $width $height `
-            ("{0} geometry {1}x{2}" -f $Label, $width, $height)
+        [Environment]::SetEnvironmentVariable("TUI_PERF_SCENARIO_SHA256", $oldHash, "Process")
+        [Environment]::SetEnvironmentVariable("YTM_PERF", $oldYtmPerf, "Process")
+        [Environment]::SetEnvironmentVariable("TUI_PERF_RUN_ID", $oldRunId, "Process")
     }
 }
 
@@ -331,104 +65,59 @@ if ($LASTEXITCODE -ne 0) { throw "invalid scenarios file" }
 $script:ScenarioHash = Get-ScenarioField "sha256"
 $pairs = [int](Get-ScenarioField "pairs")
 $candidateRepeats = [int](Get-ScenarioField "candidate_repeats")
-$script:GeometryCount = [int](Get-ScenarioField "geometry.length")
-$script:RequiresMpv = (Get-ScenarioField "requires_mpv") -eq "true"
-$script:TrafficProfile = Get-ScenarioField "traffic_profile"
-$fixtureSeconds = Get-SettingField "fixture.duration_s"
-$fixtureSampleRate = Get-SettingField "fixture.sample_rate_hz"
 $isRender = $Scenario -eq "render_and_interaction"
-if (-not $BaselineSeedHome) { $BaselineSeedHome = $SeedHome }
-if (-not $CandidateSeedHome) { $CandidateSeedHome = $SeedHome }
-$script:OutputRoot = [IO.Path]::GetFullPath($Output)
-if (Test-Path -LiteralPath $script:OutputRoot) {
-    throw "-Output must name a new path; existing evidence is never reused"
-}
-New-Item -ItemType Directory -Path $script:OutputRoot | Out-Null
-$script:FixtureFile = Join-Path $script:OutputRoot ("fixture\silence-{0}s.wav" -f $fixtureSeconds)
-if ($script:RequiresMpv -and -not (Test-Path -LiteralPath $script:FixtureFile)) {
-    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $script:FixtureFile) | Out-Null
-    & python $PythonTool fixture `
-        --output $script:FixtureFile `
-        --manifest (Join-Path (Split-Path -Parent $script:FixtureFile) "manifest.json") `
-        --seconds $fixtureSeconds `
-        --sample-rate $fixtureSampleRate | Out-Null
-    if ($LASTEXITCODE -ne 0) { throw "failed to generate deterministic silence fixture" }
-}
-
-if (-not $NoBuild) {
-    Push-Location $Repo
-    try {
-        & cargo build --release --locked --example tui_perf_sampler --example tui_perf_control --example tui_render_perf
-        if ($LASTEXITCODE -ne 0) { throw "harness build failed" }
-    } finally {
-        Pop-Location
-    }
-}
-
-if ($isRender) {
-    if (-not $CandidateRender) { $CandidateRender = Join-Path $Repo "target\release\examples\tui_render_perf.exe" }
-    if (-not (Test-Path -LiteralPath $BaselineRender -PathType Leaf)) { throw "--BaselineRender is required" }
-    if (-not (Test-Path -LiteralPath $CandidateRender -PathType Leaf)) { throw "candidate render harness missing" }
-} else {
-    if ([Console]::IsOutputRedirected -or -not [Environment]::UserInteractive) {
-        throw "Windows process scenarios require a local interactive console/ConPTY; stage and retrieve artifacts over SSH, but run this script locally"
-    }
-    foreach ($binary in @($BaselineBinary, $CandidateBinary, $Sampler, $Controller)) {
-        if (-not (Test-Path -LiteralPath $binary -PathType Leaf)) { throw "required executable missing: $binary" }
-    }
-    if ($script:RequiresMpv) {
-        foreach ($seedSpec in @(
-            @{ Role = "baseline"; Path = $BaselineSeedHome },
-            @{ Role = "candidate"; Path = $CandidateSeedHome }
-        )) {
-            if (-not $seedSpec.Path -or -not (Test-Path -LiteralPath $seedSpec.Path -PathType Container)) {
-                throw "playback scenarios require a $($seedSpec.Role) seed home"
-            }
-            foreach ($store in @("config", "data", "cache")) {
-                $storePath = Join-Path $seedSpec.Path ("stores\{0}" -f $store)
-                if (-not (Test-Path -LiteralPath $storePath -PathType Container)) {
-                    throw "$($seedSpec.Role) seed home must contain stores\$store"
-                }
-            }
-        }
-    }
-}
+if (-not $isRender) { Assert-WindowsProcessIsolation }
 
 if (-not $CandidateSourceRoot) { $CandidateSourceRoot = $Repo }
-if (-not $BaselineSourceRoot) {
-    $identityBinary = if ($isRender) { $BaselineRender } else { $BaselineBinary }
-    $binaryParent = Split-Path -Parent ([IO.Path]::GetFullPath($identityBinary))
-    $detectedRoot = & git -C $binaryParent rev-parse --show-toplevel
-    if ($LASTEXITCODE -ne 0) {
-        throw "cannot infer -BaselineSourceRoot from $identityBinary"
-    }
-    $BaselineSourceRoot = ($detectedRoot | Out-String).Trim()
-}
 foreach ($sourceRoot in @($BaselineSourceRoot, $CandidateSourceRoot)) {
     if (-not (Test-Path -LiteralPath $sourceRoot -PathType Container)) {
         throw "source root is not a directory: $sourceRoot"
     }
 }
 
+$resolvedOutput = & python $PythonTool path-preflight `
+    --output-root $Output `
+    --protected-root $BaselineSourceRoot `
+    --protected-root $CandidateSourceRoot
+if ($LASTEXITCODE -ne 0) { throw "output/source path preflight failed" }
+$script:OutputRoot = ($resolvedOutput | Out-String).Trim()
+if (-not $script:OutputRoot) { throw "path preflight returned an empty output root" }
+New-Item -ItemType Directory -Path $script:OutputRoot | Out-Null
+
+$controlledReceipt = Join-Path $script:OutputRoot "build-receipt.json"
+$buildTarget = Join-Path ([IO.Path]::GetTempPath()) ("ytt-perf-build-" + [Guid]::NewGuid().ToString("N"))
+$buildArgs = @(
+    "build", "--scenarios", $Scenarios, "--scenario", $Scenario,
+    "--baseline-root", $BaselineSourceRoot,
+    "--candidate-root", $CandidateSourceRoot,
+    "--output", $controlledReceipt,
+    "--target-root", $buildTarget
+)
+try {
+    & python $PythonTool @buildArgs | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "controlled source-bound build failed" }
+} finally {
+    if (Test-Path -LiteralPath $buildTarget) {
+        Remove-Item -LiteralPath $buildTarget -Recurse -Force
+    }
+}
+
+function Get-ReceiptArtifact([string] $Label) {
+    $value = & python $PythonTool receipt `
+        --receipt $controlledReceipt --artifact $Label --field path
+    if ($LASTEXITCODE -ne 0) { throw "cannot read artifact $Label from build receipt" }
+    return ($value | Out-String).Trim()
+}
+$BaselineRender = Get-ReceiptArtifact "baseline_render"
+$CandidateRender = Get-ReceiptArtifact "candidate_render"
+
 $manifestArgs = @(
     "manifest",
     "--scenarios", $Scenarios,
     "--scenario", $Scenario,
     "--output", (Join-Path $script:OutputRoot "host-manifest.json"),
-    "--source-root", "baseline=$BaselineSourceRoot",
-    "--source-root", "candidate=$CandidateSourceRoot",
-    "--build-command", "baseline=$BaselineBuildCommand",
-    "--build-command", "candidate=$CandidateBuildCommand"
+    "--build-receipt", $controlledReceipt
 )
-if ($isRender) {
-    $manifestArgs += @("--binary", "baseline_render=$BaselineRender")
-    $manifestArgs += @("--binary", "candidate_render=$CandidateRender")
-} else {
-    $manifestArgs += @("--binary", "baseline_ytt=$BaselineBinary")
-    $manifestArgs += @("--binary", "candidate_ytt=$CandidateBinary")
-    $manifestArgs += @("--binary", "sampler=$Sampler")
-    $manifestArgs += @("--binary", "controller=$Controller")
-}
 & python $PythonTool @manifestArgs | Out-Null
 if ($LASTEXITCODE -ne 0) { throw "failed to write host manifest" }
 
@@ -437,29 +126,36 @@ $candidateRuns = @()
 for ($pair = 1; $pair -le $pairs; $pair++) {
     $order = if ($pair % 2) { @("baseline", "candidate") } else { @("candidate", "baseline") }
     foreach ($role in $order) {
-        if ($isRender) {
-            $binary = if ($role -eq "baseline") { $BaselineRender } else { $CandidateRender }
-            $runDir = Join-Path $script:OutputRoot ("pair-{0:D2}\{1}" -f $pair, $role)
-            Run-Render $role $binary $runDir
-        } else {
-            $binary = if ($role -eq "baseline") { $BaselineBinary } else { $CandidateBinary }
-            $runRoot = Join-Path $script:OutputRoot ("pair-{0:D2}\{1}" -f $pair, $role)
-            Run-ProcessGeometries $role $binary $runRoot ("$role pair $pair")
-        }
+        $binary = if ($role -eq "baseline") { $BaselineRender } else { $CandidateRender }
+        $runDir = Join-Path $script:OutputRoot ("pair-{0:D2}\{1}" -f $pair, $role)
+        $runId = (& python $PythonTool run-start `
+            --scenarios $Scenarios --scenario $Scenario `
+            --output (Join-Path $runDir "run-contract.json") `
+            --kind paired --role $role --pair-index $pair | Out-String).Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $runId) { throw "failed to start paired run contract" }
+        Run-Render $role $binary $runDir $runId
+        & python $PythonTool run-finish --contract (Join-Path $runDir "run-contract.json") | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "failed to finish paired run contract" }
     }
-    $baselineRuns += @("--baseline-run", (Join-Path $script:OutputRoot ("pair-{0:D2}\baseline" -f $pair)))
-    $candidateRuns += @("--candidate-run", (Join-Path $script:OutputRoot ("pair-{0:D2}\candidate" -f $pair)))
+    $baselineRuns += @(
+        "--baseline-run", (Join-Path $script:OutputRoot ("pair-{0:D2}\baseline" -f $pair))
+    )
+    $candidateRuns += @(
+        "--candidate-run", (Join-Path $script:OutputRoot ("pair-{0:D2}\candidate" -f $pair))
+    )
 }
 
 $candidateRepeatRuns = @()
 for ($repeat = 1; $repeat -le $candidateRepeats; $repeat++) {
     $repeatDir = Join-Path $script:OutputRoot ("candidate-repeat-{0:D2}" -f $repeat)
-    if ($isRender) {
-        Run-Render "candidate" $CandidateRender $repeatDir
-    } else {
-        Run-ProcessGeometries "candidate" $CandidateBinary $repeatDir `
-            ("candidate diagnostic repeat $repeat")
-    }
+    $runId = (& python $PythonTool run-start `
+        --scenarios $Scenarios --scenario $Scenario `
+        --output (Join-Path $repeatDir "run-contract.json") `
+        --kind candidate_repeat --role candidate --repeat-index $repeat | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $runId) { throw "failed to start repeat run contract" }
+    Run-Render "candidate" $CandidateRender $repeatDir $runId
+    & python $PythonTool run-finish --contract (Join-Path $repeatDir "run-contract.json") | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "failed to finish repeat run contract" }
     $candidateRepeatRuns += @("--candidate-repeat-run", $repeatDir)
 }
 
@@ -472,8 +168,12 @@ $compareArgs = @(
 )
 & python $PythonTool @compareArgs
 $comparisonExitCode = $LASTEXITCODE
-& python $PythonTool checksums `
+& python $PythonTool create-checksums `
     --root $script:OutputRoot `
     --output (Join-Path $script:OutputRoot "SHA256SUMS") | Out-Null
 if ($LASTEXITCODE -ne 0) { throw "failed to write or verify SHA256SUMS" }
-if ($comparisonExitCode -ne 0) { throw "paired performance gate failed with exit code $comparisonExitCode" }
+if ($comparisonExitCode -ne 0) {
+    throw "paired performance gate failed with exit code $comparisonExitCode"
+}
+Write-Host ("Transport verification: python `"{0}`" verify-checksums --root `"{1}`" --output `"{2}`"" -f `
+    $PythonTool, $script:OutputRoot, (Join-Path $script:OutputRoot "SHA256SUMS"))

--- a/scripts/tui-perf.ps1
+++ b/scripts/tui-perf.ps1
@@ -1,0 +1,479 @@
+<#
+.SYNOPSIS
+Runs paired ytt TUI performance scenarios in isolated per-run profiles.
+
+.PARAMETER SeedHome
+Playback seed template. Persisted ytt state must be stored under
+stores\config, stores\data, and stores\cache; the whole template is copied per run.
+The resumed Song.local_path must be the literal {{TUI_PERF_PLAYLIST}} placeholder.
+BaselineSeedHome and CandidateSeedHome override this template per role, enabling explicit
+32MiB/8MiB reference vs candidate cache-pair exploration without mutating either seed.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)] [string] $Scenario,
+    [Parameter(Mandatory = $true)] [string] $Output,
+    [string] $BaselineBinary,
+    [string] $CandidateBinary,
+    [string] $BaselineRender,
+    [string] $CandidateRender,
+    [string] $BaselineSourceRoot,
+    [string] $CandidateSourceRoot,
+    [Parameter(Mandatory = $true)] [string] $BaselineBuildCommand,
+    [Parameter(Mandatory = $true)] [string] $CandidateBuildCommand,
+    [string] $SeedHome,
+    [string] $BaselineSeedHome,
+    [string] $CandidateSeedHome,
+    [string] $Sampler,
+    [string] $Controller,
+    [string] $Scenarios,
+    [switch] $NoBuild
+)
+
+$ErrorActionPreference = "Stop"
+$Repo = Split-Path -Parent $PSScriptRoot
+$PythonTool = Join-Path $PSScriptRoot "tui-perf.py"
+if (-not $Scenarios) { $Scenarios = Join-Path $PSScriptRoot "tui-perf-scenarios.json" }
+if (-not $Sampler) { $Sampler = Join-Path $Repo "target\release\examples\tui_perf_sampler.exe" }
+if (-not $Controller) { $Controller = Join-Path $Repo "target\release\examples\tui_perf_control.exe" }
+
+function Invoke-Python {
+    param([Parameter(ValueFromRemainingArguments = $true)] [string[]] $Arguments)
+    & python $PythonTool @Arguments
+    if ($LASTEXITCODE -ne 0) { throw "tui-perf.py failed with exit code $LASTEXITCODE" }
+}
+
+function Get-ScenarioField([string] $Name) {
+    $value = & python $PythonTool scenario --scenarios $Scenarios --id $Scenario --field $Name
+    if ($LASTEXITCODE -ne 0) { throw "cannot read scenario field $Name" }
+    return ($value | Out-String).Trim()
+}
+
+function Get-TrafficField([string] $Name) {
+    $value = & python $PythonTool traffic --scenarios $Scenarios --name $script:TrafficProfile --field $Name
+    if ($LASTEXITCODE -ne 0) { throw "cannot read traffic field $Name" }
+    return ($value | Out-String).Trim()
+}
+
+function Get-SettingField([string] $Name) {
+    $value = & python $PythonTool setting --scenarios $Scenarios --field $Name
+    if ($LASTEXITCODE -ne 0) { throw "cannot read top-level scenario setting $Name" }
+    return ($value | Out-String).Trim()
+}
+
+function ConvertTo-WindowsArgument([string] $Value) {
+    if ($Value -notmatch '[\s"]') { return $Value }
+    $builder = New-Object System.Text.StringBuilder
+    [void] $builder.Append('"')
+    $slashes = 0
+    foreach ($character in $Value.ToCharArray()) {
+        if ($character -eq '\') {
+            $slashes++
+        } elseif ($character -eq '"') {
+            [void] $builder.Append((('\' * ($slashes * 2 + 1)) -join ''))
+            [void] $builder.Append('"')
+            $slashes = 0
+        } else {
+            if ($slashes) { [void] $builder.Append((('\' * $slashes) -join '')); $slashes = 0 }
+            [void] $builder.Append($character)
+        }
+    }
+    if ($slashes) { [void] $builder.Append((('\' * ($slashes * 2)) -join '')) }
+    [void] $builder.Append('"')
+    return $builder.ToString()
+}
+
+function Start-ExactProcess([string] $FilePath, [string[]] $Arguments) {
+    $info = New-Object System.Diagnostics.ProcessStartInfo
+    $info.FileName = $FilePath
+    $info.UseShellExecute = $false
+    $info.CreateNoWindow = $false
+    if ($info.PSObject.Properties.Name -contains "ArgumentList") {
+        foreach ($argument in $Arguments) { [void] $info.ArgumentList.Add($argument) }
+    } else {
+        $info.Arguments = (($Arguments | ForEach-Object { ConvertTo-WindowsArgument $_ }) -join ' ')
+    }
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $info
+    if (-not $process.Start()) { throw "failed to launch $FilePath" }
+    return $process
+}
+
+function Set-IsolatedEnvironment([string] $RunDir, [string] $Home) {
+    $runtime = Join-Path $RunDir "runtime"
+    $temp = Join-Path $RunDir "tmp"
+    $roaming = Join-Path $Home "AppData\Roaming"
+    $local = Join-Path $Home "AppData\Local"
+    $configStore = Join-Path $Home "stores\config"
+    $dataStore = Join-Path $Home "stores\data"
+    $cacheStore = Join-Path $Home "stores\cache"
+    foreach ($directory in @($runtime, $temp, $roaming, $local, $configStore, $dataStore, $cacheStore)) {
+        New-Item -ItemType Directory -Force -Path $directory | Out-Null
+    }
+    $values = @{
+        HOME = $Home
+        USERPROFILE = $Home
+        APPDATA = $roaming
+        LOCALAPPDATA = $local
+        XDG_CONFIG_HOME = (Join-Path $Home ".config")
+        XDG_DATA_HOME = (Join-Path $Home ".local\share")
+        XDG_CACHE_HOME = (Join-Path $Home ".cache")
+        XDG_STATE_HOME = (Join-Path $Home ".local\state")
+        XDG_RUNTIME_DIR = $runtime
+        YTM_CONFIG_DIR = $configStore
+        YTM_DATA_DIR = $dataStore
+        YTM_CACHE_DIR = $cacheStore
+        TEMP = $temp
+        TMP = $temp
+        TERM = "xterm-256color"
+        YTM_MPV_EXTRA = "--ao=null --volume=0 --audio-display=no"
+        YTM_PERF = "1"
+        TUI_PERF_SCENARIO_SHA256 = $script:ScenarioHash
+    }
+    $prior = @{}
+    foreach ($name in $values.Keys) {
+        $prior[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
+        [Environment]::SetEnvironmentVariable($name, $values[$name], "Process")
+    }
+    return $prior
+}
+
+function Restore-Environment([hashtable] $Prior) {
+    foreach ($name in $Prior.Keys) {
+        [Environment]::SetEnvironmentVariable($name, $Prior[$name], "Process")
+    }
+}
+
+function Stop-RecordedYtt([string] $PidFile) {
+    if (-not (Test-Path -LiteralPath $PidFile)) { return }
+    $recorded = 0
+    if (-not [int]::TryParse((Get-Content -LiteralPath $PidFile -Raw).Trim(), [ref] $recorded)) { return }
+    $process = Get-Process -Id $recorded -ErrorAction SilentlyContinue
+    if ($process) {
+        # Exact sampler-recorded PID only. ytt's Windows Job Object owns its mpv descendants.
+        Stop-Process -Id $recorded -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Run-Render([string] $Role, [string] $Binary, [string] $RunDir) {
+    $runDir = $RunDir
+    New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+    $oldHash = $env:TUI_PERF_SCENARIO_SHA256
+    try {
+        $env:TUI_PERF_SCENARIO_SHA256 = $script:ScenarioHash
+        & $Binary --output (Join-Path $runDir "render.json") `
+            --warmup (Get-ScenarioField "warmup_draws") `
+            --batches (Get-ScenarioField "batches") `
+            --draws (Get-ScenarioField "draws_per_batch")
+        if ($LASTEXITCODE -ne 0) { throw "$Role render harness failed" }
+    } finally {
+        $env:TUI_PERF_SCENARIO_SHA256 = $oldHash
+    }
+}
+
+function Run-Process(
+    [string] $Role,
+    [string] $Binary,
+    [string] $RunRoot,
+    [int] $Width,
+    [int] $Height,
+    [string] $Label
+) {
+    $runDir = $RunRoot
+    if ($script:GeometryCount -gt 1) {
+        $runDir = Join-Path $RunRoot ("geometry-{0}x{1}" -f $Width, $Height)
+    }
+    $roleSeedHome = if ($Role -eq "baseline") { $BaselineSeedHome } else { $CandidateSeedHome }
+    $home = Join-Path $runDir "home"
+    $samples = Join-Path $runDir "samples.ndjson"
+    $control = Join-Path $runDir "control.ndjson"
+    $pidFile = Join-Path $runDir "ytt.pid"
+    $readyFile = Join-Path $runDir "http-ready.json"
+    New-Item -ItemType Directory -Force -Path $home | Out-Null
+    if ($roleSeedHome) {
+        Get-ChildItem -LiteralPath $roleSeedHome -Force |
+            Copy-Item -Destination $home -Recurse -Force
+    }
+    $serverProcess = $null
+    $samplerProcess = $null
+    $prior = $null
+    try {
+        if ($script:RequiresMpv) {
+            Remove-Item -LiteralPath $readyFile -Force -ErrorAction SilentlyContinue
+            $serverArgs = @(
+                $PythonTool, "serve",
+                "--file", $script:FixtureFile,
+                "--ready-file", $readyFile,
+                "--throttle-bps", (Get-TrafficField "throttle_bps"),
+                "--outage-every-bytes", (Get-TrafficField "outage_every_bytes"),
+                "--outage-ms", (Get-TrafficField "outage_ms"),
+                "--disconnect-every-bytes", (Get-TrafficField "disconnect_every_bytes")
+            )
+            $serverProcess = Start-ExactProcess "python" $serverArgs
+            $serverDeadline = [DateTime]::UtcNow.AddSeconds(10)
+            while (-not (Test-Path -LiteralPath $readyFile)) {
+                if ($serverProcess.HasExited) { throw "fixture server exited before publishing its URL" }
+                if ([DateTime]::UtcNow -ge $serverDeadline) { throw "fixture server startup timed out" }
+                Start-Sleep -Milliseconds 50
+            }
+            $fixtureUrl = (Get-Content -LiteralPath $readyFile -Raw | ConvertFrom-Json).url
+            & python $PythonTool materialize `
+                --root $home `
+                --home $home `
+                --fixture-url $fixtureUrl `
+                --seed-label $Role `
+                --manifest (Join-Path $runDir "materialize.json") | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw "failed to materialize isolated seed home" }
+        }
+        $prior = Set-IsolatedEnvironment $runDir $home
+        try {
+            $buffer = $Host.UI.RawUI.BufferSize
+            if ($buffer.Width -lt $Width -or $buffer.Height -lt $Height) {
+                $Host.UI.RawUI.BufferSize = [System.Management.Automation.Host.Size]::new(
+                    [Math]::Max($buffer.Width, $Width),
+                    [Math]::Max($buffer.Height, $Height)
+                )
+            }
+            $Host.UI.RawUI.WindowSize = [System.Management.Automation.Host.Size]::new($Width, $Height)
+        } catch {
+            throw "cannot establish the required ${Width}x${Height} interactive console for ${Label}: $_"
+        }
+        $samplerArgs = @(
+            "--output", $samples,
+            "--pid-file", $pidFile,
+            "--binary", $Binary,
+            "--warmup-secs", (Get-ScenarioField "warmup_s"),
+            "--duration-secs", (Get-ScenarioField "sample_s"),
+            "--interval-ms", "1000"
+        )
+        if ($script:RequiresMpv) { $samplerArgs += "--require-silent-mpv" }
+        $controllerEnabled = (Get-ScenarioField "controller") -eq "true"
+        # Controller runs need ytt to publish its primary descriptor inside this run's isolated
+        # runtime directory. Non-controller runs retain the private new-instance endpoint.
+        if (-not $controllerEnabled) { $samplerArgs += @("--", "--new-instance") }
+        Remove-Item -LiteralPath $pidFile -Force -ErrorAction SilentlyContinue
+        $samplerProcess = Start-ExactProcess $Sampler $samplerArgs
+
+        $readyAt = [DateTime]::UtcNow.AddSeconds(30)
+        while (-not (Test-Path -LiteralPath $pidFile)) {
+            if ($samplerProcess.HasExited) { throw "$Role sampler exited before publishing ytt PID" }
+            if ([DateTime]::UtcNow -ge $readyAt) { throw "$Role sampler timed out before publishing ytt PID" }
+            Start-Sleep -Milliseconds 100
+        }
+
+        if ($controllerEnabled) {
+            $controllerArgs = @(
+                "--output", $control,
+                "--wait-secs", "45",
+                "--observe-secs", ([double](Get-ScenarioField "warmup_s") + [double](Get-ScenarioField "sample_s")),
+                "--close-grace-secs", "15",
+                "--load", (Get-ScenarioField "controller_load")
+            )
+            $seekValues = (Get-ScenarioField "seeks_s") | ConvertFrom-Json
+            if ($seekValues.Count -gt 0) { $controllerArgs += @("--seeks", ($seekValues -join ',')) }
+            $pausePolicy = Get-ScenarioField "pause_policy"
+            $pauseHoldMs = Get-ScenarioField "pause_hold_ms"
+            if ($pausePolicy -eq "pause-resume") {
+                $controllerArgs += @("--pause-hold-ms", $pauseHoldMs)
+            } else {
+                $controllerArgs += "--no-pause"
+            }
+            & $Controller @controllerArgs
+            if ($LASTEXITCODE -ne 0) { throw "$Role controller failed" }
+        }
+
+        $timeoutSeconds = [Math]::Ceiling(
+            [double](Get-ScenarioField "warmup_s") + [double](Get-ScenarioField "sample_s") + 90
+        )
+        $deadline = [DateTime]::UtcNow.AddSeconds($timeoutSeconds)
+        while (-not $samplerProcess.HasExited) {
+            if ([DateTime]::UtcNow -ge $deadline) { throw "$Role sampler timed out" }
+            Start-Sleep -Seconds 1
+        }
+        if ($samplerProcess.ExitCode -ne 0) { throw "$Role sampler exited $($samplerProcess.ExitCode)" }
+
+        $checkArgs = @("check", "--samples", $samples, "--scenario-sha256", $script:ScenarioHash)
+        if ($script:RequiresMpv) { $checkArgs += "--require-silent-mpv" }
+        if ($controllerEnabled) {
+            $checkArgs += @("--control", $control, "--require-observer-close")
+        }
+        & python $PythonTool @checkArgs | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "$Role artifacts failed validation" }
+    } finally {
+        if ($samplerProcess -and -not $samplerProcess.HasExited) {
+            Stop-RecordedYtt $pidFile
+            try { $samplerProcess.Kill() } catch { }
+        }
+        if ($serverProcess -and -not $serverProcess.HasExited) {
+            try { $serverProcess.Kill() } catch { }
+            try { $serverProcess.WaitForExit() } catch { }
+        }
+        if ($prior) { Restore-Environment $prior }
+    }
+}
+
+function Run-ProcessGeometries(
+    [string] $Role,
+    [string] $Binary,
+    [string] $RunRoot,
+    [string] $Label
+) {
+    for ($geometryIndex = 0; $geometryIndex -lt $script:GeometryCount; $geometryIndex++) {
+        $width = [int](Get-ScenarioField ("geometry.{0}.0" -f $geometryIndex))
+        $height = [int](Get-ScenarioField ("geometry.{0}.1" -f $geometryIndex))
+        Run-Process $Role $Binary $RunRoot $width $height `
+            ("{0} geometry {1}x{2}" -f $Label, $width, $height)
+    }
+}
+
+& python $PythonTool validate --scenarios $Scenarios | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "invalid scenarios file" }
+$script:ScenarioHash = Get-ScenarioField "sha256"
+$pairs = [int](Get-ScenarioField "pairs")
+$candidateRepeats = [int](Get-ScenarioField "candidate_repeats")
+$script:GeometryCount = [int](Get-ScenarioField "geometry.length")
+$script:RequiresMpv = (Get-ScenarioField "requires_mpv") -eq "true"
+$script:TrafficProfile = Get-ScenarioField "traffic_profile"
+$fixtureSeconds = Get-SettingField "fixture.duration_s"
+$fixtureSampleRate = Get-SettingField "fixture.sample_rate_hz"
+$isRender = $Scenario -eq "render_and_interaction"
+if (-not $BaselineSeedHome) { $BaselineSeedHome = $SeedHome }
+if (-not $CandidateSeedHome) { $CandidateSeedHome = $SeedHome }
+$script:OutputRoot = [IO.Path]::GetFullPath($Output)
+if (Test-Path -LiteralPath $script:OutputRoot) {
+    throw "-Output must name a new path; existing evidence is never reused"
+}
+New-Item -ItemType Directory -Path $script:OutputRoot | Out-Null
+$script:FixtureFile = Join-Path $script:OutputRoot ("fixture\silence-{0}s.wav" -f $fixtureSeconds)
+if ($script:RequiresMpv -and -not (Test-Path -LiteralPath $script:FixtureFile)) {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $script:FixtureFile) | Out-Null
+    & python $PythonTool fixture `
+        --output $script:FixtureFile `
+        --manifest (Join-Path (Split-Path -Parent $script:FixtureFile) "manifest.json") `
+        --seconds $fixtureSeconds `
+        --sample-rate $fixtureSampleRate | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "failed to generate deterministic silence fixture" }
+}
+
+if (-not $NoBuild) {
+    Push-Location $Repo
+    try {
+        & cargo build --release --locked --example tui_perf_sampler --example tui_perf_control --example tui_render_perf
+        if ($LASTEXITCODE -ne 0) { throw "harness build failed" }
+    } finally {
+        Pop-Location
+    }
+}
+
+if ($isRender) {
+    if (-not $CandidateRender) { $CandidateRender = Join-Path $Repo "target\release\examples\tui_render_perf.exe" }
+    if (-not (Test-Path -LiteralPath $BaselineRender -PathType Leaf)) { throw "--BaselineRender is required" }
+    if (-not (Test-Path -LiteralPath $CandidateRender -PathType Leaf)) { throw "candidate render harness missing" }
+} else {
+    if ([Console]::IsOutputRedirected -or -not [Environment]::UserInteractive) {
+        throw "Windows process scenarios require a local interactive console/ConPTY; stage and retrieve artifacts over SSH, but run this script locally"
+    }
+    foreach ($binary in @($BaselineBinary, $CandidateBinary, $Sampler, $Controller)) {
+        if (-not (Test-Path -LiteralPath $binary -PathType Leaf)) { throw "required executable missing: $binary" }
+    }
+    if ($script:RequiresMpv) {
+        foreach ($seedSpec in @(
+            @{ Role = "baseline"; Path = $BaselineSeedHome },
+            @{ Role = "candidate"; Path = $CandidateSeedHome }
+        )) {
+            if (-not $seedSpec.Path -or -not (Test-Path -LiteralPath $seedSpec.Path -PathType Container)) {
+                throw "playback scenarios require a $($seedSpec.Role) seed home"
+            }
+            foreach ($store in @("config", "data", "cache")) {
+                $storePath = Join-Path $seedSpec.Path ("stores\{0}" -f $store)
+                if (-not (Test-Path -LiteralPath $storePath -PathType Container)) {
+                    throw "$($seedSpec.Role) seed home must contain stores\$store"
+                }
+            }
+        }
+    }
+}
+
+if (-not $CandidateSourceRoot) { $CandidateSourceRoot = $Repo }
+if (-not $BaselineSourceRoot) {
+    $identityBinary = if ($isRender) { $BaselineRender } else { $BaselineBinary }
+    $binaryParent = Split-Path -Parent ([IO.Path]::GetFullPath($identityBinary))
+    $detectedRoot = & git -C $binaryParent rev-parse --show-toplevel
+    if ($LASTEXITCODE -ne 0) {
+        throw "cannot infer -BaselineSourceRoot from $identityBinary"
+    }
+    $BaselineSourceRoot = ($detectedRoot | Out-String).Trim()
+}
+foreach ($sourceRoot in @($BaselineSourceRoot, $CandidateSourceRoot)) {
+    if (-not (Test-Path -LiteralPath $sourceRoot -PathType Container)) {
+        throw "source root is not a directory: $sourceRoot"
+    }
+}
+
+$manifestArgs = @(
+    "manifest",
+    "--scenarios", $Scenarios,
+    "--scenario", $Scenario,
+    "--output", (Join-Path $script:OutputRoot "host-manifest.json"),
+    "--source-root", "baseline=$BaselineSourceRoot",
+    "--source-root", "candidate=$CandidateSourceRoot",
+    "--build-command", "baseline=$BaselineBuildCommand",
+    "--build-command", "candidate=$CandidateBuildCommand"
+)
+if ($isRender) {
+    $manifestArgs += @("--binary", "baseline_render=$BaselineRender")
+    $manifestArgs += @("--binary", "candidate_render=$CandidateRender")
+} else {
+    $manifestArgs += @("--binary", "baseline_ytt=$BaselineBinary")
+    $manifestArgs += @("--binary", "candidate_ytt=$CandidateBinary")
+    $manifestArgs += @("--binary", "sampler=$Sampler")
+    $manifestArgs += @("--binary", "controller=$Controller")
+}
+& python $PythonTool @manifestArgs | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "failed to write host manifest" }
+
+$baselineRuns = @()
+$candidateRuns = @()
+for ($pair = 1; $pair -le $pairs; $pair++) {
+    $order = if ($pair % 2) { @("baseline", "candidate") } else { @("candidate", "baseline") }
+    foreach ($role in $order) {
+        if ($isRender) {
+            $binary = if ($role -eq "baseline") { $BaselineRender } else { $CandidateRender }
+            $runDir = Join-Path $script:OutputRoot ("pair-{0:D2}\{1}" -f $pair, $role)
+            Run-Render $role $binary $runDir
+        } else {
+            $binary = if ($role -eq "baseline") { $BaselineBinary } else { $CandidateBinary }
+            $runRoot = Join-Path $script:OutputRoot ("pair-{0:D2}\{1}" -f $pair, $role)
+            Run-ProcessGeometries $role $binary $runRoot ("$role pair $pair")
+        }
+    }
+    $baselineRuns += @("--baseline-run", (Join-Path $script:OutputRoot ("pair-{0:D2}\baseline" -f $pair)))
+    $candidateRuns += @("--candidate-run", (Join-Path $script:OutputRoot ("pair-{0:D2}\candidate" -f $pair)))
+}
+
+$candidateRepeatRuns = @()
+for ($repeat = 1; $repeat -le $candidateRepeats; $repeat++) {
+    $repeatDir = Join-Path $script:OutputRoot ("candidate-repeat-{0:D2}" -f $repeat)
+    if ($isRender) {
+        Run-Render "candidate" $CandidateRender $repeatDir
+    } else {
+        Run-ProcessGeometries "candidate" $CandidateBinary $repeatDir `
+            ("candidate diagnostic repeat $repeat")
+    }
+    $candidateRepeatRuns += @("--candidate-repeat-run", $repeatDir)
+}
+
+$compareArgs = @(
+    "compare", "--scenarios", $Scenarios, "--scenario", $Scenario,
+    "--host-manifest", (Join-Path $script:OutputRoot "host-manifest.json")
+) + $baselineRuns + $candidateRuns + $candidateRepeatRuns + @(
+    "--output-json", (Join-Path $script:OutputRoot "report.json"),
+    "--output-markdown", (Join-Path $script:OutputRoot "report.md")
+)
+& python $PythonTool @compareArgs
+$comparisonExitCode = $LASTEXITCODE
+& python $PythonTool checksums `
+    --root $script:OutputRoot `
+    --output (Join-Path $script:OutputRoot "SHA256SUMS") | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "failed to write or verify SHA256SUMS" }
+if ($comparisonExitCode -ne 0) { throw "paired performance gate failed with exit code $comparisonExitCode" }

--- a/scripts/tui-perf.py
+++ b/scripts/tui-perf.py
@@ -9,16 +9,25 @@ validation, paired fixed-seed bootstrap statistics, and merged JSON/Markdown rep
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
+import http.client
 import http.server
 import ipaddress
+import io
 import json
 import math
 import os
 import platform
 import random
+import re
+import secrets
+import shlex
+import signal
 import shutil
+import stat
 import statistics
+import struct
 import subprocess
 import sys
 import tempfile
@@ -33,10 +42,132 @@ from urllib.parse import urlsplit
 SCHEMA = "ytt.tui-perf.report.v1"
 DEFAULT_SCENARIOS = Path(__file__).with_name("tui-perf-scenarios.json")
 RATIO_INFINITY = 1e300
+CPU_ACCOUNTING_METHOD = "time_weighted_counter_deltas_clamped_to_measure_window"
+REQUIRED_PLAYBACK_MPV_CACHE_ARGS = {
+    "--demuxer-max-bytes": "32MiB",
+    "--demuxer-max-back-bytes": "8MiB",
+}
+BUILD_RECEIPT_SCHEMA = "ytt.tui-perf.build.v1"
+SEED_CONTRACT_SCHEMA = "ytt.tui-perf.seed-contract.v1"
+RUN_CONTRACT_SCHEMA = "ytt.tui-perf.run-contract.v1"
+HOST_IDENTITY_FIELDS = (
+    "system",
+    "release",
+    "machine",
+    "node_fingerprint",
+    "machine_id_fingerprint",
+    "boot_id_fingerprint",
+)
+SAMPLED_TREE_LIMITATION = (
+    "sampled process tree; sub-interval descendants may be missed"
+)
+RENDER_MEASUREMENT_LIMITATION = (
+    "in-process TestBackend render microbenchmark; excludes terminal I/O and OS compositor"
+)
+CLEANUP_SCOPE = "dedicated_owner_process_group_and_observed_exact_descendants"
+CLEANUP_SCOPE_LIMITATION = (
+    "process cleanup proof is limited to the dedicated owner process group and observed "
+    "exact descendants; a malicious unobserved double-fork/reparent outside portable "
+    "process-group containment may escape"
+)
+CONTROLLED_BUILD_ENV_ALLOWLIST = (
+    "PATH",
+    "HOME",
+    "USERPROFILE",
+    "SYSTEMROOT",
+    "SystemRoot",
+    "WINDIR",
+    "COMSPEC",
+    "PATHEXT",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "RUSTUP_HOME",
+    "RUSTUP_TOOLCHAIN",
+)
+HTTP_THROTTLE_CHUNK_BYTES = 4 * 1024
+HTTP_PACING_EARLY_TOLERANCE_NS = 10_000_000
+HTTP_MEANINGFUL_GET_BYTES = 64 * 1024
+HTTP_SHUTDOWN_SCHEMA = "ytt.tui-perf.http-shutdown.v1"
+HTTP_SHUTDOWN_PATH = "/__ytt_tui_perf_shutdown__"
+HTTP_SHUTDOWN_METHOD = "authenticated_loopback_http_v1"
+MAX_BOOTSTRAP_RESAMPLES = 1_000_000
+MAX_STATISTICS_SEED = (1 << 64) - 1
+CONTROL_ACTION_SCHEDULE_LATE_TOLERANCE_NS = 100_000_000
+CONTROL_PAUSE_HOLD_LATE_TOLERANCE_NS = 100_000_000
+CONTROL_MIN_RESUME_PROGRESS_S = 0.01
+TREE_DIGEST_DOMAIN = b"ytt.tui-perf.tree-digest.v2\0"
+TREE_REGULAR_FILE_ENTRY_TAG = b"\x01regular-file\0"
+EFFECTIVE_WORKTREE_DIGEST_DOMAIN = b"ytt.tui-perf.effective-worktree-digest.v2\0"
+EFFECTIVE_WORKTREE_REGULAR_ENTRY_TAG = b"\x01regular-file\0"
+EFFECTIVE_WORKTREE_SYMLINK_ENTRY_TAG = b"\x02symbolic-link\0"
+LAUNCH_POLICY_FIELDS = (
+    ("tools", "ytdlp_managed"),
+    ("update_check_enabled",),
+    ("media_controls",),
+    ("autoplay_on_start",),
+    ("autoplay_streaming",),
+    ("album_art",),
+    ("romanized_titles",),
+    ("ai_enabled",),
+    ("scrobble", "lastfm", "enabled"),
+    ("scrobble", "listenbrainz", "enabled"),
+    ("scrobble", "local_files"),
+)
+LAUNCH_POLICY_EFFECTIVE = {
+    "tools.ytdlp_managed": False,
+    "update_check_enabled": False,
+    "media_controls": False,
+    "autoplay_on_start": False,
+    "autoplay_streaming": False,
+    "album_art": False,
+    "romanized_titles": False,
+    "ai_enabled": False,
+    "scrobble.lastfm.enabled": False,
+    "scrobble.listenbrainz.enabled": False,
+    "scrobble.local_files": False,
+    "api_cookie_auth": "disabled_by_credential_absence",
+    "lyrics_fetch": "closed_nonpersistent_default_with_controlled_input",
+    "child_environment": "env_i_explicit_allowlist",
+    "ytm_perf_enabled": False,
+    "external_background_network": "disabled",
+}
+CHILD_ENVIRONMENT_POLICY = {
+    "inheritance": "empty_env_i",
+    "host_passthrough": ["PATH", "LANG", "LC_ALL", "LC_CTYPE"],
+    "isolated_keys": [
+        "HOME",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "XDG_CACHE_HOME",
+        "XDG_STATE_HOME",
+        "XDG_RUNTIME_DIR",
+        "YTM_CONFIG_DIR",
+        "YTM_DATA_DIR",
+        "YTM_CACHE_DIR",
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        "TERM",
+        "YTM_MPV_EXTRA",
+        "TUI_PERF_SCENARIO_SHA256",
+        "TUI_PERF_RUN_ID",
+    ],
+    "ambient_behavior_keys_blocked": ["GEMINI_API_KEY", "YTM_PLAY_URL", "YTM_PERF"],
+}
 
 
 class DuplicateJsonKeyError(ValueError):
     pass
+
+
+def measurement_limitations(render: bool) -> list[str]:
+    if render:
+        return [RENDER_MEASUREMENT_LIMITATION]
+    return [SAMPLED_TREE_LIMITATION, CLEANUP_SCOPE_LIMITATION]
 
 
 def reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -56,16 +187,268 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def sha256_tree(root: Path) -> str:
-    digest = hashlib.sha256()
-    for path in sorted(item for item in root.rglob("*") if item.is_file()):
-        relative = path.relative_to(root).as_posix().encode("utf-8")
+def regular_tree_files(root: Path) -> tuple[Path, list[Path]]:
+    try:
+        root_metadata = root.lstat()
+    except OSError as error:
+        raise ValueError(f"cannot inspect tree root {root}: {error}") from error
+    is_junction = bool(getattr(root, "is_junction", lambda: False)())
+    if root.is_symlink() or is_junction or not stat.S_ISDIR(root_metadata.st_mode):
+        raise ValueError(f"tree root must be a real directory: {root}")
+    root = root.resolve()
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        try:
+            metadata = path.lstat()
+        except OSError as error:
+            raise ValueError(f"cannot inspect tree entry {path}: {error}") from error
+        is_junction = bool(getattr(path, "is_junction", lambda: False)())
+        if path.is_symlink() or is_junction:
+            raise ValueError(f"tree contains a link/reparse entry: {path}")
+        if stat.S_ISDIR(metadata.st_mode):
+            continue
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError(f"tree contains a non-regular entry: {path}")
+        files.append(path)
+    files.sort(key=lambda path: path.relative_to(root).as_posix())
+    return root, files
+
+
+def update_tree_digest(digest: Any, root: Path, path: Path) -> None:
+    relative = path.relative_to(root).as_posix().encode("utf-8")
+    with path.open("rb") as stream:
+        metadata = os.fstat(stream.fileno())
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError(f"tree entry changed to a non-regular file: {path}")
+        content_length = metadata.st_size
+        if len(relative) >= 1 << 64 or content_length >= 1 << 64:
+            raise ValueError(f"tree entry is too large to encode: {path}")
+        digest.update(TREE_REGULAR_FILE_ENTRY_TAG)
         digest.update(len(relative).to_bytes(8, "big"))
         digest.update(relative)
-        with path.open("rb") as stream:
-            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-                digest.update(chunk)
+        digest.update(content_length.to_bytes(8, "big"))
+        bytes_read = 0
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            bytes_read += len(chunk)
+            digest.update(chunk)
+        if bytes_read != content_length:
+            raise ValueError(f"tree entry changed length while hashing: {path}")
+
+
+def sha256_tree(root: Path) -> str:
+    root, files = regular_tree_files(root)
+    digest = hashlib.sha256()
+    digest.update(TREE_DIGEST_DOMAIN)
+    for path in files:
+        update_tree_digest(digest, root, path)
     return digest.hexdigest()
+
+
+def tree_file_inventory(root: Path) -> list[dict[str, Any]]:
+    root, files = regular_tree_files(root)
+    return [
+        {
+            "path": path.relative_to(root).as_posix(),
+            "bytes": path.stat().st_size,
+            "sha256": sha256_file(path),
+        }
+        for path in files
+    ]
+
+
+def tree_digest_self_test() -> None:
+    def legacy_unframed_digest(root: Path) -> str:
+        root, files = regular_tree_files(root)
+        digest = hashlib.sha256()
+        for path in files:
+            relative = path.relative_to(root).as_posix().encode("utf-8")
+            digest.update(len(relative).to_bytes(8, "big"))
+            digest.update(relative)
+            digest.update(path.read_bytes())
+        return digest.hexdigest()
+
+    with tempfile.TemporaryDirectory(prefix="ytt-perf-tree-digest-self-test-") as temporary:
+        base = Path(temporary)
+        one_file = base / "one-file"
+        two_files = base / "two-files"
+        empty_overlay = base / "empty-overlay"
+        one_file.mkdir()
+        two_files.mkdir()
+        empty_overlay.mkdir()
+        prefix = b"first-content"
+        suffix = b"second-content"
+        encoded_second_entry = len(b"b").to_bytes(8, "big") + b"b" + suffix
+        (one_file / "a").write_bytes(prefix + encoded_second_entry)
+        (two_files / "a").write_bytes(prefix)
+        (two_files / "b").write_bytes(suffix)
+        if legacy_unframed_digest(one_file) != legacy_unframed_digest(two_files):
+            raise AssertionError("tree collision fixture does not reproduce legacy ambiguity")
+        if sha256_tree(one_file) == sha256_tree(two_files):
+            raise AssertionError("length-framed tree digest retained a legacy collision")
+        overlay_digest, _inventory = overlay_tree_identity(one_file, empty_overlay, [])
+        if overlay_digest != sha256_tree(one_file):
+            raise AssertionError("overlay and direct tree digests use different framing")
+
+        try:
+            sha256_tree(one_file / "a")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("tree digest accepted a non-directory tree root")
+
+        link = one_file / "link"
+        try:
+            link.symlink_to(one_file / "a")
+        except OSError:
+            pass
+        else:
+            try:
+                sha256_tree(one_file)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("tree digest accepted a symbolic link")
+            link.unlink()
+
+        if hasattr(os, "mkfifo"):
+            fifo = one_file / "fifo"
+            os.mkfifo(fifo)
+            try:
+                sha256_tree(one_file)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("tree digest accepted a non-regular entry")
+
+
+def identity_for_file(path: Path) -> dict[str, Any]:
+    path = path.resolve()
+    if not path.is_file():
+        raise ValueError(f"file does not exist: {path}")
+    return {"path": str(path), "bytes": path.stat().st_size, "sha256": sha256_file(path)}
+
+
+def checked_identity_command(command: list[str], label: str) -> str:
+    try:
+        result = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise ValueError(f"cannot determine {label}: {error}") from error
+    value = result.stdout.strip()
+    if result.returncode != 0 or not value:
+        detail = result.stderr.strip() or f"exit code {result.returncode}"
+        raise ValueError(f"cannot determine {label}: {detail}")
+    return value
+
+
+def stable_machine_id(system: str) -> str:
+    if system == "Linux":
+        path = Path("/etc/machine-id")
+        try:
+            value = path.read_text(encoding="ascii").strip().lower()
+        except OSError as error:
+            raise ValueError(f"cannot determine Linux machine ID: {error}") from error
+        if not re.fullmatch(r"[0-9a-f]{32}", value) or value == "0" * 32:
+            raise ValueError("Linux machine ID is missing or malformed")
+        return f"linux-machine-id:{value}"
+    if system == "Darwin":
+        output = checked_identity_command(
+            ["/usr/sbin/ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+            "macOS IOPlatformUUID",
+        )
+        match = re.search(r'"IOPlatformUUID"\s*=\s*"([0-9A-Fa-f-]{36})"', output)
+        if match is None:
+            raise ValueError("macOS IOPlatformUUID is missing or malformed")
+        return f"darwin-platform-uuid:{match.group(1).lower()}"
+    if system == "Windows":
+        value = checked_identity_command(
+            [
+                "powershell.exe",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "(Get-CimInstance Win32_ComputerSystemProduct).UUID",
+            ],
+            "Windows system UUID",
+        ).lower()
+        if not re.fullmatch(r"[0-9a-f-]{36}", value) or value == "00000000-0000-0000-0000-000000000000":
+            raise ValueError("Windows system UUID is missing or malformed")
+        return f"windows-system-uuid:{value}"
+    raise ValueError(f"unsupported host system for stable machine identity: {system!r}")
+
+
+def stable_boot_id(system: str) -> str:
+    if system == "Linux":
+        path = Path("/proc/sys/kernel/random/boot_id")
+        try:
+            value = path.read_text(encoding="ascii").strip().lower()
+        except OSError as error:
+            raise ValueError(f"cannot determine Linux boot ID: {error}") from error
+        if not re.fullmatch(r"[0-9a-f-]{36}", value):
+            raise ValueError("Linux boot ID is missing or malformed")
+        return f"linux-boot-id:{value}"
+    if system == "Darwin":
+        output = checked_identity_command(
+            ["/usr/sbin/sysctl", "-n", "kern.boottime"], "macOS boot time"
+        )
+        match = re.search(r"sec\s*=\s*(\d+)\s*,\s*usec\s*=\s*(\d+)", output)
+        if match is None:
+            raise ValueError("macOS boot time is missing or malformed")
+        return f"darwin-boottime:{int(match.group(1))}:{int(match.group(2))}"
+    if system == "Windows":
+        value = checked_identity_command(
+            [
+                "powershell.exe",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "(Get-CimInstance Win32_OperatingSystem).LastBootUpTime.ToUniversalTime().Ticks",
+            ],
+            "Windows boot time",
+        )
+        if not value.isdecimal() or int(value) <= 0:
+            raise ValueError("Windows boot time is missing or malformed")
+        return f"windows-boot-ticks:{value}"
+    raise ValueError(f"unsupported host system for stable boot identity: {system!r}")
+
+
+def host_identifier_fingerprint(label: str, raw: str) -> str:
+    if not raw:
+        raise ValueError(f"cannot fingerprint an empty host {label}")
+    digest = hashlib.sha256()
+    digest.update(b"ytt.tui-perf.host.v1\0")
+    digest.update(label.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(raw.encode("utf-8"))
+    return f"sha256:{digest.hexdigest()}"
+
+
+def stable_host_identity() -> dict[str, str]:
+    system = platform.system()
+    release = platform.release()
+    machine = platform.machine()
+    node = platform.node()
+    identity = {
+        "system": system,
+        "release": release,
+        "machine": machine,
+    }
+    if any(not isinstance(value, str) or not value.strip() for value in (*identity.values(), node)):
+        raise ValueError("host system/release/machine/node identity is incomplete")
+    identity["node_fingerprint"] = host_identifier_fingerprint("node", node)
+    identity["machine_id_fingerprint"] = host_identifier_fingerprint(
+        "machine_id", stable_machine_id(system)
+    )
+    identity["boot_id_fingerprint"] = host_identifier_fingerprint(
+        "boot_id", stable_boot_id(system)
+    )
+    return identity
 
 
 def run_git(root: Path, *arguments: str, binary: bool = False) -> str | bytes:
@@ -84,34 +467,269 @@ def run_git(root: Path, *arguments: str, binary: bool = False) -> str | bytes:
 
 
 def effective_worktree_digest(root: Path) -> tuple[str, int]:
+    try:
+        root_metadata = root.lstat()
+    except OSError as error:
+        raise ValueError(f"cannot inspect source root {root}: {error}") from error
+    is_junction = bool(getattr(root, "is_junction", lambda: False)())
+    if root.is_symlink() or is_junction or not stat.S_ISDIR(root_metadata.st_mode):
+        raise ValueError(f"source root must be a real directory: {root}")
+    root = root.resolve()
     raw = run_git(root, "ls-files", "-co", "--exclude-standard", "-z", binary=True)
     assert isinstance(raw, bytes)
     relative_paths = sorted(
         (item.decode("utf-8", errors="surrogateescape") for item in raw.split(b"\0") if item),
         key=lambda item: item.encode("utf-8", errors="surrogateescape"),
     )
+    if len(relative_paths) != len(set(relative_paths)):
+        raise ValueError(f"git returned duplicate effective worktree paths for {root}")
     digest = hashlib.sha256()
+    digest.update(EFFECTIVE_WORKTREE_DIGEST_DOMAIN)
+
+    def frame_prefix(tag: bytes, encoded_path: bytes, payload_length: int) -> None:
+        if len(encoded_path) >= 1 << 64 or payload_length < 0 or payload_length >= 1 << 64:
+            raise ValueError("effective worktree entry exceeds the digest framing range")
+        digest.update(tag)
+        digest.update(len(encoded_path).to_bytes(8, "big"))
+        digest.update(encoded_path)
+        digest.update(payload_length.to_bytes(8, "big"))
+
+    def metadata_signature(metadata: os.stat_result) -> tuple[int, int, int, int, int, int]:
+        return (
+            metadata.st_mode,
+            metadata.st_dev,
+            metadata.st_ino,
+            metadata.st_size,
+            metadata.st_mtime_ns,
+            metadata.st_ctime_ns,
+        )
+
     for relative in relative_paths:
         encoded = relative.encode("utf-8", errors="surrogateescape")
-        digest.update(len(encoded).to_bytes(8, "big"))
-        digest.update(encoded)
+        relative_path = Path(relative)
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            raise ValueError(f"git returned an unsafe effective worktree path: {relative!r}")
         path = root / relative
-        if path.is_symlink():
-            target = os.readlink(path).encode("utf-8", errors="surrogateescape")
-            digest.update(b"L")
-            digest.update(len(target).to_bytes(8, "big"))
+        try:
+            before = path.lstat()
+        except OSError as error:
+            raise ValueError(
+                f"effective worktree entry disappeared or is unreadable: {relative!r}"
+            ) from error
+        if stat.S_ISLNK(before.st_mode):
+            try:
+                target_text = os.readlink(path)
+                after = path.lstat()
+                target_after = os.readlink(path)
+            except OSError as error:
+                raise ValueError(
+                    f"effective worktree symlink changed while hashing: {relative!r}"
+                ) from error
+            if metadata_signature(before) != metadata_signature(after) or target_text != target_after:
+                raise ValueError(
+                    f"effective worktree symlink changed while hashing: {relative!r}"
+                )
+            target = target_text.encode("utf-8", errors="surrogateescape")
+            frame_prefix(EFFECTIVE_WORKTREE_SYMLINK_ENTRY_TAG, encoded, len(target))
             digest.update(target)
-        elif path.is_file():
-            digest.update(b"F")
+        elif stat.S_ISREG(before.st_mode):
             with path.open("rb") as stream:
+                opened = os.fstat(stream.fileno())
+                if (
+                    not stat.S_ISREG(opened.st_mode)
+                    or metadata_signature(opened) != metadata_signature(before)
+                ):
+                    raise ValueError(
+                        f"effective worktree file changed before hashing: {relative!r}"
+                    )
+                frame_prefix(
+                    EFFECTIVE_WORKTREE_REGULAR_ENTRY_TAG,
+                    encoded,
+                    opened.st_size,
+                )
+                bytes_read = 0
                 for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                    bytes_read += len(chunk)
                     digest.update(chunk)
+                opened_after = os.fstat(stream.fileno())
+            try:
+                path_after = path.lstat()
+            except OSError as error:
+                raise ValueError(
+                    f"effective worktree file changed while hashing: {relative!r}"
+                ) from error
+            if (
+                bytes_read != opened.st_size
+                or metadata_signature(opened_after) != metadata_signature(opened)
+                or metadata_signature(path_after) != metadata_signature(opened)
+            ):
+                raise ValueError(
+                    f"effective worktree file changed while hashing: {relative!r}"
+                )
         else:
-            digest.update(b"M")
+            raise ValueError(
+                f"effective worktree contains a missing or special entry: {relative!r}"
+            )
     return digest.hexdigest(), len(relative_paths)
 
 
-def source_identity(root: Path, build_command: str) -> dict[str, Any]:
+def effective_worktree_digest_self_test() -> None:
+    def legacy_effective_worktree_digest(root: Path) -> str:
+        raw = run_git(root, "ls-files", "-co", "--exclude-standard", "-z", binary=True)
+        assert isinstance(raw, bytes)
+        relative_paths = sorted(
+            (
+                item.decode("utf-8", errors="surrogateescape")
+                for item in raw.split(b"\0")
+                if item
+            ),
+            key=lambda item: item.encode("utf-8", errors="surrogateescape"),
+        )
+        digest = hashlib.sha256()
+        for relative in relative_paths:
+            encoded = relative.encode("utf-8", errors="surrogateescape")
+            digest.update(len(encoded).to_bytes(8, "big"))
+            digest.update(encoded)
+            path = root / relative
+            if path.is_symlink():
+                target = os.readlink(path).encode("utf-8", errors="surrogateescape")
+                digest.update(b"L")
+                digest.update(len(target).to_bytes(8, "big"))
+                digest.update(target)
+            elif path.is_file():
+                digest.update(b"F")
+                digest.update(path.read_bytes())
+            else:
+                digest.update(b"M")
+        return digest.hexdigest()
+
+    with tempfile.TemporaryDirectory(
+        prefix="ytt-perf-effective-worktree-digest-self-test-"
+    ) as temporary:
+        base = Path(temporary)
+        one_file = base / "one-file"
+        two_files = base / "two-files"
+        missing_file = base / "missing-file"
+        for repository in (one_file, two_files, missing_file):
+            repository.mkdir()
+            run_git(repository, "init", "--quiet")
+
+        prefix = b"first-content"
+        suffix = b"second-content"
+        encoded_second_entry = (
+            len(b"b").to_bytes(8, "big") + b"b" + b"F" + suffix
+        )
+        (one_file / "a").write_bytes(prefix + encoded_second_entry)
+        (two_files / "a").write_bytes(prefix)
+        (two_files / "b").write_bytes(suffix)
+        if legacy_effective_worktree_digest(
+            one_file
+        ) != legacy_effective_worktree_digest(two_files):
+            raise AssertionError(
+                "effective worktree collision fixture does not reproduce legacy ambiguity"
+            )
+        one_digest, one_count = effective_worktree_digest(one_file)
+        two_digest, two_count = effective_worktree_digest(two_files)
+        if (one_count, two_count) != (1, 2):
+            raise AssertionError("effective worktree collision fixture has unexpected entries")
+        if one_digest == two_digest:
+            raise AssertionError(
+                "length-framed effective worktree digest retained a legacy collision"
+            )
+
+        link = two_files / "link"
+        try:
+            link.symlink_to("a")
+        except OSError:
+            pass
+        else:
+            first_link_digest, _ = effective_worktree_digest(two_files)
+            link.unlink()
+            link.symlink_to("b")
+            second_link_digest, _ = effective_worktree_digest(two_files)
+            if first_link_digest == second_link_digest:
+                raise AssertionError(
+                    "effective worktree digest did not bind the symlink target"
+                )
+
+        tracked = missing_file / "tracked"
+        tracked.write_bytes(b"tracked-content")
+        run_git(missing_file, "add", "--", "tracked")
+        tracked.unlink()
+        try:
+            effective_worktree_digest(missing_file)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(
+                "effective worktree digest accepted a missing tracked entry"
+            )
+
+
+def effective_cargo_home() -> Path:
+    raw = os.environ.get("CARGO_HOME")
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return (Path.home() / ".cargo").resolve()
+
+
+def cargo_config_chain(root: Path) -> list[dict[str, Any]]:
+    """Bind every Cargo config source that can affect a build from ``root``.
+
+    Cargo walks from the invocation directory through every ancestor and also reads the
+    effective CARGO_HOME.  Ignored files are intentionally included here: git cleanliness
+    alone is not a build-input contract.
+    """
+    root = root.resolve()
+    entries: list[dict[str, Any]] = []
+    current = root
+    depth = 0
+    while True:
+        for name in ("config.toml", "config"):
+            path = current / ".cargo" / name
+            if path.is_file():
+                entries.append(
+                    {
+                        "scope": "source" if depth == 0 else "ancestor",
+                        "ancestor_depth": depth,
+                        "name": name,
+                        **identity_for_file(path),
+                    }
+                )
+        if current.parent == current:
+            break
+        current = current.parent
+        depth += 1
+
+    cargo_home = effective_cargo_home()
+    for name in ("config.toml", "config"):
+        path = cargo_home / name
+        if path.is_file():
+            entries.append(
+                {
+                    "scope": "cargo_home",
+                    "ancestor_depth": None,
+                    "name": name,
+                    **identity_for_file(path),
+                }
+            )
+    return entries
+
+
+def comparable_cargo_config_chain(chain: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "scope": entry["scope"],
+            "ancestor_depth": entry["ancestor_depth"],
+            "name": entry["name"],
+            "bytes": entry["bytes"],
+            "sha256": entry["sha256"],
+        }
+        for entry in chain
+    ]
+
+
+def source_identity(root: Path, build_command: str | None = None) -> dict[str, Any]:
     root = root.resolve()
     if not root.is_dir():
         raise ValueError(f"source root does not exist: {root}")
@@ -124,7 +742,7 @@ def source_identity(root: Path, build_command: str) -> dict[str, Any]:
     status = run_git(root, "status", "--porcelain=v1", "--untracked-files=all", "-z", binary=True)
     assert isinstance(status, bytes)
     effective_sha256, entry_count = effective_worktree_digest(root)
-    return {
+    identity = {
         "root": str(root),
         "head": str(run_git(root, "rev-parse", "HEAD^{commit}")),
         "tree": str(run_git(root, "rev-parse", "HEAD^{tree}")),
@@ -137,8 +755,147 @@ def source_identity(root: Path, build_command: str) -> dict[str, Any]:
             "bytes": lockfile.stat().st_size,
             "sha256": sha256_file(lockfile),
         },
-        "build_command": build_command,
+        "cargo_config_chain": cargo_config_chain(root),
+        "package_version": package_version_from_cargo_toml(root / "Cargo.toml"),
     }
+    if build_command is not None:
+        identity["build_command"] = build_command
+    return identity
+
+
+def untracked_paths(root: Path) -> list[str]:
+    raw = run_git(root, "ls-files", "--others", "--exclude-standard", "-z", binary=True)
+    assert isinstance(raw, bytes)
+    return sorted(
+        item.decode("utf-8", errors="surrogateescape")
+        for item in raw.split(b"\0")
+        if item
+    )
+
+
+def tracked_worktree_is_clean(root: Path) -> bool:
+    for arguments in (("diff", "--quiet"), ("diff", "--cached", "--quiet")):
+        result = subprocess.run(
+            ["git", "-C", str(root), *arguments],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode == 1:
+            return False
+        if result.returncode != 0:
+            detail = result.stderr.decode("utf-8", errors="replace").strip()
+            raise ValueError(f"git {' '.join(arguments)} failed in {root}: {detail}")
+    return True
+
+
+def refresh_origin_main(candidate_root: Path) -> str:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(candidate_root),
+            "fetch",
+            "--no-tags",
+            "origin",
+            "+refs/heads/main:refs/remotes/origin/main",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise ValueError(f"cannot refresh candidate origin/main: {detail}")
+    return str(run_git(candidate_root, "rev-parse", "origin/main^{commit}"))
+
+
+def validate_source_contract(
+    baseline_root: Path,
+    candidate_root: Path,
+    render: bool,
+    *,
+    refresh: bool,
+) -> tuple[dict[str, Any], dict[str, Any], str, str]:
+    baseline_root = baseline_root.resolve()
+    candidate_root = candidate_root.resolve()
+    expected_baseline = (
+        refresh_origin_main(candidate_root)
+        if refresh
+        else str(run_git(candidate_root, "rev-parse", "origin/main^{commit}"))
+    )
+    expected_candidate = str(run_git(candidate_root, "rev-parse", "HEAD^{commit}"))
+    ancestor = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(candidate_root),
+            "merge-base",
+            "--is-ancestor",
+            expected_baseline,
+            expected_candidate,
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if ancestor.returncode == 1:
+        raise ValueError("candidate HEAD must descend from the exact origin/main baseline")
+    if ancestor.returncode != 0:
+        detail = ancestor.stderr.decode("utf-8", errors="replace").strip()
+        raise ValueError(f"cannot verify candidate ancestry: {detail}")
+    if not tracked_worktree_is_clean(candidate_root) or untracked_paths(candidate_root):
+        raise ValueError("candidate source must be an exact clean HEAD with no untracked files")
+    if str(run_git(baseline_root, "rev-parse", "HEAD^{commit}")) != expected_baseline:
+        raise ValueError(
+            "baseline HEAD must equal the candidate repository's exact origin/main OID "
+            f"{expected_baseline}"
+        )
+    if not tracked_worktree_is_clean(baseline_root):
+        raise ValueError("baseline source has tracked or staged changes")
+
+    render_relative = "examples/tui_render_perf.rs"
+    candidate_harness = candidate_root / render_relative
+    baseline_harness = baseline_root / render_relative
+    baseline_untracked = untracked_paths(baseline_root)
+    if render:
+        if not candidate_harness.is_file():
+            raise ValueError(f"candidate render harness is missing: {candidate_harness}")
+        if not baseline_harness.exists():
+            baseline_harness.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(candidate_harness, baseline_harness)
+        baseline_untracked = untracked_paths(baseline_root)
+    if baseline_untracked not in ([], [render_relative]):
+        raise ValueError(
+            "baseline may contain only the untracked render harness; found "
+            f"{baseline_untracked}"
+        )
+    if baseline_untracked == [render_relative]:
+        if not candidate_harness.is_file():
+            raise ValueError("candidate has no render harness to authenticate the baseline copy")
+        if baseline_harness.read_bytes() != candidate_harness.read_bytes():
+            raise ValueError("baseline untracked render harness is not byte-identical to candidate")
+    if render and baseline_harness.read_bytes() != candidate_harness.read_bytes():
+        raise ValueError("baseline render harness is not byte-identical to candidate")
+
+    baseline_identity = source_identity(baseline_root)
+    candidate_identity = source_identity(candidate_root)
+    if baseline_identity["head"] != expected_baseline:
+        raise ValueError("baseline source identity changed while it was being captured")
+    if candidate_identity["head"] != expected_candidate:
+        raise ValueError("candidate source identity changed while it was being captured")
+    baseline_configs = comparable_cargo_config_chain(
+        baseline_identity["cargo_config_chain"]
+    )
+    candidate_configs = comparable_cargo_config_chain(
+        candidate_identity["cargo_config_chain"]
+    )
+    if baseline_configs != candidate_configs:
+        raise ValueError(
+            "baseline/candidate effective Cargo config chains differ; ignored and ancestor "
+            f"configs are build inputs (baseline={baseline_configs}, candidate={candidate_configs})"
+        )
+    return baseline_identity, candidate_identity, expected_baseline, expected_candidate
 
 
 def require_ignored_evidence_root(source_root: Path, evidence_root: Path) -> None:
@@ -202,16 +959,681 @@ def atomic_text(path: Path, value: str) -> None:
     os.replace(temporary, path)
 
 
+def atomic_bytes(path: Path, value: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    temporary.write_bytes(value)
+    os.replace(temporary, path)
+
+
+def resolve_build_tool(name: str, cwd: Path, environment: dict[str, str]) -> Path:
+    path_value = environment.get("PATH")
+    if not path_value:
+        raise ValueError("controlled build environment has no non-empty PATH")
+    suffixes = [""]
+    if os.name == "nt" and not Path(name).suffix:
+        suffixes = [
+            suffix.lower()
+            for suffix in environment.get("PATHEXT", ".COM;.EXE;.BAT;.CMD").split(os.pathsep)
+            if suffix
+        ]
+    for raw_directory in path_value.split(os.pathsep):
+        directory = Path(raw_directory or ".")
+        if not directory.is_absolute():
+            directory = cwd / directory
+        for suffix in suffixes:
+            candidate = Path(os.path.abspath(directory / f"{name}{suffix}"))
+            if candidate.is_file() and (os.name == "nt" or os.access(candidate, os.X_OK)):
+                return candidate
+    raise ValueError(f"required build tool is not on controlled PATH from {cwd}: {name}")
+
+
+def exact_tool_output(
+    executable: Path,
+    arguments: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    label: str,
+) -> str:
+    completed = subprocess.run(
+        [str(executable), *arguments],
+        cwd=cwd,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise ValueError(f"{label} failed in {cwd}: {detail}")
+    output = (completed.stdout or completed.stderr).strip()
+    if not output:
+        raise ValueError(f"{label} produced no identity output in {cwd}")
+    return output
+
+
+def controlled_build_environment() -> dict[str, str]:
+    environment = {
+        name: value
+        for name in CONTROLLED_BUILD_ENV_ALLOWLIST
+        if (value := os.environ.get(name)) is not None
+    }
+    environment["CARGO_HOME"] = str(effective_cargo_home())
+    return environment
+
+
+def captured_build_environment(
+    environment: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    environment = dict(
+        controlled_build_environment() if environment is None else environment
+    )
+    return {
+        "policy": "allowlist-v1",
+        "allowlist": list(CONTROLLED_BUILD_ENV_ALLOWLIST),
+        "variables": environment,
+        "explicitly_removed_prefixes": [
+            "CARGO_BUILD_",
+            "CARGO_TARGET_",
+            "CARGO_PROFILE_",
+        ],
+        "explicitly_removed": [
+            "RUSTC",
+            "RUSTC_WRAPPER",
+            "RUSTC_WORKSPACE_WRAPPER",
+            "RUSTFLAGS",
+            "CARGO_ENCODED_RUSTFLAGS",
+        ],
+    }
+
+
+def toolchain_selector_chain(root: Path) -> list[dict[str, Any]]:
+    root = root.resolve()
+    selectors: list[dict[str, Any]] = []
+    current = root
+    depth = 0
+    while True:
+        for name in ("rust-toolchain.toml", "rust-toolchain"):
+            path = current / name
+            if path.is_file():
+                selectors.append(
+                    {
+                        "scope": "source" if depth == 0 else "ancestor",
+                        "ancestor_depth": depth,
+                        "name": name,
+                        "selector_path": str(path),
+                        **identity_for_file(path),
+                    }
+                )
+        if current.parent == current:
+            break
+        current = current.parent
+        depth += 1
+    return selectors
+
+
+def relevant_rustup_overrides(root: Path, output: str) -> list[dict[str, Any]]:
+    root = root.resolve()
+    ancestors: list[tuple[int, Path]] = []
+    current = root
+    depth = 0
+    while True:
+        ancestors.append((depth, current))
+        if current.parent == current:
+            break
+        current = current.parent
+        depth += 1
+    overrides: list[dict[str, Any]] = []
+    for line in output.splitlines():
+        if not line.strip() or line.strip().lower() == "no overrides":
+            continue
+        for ancestor_depth, ancestor in ancestors:
+            prefix = str(ancestor)
+            if line.startswith(prefix) and line[len(prefix) : len(prefix) + 1].isspace():
+                toolchain = line[len(prefix) :].strip()
+                if toolchain:
+                    overrides.append(
+                        {
+                            "directory": prefix,
+                            "scope": "source" if ancestor_depth == 0 else "ancestor",
+                            "ancestor_depth": ancestor_depth,
+                            "toolchain": toolchain,
+                        }
+                    )
+                break
+    overrides.sort(key=lambda item: int(item["ancestor_depth"]))
+    return overrides
+
+
+def capture_effective_toolchain(
+    source_root: Path,
+    environment: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    source_root = source_root.resolve()
+    environment = dict(
+        controlled_build_environment() if environment is None else environment
+    )
+    rustup_path: Path | None
+    try:
+        rustup_path = resolve_build_tool("rustup", source_root, environment)
+    except ValueError:
+        rustup_path = None
+    rustup: dict[str, Any]
+    if rustup_path is None:
+        rustup = {
+            "available": False,
+            "rustup_toolchain_environment": environment.get("RUSTUP_TOOLCHAIN"),
+        }
+    else:
+        rustup_executable = identity_for_file(rustup_path)
+        active = exact_tool_output(
+            rustup_path,
+            ["show", "active-toolchain"],
+            cwd=source_root,
+            environment=environment,
+            label="rustup show active-toolchain",
+        )
+        override_list = exact_tool_output(
+            rustup_path,
+            ["override", "list"],
+            cwd=source_root,
+            environment=environment,
+            label="rustup override list",
+        )
+        rustup = {
+            "available": True,
+            "invocation_path": str(rustup_path),
+            "executable": rustup_executable,
+            "version": exact_tool_output(
+                rustup_path,
+                ["--version"],
+                cwd=source_root,
+                environment=environment,
+                label="rustup --version",
+            ),
+            "active_toolchain": active,
+            "active_toolchain_name": active.split(maxsplit=1)[0],
+            "relevant_directory_overrides": relevant_rustup_overrides(
+                source_root, override_list
+            ),
+            "rustup_toolchain_environment": environment.get("RUSTUP_TOOLCHAIN"),
+        }
+
+    tools: dict[str, dict[str, Any]] = {}
+    rustup_executable = rustup.get("executable")
+    for name, version_arguments in (("cargo", ["-Vv"]), ("rustc", ["-vV"])):
+        invocation_path = resolve_build_tool(name, source_root, environment)
+        invocation_executable = identity_for_file(invocation_path)
+        selected_executable = invocation_executable
+        selected_via = "controlled_path"
+        if (
+            rustup_path is not None
+            and isinstance(rustup_executable, dict)
+            and invocation_executable["bytes"] == rustup_executable["bytes"]
+            and invocation_executable["sha256"] == rustup_executable["sha256"]
+        ):
+            selected_path = Path(
+                exact_tool_output(
+                    rustup_path,
+                    ["which", name],
+                    cwd=source_root,
+                    environment=environment,
+                    label=f"rustup which {name}",
+                )
+            )
+            if not selected_path.is_absolute():
+                selected_path = source_root / selected_path
+            selected_executable = identity_for_file(selected_path)
+            selected_via = "rustup_proxy"
+        tools[name] = {
+            "invocation_path": str(invocation_path),
+            "invocation_executable": invocation_executable,
+            "selected_via": selected_via,
+            "selected_executable": selected_executable,
+            "version": exact_tool_output(
+                invocation_path,
+                version_arguments,
+                cwd=source_root,
+                environment=environment,
+                label=f"{name} {' '.join(version_arguments)}",
+            ),
+        }
+    return {
+        "source_root": str(source_root),
+        "selector_chain": toolchain_selector_chain(source_root),
+        "rustup": rustup,
+        **tools,
+    }
+
+
+def comparable_effective_toolchain(identity: dict[str, Any]) -> dict[str, Any]:
+    comparable: dict[str, Any] = {}
+    for name in ("cargo", "rustc"):
+        tool = identity[name]
+        comparable[name] = {
+            field: tool[field]
+            for field in (
+                "invocation_path",
+                "invocation_executable",
+                "selected_via",
+                "selected_executable",
+                "version",
+            )
+        }
+    if any(identity[name]["selected_via"] == "rustup_proxy" for name in ("cargo", "rustc")):
+        comparable["rustup_active_toolchain_name"] = identity["rustup"].get(
+            "active_toolchain_name"
+        )
+    return comparable
+
+
+def require_matching_effective_toolchains(toolchains: dict[str, dict[str, Any]]) -> None:
+    if set(toolchains) != {"baseline", "candidate"}:
+        raise ValueError("toolchain identities must contain exactly baseline and candidate")
+    baseline = comparable_effective_toolchain(toolchains["baseline"])
+    candidate = comparable_effective_toolchain(toolchains["candidate"])
+    if baseline != candidate:
+        raise ValueError(
+            "baseline/candidate effective Cargo and Rust toolchains differ before build "
+            f"(baseline={baseline}, candidate={candidate})"
+        )
+
+
+def capture_build_toolchains(
+    baseline_root: Path,
+    candidate_root: Path,
+    environment: dict[str, str] | None = None,
+) -> dict[str, dict[str, Any]]:
+    environment = dict(
+        controlled_build_environment() if environment is None else environment
+    )
+    toolchains = {
+        "baseline": capture_effective_toolchain(baseline_root, environment),
+        "candidate": capture_effective_toolchain(candidate_root, environment),
+    }
+    require_matching_effective_toolchains(toolchains)
+    return toolchains
+
+
+def validate_recorded_build_toolchains(
+    recorded: Any,
+    baseline_root: Path,
+    candidate_root: Path,
+    environment: dict[str, str] | None = None,
+) -> dict[str, dict[str, Any]]:
+    current = capture_build_toolchains(
+        baseline_root, candidate_root, environment
+    )
+    require_artifact_value(
+        Path("<build-receipt>"),
+        "source-specific toolchains",
+        recorded,
+        current,
+    )
+    return current
+
+
+def summarized_toolchain(identity: dict[str, Any]) -> dict[str, str]:
+    return {name: str(identity[name]["version"]) for name in ("cargo", "rustc")}
+
+
+def pinned_compiler_binding(identity: dict[str, Any]) -> dict[str, Any]:
+    rustc = identity["rustc"]["selected_executable"]
+    rustc_path = Path(str(rustc["path"]))
+    if not rustc_path.is_absolute():
+        raise ValueError("selected rustc path must be absolute")
+    require_artifact_value(
+        rustc_path,
+        "selected rustc executable",
+        identity_for_file(rustc_path),
+        rustc,
+    )
+    return {
+        "policy": "absolute_rustc_without_wrappers_v1",
+        "rustc": rustc,
+        "environment": {
+            "RUSTC": str(rustc_path),
+            # Empty explicitly overrides build.rustc-wrapper from any captured Cargo config.
+            "RUSTC_WRAPPER": "",
+            "RUSTC_WORKSPACE_WRAPPER": "",
+        },
+    }
+
+
+def build_specs(render: bool) -> list[tuple[str, list[str], dict[str, str]]]:
+    if render:
+        return [
+            ("baseline", ["--example", "tui_render_perf"], {"tui_render_perf": "baseline_render"}),
+            ("candidate", ["--example", "tui_render_perf"], {"tui_render_perf": "candidate_render"}),
+        ]
+    return [
+        ("baseline", ["--bin", "ytt"], {"ytt": "baseline_ytt"}),
+        (
+            "candidate",
+            [
+                "--bin",
+                "ytt",
+                "--example",
+                "tui_perf_sampler",
+                "--example",
+                "tui_perf_control",
+            ],
+            {
+                "ytt": "candidate_ytt",
+                "tui_perf_sampler": "sampler",
+                "tui_perf_control": "controller",
+            },
+        ),
+    ]
+
+
+def run_fixed_cargo_build(
+    source_root: Path,
+    target_dir: Path,
+    selectors: list[str],
+    environment: dict[str, str],
+    expected_toolchain: dict[str, Any],
+) -> tuple[list[str], dict[str, Path]]:
+    command = [
+        "cargo",
+        "build",
+        "--release",
+        "--locked",
+        "--message-format=json-render-diagnostics",
+        *selectors,
+    ]
+    require_artifact_value(
+        source_root,
+        "effective toolchain immediately before build",
+        capture_effective_toolchain(source_root, environment),
+        expected_toolchain,
+    )
+    cargo_path = Path(expected_toolchain["cargo"]["invocation_path"])
+    require_artifact_value(
+        source_root,
+        "Cargo invocation executable before build",
+        identity_for_file(cargo_path),
+        expected_toolchain["cargo"]["invocation_executable"],
+    )
+    compiler_binding = pinned_compiler_binding(expected_toolchain)
+    build_environment = dict(environment)
+    build_environment["CARGO_TARGET_DIR"] = str(target_dir.resolve())
+    build_environment.update(compiler_binding["environment"])
+    completed = subprocess.run(
+        [str(cargo_path), *command[1:]],
+        cwd=source_root,
+        env=build_environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise ValueError(
+            f"fixed cargo build failed in {source_root}:\n{completed.stderr.strip()}"
+        )
+    require_artifact_value(
+        source_root,
+        "effective toolchain immediately after build",
+        capture_effective_toolchain(source_root, environment),
+        expected_toolchain,
+    )
+    require_artifact_value(
+        source_root,
+        "pinned compiler binding immediately after build",
+        pinned_compiler_binding(expected_toolchain),
+        compiler_binding,
+    )
+    executables: dict[str, Path] = {}
+    for line in completed.stdout.splitlines():
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if message.get("reason") != "compiler-artifact" or not message.get("executable"):
+            continue
+        target = message.get("target")
+        if isinstance(target, dict) and isinstance(target.get("name"), str):
+            executables[target["name"]] = Path(message["executable"]).resolve()
+    return command, executables
+
+
+def harness_source_identities(
+    baseline_root: Path, candidate_root: Path, render: bool
+) -> dict[str, Any]:
+    names = ["tui_render_perf.rs"] if render else ["tui_perf_sampler.rs", "tui_perf_control.rs"]
+    identities: dict[str, Any] = {}
+    for name in names:
+        candidate = candidate_root / "examples" / name
+        identities[name] = {"candidate": identity_for_file(candidate)}
+        if render:
+            baseline = baseline_root / "examples" / name
+            baseline_identity = identity_for_file(baseline)
+            if baseline_identity["sha256"] != identities[name]["candidate"]["sha256"]:
+                raise ValueError("baseline and candidate render harness sources differ")
+            identities[name]["baseline"] = baseline_identity
+    return identities
+
+
+def copy_receipted_binary(source: Path, destination_root: Path, label: str) -> dict[str, Any]:
+    suffix = source.suffix if source.suffix.lower() == ".exe" else ""
+    destination = destination_root / "binaries" / f"{label}{suffix}"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(destination.name + ".tmp")
+    shutil.copy2(source, temporary)
+    os.replace(temporary, destination)
+    copied = identity_for_file(destination)
+    built = identity_for_file(source)
+    if copied["sha256"] != built["sha256"] or copied["bytes"] != built["bytes"]:
+        raise ValueError(f"copied build output changed for {label}")
+    return {**copied, "built_output": built}
+
+
+def validate_build_receipt(
+    receipt: dict[str, Any],
+    baseline_root: Path,
+    candidate_root: Path,
+    render: bool,
+    *,
+    refresh: bool,
+) -> None:
+    if receipt.get("schema") != BUILD_RECEIPT_SCHEMA:
+        raise ValueError("build receipt has an unsupported schema")
+    if receipt.get("build_kind") != ("render" if render else "process"):
+        raise ValueError("build receipt kind does not match the selected scenario")
+    baseline, candidate, expected_baseline, expected_candidate = validate_source_contract(
+        baseline_root, candidate_root, render, refresh=refresh
+    )
+    require_artifact_value(Path("<build-receipt>"), "baseline OID", receipt.get("baseline_oid"), expected_baseline)
+    require_artifact_value(Path("<build-receipt>"), "candidate OID", receipt.get("candidate_oid"), expected_candidate)
+    require_artifact_value(Path("<build-receipt>"), "baseline source", receipt.get("sources", {}).get("baseline"), baseline)
+    require_artifact_value(Path("<build-receipt>"), "candidate source", receipt.get("sources", {}).get("candidate"), candidate)
+    environment = controlled_build_environment()
+    toolchains = validate_recorded_build_toolchains(
+        receipt.get("toolchains"),
+        baseline_root,
+        candidate_root,
+        environment,
+    )
+    require_artifact_value(
+        Path("<build-receipt>"),
+        "common toolchain summary",
+        receipt.get("toolchain"),
+        summarized_toolchain(toolchains["baseline"]),
+    )
+    require_artifact_value(
+        Path("<build-receipt>"),
+        "build environment",
+        receipt.get("build_environment"),
+        captured_build_environment(environment),
+    )
+    require_artifact_value(
+        Path("<build-receipt>"),
+        "compiler bindings",
+        receipt.get("compiler_bindings"),
+        {
+            role: pinned_compiler_binding(toolchains[role])
+            for role in ("baseline", "candidate")
+        },
+    )
+    require_artifact_value(
+        Path("<build-receipt>"),
+        "harness sources",
+        receipt.get("harness_sources"),
+        harness_source_identities(baseline_root, candidate_root, render),
+    )
+    require_artifact_value(
+        Path("<build-receipt>"),
+        "orchestrator",
+        receipt.get("orchestrator"),
+        identity_for_file(Path(__file__)),
+    )
+    artifacts = receipt.get("artifacts")
+    if not isinstance(artifacts, dict):
+        raise ValueError("build receipt artifacts must be an object")
+    expected_labels = {
+        label
+        for _role, _selectors, mapping in build_specs(render)
+        for label in mapping.values()
+    }
+    if set(artifacts) != expected_labels:
+        raise ValueError(
+            f"build receipt artifacts are {sorted(artifacts)}, expected {sorted(expected_labels)}"
+        )
+    expected_commands: dict[str, tuple[str, list[str]]] = {}
+    for role, selectors, mapping in build_specs(render):
+        command = [
+            "cargo",
+            "build",
+            "--release",
+            "--locked",
+            "--message-format=json-render-diagnostics",
+            *selectors,
+        ]
+        for label in mapping.values():
+            expected_commands[label] = (role, command)
+    for label, artifact in artifacts.items():
+        if not isinstance(artifact, dict):
+            raise ValueError(f"build receipt artifact {label} must be an object")
+        role, command = expected_commands[label]
+        require_artifact_value(Path("<build-receipt>"), f"{label} source role", artifact.get("source_role"), role)
+        require_artifact_value(Path("<build-receipt>"), f"{label} build command", artifact.get("build_command"), command)
+        path = Path(str(artifact.get("path", "")))
+        current = identity_for_file(path)
+        for field in ("path", "bytes", "sha256"):
+            require_artifact_value(Path("<build-receipt>"), f"{label} {field}", artifact.get(field), current[field])
+
+
+def command_build(args: argparse.Namespace) -> int:
+    if args.output.exists():
+        raise ValueError("build receipt output must name a new path")
+    document, _ = load_scenarios(args.scenarios)
+    scenario = find_scenario(document, args.scenario)
+    render = scenario["id"] == "render_and_interaction"
+    baseline_root = args.baseline_root.resolve()
+    candidate_root = args.candidate_root.resolve()
+    evidence_root = args.output.resolve().parent
+    require_ignored_evidence_root(baseline_root, evidence_root)
+    require_ignored_evidence_root(candidate_root, evidence_root)
+
+    target_root = args.target_root.resolve()
+    if target_root.exists():
+        raise ValueError("--target-root must be a new path for a fresh controlled build")
+    baseline, candidate, baseline_oid, candidate_oid = validate_source_contract(
+        baseline_root, candidate_root, render, refresh=True
+    )
+    harness_sources = harness_source_identities(baseline_root, candidate_root, render)
+    environment = controlled_build_environment()
+    toolchains = capture_build_toolchains(
+        baseline_root, candidate_root, environment
+    )
+    toolchain = summarized_toolchain(toolchains["baseline"])
+    build_environment = captured_build_environment(environment)
+    compiler_bindings = {
+        role: pinned_compiler_binding(toolchains[role])
+        for role in ("baseline", "candidate")
+    }
+    target_root.mkdir(parents=True)
+    sources = {"baseline": baseline, "candidate": candidate}
+    artifacts: dict[str, Any] = {}
+    for role, selectors, mapping in build_specs(render):
+        source_root = baseline_root if role == "baseline" else candidate_root
+        target_dir = target_root / role
+        command, executables = run_fixed_cargo_build(
+            source_root,
+            target_dir,
+            selectors,
+            environment,
+            toolchains[role],
+        )
+        missing = sorted(set(mapping) - set(executables))
+        if missing:
+            raise ValueError(f"cargo did not report expected executables: {missing}")
+        for cargo_name, label in mapping.items():
+            copied = copy_receipted_binary(executables[cargo_name], evidence_root, label)
+            artifacts[label] = {
+                **copied,
+                "source_role": role,
+                "build_command": command,
+                "target_dir": str(target_dir),
+            }
+
+    baseline_after, candidate_after, baseline_after_oid, candidate_after_oid = validate_source_contract(
+        baseline_root, candidate_root, render, refresh=False
+    )
+    if (baseline_after, candidate_after, baseline_after_oid, candidate_after_oid) != (
+        baseline,
+        candidate,
+        baseline_oid,
+        candidate_oid,
+    ):
+        raise ValueError("source identity changed during controlled build")
+    receipt = {
+        "schema": BUILD_RECEIPT_SCHEMA,
+        "build_kind": "render" if render else "process",
+        "generated_unix_s": int(time.time()),
+        "baseline_oid": baseline_oid,
+        "candidate_oid": candidate_oid,
+        "sources": sources,
+        "toolchain": toolchain,
+        "toolchains": toolchains,
+        "build_environment": build_environment,
+        "compiler_bindings": compiler_bindings,
+        "harness_sources": harness_sources,
+        "orchestrator": identity_for_file(Path(__file__)),
+        "artifacts": artifacts,
+    }
+    atomic_json(args.output, receipt)
+    validate_build_receipt(receipt, baseline_root, candidate_root, render, refresh=False)
+    print(json.dumps({"ok": True, "output": str(args.output.resolve()), "fresh_build": True}))
+    return 0
+
+
+def command_receipt(args: argparse.Namespace) -> int:
+    receipt = load_json_object(args.receipt)
+    if receipt.get("schema") != BUILD_RECEIPT_SCHEMA:
+        raise ValueError("unsupported build receipt schema")
+    artifact = receipt.get("artifacts", {}).get(args.artifact)
+    if not isinstance(artifact, dict):
+        raise ValueError(f"build receipt has no artifact {args.artifact!r}")
+    value = dotted(artifact, args.field)
+    print(value if not isinstance(value, (dict, list)) else json.dumps(value, separators=(",", ":")))
+    return 0
+
+
 def checksum_targets(root: Path, output: Path) -> list[Path]:
     root = root.resolve()
     output = output.resolve()
+    temporary_output = output.with_name(output.name + ".tmp").resolve()
     return sorted(
         (
             path
             for path in root.rglob("*")
             if path.is_file()
             and path.resolve() != output
-            and path.name != output.name + ".tmp"
+            and path.resolve() != temporary_output
         ),
         key=lambda path: path.relative_to(root).as_posix().encode("utf-8"),
     )
@@ -268,12 +1690,40 @@ def verify_checksums(root: Path, output: Path) -> int:
     return len(listed)
 
 
-def command_checksums(args: argparse.Namespace) -> int:
+def command_create_checksums(args: argparse.Namespace) -> int:
     count = write_checksums(args.root, args.output)
     verified = verify_checksums(args.root, args.output)
     if verified != count:
         raise ValueError("checksum write/verify count mismatch")
-    print(json.dumps({"ok": True, "output": str(args.output.resolve()), "files": count}))
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "mode": "create_overwrite",
+                "output": str(args.output.resolve()),
+                "files": count,
+            }
+        )
+    )
+    return 0
+
+
+def command_verify_checksums(args: argparse.Namespace) -> int:
+    before = sha256_file(args.output)
+    count = verify_checksums(args.root, args.output)
+    after = sha256_file(args.output)
+    if after != before:
+        raise ValueError("read-only checksum verification changed SHA256SUMS")
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "mode": "verify_read_only",
+                "output": str(args.output.resolve()),
+                "files": count,
+            }
+        )
+    )
     return 0
 
 
@@ -287,14 +1737,66 @@ def load_scenarios(path: Path) -> tuple[dict[str, Any], str]:
     return document, hashlib.sha256(raw).hexdigest()
 
 
+def scenario_finite_number(value: Any) -> bool:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return False
+    try:
+        return math.isfinite(float(value))
+    except (OverflowError, ValueError):
+        return False
+
+
 def validate_scenarios(document: dict[str, Any]) -> None:
     if document.get("schema") != "ytt.tui-perf.scenarios.v1":
         raise ValueError("scenario schema must be ytt.tui-perf.scenarios.v1")
     if document.get("version") != 1:
         raise ValueError("scenario version must be 1")
     stats = document.get("statistics")
-    if not isinstance(stats, dict) or int(stats.get("bootstrap_resamples", 0)) < 1:
-        raise ValueError("statistics.bootstrap_resamples must be positive")
+    if not isinstance(stats, dict):
+        raise ValueError("statistics must be an object")
+    bootstrap_resamples = stats.get("bootstrap_resamples")
+    if (
+        not isinstance(bootstrap_resamples, int)
+        or isinstance(bootstrap_resamples, bool)
+        or not 1 <= bootstrap_resamples <= MAX_BOOTSTRAP_RESAMPLES
+    ):
+        raise ValueError(
+            "statistics.bootstrap_resamples must be an integer in "
+            f"[1,{MAX_BOOTSTRAP_RESAMPLES}]"
+        )
+    seed = stats.get("seed")
+    if (
+        not isinstance(seed, int)
+        or isinstance(seed, bool)
+        or not 0 <= seed <= MAX_STATISTICS_SEED
+    ):
+        raise ValueError(
+            "statistics.seed must be an integer in "
+            f"[0,{MAX_STATISTICS_SEED}]"
+        )
+    confidence = stats.get("one_sided_confidence")
+    if (
+        not scenario_finite_number(confidence)
+        or not 0 < float(confidence) < 1
+    ):
+        raise ValueError("statistics.one_sided_confidence must be finite and in (0,1)")
+    baseline_cv_max = stats.get("baseline_cv_max")
+    if (
+        not scenario_finite_number(baseline_cv_max)
+        or float(baseline_cv_max) < 0
+    ):
+        raise ValueError("statistics.baseline_cv_max must be finite and non-negative")
+    sampling = document.get("sampling")
+    if not isinstance(sampling, dict):
+        raise ValueError("sampling must be an object")
+    if sampling.get("measurement_kind") != "sampled_process_tree":
+        raise ValueError("sampling.measurement_kind must be sampled_process_tree")
+    interval_ms = sampling.get("interval_ms")
+    if not isinstance(interval_ms, int) or isinstance(interval_ms, bool) or interval_ms <= 0:
+        raise ValueError("sampling.interval_ms must be a positive integer")
+    limitations = sampling.get("limitations")
+    if not isinstance(limitations, list) or SAMPLED_TREE_LIMITATION not in limitations:
+        raise ValueError("sampling.limitations must disclose sub-interval descendant loss")
     traffic_profiles = document.get("traffic_profiles")
     if not isinstance(traffic_profiles, dict) or not traffic_profiles:
         raise ValueError("traffic_profiles must be a non-empty object")
@@ -315,8 +1817,8 @@ def validate_scenarios(document: dict[str, Any]) -> None:
         raise ValueError("fixture must be an object")
     for field in ("duration_s", "sample_rate_hz", "margin_s"):
         value = fixture.get(field)
-        if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
-            raise ValueError(f"fixture.{field} must be positive")
+        if not scenario_finite_number(value) or float(value) <= 0:
+            raise ValueError(f"fixture.{field} must be finite and positive")
     scenarios = document.get("scenarios")
     if not isinstance(scenarios, list) or not scenarios:
         raise ValueError("scenarios must be a non-empty list")
@@ -331,18 +1833,27 @@ def validate_scenarios(document: dict[str, Any]) -> None:
         pairs = scenario.get("pairs")
         if not isinstance(pairs, int) or isinstance(pairs, bool) or pairs < 1:
             raise ValueError(f"{name}.pairs must be a positive integer")
+        min_improved_pairs = scenario.get("min_improved_pairs")
+        if "min_improved_pairs" in scenario and (
+            not isinstance(min_improved_pairs, int)
+            or isinstance(min_improved_pairs, bool)
+            or not 0 <= min_improved_pairs <= pairs
+        ):
+            raise ValueError(
+                f"{name}.min_improved_pairs must be an integer in [0,{pairs}]"
+            )
         repeats = scenario.get("candidate_repeats")
         if not isinstance(repeats, int) or isinstance(repeats, bool) or repeats < 0:
             raise ValueError(f"{name}.candidate_repeats must be a non-negative integer")
         for field in ("warmup_s", "sample_s"):
             value = scenario.get(field)
             if (
-                not isinstance(value, (int, float))
-                or isinstance(value, bool)
-                or not math.isfinite(value)
-                or value < 0
+                not scenario_finite_number(value)
+                or float(value) < 0
             ):
                 raise ValueError(f"{name}.{field} must be finite and non-negative")
+        if name != "render_and_interaction" and float(scenario["sample_s"]) <= 0:
+            raise ValueError(f"{name}.sample_s must be positive for process sampling")
         geometry = scenario.get("geometry")
         if not (
             isinstance(geometry, list)
@@ -350,11 +1861,18 @@ def validate_scenarios(document: dict[str, Any]) -> None:
             and all(
                 isinstance(item, list)
                 and len(item) == 2
-                and all(isinstance(value, int) and value > 0 for value in item)
+                and all(
+                    isinstance(value, int)
+                    and not isinstance(value, bool)
+                    and value > 0
+                    for value in item
+                )
                 for item in geometry
             )
         ):
             raise ValueError(f"{name}.geometry must contain positive [width,height] pairs")
+        if len({tuple(item) for item in geometry}) != len(geometry):
+            raise ValueError(f"{name}.geometry must not contain duplicate pairs")
         profile = scenario.get("traffic_profile")
         if profile not in traffic_profiles:
             raise ValueError(f"{name}.traffic_profile references unknown profile {profile!r}")
@@ -386,15 +1904,59 @@ def validate_scenarios(document: dict[str, Any]) -> None:
             if not (
                 isinstance(seeks, list)
                 and all(
-                    isinstance(value, (int, float))
-                    and not isinstance(value, bool)
-                    and math.isfinite(value)
-                    and value >= 0
+                    scenario_finite_number(value)
+                    and float(value) >= 0
                     for value in seeks
                 )
             ):
                 raise ValueError(f"{name}.seeks_s must contain finite non-negative numbers")
+        steady_playback = (
+            controller
+            and requires_mpv
+            and pause_policy == "none"
+            and scenario.get("seeks_s") == []
+        )
+        progress_fields = (
+            "minimum_playback_progress_fraction",
+            "time_pos_tail_tolerance_s",
+        )
+        if steady_playback:
+            progress_fraction = scenario.get("minimum_playback_progress_fraction")
+            tail_tolerance = scenario.get("time_pos_tail_tolerance_s")
+            if (
+                not scenario_finite_number(progress_fraction)
+                or not 0 < float(progress_fraction) <= 1
+            ):
+                raise ValueError(
+                    f"{name}.minimum_playback_progress_fraction must be in (0,1]"
+                )
+            if (
+                not scenario_finite_number(tail_tolerance)
+                or float(tail_tolerance) <= 0
+            ):
+                raise ValueError(f"{name}.time_pos_tail_tolerance_s must be positive")
+        elif any(field in scenario for field in progress_fields):
+            raise ValueError(
+                f"{name} may declare steady playback progress only for no-seek, "
+                "no-pause playback"
+            )
         if requires_mpv:
+            expected_mpv_cache = scenario.get("expected_effective_mpv_cache_args")
+            if expected_mpv_cache != REQUIRED_PLAYBACK_MPV_CACHE_ARGS:
+                raise ValueError(
+                    f"{name}.expected_effective_mpv_cache_args must declare the exact "
+                    "32MiB/8MiB effective mpv cache argv contract"
+                )
+            seed_contract = scenario.get("seed_contract")
+            if not isinstance(seed_contract, dict):
+                raise ValueError(f"{name}.seed_contract must be an object")
+            if seed_contract.get("require_identical_tree") is not True:
+                raise ValueError(f"{name}.seed_contract must require identical trees")
+            if seed_contract.get("require_identical_cache_policy") is not True:
+                raise ValueError(f"{name}.seed_contract must require identical cache policy")
+            expected_cache = seed_contract.get("expected_cache_policy")
+            if expected_cache is not None and not isinstance(expected_cache, dict):
+                raise ValueError(f"{name}.seed_contract.expected_cache_policy must be object or null")
             margin = float(fixture["margin_s"])
             observation_end = float(scenario["warmup_s"]) + float(scenario["sample_s"])
             furthest_seek = max((float(value) for value in scenario.get("seeks_s", [])), default=0.0)
@@ -403,21 +1965,212 @@ def validate_scenarios(document: dict[str, Any]) -> None:
                 raise ValueError(
                     f"fixture.duration_s must be at least {required_duration:g} for {name}"
                 )
-        metrics = scenario.get("metrics", {})
-        if not isinstance(metrics, dict):
-            raise ValueError(f"{name}.metrics must be an object")
+        elif "expected_effective_mpv_cache_args" in scenario:
+            raise ValueError(
+                f"{name}.expected_effective_mpv_cache_args requires requires_mpv=true"
+            )
+        metrics = scenario.get("metrics")
+        if not isinstance(metrics, dict) or not metrics:
+            raise ValueError(f"{name}.metrics must be a non-empty object")
         for metric, policy in metrics.items():
-            if not isinstance(metric, str) or not isinstance(policy, dict):
+            if not isinstance(metric, str) or not metric or not isinstance(policy, dict):
                 raise ValueError(f"{name}.metrics entries must be object policies")
             comparison = policy.get("comparison", "ratio")
             if comparison not in {"ratio", "latency", "no_increase", "exact"}:
                 raise ValueError(f"{name}.{metric}: unsupported comparison {comparison!r}")
-            if comparison in {"ratio", "latency"} and not isinstance(
-                policy.get("max_ratio"), (int, float)
-            ):
-                raise ValueError(f"{name}.{metric}: ratio policy needs max_ratio")
-            if comparison == "latency" and not isinstance(policy.get("max_delta"), (int, float)):
+            for threshold in ("max_ratio", "max_delta"):
+                if threshold not in policy:
+                    continue
+                value = policy[threshold]
+                if not scenario_finite_number(value):
+                    raise ValueError(
+                        f"{name}.{metric}: {threshold} must be a finite number"
+                    )
+            if comparison in {"ratio", "latency"}:
+                max_ratio = policy.get("max_ratio")
+                if not isinstance(max_ratio, (int, float)) or isinstance(max_ratio, bool):
+                    raise ValueError(f"{name}.{metric}: ratio policy needs max_ratio")
+                if float(max_ratio) < 0:
+                    raise ValueError(f"{name}.{metric}: max_ratio must be non-negative")
+            if comparison == "latency" and "max_delta" not in policy:
                 raise ValueError(f"{name}.{metric}: latency policy needs max_delta")
+            metric_min_improved = policy.get("min_improved_pairs")
+            if "min_improved_pairs" in policy and (
+                not isinstance(metric_min_improved, int)
+                or isinstance(metric_min_improved, bool)
+                or not 0 <= metric_min_improved <= pairs
+            ):
+                raise ValueError(
+                    f"{name}.{metric}: min_improved_pairs must be an integer in [0,{pairs}]"
+                )
+
+
+def scenario_validation_self_test() -> None:
+    document, _digest = load_scenarios(DEFAULT_SCENARIOS)
+
+    def first_metric(scenario_document: dict[str, Any]) -> dict[str, Any]:
+        return next(iter(scenario_document["scenarios"][0]["metrics"].values()))
+
+    mutations: list[tuple[str, Any]] = [
+        (
+            "boolean bootstrap resamples",
+            lambda value: value["statistics"].__setitem__("bootstrap_resamples", True),
+        ),
+        (
+            "floating bootstrap resamples",
+            lambda value: value["statistics"].__setitem__("bootstrap_resamples", 50_000.0),
+        ),
+        (
+            "zero bootstrap resamples",
+            lambda value: value["statistics"].__setitem__("bootstrap_resamples", 0),
+        ),
+        (
+            "excessive bootstrap resamples",
+            lambda value: value["statistics"].__setitem__(
+                "bootstrap_resamples", MAX_BOOTSTRAP_RESAMPLES + 1
+            ),
+        ),
+        (
+            "boolean statistics seed",
+            lambda value: value["statistics"].__setitem__("seed", False),
+        ),
+        (
+            "negative statistics seed",
+            lambda value: value["statistics"].__setitem__("seed", -1),
+        ),
+        (
+            "oversized statistics seed",
+            lambda value: value["statistics"].__setitem__(
+                "seed", MAX_STATISTICS_SEED + 1
+            ),
+        ),
+        (
+            "non-finite confidence",
+            lambda value: value["statistics"].__setitem__(
+                "one_sided_confidence", math.nan
+            ),
+        ),
+        (
+            "zero confidence",
+            lambda value: value["statistics"].__setitem__("one_sided_confidence", 0),
+        ),
+        (
+            "unit confidence",
+            lambda value: value["statistics"].__setitem__("one_sided_confidence", 1),
+        ),
+        (
+            "non-finite CV limit",
+            lambda value: value["statistics"].__setitem__("baseline_cv_max", math.inf),
+        ),
+        (
+            "negative CV limit",
+            lambda value: value["statistics"].__setitem__("baseline_cv_max", -0.1),
+        ),
+        (
+            "non-finite fixture duration",
+            lambda value: value["fixture"].__setitem__("duration_s", math.nan),
+        ),
+        (
+            "non-finite fixture sample rate",
+            lambda value: value["fixture"].__setitem__("sample_rate_hz", math.inf),
+        ),
+        (
+            "overflowing fixture margin",
+            lambda value: value["fixture"].__setitem__("margin_s", 10**1000),
+        ),
+        (
+            "overflowing warmup",
+            lambda value: value["scenarios"][0].__setitem__("warmup_s", 10**1000),
+        ),
+        (
+            "non-finite sample duration",
+            lambda value: value["scenarios"][0].__setitem__("sample_s", math.inf),
+        ),
+        (
+            "overflowing seek target",
+            lambda value: value["scenarios"][1]["seeks_s"].__setitem__(0, 10**1000),
+        ),
+        (
+            "overflowing steady progress fraction",
+            lambda value: value["scenarios"][5].__setitem__(
+                "minimum_playback_progress_fraction", 10**1000
+            ),
+        ),
+        (
+            "non-finite steady tail tolerance",
+            lambda value: value["scenarios"][5].__setitem__(
+                "time_pos_tail_tolerance_s", math.inf
+            ),
+        ),
+        (
+            "boolean scenario improved-pair count",
+            lambda value: value["scenarios"][0].__setitem__("min_improved_pairs", True),
+        ),
+        (
+            "null scenario improved-pair count",
+            lambda value: value["scenarios"][0].__setitem__("min_improved_pairs", None),
+        ),
+        (
+            "scenario improved-pair count above pairs",
+            lambda value: value["scenarios"][0].__setitem__(
+                "min_improved_pairs", value["scenarios"][0]["pairs"] + 1
+            ),
+        ),
+        (
+            "boolean metric improved-pair count",
+            lambda value: first_metric(value).__setitem__("min_improved_pairs", False),
+        ),
+        (
+            "null metric improved-pair count",
+            lambda value: first_metric(value).__setitem__("min_improved_pairs", None),
+        ),
+        (
+            "metric improved-pair count above pairs",
+            lambda value: first_metric(value).__setitem__(
+                "min_improved_pairs", value["scenarios"][0]["pairs"] + 1
+            ),
+        ),
+        (
+            "non-finite ratio threshold",
+            lambda value: first_metric(value).__setitem__("max_ratio", math.nan),
+        ),
+        (
+            "boolean ratio threshold",
+            lambda value: first_metric(value).__setitem__("max_ratio", True),
+        ),
+        (
+            "negative ratio threshold",
+            lambda value: first_metric(value).__setitem__("max_ratio", -0.1),
+        ),
+        (
+            "non-finite latency delta threshold",
+            lambda value: value["scenarios"][1]["metrics"][
+                "operation.resume_session.p95_ms"
+            ].__setitem__("max_delta", math.inf),
+        ),
+        (
+            "non-finite no-increase delta threshold",
+            lambda value: value["scenarios"][1]["metrics"][
+                "buffering_events"
+            ].__setitem__("max_delta", math.nan),
+        ),
+        (
+            "duplicate geometry",
+            lambda value: value["scenarios"][0]["geometry"].append([80, 24]),
+        ),
+        (
+            "boolean geometry component",
+            lambda value: value["scenarios"][0]["geometry"][0].__setitem__(0, True),
+        ),
+    ]
+    for label, mutate in mutations:
+        invalid = json.loads(json.dumps(document))
+        mutate(invalid)
+        try:
+            validate_scenarios(invalid)
+        except ValueError:
+            continue
+        raise AssertionError(f"scenario validation accepted {label}")
 
 
 def find_scenario(document: dict[str, Any], name: str) -> dict[str, Any]:
@@ -489,6 +2242,919 @@ def command_setting(args: argparse.Namespace) -> int:
     else:
         print(value)
     return 0
+
+
+def command_run_start(args: argparse.Namespace) -> int:
+    if args.output.exists():
+        raise ValueError("run contract output must name a new path")
+    document, scenario_hash = load_scenarios(args.scenarios)
+    scenario = find_scenario(document, args.scenario)
+    pairs = int(scenario["pairs"])
+    repeats = int(scenario.get("candidate_repeats", 0))
+    if args.kind == "paired":
+        if args.pair_index is None or not 1 <= args.pair_index <= pairs:
+            raise ValueError(f"paired run requires --pair-index in 1..{pairs}")
+        if args.repeat_index is not None:
+            raise ValueError("paired run must not set --repeat-index")
+        order = (
+            ["baseline", "candidate"]
+            if args.pair_index % 2 == 1
+            else ["candidate", "baseline"]
+        )
+        ordinal = order.index(args.role) + 1
+        pair_index = args.pair_index
+        repeat_index = None
+    else:
+        if args.role != "candidate":
+            raise ValueError("candidate_repeat run role must be candidate")
+        if args.repeat_index is None or not 1 <= args.repeat_index <= repeats:
+            raise ValueError(f"candidate_repeat requires --repeat-index in 1..{repeats}")
+        if args.pair_index is not None:
+            raise ValueError("candidate_repeat must not set --pair-index")
+        order = None
+        ordinal = None
+        pair_index = None
+        repeat_index = args.repeat_index
+    geometry_index = getattr(args, "geometry_index", None)
+    requested_width = getattr(args, "width", None)
+    requested_height = getattr(args, "height", None)
+    terminal_geometry = None
+    if geometry_index is not None:
+        if scenario["id"] == "render_and_interaction" or len(scenario["geometry"]) <= 1:
+            raise ValueError("per-geometry contracts are only valid for multi-geometry process runs")
+        if not 0 <= geometry_index < len(scenario["geometry"]):
+            raise ValueError(
+                f"--geometry-index must be in 0..{len(scenario['geometry']) - 1}"
+            )
+        terminal_geometry = [requested_width, requested_height]
+        require_artifact_value(
+            args.output,
+            "requested terminal geometry",
+            terminal_geometry,
+            scenario["geometry"][geometry_index],
+        )
+    elif requested_width is not None or requested_height is not None:
+        raise ValueError("--width/--height require --geometry-index")
+    elif scenario["id"] != "render_and_interaction" and len(scenario["geometry"]) == 1:
+        terminal_geometry = scenario["geometry"][0]
+    host_identity = stable_host_identity()
+    started_unix_ns = time.time_ns()
+    started_monotonic_ns = time.monotonic_ns()
+    run_id = (
+        f"{args.scenario}:{args.kind}:{args.role}:"
+        f"{pair_index if pair_index is not None else repeat_index}:"
+        f"{secrets.token_hex(16)}"
+    )
+    contract = {
+        "schema": RUN_CONTRACT_SCHEMA,
+        "state": "running",
+        "run_id": run_id,
+        "scenario": args.scenario,
+        "scenario_sha256": scenario_hash,
+        "kind": args.kind,
+        "role": args.role,
+        "pair_index": pair_index,
+        "pair_order": order,
+        "within_pair_ordinal": ordinal,
+        "repeat_index": repeat_index,
+        "geometry": scenario["geometry"],
+        "geometry_index": geometry_index,
+        "terminal_geometry": terminal_geometry,
+        "started_unix_ns": started_unix_ns,
+        "started_monotonic_ns": started_monotonic_ns,
+        "monotonic_clock": time.get_clock_info("monotonic").implementation,
+        "host": host_identity,
+    }
+    atomic_json(args.output, contract)
+    print(run_id)
+    return 0
+
+
+def command_run_finish(args: argparse.Namespace) -> int:
+    contract = load_json_object(args.contract)
+    require_artifact_value(args.contract, "schema", contract.get("schema"), RUN_CONTRACT_SCHEMA)
+    require_artifact_value(args.contract, "state", contract.get("state"), "running")
+    require_artifact_value(
+        args.contract, "current host identity", contract.get("host"), stable_host_identity()
+    )
+    started_monotonic_ns = non_negative_integer(
+        contract.get("started_monotonic_ns"), "started_monotonic_ns", args.contract
+    )
+    finished_monotonic_ns = time.monotonic_ns()
+    finished_unix_ns = time.time_ns()
+    if finished_monotonic_ns <= started_monotonic_ns:
+        raise ValueError(f"{args.contract}: run finish must follow run start")
+    finished = {
+        **contract,
+        "state": "finished",
+        "finished_unix_ns": finished_unix_ns,
+        "finished_monotonic_ns": finished_monotonic_ns,
+        "duration_ns": finished_monotonic_ns - started_monotonic_ns,
+    }
+    atomic_json(args.contract, finished)
+    print(json.dumps({"ok": True, "run_id": finished["run_id"]}))
+    return 0
+
+
+def package_version_from_cargo_toml(cargo_toml: Path) -> str:
+    match = re.search(
+        r"(?ms)^\[package\]\s*.*?^version\s*=\s*\"([^\"]+)\"",
+        cargo_toml.read_text(encoding="utf-8"),
+    )
+    if not match:
+        raise ValueError(f"cannot determine package version from {cargo_toml}")
+    return match.group(1)
+
+
+def project_package_version() -> str:
+    return package_version_from_cargo_toml(
+        Path(__file__).resolve().parent.parent / "Cargo.toml"
+    )
+
+
+def playlist_marker_occurrences(root: Path, marker: str) -> int:
+    count = 0
+    for path in sorted(item for item in root.rglob("*.json") if item.is_file()):
+        try:
+            count += path.read_text(encoding="utf-8").count(marker)
+        except (OSError, UnicodeDecodeError):
+            continue
+    return count
+
+
+def validate_active_session_playlist(root: Path, expected_local_path: str) -> dict[str, Any]:
+    session = root / "stores" / "cache" / "session.json"
+    journal = session.with_name("session.json.intent.jsonl")
+    sidecar = session.with_name("session.json.intent.latest.json")
+    replay_inputs = [path.relative_to(root).as_posix() for path in (journal, sidecar) if path.exists()]
+    if replay_inputs:
+        raise ValueError(
+            "performance seeds must not contain session intent replay files: "
+            f"{replay_inputs}"
+        )
+    if not session.is_file():
+        raise ValueError("seed must contain exact stores/cache/session.json")
+    try:
+        document = json.loads(
+            session.read_text(encoding="utf-8"),
+            object_pairs_hook=reject_duplicate_json_keys,
+        )
+    except (OSError, json.JSONDecodeError, DuplicateJsonKeyError) as error:
+        raise ValueError(f"invalid session cache {session}: {error}") from error
+    if not isinstance(document, dict):
+        raise ValueError(f"{session}: session cache must be an object")
+    require_artifact_value(session, "session schema", document.get("schema_version"), 2)
+    require_artifact_value(
+        session, "session app version", document.get("app_version"), project_package_version()
+    )
+    last_mode = document.get("last_mode")
+    queue_field = {"normal": "normal_queue", "radio": "radio_queue", "local": "local_queue"}.get(last_mode)
+    if queue_field is None:
+        raise ValueError(f"{session}: last_mode must select normal, radio, or local")
+    queue = document.get(queue_field)
+    if not isinstance(queue, dict):
+        raise ValueError(f"{session}: active {queue_field} must be an object")
+    songs = queue.get("songs")
+    order = queue.get("order")
+    cursor = queue.get("cursor")
+    if not isinstance(songs, list) or not 1 <= len(songs) <= 999:
+        raise ValueError(f"{session}: active songs must contain 1..999 entries")
+    if (
+        not isinstance(order, list)
+        or any(not isinstance(value, int) or isinstance(value, bool) for value in order)
+        or sorted(order) != list(range(len(songs)))
+    ):
+        raise ValueError(f"{session}: active order must be an exact song-index permutation")
+    if not isinstance(cursor, int) or isinstance(cursor, bool) or not 0 <= cursor < len(order):
+        raise ValueError(f"{session}: active cursor is outside the queue order")
+    current_song_index = order[cursor]
+    current = songs[current_song_index]
+    if not isinstance(current, dict):
+        raise ValueError(f"{session}: active current song must be an object")
+    require_artifact_value(
+        session,
+        "active current Song.local_path",
+        current.get("local_path"),
+        expected_local_path,
+    )
+    occurrences = playlist_marker_occurrences(root, expected_local_path)
+    require_artifact_value(
+        session,
+        f"total JSON occurrence count for {expected_local_path!r}",
+        occurrences,
+        1,
+    )
+    return {
+        "session": session.relative_to(root).as_posix(),
+        "schema_version": 2,
+        "app_version": project_package_version(),
+        "last_mode": last_mode,
+        "active_queue": queue_field,
+        "cursor": cursor,
+        "current_song_index": current_song_index,
+        "local_path": expected_local_path,
+        "total_json_occurrences": occurrences,
+        "intent_replay_files": [],
+    }
+
+
+def deterministic_fixture_song(local_path: str) -> dict[str, Any]:
+    return {
+        "video_id": "tui-perf-fixture",
+        "title": "Deterministic TUI Performance Fixture",
+        "artist": "ytm-tui perf harness",
+        "duration": "18:00",
+        "duration_secs": 1080,
+        "local_path": local_path,
+    }
+
+
+def materialize_single_song_active_session(root: Path, local_path: str) -> Path:
+    session = root / "stores" / "cache" / "session.json"
+    document = load_json_object(session)
+    queue_field = {
+        "normal": "normal_queue",
+        "radio": "radio_queue",
+        "local": "local_queue",
+    }.get(document.get("last_mode"))
+    if queue_field is None:
+        raise ValueError(f"{session}: last_mode does not identify an active queue")
+    document[queue_field] = {
+        "songs": [deterministic_fixture_song(local_path)],
+        "order": [0],
+        "cursor": 0,
+        "shuffle": False,
+        "repeat": "off",
+    }
+    for inactive in {"normal_queue", "radio_queue", "local_queue"} - {queue_field}:
+        document[inactive] = None
+    atomic_json(session, document)
+    return session
+
+
+def validate_materialized_active_session_playlist(
+    root: Path, expected_local_path: str
+) -> dict[str, Any]:
+    contract = validate_active_session_playlist(root, expected_local_path)
+    session = root / "stores" / "cache" / "session.json"
+    document = load_json_object(session)
+    queue_field = contract["active_queue"]
+    expected_queue = {
+        "songs": [deterministic_fixture_song(expected_local_path)],
+        "order": [0],
+        "cursor": 0,
+        "shuffle": False,
+        "repeat": "off",
+    }
+    require_artifact_value(
+        session, "deterministic single-song active queue", document.get(queue_field), expected_queue
+    )
+    inactive = {
+        field: document.get(field)
+        for field in ("normal_queue", "radio_queue", "local_queue")
+        if field != queue_field
+    }
+    require_artifact_value(
+        session,
+        "inactive queue isolation",
+        inactive,
+        {field: None for field in inactive},
+    )
+    return {
+        **contract,
+        "deterministic_single_song": True,
+        "inactive_queues_cleared": True,
+    }
+
+
+def materialized_session_self_test() -> None:
+    with tempfile.TemporaryDirectory(prefix="ytt-perf-session-self-test-") as temporary:
+        root = Path(temporary)
+        session = root / "stores" / "cache" / "session.json"
+        session.parent.mkdir(parents=True)
+        remote = "https://remote.example.invalid/watch?v=must-not-survive"
+        atomic_json(
+            session,
+            {
+                "schema_version": 2,
+                "app_version": project_package_version(),
+                "last_mode": "normal",
+                "normal_queue": {
+                    "songs": [
+                        {"title": "seed current", "local_path": "{{TUI_PERF_PLAYLIST}}"},
+                        {
+                            "title": "hostile remote next track",
+                            "local_path": remote,
+                            "thumbnails": [{"url": remote}],
+                        },
+                    ],
+                    "order": [0, 1],
+                    "cursor": 0,
+                    "shuffle": True,
+                    "repeat": "all",
+                },
+                "radio_queue": {
+                    "songs": [{"title": "inactive remote", "local_path": remote}],
+                    "order": [0],
+                    "cursor": 0,
+                },
+                "local_queue": None,
+            },
+        )
+        validate_active_session_playlist(root, "{{TUI_PERF_PLAYLIST}}")
+        local_path = str(root / "fixture.m3u8")
+        materialize_single_song_active_session(root, local_path)
+        validate_materialized_active_session_playlist(root, local_path)
+        if remote in session.read_text(encoding="utf-8"):
+            raise AssertionError("materialized session retained a remote queue target")
+
+        tampered = load_json_object(session)
+        active = tampered["normal_queue"]
+        active["songs"].append({"title": "tampered remote", "local_path": remote})
+        active["order"].append(1)
+        atomic_json(session, tampered)
+        try:
+            validate_materialized_active_session_playlist(root, local_path)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("materialized session accepted a hostile second track")
+
+
+def byte_exact_tree_state_for_self_test(
+    root: Path,
+) -> tuple[tuple[str, str, bytes | None], ...]:
+    resolved = root.resolve()
+    entries: list[tuple[str, str, bytes | None]] = [(".", "directory", None)]
+    for path in sorted(
+        resolved.rglob("*"), key=lambda item: item.relative_to(resolved).as_posix()
+    ):
+        relative = path.relative_to(resolved).as_posix()
+        metadata = path.lstat()
+        if path.is_symlink() or bool(getattr(path, "is_junction", lambda: False)()):
+            raise AssertionError(f"self-test input tree unexpectedly contains a link: {path}")
+        if stat.S_ISDIR(metadata.st_mode):
+            entries.append((relative, "directory", None))
+        elif stat.S_ISREG(metadata.st_mode):
+            entries.append((relative, "file", path.read_bytes()))
+        else:
+            raise AssertionError(f"self-test input tree contains a special entry: {path}")
+    return tuple(entries)
+
+
+def materialize_command_self_test() -> None:
+    with tempfile.TemporaryDirectory(prefix="ytt-perf-materialize-self-test-") as temporary:
+        base = Path(temporary)
+        home = base / "home"
+        for store in ("config", "data", "cache"):
+            (home / "stores" / store).mkdir(parents=True)
+        atomic_json(home / "stores" / "config" / "config.json", {})
+        remote = "https://remote.example.invalid/hostile-next-track"
+        session = home / "stores" / "cache" / "session.json"
+        atomic_json(
+            session,
+            {
+                "schema_version": 2,
+                "app_version": project_package_version(),
+                "last_mode": "normal",
+                "normal_queue": {
+                    "songs": [
+                        {"title": "seed current", "local_path": "{{TUI_PERF_PLAYLIST}}"},
+                        {"title": "hostile next", "local_path": remote},
+                    ],
+                    "order": [0, 1],
+                    "cursor": 0,
+                },
+                "radio_queue": {
+                    "songs": [{"title": "hostile inactive", "local_path": remote}],
+                    "order": [0],
+                    "cursor": 0,
+                },
+                "local_queue": None,
+            },
+        )
+
+        def expect_path_rejected(
+            label: str, manifest_path: Path, input_snapshot: Path
+        ) -> None:
+            before = byte_exact_tree_state_for_self_test(home)
+            try:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    command_materialize(
+                        argparse.Namespace(
+                            root=home,
+                            home=home,
+                            fixture_url="http://127.0.0.1:8123/fixture.wav",
+                            playlist_relative=Path("fixture/tui-perf-stream.m3u"),
+                            manifest=manifest_path,
+                            input_snapshot=input_snapshot,
+                            seed_label=f"rejected-{label}",
+                        )
+                    )
+            except ValueError:
+                pass
+            else:
+                raise AssertionError(f"materialize accepted invalid {label} paths")
+            if byte_exact_tree_state_for_self_test(home) != before:
+                raise AssertionError(
+                    f"materialize invalid {label} paths changed input-tree bytes or shape"
+                )
+
+        contained_outputs = home / "rejected-materialize-outputs"
+        expect_path_rejected(
+            "contained",
+            contained_outputs / "materialize.json",
+            contained_outputs / "materialized-inputs",
+        )
+
+        occupied_parent = base / "rejected-occupied-snapshot"
+        occupied_parent.mkdir()
+        occupied_snapshot = occupied_parent / "materialized-inputs"
+        occupied_snapshot.mkdir()
+        expect_path_rejected(
+            "occupied-snapshot",
+            occupied_parent / "materialize.json",
+            occupied_snapshot,
+        )
+
+        occupied_manifest_parent = base / "rejected-occupied-manifest"
+        occupied_manifest_parent.mkdir()
+        occupied_manifest = occupied_manifest_parent / "materialize.json"
+        atomic_text(occupied_manifest, "do-not-overwrite\n")
+        expect_path_rejected(
+            "occupied-manifest",
+            occupied_manifest,
+            occupied_manifest_parent / "materialized-inputs",
+        )
+        if occupied_manifest.read_text(encoding="utf-8") != "do-not-overwrite\n":
+            raise AssertionError("rejected materialize overwrote an occupied manifest")
+
+        mismatched_manifest_parent = base / "rejected-manifest-parent"
+        mismatched_snapshot_parent = base / "rejected-snapshot-parent"
+        mismatched_manifest_parent.mkdir()
+        mismatched_snapshot_parent.mkdir()
+        expect_path_rejected(
+            "mismatched-parent",
+            mismatched_manifest_parent / "materialize.json",
+            mismatched_snapshot_parent / "materialized-inputs",
+        )
+
+        evidence = base / "evidence"
+        evidence.mkdir()
+        manifest_path = evidence / "materialize.json"
+        input_snapshot = evidence / "materialized-inputs"
+        with contextlib.redirect_stdout(io.StringIO()):
+            command_materialize(
+                argparse.Namespace(
+                    root=home,
+                    home=home,
+                    fixture_url="http://127.0.0.1:8123/fixture.wav",
+                    playlist_relative=Path("fixture/tui-perf-stream.m3u"),
+                    manifest=manifest_path,
+                    input_snapshot=input_snapshot,
+                    seed_label="hostile-self-test",
+                )
+            )
+        manifest = load_json_object(manifest_path)
+        expected_path = str(home.resolve() / "fixture" / "tui-perf-stream.m3u")
+        live_contract = validate_materialized_active_session_playlist(home.resolve(), expected_path)
+        snapshot_contract = validate_materialized_active_session_playlist(
+            input_snapshot, expected_path
+        )
+        require_artifact_value(
+            manifest_path,
+            "materialized active playlist contract",
+            manifest.get("materialized_active_playlist_contract"),
+            live_contract,
+        )
+        require_artifact_value(
+            manifest_path,
+            "materialized snapshot active playlist contract",
+            snapshot_contract,
+            live_contract,
+        )
+        require_artifact_value(
+            manifest_path,
+            "materialized changed path inventory",
+            manifest.get("changed"),
+            ["fixture/tui-perf-stream.m3u", "stores/cache/session.json"],
+        )
+        for materialized_session in (
+            session,
+            input_snapshot / "stores" / "cache" / "session.json",
+        ):
+            if remote in materialized_session.read_text(encoding="utf-8"):
+                raise AssertionError("materialize command retained a hostile remote queue target")
+
+        tampered = load_json_object(input_snapshot / "stores" / "cache" / "session.json")
+        tampered["normal_queue"]["songs"].append(
+            {"title": "tampered next", "local_path": remote}
+        )
+        tampered["normal_queue"]["order"].append(1)
+        atomic_json(input_snapshot / "stores" / "cache" / "session.json", tampered)
+        try:
+            validate_materialized_active_session_playlist(input_snapshot, expected_path)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("materialized snapshot accepted a hostile second track")
+
+
+def reject_seed_symlinks(root: Path) -> None:
+    links = sorted(path.relative_to(root).as_posix() for path in root.rglob("*") if path.is_symlink())
+    if links:
+        raise ValueError(f"seed templates must not contain symlinks: {links}")
+
+
+def resolved_paths_overlap(first: Path, second: Path) -> bool:
+    try:
+        first.relative_to(second)
+        return True
+    except ValueError:
+        pass
+    try:
+        second.relative_to(first)
+        return True
+    except ValueError:
+        return False
+
+
+def path_entry_exists(path: Path) -> bool:
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as error:
+        raise ValueError(f"cannot inspect path {path}: {error}") from error
+    return True
+
+
+def reject_output_root_overlap(output_root: Path, protected_roots: list[Path]) -> Path:
+    resolved_output = output_root.resolve()
+    resolved_roots = [root.resolve() for root in protected_roots]
+    for index, root in enumerate(resolved_roots):
+        if not root.is_dir():
+            raise ValueError(f"protected root {index} does not exist: {root}")
+        if resolved_paths_overlap(resolved_output, root):
+            raise ValueError(
+                "new evidence output root must not equal, contain, or be contained by "
+                f"protected root {index}: output={resolved_output}, root={root}"
+            )
+    if path_entry_exists(output_root) or path_entry_exists(resolved_output):
+        raise ValueError(f"evidence output root must name a new path: {resolved_output}")
+    return resolved_output
+
+
+def command_path_preflight(args: argparse.Namespace) -> int:
+    output_root = reject_output_root_overlap(args.output_root, args.protected_root)
+    print(output_root)
+    return 0
+
+
+def resolve_seed_contract_paths(
+    args: argparse.Namespace,
+) -> tuple[dict[str, Path], Path, Path, Path]:
+    roots = {
+        "baseline": args.baseline_root.resolve(),
+        "candidate": args.candidate_root.resolve(),
+    }
+    output = args.output.resolve()
+    evidence_root = output.parent
+    snapshot = args.snapshot.resolve()
+    if snapshot.parent != evidence_root:
+        raise ValueError("seed snapshot and contract output must be direct siblings in one evidence root")
+    if snapshot == output:
+        raise ValueError("seed snapshot and contract output must be distinct paths")
+    protected_outputs = {
+        "evidence root": evidence_root,
+        "snapshot": snapshot,
+        "contract output": output,
+    }
+    for role, root in roots.items():
+        for label, protected in protected_outputs.items():
+            if resolved_paths_overlap(protected, root):
+                raise ValueError(
+                    f"{label} must not equal, contain, or be contained by {role} seed root: "
+                    f"{protected} versus {root}"
+                )
+    if path_entry_exists(args.output) or path_entry_exists(output):
+        raise ValueError("seed contract output must name a new path")
+    if path_entry_exists(args.snapshot) or path_entry_exists(snapshot):
+        raise ValueError("--snapshot must name a new path")
+    return roots, output, evidence_root, snapshot
+
+
+def command_seed_contract(args: argparse.Namespace) -> int:
+    roots, output, evidence_root, snapshot = resolve_seed_contract_paths(args)
+    document, scenario_hash = load_scenarios(args.scenarios)
+    scenario = find_scenario(document, args.scenario)
+    if not scenario["requires_mpv"]:
+        raise ValueError("seed-contract is only valid for playback scenarios")
+    for role, root in roots.items():
+        if not root.is_dir():
+            raise ValueError(f"{role} seed root does not exist: {root}")
+        reject_seed_symlinks(root)
+        for store in ("config", "data", "cache"):
+            if not (root / "stores" / store).is_dir():
+                raise ValueError(f"{role} seed root is missing stores/{store}")
+    tree_hashes = {role: sha256_tree(root) for role, root in roots.items()}
+    policies = {role: seed_cache_policy(root) for role, root in roots.items()}
+    if len(set(tree_hashes.values())) != 1:
+        raise ValueError(f"baseline/candidate seed tree SHA-256 differs: {tree_hashes}")
+    if policies["baseline"] != policies["candidate"]:
+        raise ValueError("baseline/candidate seed cache policy differs")
+    expected = scenario["seed_contract"].get("expected_cache_policy")
+    if expected is not None and policies["baseline"] != expected:
+        raise ValueError(
+            f"seed cache policy {policies['baseline']!r} does not match scenario contract {expected!r}"
+        )
+    playlist_contracts = {
+        role: validate_active_session_playlist(root, "{{TUI_PERF_PLAYLIST}}")
+        for role, root in roots.items()
+    }
+    placeholders = {
+        role: contract["total_json_occurrences"]
+        for role, contract in playlist_contracts.items()
+    }
+
+    snapshot.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(roots["baseline"], snapshot)
+    reject_seed_symlinks(snapshot)
+    snapshot_hash = sha256_tree(snapshot)
+    if snapshot_hash != tree_hashes["baseline"]:
+        raise ValueError("copied seed snapshot does not match the validated seed tree")
+    try:
+        snapshot_relative = snapshot.relative_to(evidence_root).as_posix()
+    except ValueError as error:
+        raise ValueError("seed snapshot must stay inside the evidence root") from error
+    manifest = {
+        "schema": SEED_CONTRACT_SCHEMA,
+        "scenario": scenario["id"],
+        "scenario_sha256": scenario_hash,
+        "contract": scenario["seed_contract"],
+        "source_roots": {role: str(root) for role, root in roots.items()},
+        "source_tree_sha256": tree_hashes,
+        "cache_policy": policies["baseline"],
+        "playlist_placeholder_count": placeholders,
+        "active_playlist_contract": playlist_contracts["baseline"],
+        "snapshot": snapshot_relative,
+        "snapshot_tree_sha256": snapshot_hash,
+        "snapshot_files": tree_file_inventory(snapshot),
+    }
+    atomic_json(output, manifest)
+    print(json.dumps({"ok": True, "output": str(output), "tree_sha256": snapshot_hash}))
+    return 0
+
+
+def seed_path_containment_self_test() -> None:
+    def filesystem_snapshot(root: Path) -> list[tuple[str, str, bytes | None]]:
+        result: list[tuple[str, str, bytes | None]] = []
+        for path in [root, *sorted(root.rglob("*"))]:
+            relative = "." if path == root else path.relative_to(root).as_posix()
+            metadata = path.lstat()
+            if stat.S_ISDIR(metadata.st_mode):
+                result.append((relative, "directory", None))
+            elif stat.S_ISREG(metadata.st_mode):
+                result.append((relative, "regular", path.read_bytes()))
+            elif stat.S_ISLNK(metadata.st_mode):
+                result.append(
+                    (
+                        relative,
+                        "symlink",
+                        os.readlink(path).encode("utf-8", errors="surrogateescape"),
+                    )
+                )
+            else:
+                result.append((relative, f"mode:{metadata.st_mode}", None))
+        return result
+
+    def rejected_seed_contract(
+        baseline: Path, candidate: Path, evidence_root: Path
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                "seed-contract",
+                "--scenarios",
+                str(evidence_root / "must-not-be-read.json"),
+                "--scenario",
+                "playback_fresh_default",
+                "--baseline-root",
+                str(baseline),
+                "--candidate-root",
+                str(candidate),
+                "--snapshot",
+                str(evidence_root / "seed-template"),
+                "--output",
+                str(evidence_root / "seed-contract.json"),
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+
+    with tempfile.TemporaryDirectory(
+        prefix="ytt-perf-seed-containment-self-test-"
+    ) as temporary:
+        base = Path(temporary)
+
+        baseline = base / "output-under-baseline"
+        candidate = base / "output-under-baseline-candidate"
+        baseline.mkdir()
+        candidate.mkdir()
+        (baseline / "seed-sentinel.bin").write_bytes(b"baseline-seed-must-not-change")
+        (candidate / "seed-sentinel.bin").write_bytes(b"candidate-seed-must-not-change")
+        evidence = baseline / "nested-evidence"
+        before_baseline = filesystem_snapshot(baseline)
+        before_candidate = filesystem_snapshot(candidate)
+        result = rejected_seed_contract(baseline, candidate, evidence)
+        if result.returncode == 0 or "must not equal, contain, or be contained by" not in result.stderr:
+            raise AssertionError(
+                "seed contract did not fail fast when output was under the baseline seed: "
+                f"{result.stderr}"
+            )
+        if evidence.exists():
+            raise AssertionError("rejected seed contract created output under its baseline seed")
+        if (
+            filesystem_snapshot(baseline) != before_baseline
+            or filesystem_snapshot(candidate) != before_candidate
+        ):
+            raise AssertionError("rejected output-under-seed contract mutated a seed tree")
+
+        outer_evidence = base / "baseline-under-output"
+        nested_baseline = outer_evidence / "baseline-seed"
+        second_candidate = base / "baseline-under-output-candidate"
+        nested_baseline.mkdir(parents=True)
+        second_candidate.mkdir()
+        (nested_baseline / "seed-sentinel.bin").write_bytes(b"nested-baseline-must-not-change")
+        (second_candidate / "seed-sentinel.bin").write_bytes(b"candidate-must-not-change")
+        before_evidence = filesystem_snapshot(outer_evidence)
+        before_second_candidate = filesystem_snapshot(second_candidate)
+        result = rejected_seed_contract(
+            nested_baseline, second_candidate, outer_evidence
+        )
+        if result.returncode == 0 or "must not equal, contain, or be contained by" not in result.stderr:
+            raise AssertionError(
+                "seed contract did not fail fast when the baseline seed was under output: "
+                f"{result.stderr}"
+            )
+        if (
+            (outer_evidence / "seed-contract.json").exists()
+            or (outer_evidence / "seed-template").exists()
+        ):
+            raise AssertionError("rejected baseline-under-output contract created an output")
+        if (
+            filesystem_snapshot(outer_evidence) != before_evidence
+            or filesystem_snapshot(second_candidate) != before_second_candidate
+        ):
+            raise AssertionError("rejected seed-under-output contract mutated a seed tree")
+
+        valid_baseline = base / "valid-baseline"
+        valid_candidate = base / "valid-candidate"
+        for root in (valid_baseline, valid_candidate):
+            for store in ("config", "data", "cache"):
+                (root / "stores" / store).mkdir(parents=True)
+            atomic_json(root / "stores" / "config" / "config.json", {})
+            atomic_json(
+                root / "stores" / "cache" / "session.json",
+                {
+                    "schema_version": 2,
+                    "app_version": project_package_version(),
+                    "last_mode": "normal",
+                    "normal_queue": {
+                        "songs": [{"local_path": "{{TUI_PERF_PLAYLIST}}"}],
+                        "order": [0],
+                        "cursor": 0,
+                    },
+                    "radio_queue": None,
+                    "local_queue": None,
+                },
+            )
+        valid_evidence = base / "valid-evidence"
+        valid = subprocess.run(
+            [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                "seed-contract",
+                "--scenarios",
+                str(DEFAULT_SCENARIOS),
+                "--scenario",
+                "playback_fresh_default",
+                "--baseline-root",
+                str(valid_baseline),
+                "--candidate-root",
+                str(valid_candidate),
+                "--snapshot",
+                str(valid_evidence / "seed-template"),
+                "--output",
+                str(valid_evidence / "seed-contract.json"),
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        if valid.returncode != 0:
+            raise AssertionError(f"disjoint seed contract failed: {valid.stderr}")
+        if not (valid_evidence / "seed-contract.json").is_file() or not (
+            valid_evidence / "seed-template"
+        ).is_dir():
+            raise AssertionError("disjoint seed contract did not create its expected siblings")
+
+
+def validate_seed_contract_manifest(
+    path: Path,
+    evidence_root: Path,
+    scenario: dict[str, Any],
+    scenario_hash: str,
+) -> tuple[dict[str, Any], Path]:
+    evidence_root = evidence_root.resolve()
+    manifest = load_json_object(path)
+    require_artifact_value(path, "schema", manifest.get("schema"), SEED_CONTRACT_SCHEMA)
+    require_artifact_value(path, "scenario", manifest.get("scenario"), scenario["id"])
+    require_artifact_value(path, "scenario SHA-256", manifest.get("scenario_sha256"), scenario_hash)
+    require_artifact_value(path, "seed contract", manifest.get("contract"), scenario["seed_contract"])
+    source_hashes = manifest.get("source_tree_sha256")
+    snapshot_digest = manifest.get("snapshot_tree_sha256")
+    if (
+        not isinstance(source_hashes, dict)
+        or set(source_hashes) != {"baseline", "candidate"}
+        or not isinstance(snapshot_digest, str)
+        or any(value != snapshot_digest for value in source_hashes.values())
+    ):
+        raise ValueError(f"{path}: source seed trees are not identical to the snapshot")
+    expected = scenario["seed_contract"].get("expected_cache_policy")
+    if expected is not None:
+        require_artifact_value(path, "cache policy", manifest.get("cache_policy"), expected)
+    snapshot = (evidence_root / str(manifest.get("snapshot", ""))).resolve()
+    try:
+        snapshot.relative_to(evidence_root)
+    except ValueError as error:
+        raise ValueError(f"{path}: seed snapshot escapes evidence root") from error
+    if not snapshot.is_dir():
+        raise ValueError(f"{path}: seed snapshot does not exist: {snapshot}")
+    reject_seed_symlinks(snapshot)
+    require_artifact_value(
+        path, "snapshot tree SHA-256", sha256_tree(snapshot), snapshot_digest
+    )
+    require_artifact_value(
+        path, "snapshot cache policy", seed_cache_policy(snapshot), manifest.get("cache_policy")
+    )
+    snapshot_playlist_contract = validate_active_session_playlist(
+        snapshot, "{{TUI_PERF_PLAYLIST}}"
+    )
+    placeholder_count = snapshot_playlist_contract["total_json_occurrences"]
+    require_artifact_value(
+        path,
+        "playlist placeholder counts",
+        manifest.get("playlist_placeholder_count"),
+        {"baseline": placeholder_count, "candidate": placeholder_count},
+    )
+    require_artifact_value(
+        path,
+        "active playlist contract",
+        manifest.get("active_playlist_contract"),
+        snapshot_playlist_contract,
+    )
+    require_artifact_value(path, "snapshot file inventory", tree_file_inventory(snapshot), manifest.get("snapshot_files"))
+    return manifest, snapshot
+
+
+def overlay_tree_identity(
+    base: Path, overlay: Path, changed: list[str]
+) -> tuple[str, list[dict[str, Any]]]:
+    reject_seed_symlinks(base)
+    reject_seed_symlinks(overlay)
+    base, base_files = regular_tree_files(base)
+    overlay, overlay_files = regular_tree_files(overlay)
+    overlay_paths = sorted(
+        path.relative_to(overlay).as_posix()
+        for path in overlay_files
+    )
+    if overlay_paths != sorted(changed):
+        raise ValueError(
+            f"materialized input snapshot contains {overlay_paths}, expected {sorted(changed)}"
+        )
+    selected = {
+        path.relative_to(base).as_posix(): (path, base)
+        for path in base_files
+    }
+    for relative in overlay_paths:
+        selected[relative] = (overlay / relative, overlay)
+    digest = hashlib.sha256()
+    digest.update(TREE_DIGEST_DOMAIN)
+    inventory = []
+    for relative in sorted(selected):
+        path, source_root = selected[relative]
+        update_tree_digest(digest, source_root, path)
+        inventory.append(
+            {"path": relative, "bytes": path.stat().st_size, "sha256": sha256_file(path)}
+        )
+    return digest.hexdigest(), inventory
 
 
 def tool_version(command: list[str]) -> dict[str, Any]:
@@ -573,46 +3239,33 @@ def cpu_model() -> str:
     return platform.processor() or platform.machine()
 
 
-def labeled_specs(specs: list[str], option: str) -> dict[str, str]:
-    values: dict[str, str] = {}
-    for spec in specs:
-        label, separator, value = spec.partition("=")
-        if not separator or not label or not value:
-            raise ValueError(f"{option} must use LABEL=VALUE")
-        if label in values:
-            raise ValueError(f"{option} repeats label {label!r}")
-        values[label] = value
-    return values
-
-
 def command_manifest(args: argparse.Namespace) -> int:
-    _, scenario_hash = load_scenarios(args.scenarios)
-    binaries: dict[str, Any] = {}
-    for label, raw_path in labeled_specs(args.binary, "--binary").items():
-        path = Path(raw_path)
-        if not path.is_file():
-            raise ValueError(f"manifest binary does not exist: {path}")
-        binaries[label] = {
-            "path": str(path.resolve()),
-            "bytes": path.stat().st_size,
-            "sha256": sha256_file(path),
-        }
-    source_roots = labeled_specs(args.source_root, "--source-root")
-    build_commands = labeled_specs(args.build_command, "--build-command")
-    required_sources = {"baseline", "candidate"}
-    if set(source_roots) != required_sources:
-        raise ValueError("--source-root requires exactly baseline=PATH and candidate=PATH")
-    if set(build_commands) != required_sources:
-        raise ValueError(
-            "--build-command requires exactly baseline=COMMAND and candidate=COMMAND"
-        )
+    document, scenario_hash = load_scenarios(args.scenarios)
+    scenario = find_scenario(document, args.scenario)
+    render = scenario["id"] == "render_and_interaction"
     evidence_root = args.output.resolve().parent
-    for source_root in source_roots.values():
-        require_ignored_evidence_root(Path(source_root), evidence_root)
-    sources = {
-        label: source_identity(Path(source_roots[label]), build_commands[label])
-        for label in sorted(required_sources)
+    receipt_path = args.build_receipt.resolve()
+    try:
+        receipt_path.relative_to(evidence_root)
+    except ValueError as error:
+        raise ValueError("build receipt must stay inside the evidence root") from error
+    receipt = load_json_object(receipt_path)
+    sources = receipt.get("sources", {})
+    if not isinstance(sources, dict):
+        raise ValueError("build receipt sources are missing")
+    baseline_root = Path(str(sources.get("baseline", {}).get("root", "")))
+    candidate_root = Path(str(sources.get("candidate", {}).get("root", "")))
+    validate_build_receipt(
+        receipt, baseline_root, candidate_root, render, refresh=False
+    )
+    binaries = {
+        label: {field: artifact[field] for field in ("path", "bytes", "sha256")}
+        for label, artifact in receipt["artifacts"].items()
     }
+    scenario_snapshot = evidence_root / "scenario.json"
+    atomic_bytes(scenario_snapshot, args.scenarios.read_bytes())
+    if sha256_file(scenario_snapshot) != scenario_hash:
+        raise ValueError("scenario snapshot changed while being copied")
     tool_commands = {
         "python": [sys.executable, "--version"],
         "mpv_on_path": ["mpv", "--version"],
@@ -634,16 +3287,14 @@ def command_manifest(args: argparse.Namespace) -> int:
         "scenario": args.scenario,
         "scenario_sha256": scenario_hash,
         "scenario_file": {
-            "path": str(args.scenarios.resolve()),
-            "bytes": args.scenarios.stat().st_size,
+            "path": scenario_snapshot.relative_to(evidence_root).as_posix(),
+            "bytes": scenario_snapshot.stat().st_size,
             "sha256": scenario_hash,
         },
         "generated_unix_s": int(time.time()),
         "host": {
-            "system": platform.system(),
-            "release": platform.release(),
+            **stable_host_identity(),
             "version": platform.version(),
-            "machine": platform.machine(),
             "cpu_model": cpu_model(),
             "logical_cpu_count": os.cpu_count(),
             "total_memory_bytes": total_memory_bytes(),
@@ -651,6 +3302,13 @@ def command_manifest(args: argparse.Namespace) -> int:
         "tools": {name: tool_version(command) for name, command in tool_commands.items()},
         "binaries": binaries,
         "sources": sources,
+        "build_receipt": {
+            **identity_for_file(receipt_path),
+            "path": receipt_path.relative_to(evidence_root).as_posix(),
+        },
+        "orchestrator": receipt["orchestrator"],
+        "measurement_scope": document["sampling"],
+        "limitations": measurement_limitations(render),
         "note": "actual mpv argv and executable are recorded in each sampler artifact",
     }
     atomic_json(args.output, manifest)
@@ -658,18 +3316,48 @@ def command_manifest(args: argparse.Namespace) -> int:
     return 0
 
 
+def resolve_materialize_output_paths(
+    args: argparse.Namespace, root: Path
+) -> tuple[Path, Path]:
+    manifest = args.manifest.resolve()
+    input_snapshot = args.input_snapshot.resolve()
+    outputs = (
+        ("--manifest", args.manifest, manifest),
+        ("--input-snapshot", args.input_snapshot, input_snapshot),
+    )
+    for label, supplied, resolved in outputs:
+        if resolved_paths_overlap(resolved, root):
+            raise ValueError(f"{label} must stay outside the mutable home")
+        if path_entry_exists(supplied) or path_entry_exists(resolved):
+            raise ValueError(f"{label} must name a new path")
+    if manifest == input_snapshot:
+        raise ValueError("--manifest and --input-snapshot must be distinct paths")
+    if input_snapshot.parent != manifest.parent:
+        raise ValueError("--input-snapshot must be directly beside --manifest")
+    if not manifest.parent.is_dir():
+        raise ValueError("materialize output parent must be an existing directory")
+    return manifest, input_snapshot
+
+
 def command_materialize(args: argparse.Namespace) -> int:
     if not args.root.is_dir():
         raise ValueError(f"seed root does not exist: {args.root}")
     root = args.root.resolve()
     home = args.home.resolve()
+    if home != root:
+        raise ValueError("--home must equal --root so the initial-state digest is unambiguous")
+    reject_seed_symlinks(root)
     seed_tree_sha256 = sha256_tree(root)
     cache_policy = seed_cache_policy(root)
+    seed_playlist_contract = validate_active_session_playlist(
+        root, "{{TUI_PERF_PLAYLIST}}"
+    )
     playlist = (root / args.playlist_relative).resolve()
     try:
         playlist.relative_to(root)
     except ValueError as error:
         raise ValueError("--playlist-relative must stay inside --root") from error
+    manifest_path, input_snapshot = resolve_materialize_output_paths(args, root)
 
     parsed_url = urlsplit(args.fixture_url)
     try:
@@ -701,16 +3389,18 @@ def command_materialize(args: argparse.Namespace) -> int:
         if path.suffix.lower() == ".json":
             playlist_references += text.count("{{TUI_PERF_PLAYLIST}}")
         seed_files.append((path, text))
-    if playlist_references == 0:
-        raise ValueError(
-            "seed JSON must reference {{TUI_PERF_PLAYLIST}} as the resumed Song.local_path"
-        )
+    require_artifact_value(
+        root,
+        "playlist marker references",
+        playlist_references,
+        seed_playlist_contract["total_json_occurrences"],
+    )
 
     atomic_text(
         playlist,
         f"#EXTM3U\n#EXTINF:-1,ytt deterministic performance fixture\n{args.fixture_url}\n",
     )
-    changed = [str(playlist)]
+    changed_paths = [playlist]
     for path, text in seed_files:
         if not any(marker in text for marker in replacements):
             continue
@@ -723,24 +3413,1569 @@ def command_materialize(args: argparse.Namespace) -> int:
             except (json.JSONDecodeError, DuplicateJsonKeyError) as error:
                 raise ValueError(f"materialized JSON is invalid at {path}: {error}") from error
         atomic_text(path, text)
-        changed.append(str(path))
+        changed_paths.append(path)
+    changed_paths.append(materialize_single_song_active_session(root, str(playlist)))
+    changed = sorted(
+        {
+            path.resolve().relative_to(root).as_posix()
+            for path in changed_paths
+        }
+    )
+    materialized_playlist_contract = validate_materialized_active_session_playlist(
+        root, str(playlist)
+    )
+    input_snapshot.mkdir(parents=True)
+    for relative in changed:
+        source = root / relative
+        destination = input_snapshot / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+    materialized_tree_sha256 = sha256_tree(root)
+    playlist_relative = playlist.relative_to(root).as_posix()
+    expected_playlist = (
+        f"#EXTM3U\n#EXTINF:-1,ytt deterministic performance fixture\n{args.fixture_url}\n"
+    )
+    if playlist.read_text(encoding="utf-8") != expected_playlist:
+        raise ValueError("materialized playlist does not contain the exact fixture URL")
     manifest = {
         "schema": "ytt.tui-perf.materialize.v1",
         "changed": changed,
         "fixture_url": args.fixture_url,
         "fixture_host": str(fixture_ip),
-        "playlist": str(playlist),
+        "playlist": playlist_relative,
+        "playlist_sha256": sha256_file(playlist),
         "playback_target_mode": "local_m3u_indirection",
         "external_dns_required": False,
         "playlist_references": playlist_references,
+        "seed_active_playlist_contract": seed_playlist_contract,
+        "materialized_active_playlist_contract": materialized_playlist_contract,
         "seed_label": args.seed_label,
         "seed_tree_sha256": seed_tree_sha256,
         "seed_cache_policy": cache_policy,
+        "materialized_tree_sha256": materialized_tree_sha256,
+        "materialized_files": tree_file_inventory(root),
+        "input_snapshot": input_snapshot.name,
+        "input_snapshot_files": tree_file_inventory(input_snapshot),
+        "materializer_sha256": sha256_file(Path(__file__)),
     }
-    if args.manifest:
-        atomic_json(args.manifest, manifest)
+    atomic_json(manifest_path, manifest)
     print(json.dumps(manifest, sort_keys=True))
     return 0
+
+
+def launch_policy_projection(document: dict[str, Any]) -> dict[str, Any]:
+    """Return the config with only launch-policy-owned leaves removed.
+
+    The projection binds every unrelated value without serializing those values into the
+    manifest.  Empty policy-only containers are ignored so adding a previously absent
+    ``tools`` or ``scrobble`` object is not mistaken for a secret-bearing config change.
+    """
+
+    omitted = object()
+
+    def project(value: Any, path: tuple[str, ...]) -> Any:
+        if path in LAUNCH_POLICY_FIELDS:
+            return omitted
+        if isinstance(value, dict):
+            result = {}
+            for key, item in value.items():
+                child = project(item, (*path, key))
+                if child is not omitted:
+                    result[key] = child
+            owns_descendant = bool(path) and any(
+                field[: len(path)] == path for field in LAUNCH_POLICY_FIELDS
+            )
+            if not result and owns_descendant:
+                return omitted
+            return result
+        if isinstance(value, list):
+            return [project(item, (*path, str(index))) for index, item in enumerate(value)]
+        return value
+
+    projected = project(document, ())
+    if not isinstance(projected, dict):
+        raise AssertionError("launch-policy projection must remain an object")
+    return projected
+
+
+def json_value_sha256(value: Any) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def inline_cookie_has_session(value: Any) -> bool:
+    if value is None:
+        return False
+    if not isinstance(value, str):
+        raise ValueError("launch config cookie must be a string or null")
+    for pair in value.split(";"):
+        name, separator, _cookie_value = pair.strip().partition("=")
+        if separator and name.strip() in {"SAPISID", "__Secure-3PAPISID"}:
+            return True
+    return False
+
+
+def netscape_cookie_file_has_session(path: Path) -> bool:
+    try:
+        metadata = path.lstat()
+    except OSError as error:
+        raise ValueError("cannot inspect a possible default cookies file") from error
+    if path.is_symlink() or not path.is_file() or metadata.st_size > 4 * 1024 * 1024:
+        raise ValueError("possible default cookies file is not a safe bounded regular file")
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise ValueError("cannot safely decode a possible default cookies file") from error
+    for raw in content.splitlines():
+        line = raw.removeprefix("#HttpOnly_")
+        if not line.strip() or line.startswith("#"):
+            continue
+        fields = line.split("\t")
+        if len(fields) < 7:
+            continue
+        domain = fields[0].strip().lstrip(".")
+        if domain != "youtube.com" and not domain.endswith(".youtube.com"):
+            continue
+        if fields[5].strip() in {"SAPISID", "__Secure-3PAPISID"}:
+            return True
+    return False
+
+
+def launch_api_credential_proof(document: dict[str, Any], root: Path) -> dict[str, Any]:
+    """Fail closed when startup cookie authentication could contact YouTube Music.
+
+    ``api::spawn`` initializes a configured browser token immediately; ytmapi obtains its
+    client version with an external GET.  The performance seed must therefore prove that no
+    session-bearing inline/default cookie can reach that path.  Values are never returned or
+    included in an error.
+    """
+
+    if inline_cookie_has_session(document.get("cookie")):
+        raise ValueError("launch policy rejects a credential-bearing inline API cookie")
+    explicit = document.get("cookies_file")
+    if explicit is not None:
+        if not isinstance(explicit, str):
+            raise ValueError("launch config cookies_file must be a string or null")
+        # Even an empty PathBuf is Some(path) in Config.  Reject every explicit value so a
+        # relative path cannot resolve against an orchestrator-dependent working directory.
+        raise ValueError("launch policy rejects an explicit API cookies_file path")
+    user_dirs = root / ".config" / "user-dirs.dirs"
+    if user_dirs.exists():
+        raise ValueError("launch policy rejects an XDG user-dirs override")
+    credential_files = 0
+    for candidate in sorted(
+        path for path in root.rglob("*") if path.name.lower() == "cookies.txt"
+    ):
+        credential_files += int(netscape_cookie_file_has_session(candidate))
+    if credential_files:
+        raise ValueError("launch policy rejects a credential-bearing default API cookie file")
+    return {
+        "inline_session_cookie_present": False,
+        "explicit_cookies_file_configured": False,
+        "credential_bearing_default_cookie_files": 0,
+        "user_dirs_override_present": False,
+    }
+
+
+def apply_launch_policy(document: dict[str, Any]) -> None:
+    tools_config = document.setdefault("tools", {})
+    if not isinstance(tools_config, dict):
+        raise ValueError("launch config tools must be an object")
+    scrobble = document.setdefault("scrobble", {})
+    if not isinstance(scrobble, dict):
+        raise ValueError("launch config scrobble must be an object")
+    lastfm = scrobble.setdefault("lastfm", {})
+    if not isinstance(lastfm, dict):
+        raise ValueError("launch config scrobble.lastfm must be an object")
+    listenbrainz = scrobble.setdefault("listenbrainz", {})
+    if not isinstance(listenbrainz, dict):
+        raise ValueError("launch config scrobble.listenbrainz must be an object")
+    tools_config["ytdlp_managed"] = False
+    document["update_check_enabled"] = False
+    document["media_controls"] = False
+    document["autoplay_on_start"] = False
+    document["autoplay_streaming"] = False
+    document["album_art"] = False
+    document["romanized_titles"] = False
+    document["ai_enabled"] = False
+    lastfm["enabled"] = False
+    listenbrainz["enabled"] = False
+    scrobble["local_files"] = False
+
+
+def validate_effective_launch_config(path: Path, document: dict[str, Any]) -> None:
+    expected = {
+        ("tools", "ytdlp_managed"): False,
+        ("update_check_enabled",): False,
+        ("media_controls",): False,
+        ("autoplay_on_start",): False,
+        ("autoplay_streaming",): False,
+        ("album_art",): False,
+        ("romanized_titles",): False,
+        ("ai_enabled",): False,
+        ("scrobble", "lastfm", "enabled"): False,
+        ("scrobble", "listenbrainz", "enabled"): False,
+        ("scrobble", "local_files"): False,
+    }
+    for fields, value in expected.items():
+        current: Any = document
+        for field in fields:
+            if not isinstance(current, dict) or field not in current:
+                raise ValueError(f"{path}: launch policy field {'.'.join(fields)} is missing")
+            current = current[field]
+        require_artifact_value(path, f"launch policy {'.'.join(fields)}", current, value)
+
+
+def resolve_launch_policy_output_paths(
+    args: argparse.Namespace, root: Path
+) -> tuple[Path, Path]:
+    output = args.output.resolve()
+    snapshot = output.parent / "launch-policy-inputs"
+    for label, supplied, resolved in (
+        ("launch-policy output", args.output, output),
+        ("launch-policy snapshot", snapshot, snapshot),
+    ):
+        if resolved_paths_overlap(resolved, root):
+            raise ValueError(f"{label} must stay outside the mutable home")
+        if path_entry_exists(supplied) or path_entry_exists(resolved):
+            raise ValueError(f"{label} must name a new path")
+    if output == snapshot:
+        raise ValueError("launch-policy output and snapshot must be distinct paths")
+    if not output.parent.is_dir():
+        raise ValueError("launch-policy output parent must be an existing directory")
+    return output, snapshot
+
+
+def command_launch_policy(args: argparse.Namespace) -> int:
+    root = args.root.resolve()
+    if not root.is_dir():
+        raise ValueError(f"launch-policy root does not exist: {root}")
+    output, snapshot = resolve_launch_policy_output_paths(args, root)
+    config = root / "stores" / "config" / "config.json"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    before = identity_for_file(config) if config.is_file() else None
+    if config.is_file():
+        try:
+            document = json.loads(
+                config.read_text(encoding="utf-8"),
+                object_pairs_hook=reject_duplicate_json_keys,
+            )
+        except (OSError, json.JSONDecodeError, DuplicateJsonKeyError) as error:
+            raise ValueError(f"cannot freeze invalid launch config {config}: {error}") from error
+        if not isinstance(document, dict):
+            raise ValueError(f"{config}: launch config must be an object")
+    else:
+        document = {}
+    credential_proof = launch_api_credential_proof(document, root)
+    preserved_projection = launch_policy_projection(document)
+    apply_launch_policy(document)
+    if launch_policy_projection(document) != preserved_projection:
+        raise AssertionError("launch policy changed a non-policy config field")
+    validate_effective_launch_config(config, document)
+    atomic_json(config, document)
+    snapshot.mkdir(parents=True)
+    snapshot_policy = snapshot / "effective-policy.json"
+    atomic_json(
+        snapshot_policy,
+        {
+            "schema": "ytt.tui-perf.launch-policy-input.v1",
+            "effective": LAUNCH_POLICY_EFFECTIVE,
+            "api_credential_proof": credential_proof,
+            "child_environment_policy": CHILD_ENVIRONMENT_POLICY,
+            "policy_fields": [".".join(fields) for fields in LAUNCH_POLICY_FIELDS],
+        },
+    )
+    manifest = {
+        "schema": "ytt.tui-perf.launch-policy.v1",
+        "root": str(root),
+        "config": "stores/config/config.json",
+        "config_before": before,
+        "config_after": identity_for_file(config),
+        "snapshot": snapshot.name,
+        "snapshot_policy": snapshot_policy.name,
+        "snapshot_files": tree_file_inventory(snapshot),
+        "policy_fields": [".".join(fields) for fields in LAUNCH_POLICY_FIELDS],
+        "preserved_config_projection_sha256": json_value_sha256(preserved_projection),
+        "api_credential_proof": credential_proof,
+        "child_environment_policy": CHILD_ENVIRONMENT_POLICY,
+        "effective": LAUNCH_POLICY_EFFECTIVE,
+    }
+    atomic_json(output, manifest)
+    print(json.dumps({"ok": True, "output": str(output), "snapshot": str(snapshot)}))
+    return 0
+
+
+def unix_process_observation(pid: int, *, hash_executable: bool = True) -> dict[str, Any] | None:
+    if pid <= 0:
+        return None
+    if sys.platform.startswith("linux"):
+        proc = Path("/proc") / str(pid)
+        try:
+            raw_stat = (proc / "stat").read_text(encoding="utf-8")
+            closing = raw_stat.rfind(")")
+            fields = raw_stat[closing + 2 :].split()
+            start_ticks = int(fields[19])
+            boot_time = next(
+                int(line.split()[1])
+                for line in Path("/proc/stat").read_text(encoding="utf-8").splitlines()
+                if line.startswith("btime ")
+            )
+            ticks = int(os.sysconf("SC_CLK_TCK"))
+            executable = (proc / "exe").resolve(strict=True)
+            command = [
+                part.decode("utf-8", errors="surrogateescape")
+                for part in (proc / "cmdline").read_bytes().split(b"\0")
+                if part
+            ]
+        except (FileNotFoundError, ProcessLookupError):
+            return None
+        except (OSError, ValueError, StopIteration) as error:
+            raise ValueError(f"cannot inspect Linux PID {pid}: {error}") from error
+        return {
+            "pid": pid,
+            "parent_pid": int(fields[1]),
+            "process_group_id": int(fields[2]),
+            "start_time_unix_s": boot_time + start_ticks // ticks,
+            "executable": str(executable),
+            "executable_bytes": executable.stat().st_size,
+            "executable_sha256": sha256_file(executable) if hash_executable else None,
+            "command": command,
+        }
+    if sys.platform == "darwin":
+        try:
+            import ctypes
+
+            buffer = ctypes.create_string_buffer(4096)
+            libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+            length = libproc.proc_pidpath(pid, buffer, len(buffer))
+            if length <= 0:
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    return None
+                environment = controlled_build_environment()
+                environment["LC_ALL"] = "C"
+                state = subprocess.run(
+                    ["/bin/ps", "-p", str(pid), "-o", "state="],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    env=environment,
+                    check=False,
+                )
+                if state.returncode == 0 and state.stdout.strip().startswith("Z"):
+                    return None
+                raise ValueError(f"proc_pidpath failed for PID {pid}")
+            executable = Path(os.fsdecode(buffer.value)).resolve(strict=True)
+            libc = ctypes.CDLL("/usr/lib/libSystem.B.dylib", use_errno=True)
+            mib = (ctypes.c_int * 3)(1, 49, pid)  # CTL_KERN, KERN_PROCARGS2, pid
+            size = ctypes.c_size_t()
+            if libc.sysctl(mib, 3, None, ctypes.byref(size), None, 0) != 0 or size.value == 0:
+                raise ValueError(f"KERN_PROCARGS2 size query failed for PID {pid}")
+            argv_buffer = ctypes.create_string_buffer(size.value)
+            if libc.sysctl(
+                mib, 3, argv_buffer, ctypes.byref(size), None, 0
+            ) != 0:
+                raise ValueError(f"KERN_PROCARGS2 read failed for PID {pid}")
+            raw_argv = argv_buffer.raw[: size.value]
+            if len(raw_argv) < struct.calcsize("i"):
+                raise ValueError(f"KERN_PROCARGS2 result is truncated for PID {pid}")
+            argc = struct.unpack_from("i", raw_argv)[0]
+            cursor = struct.calcsize("i")
+            executable_end = raw_argv.find(b"\0", cursor)
+            if argc < 0 or executable_end < 0:
+                raise ValueError(f"KERN_PROCARGS2 header is invalid for PID {pid}")
+            cursor = executable_end + 1
+            while cursor < len(raw_argv) and raw_argv[cursor] == 0:
+                cursor += 1
+            command: list[str] = []
+            for _ in range(argc):
+                end = raw_argv.find(b"\0", cursor)
+                if end < 0:
+                    raise ValueError(f"KERN_PROCARGS2 argv is truncated for PID {pid}")
+                command.append(raw_argv[cursor:end].decode("utf-8", errors="surrogateescape"))
+                cursor = end + 1
+            environment = controlled_build_environment()
+            environment["LC_ALL"] = "C"
+            completed = subprocess.run(
+                ["/bin/ps", "-p", str(pid), "-o", "lstart="],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=environment,
+                check=False,
+            )
+            if completed.returncode != 0 or not completed.stdout.strip():
+                return None
+            line = completed.stdout.strip()
+            match = re.fullmatch(
+                r"(\w{3}\s+\w{3}\s+\d+\s+\d\d:\d\d:\d\d\s+\d{4})",
+                line,
+            )
+            if not match:
+                raise ValueError(f"cannot parse ps start/command for PID {pid}: {line!r}")
+            start = int(time.mktime(time.strptime(match.group(1), "%a %b %d %H:%M:%S %Y")))
+            relation = subprocess.run(
+                ["/bin/ps", "-p", str(pid), "-o", "ppid=", "-o", "pgid="],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=environment,
+                check=False,
+            )
+            relation_fields = relation.stdout.split()
+            if relation.returncode != 0 or len(relation_fields) != 2:
+                return None
+            parent_pid, process_group_id = map(int, relation_fields)
+        except ProcessLookupError:
+            return None
+        except (OSError, ValueError) as error:
+            raise ValueError(f"cannot inspect macOS PID {pid}: {error}") from error
+        return {
+            "pid": pid,
+            "parent_pid": parent_pid,
+            "process_group_id": process_group_id,
+            "start_time_unix_s": start,
+            "executable": str(executable),
+            "executable_bytes": executable.stat().st_size,
+            "executable_sha256": sha256_file(executable) if hash_executable else None,
+            "command": command,
+        }
+    raise ValueError("exact cleanup is supported only on Linux and macOS")
+
+
+def native_process_start_token(pid: int) -> str | None:
+    """Return an OS-native token that changes when a numeric PID is reused."""
+    if pid <= 0:
+        return None
+    if sys.platform.startswith("linux"):
+        try:
+            raw_stat = (Path("/proc") / str(pid) / "stat").read_text(encoding="utf-8")
+            closing = raw_stat.rfind(")")
+            if closing < 0:
+                raise ValueError("missing comm terminator")
+            fields = raw_stat[closing + 2 :].split()
+            start_ticks = int(fields[19])
+            boot_fingerprint = host_identifier_fingerprint(
+                "boot_id", stable_boot_id("Linux")
+            )
+        except (FileNotFoundError, ProcessLookupError):
+            return None
+        except (OSError, ValueError, IndexError) as error:
+            raise ValueError(
+                f"cannot read native Linux start token for PID {pid}: {error}"
+            ) from error
+        return f"linux-proc-start:{boot_fingerprint}:{start_ticks}"
+    if sys.platform == "darwin":
+        try:
+            import ctypes
+
+            class ProcBsdInfo(ctypes.Structure):
+                _fields_ = [
+                    ("pbi_flags", ctypes.c_uint32),
+                    ("pbi_status", ctypes.c_uint32),
+                    ("pbi_xstatus", ctypes.c_uint32),
+                    ("pbi_pid", ctypes.c_uint32),
+                    ("pbi_ppid", ctypes.c_uint32),
+                    ("pbi_uid", ctypes.c_uint32),
+                    ("pbi_gid", ctypes.c_uint32),
+                    ("pbi_ruid", ctypes.c_uint32),
+                    ("pbi_rgid", ctypes.c_uint32),
+                    ("pbi_svuid", ctypes.c_uint32),
+                    ("pbi_svgid", ctypes.c_uint32),
+                    ("rfu_1", ctypes.c_uint32),
+                    ("pbi_comm", ctypes.c_char * 16),
+                    ("pbi_name", ctypes.c_char * 32),
+                    ("pbi_nfiles", ctypes.c_uint32),
+                    ("pbi_pgid", ctypes.c_uint32),
+                    ("pbi_pjobc", ctypes.c_uint32),
+                    ("e_tdev", ctypes.c_uint32),
+                    ("e_tpgid", ctypes.c_uint32),
+                    ("pbi_nice", ctypes.c_int32),
+                    ("pbi_start_tvsec", ctypes.c_uint64),
+                    ("pbi_start_tvusec", ctypes.c_uint64),
+                ]
+
+            info = ProcBsdInfo()
+            libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+            libproc.proc_pidinfo.argtypes = [
+                ctypes.c_int,
+                ctypes.c_int,
+                ctypes.c_uint64,
+                ctypes.c_void_p,
+                ctypes.c_int,
+            ]
+            libproc.proc_pidinfo.restype = ctypes.c_int
+            read_size = libproc.proc_pidinfo(
+                pid,
+                3,  # PROC_PIDTBSDINFO
+                0,
+                ctypes.byref(info),
+                ctypes.sizeof(info),
+            )
+            if read_size != ctypes.sizeof(info):
+                state = unix_process_state(pid)
+                if state is None or state.startswith("Z"):
+                    return None
+                error_number = ctypes.get_errno()
+                raise ValueError(
+                    "proc_pidinfo returned "
+                    f"{read_size}/{ctypes.sizeof(info)} bytes (errno {error_number})"
+                )
+            if info.pbi_pid != pid or info.pbi_start_tvsec <= 0:
+                raise ValueError("proc_pidinfo returned an invalid process identity")
+        except ProcessLookupError:
+            return None
+        except (OSError, ValueError) as error:
+            raise ValueError(
+                f"cannot read native macOS start token for PID {pid}: {error}"
+            ) from error
+        return f"darwin-proc-start:{info.pbi_start_tvsec}:{info.pbi_start_tvusec}"
+    raise ValueError("native process start tokens are supported only on Linux and macOS")
+
+
+def fixture_server_process_observation(pid: int) -> dict[str, Any] | None:
+    token_before = native_process_start_token(pid)
+    if token_before is None:
+        return None
+    observation = unix_process_observation(pid, hash_executable=True)
+    token_after = native_process_start_token(pid)
+    if observation is None or token_after is None or token_before != token_after:
+        return None
+    command = observation.get("command")
+    if not isinstance(command, list) or not command or not all(
+        isinstance(item, str) for item in command
+    ):
+        raise ValueError(f"fixture server PID {pid} has no exact argv identity")
+    return {
+        field: observation[field]
+        for field in (
+            "pid",
+            "start_time_unix_s",
+            "executable",
+            "executable_bytes",
+            "executable_sha256",
+            "command",
+        )
+    } | {"native_start_token": token_before}
+
+
+def fixture_server_identity_matches(
+    identity: dict[str, Any], observation: dict[str, Any] | None
+) -> bool:
+    if observation is None:
+        return False
+    return all(
+        observation.get(field) == identity.get(field)
+        for field in (
+            "pid",
+            "start_time_unix_s",
+            "native_start_token",
+            "executable",
+            "executable_bytes",
+            "executable_sha256",
+            "command",
+        )
+    )
+
+
+def validated_live_identity(
+    document: dict[str, Any], path: Path
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any] | None,
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+]:
+    require_artifact_value(path, "schema", document.get("schema"), "ytt.tui-perf.live-identity.v1")
+    require_artifact_value(
+        path, "cleanup scope", document.get("cleanup_scope"), CLEANUP_SCOPE
+    )
+    if not isinstance(document.get("run_id"), str) or not document["run_id"]:
+        raise ValueError(f"{path}: live identity run_id is missing")
+    state = document.get("state")
+    if state not in {"startup", "owner_starting", "running", "cleanup_requested", "cleaned"}:
+        raise ValueError(
+            f"{path}: invalid live identity lifecycle state {state!r}"
+        )
+    producer = document.get("producer")
+    owner = document.get("owner")
+    partial_owner = document.get("partial_owner")
+    mpv = document.get("mpv")
+    descendants = document.get("descendants")
+    if (
+        not isinstance(producer, dict)
+        or (owner is not None and not isinstance(owner, dict))
+        or (partial_owner is not None and not isinstance(partial_owner, dict))
+        or not isinstance(mpv, list)
+        or not all(isinstance(item, dict) for item in mpv)
+        or not isinstance(descendants, list)
+        or not all(isinstance(item, dict) for item in descendants)
+    ):
+        raise ValueError(f"{path}: live producer/owner/descendant identity is malformed")
+    if state == "running" and not isinstance(owner, dict):
+        raise ValueError(f"{path}: {state} live identity requires a complete owner")
+    if state == "owner_starting" and not isinstance(partial_owner, dict):
+        raise ValueError(f"{path}: owner_starting identity requires partial_owner")
+
+    def validate_core(label: str, identity: dict[str, Any]) -> None:
+        for field in ("pid", "start_time_unix_s", "executable_bytes"):
+            value = non_negative_integer(identity.get(field), f"{label} {field}", path)
+            if value == 0:
+                raise ValueError(f"{path}: {label} {field} must be positive")
+        executable = identity.get("executable")
+        digest = identity.get("executable_sha256")
+        if (
+            not isinstance(executable, str)
+            or not executable
+            or not isinstance(digest, str)
+            or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+        ):
+            raise ValueError(f"{path}: {label} executable identity is invalid")
+
+    validate_core("producer", producer)
+    producer_group = non_negative_integer(
+        producer.get("process_group_id"), "producer process_group_id", path
+    )
+    if producer_group == 0:
+        raise ValueError(f"{path}: producer process_group_id must be positive")
+    if isinstance(owner, dict):
+        validate_core("owner", owner)
+        owner_group = non_negative_integer(
+            owner.get("process_group_id"), "owner process_group_id", path
+        )
+        if owner_group == 0:
+            raise ValueError(f"{path}: owner process_group_id must be positive")
+        if owner_group != owner["pid"]:
+            raise ValueError(
+                f"{path}: owner must lead its dedicated process group "
+                f"(PID {owner['pid']}, PGID {owner_group})"
+            )
+        if owner_group == producer_group:
+            raise ValueError(f"{path}: owner process group must differ from producer group")
+        if producer["pid"] == owner["pid"]:
+            raise ValueError(f"{path}: producer and owner PID must differ")
+    if isinstance(partial_owner, dict):
+        for field in ("pid", "start_time_unix_s", "process_group_id"):
+            value = non_negative_integer(
+                partial_owner.get(field), f"partial_owner {field}", path
+            )
+            if value == 0:
+                raise ValueError(f"{path}: partial_owner {field} must be positive")
+        if partial_owner["pid"] == producer["pid"]:
+            raise ValueError(f"{path}: producer and partial owner PID must differ")
+        if partial_owner["process_group_id"] != partial_owner["pid"]:
+            raise ValueError(
+                f"{path}: partial owner must lead its dedicated process group "
+                f"(PID {partial_owner['pid']}, PGID {partial_owner['process_group_id']})"
+            )
+        if partial_owner["process_group_id"] == producer_group:
+            raise ValueError(
+                f"{path}: partial owner process group must differ from producer group"
+            )
+        if isinstance(owner, dict):
+            for field in ("pid", "start_time_unix_s", "process_group_id"):
+                require_artifact_value(
+                    path,
+                    f"partial/full owner {field}",
+                    partial_owner[field],
+                    owner[field],
+                )
+    descendant_by_pid: dict[int, dict[str, Any]] = {}
+    for index, identity in enumerate(descendants):
+        label = f"descendants[{index}]"
+        validate_core(label, identity)
+        pid = identity["pid"]
+        reserved_pids = {producer["pid"]}
+        if isinstance(owner, dict):
+            reserved_pids.add(owner["pid"])
+        if pid in reserved_pids or pid in descendant_by_pid:
+            raise ValueError(f"{path}: duplicate live identity PID {pid}")
+        role = identity.get("role")
+        command = identity.get("command")
+        if role not in {"mpv", "other"}:
+            raise ValueError(f"{path}: {label} role must be mpv or other")
+        if not isinstance(command, list) or not command or not all(
+            isinstance(item, str) for item in command
+        ):
+            raise ValueError(f"{path}: {label} exact command is invalid")
+        descendant_by_pid[pid] = identity
+    seen_mpv: set[int] = set()
+    for index, identity in enumerate(mpv):
+        label = f"mpv[{index}]"
+        validate_core(label, identity)
+        pid = identity["pid"]
+        if pid in seen_mpv:
+            raise ValueError(f"{path}: duplicate mpv identity PID {pid}")
+        seen_mpv.add(pid)
+        argv = identity.get("input_ipc_server_argv")
+        if not isinstance(argv, list) or not argv or not all(isinstance(item, str) for item in argv):
+            raise ValueError(f"{path}: {label} IPC argv identity is invalid")
+        descendant = descendant_by_pid.get(pid)
+        if descendant is None or descendant.get("role") != "mpv":
+            raise ValueError(f"{path}: {label} is not present in the recursive descendant inventory")
+        for field in (
+            "pid",
+            "start_time_unix_s",
+            "executable",
+            "executable_bytes",
+            "executable_sha256",
+        ):
+            require_artifact_value(path, f"{label} {field}", identity.get(field), descendant.get(field))
+        observed_argv, _endpoint = mpv_ipc_identity(descendant["command"])
+        require_artifact_value(path, f"{label} IPC argv", argv, observed_argv)
+    return producer, owner, mpv, descendants
+
+
+def live_identity_matches(
+    identity: dict[str, Any],
+    observation: dict[str, Any] | None,
+    *,
+    mpv: bool = False,
+    exact_command: bool = False,
+    verify_hash: bool = True,
+) -> bool:
+    if observation is None:
+        return False
+    fields = ["pid", "start_time_unix_s", "executable", "executable_bytes"]
+    if verify_hash:
+        fields.append("executable_sha256")
+    for field in fields:
+        if observation.get(field) != identity.get(field):
+            return False
+    if exact_command and observation.get("command") != identity.get("command"):
+        return False
+    if mpv:
+        argv, _endpoint = mpv_ipc_identity(observation.get("command", []))
+        return argv == identity.get("input_ipc_server_argv")
+    return True
+
+
+def unix_process_relations() -> dict[int, tuple[int, int]]:
+    if sys.platform.startswith("linux"):
+        relations: dict[int, tuple[int, int]] = {}
+        for entry in Path("/proc").iterdir():
+            if not entry.name.isdigit():
+                continue
+            try:
+                raw_stat = (entry / "stat").read_text(encoding="utf-8")
+                closing = raw_stat.rfind(")")
+                fields = raw_stat[closing + 2 :].split()
+                relations[int(entry.name)] = (int(fields[1]), int(fields[2]))
+            except (FileNotFoundError, ProcessLookupError, OSError, ValueError, IndexError):
+                continue
+        return relations
+    if sys.platform == "darwin":
+        environment = controlled_build_environment()
+        environment["LC_ALL"] = "C"
+        completed = subprocess.run(
+            ["/bin/ps", "-axo", "pid=", "-o", "ppid=", "-o", "pgid="],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=environment,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise ValueError(f"cannot inventory process relations: {completed.stderr.strip()}")
+        relations = {}
+        for line in completed.stdout.splitlines():
+            fields = line.split()
+            if len(fields) == 3:
+                pid, parent, group = map(int, fields)
+                relations[pid] = (parent, group)
+        return relations
+    raise ValueError("exact cleanup is supported only on Linux and macOS")
+
+
+def unix_process_state(pid: int) -> str | None:
+    if sys.platform.startswith("linux"):
+        try:
+            raw_stat = (Path("/proc") / str(pid) / "stat").read_text(encoding="utf-8")
+            closing = raw_stat.rfind(")")
+            if closing < 0:
+                raise ValueError("missing comm terminator")
+            fields = raw_stat[closing + 2 :].split()
+            return fields[0] if fields else None
+        except (FileNotFoundError, ProcessLookupError):
+            return None
+        except (OSError, ValueError) as error:
+            raise ValueError(f"cannot inspect Linux process state for PID {pid}: {error}") from error
+    if sys.platform == "darwin":
+        environment = controlled_build_environment()
+        environment["LC_ALL"] = "C"
+        completed = subprocess.run(
+            ["/bin/ps", "-p", str(pid), "-o", "state="],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=environment,
+            check=False,
+        )
+        if completed.returncode != 0:
+            return None
+        state = completed.stdout.strip()
+        return state or None
+    raise ValueError("exact cleanup is supported only on Linux and macOS")
+
+
+def wait_for_process_group_stopped(group: int, deadline: float) -> list[int]:
+    last_states: dict[int, str | None] = {}
+    while time.monotonic() < deadline:
+        relations = unix_process_relations()
+        members = sorted(
+            pid for pid, (_parent, process_group) in relations.items() if process_group == group
+        )
+        last_states = {pid: unix_process_state(pid) for pid in members}
+        if members and all(
+            state is not None and state[:1] in {"T", "t"}
+            for state in last_states.values()
+        ):
+            return members
+        time.sleep(0.01)
+    raise ValueError(
+        f"dedicated owner process group {group} did not become fully stopped: {last_states}"
+    )
+
+
+def cleanup_descendant_identity(observation: dict[str, Any]) -> dict[str, Any]:
+    command = observation.get("command")
+    if not isinstance(command, list) or not command:
+        raise ValueError(f"PID {observation.get('pid')} has no exact argv for cleanup")
+    executable_name = Path(str(observation["executable"])).stem.lower()
+    argv0 = Path(command[0]).stem.lower()
+    ipc_argv, _endpoint = mpv_ipc_identity(command)
+    role = (
+        "mpv"
+        if executable_name == "mpv" or argv0 == "mpv" or ipc_argv is not None
+        else "other"
+    )
+    return {
+        field: observation[field]
+        for field in (
+            "pid",
+            "start_time_unix_s",
+            "executable",
+            "executable_bytes",
+            "executable_sha256",
+        )
+    } | {"role": role, "command": command}
+
+
+def mpv_identities_from_descendants(descendants: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    result = []
+    for descendant in descendants:
+        if descendant["role"] != "mpv":
+            continue
+        argv, _endpoint = mpv_ipc_identity(descendant["command"])
+        if argv is None:
+            raise ValueError(
+                f"mpv PID {descendant['pid']} has no exact --input-ipc-server argv"
+            )
+        result.append(
+            {
+                field: descendant[field]
+                for field in (
+                    "pid",
+                    "start_time_unix_s",
+                    "executable",
+                    "executable_bytes",
+                    "executable_sha256",
+                )
+            }
+            | {"input_ipc_server_argv": argv}
+        )
+    return result
+
+
+def command_cleanup(args: argparse.Namespace) -> int:
+    if os.name == "nt":
+        raise ValueError("exact cleanup CLI is Unix-only")
+    if not math.isfinite(args.timeout_secs) or args.timeout_secs <= 0:
+        raise ValueError("--timeout-secs must be finite and positive")
+    deadline = time.monotonic() + args.timeout_secs
+    document: dict[str, Any] | None = None
+    last_error: Exception | None = None
+    while time.monotonic() <= deadline:
+        try:
+            if args.identity.is_file():
+                document = load_json_object(args.identity)
+                validated_live_identity(document, args.identity)
+                break
+        except (OSError, ValueError) as error:
+            last_error = error
+        time.sleep(0.02)
+    if document is None:
+        raise ValueError(
+            f"no valid live identity appeared before cleanup deadline: {last_error or args.identity}"
+        )
+    producer, owner, _mpv_identities, descendant_identities = validated_live_identity(
+        document, args.identity
+    )
+    partial_owner = document.get("partial_owner")
+    if owner is None and isinstance(partial_owner, dict):
+        observation = unix_process_observation(
+            int(partial_owner["pid"]), hash_executable=True
+        )
+        if observation is not None:
+            for field in ("pid", "start_time_unix_s", "process_group_id"):
+                require_artifact_value(
+                    args.identity,
+                    f"partial owner {field}",
+                    observation.get(field),
+                    partial_owner[field],
+                )
+            require_artifact_value(
+                args.identity,
+                "partial owner parent PID",
+                observation.get("parent_pid"),
+                producer["pid"],
+            )
+            owner = observation
+
+    def still_exact(
+        identity: dict[str, Any], *, exact_command: bool = False, verify_hash: bool = False
+    ) -> bool:
+        return live_identity_matches(
+            identity,
+            unix_process_observation(
+                int(identity["pid"]), hash_executable=verify_hash
+            ),
+            exact_command=exact_command,
+            verify_hash=verify_hash,
+        )
+
+    targets = ([(owner, False)] if owner is not None else []) + [
+        (item, True) for item in descendant_identities
+    ]
+    if document["state"] == "cleaned":
+        while time.monotonic() < deadline and still_exact(producer, verify_hash=False):
+            time.sleep(0.02)
+        survivors = [
+            identity["pid"]
+            for identity, exact_command in [(producer, False), *targets]
+            if still_exact(identity, exact_command=exact_command, verify_hash=True)
+        ]
+        if survivors:
+            raise ValueError(f"{args.identity}: cleaned identity still has exact survivors {survivors}")
+        require_artifact_value(args.identity, "cleanup proof", document.get("cleanup_proven"), True)
+        print(json.dumps({"ok": True, "already_cleaned": True, "identity": str(args.identity)}))
+        return 0
+
+    stopped: list[dict[str, Any]] = []
+    frozen_owner_group: int | None = None
+    owner_group_killed = False
+
+    def signal_exact(
+        identity: dict[str, Any], requested_signal: signal.Signals, *, exact_command: bool = False
+    ) -> bool:
+        if not still_exact(identity, exact_command=exact_command, verify_hash=True):
+            return False
+        try:
+            os.kill(int(identity["pid"]), requested_signal)
+        except ProcessLookupError:
+            return False
+        return True
+
+    cleanup_document: dict[str, Any] | None = None
+    try:
+        if signal_exact(producer, signal.SIGSTOP):
+            stopped.append(producer)
+        time.sleep(0.03)
+        for identity in stopped:
+            if not still_exact(identity, verify_hash=True):
+                raise ValueError(
+                    f"{args.identity}: exact PID {identity['pid']} changed while freezing cleanup writers/tree"
+                )
+
+        producer_group = int(producer["process_group_id"])
+        if owner is None:
+            relations = unix_process_relations()
+            owner_candidates = sorted(
+                pid
+                for pid, (parent, process_group) in relations.items()
+                if parent == int(producer["pid"])
+                and pid == process_group
+                and process_group != producer_group
+                and pid != os.getpid()
+            )
+            if len(owner_candidates) > 1:
+                raise ValueError(
+                    f"{args.identity}: startup cleanup found multiple dedicated owner candidates "
+                    f"{owner_candidates}"
+                )
+            if owner_candidates:
+                candidate = unix_process_observation(
+                    owner_candidates[0], hash_executable=True
+                )
+                if candidate is None:
+                    raise ValueError(
+                        f"{args.identity}: startup owner candidate disappeared before identity capture"
+                    )
+                require_artifact_value(
+                    args.identity,
+                    "startup owner parent PID",
+                    candidate.get("parent_pid"),
+                    producer["pid"],
+                )
+                owner = candidate
+
+        if owner is not None:
+            owner_observation = unix_process_observation(
+                int(owner["pid"]), hash_executable=True
+            )
+            if live_identity_matches(owner, owner_observation, verify_hash=True):
+                owner_group = int(owner_observation["process_group_id"])
+                require_artifact_value(
+                    args.identity,
+                    "observed owner process group",
+                    owner_group,
+                    owner["process_group_id"],
+                )
+                if owner_group != int(owner["pid"]):
+                    raise ValueError(
+                        f"{args.identity}: exact owner PID {owner['pid']} is not leader of "
+                        f"dedicated process group {owner_group}"
+                    )
+                if owner_group == producer_group:
+                    raise ValueError(
+                        f"{args.identity}: owner process group is not isolated from producer"
+                    )
+                if owner_group == os.getpgrp():
+                    raise ValueError(
+                        f"{args.identity}: refusing to freeze cleanup orchestrator process group"
+                    )
+                try:
+                    os.killpg(owner_group, signal.SIGSTOP)
+                except ProcessLookupError as error:
+                    raise ValueError(
+                        f"{args.identity}: dedicated owner process group {owner_group} disappeared "
+                        "before atomic freeze"
+                    ) from error
+                frozen_owner_group = owner_group
+                wait_for_process_group_stopped(owner_group, deadline)
+                frozen_owner = unix_process_observation(
+                    int(owner["pid"]), hash_executable=True
+                )
+                if not live_identity_matches(owner, frozen_owner, verify_hash=True):
+                    raise ValueError(
+                        f"{args.identity}: exact owner changed during process-group freeze"
+                    )
+                require_artifact_value(
+                    args.identity,
+                    "frozen owner process group",
+                    frozen_owner.get("process_group_id"),
+                    owner_group,
+                )
+            else:
+                recorded_group = int(owner["process_group_id"])
+                recorded_group_members = sorted(
+                    pid
+                    for pid, (_parent, process_group) in unix_process_relations().items()
+                    if process_group == recorded_group
+                )
+                if recorded_group_members:
+                    raise ValueError(
+                        f"{args.identity}: cannot safely freeze recorded owner process group "
+                        f"{recorded_group} without its exact leader; members={recorded_group_members}"
+                    )
+
+        # Keep every previously captured exact-alive descendant, including a grandchild that
+        # was reparented after a short-lived intermediate exited.
+        discovered: dict[tuple[int, int], dict[str, Any]] = {}
+        for identity in descendant_identities:
+            if still_exact(identity, exact_command=True, verify_hash=True):
+                discovered[(identity["pid"], identity["start_time_unix_s"])] = identity
+
+        stable_inventory: set[tuple[int, int]] | None = None
+        stable_count = 0
+        while time.monotonic() < deadline and stable_count < 3:
+            relations = unix_process_relations()
+            recursive = {int(producer["pid"])}
+            if owner is not None:
+                recursive.add(int(owner["pid"]))
+            changed = True
+            while changed:
+                before = len(recursive)
+                recursive.update(
+                    pid for pid, (parent, _group) in relations.items() if parent in recursive
+                )
+                changed = len(recursive) != before
+            reserved_pids = {int(producer["pid"]), os.getpid()}
+            if owner is not None:
+                reserved_pids.add(int(owner["pid"]))
+            candidate_pids = recursive - reserved_pids
+            if frozen_owner_group is not None:
+                candidate_pids.update(
+                    pid
+                    for pid, (_parent, group) in relations.items()
+                    if group == frozen_owner_group
+                )
+            candidate_pids -= reserved_pids
+            for pid in sorted(candidate_pids):
+                observation = unix_process_observation(pid, hash_executable=True)
+                if observation is None:
+                    continue
+                identity = cleanup_descendant_identity(observation)
+                discovered[(identity["pid"], identity["start_time_unix_s"])] = identity
+                if signal_exact(identity, signal.SIGSTOP, exact_command=True):
+                    stopped.append(identity)
+            inventory = set(discovered)
+            if inventory == stable_inventory:
+                stable_count += 1
+            else:
+                stable_inventory = inventory
+                stable_count = 1
+            time.sleep(0.02)
+        if stable_count < 3:
+            raise ValueError(f"{args.identity}: recursive descendant inventory did not stabilize")
+        if frozen_owner_group is not None:
+            wait_for_process_group_stopped(frozen_owner_group, deadline)
+        descendant_identities = sorted(
+            discovered.values(), key=lambda identity: (identity["pid"], identity["start_time_unix_s"])
+        )
+        mpv_identities = mpv_identities_from_descendants(descendant_identities)
+        cleanup_document = {
+            **document,
+            "state": "cleanup_requested",
+            "owner": owner,
+            "cleanup_scope": CLEANUP_SCOPE,
+            "cleanup_proven": False,
+            "descendants": descendant_identities,
+            "mpv": mpv_identities,
+            "cleanup_requested_unix_ns": time.time_ns(),
+            "updated_unix_ns": time.time_ns(),
+        }
+        atomic_json(args.identity, cleanup_document)
+
+        targets = ([(owner, False)] if owner is not None else []) + [
+            (item, True) for item in descendant_identities
+        ]
+        if frozen_owner_group is not None:
+            frozen_owner = (
+                unix_process_observation(int(owner["pid"]), hash_executable=True)
+                if owner is not None
+                else None
+            )
+            if owner is None or not live_identity_matches(
+                owner, frozen_owner, verify_hash=True
+            ):
+                raise ValueError(
+                    f"{args.identity}: exact owner changed before dedicated process-group kill"
+                )
+            require_artifact_value(
+                args.identity,
+                "owner process group before kill",
+                frozen_owner.get("process_group_id"),
+                frozen_owner_group,
+            )
+            try:
+                os.killpg(frozen_owner_group, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            owner_group_killed = True
+        for identity, exact_command in reversed(targets):
+            signal_exact(identity, signal.SIGKILL, exact_command=exact_command)
+        signal_exact(producer, signal.SIGKILL)
+        while time.monotonic() < deadline and any(
+            still_exact(identity, exact_command=exact_command)
+            for identity, exact_command in [(producer, False), *targets]
+        ):
+            time.sleep(0.05)
+    finally:
+        if frozen_owner_group is not None and not owner_group_killed and owner is not None:
+            current_owner = unix_process_observation(
+                int(owner["pid"]), hash_executable=True
+            )
+            if live_identity_matches(owner, current_owner, verify_hash=True) and (
+                current_owner.get("process_group_id") == frozen_owner_group
+            ):
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(frozen_owner_group, signal.SIGCONT)
+        for identity in stopped:
+            signal_exact(identity, signal.SIGCONT)
+
+    targets = ([(owner, False)] if owner is not None else []) + [
+        (item, True) for item in descendant_identities
+    ]
+    survivors = [
+        identity["pid"]
+        for identity, exact_command in [(producer, False), *targets]
+        if still_exact(identity, exact_command=exact_command, verify_hash=True)
+    ]
+    if survivors:
+        raise ValueError(f"{args.identity}: exact processes survived cleanup {survivors}")
+    if cleanup_document is None:
+        raise ValueError(f"{args.identity}: cleanup request was not durably published")
+    cleaned = {
+        **cleanup_document,
+        "state": "cleaned",
+        "cleanup_scope": CLEANUP_SCOPE,
+        "cleanup_proven": True,
+        "cleanup_method": "verified_unix_dedicated_process_group_and_observed_exact_descendants",
+        "updated_unix_ns": time.time_ns(),
+    }
+    atomic_json(args.identity, cleaned)
+    print(json.dumps({"ok": True, "already_cleaned": False, "identity": str(args.identity)}))
+    return 0
+
+
+def validate_launch_policy(path: Path, run_root: Path) -> tuple[dict[str, Any], list[Path]]:
+    manifest = load_json_object(path)
+    require_artifact_value(path, "schema", manifest.get("schema"), "ytt.tui-perf.launch-policy.v1")
+    home = (run_root / "home").resolve()
+    require_artifact_value(path, "root", Path(str(manifest.get("root", ""))).resolve(), home)
+    require_artifact_value(path, "config path", manifest.get("config"), "stores/config/config.json")
+    require_artifact_value(
+        path,
+        "effective launch policy",
+        manifest.get("effective"),
+        LAUNCH_POLICY_EFFECTIVE,
+    )
+    expected_policy_fields = [".".join(fields) for fields in LAUNCH_POLICY_FIELDS]
+    require_artifact_value(
+        path, "launch policy field inventory", manifest.get("policy_fields"), expected_policy_fields
+    )
+    snapshot = run_root / "launch-policy-inputs"
+    require_artifact_value(path, "snapshot", manifest.get("snapshot"), snapshot.name)
+    require_artifact_value(
+        path, "snapshot policy path", manifest.get("snapshot_policy"), "effective-policy.json"
+    )
+    snapshot_policy = snapshot / "effective-policy.json"
+    if not snapshot_policy.is_file():
+        raise ValueError(f"{path}: launch policy effective snapshot is missing")
+    snapshot_document = load_json_object(snapshot_policy)
+    require_artifact_value(
+        snapshot_policy,
+        "schema",
+        snapshot_document.get("schema"),
+        "ytt.tui-perf.launch-policy-input.v1",
+    )
+    require_artifact_value(
+        snapshot_policy,
+        "effective launch policy",
+        snapshot_document.get("effective"),
+        LAUNCH_POLICY_EFFECTIVE,
+    )
+    require_artifact_value(
+        snapshot_policy,
+        "launch policy field inventory",
+        snapshot_document.get("policy_fields"),
+        expected_policy_fields,
+    )
+    require_artifact_value(
+        path,
+        "child environment policy",
+        manifest.get("child_environment_policy"),
+        CHILD_ENVIRONMENT_POLICY,
+    )
+    require_artifact_value(
+        snapshot_policy,
+        "child environment policy",
+        snapshot_document.get("child_environment_policy"),
+        CHILD_ENVIRONMENT_POLICY,
+    )
+    config = (home / "stores" / "config" / "config.json").resolve()
+    try:
+        config.relative_to(home)
+    except ValueError as error:
+        raise ValueError(f"{path}: live launch config escapes the isolated home") from error
+    if not config.is_file():
+        raise ValueError(f"{path}: live launch policy config is missing")
+    document = load_json_object(config)
+    validate_effective_launch_config(config, document)
+    credential_proof = launch_api_credential_proof(document, home)
+    require_artifact_value(
+        path, "API credential absence proof", manifest.get("api_credential_proof"), credential_proof
+    )
+    require_artifact_value(
+        snapshot_policy,
+        "API credential absence proof",
+        snapshot_document.get("api_credential_proof"),
+        credential_proof,
+    )
+    require_artifact_value(
+        path,
+        "preserved config projection SHA-256",
+        manifest.get("preserved_config_projection_sha256"),
+        json_value_sha256(launch_policy_projection(document)),
+    )
+    recorded_config = manifest.get("config_after")
+    if not isinstance(recorded_config, dict):
+        raise ValueError(f"{path}: config_after identity is malformed")
+    live_identity = identity_for_file(config)
+    require_artifact_value(
+        path,
+        "config content identity",
+        recorded_config,
+        live_identity,
+    )
+    require_artifact_value(path, "snapshot inventory", manifest.get("snapshot_files"), tree_file_inventory(snapshot))
+    return manifest, [path, snapshot_policy]
+
+
+def launch_policy_self_test() -> None:
+    def expect_path_rejected(
+        base: Path,
+        name: str,
+        output_for: Any,
+        setup: Any = None,
+    ) -> None:
+        run_root = base / name
+        home = run_root / "home"
+        config = home / "stores" / "config" / "config.json"
+        config.parent.mkdir(parents=True)
+        atomic_json(config, {"unrelated": {"preserve": "byte-identical"}})
+        if setup is not None:
+            setup(run_root)
+        output = output_for(run_root, home)
+        output_existed = path_entry_exists(output)
+        before = byte_exact_tree_state_for_self_test(home)
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                command_launch_policy(argparse.Namespace(root=home, output=output))
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"launch policy accepted invalid {name} paths")
+        if byte_exact_tree_state_for_self_test(home) != before:
+            raise AssertionError(
+                f"launch policy invalid {name} paths changed input-tree bytes or shape"
+            )
+        if not output_existed and path_entry_exists(output):
+            raise AssertionError(f"rejected launch policy created invalid {name} output")
+
+    def expect_rejected(
+        base: Path,
+        name: str,
+        document: dict[str, Any],
+        setup: Any = None,
+    ) -> None:
+        run_root = base / name
+        home = run_root / "home"
+        config = home / "stores" / "config" / "config.json"
+        config.parent.mkdir(parents=True)
+        atomic_json(config, document)
+        if setup is not None:
+            setup(home)
+        before = config.read_bytes()
+        output = run_root / "launch-policy.json"
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                command_launch_policy(argparse.Namespace(root=home, output=output))
+        except ValueError as error:
+            if "self-test-secret" in str(error):
+                raise AssertionError("launch-policy rejection leaked a cookie value") from error
+        else:
+            raise AssertionError(f"launch policy accepted hostile seed {name}")
+        if config.read_bytes() != before:
+            raise AssertionError("rejected launch policy mutated its source config")
+        if output.exists() or (run_root / "launch-policy-inputs").exists():
+            raise AssertionError("rejected launch policy archived an untrusted config")
+
+    with tempfile.TemporaryDirectory(prefix="ytt-perf-launch-policy-self-test-") as temporary:
+        base = Path(temporary)
+
+        expect_path_rejected(
+            base,
+            "output-inside-home",
+            lambda _run_root, home: home / "artifacts" / "launch-policy.json",
+        )
+
+        def occupy_snapshot(run_root: Path) -> None:
+            (run_root / "launch-policy-inputs").mkdir()
+
+        expect_path_rejected(
+            base,
+            "occupied-snapshot",
+            lambda run_root, _home: run_root / "launch-policy.json",
+            occupy_snapshot,
+        )
+        expect_path_rejected(
+            base,
+            "output-snapshot-alias",
+            lambda run_root, _home: run_root / "launch-policy-inputs",
+        )
+
+        run_root = base / "valid"
+        home = run_root / "home"
+        config = home / "stores" / "config" / "config.json"
+        config.parent.mkdir(parents=True)
+        secrets_by_path = {
+            "cookie": "PREF=self-test-secret-nonauth-cookie",
+            "gemini_api_key": "self-test-secret-gemini",
+            "lastfm_session": "self-test-secret-lastfm-session",
+            "lastfm_api_secret": "self-test-secret-lastfm-api",
+            "listenbrainz_token": "self-test-secret-listenbrainz",
+        }
+        hostile = {
+            "cookie": secrets_by_path["cookie"],
+            "cookies_file": None,
+            "gemini_api_key": secrets_by_path["gemini_api_key"],
+            "media_controls": True,
+            "update_check_enabled": True,
+            "autoplay_on_start": True,
+            "autoplay_streaming": True,
+            "album_art": True,
+            "romanized_titles": True,
+            "ai_enabled": True,
+            "tools": {"ytdlp_managed": True, "ytdlp_channel": "stable"},
+            "scrobble": {
+                "lastfm": {
+                    "enabled": True,
+                    "session_key": secrets_by_path["lastfm_session"],
+                    "api_secret": secrets_by_path["lastfm_api_secret"],
+                    "username": "self-test-user",
+                    "love_sync": True,
+                },
+                "listenbrainz": {
+                    "enabled": True,
+                    "token": secrets_by_path["listenbrainz_token"],
+                    "api_url": "https://listen.example.invalid",
+                },
+                "local_files": True,
+            },
+            "unrelated": {"nested": [1, "keep-me"]},
+        }
+        atomic_json(config, hostile)
+        original_projection = launch_policy_projection(hostile)
+        output = run_root / "launch-policy.json"
+        with contextlib.redirect_stdout(io.StringIO()):
+            command_launch_policy(argparse.Namespace(root=home, output=output))
+        frozen = load_json_object(config)
+        validate_effective_launch_config(config, frozen)
+        if launch_policy_projection(frozen) != original_projection:
+            raise AssertionError("launch policy changed a secret or unrelated config field")
+        if frozen["scrobble"]["lastfm"]["session_key"] != secrets_by_path["lastfm_session"]:
+            raise AssertionError("launch policy changed the Last.fm session secret")
+        if frozen["scrobble"]["listenbrainz"]["token"] != secrets_by_path["listenbrainz_token"]:
+            raise AssertionError("launch policy changed the ListenBrainz token")
+        validate_launch_policy(output, run_root)
+        policy_artifacts = [
+            output,
+            run_root / "launch-policy-inputs" / "effective-policy.json",
+        ]
+        serialized_policy = "\n".join(
+            artifact.read_text(encoding="utf-8") for artifact in policy_artifacts
+        )
+        for secret in secrets_by_path.values():
+            if secret in serialized_policy:
+                raise AssertionError("launch policy artifact contains a raw secret value")
+
+        snapshot_policy = policy_artifacts[1]
+        original_snapshot = snapshot_policy.read_bytes()
+        tampered = load_json_object(snapshot_policy)
+        tampered["effective"] = {**LAUNCH_POLICY_EFFECTIVE, "media_controls": True}
+        atomic_json(snapshot_policy, tampered)
+        try:
+            validate_launch_policy(output, run_root)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("launch policy validator accepted a tampered effective snapshot")
+        atomic_bytes(snapshot_policy, original_snapshot)
+        validate_launch_policy(output, run_root)
+
+        expect_rejected(
+            base,
+            "inline-cookie",
+            {"cookie": "SAPISID=self-test-secret-inline"},
+        )
+        expect_rejected(base, "explicit-empty-path", {"cookies_file": ""})
+
+        def default_cookie(home_root: Path) -> None:
+            cookie = home_root / "Music" / "yututui" / "cookies.txt"
+            cookie.parent.mkdir(parents=True)
+            cookie.write_text(
+                ".youtube.com\tTRUE\t/\tTRUE\t1999999999\tSAPISID\tself-test-secret-file\n",
+                encoding="utf-8",
+            )
+
+        expect_rejected(base, "default-cookie", {}, default_cookie)
+
+        def user_dirs_override(home_root: Path) -> None:
+            user_dirs = home_root / ".config" / "user-dirs.dirs"
+            user_dirs.parent.mkdir(parents=True)
+            user_dirs.write_text('XDG_MUSIC_DIR="/outside-isolated-home"\n', encoding="utf-8")
+
+        expect_rejected(base, "xdg-user-dirs-override", {}, user_dirs_override)
+
+
+def child_environment_policy_self_test() -> None:
+    shell_path = Path(__file__).resolve().with_suffix(".sh")
+    shell = shell_path.read_text(encoding="utf-8")
+    try:
+        isolated_block = shell.split("  local -a isolated_env=(", 1)[1].split("\n  )", 1)[0]
+    except IndexError as error:
+        raise AssertionError("cannot locate the isolated child environment in tui-perf.sh") from error
+    for required in (
+        '"PATH=$PATH"',
+        '"HOME=$home"',
+        '"XDG_CONFIG_HOME=$home/.config"',
+        '"XDG_DATA_HOME=$home/.local/share"',
+        '"XDG_CACHE_HOME=$home/.cache"',
+        '"XDG_STATE_HOME=$home/.local/state"',
+        '"XDG_RUNTIME_DIR=$runtime"',
+        '"YTM_CONFIG_DIR=$config_store"',
+        '"YTM_DATA_DIR=$data_store"',
+        '"YTM_CACHE_DIR=$cache_store"',
+        '"TMPDIR=$tmp"',
+        '"TEMP=$tmp"',
+        '"TMP=$tmp"',
+        '"TERM=xterm-256color"',
+        '"YTM_MPV_EXTRA=--ao=null --volume=0 --audio-display=no"',
+        '"TUI_PERF_SCENARIO_SHA256=$scenario_hash"',
+        '"TUI_PERF_RUN_ID=$run_id"',
+    ):
+        if required not in isolated_block:
+            raise AssertionError(f"isolated child environment is missing {required}")
+    for forbidden in ('"GEMINI_API_KEY=', '"YTM_PLAY_URL=', '"YTM_PERF='):
+        if forbidden in isolated_block:
+            raise AssertionError(f"isolated child environment inherited {forbidden}")
+    for required_command in (
+        'env -i "${isolated_env[@]}" "$sampler"',
+        'env -i "${isolated_env[@]}" "$controller"',
+    ):
+        if required_command not in shell:
+            raise AssertionError(f"child process does not use empty-environment launch: {required_command}")
+
+    ambient = {
+        **os.environ,
+        "GEMINI_API_KEY": "hostile-ambient-value",
+        "YTM_PLAY_URL": "https://remote.example.invalid/must-not-survive",
+        "YTM_PERF": "1",
+    }
+    preserved_path = os.environ.get("PATH", "")
+    probe = subprocess.run(
+        [
+            "env",
+            "-i",
+            f"PATH={preserved_path}",
+            "LANG=C",
+            sys.executable,
+            "-c",
+            (
+                "import json,os; "
+                "print(json.dumps({k:os.environ.get(k) for k in "
+                "['PATH','LANG','GEMINI_API_KEY','YTM_PLAY_URL','YTM_PERF']}))"
+            ),
+        ],
+        env=ambient,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if probe.returncode != 0:
+        raise AssertionError(f"env -i policy probe failed: {probe.stderr.strip()}")
+    observed = json.loads(probe.stdout)
+    require_artifact_value(shell_path, "child PATH passthrough", observed["PATH"], preserved_path)
+    require_artifact_value(shell_path, "child LANG passthrough", observed["LANG"], "C")
+    for key in ("GEMINI_API_KEY", "YTM_PLAY_URL", "YTM_PERF"):
+        if observed[key] is not None:
+            raise AssertionError(f"env -i policy retained hostile ambient key {key}")
 
 
 def command_fixture(args: argparse.Namespace) -> int:
@@ -813,6 +5048,14 @@ def command_check(args: argparse.Namespace) -> int:
                 and identity["input_ipc_server_argv"]
             ):
                 raise ValueError("sampler mpv cleanup identity is incomplete")
+        validate_measured_samples(
+            args.samples,
+            headers[0],
+            summaries[0],
+            [record for record in records if record.get("kind") == "sample"],
+            True,
+            REQUIRED_PLAYBACK_MPV_CACHE_ARGS,
+        )
     if args.control:
         control = read_ndjson(args.control)
         control_summaries = [record for record in control if record.get("kind") == "summary"]
@@ -828,6 +5071,20 @@ def command_check(args: argparse.Namespace) -> int:
             raise ValueError("control output needs exactly one header")
         if args.scenario_sha256 and control_headers[0].get("scenario_sha256") != args.scenario_sha256:
             raise ValueError("control scenario SHA-256 does not match the selected scenario file")
+        require_artifact_value(
+            args.control,
+            "controller buffering cutoff",
+            control_headers[0].get("buffering_cutoff_ns"),
+            control_summaries[0].get("buffering_cutoff_ns"),
+        )
+        require_artifact_value(
+            args.control,
+            "controller buffering cutoff/observation duration",
+            control_headers[0].get("buffering_cutoff_ns"),
+            control_headers[0].get("observe_ns"),
+        )
+        validate_control_buffering(args.control, control, control_summaries[0])
+        validate_control_time_pos_summary(args.control, control, control_summaries[0])
     print(json.dumps({"ok": True, "measured_samples": len(measured)}))
     return 0
 
@@ -837,17 +5094,70 @@ class FixtureServer(http.server.ThreadingHTTPServer):
 
     def __init__(self, address: tuple[str, int], handler: type[http.server.BaseHTTPRequestHandler],
                  file: Path, throttle_bps: int, outage_every_bytes: int, outage_ms: int,
-                 disconnect_every_bytes: int):
+                 disconnect_every_bytes: int, request_log: Path, run_id: str,
+                 shutdown_token: str | None = None):
         super().__init__(address, handler)
         self.fixture_file = file
+        self.fixture_sha256 = sha256_file(file)
+        self.run_id = run_id
+        self.shutdown_token = shutdown_token
+        self.request_log = request_log.resolve()
+        if self.request_log.exists():
+            raise ValueError("--request-log must name a new path")
+        self.request_log.parent.mkdir(parents=True, exist_ok=True)
+        self.request_log.touch()
         self.throttle_bps = throttle_bps
         self.outage_every_bytes = outage_every_bytes
         self.outage_ms = outage_ms
         self.disconnect_every_bytes = disconnect_every_bytes
         self.transfer_lock = threading.Lock()
-        self.total_transferred = 0
+        self.log_lock = threading.Lock()
+        self.request_counter = 0
+        self.total_socket_bytes_accepted = 0
         self.next_outage = outage_every_bytes if outage_every_bytes else 0
         self.next_disconnect = disconnect_every_bytes if disconnect_every_bytes else 0
+        self.pacing_origin_monotonic_ns = time.monotonic_ns()
+        # Zero initial credit: the first throttled chunk reserves its full byte-time before
+        # any body byte is written.  One shared deadline makes concurrent Range connections
+        # consume the same aggregate budget rather than receiving a budget per handler.
+        self.next_byte_deadline_monotonic_ns = self.pacing_origin_monotonic_ns
+
+    def next_request_id(self) -> int:
+        with self.log_lock:
+            self.request_counter += 1
+            return self.request_counter
+
+    def log_request(self, record: dict[str, Any]) -> None:
+        value = {
+            "schema": "ytt.tui-perf.http-request.v1",
+            "run_id": self.run_id,
+            "server_pid": os.getpid(),
+            "fixture_sha256": self.fixture_sha256,
+            **record,
+        }
+        encoded = json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n"
+        with self.log_lock:
+            with self.request_log.open("a", encoding="utf-8") as stream:
+                stream.write(encoded)
+                stream.flush()
+                os.fsync(stream.fileno())
+
+    def reserve_pacing_deadline(self, byte_count: int) -> tuple[int, int | None]:
+        reserved_ns = time.monotonic_ns()
+        if not self.throttle_bps:
+            return reserved_ns, None
+        byte_time_ns = (byte_count * 1_000_000_000 + self.throttle_bps - 1) // self.throttle_bps
+        deadline_ns = max(self.next_byte_deadline_monotonic_ns, reserved_ns) + byte_time_ns
+        self.next_byte_deadline_monotonic_ns = deadline_ns
+        return reserved_ns, deadline_ns
+
+    @staticmethod
+    def wait_for_pacing_deadline(deadline_ns: int | None) -> None:
+        while deadline_ns is not None:
+            remaining_ns = deadline_ns - time.monotonic_ns()
+            if remaining_ns <= 0:
+                return
+            time.sleep(remaining_ns / 1_000_000_000)
 
 
 class RangeFixtureHandler(http.server.BaseHTTPRequestHandler):
@@ -863,22 +5173,101 @@ class RangeFixtureHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self) -> None:  # noqa: N802 (BaseHTTPRequestHandler API)
         self._serve(send_body=True)
 
+    def do_POST(self) -> None:  # noqa: N802 (BaseHTTPRequestHandler API)
+        server = self.perf_server
+        path = self.path.split("?", 1)[0]
+        authorization = self.headers.get("Authorization", "")
+        requested_run_id = self.headers.get("X-Ytt-Tui-Perf-Run-Id", "")
+        expected_authorization = (
+            f"Bearer {server.shutdown_token}" if server.shutdown_token is not None else ""
+        )
+        authorized = (
+            path == HTTP_SHUTDOWN_PATH
+            and server.shutdown_token is not None
+            and secrets.compare_digest(authorization, expected_authorization)
+            and secrets.compare_digest(requested_run_id, server.run_id)
+            and self.headers.get("Content-Length") in {None, "0"}
+        )
+        if not authorized:
+            self.send_response(403)
+            self.send_header("Content-Length", "0")
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.close_connection = True
+            return
+        token_sha256 = hashlib.sha256(server.shutdown_token.encode("ascii")).hexdigest()
+        payload = json.dumps(
+            {
+                "schema": HTTP_SHUTDOWN_SCHEMA,
+                "run_id": server.run_id,
+                "pid": os.getpid(),
+                "token_sha256": token_sha256,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(payload)
+        self.wfile.flush()
+        self.close_connection = True
+        threading.Thread(
+            target=server.shutdown,
+            name="ytt-tui-perf-http-shutdown",
+            daemon=True,
+        ).start()
+
     def _serve(self, send_body: bool) -> None:
         server = self.perf_server
-        if self.path.split("?", 1)[0] not in {"/fixture.wav", "/" + server.fixture_file.name}:
+        request_id = server.next_request_id()
+        path = self.path.split("?", 1)[0]
+        method = "GET" if send_body else "HEAD"
+        started_ns = time.monotonic_ns()
+        if path != "/fixture.wav":
+            server.log_request({
+                "kind": "request_terminal", "request_id": request_id, "method": method,
+                "path": path, "range_header": self.headers.get("Range"), "status": 404,
+                "planned_start": None, "planned_end": None, "bytes_planned": 0,
+                "server_socket_bytes_accepted": 0,
+                "started_monotonic_ns": started_ns,
+                "finished_monotonic_ns": time.monotonic_ns(), "terminal_reason": "unexpected_path",
+                "outage_or_disconnect_action": None,
+            })
             self.send_error(404)
             return
         size = server.fixture_file.stat().st_size
         try:
             start, end, partial = parse_range(self.headers.get("Range"), size)
         except ValueError:
+            server.log_request({
+                "kind": "request_terminal", "request_id": request_id, "method": method,
+                "path": path, "range_header": self.headers.get("Range"), "status": 416,
+                "planned_start": None, "planned_end": None, "bytes_planned": 0,
+                "server_socket_bytes_accepted": 0,
+                "started_monotonic_ns": started_ns,
+                "finished_monotonic_ns": time.monotonic_ns(), "terminal_reason": "invalid_range",
+                "outage_or_disconnect_action": None,
+            })
             self.send_response(416)
             self.send_header("Content-Range", f"bytes */{size}")
             self.send_header("Content-Length", "0")
             self.end_headers()
             return
         length = end - start + 1
-        self.send_response(206 if partial else 200)
+        status = 206 if partial else 200
+        server.log_request({
+            "kind": "request_started", "request_id": request_id, "method": method,
+            "path": path, "range_header": self.headers.get("Range"), "status": status,
+            "planned_start": start, "planned_end": end, "bytes_planned": length,
+            "server_socket_bytes_accepted": 0,
+            "started_monotonic_ns": started_ns,
+            "finished_monotonic_ns": None, "terminal_reason": None,
+            "outage_or_disconnect_action": None,
+        })
+        self.send_response(status)
         self.send_header("Accept-Ranges", "bytes")
         self.send_header("Content-Type", "audio/wav")
         self.send_header("Content-Length", str(length))
@@ -887,33 +5276,103 @@ class RangeFixtureHandler(http.server.BaseHTTPRequestHandler):
             self.send_header("Content-Range", f"bytes {start}-{end}/{size}")
         self.end_headers()
         if not send_body:
+            server.log_request({
+                "kind": "request_terminal", "request_id": request_id, "method": method,
+                "path": path, "range_header": self.headers.get("Range"), "status": status,
+                "planned_start": start, "planned_end": end, "bytes_planned": length,
+                "server_socket_bytes_accepted": 0,
+                "started_monotonic_ns": started_ns,
+                "finished_monotonic_ns": time.monotonic_ns(), "terminal_reason": "head_complete",
+                "outage_or_disconnect_action": None,
+            })
             return
 
         remaining = length
+        delivered = 0
+        terminal_reason = "complete"
         with server.fixture_file.open("rb") as stream:
             stream.seek(start)
             while remaining:
-                chunk = stream.read(min(64 * 1024, remaining))
-                if not chunk:
-                    return
-                action = transfer_action(server, len(chunk))
-                if action == "outage":
-                    time.sleep(server.outage_ms / 1000.0)
-                elif action == "disconnect":
-                    self.close_connection = True
-                    return
-                started = time.monotonic()
-                try:
-                    self.wfile.write(chunk)
-                    self.wfile.flush()
-                except (BrokenPipeError, ConnectionResetError):
-                    return
-                remaining -= len(chunk)
-                if server.throttle_bps:
-                    target = len(chunk) / server.throttle_bps
-                    delay = target - (time.monotonic() - started)
-                    if delay > 0:
-                        time.sleep(delay)
+                with server.transfer_lock:
+                    max_chunk = HTTP_THROTTLE_CHUNK_BYTES if server.throttle_bps else 64 * 1024
+                    limit = min(max_chunk, remaining)
+                    thresholds = [
+                        threshold - server.total_socket_bytes_accepted
+                        for threshold in (server.next_outage, server.next_disconnect)
+                        if threshold and threshold > server.total_socket_bytes_accepted
+                    ]
+                    if thresholds:
+                        limit = min(limit, min(thresholds))
+                    chunk = stream.read(limit)
+                    if not chunk:
+                        terminal_reason = "fixture_eof"
+                        break
+                    pacing_reserved_ns, pacing_deadline_ns = server.reserve_pacing_deadline(
+                        len(chunk)
+                    )
+                    server.wait_for_pacing_deadline(pacing_deadline_ns)
+                    write_started_ns = time.monotonic_ns()
+                    try:
+                        self.wfile.write(chunk)
+                        self.wfile.flush()
+                    except (BrokenPipeError, ConnectionResetError):
+                        # No body bytes were delivered.  Because this handler still owns the
+                        # global transfer lock, discard the failed reservation without granting
+                        # future credit; the next successful chunk will wait its complete time.
+                        if server.throttle_bps:
+                            server.next_byte_deadline_monotonic_ns = time.monotonic_ns()
+                        terminal_reason = "client_disconnect"
+                        break
+                    write_finished_ns = time.monotonic_ns()
+                    remaining -= len(chunk)
+                    delivered += len(chunk)
+                    server.total_socket_bytes_accepted += len(chunk)
+                    actions: list[dict[str, Any]] = []
+                    if (
+                        server.next_outage
+                        and server.total_socket_bytes_accepted >= server.next_outage
+                    ):
+                        actions.append({"action": "outage", "threshold": server.next_outage})
+                        server.next_outage += server.outage_every_bytes
+                    if (
+                        server.next_disconnect
+                        and server.total_socket_bytes_accepted >= server.next_disconnect
+                    ):
+                        actions.append({"action": "disconnect", "threshold": server.next_disconnect})
+                        server.next_disconnect += server.disconnect_every_bytes
+                    server.log_request({
+                        "kind": "delivery", "request_id": request_id, "method": method,
+                        "path": path, "range_header": self.headers.get("Range"), "status": status,
+                        "planned_start": start, "planned_end": end, "bytes_planned": length,
+                        "server_socket_bytes_accepted": len(chunk),
+                        "request_server_socket_bytes_accepted": delivered,
+                        "global_server_socket_bytes_accepted": (
+                            server.total_socket_bytes_accepted
+                        ),
+                        "started_monotonic_ns": started_ns,
+                        "finished_monotonic_ns": time.monotonic_ns(), "terminal_reason": None,
+                        "pacing_reserved_monotonic_ns": pacing_reserved_ns,
+                        "pacing_deadline_monotonic_ns": pacing_deadline_ns,
+                        "write_started_monotonic_ns": write_started_ns,
+                        "write_finished_monotonic_ns": write_finished_ns,
+                        "outage_or_disconnect_action": actions or None,
+                    })
+                    if any(action["action"] == "outage" for action in actions):
+                        time.sleep(server.outage_ms / 1000.0)
+                    if any(action["action"] == "disconnect" for action in actions):
+                        terminal_reason = "planned_disconnect"
+                        self.close_connection = True
+                        remaining = 0
+                        break
+        server.log_request({
+            "kind": "request_terminal", "request_id": request_id, "method": method,
+            "path": path, "range_header": self.headers.get("Range"), "status": status,
+            "planned_start": start, "planned_end": end, "bytes_planned": length,
+            "server_socket_bytes_accepted": delivered,
+            "started_monotonic_ns": started_ns,
+            "finished_monotonic_ns": time.monotonic_ns(), "terminal_reason": terminal_reason,
+            "outage_or_disconnect_action": None,
+        })
 
     def log_message(self, fmt: str, *values: Any) -> None:
         if getattr(self.server, "verbose", False):
@@ -938,26 +5397,222 @@ def parse_range(header: str | None, size: int) -> tuple[int, int, bool]:
     return start, min(end, size - 1), True
 
 
-def transfer_action(server: FixtureServer, count: int) -> str | None:
-    with server.transfer_lock:
-        server.total_transferred += count
-        if server.next_disconnect and server.total_transferred >= server.next_disconnect:
-            while server.next_disconnect <= server.total_transferred:
-                server.next_disconnect += server.disconnect_every_bytes
-            return "disconnect"
-        if server.next_outage and server.total_transferred >= server.next_outage:
-            while server.next_outage <= server.total_transferred:
-                server.next_outage += server.outage_every_bytes
-            return "outage"
-    return None
+def exact_cli_argument_values(command: list[str], flag: str) -> list[str]:
+    values: list[str] = []
+    index = 0
+    while index < len(command):
+        argument = command[index]
+        if argument == flag:
+            if index + 1 >= len(command):
+                raise ValueError(f"exact command has a terminal {flag}")
+            values.append(command[index + 1])
+            index += 2
+            continue
+        prefix = f"{flag}="
+        if argument.startswith(prefix):
+            values.append(argument[len(prefix) :])
+        index += 1
+    return values
+
+
+def validate_fixture_server_manifest(
+    path: Path, document: dict[str, Any], expected_run_id: str | None
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    require_artifact_value(path, "HTTP schema", document.get("schema"), "ytt.tui-perf.http.v1")
+    run_id = document.get("run_id")
+    if not isinstance(run_id, str) or not run_id:
+        raise ValueError(f"{path}: HTTP run_id is missing")
+    if expected_run_id is not None:
+        require_artifact_value(path, "HTTP shutdown run_id", run_id, expected_run_id)
+    pid = non_negative_integer(document.get("pid"), "HTTP server PID", path)
+    if pid == 0:
+        raise ValueError(f"{path}: HTTP server PID must be positive")
+    host = document.get("host")
+    if not isinstance(host, str):
+        raise ValueError(f"{path}: HTTP server host is malformed")
+    try:
+        host_address = ipaddress.ip_address(host)
+    except ValueError as error:
+        raise ValueError(f"{path}: HTTP server host is malformed") from error
+    if not host_address.is_loopback:
+        raise ValueError(f"{path}: HTTP shutdown endpoint is not loopback")
+    port = non_negative_integer(document.get("port"), "HTTP server port", path)
+    if port <= 0 or port > 65535:
+        raise ValueError(f"{path}: HTTP server port is outside 1..65535")
+    require_artifact_value(
+        path,
+        "HTTP fixture URL",
+        document.get("url"),
+        f"http://{host}:{port}/fixture.wav",
+    )
+
+    shutdown = document.get("shutdown")
+    if not isinstance(shutdown, dict):
+        raise ValueError(f"{path}: authenticated HTTP shutdown identity is missing")
+    require_artifact_value(path, "HTTP shutdown schema", shutdown.get("schema"), HTTP_SHUTDOWN_SCHEMA)
+    require_artifact_value(path, "HTTP shutdown method", shutdown.get("method"), HTTP_SHUTDOWN_METHOD)
+    require_artifact_value(path, "HTTP shutdown path", shutdown.get("path"), HTTP_SHUTDOWN_PATH)
+    token = shutdown.get("token")
+    if not isinstance(token, str) or re.fullmatch(r"[A-Za-z0-9_-]{43,128}", token) is None:
+        raise ValueError(f"{path}: HTTP shutdown token is malformed")
+    token_sha256 = hashlib.sha256(token.encode("ascii")).hexdigest()
+    require_artifact_value(
+        path, "HTTP shutdown token SHA-256", shutdown.get("token_sha256"), token_sha256
+    )
+    require_artifact_value(path, "HTTP shutdown run_id binding", shutdown.get("run_id"), run_id)
+
+    identity = document.get("server_process")
+    if not isinstance(identity, dict):
+        raise ValueError(f"{path}: exact HTTP server process identity is missing")
+    require_artifact_value(
+        path,
+        "HTTP server process identity schema",
+        identity.get("schema"),
+        "ytt.tui-perf.http-process.v1",
+    )
+    require_artifact_value(path, "HTTP server identity PID", identity.get("pid"), pid)
+    for field in ("start_time_unix_s", "executable_bytes"):
+        if non_negative_integer(identity.get(field), f"HTTP server {field}", path) <= 0:
+            raise ValueError(f"{path}: HTTP server {field} must be positive")
+    native_start_token = identity.get("native_start_token")
+    executable = identity.get("executable")
+    executable_sha256 = identity.get("executable_sha256")
+    command = identity.get("command")
+    if (
+        not isinstance(native_start_token, str)
+        or not native_start_token
+        or not isinstance(executable, str)
+        or not executable
+        or not isinstance(executable_sha256, str)
+        or re.fullmatch(r"[0-9a-f]{64}", executable_sha256) is None
+        or not isinstance(command, list)
+        or not command
+        or not all(isinstance(item, str) for item in command)
+    ):
+        raise ValueError(f"{path}: exact HTTP server executable/argv identity is malformed")
+    if exact_cli_argument_values(command, "--run-id") != [run_id]:
+        raise ValueError(f"{path}: exact HTTP server argv does not bind its run_id")
+    if exact_cli_argument_values(command, "--shutdown-token") != [token]:
+        raise ValueError(f"{path}: exact HTTP server argv does not bind its shutdown token")
+    if command.count("serve") != 1:
+        raise ValueError(f"{path}: exact HTTP server argv does not bind the serve subcommand")
+    return identity, shutdown
+
+
+def stop_fixture_server(
+    identity_path: Path, expected_run_id: str | None, timeout_secs: float
+) -> dict[str, Any]:
+    if os.name == "nt":
+        raise ValueError("exact fixture server shutdown CLI is Unix-only")
+    if not math.isfinite(timeout_secs) or timeout_secs <= 0:
+        raise ValueError("--timeout-secs must be finite and positive")
+    document = load_json_object(identity_path)
+    identity, shutdown = validate_fixture_server_manifest(
+        identity_path, document, expected_run_id
+    )
+    observation = fixture_server_process_observation(int(identity["pid"]))
+    if not fixture_server_identity_matches(identity, observation):
+        return {
+            "ok": True,
+            "already_stopped": True,
+            "identity": str(identity_path),
+            "reason": "exact_process_identity_not_live",
+        }
+
+    deadline = time.monotonic() + timeout_secs
+    remaining = max(0.05, deadline - time.monotonic())
+    connection = http.client.HTTPConnection(
+        str(document["host"]), int(document["port"]), timeout=min(2.0, remaining)
+    )
+    try:
+        connection.request(
+            "POST",
+            str(shutdown["path"]),
+            body=b"",
+            headers={
+                "Authorization": f"Bearer {shutdown['token']}",
+                "Content-Length": "0",
+                "X-Ytt-Tui-Perf-Run-Id": str(document["run_id"]),
+            },
+        )
+        response = connection.getresponse()
+        payload_bytes = response.read()
+    except (OSError, http.client.HTTPException) as error:
+        current = fixture_server_process_observation(int(identity["pid"]))
+        if not fixture_server_identity_matches(identity, current):
+            return {
+                "ok": True,
+                "already_stopped": True,
+                "identity": str(identity_path),
+                "reason": "exact_process_exited_before_shutdown_response",
+            }
+        raise ValueError(
+            f"{identity_path}: authenticated fixture shutdown request failed: {error}"
+        ) from error
+    finally:
+        connection.close()
+    if response.status != 200:
+        raise ValueError(
+            f"{identity_path}: authenticated fixture shutdown returned HTTP {response.status}"
+        )
+    try:
+        payload = json.loads(
+            payload_bytes.decode("utf-8"), object_pairs_hook=reject_duplicate_json_keys
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, DuplicateJsonKeyError) as error:
+        raise ValueError(
+            f"{identity_path}: authenticated fixture shutdown response is malformed"
+        ) from error
+    if not isinstance(payload, dict):
+        raise ValueError(f"{identity_path}: fixture shutdown response must be an object")
+    require_artifact_value(
+        identity_path, "fixture shutdown response schema", payload.get("schema"), HTTP_SHUTDOWN_SCHEMA
+    )
+    require_artifact_value(
+        identity_path, "fixture shutdown response run_id", payload.get("run_id"), document["run_id"]
+    )
+    require_artifact_value(
+        identity_path, "fixture shutdown response PID", payload.get("pid"), identity["pid"]
+    )
+    require_artifact_value(
+        identity_path,
+        "fixture shutdown response token SHA-256",
+        payload.get("token_sha256"),
+        shutdown["token_sha256"],
+    )
+    while time.monotonic() < deadline:
+        current = fixture_server_process_observation(int(identity["pid"]))
+        if not fixture_server_identity_matches(identity, current):
+            return {
+                "ok": True,
+                "already_stopped": False,
+                "identity": str(identity_path),
+                "reason": "authenticated_loopback_shutdown",
+            }
+        time.sleep(0.02)
+    raise ValueError(
+        f"{identity_path}: exact fixture server survived authenticated shutdown"
+    )
+
+
+def command_stop_server(args: argparse.Namespace) -> int:
+    result = stop_fixture_server(args.identity, args.expected_run_id, args.timeout_secs)
+    print(json.dumps(result, sort_keys=True))
+    return 0
 
 
 def command_serve(args: argparse.Namespace) -> int:
     if not args.file.is_file():
         raise ValueError(f"fixture does not exist: {args.file}")
+    if not args.run_id:
+        raise ValueError("--run-id must not be empty")
+    if re.fullmatch(r"[A-Za-z0-9_-]{43,128}", args.shutdown_token) is None:
+        raise ValueError("--shutdown-token must be a 43..128 character URL-safe secret")
     for name in ("throttle_bps", "outage_every_bytes", "outage_ms", "disconnect_every_bytes"):
         if getattr(args, name) < 0:
             raise ValueError(f"--{name.replace('_', '-')} must be non-negative")
+    started_unix_ns = time.time_ns()
+    started_monotonic_ns = time.monotonic_ns()
     server = FixtureServer(
         (args.host, args.port),
         RangeFixtureHandler,
@@ -966,9 +5621,15 @@ def command_serve(args: argparse.Namespace) -> int:
         args.outage_every_bytes,
         args.outage_ms,
         args.disconnect_every_bytes,
+        args.request_log,
+        args.run_id,
+        args.shutdown_token,
     )
     server.verbose = args.verbose  # type: ignore[attr-defined]
     host, port = server.server_address[:2]
+    server_process = fixture_server_process_observation(os.getpid())
+    if server_process is None:
+        raise ValueError("cannot capture the exact fixture server process identity")
     manifest = {
         "schema": "ytt.tui-perf.http.v1",
         "pid": os.getpid(),
@@ -976,7 +5637,34 @@ def command_serve(args: argparse.Namespace) -> int:
         "port": port,
         "url": f"http://{host}:{port}/fixture.wav",
         "fixture_sha256": sha256_file(args.file),
+        "fixture_bytes": args.file.stat().st_size,
+        "run_id": args.run_id,
+        "server_process": {
+            "schema": "ytt.tui-perf.http-process.v1",
+            **server_process,
+        },
+        "shutdown": {
+            "schema": HTTP_SHUTDOWN_SCHEMA,
+            "method": HTTP_SHUTDOWN_METHOD,
+            "path": HTTP_SHUTDOWN_PATH,
+            "run_id": args.run_id,
+            "token": args.shutdown_token,
+            "token_sha256": hashlib.sha256(
+                args.shutdown_token.encode("ascii")
+            ).hexdigest(),
+        },
+        "started_unix_ns": started_unix_ns,
+        "started_monotonic_ns": started_monotonic_ns,
+        "request_log": str(args.request_log.resolve()),
         "throttle_bps": args.throttle_bps,
+        "pacing_policy": "global_monotonic_next_byte_deadline_v1",
+        "pacing_origin_monotonic_ns": server.pacing_origin_monotonic_ns,
+        "pacing_initial_credit_bytes": 0,
+        "pacing_max_chunk_bytes": HTTP_THROTTLE_CHUNK_BYTES,
+        "delivery_evidence": "server_socket_bytes_accepted",
+        "delivery_evidence_limitation": (
+            "wfile_write_flush_proves_kernel_socket_acceptance_not_client_decode_or_playback"
+        ),
         "outage_every_bytes": args.outage_every_bytes,
         "outage_ms": args.outage_ms,
         "disconnect_every_bytes": args.disconnect_every_bytes,
@@ -994,6 +5682,920 @@ def command_serve(args: argparse.Namespace) -> int:
     finally:
         server.server_close()
     return 0
+
+
+def validate_http_request_log(
+    path: Path,
+    http: dict[str, Any],
+    profile: dict[str, Any],
+    run_contract: dict[str, Any] | None = None,
+) -> None:
+    records = read_ndjson(path)
+    if not records:
+        raise ValueError(f"{path}: HTTP request log is empty")
+    throttle_bps = non_negative_integer(profile.get("throttle_bps"), "throttle_bps", path)
+    outage_every_bytes = non_negative_integer(
+        profile.get("outage_every_bytes"), "outage_every_bytes", path
+    )
+    outage_ms = non_negative_integer(profile.get("outage_ms"), "outage_ms", path)
+    disconnect_every_bytes = non_negative_integer(
+        profile.get("disconnect_every_bytes"), "disconnect_every_bytes", path
+    )
+    require_artifact_value(path, "HTTP throttle", http.get("throttle_bps"), throttle_bps)
+    require_artifact_value(
+        path, "HTTP outage threshold", http.get("outage_every_bytes"), outage_every_bytes
+    )
+    require_artifact_value(path, "HTTP outage delay", http.get("outage_ms"), outage_ms)
+    require_artifact_value(
+        path,
+        "HTTP disconnect threshold",
+        http.get("disconnect_every_bytes"),
+        disconnect_every_bytes,
+    )
+    require_artifact_value(
+        path,
+        "HTTP pacing policy",
+        http.get("pacing_policy"),
+        "global_monotonic_next_byte_deadline_v1",
+    )
+    require_artifact_value(
+        path, "HTTP pacing initial credit", http.get("pacing_initial_credit_bytes"), 0
+    )
+    require_artifact_value(
+        path,
+        "HTTP pacing maximum chunk",
+        http.get("pacing_max_chunk_bytes"),
+        HTTP_THROTTLE_CHUNK_BYTES,
+    )
+    require_artifact_value(
+        path,
+        "HTTP delivery evidence",
+        http.get("delivery_evidence"),
+        "server_socket_bytes_accepted",
+    )
+    require_artifact_value(
+        path,
+        "HTTP delivery evidence limitation",
+        http.get("delivery_evidence_limitation"),
+        "wfile_write_flush_proves_kernel_socket_acceptance_not_client_decode_or_playback",
+    )
+    server_started_ns = non_negative_integer(
+        http.get("started_monotonic_ns"), "HTTP server monotonic start", path
+    )
+    pacing_origin_ns = non_negative_integer(
+        http.get("pacing_origin_monotonic_ns"), "HTTP pacing origin", path
+    )
+    if pacing_origin_ns < server_started_ns:
+        raise ValueError(f"{path}: HTTP pacing origin precedes server startup")
+    if run_contract is not None and not (
+        run_contract["started_monotonic_ns"]
+        <= pacing_origin_ns
+        <= run_contract["finished_monotonic_ns"]
+    ):
+        raise ValueError(f"{path}: HTTP pacing origin escapes its run contract")
+    starts: dict[int, dict[str, Any]] = {}
+    request_delivered: dict[int, int] = {}
+    request_last_write_finished: dict[int, int] = {}
+    terminal_ids: set[int] = set()
+    global_delivered = 0
+    get_count = 0
+    total_get_server_socket_bytes_accepted = 0
+    previous_pacing_deadline_ns = pacing_origin_ns
+    previous_write_finished_ns: int | None = None
+    fault_thresholds_seen: dict[str, set[int]] = {
+        "outage": set(),
+        "disconnect": set(),
+    }
+    pending_outage: dict[str, Any] | None = None
+    disconnect_actions: dict[int, int] = {}
+    disconnect_terminals: set[int] = set()
+    fixture_bytes = non_negative_integer(http.get("fixture_bytes"), "fixture_bytes", path)
+    for index, record in enumerate(records):
+        require_artifact_value(path, f"HTTP record {index} schema", record.get("schema"), "ytt.tui-perf.http-request.v1")
+        require_artifact_value(path, f"HTTP record {index} run_id", record.get("run_id"), http.get("run_id"))
+        require_artifact_value(path, f"HTTP record {index} server PID", record.get("server_pid"), http.get("pid"))
+        require_artifact_value(path, f"HTTP record {index} fixture", record.get("fixture_sha256"), http.get("fixture_sha256"))
+        request_id = non_negative_integer(record.get("request_id"), "request_id", path)
+        if request_id == 0:
+            raise ValueError(f"{path}: request_id must be positive")
+        kind = record.get("kind")
+        if kind not in {"request_started", "delivery", "request_terminal"}:
+            raise ValueError(f"{path}: HTTP record {index} has unexpected kind {kind!r}")
+        method = record.get("method")
+        request_path = record.get("path")
+        if method not in {"GET", "HEAD"} or request_path != "/fixture.wav":
+            raise ValueError(f"{path}: unexpected HTTP request {method!r} {request_path!r}")
+        started_ns = non_negative_integer(record.get("started_monotonic_ns"), "HTTP started time", path)
+        finished_ns = record.get("finished_monotonic_ns")
+        if finished_ns is not None:
+            finished_ns = non_negative_integer(finished_ns, "HTTP finished time", path)
+            if finished_ns < started_ns:
+                raise ValueError(f"{path}: HTTP request finished before it started")
+        if run_contract is not None:
+            if started_ns < run_contract["started_monotonic_ns"] or (
+                finished_ns is not None
+                and finished_ns > run_contract["finished_monotonic_ns"]
+            ):
+                raise ValueError(f"{path}: HTTP request interval escapes its run contract")
+        if kind == "request_started":
+            if request_id in starts:
+                raise ValueError(f"{path}: duplicate HTTP request start {request_id}")
+            if finished_ns is not None:
+                raise ValueError(f"{path}: HTTP request start {request_id} is already finished")
+            status = record.get("status")
+            if status not in {200, 206}:
+                raise ValueError(f"{path}: started request has invalid status {status!r}")
+            planned_start = non_negative_integer(record.get("planned_start"), "planned_start", path)
+            planned_end = non_negative_integer(record.get("planned_end"), "planned_end", path)
+            planned_bytes = non_negative_integer(record.get("bytes_planned"), "bytes_planned", path)
+            if planned_start > planned_end or planned_end >= fixture_bytes or planned_bytes != planned_end - planned_start + 1:
+                raise ValueError(f"{path}: request {request_id} has invalid planned byte range")
+            if status == 200 and (planned_start != 0 or planned_end != fixture_bytes - 1):
+                raise ValueError(f"{path}: full response does not cover the fixture")
+            if status == 206 and not isinstance(record.get("range_header"), str):
+                raise ValueError(f"{path}: partial response has no Range header")
+            require_artifact_value(
+                path,
+                f"request {request_id} initial server socket bytes accepted",
+                record.get("server_socket_bytes_accepted"),
+                0,
+            )
+            starts[request_id] = record
+            request_delivered[request_id] = 0
+            get_count += int(method == "GET")
+            continue
+        start = starts.get(request_id)
+        if start is None:
+            raise ValueError(f"{path}: HTTP {kind} precedes request start {request_id}")
+        if request_id in terminal_ids:
+            raise ValueError(f"{path}: HTTP {kind} follows terminal record {request_id}")
+        for field in ("method", "path", "range_header", "status", "planned_start", "planned_end", "bytes_planned", "started_monotonic_ns"):
+            require_artifact_value(path, f"request {request_id} stable {field}", record.get(field), start.get(field))
+        if kind == "delivery":
+            if request_id in disconnect_actions:
+                raise ValueError(
+                    f"{path}: delivery follows request {request_id}'s disconnect action"
+                )
+            if finished_ns is None:
+                raise ValueError(f"{path}: HTTP delivery {request_id} has no completion time")
+            delivered = non_negative_integer(
+                record.get("server_socket_bytes_accepted"),
+                "server socket bytes accepted",
+                path,
+            )
+            if delivered == 0:
+                raise ValueError(f"{path}: zero-length HTTP delivery")
+            if throttle_bps and delivered > HTTP_THROTTLE_CHUNK_BYTES:
+                raise ValueError(
+                    f"{path}: throttled HTTP delivery exceeds the bounded chunk size"
+                )
+            request_delivered[request_id] += delivered
+            if request_delivered[request_id] > start["bytes_planned"]:
+                raise ValueError(f"{path}: request {request_id} delivered beyond its byte range")
+            require_artifact_value(
+                path,
+                f"request {request_id} cumulative server socket bytes accepted",
+                record.get("request_server_socket_bytes_accepted"),
+                request_delivered[request_id],
+            )
+            previous_global = global_delivered
+            global_delivered += delivered
+            require_artifact_value(
+                path,
+                "global server socket bytes accepted",
+                record.get("global_server_socket_bytes_accepted"),
+                global_delivered,
+            )
+            pacing_reserved_ns = non_negative_integer(
+                record.get("pacing_reserved_monotonic_ns"),
+                "HTTP pacing reservation time",
+                path,
+            )
+            write_started_ns = non_negative_integer(
+                record.get("write_started_monotonic_ns"), "HTTP write start", path
+            )
+            write_finished_ns = non_negative_integer(
+                record.get("write_finished_monotonic_ns"), "HTTP write finish", path
+            )
+            if not (
+                start["started_monotonic_ns"]
+                <= pacing_reserved_ns
+                <= write_started_ns
+                <= write_finished_ns
+                <= finished_ns
+            ):
+                raise ValueError(f"{path}: HTTP delivery timestamps are not monotonic")
+            if pending_outage is not None:
+                required_after_outage_ns = (
+                    pending_outage["write_finished_monotonic_ns"]
+                    + outage_ms * 1_000_000
+                )
+                # The transfer lock remains held during an outage.  Consequently both the
+                # next global reservation and its write must occur after the delay; use the
+                # existing early-wakeup tolerance explicitly when checking that boundary.
+                next_reservation_or_write_ns = min(pacing_reserved_ns, write_started_ns)
+                if (
+                    next_reservation_or_write_ns + HTTP_PACING_EARLY_TOLERANCE_NS
+                    < required_after_outage_ns
+                ):
+                    raise ValueError(
+                        f"{path}: outage at threshold "
+                        f"{pending_outage['threshold']} has no delayed next global delivery"
+                    )
+                pending_outage = None
+            if (
+                previous_write_finished_ns is not None
+                and write_started_ns < previous_write_finished_ns
+            ):
+                raise ValueError(f"{path}: globally serialized HTTP writes overlap")
+            if throttle_bps:
+                pacing_deadline_ns = non_negative_integer(
+                    record.get("pacing_deadline_monotonic_ns"),
+                    "HTTP pacing deadline",
+                    path,
+                )
+                byte_time_ns = (
+                    delivered * 1_000_000_000 + throttle_bps - 1
+                ) // throttle_bps
+                expected_deadline_ns = max(
+                    previous_pacing_deadline_ns, pacing_reserved_ns
+                ) + byte_time_ns
+                require_artifact_value(
+                    path,
+                    "global HTTP pacing deadline",
+                    pacing_deadline_ns,
+                    expected_deadline_ns,
+                )
+                if write_started_ns + HTTP_PACING_EARLY_TOLERANCE_NS < pacing_deadline_ns:
+                    raise ValueError(f"{path}: HTTP bytes were written before their pacing deadline")
+                global_envelope_ns = pacing_origin_ns + (
+                    global_delivered * 1_000_000_000 + throttle_bps - 1
+                ) // throttle_bps
+                if write_started_ns + HTTP_PACING_EARLY_TOLERANCE_NS < global_envelope_ns:
+                    raise ValueError(f"{path}: global HTTP byte-time envelope was exceeded")
+                previous_pacing_deadline_ns = pacing_deadline_ns
+            elif record.get("pacing_deadline_monotonic_ns") is not None:
+                raise ValueError(f"{path}: unthrottled delivery recorded a pacing deadline")
+            previous_write_finished_ns = write_finished_ns
+            request_last_write_finished[request_id] = write_finished_ns
+            expected_actions = []
+            for action, every in (
+                ("outage", outage_every_bytes),
+                ("disconnect", disconnect_every_bytes),
+            ):
+                if every:
+                    first = ((previous_global // every) + 1) * every
+                    expected_actions.extend(
+                        {"action": action, "threshold": threshold}
+                        for threshold in range(first, global_delivered + 1, every)
+                    )
+            expected_actions.sort(key=lambda item: (item["threshold"], 0 if item["action"] == "outage" else 1))
+            actual_actions = record.get("outage_or_disconnect_action") or []
+            if not isinstance(actual_actions, list):
+                raise ValueError(f"{path}: delivery fault action must be an array or null")
+            if not all(isinstance(action, dict) for action in actual_actions):
+                raise ValueError(f"{path}: delivery fault actions must be objects")
+            actual_actions = sorted(
+                actual_actions,
+                key=lambda item: (
+                    item.get("threshold", -1),
+                    0 if item.get("action") == "outage" else 1,
+                ),
+            )
+            require_artifact_value(path, "HTTP fault action sequence", actual_actions, expected_actions)
+            action_names = {action["action"] for action in actual_actions}
+            for action in actual_actions:
+                fault_thresholds_seen[action["action"]].add(action["threshold"])
+            outage_actions = [
+                action for action in actual_actions if action["action"] == "outage"
+            ]
+            if outage_actions:
+                pending_outage = {
+                    "request_id": request_id,
+                    "threshold": outage_actions[-1]["threshold"],
+                    "write_finished_monotonic_ns": write_finished_ns,
+                    "coincident_disconnect": "disconnect" in action_names,
+                }
+            disconnect_actions_for_delivery = [
+                action for action in actual_actions if action["action"] == "disconnect"
+            ]
+            if disconnect_actions_for_delivery:
+                if request_id in disconnect_actions:
+                    raise ValueError(
+                        f"{path}: request {request_id} has multiple disconnect actions"
+                    )
+                disconnect_actions[request_id] = disconnect_actions_for_delivery[-1][
+                    "threshold"
+                ]
+            if start["method"] == "GET":
+                total_get_server_socket_bytes_accepted += delivered
+        else:
+            if finished_ns is None:
+                raise ValueError(f"{path}: HTTP terminal record {request_id} has no finish time")
+            terminal_ids.add(request_id)
+            require_artifact_value(
+                path,
+                f"request {request_id} terminal server socket bytes accepted",
+                record.get("server_socket_bytes_accepted"),
+                request_delivered[request_id],
+            )
+            if not isinstance(record.get("terminal_reason"), str) or not record["terminal_reason"]:
+                raise ValueError(f"{path}: HTTP terminal reason is missing")
+            disconnect_threshold = disconnect_actions.get(request_id)
+            if disconnect_threshold is not None:
+                if record["terminal_reason"] != "planned_disconnect":
+                    raise ValueError(
+                        f"{path}: disconnect action at threshold {disconnect_threshold} "
+                        "is not bound to a planned_disconnect terminal"
+                    )
+                disconnect_terminals.add(request_id)
+            elif record["terminal_reason"] == "planned_disconnect":
+                raise ValueError(
+                    f"{path}: planned_disconnect terminal {request_id} has no disconnect action"
+                )
+            if finished_ns < request_last_write_finished.get(request_id, start["started_monotonic_ns"]):
+                raise ValueError(f"{path}: HTTP terminal record predates its final write")
+            if (
+                pending_outage is not None
+                and pending_outage["request_id"] == request_id
+                and pending_outage["coincident_disconnect"]
+                and record["terminal_reason"] == "planned_disconnect"
+            ):
+                required_after_outage_ns = (
+                    pending_outage["write_finished_monotonic_ns"]
+                    + outage_ms * 1_000_000
+                )
+                if finished_ns + HTTP_PACING_EARLY_TOLERANCE_NS < required_after_outage_ns:
+                    raise ValueError(
+                        f"{path}: outage at threshold "
+                        f"{pending_outage['threshold']} has no delayed disconnect terminal"
+                    )
+                pending_outage = None
+            if record["terminal_reason"] == "complete" and (
+                start["method"] != "GET"
+                or request_delivered[request_id] != start["bytes_planned"]
+            ):
+                raise ValueError(f"{path}: completed HTTP request did not deliver its full range")
+            if record["terminal_reason"] == "head_complete" and (
+                start["method"] != "HEAD" or request_delivered[request_id] != 0
+            ):
+                raise ValueError(f"{path}: HEAD completion contains body bytes")
+    for action, first_threshold in (
+        ("outage", outage_every_bytes),
+        ("disconnect", disconnect_every_bytes),
+    ):
+        if first_threshold and first_threshold not in fault_thresholds_seen[action]:
+            raise ValueError(
+                f"{path}: configured {action} fault did not cross and record its first "
+                f"threshold {first_threshold}"
+            )
+    missing_disconnect_terminals = set(disconnect_actions) - disconnect_terminals
+    if missing_disconnect_terminals:
+        raise ValueError(
+            f"{path}: disconnect actions have no planned_disconnect terminal for requests "
+            f"{sorted(missing_disconnect_terminals)}"
+        )
+    if pending_outage is not None:
+        raise ValueError(
+            f"{path}: outage at threshold {pending_outage['threshold']} has no delayed "
+            "next global delivery"
+        )
+    # The orchestrator terminates the per-run fixture process after the measured owner and mpv
+    # are gone.  A handler that was blocked in a paced write may therefore have no terminal
+    # record.  Disconnect actions are the exception because the handler emits their bound
+    # terminal immediately; outage actions also need the timing proof checked above.
+    if fixture_bytes < HTTP_MEANINGFUL_GET_BYTES:
+        raise ValueError(f"{path}: fixture is too small to prove meaningful playback")
+    if (
+        get_count < 1
+        or total_get_server_socket_bytes_accepted < HTTP_MEANINGFUL_GET_BYTES
+    ):
+        raise ValueError(
+            f"{path}: server did not prove at least {HTTP_MEANINGFUL_GET_BYTES} "
+            "GET bytes accepted by the server socket "
+            f"(GETs={get_count}, bytes={total_get_server_socket_bytes_accepted}); "
+            "this is transport evidence, not client decode or playback proof"
+        )
+
+
+def http_pacing_self_test() -> None:
+    throttle_bps = 64 * 1024
+    fixture_bytes = HTTP_MEANINGFUL_GET_BYTES
+    origin_ns = 10_000_000_000
+    profile = {
+        "throttle_bps": throttle_bps,
+        "outage_every_bytes": 0,
+        "outage_ms": 0,
+        "disconnect_every_bytes": 0,
+    }
+    http = {
+        "schema": "ytt.tui-perf.http.v1",
+        "pid": 4242,
+        "run_id": "http-self-test",
+        "fixture_sha256": "a" * 64,
+        "fixture_bytes": fixture_bytes,
+        "started_monotonic_ns": origin_ns - 1,
+        "throttle_bps": throttle_bps,
+        "pacing_policy": "global_monotonic_next_byte_deadline_v1",
+        "pacing_origin_monotonic_ns": origin_ns,
+        "pacing_initial_credit_bytes": 0,
+        "pacing_max_chunk_bytes": HTTP_THROTTLE_CHUNK_BYTES,
+        "delivery_evidence": "server_socket_bytes_accepted",
+        "delivery_evidence_limitation": (
+            "wfile_write_flush_proves_kernel_socket_acceptance_not_client_decode_or_playback"
+        ),
+        "outage_every_bytes": profile["outage_every_bytes"],
+        "outage_ms": profile["outage_ms"],
+        "disconnect_every_bytes": profile["disconnect_every_bytes"],
+    }
+
+    def build_records(
+        requests: list[dict[str, Any]],
+        schedule: list[tuple[int, int]],
+        traffic_profile: dict[str, Any] | None = None,
+        apply_outage_delay: bool = True,
+    ) -> list[dict[str, Any]]:
+        active_profile = traffic_profile or profile
+        active_throttle_bps = int(active_profile["throttle_bps"])
+        records: list[dict[str, Any]] = []
+        specs = {int(item["request_id"]): item for item in requests}
+        accepted = {request_id: 0 for request_id in specs}
+        disconnected: set[int] = set()
+
+        def common() -> dict[str, Any]:
+            return {
+                "schema": "ytt.tui-perf.http-request.v1",
+                "run_id": http["run_id"],
+                "server_pid": http["pid"],
+                "fixture_sha256": http["fixture_sha256"],
+            }
+
+        for request_id, spec in specs.items():
+            planned = int(spec["planned_end"]) - int(spec["planned_start"]) + 1
+            records.append(
+                {
+                    **common(),
+                    "kind": "request_started",
+                    "request_id": request_id,
+                    "method": "GET",
+                    "path": "/fixture.wav",
+                    "range_header": spec["range_header"],
+                    "status": spec["status"],
+                    "planned_start": spec["planned_start"],
+                    "planned_end": spec["planned_end"],
+                    "bytes_planned": planned,
+                    "server_socket_bytes_accepted": 0,
+                    "started_monotonic_ns": origin_ns,
+                    "finished_monotonic_ns": None,
+                    "terminal_reason": None,
+                    "outage_or_disconnect_action": None,
+                }
+            )
+
+        previous_deadline_ns = origin_ns
+        previous_write_finished_ns = origin_ns
+        next_transfer_available_ns = origin_ns
+        global_accepted = 0
+        for request_id, byte_count in schedule:
+            if request_id in disconnected:
+                raise AssertionError("synthetic HTTP schedule continued after disconnect")
+            spec = specs[request_id]
+            planned = int(spec["planned_end"]) - int(spec["planned_start"]) + 1
+            reserved_ns = next_transfer_available_ns
+            if active_throttle_bps:
+                byte_time_ns = (
+                    byte_count * 1_000_000_000 + active_throttle_bps - 1
+                ) // active_throttle_bps
+                deadline_ns = max(previous_deadline_ns, reserved_ns) + byte_time_ns
+                write_started_ns = deadline_ns
+            else:
+                deadline_ns = None
+                write_started_ns = reserved_ns
+            write_finished_ns = write_started_ns + 1
+            accepted[request_id] += byte_count
+            previous_global = global_accepted
+            global_accepted += byte_count
+            actions: list[dict[str, Any]] = []
+            for action, every in (
+                ("outage", int(active_profile["outage_every_bytes"])),
+                ("disconnect", int(active_profile["disconnect_every_bytes"])),
+            ):
+                if every:
+                    first = ((previous_global // every) + 1) * every
+                    actions.extend(
+                        {"action": action, "threshold": threshold}
+                        for threshold in range(first, global_accepted + 1, every)
+                    )
+            actions.sort(
+                key=lambda item: (
+                    item["threshold"],
+                    0 if item["action"] == "outage" else 1,
+                )
+            )
+            records.append(
+                {
+                    **common(),
+                    "kind": "delivery",
+                    "request_id": request_id,
+                    "method": "GET",
+                    "path": "/fixture.wav",
+                    "range_header": spec["range_header"],
+                    "status": spec["status"],
+                    "planned_start": spec["planned_start"],
+                    "planned_end": spec["planned_end"],
+                    "bytes_planned": planned,
+                    "server_socket_bytes_accepted": byte_count,
+                    "request_server_socket_bytes_accepted": accepted[request_id],
+                    "global_server_socket_bytes_accepted": global_accepted,
+                    "started_monotonic_ns": origin_ns,
+                    "finished_monotonic_ns": write_finished_ns,
+                    "terminal_reason": None,
+                    "pacing_reserved_monotonic_ns": reserved_ns,
+                    "pacing_deadline_monotonic_ns": deadline_ns,
+                    "write_started_monotonic_ns": write_started_ns,
+                    "write_finished_monotonic_ns": write_finished_ns,
+                    "outage_or_disconnect_action": actions or None,
+                }
+            )
+            if deadline_ns is not None:
+                previous_deadline_ns = deadline_ns
+            previous_write_finished_ns = write_finished_ns
+            next_transfer_available_ns = write_finished_ns
+            if apply_outage_delay and any(
+                action["action"] == "outage" for action in actions
+            ):
+                next_transfer_available_ns += int(active_profile["outage_ms"]) * 1_000_000
+            if any(action["action"] == "disconnect" for action in actions):
+                disconnected.add(request_id)
+
+        for request_id, spec in specs.items():
+            planned = int(spec["planned_end"]) - int(spec["planned_start"]) + 1
+            if accepted[request_id] != planned and request_id not in disconnected:
+                continue
+            records.append(
+                {
+                    **common(),
+                    "kind": "request_terminal",
+                    "request_id": request_id,
+                    "method": "GET",
+                    "path": "/fixture.wav",
+                    "range_header": spec["range_header"],
+                    "status": spec["status"],
+                    "planned_start": spec["planned_start"],
+                    "planned_end": spec["planned_end"],
+                    "bytes_planned": planned,
+                    "server_socket_bytes_accepted": accepted[request_id],
+                    "started_monotonic_ns": origin_ns,
+                    "finished_monotonic_ns": (
+                        max(previous_write_finished_ns, next_transfer_available_ns)
+                        + request_id
+                    ),
+                    "terminal_reason": (
+                        "planned_disconnect"
+                        if request_id in disconnected
+                        else "complete"
+                    ),
+                    "outage_or_disconnect_action": None,
+                }
+            )
+        return records
+
+    full_request = [
+        {
+            "request_id": 1,
+            "range_header": None,
+            "status": 200,
+            "planned_start": 0,
+            "planned_end": fixture_bytes - 1,
+        }
+    ]
+    split_requests = [
+        {
+            "request_id": 1,
+            "range_header": "bytes=0-32767",
+            "status": 206,
+            "planned_start": 0,
+            "planned_end": fixture_bytes // 2 - 1,
+        },
+        {
+            "request_id": 2,
+            "range_header": "bytes=32768-65535",
+            "status": 206,
+            "planned_start": fixture_bytes // 2,
+            "planned_end": fixture_bytes - 1,
+        },
+    ]
+
+    with tempfile.TemporaryDirectory(prefix="ytt-perf-http-self-test-") as temporary:
+        root = Path(temporary)
+
+        def write_log(name: str, records: list[dict[str, Any]]) -> Path:
+            path = root / f"{name}.ndjson"
+            path.write_text(
+                "".join(
+                    json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
+                    for record in records
+                ),
+                encoding="utf-8",
+            )
+            return path
+
+        def expect_rejected(
+            name: str,
+            records: list[dict[str, Any]],
+            http_document: dict[str, Any] | None = None,
+            traffic_profile: dict[str, Any] | None = None,
+        ) -> None:
+            try:
+                validate_http_request_log(
+                    write_log(name, records),
+                    http_document or http,
+                    traffic_profile or profile,
+                )
+            except ValueError:
+                pass
+            else:
+                raise AssertionError(f"HTTP validator accepted hostile proof {name}")
+
+        def http_for_profile(traffic_profile: dict[str, Any]) -> dict[str, Any]:
+            return {
+                **http,
+                "throttle_bps": traffic_profile["throttle_bps"],
+                "outage_every_bytes": traffic_profile["outage_every_bytes"],
+                "outage_ms": traffic_profile["outage_ms"],
+                "disconnect_every_bytes": traffic_profile["disconnect_every_bytes"],
+            }
+
+        valid = build_records(
+            split_requests,
+            [
+                (request_id, HTTP_THROTTLE_CHUNK_BYTES)
+                for _round in range(8)
+                for request_id in (1, 2)
+            ],
+        )
+        validate_http_request_log(write_log("valid-shared-global-budget", valid), http, profile)
+
+        instant = json.loads(json.dumps(valid))
+        first_delivery = next(
+            record for record in instant if record["kind"] == "delivery"
+        )
+        first_delivery["write_started_monotonic_ns"] = (
+            first_delivery["pacing_deadline_monotonic_ns"]
+            - HTTP_PACING_EARLY_TOLERANCE_NS
+            - 1
+        )
+        expect_rejected("instant-64k", instant)
+
+        large_chunk = build_records(full_request, [(1, fixture_bytes)])
+        expect_rejected("single-64k-chunk", large_chunk)
+
+        tiny_only = build_records(full_request, [(1, HTTP_THROTTLE_CHUNK_BYTES)])
+        expect_rejected("tiny-only", tiny_only)
+
+        tampered_credit = {**http, "pacing_initial_credit_bytes": fixture_bytes}
+        expect_rejected("initial-credit", valid, tampered_credit)
+
+        unexercised_fault_profile = {
+            "throttle_bps": throttle_bps,
+            "outage_every_bytes": fixture_bytes * 2,
+            "outage_ms": 1_500,
+            "disconnect_every_bytes": fixture_bytes * 4,
+        }
+        expect_rejected(
+            "configured-faults-unexercised-64k",
+            valid,
+            http_for_profile(unexercised_fault_profile),
+            unexercised_fault_profile,
+        )
+
+        exercised_fault_profile = {
+            "throttle_bps": throttle_bps,
+            "outage_every_bytes": fixture_bytes // 2,
+            "outage_ms": 1_500,
+            "disconnect_every_bytes": fixture_bytes,
+        }
+        fault_schedule = [
+            (1, HTTP_THROTTLE_CHUNK_BYTES)
+            for _ in range(fixture_bytes // HTTP_THROTTLE_CHUNK_BYTES)
+        ]
+        missing_outage_delay = build_records(
+            full_request,
+            fault_schedule,
+            exercised_fault_profile,
+            apply_outage_delay=False,
+        )
+        expect_rejected(
+            "correctly-marked-missing-outage-delay",
+            missing_outage_delay,
+            http_for_profile(exercised_fault_profile),
+            exercised_fault_profile,
+        )
+        delayed_outage_and_disconnect = build_records(
+            full_request,
+            fault_schedule,
+            exercised_fault_profile,
+        )
+        validate_http_request_log(
+            write_log(
+                "delayed-outage-and-planned-disconnect",
+                delayed_outage_and_disconnect,
+            ),
+            http_for_profile(exercised_fault_profile),
+            exercised_fault_profile,
+        )
+
+        fixture = root / "fixture.bin"
+        fixture.write_bytes(b"\0" * fixture_bytes)
+        server = FixtureServer(
+            ("127.0.0.1", 0),
+            RangeFixtureHandler,
+            fixture,
+            throttle_bps,
+            0,
+            0,
+            0,
+            root / "reservation.ndjson",
+            "reservation-self-test",
+        )
+        try:
+            first_reserved, first_deadline = server.reserve_pacing_deadline(
+                HTTP_THROTTLE_CHUNK_BYTES
+            )
+            byte_time_ns = (
+                HTTP_THROTTLE_CHUNK_BYTES * 1_000_000_000 + throttle_bps - 1
+            ) // throttle_bps
+            if first_deadline != (
+                max(server.pacing_origin_monotonic_ns, first_reserved) + byte_time_ns
+            ):
+                raise AssertionError("HTTP throttle granted initial byte credit")
+            second_reserved, second_deadline = server.reserve_pacing_deadline(
+                HTTP_THROTTLE_CHUNK_BYTES
+            )
+            if second_deadline != max(first_deadline, second_reserved) + byte_time_ns:
+                raise AssertionError("HTTP throttle did not share its global pacing deadline")
+        finally:
+            server.server_close()
+
+        import http.client as http_client
+
+        live_log = root / "live-handler.ndjson"
+        live_server = FixtureServer(
+            ("127.0.0.1", 0),
+            RangeFixtureHandler,
+            fixture,
+            throttle_bps,
+            0,
+            0,
+            0,
+            live_log,
+            "live-handler-self-test",
+        )
+        live_thread = threading.Thread(
+            target=live_server.serve_forever,
+            kwargs={"poll_interval": 0.01},
+            daemon=True,
+        )
+        live_thread.start()
+        connection = http_client.HTTPConnection(
+            str(live_server.server_address[0]),
+            int(live_server.server_address[1]),
+            timeout=5,
+        )
+        try:
+            connection.request("GET", "/fixture.wav")
+            response = connection.getresponse()
+            body = response.read()
+            if response.status != 200 or len(body) != fixture_bytes:
+                raise AssertionError("live HTTP fixture did not return the complete fixture")
+        finally:
+            connection.close()
+            live_server.shutdown()
+            live_thread.join(timeout=5)
+            live_server.server_close()
+        if live_thread.is_alive():
+            raise AssertionError("live HTTP fixture self-test did not stop")
+        validate_http_request_log(
+            live_log,
+            {
+                **http,
+                "pid": os.getpid(),
+                "run_id": "live-handler-self-test",
+                "fixture_sha256": sha256_file(fixture),
+                "started_monotonic_ns": live_server.pacing_origin_monotonic_ns - 1,
+                "pacing_origin_monotonic_ns": live_server.pacing_origin_monotonic_ns,
+            },
+            profile,
+        )
+
+
+def http_server_shutdown_self_test() -> None:
+    if os.name == "nt":
+        return
+    with tempfile.TemporaryDirectory(
+        prefix="ytt-perf-http-shutdown-self-test-"
+    ) as temporary:
+        root = Path(temporary)
+        fixture = root / "fixture.bin"
+        request_log = root / "requests.ndjson"
+        ready = root / "ready.json"
+        fixture.write_bytes(b"fixture-server-shutdown-self-test")
+        run_id = "http-shutdown-self-test"
+        # Force the argparse-hostile edge case: a separate value beginning with `-` can be
+        # mistaken for another option, so every real launch must use --shutdown-token=VALUE.
+        shutdown_token = "-" + "A" * 42
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                "serve",
+                "--file",
+                str(fixture),
+                "--ready-file",
+                str(ready),
+                "--request-log",
+                str(request_log),
+                "--run-id",
+                run_id,
+                f"--shutdown-token={shutdown_token}",
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        sentinel: subprocess.Popen[str] | None = None
+        try:
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not ready.is_file():
+                if process.poll() is not None:
+                    raise AssertionError(
+                        "fixture shutdown self-test server exited before readiness: "
+                        f"{process.stderr.read()}"
+                    )
+                time.sleep(0.01)
+            if not ready.is_file():
+                raise AssertionError("fixture shutdown self-test server did not become ready")
+            manifest = load_json_object(ready)
+            require_artifact_value(ready, "self-test server PID", manifest.get("pid"), process.pid)
+            stopped = stop_fixture_server(ready, run_id, 5.0)
+            if stopped["already_stopped"]:
+                raise AssertionError("live fixture server was reported as already stopped")
+            process.wait(timeout=2)
+            if process.returncode != 0:
+                raise AssertionError(
+                    "fixture server failed during authenticated shutdown: "
+                    f"{process.stderr.read()}"
+                )
+
+            sentinel = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    "import time; time.sleep(60)",
+                    "serve",
+                    "--run-id",
+                    run_id,
+                    f"--shutdown-token={shutdown_token}",
+                ],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            sentinel_identity: dict[str, Any] | None = None
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline and sentinel_identity is None:
+                sentinel_identity = fixture_server_process_observation(sentinel.pid)
+                time.sleep(0.01)
+            if sentinel_identity is None:
+                raise AssertionError("stale-PID sentinel did not become observable")
+            stale_token = manifest["server_process"]["native_start_token"]
+            if sentinel_identity["native_start_token"] == stale_token:
+                raise AssertionError("stale-PID fixture did not receive a distinct start token")
+            sentinel_identity["native_start_token"] = stale_token
+            stale_manifest = json.loads(json.dumps(manifest))
+            stale_manifest["pid"] = sentinel.pid
+            stale_manifest["server_process"] = {
+                "schema": "ytt.tui-perf.http-process.v1",
+                **sentinel_identity,
+            }
+            stale_path = root / "stale-ready.json"
+            atomic_json(stale_path, stale_manifest)
+            stale_result = stop_fixture_server(stale_path, run_id, 0.5)
+            if not stale_result["already_stopped"]:
+                raise AssertionError("stale fixture server identity was treated as live")
+            if sentinel.poll() is not None:
+                raise AssertionError(
+                    "stale-PID fixture server shutdown signaled the unrelated sentinel"
+                )
+        finally:
+            for child in (sentinel, process):
+                if child is not None and child.poll() is None:
+                    child.kill()
+                if child is not None:
+                    with contextlib.suppress(subprocess.TimeoutExpired):
+                        child.wait(timeout=2)
 
 
 def read_ndjson(path: Path) -> list[dict[str, Any]]:
@@ -1019,6 +6621,44 @@ def quantile(values: list[float], q: float) -> float:
     return ordered[min(index, len(ordered) - 1)]
 
 
+def exact_latency_histogram(
+    value: Any, path: Path, label: str
+) -> list[tuple[int, int]]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{path}: {label} latency_histogram must be non-empty")
+    histogram = []
+    previous_ns = -1
+    for index, bucket in enumerate(value):
+        if not isinstance(bucket, dict) or set(bucket) != {"ns", "count"}:
+            raise ValueError(f"{path}: {label} histogram bucket {index} has invalid schema")
+        ns = non_negative_integer(bucket.get("ns"), f"{label} histogram ns", path)
+        count = non_negative_integer(bucket.get("count"), f"{label} histogram count", path)
+        if count == 0 or ns <= previous_ns:
+            raise ValueError(f"{path}: {label} histogram must be strictly sorted with positive counts")
+        previous_ns = ns
+        histogram.append((ns, count))
+    return histogram
+
+
+def histogram_quantile(histogram: list[tuple[int, int]], q: float) -> int:
+    count = sum(bucket_count for _ns, bucket_count in histogram)
+    target = math.ceil((count - 1) * q)
+    seen = 0
+    for ns, bucket_count in histogram:
+        seen += bucket_count
+        if target < seen:
+            return ns
+    raise AssertionError("non-empty histogram did not contain its quantile")
+
+
+def merged_histogram(histograms: list[list[tuple[int, int]]]) -> list[tuple[int, int]]:
+    merged: dict[int, int] = {}
+    for histogram in histograms:
+        for ns, count in histogram:
+            merged[ns] = merged.get(ns, 0) + count
+    return sorted(merged.items())
+
+
 def render_metrics_from_document(document: dict[str, Any], path: Path) -> dict[str, Any]:
     metrics: dict[str, Any] = {}
     for case in document.get("cases", []):
@@ -1034,14 +6674,63 @@ def render_metrics_from_document(document: dict[str, Any], path: Path) -> dict[s
                 f"{path}: render case {case.get('name')} measured_draws {measured_draws!r} "
                 f"does not match batch total {sum(batch_draws)}"
             )
-        case_p95 = case.get("p95_draw_ns")
-        if (
-            not isinstance(case_p95, (int, float))
-            or isinstance(case_p95, bool)
-            or not math.isfinite(float(case_p95))
-            or float(case_p95) < 0
-        ):
-            raise ValueError(f"{path}: render case {case.get('name')} has invalid case p95")
+        batch_histograms = []
+        for batch_index, batch in enumerate(batches):
+            label = f"render case {case.get('name')} batch {batch_index}"
+            histogram = exact_latency_histogram(batch.get("latency_histogram"), path, label)
+            count = sum(bucket_count for _ns, bucket_count in histogram)
+            total = sum(ns * bucket_count for ns, bucket_count in histogram)
+            require_artifact_value(path, f"{label} histogram count", count, batch["draws"])
+            require_artifact_value(path, f"{label} total", batch.get("total_ns"), total)
+            mean = finite_non_negative_number(batch.get("mean_draw_ns"), f"{label} mean", path)
+            if not math.isclose(mean, total / count, rel_tol=1e-12, abs_tol=1e-9):
+                raise ValueError(f"{path}: {label} mean does not match histogram")
+            require_artifact_value(path, f"{label} p50", batch.get("p50_draw_ns"), histogram_quantile(histogram, 0.50))
+            require_artifact_value(path, f"{label} p95", batch.get("p95_draw_ns"), histogram_quantile(histogram, 0.95))
+            require_artifact_value(path, f"{label} max", batch.get("max_draw_ns"), histogram[-1][0])
+            allocation_values = {
+                allocation_field: non_negative_integer(
+                    batch.get(allocation_field), f"{label} {allocation_field}", path
+                )
+                for allocation_field in (
+                    "allocations", "reallocations", "allocated_bytes", "deallocated_bytes",
+                    "peak_live_bytes_delta",
+                )
+            }
+            retained_bytes_delta = batch.get("retained_bytes_delta")
+            if not isinstance(retained_bytes_delta, int) or isinstance(retained_bytes_delta, bool):
+                raise ValueError(f"{path}: {label} retained_bytes_delta must be an integer")
+            expected_retained = (
+                allocation_values["allocated_bytes"]
+                - allocation_values["deallocated_bytes"]
+            )
+            require_artifact_value(
+                path,
+                f"{label} allocator byte conservation",
+                retained_bytes_delta,
+                expected_retained,
+            )
+            if allocation_values["peak_live_bytes_delta"] < max(0, retained_bytes_delta):
+                raise ValueError(
+                    f"{path}: {label} peak live bytes cannot be below final retained bytes"
+                )
+            batch_histograms.append(histogram)
+
+        case_histogram = exact_latency_histogram(
+            case.get("latency_histogram"), path, f"render case {case.get('name')}"
+        )
+        expected_case_histogram = merged_histogram(batch_histograms)
+        require_artifact_value(path, f"render case {case.get('name')} global histogram", case_histogram, expected_case_histogram)
+        case_count = sum(count for _ns, count in case_histogram)
+        case_total = sum(ns * count for ns, count in case_histogram)
+        require_artifact_value(path, f"render case {case.get('name')} total", case.get("total_draw_ns"), case_total)
+        case_mean = finite_non_negative_number(case.get("mean_draw_ns"), f"render case {case.get('name')} mean", path)
+        if not math.isclose(case_mean, case_total / case_count, rel_tol=1e-12, abs_tol=1e-9):
+            raise ValueError(f"{path}: render case {case.get('name')} global mean does not match histogram")
+        require_artifact_value(path, f"render case {case.get('name')} p50", case.get("p50_draw_ns"), histogram_quantile(case_histogram, 0.50))
+        case_p95 = histogram_quantile(case_histogram, 0.95)
+        require_artifact_value(path, f"render case {case.get('name')} p95", case.get("p95_draw_ns"), case_p95)
+        require_artifact_value(path, f"render case {case.get('name')} max", case.get("max_draw_ns"), case_histogram[-1][0])
 
         prefix = f"render.{case['name']}"
         for name in (
@@ -1104,7 +6793,19 @@ def metrics_from_file(path: Path) -> dict[str, Any]:
         operations: dict[str, list[float]] = {}
         for record in records:
             if record.get("kind") == "operation":
-                operations.setdefault(str(record.get("operation")), []).append(float(record["latency_ms"]))
+                started_ns = record.get("operation_started_ns")
+                completed_ns = record.get("operation_completed_ns")
+                if (
+                    not isinstance(started_ns, int)
+                    or isinstance(started_ns, bool)
+                    or not isinstance(completed_ns, int)
+                    or isinstance(completed_ns, bool)
+                    or completed_ns < started_ns
+                ):
+                    raise ValueError(f"{path}: operation has invalid raw timestamps")
+                operations.setdefault(str(record.get("operation")), []).append(
+                    (completed_ns - started_ns) / 1_000_000.0
+                )
         for name, values in operations.items():
             metrics[f"operation.{name}.p95_ms"] = quantile(values, 0.95)
             metrics[f"operation.{name}.mean_ms"] = statistics.fmean(values)
@@ -1189,6 +6890,7 @@ def require_artifact_value(path: Path, label: str, actual: Any, expected: Any) -
 def validate_host_manifest(
     path: Path,
     scenario: dict[str, Any],
+    scenario_document: dict[str, Any],
     scenario_hash: str,
     render: bool,
 ) -> dict[str, Any]:
@@ -1196,15 +6898,34 @@ def validate_host_manifest(
     require_artifact_value(path, "schema", manifest.get("schema"), "ytt.tui-perf.host.v1")
     require_artifact_value(path, "scenario", manifest.get("scenario"), scenario["id"])
     require_artifact_value(path, "scenario_sha256", manifest.get("scenario_sha256"), scenario_hash)
+    require_artifact_value(
+        path, "measurement scope", manifest.get("measurement_scope"), scenario_document["sampling"]
+    )
+    require_artifact_value(
+        path,
+        "sampling and cleanup limitations",
+        manifest.get("limitations"),
+        measurement_limitations(render),
+    )
+    evidence_root = path.resolve().parent
+    scenario_identity = manifest.get("scenario_file")
+    if not isinstance(scenario_identity, dict):
+        raise ValueError(f"{path}: scenario_file must be an object")
+    scenario_path = (evidence_root / str(scenario_identity.get("path", ""))).resolve()
+    try:
+        scenario_path.relative_to(evidence_root)
+    except ValueError as error:
+        raise ValueError(f"{path}: scenario snapshot escapes evidence root") from error
+    current_scenario = identity_for_file(scenario_path)
+    for field in ("bytes", "sha256"):
+        require_artifact_value(path, f"scenario snapshot {field}", scenario_identity.get(field), current_scenario[field])
+    require_artifact_value(path, "scenario snapshot SHA-256", current_scenario["sha256"], scenario_hash)
     host = manifest.get("host")
     if not isinstance(host, dict):
         raise ValueError(f"{path}: host must be an object")
-    require_artifact_value(
-        path,
-        "host system",
-        normalized_os(host.get("system")),
-        normalized_os(platform.system()),
-    )
+    current_host_identity = stable_host_identity()
+    for field, expected in current_host_identity.items():
+        require_artifact_value(path, f"host {field}", host.get(field), expected)
 
     expected_binaries = (
         {"baseline_render", "candidate_render"}
@@ -1213,9 +6934,10 @@ def validate_host_manifest(
     )
     binaries = manifest.get("binaries")
     binary_labels = set(binaries) if isinstance(binaries, dict) else set()
-    if not isinstance(binaries, dict) or not expected_binaries.issubset(binary_labels):
+    if not isinstance(binaries, dict) or expected_binaries != binary_labels:
         missing = sorted(expected_binaries - binary_labels)
-        raise ValueError(f"{path}: missing required binary identities: {missing}")
+        extra = sorted(binary_labels - expected_binaries)
+        raise ValueError(f"{path}: invalid binary identities; missing={missing}, extra={extra}")
     for label in sorted(expected_binaries):
         identity = binaries[label]
         if not isinstance(identity, dict):
@@ -1228,18 +6950,35 @@ def validate_host_manifest(
             path, f"{label} SHA-256", sha256_file(binary), identity.get("sha256")
         )
 
-    sources = manifest.get("sources")
+    receipt_identity = manifest.get("build_receipt")
+    if not isinstance(receipt_identity, dict):
+        raise ValueError(f"{path}: build_receipt must be an object")
+    receipt_path = (evidence_root / str(receipt_identity.get("path", ""))).resolve()
+    try:
+        receipt_path.relative_to(evidence_root)
+    except ValueError as error:
+        raise ValueError(f"{path}: build receipt escapes evidence root") from error
+    current_receipt = identity_for_file(receipt_path)
+    for field in ("bytes", "sha256"):
+        require_artifact_value(path, f"build receipt {field}", receipt_identity.get(field), current_receipt[field])
+    receipt = load_json_object(receipt_path)
+    sources = receipt.get("sources")
     if not isinstance(sources, dict) or set(sources) != {"baseline", "candidate"}:
-        raise ValueError(f"{path}: sources must contain exactly baseline and candidate")
-    for label in ("baseline", "candidate"):
-        recorded = sources[label]
-        if not isinstance(recorded, dict):
-            raise ValueError(f"{path}: source identity {label!r} must be an object")
-        build_command = recorded.get("build_command")
-        if not isinstance(build_command, str) or not build_command.strip():
-            raise ValueError(f"{path}: source {label!r} has no build command")
-        current = source_identity(Path(str(recorded.get("root", ""))), build_command)
-        require_artifact_value(path, f"{label} source identity", current, recorded)
+        raise ValueError(f"{receipt_path}: sources must contain exactly baseline and candidate")
+    validate_build_receipt(
+        receipt,
+        Path(str(sources["baseline"].get("root", ""))),
+        Path(str(sources["candidate"].get("root", ""))),
+        render,
+        refresh=False,
+    )
+    require_artifact_value(path, "receipt orchestrator", manifest.get("orchestrator"), receipt["orchestrator"])
+    require_artifact_value(path, "receipt sources", manifest.get("sources"), sources)
+    receipt_binaries = {
+        label: {field: artifact[field] for field in ("path", "bytes", "sha256")}
+        for label, artifact in receipt["artifacts"].items()
+    }
+    require_artifact_value(path, "receipt binaries", binaries, receipt_binaries)
     return manifest
 
 
@@ -1251,11 +6990,22 @@ def validate_render_document(
     scenario_hash: str,
     host_os: str,
     manifest: dict[str, Any],
+    run_contract: dict[str, Any] | None = None,
 ) -> None:
     require_artifact_value(path, "schema", document.get("schema"), "ytt.tui-perf.render.v1")
     require_artifact_value(path, "kind", document.get("kind"), "render_summary")
     require_artifact_value(path, "scenario SHA-256", document.get("scenario_sha256"), scenario_hash)
     require_artifact_value(path, "OS", normalized_os(document.get("os")), host_os)
+    if run_contract is not None:
+        require_artifact_value(path, "run ID", document.get("run_id"), run_contract["run_id"])
+        started_unix_ns = non_negative_integer(
+            document.get("started_unix_ns"), "render started_unix_ns", path
+        )
+        finished_unix_ns = non_negative_integer(
+            document.get("finished_unix_ns"), "render finished_unix_ns", path
+        )
+        if not run_contract["started_unix_ns"] <= started_unix_ns < finished_unix_ns <= run_contract["finished_unix_ns"]:
+            raise ValueError(f"{path}: render producer interval escapes its run contract")
     binary_label = f"{role}_render"
     expected_binary = manifest["binaries"][binary_label]["sha256"]
     require_artifact_value(
@@ -1286,6 +7036,9 @@ def validate_render_document(
                 batch.get("draws"),
                 scenario["draws_per_batch"],
             )
+    # Recompute every timing statistic from the exact raw histogram before accepting the
+    # document; identity/count checks alone must not let a forged p95 reach comparison.
+    render_metrics_from_document(document, path)
 
 
 def process_run_directories(path: Path, scenario: dict[str, Any]) -> list[Path]:
@@ -1295,13 +7048,1526 @@ def process_run_directories(path: Path, scenario: dict[str, Any]) -> list[Path]:
         if unexpected:
             raise ValueError(f"{path}: single-geometry run has unexpected directories {unexpected}")
         return [path]
-    expected = {f"geometry-{width}x{height}" for width, height in geometry}
+    expected_order = [f"geometry-{width}x{height}" for width, height in geometry]
+    expected = set(expected_order)
     actual = {item.name for item in path.glob("geometry-*") if item.is_dir()}
     if actual != expected:
         raise ValueError(
             f"{path}: geometry directories are {sorted(actual)}, expected {sorted(expected)}"
         )
-    return [path / name for name in sorted(expected)]
+    return [path / name for name in expected_order]
+
+
+def finite_non_negative_number(value: Any, label: str, path: Path) -> float:
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(float(value))
+        or float(value) < 0
+    ):
+        raise ValueError(f"{path}: {label} must be finite and non-negative")
+    return float(value)
+
+
+def non_negative_integer(value: Any, label: str, path: Path) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"{path}: {label} must be a non-negative integer")
+    return value
+
+
+def validate_control_buffering(
+    path: Path,
+    records: list[dict[str, Any]],
+    summary: dict[str, Any],
+) -> None:
+    require_artifact_value(path, "control summary schema", summary.get("schema"), "ytt.tui-perf.control.v1")
+    summary_elapsed_ns = non_negative_integer(
+        summary.get("elapsed_ns"), "summary elapsed_ns", path
+    )
+    buffering_cutoff_ns = non_negative_integer(
+        summary.get("buffering_cutoff_ns"), "summary buffering_cutoff_ns", path
+    )
+    if buffering_cutoff_ns > summary_elapsed_ns:
+        raise ValueError(f"{path}: buffering cutoff occurs after the summary boundary")
+    summary_events = non_negative_integer(
+        summary.get("buffering_events"), "summary buffering_events", path
+    )
+    summary_ms = non_negative_integer(
+        summary.get("buffering_ms"), "summary buffering_ms", path
+    )
+
+    buffering_started_ns: int | None = None
+    buffering_events = 0
+    buffering_total_ns = 0
+    previous_elapsed_ns = -1
+    for index, record in enumerate(records):
+        if record.get("kind") != "mpv_event":
+            continue
+        require_artifact_value(
+            path,
+            f"mpv event {index} schema",
+            record.get("schema"),
+            "ytt.tui-perf.control.v1",
+        )
+        elapsed_ns = non_negative_integer(
+            record.get("elapsed_ns"), f"mpv event {index} elapsed_ns", path
+        )
+        if elapsed_ns < previous_elapsed_ns:
+            raise ValueError(f"{path}: mpv event elapsed_ns values must be monotonic")
+        if elapsed_ns > summary_elapsed_ns:
+            raise ValueError(f"{path}: mpv event occurs after the summary boundary")
+        previous_elapsed_ns = elapsed_ns
+        event = record.get("event")
+        if not isinstance(event, dict):
+            raise ValueError(f"{path}: mpv event {index} payload must be an object")
+        if (
+            event.get("event") != "property-change"
+            or event.get("name") != "paused-for-cache"
+            or not isinstance(event.get("data"), bool)
+        ):
+            continue
+        if elapsed_ns >= buffering_cutoff_ns:
+            if buffering_started_ns is not None:
+                buffering_total_ns += buffering_cutoff_ns - buffering_started_ns
+                buffering_started_ns = None
+            continue
+        if event["data"] and buffering_started_ns is None:
+            buffering_started_ns = elapsed_ns
+            buffering_events += 1
+        elif not event["data"] and buffering_started_ns is not None:
+            buffering_total_ns += elapsed_ns - buffering_started_ns
+            buffering_started_ns = None
+    if buffering_started_ns is not None:
+        buffering_total_ns += buffering_cutoff_ns - buffering_started_ns
+
+    require_artifact_value(
+        path, "recomputed buffering_events", summary_events, buffering_events
+    )
+    require_artifact_value(
+        path,
+        "recomputed buffering_ms",
+        summary_ms,
+        buffering_total_ns // 1_000_000,
+    )
+
+
+def validate_control_time_pos_summary(
+    path: Path,
+    records: list[dict[str, Any]],
+    summary: dict[str, Any],
+) -> tuple[int, float, int, float] | None:
+    cutoff_ns = non_negative_integer(
+        summary.get("buffering_cutoff_ns"), "summary buffering_cutoff_ns", path
+    )
+    first: tuple[int, float] | None = None
+    last: tuple[int, float] | None = None
+    for index, record in enumerate(records):
+        if record.get("kind") != "mpv_event":
+            continue
+        elapsed_ns = non_negative_integer(
+            record.get("elapsed_ns"), f"mpv event {index} elapsed_ns", path
+        )
+        if elapsed_ns > cutoff_ns:
+            continue
+        event = record.get("event")
+        if not isinstance(event, dict) or (
+            event.get("event") != "property-change"
+            or event.get("name") != "time-pos"
+        ):
+            continue
+        value = event.get("data")
+        if value is None:
+            continue
+        position = finite_non_negative_number(
+            value, f"mpv event {index} time-pos", path
+        )
+        if first is None:
+            first = (elapsed_ns, position)
+        last = (elapsed_ns, position)
+
+    expected = {
+        "cutoff_first_time_pos_ns": first[0] if first else None,
+        "cutoff_first_time_pos_s": first[1] if first else None,
+        "cutoff_last_time_pos_ns": last[0] if last else None,
+        "cutoff_last_time_pos_s": last[1] if last else None,
+    }
+    for field, value in expected.items():
+        require_artifact_value(path, f"recomputed {field}", summary.get(field), value)
+    if first is None or last is None:
+        return None
+    return first[0], first[1], last[0], last[1]
+
+
+def validate_steady_playback_progress(
+    path: Path,
+    records: list[dict[str, Any]],
+    summary: dict[str, Any],
+    scenario: dict[str, Any],
+) -> None:
+    fraction = scenario.get("minimum_playback_progress_fraction")
+    if fraction is None:
+        return
+    progress = validate_control_time_pos_summary(path, records, summary)
+    if progress is None:
+        raise ValueError(f"{path}: steady playback has no time-pos evidence")
+    first_ns, first_s, last_ns, last_s = progress
+    cutoff_ns = non_negative_integer(
+        summary.get("buffering_cutoff_ns"), "summary buffering_cutoff_ns", path
+    )
+    tail_tolerance_s = finite_non_negative_number(
+        scenario.get("time_pos_tail_tolerance_s"),
+        "time_pos_tail_tolerance_s",
+        path,
+    )
+    tail_tolerance_ns = int(tail_tolerance_s * 1_000_000_000)
+    if last_ns + tail_tolerance_ns < cutoff_ns:
+        raise ValueError(
+            f"{path}: final time-pos evidence is not within {tail_tolerance_s:g}s "
+            "of the fixed observation cutoff"
+        )
+    minimum_progress_s = cutoff_ns / 1_000_000_000 * float(fraction)
+    actual_progress_s = last_s - first_s
+    if actual_progress_s < minimum_progress_s:
+        raise ValueError(
+            f"{path}: steady playback advanced {actual_progress_s:g}s from "
+            f"{first_ns}ns to {last_ns}ns; requires at least {minimum_progress_s:g}s"
+        )
+
+
+def normalized_seek_target_ms(value: Any, label: str, path: Path) -> int:
+    seconds = finite_non_negative_number(value, label, path)
+    scaled = seconds * 1_000.0
+    if not math.isfinite(scaled) or scaled >= 1 << 64:
+        raise ValueError(f"{path}: {label} exceeds the controller transport range")
+    milliseconds = math.floor(scaled + 0.5)
+    if milliseconds >= 1 << 64:
+        raise ValueError(f"{path}: {label} exceeds the controller transport range")
+    return milliseconds
+
+
+def controller_scheduled_offset_ns(
+    observation_ns: int, ordinal: int, total_actions: int
+) -> int:
+    if observation_ns == 0 or ordinal == 0 or total_actions == 0:
+        return 0
+    if not 0 < ordinal <= total_actions:
+        raise ValueError("controller schedule ordinal is outside the action count")
+    return observation_ns * ordinal // (total_actions + 1)
+
+
+def validate_control_operations(
+    path: Path,
+    records: list[dict[str, Any]],
+    summary_elapsed_ns: int,
+    scenario: dict[str, Any],
+) -> None:
+    operation_entries = [
+        (stream_index, record)
+        for stream_index, record in enumerate(records)
+        if record.get("kind") == "operation"
+    ]
+    operation_windows: list[tuple[int, int, str, dict[str, Any]]] = []
+    actual_seek_targets_ms: list[int] = []
+    previous_completed_ns: int | None = None
+    for index, (stream_index, record) in enumerate(operation_entries):
+        require_artifact_value(
+            path,
+            f"operation {index} schema",
+            record.get("schema"),
+            "ytt.tui-perf.control.v1",
+        )
+        started_ns = non_negative_integer(
+            record.get("operation_started_ns"), f"operation {index} started", path
+        )
+        completed_ns = non_negative_integer(
+            record.get("operation_completed_ns"), f"operation {index} completed", path
+        )
+        if completed_ns < started_ns or completed_ns > summary_elapsed_ns:
+            raise ValueError(f"{path}: operation {index} timestamps are outside observation")
+        if previous_completed_ns is not None and started_ns < previous_completed_ns:
+            raise ValueError(f"{path}: operation {index} overlaps its predecessor")
+        previous_completed_ns = completed_ns
+        actual_latency = finite_non_negative_number(
+            record.get("latency_ms"), f"operation {index} latency_ms", path
+        )
+        expected_latency = (completed_ns - started_ns) / 1_000_000.0
+        if not math.isclose(
+            actual_latency, expected_latency, rel_tol=1e-12, abs_tol=1e-12
+        ):
+            raise ValueError(
+                f"{path}: operation {index} latency does not match raw timestamps"
+            )
+        completion_source = record.get("completion_source")
+        completion_event_ns = record.get("completion_event_elapsed_ns")
+        completion_event_payload: dict[str, Any] | None = None
+        if completion_source == "mpv_event":
+            require_artifact_value(
+                path,
+                f"operation {index} completion timestamp",
+                completion_event_ns,
+                completed_ns,
+            )
+            matches = [
+                (event_index, event)
+                for event_index, event in enumerate(records)
+                if event.get("kind") == "mpv_event"
+                and event.get("elapsed_ns") == completed_ns
+            ]
+            if len(matches) != 1:
+                raise ValueError(
+                    f"{path}: operation {index} completion event is not unique"
+                )
+            event_index, event_record = matches[0]
+            if event_index >= stream_index:
+                raise ValueError(
+                    f"{path}: operation {index} completion event is out of stream order"
+                )
+            event = event_record.get("event")
+            if not isinstance(event, dict):
+                raise ValueError(f"{path}: operation {index} completion event is malformed")
+            completion_event_payload = event
+            require_artifact_value(
+                path,
+                f"operation {index} event type",
+                record.get("completion_event_type"),
+                event.get("event"),
+            )
+            require_artifact_value(
+                path,
+                f"operation {index} property",
+                record.get("completion_property"),
+                event.get("name"),
+            )
+        elif completion_source == "status":
+            require_artifact_value(
+                path,
+                f"operation {index} event timestamp",
+                completion_event_ns,
+                None,
+            )
+            require_artifact_value(
+                path,
+                f"operation {index} event type",
+                record.get("completion_event_type"),
+                None,
+            )
+            require_artifact_value(
+                path,
+                f"operation {index} property",
+                record.get("completion_property"),
+                None,
+            )
+        else:
+            raise ValueError(f"{path}: operation {index} has invalid completion source")
+
+        operation_name = record.get("operation")
+        if not isinstance(operation_name, str):
+            raise ValueError(f"{path}: operation {index} name must be a string")
+        detail = record.get("detail")
+        if not isinstance(detail, dict):
+            raise ValueError(f"{path}: operation {index} detail must be an object")
+        if operation_name in {"resume_session", "play_query"}:
+            require_artifact_value(
+                path,
+                f"operation {index} load completion",
+                record.get("completion_event_type"),
+                "playback-restart",
+            )
+        elif operation_name == "seek":
+            require_artifact_value(
+                path,
+                f"operation {index} seek property",
+                record.get("completion_property"),
+                "time-pos",
+            )
+            target = finite_non_negative_number(
+                detail.get("target_s"), "seek target", path
+            )
+            actual_seek_targets_ms.append(
+                normalized_seek_target_ms(target, "seek target", path)
+            )
+            observed = finite_non_negative_number(
+                detail.get("observed_target_s"), "seek observed target", path
+            )
+            if completion_event_payload is None:
+                raise ValueError(f"{path}: seek completion has no raw mpv event payload")
+            raw_observed = finite_non_negative_number(
+                completion_event_payload.get("data"),
+                "seek raw time-pos",
+                path,
+            )
+            require_artifact_value(
+                path,
+                f"operation {index} raw seek observation",
+                raw_observed,
+                observed,
+            )
+            tolerance = finite_non_negative_number(
+                detail.get("target_tolerance_s"), "seek tolerance", path
+            )
+            normalized_target_s = (
+                normalized_seek_target_ms(target, "seek target", path) / 1_000.0
+            )
+            if tolerance != 2.0 or abs(raw_observed - normalized_target_s) > tolerance:
+                raise ValueError(
+                    f"{path}: raw seek completion is not bound to its normalized target"
+                )
+            restart_ns = non_negative_integer(
+                detail.get("playback_restart_elapsed_ns"),
+                "seek restart timestamp",
+                path,
+            )
+            if not started_ns <= restart_ns <= completed_ns:
+                raise ValueError(f"{path}: seek restart is outside the operation")
+            restart_matches = [
+                event_index
+                for event_index, event in enumerate(records)
+                if event.get("kind") == "mpv_event"
+                and event.get("elapsed_ns") == restart_ns
+                and isinstance(event.get("event"), dict)
+                and event["event"].get("event") == "playback-restart"
+            ]
+            if len(restart_matches) != 1 or restart_matches[0] >= stream_index:
+                raise ValueError(f"{path}: seek restart proof is missing or out of order")
+        elif operation_name == "pause":
+            require_artifact_value(
+                path, f"operation {index} pause source", completion_source, "status"
+            )
+            require_artifact_value(
+                path,
+                f"operation {index} pause status field",
+                detail.get("status_field"),
+                "paused",
+            )
+            require_artifact_value(
+                path,
+                f"operation {index} pause status value",
+                detail.get("status_value"),
+                True,
+            )
+        elif operation_name == "resume":
+            require_artifact_value(
+                path,
+                f"operation {index} resume property",
+                record.get("completion_property"),
+                "time-pos",
+            )
+            if completion_event_payload is None:
+                raise ValueError(f"{path}: resume completion has no raw mpv event payload")
+            completion_position = finite_non_negative_number(
+                completion_event_payload.get("data"),
+                "resume raw completion time-pos",
+                path,
+            )
+            pre_resume_positions: list[tuple[int, float]] = []
+            for event_index, event_record in enumerate(records[:stream_index]):
+                payload = event_record.get("event")
+                if (
+                    event_record.get("kind") != "mpv_event"
+                    or not isinstance(payload, dict)
+                    or payload.get("event") != "property-change"
+                    or payload.get("name") != "time-pos"
+                ):
+                    continue
+                elapsed_ns = non_negative_integer(
+                    event_record.get("elapsed_ns"),
+                    "pre-resume time-pos elapsed_ns",
+                    path,
+                )
+                if elapsed_ns <= started_ns:
+                    pre_resume_positions.append(
+                        (
+                            event_index,
+                            finite_non_negative_number(
+                                payload.get("data"),
+                                "pre-resume raw time-pos",
+                                path,
+                            ),
+                        )
+                    )
+            if not pre_resume_positions:
+                raise ValueError(f"{path}: resume has no raw pre-resume time-pos boundary")
+            _boundary_event_index, paused_boundary = pre_resume_positions[-1]
+            paused_detail = finite_non_negative_number(
+                detail.get("paused_time_pos_s"), "resume paused time-pos detail", path
+            )
+            require_artifact_value(
+                path,
+                f"operation {index} raw paused boundary",
+                paused_boundary,
+                paused_detail,
+            )
+            if completion_position <= paused_boundary + CONTROL_MIN_RESUME_PROGRESS_S:
+                raise ValueError(
+                    f"{path}: raw resume completion does not advance beyond the paused boundary"
+                )
+        operation_windows.append((started_ns, completed_ns, operation_name, detail))
+
+    expected_load = scenario.get("controller_load")
+    expected_load_operation = {
+        "resume-session": "resume_session",
+        "none": "ready",
+    }.get(expected_load)
+    if expected_load_operation is None:
+        raise ValueError(f"{path}: controller load policy is invalid")
+    expected_operations = [expected_load_operation]
+    expected_operations.extend("seek" for _ in scenario.get("seeks_s", []))
+    if scenario["pause_policy"] == "pause-resume":
+        expected_operations.extend(("pause", "resume"))
+    operations = [name for _started, _completed, name, _detail in operation_windows]
+    require_artifact_value(
+        path, "exact controller operation order", operations, expected_operations
+    )
+
+    expected_seek_targets_ms = [
+        normalized_seek_target_ms(value, "scenario seek target", path)
+        for value in scenario.get("seeks_s", [])
+    ]
+    require_artifact_value(
+        path,
+        "normalized controller seek targets",
+        actual_seek_targets_ms,
+        expected_seek_targets_ms,
+    )
+
+    observation_s = finite_non_negative_number(
+        scenario.get("warmup_s"), "scenario warmup_s", path
+    ) + finite_non_negative_number(
+        scenario.get("sample_s"), "scenario sample_s", path
+    )
+    observation_ns = int(observation_s * 1_000_000_000)
+    scheduled_action_count = len(expected_seek_targets_ms) + int(
+        scenario["pause_policy"] == "pause-resume"
+    )
+    scheduled_starts: list[tuple[int, int, str]] = [
+        (0, 0, expected_load_operation)
+    ]
+    scheduled_starts.extend(
+        (
+            seek_index + 1,
+            controller_scheduled_offset_ns(
+                observation_ns, seek_index + 1, scheduled_action_count
+            ),
+            "seek",
+        )
+        for seek_index in range(len(expected_seek_targets_ms))
+    )
+    if scenario["pause_policy"] == "pause-resume":
+        scheduled_starts.append(
+            (
+                len(expected_seek_targets_ms) + 1,
+                controller_scheduled_offset_ns(
+                    observation_ns, scheduled_action_count, scheduled_action_count
+                ),
+                "pause",
+            )
+        )
+    for operation_index, expected_start_ns, operation_name in scheduled_starts:
+        actual_start_ns = operation_windows[operation_index][0]
+        latest_start_ns = (
+            expected_start_ns + CONTROL_ACTION_SCHEDULE_LATE_TOLERANCE_NS
+        )
+        if not expected_start_ns <= actual_start_ns <= latest_start_ns:
+            raise ValueError(
+                f"{path}: {operation_name} operation {operation_index} started at "
+                f"{actual_start_ns}ns, outside its scheduled "
+                f"{expected_start_ns}..{latest_start_ns}ns window"
+            )
+
+    if scenario["pause_policy"] == "pause-resume":
+        pause_index = len(expected_operations) - 2
+        resume_index = len(expected_operations) - 1
+        _pause_started, pause_completed, _pause_name, _pause_detail = operation_windows[
+            pause_index
+        ]
+        resume_started, _resume_completed, _resume_name, resume_detail = operation_windows[
+            resume_index
+        ]
+        hold_ms = non_negative_integer(
+            scenario.get("pause_hold_ms"), "scenario pause_hold_ms", path
+        )
+        require_artifact_value(
+            path, "resume pause hold detail", resume_detail.get("pause_hold_ms"), hold_ms
+        )
+        expected_gap_ns = hold_ms * 1_000_000
+        actual_gap_ns = resume_started - pause_completed
+        if not (
+            expected_gap_ns
+            <= actual_gap_ns
+            <= expected_gap_ns + CONTROL_PAUSE_HOLD_LATE_TOLERANCE_NS
+        ):
+            raise ValueError(
+                f"{path}: confirmed pause interval {actual_gap_ns}ns is outside "
+                f"{expected_gap_ns}.."
+                f"{expected_gap_ns + CONTROL_PAUSE_HOLD_LATE_TOLERANCE_NS}ns"
+            )
+
+
+def control_operations_self_test() -> None:
+    schema = "ytt.tui-perf.control.v1"
+
+    def event(
+        elapsed_ns: int,
+        event_type: str,
+        name: str | None = None,
+        data: Any = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"event": event_type}
+        if name is not None:
+            payload["name"] = name
+            payload["data"] = data
+        return {
+            "schema": schema,
+            "kind": "mpv_event",
+            "elapsed_ns": elapsed_ns,
+            "event": payload,
+        }
+
+    def operation(
+        name: str,
+        started_ns: int,
+        completed_ns: int,
+        source: str,
+        event_type: str | None,
+        property_name: str | None,
+        detail: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "schema": schema,
+            "kind": "operation",
+            "operation": name,
+            "operation_started_ns": started_ns,
+            "operation_completed_ns": completed_ns,
+            "latency_ms": (completed_ns - started_ns) / 1_000_000.0,
+            "completion_source": source,
+            "completion_event_elapsed_ns": completed_ns if source == "mpv_event" else None,
+            "completion_event_type": event_type,
+            "completion_property": property_name,
+            "detail": detail,
+        }
+
+    records = [
+        event(20_000_000, "playback-restart"),
+        operation(
+            "resume_session",
+            10_000_000,
+            20_000_000,
+            "mpv_event",
+            "playback-restart",
+            None,
+            {},
+        ),
+        event(35_000_000, "playback-restart"),
+        event(40_000_000, "property-change", "time-pos", 15.0),
+        operation(
+            "seek",
+            30_000_000,
+            40_000_000,
+            "mpv_event",
+            "property-change",
+            "time-pos",
+            {
+                "target_s": 15.0,
+                "observed_target_s": 15.0,
+                "target_tolerance_s": 2.0,
+                "playback_restart_elapsed_ns": 35_000_000,
+            },
+        ),
+        event(55_000_000, "playback-restart"),
+        event(60_000_000, "property-change", "time-pos", 90.0),
+        operation(
+            "seek",
+            50_000_000,
+            60_000_000,
+            "mpv_event",
+            "property-change",
+            "time-pos",
+            {
+                "target_s": 90.0,
+                "observed_target_s": 90.0,
+                "target_tolerance_s": 2.0,
+                "playback_restart_elapsed_ns": 55_000_000,
+            },
+        ),
+        operation(
+            "pause",
+            75_000_000,
+            80_000_000,
+            "status",
+            None,
+            None,
+            {"status_field": "paused", "status_value": True},
+        ),
+        event(100_000_000, "property-change", "time-pos", 90.0),
+        event(600_000_000, "property-change", "time-pos", 90.02),
+        operation(
+            "resume",
+            580_000_000,
+            600_000_000,
+            "mpv_event",
+            "property-change",
+            "time-pos",
+            {"pause_hold_ms": 500, "paused_time_pos_s": 90.0},
+        ),
+    ]
+    scenario = {
+        "controller_load": "resume-session",
+        "seeks_s": [15, 90],
+        "pause_policy": "pause-resume",
+        "pause_hold_ms": 500,
+        "warmup_s": 0,
+        "sample_s": 0.1,
+    }
+    path = Path("<control-operation-self-test>")
+    validate_control_operations(path, records, 700_000_000, scenario)
+
+    def expect_rejected(
+        label: str,
+        tampered: list[dict[str, Any]],
+        summary_elapsed_ns: int = 700_000_000,
+        expected_error: str | None = None,
+    ) -> None:
+        try:
+            validate_control_operations(path, tampered, summary_elapsed_ns, scenario)
+        except ValueError as error:
+            if expected_error is not None and expected_error not in str(error):
+                raise AssertionError(
+                    f"controller operation tampering {label!r} failed for the wrong "
+                    f"reason: {error}"
+                ) from error
+        else:
+            raise AssertionError(f"controller operation tampering was accepted: {label}")
+
+    def shift_suffix(start_ns: int) -> list[dict[str, Any]]:
+        shifted = json.loads(json.dumps(records))
+        delta_ns = CONTROL_ACTION_SCHEDULE_LATE_TOLERANCE_NS + 1
+        for record in shifted:
+            if record.get("kind") == "mpv_event":
+                if record["elapsed_ns"] >= start_ns:
+                    record["elapsed_ns"] += delta_ns
+                continue
+            if record.get("kind") != "operation":
+                continue
+            if record["operation_started_ns"] < start_ns:
+                continue
+            record["operation_started_ns"] += delta_ns
+            record["operation_completed_ns"] += delta_ns
+            completion_ns = record.get("completion_event_elapsed_ns")
+            if completion_ns is not None:
+                record["completion_event_elapsed_ns"] = completion_ns + delta_ns
+            restart_ns = record.get("detail", {}).get("playback_restart_elapsed_ns")
+            if restart_ns is not None:
+                record["detail"]["playback_restart_elapsed_ns"] = restart_ns + delta_ns
+        return shifted
+
+    late_load = shift_suffix(0)
+    expect_rejected(
+        "late immediate load",
+        late_load,
+        900_000_000,
+        "resume_session operation 0 started",
+    )
+
+    early_seek = json.loads(json.dumps(records))
+    first_seek = next(
+        record
+        for record in early_seek
+        if record.get("kind") == "operation" and record.get("operation") == "seek"
+    )
+    first_seek["operation_started_ns"] = 24_999_999
+    first_seek["latency_ms"] = (
+        first_seek["operation_completed_ns"] - first_seek["operation_started_ns"]
+    ) / 1_000_000.0
+    expect_rejected(
+        "early scheduled seek",
+        early_seek,
+        expected_error="seek operation 1 started",
+    )
+
+    late_seek = shift_suffix(30_000_000)
+    expect_rejected(
+        "late scheduled seek",
+        late_seek,
+        900_000_000,
+        "seek operation 1 started",
+    )
+
+    late_pause = shift_suffix(75_000_000)
+    expect_rejected(
+        "late scheduled pause",
+        late_pause,
+        900_000_000,
+        "pause operation 3 started",
+    )
+
+    target_swap = json.loads(json.dumps(records))
+    target_operations = [
+        record
+        for record in target_swap
+        if record.get("kind") == "operation" and record.get("operation") == "seek"
+    ]
+    for record, target in zip(target_operations, (90.0, 15.0)):
+        record["detail"]["target_s"] = target
+        record["detail"]["observed_target_s"] = target
+        completion_event = next(
+            event_record
+            for event_record in target_swap
+            if event_record.get("kind") == "mpv_event"
+            and event_record.get("elapsed_ns") == record["operation_completed_ns"]
+        )
+        completion_event["event"]["data"] = target
+    expect_rejected("seek target swap", target_swap)
+
+    wrong_order = json.loads(json.dumps(records))
+    pause_stream_index = next(
+        index
+        for index, record in enumerate(wrong_order)
+        if record.get("operation") == "pause"
+    )
+    final_seek_stream_index = [
+        index
+        for index, record in enumerate(wrong_order)
+        if record.get("operation") == "seek"
+    ][-1]
+    pause_record = wrong_order.pop(pause_stream_index)
+    pause_record["operation_started_ns"] = 45_000_000
+    pause_record["operation_completed_ns"] = 46_000_000
+    pause_record["latency_ms"] = 1.0
+    wrong_order.insert(final_seek_stream_index, pause_record)
+    expect_rejected("operation order", wrong_order)
+
+    overlap = json.loads(json.dumps(records))
+    seek_operations = [
+        record
+        for record in overlap
+        if record.get("kind") == "operation" and record.get("operation") == "seek"
+    ]
+    seek_operations[1]["operation_started_ns"] = 39_999_999
+    seek_operations[1]["latency_ms"] = (
+        seek_operations[1]["operation_completed_ns"]
+        - seek_operations[1]["operation_started_ns"]
+    ) / 1_000_000.0
+    expect_rejected("overlapping operations", overlap)
+
+    short_pause = json.loads(json.dumps(records))
+    resume = next(record for record in short_pause if record.get("operation") == "resume")
+    resume["operation_started_ns"] = 579_999_999
+    resume["latency_ms"] = (
+        resume["operation_completed_ns"] - resume["operation_started_ns"]
+    ) / 1_000_000.0
+    expect_rejected("short pause", short_pause)
+
+    long_pause = json.loads(json.dumps(records))
+    resume = next(record for record in long_pause if record.get("operation") == "resume")
+    old_completion_ns = resume["operation_completed_ns"]
+    resume["operation_started_ns"] = (
+        80_000_000 + 500_000_000 + CONTROL_PAUSE_HOLD_LATE_TOLERANCE_NS + 1
+    )
+    resume["operation_completed_ns"] = resume["operation_started_ns"] + 20_000_000
+    resume["completion_event_elapsed_ns"] = resume["operation_completed_ns"]
+    resume["latency_ms"] = 20.0
+    completion_event = next(
+        record
+        for record in long_pause
+        if record.get("kind") == "mpv_event"
+        and record.get("elapsed_ns") == old_completion_ns
+    )
+    completion_event["elapsed_ns"] = resume["operation_completed_ns"]
+    expect_rejected("long pause", long_pause, 800_000_000)
+
+    detail_tamper = json.loads(json.dumps(records))
+    resume = next(record for record in detail_tamper if record.get("operation") == "resume")
+    resume["detail"]["pause_hold_ms"] = 499
+    expect_rejected("pause detail", detail_tamper)
+
+    raw_seek_tamper = json.loads(json.dumps(records))
+    seek_event = next(
+        record
+        for record in raw_seek_tamper
+        if record.get("kind") == "mpv_event" and record.get("elapsed_ns") == 40_000_000
+    )
+    seek_event["event"]["data"] = 14.5
+    expect_rejected("raw seek payload", raw_seek_tamper)
+
+    raw_resume_tamper = json.loads(json.dumps(records))
+    resume_event = next(
+        record
+        for record in raw_resume_tamper
+        if record.get("kind") == "mpv_event" and record.get("elapsed_ns") == 600_000_000
+    )
+    resume_event["event"]["data"] = 90.005
+    expect_rejected("raw resume payload", raw_resume_tamper)
+
+    raw_boundary_tamper = json.loads(json.dumps(records))
+    boundary_event = next(
+        record
+        for record in raw_boundary_tamper
+        if record.get("kind") == "mpv_event" and record.get("elapsed_ns") == 100_000_000
+    )
+    boundary_event["event"]["data"] = 89.0
+    expect_rejected("raw paused boundary", raw_boundary_tamper)
+
+
+def portable_executable_stem(value: str) -> str:
+    basename = value.replace("\\", "/").rsplit("/", 1)[-1].lower()
+    return basename[:-4] if basename.endswith(".exe") else basename.rsplit(".", 1)[0]
+
+
+def raw_process_role(root_pid: int, process: dict[str, Any]) -> str:
+    if process["pid"] == root_pid:
+        return "ytt"
+    name = process["name"].lower()
+    command = process["command"]
+    argv0 = portable_executable_stem(command[0]) if command else ""
+    return "mpv" if name in {"mpv", "mpv.exe"} or argv0 == "mpv" else "other"
+
+
+def mpv_last_option(command: list[str], option: str) -> str | None:
+    value: str | None = None
+    index = 0
+    prefix = f"--{option}="
+    split = f"--{option}"
+    while index < len(command):
+        argument = command[index]
+        if argument.startswith(prefix):
+            value = argument[len(prefix) :]
+        elif argument == split:
+            if index + 1 < len(command):
+                index += 1
+                value = command[index]
+            else:
+                value = None
+        index += 1
+    return value
+
+
+def require_effective_mpv_cache_args(
+    path: Path,
+    command: list[str],
+    expected: dict[str, str],
+    context: str,
+) -> None:
+    if expected != REQUIRED_PLAYBACK_MPV_CACHE_ARGS:
+        raise ValueError(f"{path}: {context} has no valid expected mpv cache argv contract")
+    for argument, expected_value in expected.items():
+        actual = mpv_last_option(command, argument.removeprefix("--"))
+        if actual != expected_value:
+            raise ValueError(
+                f"{path}: {context} effective {argument} is {actual!r}, "
+                f"expected {expected_value!r} by last-option-wins"
+            )
+
+
+def mpv_cache_argv_contract_self_test() -> None:
+    path = Path("<mpv-cache-argv-self-test>")
+    valid = [
+        "mpv",
+        "--demuxer-max-bytes=1MiB",
+        "--demuxer-max-back-bytes",
+        "1MiB",
+        "--demuxer-max-bytes",
+        "32MiB",
+        "--demuxer-max-back-bytes=8MiB",
+    ]
+    require_effective_mpv_cache_args(
+        path, valid, REQUIRED_PLAYBACK_MPV_CACHE_ARGS, "valid command"
+    )
+
+    def expect_rejected(label: str, command: list[str]) -> None:
+        try:
+            require_effective_mpv_cache_args(
+                path, command, REQUIRED_PLAYBACK_MPV_CACHE_ARGS, label
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"mpv cache argv contract accepted {label}")
+
+    expect_rejected(
+        "missing backward cache option",
+        ["mpv", "--demuxer-max-bytes=32MiB"],
+    )
+    expect_rejected(
+        "later forward cache override",
+        [*valid, "--demuxer-max-bytes=16MiB"],
+    )
+
+
+def silent_mpv_command(command: list[str]) -> bool:
+    ao = mpv_last_option(command, "ao")
+    volume = mpv_last_option(command, "volume")
+    try:
+        numeric_volume = float(volume) if volume is not None else None
+    except ValueError:
+        numeric_volume = None
+    return ao is not None and ao.lower() == "null" and numeric_volume == 0.0
+
+
+def mpv_ipc_identity(command: list[str]) -> tuple[list[str] | None, str | None]:
+    identity: list[str] = []
+    endpoint: str | None = None
+    index = 0
+    while index < len(command):
+        argument = command[index]
+        if argument.startswith("--input-ipc-server="):
+            value = argument.split("=", 1)[1]
+            identity.append(argument)
+            if value:
+                endpoint = value
+        elif argument == "--input-ipc-server":
+            if index + 1 >= len(command):
+                return None, None
+            value = command[index + 1]
+            identity.extend((argument, value))
+            if value:
+                endpoint = value
+            index += 1
+        index += 1
+    return (identity, endpoint) if identity and endpoint else (None, None)
+
+
+def validate_measured_samples(
+    path: Path,
+    header: dict[str, Any],
+    summary: dict[str, Any],
+    all_samples: list[dict[str, Any]],
+    require_mpv: bool,
+    expected_mpv_cache_args: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    if require_mpv and expected_mpv_cache_args != REQUIRED_PLAYBACK_MPV_CACHE_ARGS:
+        raise ValueError(f"{path}: playback samples have no valid expected mpv cache argv contract")
+    if not require_mpv and expected_mpv_cache_args is not None:
+        raise ValueError(f"{path}: non-playback samples cannot declare expected mpv cache argv")
+    warmup_ms = non_negative_integer(header.get("warmup_ms"), "warmup_ms", path)
+    duration_ms = non_negative_integer(header.get("duration_ms"), "duration_ms", path)
+    interval_ms = non_negative_integer(header.get("interval_ms"), "interval_ms", path)
+    if interval_ms == 0:
+        raise ValueError(f"{path}: interval_ms must be positive")
+    require_artifact_value(
+        path, "CPU accounting method", header.get("cpu_accounting"), CPU_ACCOUNTING_METHOD
+    )
+    cpu_window_start_ns = non_negative_integer(
+        header.get("cpu_window_start_ns"), "cpu_window_start_ns", path
+    )
+    cpu_window_end_ns = non_negative_integer(
+        header.get("cpu_window_end_ns"), "cpu_window_end_ns", path
+    )
+    if cpu_window_end_ns <= cpu_window_start_ns:
+        raise ValueError(f"{path}: CPU measurement window must be positive")
+    cpu_window_duration_ns = cpu_window_end_ns - cpu_window_start_ns
+    require_artifact_value(
+        path, "CPU window warmup milliseconds", cpu_window_start_ns // 1_000_000, warmup_ms
+    )
+    require_artifact_value(
+        path,
+        "CPU window duration milliseconds",
+        cpu_window_duration_ns // 1_000_000,
+        duration_ms,
+    )
+    require_artifact_value(
+        path, "summary CPU accounting method", summary.get("cpu_accounting"), CPU_ACCOUNTING_METHOD
+    )
+    require_artifact_value(
+        path,
+        "summary CPU window start",
+        summary.get("cpu_window_start_ns"),
+        cpu_window_start_ns,
+    )
+    require_artifact_value(
+        path,
+        "summary CPU window end",
+        summary.get("cpu_window_end_ns"),
+        cpu_window_end_ns,
+    )
+    measured = [record for record in all_samples if record.get("phase") == "measure"]
+    if not measured:
+        raise ValueError(f"{path}: no measured samples")
+    expected_samples = max(
+        2, math.ceil(cpu_window_duration_ns / (interval_ms * 1_000_000)) + 1
+    )
+    if not expected_samples - 1 <= len(measured) <= expected_samples + 1:
+        raise ValueError(
+            f"{path}: measured sample count {len(measured)} is outside "
+            f"{expected_samples}±1"
+        )
+    root_pid = non_negative_integer(header.get("root_pid"), "root_pid", path)
+    if root_pid == 0:
+        raise ValueError(f"{path}: root_pid must be positive")
+    elapsed = []
+    role_points: dict[str, list[tuple[float, int, int]]] = {}
+    previous_by_identity: dict[tuple[int, int], tuple[int, int]] = {}
+    start_by_pid: dict[int, int] = {}
+    recomputed_samples: list[dict[str, Any]] = []
+    last_mpv_identities: list[dict[str, Any]] = []
+    proof = {
+        "samples": 0,
+        "samples_with_mpv": 0,
+        "samples_all_silent": 0,
+        "samples_all_cleanup_identified": 0,
+    }
+    previous_observed_ns = -1
+    total_cpu_overlap_ns = 0
+    for index, record in enumerate(all_samples):
+        require_artifact_value(path, f"sample {index} schema", record.get("schema"), "ytt.tui-perf.samples.v1")
+        observed_ns = non_negative_integer(
+            record.get("observed_elapsed_ns"), f"sample {index} observed_elapsed_ns", path
+        )
+        if observed_ns <= previous_observed_ns:
+            raise ValueError(f"{path}: sample observed_elapsed_ns must be strictly increasing")
+        expected_cpu_overlap_ns = 0
+        if previous_observed_ns >= 0:
+            expected_cpu_overlap_ns = max(
+                0,
+                min(observed_ns, cpu_window_end_ns)
+                - max(previous_observed_ns, cpu_window_start_ns),
+            )
+        recorded_cpu_overlap_ns = non_negative_integer(
+            record.get("cpu_interval_overlap_ns"),
+            f"sample {index} cpu_interval_overlap_ns",
+            path,
+        )
+        require_artifact_value(
+            path,
+            f"sample {index} CPU interval overlap",
+            recorded_cpu_overlap_ns,
+            expected_cpu_overlap_ns,
+        )
+        total_cpu_overlap_ns += expected_cpu_overlap_ns
+        previous_observed_ns = observed_ns
+        raw_elapsed = non_negative_integer(record.get("elapsed_ms"), f"sample {index} elapsed_ms", path)
+        require_artifact_value(path, f"sample {index} elapsed_ms", raw_elapsed, observed_ns // 1_000_000)
+        expected_phase = "warmup" if observed_ns < cpu_window_start_ns else "measure"
+        require_artifact_value(path, f"sample {index} phase", record.get("phase"), expected_phase)
+        processes = record.get("processes")
+        if not isinstance(processes, list) or not processes:
+            raise ValueError(f"{path}: sample {index} processes must be a non-empty array")
+        seen_pids: set[int] = set()
+        parent_by_pid: dict[int, int | None] = {}
+        computed_roles: dict[str, dict[str, int | float]] = {}
+        sample_mpv: list[dict[str, Any]] = []
+        for process_index, process in enumerate(processes):
+            if not isinstance(process, dict):
+                raise ValueError(f"{path}: sample {index} process {process_index} is not an object")
+            expected_fields = {
+                "pid", "parent_pid", "role", "name", "start_time_unix_s",
+                "accumulated_cpu_ms", "cpu_percent", "rss_bytes", "command",
+                "executable", "executable_bytes", "executable_sha256",
+            }
+            if set(process) != expected_fields:
+                raise ValueError(
+                    f"{path}: sample {index} process {process_index} fields are "
+                    f"{sorted(process)}, expected {sorted(expected_fields)}"
+                )
+            pid = non_negative_integer(process.get("pid"), "process pid", path)
+            if pid == 0 or pid in seen_pids:
+                raise ValueError(f"{path}: sample {index} has duplicate/zero process PID {pid}")
+            seen_pids.add(pid)
+            parent_pid = process.get("parent_pid")
+            if parent_pid is not None:
+                non_negative_integer(parent_pid, "process parent_pid", path)
+            parent_by_pid[pid] = parent_pid
+            name = process.get("name")
+            command = process.get("command")
+            if not isinstance(name, str) or not name:
+                raise ValueError(f"{path}: sample {index} process {pid} has invalid name")
+            if not isinstance(command, list) or not all(isinstance(item, str) for item in command):
+                raise ValueError(f"{path}: sample {index} process {pid} has invalid command")
+            start_time = non_negative_integer(process.get("start_time_unix_s"), "process start time", path)
+            if pid in start_by_pid and start_by_pid[pid] != start_time:
+                raise ValueError(f"{path}: PID {pid} was reused across raw samples")
+            start_by_pid[pid] = start_time
+            accumulated = non_negative_integer(process.get("accumulated_cpu_ms"), "accumulated CPU", path)
+            rss = non_negative_integer(process.get("rss_bytes"), "process RSS", path)
+            identity = (pid, start_time)
+            previous = previous_by_identity.get(identity)
+            if previous is None:
+                expected_cpu = 0.0
+            else:
+                previous_accumulated, previous_ns = previous
+                if accumulated < previous_accumulated:
+                    raise ValueError(f"{path}: accumulated CPU decreased for PID {pid}")
+                expected_cpu = (
+                    (accumulated - previous_accumulated) * 100_000_000.0
+                    / (observed_ns - previous_ns)
+                )
+            previous_by_identity[identity] = (accumulated, observed_ns)
+            actual_cpu = finite_non_negative_number(process.get("cpu_percent"), "process cpu_percent", path)
+            if not math.isclose(actual_cpu, expected_cpu, rel_tol=1e-12, abs_tol=1e-9):
+                raise ValueError(
+                    f"{path}: PID {pid} CPU {actual_cpu} does not match accumulated/raw-time {expected_cpu}"
+                )
+            expected_role = raw_process_role(root_pid, process)
+            require_artifact_value(path, f"PID {pid} role", process.get("role"), expected_role)
+            executable = process.get("executable")
+            executable_bytes = process.get("executable_bytes")
+            executable_sha = process.get("executable_sha256")
+            if executable is not None and (not isinstance(executable, str) or not executable):
+                raise ValueError(f"{path}: PID {pid} executable must be null or non-empty")
+            if executable_sha is not None and (
+                not isinstance(executable_sha, str) or re.fullmatch(r"[0-9a-f]{64}", executable_sha) is None
+            ):
+                raise ValueError(f"{path}: PID {pid} executable SHA-256 is invalid")
+            if executable_bytes is not None:
+                executable_bytes = non_negative_integer(
+                    executable_bytes, "process executable bytes", path
+                )
+            if pid == root_pid:
+                if not executable or not executable_bytes:
+                    raise ValueError(f"{path}: root process has no executable identity")
+                require_artifact_value(path, "root executable SHA-256", executable_sha, header.get("binary_sha256"))
+            if expected_role == "mpv" and (
+                not executable or not executable_bytes or executable_sha is None
+            ):
+                raise ValueError(f"{path}: measured mpv PID {pid} has no executable identity")
+            if (executable is None) != (executable_bytes is None) or (
+                executable is None
+            ) != (executable_sha is None):
+                raise ValueError(f"{path}: PID {pid} executable identity is partial")
+            aggregate = computed_roles.setdefault(
+                expected_role, {"processes": 0, "cpu_percent": 0.0, "rss_bytes": 0}
+            )
+            aggregate["processes"] = int(aggregate["processes"]) + 1
+            aggregate["cpu_percent"] = float(aggregate["cpu_percent"]) + expected_cpu
+            aggregate["rss_bytes"] = int(aggregate["rss_bytes"]) + rss
+            if expected_role == "mpv":
+                if expected_phase == "measure":
+                    require_effective_mpv_cache_args(
+                        path,
+                        command,
+                        expected_mpv_cache_args or {},
+                        f"sample {index} mpv PID {pid}",
+                    )
+                identity_argv, endpoint = mpv_ipc_identity(command)
+                sample_mpv.append(
+                    {
+                        "pid": pid,
+                        "start_time_unix_s": start_time,
+                        "input_ipc_server_argv": identity_argv,
+                        "endpoint": endpoint,
+                        "silent": silent_mpv_command(command),
+                        "process": process,
+                    }
+                )
+        if root_pid not in seen_pids:
+            raise ValueError(f"{path}: sample {index} does not contain root PID {root_pid}")
+        for descendant_pid in parent_by_pid:
+            if descendant_pid == root_pid:
+                continue
+            current = descendant_pid
+            visited: set[int] = set()
+            while current != root_pid:
+                if current in visited:
+                    raise ValueError(
+                        f"{path}: sample {index} PID {descendant_pid} has a parent cycle"
+                    )
+                visited.add(current)
+                parent = parent_by_pid.get(current)
+                if parent is None:
+                    raise ValueError(
+                        f"{path}: sample {index} PID {descendant_pid} has a missing parent"
+                    )
+                if parent == current:
+                    raise ValueError(
+                        f"{path}: sample {index} PID {current} is its own parent"
+                    )
+                if parent not in parent_by_pid:
+                    raise ValueError(
+                        f"{path}: sample {index} PID {descendant_pid} escapes the sampled root"
+                    )
+                current = parent
+        tree = {
+            "processes": sum(int(item["processes"]) for item in computed_roles.values()),
+            "cpu_percent": sum(float(item["cpu_percent"]) for item in computed_roles.values()),
+            "rss_bytes": sum(int(item["rss_bytes"]) for item in computed_roles.values()),
+        }
+        expected_roles = {**computed_roles, "tree": tree}
+        roles = record.get("roles")
+        if not isinstance(roles, dict) or set(roles) != set(expected_roles):
+            raise ValueError(f"{path}: sample {index} role inventory does not match raw processes")
+        for role_name, expected_values in expected_roles.items():
+            values = roles[role_name]
+            if not isinstance(values, dict) or set(values) != {"processes", "cpu_percent", "rss_bytes"}:
+                raise ValueError(f"{path}: sample {index} role {role_name} has invalid schema")
+            require_artifact_value(path, f"sample {index} {role_name} processes", values["processes"], expected_values["processes"])
+            require_artifact_value(path, f"sample {index} {role_name} RSS", values["rss_bytes"], expected_values["rss_bytes"])
+            actual_role_cpu = finite_non_negative_number(values["cpu_percent"], f"sample {index} {role_name} CPU", path)
+            if not math.isclose(actual_role_cpu, float(expected_values["cpu_percent"]), rel_tol=1e-12, abs_tol=1e-9):
+                raise ValueError(f"{path}: sample {index} {role_name} CPU does not match raw processes")
+        present = bool(sample_mpv)
+        all_silent = present and all(item["silent"] for item in sample_mpv)
+        all_identified = present and all(item["input_ipc_server_argv"] is not None for item in sample_mpv)
+        require_artifact_value(path, f"sample {index} mpv_present", record.get("mpv_present"), present)
+        require_artifact_value(path, f"sample {index} mpv_all_silent", record.get("mpv_all_silent_this_sample"), all_silent)
+        if sample_mpv and all_identified:
+            last_mpv_identities = [
+                {
+                    "pid": item["pid"],
+                    "start_time_unix_s": item["start_time_unix_s"],
+                    "executable": item["process"]["executable"],
+                    "executable_bytes": item["process"]["executable_bytes"],
+                    "executable_sha256": item["process"]["executable_sha256"],
+                    "input_ipc_server_argv": item["input_ipc_server_argv"],
+                }
+                for item in sample_mpv
+            ]
+        if expected_phase == "measure":
+            proof["samples"] += 1
+            proof["samples_with_mpv"] += int(present)
+            proof["samples_all_silent"] += int(all_silent)
+            proof["samples_all_cleanup_identified"] += int(all_identified)
+            raw_elapsed = observed_ns // 1_000_000
+            elapsed.append(raw_elapsed)
+            for role_name, values in expected_roles.items():
+                role_points.setdefault(role_name, []).append(
+                    (
+                        float(values["cpu_percent"]),
+                        int(values["rss_bytes"]),
+                        expected_cpu_overlap_ns,
+                    )
+                )
+        recomputed_samples.append({"record": record, "mpv": sample_mpv, "roles": expected_roles})
+    if elapsed != sorted(elapsed) or len(elapsed) != len(set(elapsed)):
+        raise ValueError(f"{path}: measured elapsed_ms values must be strictly increasing")
+    if len(elapsed) >= 2:
+        expected_span = (len(elapsed) - 1) * interval_ms
+        actual_span = elapsed[-1] - elapsed[0]
+        schedule_tolerance = max(50, interval_ms // 4)
+        if abs(actual_span - expected_span) > schedule_tolerance:
+            raise ValueError(
+                f"{path}: measured sampling span {actual_span}ms does not match "
+                f"{expected_span}ms within {schedule_tolerance}ms"
+            )
+    if elapsed[0] < max(0, warmup_ms - interval_ms) or elapsed[0] > warmup_ms + interval_ms:
+        raise ValueError(f"{path}: measured phase starts outside one sampling interval of warmup")
+    if previous_observed_ns < cpu_window_end_ns:
+        raise ValueError(f"{path}: final raw CPU interval does not reach the declared window end")
+    if elapsed[-1] > (cpu_window_end_ns // 1_000_000) + interval_ms:
+        raise ValueError(f"{path}: final measured sample is more than one interval late")
+    if total_cpu_overlap_ns != cpu_window_duration_ns:
+        raise ValueError(
+            f"{path}: raw CPU intervals cover {total_cpu_overlap_ns}ns, "
+            f"expected the full {cpu_window_duration_ns}ns measurement window"
+        )
+
+    summary_roles = summary.get("roles")
+    if not isinstance(summary_roles, dict) or set(summary_roles) != set(role_points):
+        raise ValueError(f"{path}: summary roles do not match measured raw roles")
+    for role, points in role_points.items():
+        values = summary_roles[role]
+        if not isinstance(values, dict):
+            raise ValueError(f"{path}: summary role {role} must be an object")
+        expected_cpu = (
+            sum(cpu * overlap_ns for cpu, _rss, overlap_ns in points)
+            / cpu_window_duration_ns
+        )
+        expected_mean_rss = sum(rss for _cpu, rss, _overlap_ns in points) // len(points)
+        expected_peak_rss = max(rss for _cpu, rss, _overlap_ns in points)
+        require_artifact_value(path, f"{role} summary samples", values.get("samples"), len(points))
+        actual_cpu = finite_non_negative_number(
+            values.get("mean_cpu_percent"), f"summary {role}.mean_cpu_percent", path
+        )
+        if not math.isclose(actual_cpu, expected_cpu, rel_tol=1e-12, abs_tol=1e-9):
+            raise ValueError(
+                f"{path}: {role} mean CPU {actual_cpu} does not match raw {expected_cpu}"
+            )
+        require_artifact_value(
+            path, f"{role} mean RSS", values.get("mean_rss_bytes"), expected_mean_rss
+        )
+        require_artifact_value(
+            path, f"{role} peak RSS", values.get("peak_rss_bytes"), expected_peak_rss
+        )
+    proven = proof["samples"] > 0 and proof["samples_with_mpv"] == proof["samples"] and proof["samples_all_silent"] == proof["samples"]
+    cleanup_proven = proof["samples"] > 0 and proof["samples_all_cleanup_identified"] == proof["samples"]
+    require_artifact_value(path, "summary root PID", summary.get("root_pid"), root_pid)
+    require_artifact_value(path, "summary measured mpv proof", summary.get("measured_mpv_proof"), proof)
+    require_artifact_value(path, "summary silent mpv proof", summary.get("silent_mpv_proven"), proven)
+    require_artifact_value(path, "summary last mpv identity", summary.get("last_observed_mpv"), last_mpv_identities)
+    if require_mpv and (not proven or not cleanup_proven):
+        raise ValueError(f"{path}: raw measured samples do not prove silent, cleanup-identified mpv")
+    return {
+        "root_pid": root_pid,
+        "samples": recomputed_samples,
+        "measured": [item for item in recomputed_samples if item["record"]["phase"] == "measure"],
+        "last_mpv_identities": last_mpv_identities,
+    }
+
+
+def sample_tree_topology_self_test() -> None:
+    header = {
+        "root_pid": 100,
+        "binary_sha256": "ab" * 32,
+        "warmup_ms": 1_000,
+        "duration_ms": 2_000,
+        "cpu_accounting": CPU_ACCOUNTING_METHOD,
+        "cpu_window_start_ns": 1_000_000_000,
+        "cpu_window_end_ns": 3_000_000_000,
+        "interval_ms": 1_000,
+    }
+
+    def process(
+        pid: int,
+        parent_pid: int | None,
+        role: str,
+        name: str,
+        start_time: int,
+        accumulated_cpu_ms: int,
+        cpu_percent: float,
+        rss_bytes: int,
+        root: bool = False,
+    ) -> dict[str, Any]:
+        return {
+            "pid": pid,
+            "parent_pid": parent_pid,
+            "role": role,
+            "name": name,
+            "start_time_unix_s": start_time,
+            "accumulated_cpu_ms": accumulated_cpu_ms,
+            "cpu_percent": cpu_percent,
+            "rss_bytes": rss_bytes,
+            "command": [f"/tmp/{name}"],
+            "executable": "/tmp/ytt" if root else None,
+            "executable_bytes": 1 if root else None,
+            "executable_sha256": "ab" * 32 if root else None,
+        }
+
+    def sample(
+        elapsed_ms: int,
+        cpu_overlap_ms: int,
+        root_values: tuple[int, float, int],
+        first_values: tuple[int, float, int],
+        second_values: tuple[int, float, int],
+    ) -> dict[str, Any]:
+        root_accumulated, root_cpu, root_rss = root_values
+        first_accumulated, first_cpu, first_rss = first_values
+        second_accumulated, second_cpu, second_rss = second_values
+        other_cpu = first_cpu + second_cpu
+        other_rss = first_rss + second_rss
+        tree_cpu = root_cpu + other_cpu
+        tree_rss = root_rss + other_rss
+        return {
+            "schema": "ytt.tui-perf.samples.v1",
+            "kind": "sample",
+            "elapsed_ms": elapsed_ms,
+            "observed_elapsed_ns": elapsed_ms * 1_000_000,
+            "cpu_interval_overlap_ns": cpu_overlap_ms * 1_000_000,
+            "phase": "warmup" if elapsed_ms < 1_000 else "measure",
+            "mpv_present": False,
+            "mpv_all_silent_this_sample": False,
+            "roles": {
+                "ytt": {
+                    "processes": 1,
+                    "cpu_percent": root_cpu,
+                    "rss_bytes": root_rss,
+                },
+                "other": {
+                    "processes": 2,
+                    "cpu_percent": other_cpu,
+                    "rss_bytes": other_rss,
+                },
+                "tree": {
+                    "processes": 3,
+                    "cpu_percent": tree_cpu,
+                    "rss_bytes": tree_rss,
+                },
+            },
+            "processes": [
+                process(
+                    100,
+                    1,
+                    "ytt",
+                    "ytt",
+                    50,
+                    root_accumulated,
+                    root_cpu,
+                    root_rss,
+                    True,
+                ),
+                process(
+                    200,
+                    100,
+                    "other",
+                    "helper-a",
+                    51,
+                    first_accumulated,
+                    first_cpu,
+                    first_rss,
+                ),
+                process(
+                    201,
+                    100,
+                    "other",
+                    "helper-b",
+                    52,
+                    second_accumulated,
+                    second_cpu,
+                    second_rss,
+                ),
+            ],
+        }
+
+    records = [
+        sample(0, 0, (0, 0.0, 50), (0, 0.0, 10), (0, 0.0, 15)),
+        sample(1_000, 0, (100, 10.0, 100), (20, 2.0, 20), (30, 3.0, 25)),
+        sample(2_000, 1_000, (300, 20.0, 200), (60, 4.0, 30), (80, 5.0, 35)),
+        sample(3_000, 1_000, (600, 30.0, 300), (120, 6.0, 40), (150, 7.0, 45)),
+    ]
+    summary = {
+        "cpu_accounting": CPU_ACCOUNTING_METHOD,
+        "cpu_window_start_ns": 1_000_000_000,
+        "cpu_window_end_ns": 3_000_000_000,
+        "roles": {
+            "ytt": {
+                "samples": 3,
+                "mean_cpu_percent": 25.0,
+                "mean_rss_bytes": 200,
+                "peak_rss_bytes": 300,
+            },
+            "other": {
+                "samples": 3,
+                "mean_cpu_percent": 11.0,
+                "mean_rss_bytes": 65,
+                "peak_rss_bytes": 85,
+            },
+            "tree": {
+                "samples": 3,
+                "mean_cpu_percent": 36.0,
+                "mean_rss_bytes": 265,
+                "peak_rss_bytes": 385,
+            },
+        },
+        "root_pid": 100,
+        "silent_mpv_proven": False,
+        "measured_mpv_proof": {
+            "samples": 3,
+            "samples_with_mpv": 0,
+            "samples_all_silent": 0,
+            "samples_all_cleanup_identified": 0,
+        },
+        "last_observed_mpv": [],
+    }
+    path = Path("<sample-tree-self-test>")
+    validate_measured_samples(path, header, summary, records, False)
+
+    def expect_parent_rejected(
+        label: str, first_parent: int | None, second_parent: int | None = 100
+    ) -> None:
+        tampered = json.loads(json.dumps(records))
+        for record in tampered:
+            by_pid = {item["pid"]: item for item in record["processes"]}
+            by_pid[200]["parent_pid"] = first_parent
+            by_pid[201]["parent_pid"] = second_parent
+        try:
+            validate_measured_samples(path, header, summary, tampered, False)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"sample parent topology tampering was accepted: {label}")
+
+    # Roles, CPU, RSS, and summary totals remain exactly recomputed; only ancestry is hostile.
+    expect_parent_rejected("A-B cycle", 201, 200)
+    expect_parent_rejected("self parent", 200)
+    expect_parent_rejected("missing parent", None)
+    expect_parent_rejected("escaped parent", 999)
 
 
 def validate_process_directory(
@@ -1312,6 +8578,9 @@ def validate_process_directory(
     scenario_hash: str,
     host_os: str,
     manifest: dict[str, Any],
+    seed_context: tuple[dict[str, Any], Path] | None,
+    run_contract: dict[str, Any],
+    additional_metric_files: list[Path],
 ) -> list[Path]:
     samples_path = path / "samples.ndjson"
     if not samples_path.is_file():
@@ -1324,17 +8593,49 @@ def validate_process_directory(
         for record in samples
         if record.get("kind") == "sample" and record.get("phase") == "measure"
     ]
+    all_sample_records = [record for record in samples if record.get("kind") == "sample"]
+    unexpected_sample_kinds = sorted(
+        {
+            str(record.get("kind"))
+            for record in samples
+            if record.get("kind") not in {"header", "sample", "summary", "error"}
+        }
+    )
+    if unexpected_sample_kinds:
+        raise ValueError(
+            f"{samples_path}: unexpected sampler record kinds {unexpected_sample_kinds}"
+        )
     if len(headers) != 1 or len(summaries) != 1 or not measured:
         raise ValueError(f"{samples_path}: incomplete sampler header, summary, or measurements")
     header = headers[0]
+    summary = summaries[0]
     require_artifact_value(samples_path, "schema", header.get("schema"), "ytt.tui-perf.samples.v1")
     require_artifact_value(samples_path, "scenario SHA-256", header.get("scenario_sha256"), scenario_hash)
+    require_artifact_value(samples_path, "run ID", header.get("run_id"), run_contract["run_id"])
+    require_artifact_value(
+        samples_path, "summary run ID", summary.get("run_id"), run_contract["run_id"]
+    )
+    validate_sampler_terminal_geometry(samples_path, header, summary, run_contract)
+    sampler_started_unix_ns = non_negative_integer(
+        header.get("observation_started_unix_ns"), "sampler observation start", samples_path
+    )
+    sampler_finished_unix_ns = non_negative_integer(
+        summary.get("observation_finished_unix_ns"), "sampler observation finish", samples_path
+    )
+    if not run_contract["started_unix_ns"] <= sampler_started_unix_ns < sampler_finished_unix_ns <= run_contract["finished_unix_ns"]:
+        raise ValueError(f"{samples_path}: sampler producer interval escapes its run contract")
     require_artifact_value(samples_path, "OS", normalized_os(header.get("os")), host_os)
     require_artifact_value(
         samples_path,
         "executed binary SHA-256",
         header.get("binary_sha256"),
         manifest["binaries"][f"{role}_ytt"]["sha256"],
+    )
+    require_artifact_value(
+        samples_path,
+        "sampler producer SHA-256",
+        header.get("producer_binary_sha256"),
+        manifest["binaries"]["sampler"]["sha256"],
     )
     require_artifact_value(
         samples_path,
@@ -1348,6 +8649,28 @@ def validate_process_directory(
         header.get("duration_ms"),
         int(float(scenario["sample_s"]) * 1000),
     )
+    expected_cpu_window_start_ns = int(round(float(scenario["warmup_s"]) * 1_000_000_000))
+    expected_cpu_window_end_ns = expected_cpu_window_start_ns + int(
+        round(float(scenario["sample_s"]) * 1_000_000_000)
+    )
+    require_artifact_value(
+        samples_path,
+        "CPU accounting method",
+        header.get("cpu_accounting"),
+        CPU_ACCOUNTING_METHOD,
+    )
+    require_artifact_value(
+        samples_path,
+        "CPU window start",
+        header.get("cpu_window_start_ns"),
+        expected_cpu_window_start_ns,
+    )
+    require_artifact_value(
+        samples_path,
+        "CPU window end",
+        header.get("cpu_window_end_ns"),
+        expected_cpu_window_end_ns,
+    )
     require_artifact_value(
         samples_path,
         "interval_ms",
@@ -1360,15 +8683,113 @@ def validate_process_directory(
         header.get("require_silent_mpv"),
         scenario["requires_mpv"],
     )
+    require_artifact_value(
+        samples_path,
+        "controller barrier policy",
+        header.get("controller_barrier_required"),
+        bool(scenario["controller"]),
+    )
+    require_artifact_value(
+        samples_path,
+        "YTM_PERF launch instrumentation",
+        header.get("child_ytm_perf_enabled"),
+        False,
+    )
     if any(record.get("kind") == "error" for record in samples):
         raise ValueError(f"{samples_path}: sampler recorded an error")
+    sample_validation = validate_measured_samples(
+        samples_path,
+        header,
+        summary,
+        all_sample_records,
+        bool(scenario["requires_mpv"]),
+        scenario.get("expected_effective_mpv_cache_args"),
+    )
 
-    artifacts = [samples_path]
+    identity_path = path / "process-identity.json"
+    if not identity_path.is_file():
+        raise ValueError(f"{path}: missing process-identity.json")
+    live_identity = load_json_object(identity_path)
+    live_producer, live_owner, live_mpv, live_descendants = validated_live_identity(
+        live_identity, identity_path
+    )
+    require_artifact_value(
+        identity_path, "run ID", live_identity.get("run_id"), run_contract["run_id"]
+    )
+    require_artifact_value(identity_path, "cleanup state", live_identity.get("state"), "cleaned")
+    require_artifact_value(identity_path, "cleanup proof", live_identity.get("cleanup_proven"), True)
+    first_root = next(
+        process
+        for process in sample_validation["measured"][0]["record"]["processes"]
+        if process["pid"] == sample_validation["root_pid"]
+    )
+    expected_owner = {
+        field: first_root[field]
+        for field in (
+            "pid", "start_time_unix_s", "executable", "executable_bytes", "executable_sha256"
+        )
+    }
+    if not isinstance(live_owner, dict):
+        raise ValueError(f"{identity_path}: cleaned measured run has no complete owner identity")
+    for field, expected in expected_owner.items():
+        require_artifact_value(
+            identity_path, f"owner identity {field}", live_owner.get(field), expected
+        )
+    require_artifact_value(
+        identity_path,
+        "sampler producer executable SHA-256",
+        live_producer.get("executable_sha256"),
+        header.get("producer_binary_sha256"),
+    )
+    require_artifact_value(
+        identity_path,
+        "mpv identity",
+        live_mpv,
+        sample_validation["last_mpv_identities"],
+    )
+    last_processes = sample_validation["samples"][-1]["record"]["processes"]
+    expected_descendants = [
+        {
+            "pid": process["pid"],
+            "start_time_unix_s": process["start_time_unix_s"],
+            "executable": process["executable"],
+            "executable_bytes": process["executable_bytes"],
+            "executable_sha256": process["executable_sha256"],
+            "role": process["role"],
+            "command": process["command"],
+        }
+        for process in last_processes
+        if process["pid"] != sample_validation["root_pid"]
+    ]
+    require_artifact_value(
+        identity_path, "recursive descendant identity", live_descendants, expected_descendants
+    )
+
+    launch_policy_path = path / "launch-policy.json"
+    if not launch_policy_path.is_file():
+        raise ValueError(f"{path}: missing launch-policy.json")
+    _launch_policy, launch_artifacts = validate_launch_policy(launch_policy_path, path)
+    artifacts = [samples_path, identity_path, *launch_artifacts, *additional_metric_files]
     if scenario["controller"]:
         control_path = path / "control.ndjson"
         if not control_path.is_file():
             raise ValueError(f"{path}: missing control.ndjson")
         control = read_ndjson(control_path)
+        unexpected_control_kinds = sorted(
+            {
+                str(record.get("kind"))
+                for record in control
+                if record.get("kind")
+                not in {"header", "mpv_event", "operation", "summary", "error"}
+            }
+        )
+        if unexpected_control_kinds:
+            raise ValueError(
+                f"{control_path}: unexpected controller record kinds "
+                f"{unexpected_control_kinds}"
+            )
+        if any(record.get("kind") == "error" for record in control):
+            raise ValueError(f"{control_path}: controller recorded an error")
         control_headers = [record for record in control if record.get("kind") == "header"]
         control_summaries = [record for record in control if record.get("kind") == "summary"]
         if len(control_headers) != 1 or len(control_summaries) != 1:
@@ -1376,7 +8797,134 @@ def validate_process_directory(
         control_header = control_headers[0]
         require_artifact_value(control_path, "schema", control_header.get("schema"), "ytt.tui-perf.control.v1")
         require_artifact_value(control_path, "scenario SHA-256", control_header.get("scenario_sha256"), scenario_hash)
+        require_artifact_value(control_path, "run ID", control_header.get("run_id"), run_contract["run_id"])
         require_artifact_value(control_path, "OS", normalized_os(control_header.get("os")), host_os)
+        require_artifact_value(
+            control_path,
+            "controller producer SHA-256",
+            control_header.get("producer_binary_sha256"),
+            manifest["binaries"]["controller"]["sha256"],
+        )
+        expected_observe_ns = int(
+            (float(scenario["warmup_s"]) + float(scenario["sample_s"]))
+            * 1_000_000_000
+        )
+        require_artifact_value(control_path, "confirmed subscriptions", control_header.get("subscriptions_confirmed"), True)
+        require_artifact_value(control_path, "observation duration", control_header.get("observe_ns"), expected_observe_ns)
+        require_artifact_value(
+            control_path,
+            "buffering cutoff",
+            control_header.get("buffering_cutoff_ns"),
+            expected_observe_ns,
+        )
+        close_grace_ns = non_negative_integer(control_header.get("close_grace_ns"), "close_grace_ns", control_path)
+        if close_grace_ns == 0:
+            raise ValueError(f"{control_path}: close_grace_ns must be positive")
+        sampler_started_ns = sampler_started_unix_ns
+        controller_started_ns = non_negative_integer(
+            control_header.get("observation_started_unix_ns"), "controller observation start", control_path
+        )
+        if sampler_started_ns < controller_started_ns or sampler_started_ns - controller_started_ns > 1_000_000_000:
+            raise ValueError(f"{control_path}: sampler/controller barrier starts are not aligned")
+
+        measured_validation = sample_validation["measured"]
+        owner_rows = []
+        mpv_rows = []
+        for sample_index, sample_item in enumerate(measured_validation):
+            roots = [
+                process
+                for process in sample_item["record"]["processes"]
+                if process["pid"] == sample_validation["root_pid"]
+            ]
+            if len(roots) != 1:
+                raise ValueError(f"{samples_path}: measured sample {sample_index} has invalid owner inventory")
+            owner_rows.append(roots[0])
+            if len(sample_item["mpv"]) != 1:
+                raise ValueError(f"{samples_path}: measured sample {sample_index} must contain exactly one mpv")
+            mpv_rows.append(sample_item["mpv"][0])
+        owner_identity = {
+            (row["pid"], row["start_time_unix_s"], row["executable"], row["executable_bytes"], row["executable_sha256"])
+            for row in owner_rows
+        }
+        mpv_identity = {
+            (
+                item["pid"], item["start_time_unix_s"], item["process"]["executable"],
+                item["process"]["executable_bytes"], item["process"]["executable_sha256"], item["endpoint"],
+            )
+            for item in mpv_rows
+        }
+        if len(owner_identity) != 1 or len(mpv_identity) != 1:
+            raise ValueError(f"{samples_path}: owner/mpv executable identity changed during measurement")
+        owner_pid, owner_start, owner_exe, owner_bytes, owner_sha = next(iter(owner_identity))
+        mpv_pid, mpv_start, mpv_exe, mpv_bytes, mpv_sha, mpv_endpoint = next(iter(mpv_identity))
+        for label, actual, expected in (
+            ("owner PID", control_header.get("owner_pid"), owner_pid),
+            ("owner start", control_header.get("owner_start_time_unix_s"), owner_start),
+            ("owner executable", control_header.get("owner_executable"), owner_exe),
+            ("owner executable bytes", control_header.get("owner_executable_bytes"), owner_bytes),
+            ("owner executable SHA-256", control_header.get("owner_executable_sha256"), owner_sha),
+            ("mpv PID", control_header.get("mpv_pid"), mpv_pid),
+            ("mpv start", control_header.get("mpv_start_time_unix_s"), mpv_start),
+            ("mpv executable", control_header.get("mpv_executable"), mpv_exe),
+            ("mpv executable bytes", control_header.get("mpv_executable_bytes"), mpv_bytes),
+            ("mpv executable SHA-256", control_header.get("mpv_executable_sha256"), mpv_sha),
+            ("mpv endpoint", control_header.get("mpv_endpoint"), mpv_endpoint),
+        ):
+            require_artifact_value(control_path, label, actual, expected)
+
+        ready_path = path / "controller-ready.json"
+        if not ready_path.is_file():
+            raise ValueError(f"{path}: missing controller-ready.json")
+        ready = load_json_object(ready_path)
+        require_artifact_value(ready_path, "schema", ready.get("schema"), "ytt.tui-perf.controller-ready.v1")
+        require_artifact_value(ready_path, "run ID", ready.get("run_id"), run_contract["run_id"])
+        require_artifact_value(ready_path, "scenario SHA-256", ready.get("scenario_sha256"), scenario_hash)
+        require_artifact_value(ready_path, "owner PID", ready.get("owner_pid"), owner_pid)
+        require_artifact_value(ready_path, "owner start", ready.get("owner_start_time_unix_s"), owner_start)
+        require_artifact_value(ready_path, "mpv PID", ready.get("mpv_pid"), mpv_pid)
+        require_artifact_value(ready_path, "mpv start", ready.get("mpv_start_time_unix_s"), mpv_start)
+        require_artifact_value(ready_path, "mpv endpoint", ready.get("mpv_endpoint"), mpv_endpoint)
+        require_artifact_value(ready_path, "confirmed subscriptions", ready.get("subscriptions_confirmed"), True)
+        require_artifact_value(ready_path, "observation start", ready.get("observation_started_unix_ns"), controller_started_ns)
+
+        control_summary = control_summaries[0]
+        require_artifact_value(
+            control_path, "summary run ID", control_summary.get("run_id"), run_contract["run_id"]
+        )
+        controller_finished_ns = non_negative_integer(
+            control_summary.get("observation_finished_unix_ns"),
+            "controller observation finish",
+            control_path,
+        )
+        if not run_contract["started_unix_ns"] <= controller_started_ns < controller_finished_ns <= run_contract["finished_unix_ns"]:
+            raise ValueError(f"{control_path}: controller producer interval escapes its run contract")
+        validate_control_buffering(control_path, control, control_summary)
+        validate_control_time_pos_summary(control_path, control, control_summary)
+        validate_steady_playback_progress(
+            control_path, control, control_summary, scenario
+        )
+        summary_elapsed_ns = non_negative_integer(control_summary.get("elapsed_ns"), "summary elapsed_ns", control_path)
+        require_artifact_value(control_path, "expected observation coverage", control_summary.get("expected_observation_ns"), expected_observe_ns)
+        require_artifact_value(control_path, "actual observation coverage", control_summary.get("actual_coverage_ns"), expected_observe_ns)
+        require_artifact_value(
+            control_path,
+            "summary buffering cutoff",
+            control_summary.get("buffering_cutoff_ns"),
+            expected_observe_ns,
+        )
+        require_artifact_value(control_path, "terminal kind", control_summary.get("terminal_kind"), "clean_eof")
+        terminal_ns = non_negative_integer(control_summary.get("terminal_observed_ns"), "terminal_observed_ns", control_path)
+        if terminal_ns < expected_observe_ns or terminal_ns > summary_elapsed_ns:
+            raise ValueError(f"{control_path}: clean EOF is outside the declared coverage")
+        if summary_elapsed_ns > expected_observe_ns + close_grace_ns + 1_000_000_000:
+            raise ValueError(f"{control_path}: controller exceeded observation plus close grace")
+        event_ns = [
+            non_negative_integer(record.get("elapsed_ns"), "mpv event elapsed_ns", control_path)
+            for record in control
+            if record.get("kind") == "mpv_event"
+        ]
+        require_artifact_value(control_path, "first event boundary", control_summary.get("first_event_ns"), event_ns[0] if event_ns else None)
+        require_artifact_value(control_path, "last event boundary", control_summary.get("last_event_ns"), event_ns[-1] if event_ns else None)
         require_artifact_value(
             control_path,
             "pause policy",
@@ -1391,26 +8939,19 @@ def validate_process_directory(
             control_summaries[0].get("observation_end"),
             "mpv_ipc_closed",
         )
-        operations = [record.get("operation") for record in control if record.get("kind") == "operation"]
-        expected_load = scenario.get("controller_load")
-        expected_load_operation = {"resume-session": "resume_session", "none": "ready"}.get(expected_load)
-        if expected_load_operation is None or operations.count(expected_load_operation) != 1:
-            raise ValueError(f"{control_path}: controller load operation does not match {expected_load!r}")
-        require_artifact_value(
-            control_path,
-            "seek operation count",
-            operations.count("seek"),
-            len(scenario.get("seeks_s", [])),
+        validate_control_operations(
+            control_path, control, summary_elapsed_ns, scenario
         )
-        expected_pause_count = 1 if scenario["pause_policy"] == "pause-resume" else 0
-        require_artifact_value(control_path, "pause operation count", operations.count("pause"), expected_pause_count)
-        require_artifact_value(control_path, "resume operation count", operations.count("resume"), expected_pause_count)
-        artifacts.append(control_path)
+        artifacts.extend((control_path, ready_path))
 
     if scenario["requires_mpv"]:
+        if seed_context is None:
+            raise ValueError(f"{path}: playback run has no validated seed contract")
+        seed_manifest, seed_snapshot = seed_context
         materialize_path = path / "materialize.json"
         http_path = path / "http-ready.json"
-        for support in (materialize_path, http_path):
+        http_requests_path = path / "http-requests.ndjson"
+        for support in (materialize_path, http_path, http_requests_path):
             if not support.is_file():
                 raise ValueError(f"{path}: missing {support.name}")
         materialize = load_json_object(materialize_path)
@@ -1423,16 +8964,407 @@ def validate_process_directory(
             "local_m3u_indirection",
         )
         require_artifact_value(materialize_path, "external DNS", materialize.get("external_dns_required"), False)
+        require_artifact_value(
+            materialize_path,
+            "seed tree SHA-256",
+            materialize.get("seed_tree_sha256"),
+            seed_manifest["snapshot_tree_sha256"],
+        )
+        require_artifact_value(
+            materialize_path,
+            "seed cache policy",
+            materialize.get("seed_cache_policy"),
+            seed_manifest["cache_policy"],
+        )
+        require_artifact_value(
+            materialize_path,
+            "materializer SHA-256",
+            materialize.get("materializer_sha256"),
+            manifest["orchestrator"]["sha256"],
+        )
         http = load_json_object(http_path)
         require_artifact_value(http_path, "schema", http.get("schema"), "ytt.tui-perf.http.v1")
         require_artifact_value(http_path, "loopback binding", http.get("bind_is_loopback"), True)
         require_artifact_value(http_path, "playback target", http.get("playback_target_mode"), "local_m3u_indirection")
         require_artifact_value(http_path, "external DNS", http.get("external_dns_required"), False)
+        require_artifact_value(http_path, "run ID", http.get("run_id"), run_contract["run_id"])
+        http_started_unix_ns = non_negative_integer(
+            http.get("started_unix_ns"), "HTTP server wall start", http_path
+        )
+        http_started_monotonic_ns = non_negative_integer(
+            http.get("started_monotonic_ns"), "HTTP server monotonic start", http_path
+        )
+        if not (
+            run_contract["started_unix_ns"] <= http_started_unix_ns <= run_contract["finished_unix_ns"]
+            and run_contract["started_monotonic_ns"]
+            <= http_started_monotonic_ns
+            <= run_contract["finished_monotonic_ns"]
+        ):
+            raise ValueError(f"{http_path}: HTTP server start escapes its run contract")
+        parsed_http = urlsplit(str(http.get("url", "")))
+        try:
+            http_ip = ipaddress.ip_address(parsed_http.hostname or "")
+        except ValueError as error:
+            raise ValueError(f"{http_path}: URL host is not an IP literal") from error
+        if parsed_http.scheme != "http" or not http_ip.is_loopback:
+            raise ValueError(f"{http_path}: URL must use an HTTP loopback endpoint")
+        require_artifact_value(http_path, "URL host", str(http_ip), str(http.get("host")))
+        require_artifact_value(
+            materialize_path, "fixture URL", materialize.get("fixture_url"), http.get("url")
+        )
+        require_artifact_value(
+            materialize_path, "fixture host", materialize.get("fixture_host"), str(http.get("host"))
+        )
         profile = scenario_document["traffic_profiles"][scenario["traffic_profile"]]
         for field in ("throttle_bps", "outage_every_bytes", "outage_ms", "disconnect_every_bytes"):
             require_artifact_value(http_path, field, http.get(field), profile[field])
-        artifacts.extend((materialize_path, http_path))
+        require_artifact_value(
+            http_path,
+            "request log path",
+            Path(str(http.get("request_log", ""))).resolve(),
+            http_requests_path.resolve(),
+        )
+        if not isinstance(http.get("run_id"), str) or not http["run_id"]:
+            raise ValueError(f"{http_path}: run_id is missing")
+        validate_http_request_log(http_requests_path, http, profile, run_contract)
+        changed = materialize.get("changed")
+        if not isinstance(changed, list) or not changed or not all(
+            isinstance(relative, str) and relative for relative in changed
+        ):
+            raise ValueError(f"{materialize_path}: changed must be a non-empty path list")
+        input_snapshot = path / "materialized-inputs"
+        if materialize.get("input_snapshot") != input_snapshot.name or not input_snapshot.is_dir():
+            raise ValueError(f"{materialize_path}: materialized input snapshot is missing")
+        overlay_digest, overlay_inventory = overlay_tree_identity(
+            seed_snapshot, input_snapshot, changed
+        )
+        require_artifact_value(
+            materialize_path,
+            "materialized tree SHA-256",
+            materialize.get("materialized_tree_sha256"),
+            overlay_digest,
+        )
+        require_artifact_value(
+            materialize_path,
+            "materialized file inventory",
+            materialize.get("materialized_files"),
+            overlay_inventory,
+        )
+        require_artifact_value(
+            materialize_path,
+            "input snapshot file inventory",
+            materialize.get("input_snapshot_files"),
+            tree_file_inventory(input_snapshot),
+        )
+        playlist_relative = materialize.get("playlist")
+        if not isinstance(playlist_relative, str) or playlist_relative not in changed:
+            raise ValueError(f"{materialize_path}: playlist is not a changed relative input")
+        playlist = (input_snapshot / playlist_relative).resolve()
+        try:
+            playlist.relative_to(input_snapshot.resolve())
+        except ValueError as error:
+            raise ValueError(f"{materialize_path}: playlist escapes input snapshot") from error
+        expected_playlist = (
+            "#EXTM3U\n#EXTINF:-1,ytt deterministic performance fixture\n"
+            f"{http.get('url')}\n"
+        )
+        require_artifact_value(
+            playlist, "playlist content", playlist.read_text(encoding="utf-8"), expected_playlist
+        )
+        require_artifact_value(
+            materialize_path,
+            "playlist SHA-256",
+            materialize.get("playlist_sha256"),
+            sha256_file(playlist),
+        )
+        require_artifact_value(
+            materialize_path,
+            "seed active playlist contract",
+            materialize.get("seed_active_playlist_contract"),
+            seed_manifest["active_playlist_contract"],
+        )
+        materialized_contract = materialize.get("materialized_active_playlist_contract")
+        if not isinstance(materialized_contract, dict):
+            raise ValueError(f"{materialize_path}: materialized active playlist contract is missing")
+        require_artifact_value(
+            materialize_path,
+            "materialized active playlist",
+            validate_materialized_active_session_playlist(
+                input_snapshot, str(materialized_contract.get("local_path", ""))
+            ),
+            materialized_contract,
+        )
+        require_artifact_value(
+            materialize_path,
+            "materialized active local_path",
+            materialized_contract.get("local_path"),
+            str((path / "home" / playlist_relative).resolve()),
+        )
+        artifacts.extend((materialize_path, http_path, http_requests_path))
+        artifacts.extend(
+            sorted(item for item in input_snapshot.rglob("*") if item.is_file())
+        )
+    expected_metric_files = {
+        artifact.resolve()
+        for artifact in artifacts
+        if artifact.parent.resolve() == path.resolve()
+        and artifact.suffix in {".json", ".ndjson"}
+    }
+    actual_metric_files = {
+        item.resolve()
+        for item in path.iterdir()
+        if item.is_file() and item.suffix in {".json", ".ndjson"}
+    }
+    if actual_metric_files != expected_metric_files:
+        unexpected = sorted(str(item) for item in actual_metric_files - expected_metric_files)
+        missing = sorted(str(item) for item in expected_metric_files - actual_metric_files)
+        raise ValueError(
+            f"{path}: metric input inventory mismatch; unexpected={unexpected}, missing={missing}"
+        )
     return artifacts
+
+
+def validate_sampler_terminal_geometry(
+    path: Path,
+    header: dict[str, Any],
+    summary: dict[str, Any],
+    run_contract: dict[str, Any],
+) -> None:
+    expected = run_contract.get("terminal_geometry")
+    if (
+        not isinstance(expected, list)
+        or len(expected) != 2
+        or any(
+            not isinstance(value, int) or isinstance(value, bool) or value <= 0
+            for value in expected
+        )
+    ):
+        raise ValueError(f"{path}: process run contract terminal geometry is malformed")
+    require_artifact_value(
+        path, "sampler terminal geometry", header.get("terminal_geometry"), expected
+    )
+    require_artifact_value(
+        path,
+        "sampler summary terminal geometry",
+        summary.get("terminal_geometry"),
+        expected,
+    )
+
+
+def validate_run_contract(
+    path: Path,
+    *,
+    scenario: dict[str, Any],
+    scenario_hash: str,
+    host_identity: dict[str, str],
+    kind: str,
+    role: str,
+    pair_index: int | None,
+    repeat_index: int | None,
+    geometry_index: int | None,
+) -> dict[str, Any]:
+    contract = load_json_object(path)
+    expected_fields = {
+        "schema",
+        "state",
+        "run_id",
+        "scenario",
+        "scenario_sha256",
+        "kind",
+        "role",
+        "pair_index",
+        "pair_order",
+        "within_pair_ordinal",
+        "repeat_index",
+        "geometry",
+        "geometry_index",
+        "terminal_geometry",
+        "started_unix_ns",
+        "started_monotonic_ns",
+        "finished_unix_ns",
+        "finished_monotonic_ns",
+        "duration_ns",
+        "monotonic_clock",
+        "host",
+    }
+    if set(contract) != expected_fields:
+        raise ValueError(
+            f"{path}: run contract fields are {sorted(contract)}, expected {sorted(expected_fields)}"
+        )
+    require_artifact_value(path, "schema", contract["schema"], RUN_CONTRACT_SCHEMA)
+    require_artifact_value(path, "state", contract["state"], "finished")
+    require_artifact_value(path, "scenario", contract["scenario"], scenario["id"])
+    require_artifact_value(path, "scenario SHA-256", contract["scenario_sha256"], scenario_hash)
+    require_artifact_value(path, "kind", contract["kind"], kind)
+    require_artifact_value(path, "role", contract["role"], role)
+    require_artifact_value(path, "pair index", contract["pair_index"], pair_index)
+    require_artifact_value(path, "repeat index", contract["repeat_index"], repeat_index)
+    require_artifact_value(path, "geometry", contract["geometry"], scenario["geometry"])
+    require_artifact_value(path, "geometry index", contract["geometry_index"], geometry_index)
+    expected_terminal_geometry = None
+    if geometry_index is not None:
+        expected_terminal_geometry = scenario["geometry"][geometry_index]
+    elif scenario["id"] != "render_and_interaction" and len(scenario["geometry"]) == 1:
+        expected_terminal_geometry = scenario["geometry"][0]
+    require_artifact_value(
+        path,
+        "terminal geometry",
+        contract["terminal_geometry"],
+        expected_terminal_geometry,
+    )
+    run_id = contract["run_id"]
+    if not isinstance(run_id, str) or not re.fullmatch(r"[^:]+:[^:]+:[^:]+:\d+:[0-9a-f]{32}", run_id):
+        raise ValueError(f"{path}: run_id is malformed")
+    if kind == "paired":
+        if pair_index is None:
+            raise AssertionError("paired contract validation requires a pair index")
+        order = (
+            ["baseline", "candidate"]
+            if pair_index % 2 == 1
+            else ["candidate", "baseline"]
+        )
+        require_artifact_value(path, "pair order", contract["pair_order"], order)
+        require_artifact_value(
+            path, "within-pair ordinal", contract["within_pair_ordinal"], order.index(role) + 1
+        )
+    else:
+        require_artifact_value(path, "pair order", contract["pair_order"], None)
+        require_artifact_value(path, "within-pair ordinal", contract["within_pair_ordinal"], None)
+    timestamps = {
+        name: non_negative_integer(contract[name], name, path)
+        for name in (
+            "started_unix_ns",
+            "started_monotonic_ns",
+            "finished_unix_ns",
+            "finished_monotonic_ns",
+            "duration_ns",
+        )
+    }
+    if any(value == 0 for value in timestamps.values()):
+        raise ValueError(f"{path}: run timestamps/duration must be positive")
+    if timestamps["finished_unix_ns"] <= timestamps["started_unix_ns"]:
+        raise ValueError(f"{path}: finished wall time must follow start")
+    if timestamps["finished_monotonic_ns"] <= timestamps["started_monotonic_ns"]:
+        raise ValueError(f"{path}: finished monotonic time must follow start")
+    require_artifact_value(
+        path,
+        "duration",
+        timestamps["duration_ns"],
+        timestamps["finished_monotonic_ns"] - timestamps["started_monotonic_ns"],
+    )
+    monotonic_clock = contract["monotonic_clock"]
+    if not isinstance(monotonic_clock, str) or not monotonic_clock:
+        raise ValueError(f"{path}: monotonic clock implementation is missing")
+    host = contract["host"]
+    if not isinstance(host, dict) or set(host) != set(HOST_IDENTITY_FIELDS):
+        raise ValueError(f"{path}: run host identity is malformed")
+    if any(not isinstance(host[field], str) or not host[field] for field in host):
+        raise ValueError(f"{path}: run host identity contains an empty field")
+    require_artifact_value(path, "host identity", host, host_identity)
+    return contract
+
+
+def validate_run_contract_collection(
+    evidence_root: Path,
+    args: argparse.Namespace,
+    scenario: dict[str, Any],
+    scenario_hash: str,
+    host_identity: dict[str, str],
+) -> tuple[dict[Path, dict[str, Any]], list[dict[str, Any]]]:
+    contracts: dict[Path, dict[str, Any]] = {}
+    chronological: list[dict[str, Any]] = []
+    per_geometry = (
+        scenario["id"] != "render_and_interaction" and len(scenario["geometry"]) > 1
+    )
+
+    def validate_one_run(
+        run_path: Path,
+        *,
+        kind: str,
+        role: str,
+        pair_index: int | None,
+        repeat_index: int | None,
+    ) -> list[dict[str, Any]]:
+        locations = (
+            [
+                (run_path / f"geometry-{width}x{height}", geometry_index)
+                for geometry_index, (width, height) in enumerate(scenario["geometry"])
+            ]
+            if per_geometry
+            else [(run_path, None)]
+        )
+        result = []
+        for directory, geometry_index in locations:
+            contract = validate_run_contract(
+                directory / "run-contract.json",
+                scenario=scenario,
+                scenario_hash=scenario_hash,
+                host_identity=host_identity,
+                kind=kind,
+                role=role,
+                pair_index=pair_index,
+                repeat_index=repeat_index,
+                geometry_index=geometry_index,
+            )
+            contracts[directory.resolve()] = contract
+            result.append(contract)
+        return result
+
+    for pair_index, (baseline_path, candidate_path) in enumerate(
+        zip(args.baseline_run, args.candidate_run), start=1
+    ):
+        expected_paths = {
+            "baseline": (evidence_root / f"pair-{pair_index:02d}" / "baseline").resolve(),
+            "candidate": (evidence_root / f"pair-{pair_index:02d}" / "candidate").resolve(),
+        }
+        supplied = {"baseline": baseline_path.resolve(), "candidate": candidate_path.resolve()}
+        require_artifact_value(
+            evidence_root / f"pair-{pair_index:02d}",
+            "paired run paths",
+            supplied,
+            expected_paths,
+        )
+        pair_contracts: dict[str, list[dict[str, Any]]] = {}
+        for role in ("baseline", "candidate"):
+            run_path = supplied[role]
+            pair_contracts[role] = validate_one_run(
+                run_path,
+                kind="paired",
+                role=role,
+                pair_index=pair_index,
+                repeat_index=None,
+            )
+        order = (
+            ["baseline", "candidate"]
+            if pair_index % 2 == 1
+            else ["candidate", "baseline"]
+        )
+        for role in order:
+            chronological.extend(pair_contracts[role])
+    for repeat_index, supplied_path in enumerate(args.candidate_repeat_run, start=1):
+        expected = (evidence_root / f"candidate-repeat-{repeat_index:02d}").resolve()
+        require_artifact_value(expected, "candidate repeat path", supplied_path.resolve(), expected)
+        repeat_contracts = validate_one_run(
+            expected,
+            kind="candidate_repeat",
+            role="candidate",
+            pair_index=None,
+            repeat_index=repeat_index,
+        )
+        chronological.extend(repeat_contracts)
+    run_ids = [contract["run_id"] for contract in chronological]
+    if len(run_ids) != len(set(run_ids)):
+        raise ValueError("run IDs must be unique across all paired/repeat runs")
+    clocks = {contract["monotonic_clock"] for contract in chronological}
+    hosts = {json.dumps(contract["host"], sort_keys=True) for contract in chronological}
+    if len(clocks) != 1 or len(hosts) != 1:
+        raise ValueError("run chronology requires one host and monotonic clock")
+    for previous, current in zip(chronological, chronological[1:]):
+        if previous["finished_monotonic_ns"] > current["started_monotonic_ns"]:
+            raise ValueError(
+                f"run chronology overlaps or is reordered: {previous['run_id']} -> {current['run_id']}"
+            )
+    return contracts, chronological
 
 
 def validate_run_artifacts(
@@ -1443,8 +9375,12 @@ def validate_run_artifacts(
     scenario_hash: str,
     host_os: str,
     manifest: dict[str, Any],
+    seed_context: tuple[dict[str, Any], Path] | None,
+    run_contracts: dict[Path, dict[str, Any]],
 ) -> list[Path]:
     if scenario["id"] == "render_and_interaction":
+        run_contract = run_contracts[path.resolve()]
+        contract_path = path / "run-contract.json"
         render_path = path / "render.json"
         if not render_path.is_file():
             raise ValueError(f"{path}: missing render.json")
@@ -1456,10 +9392,30 @@ def validate_run_artifacts(
             scenario_hash,
             host_os,
             manifest,
+            run_contract,
         )
-        return [render_path]
+        actual = {
+            item.resolve()
+            for item in path.iterdir()
+            if item.is_file() and item.suffix in {".json", ".ndjson"}
+        }
+        if actual != {render_path.resolve(), contract_path.resolve()}:
+            raise ValueError(f"{path}: render run contains unexpected metric JSON/NDJSON")
+        return [contract_path, render_path]
     artifacts: list[Path] = []
-    for directory in process_run_directories(path, scenario):
+    directories = process_run_directories(path, scenario)
+    if directories != [path]:
+        root_metric_files = sorted(
+            item.name
+            for item in path.iterdir()
+            if item.is_file() and item.suffix in {".json", ".ndjson"}
+        )
+        if root_metric_files:
+            raise ValueError(
+                f"{path}: multi-geometry root has unexpected metric files {root_metric_files}"
+            )
+    for directory in directories:
+        run_contract = run_contracts[directory.resolve()]
         artifacts.extend(
             validate_process_directory(
                 directory,
@@ -1469,9 +9425,47 @@ def validate_run_artifacts(
                 scenario_hash,
                 host_os,
                 manifest,
+                seed_context,
+                run_contract,
+                [directory / "run-contract.json"],
             )
         )
     return artifacts
+
+
+def measured_mpv_executable_provenance(
+    path: Path, scenario: dict[str, Any]
+) -> dict[str, Any]:
+    identities: set[tuple[str, int, str]] = set()
+    for directory in process_run_directories(path, scenario):
+        records = read_ndjson(directory / "samples.ndjson")
+        for record in records:
+            if record.get("kind") != "sample" or record.get("phase") != "measure":
+                continue
+            for process in record.get("processes", []):
+                if isinstance(process, dict) and process.get("role") == "mpv":
+                    executable = process.get("executable")
+                    executable_bytes = process.get("executable_bytes")
+                    executable_sha256 = process.get("executable_sha256")
+                    if (
+                        not isinstance(executable, str)
+                        or not isinstance(executable_bytes, int)
+                        or isinstance(executable_bytes, bool)
+                        or executable_bytes <= 0
+                        or not isinstance(executable_sha256, str)
+                    ):
+                        raise ValueError(f"{directory}: measured mpv executable identity is malformed")
+                    identities.add((executable, executable_bytes, executable_sha256))
+    if len(identities) != 1:
+        raise ValueError(
+            f"{path}: measured geometries/samples used {len(identities)} mpv executable identities"
+        )
+    executable, executable_bytes, executable_sha256 = next(iter(identities))
+    return {
+        "executable": executable,
+        "executable_bytes": executable_bytes,
+        "executable_sha256": executable_sha256,
+    }
 
 
 def relative_artifact(path: Path, root: Path, role: str) -> dict[str, Any]:
@@ -1490,11 +9484,11 @@ def relative_artifact(path: Path, root: Path, role: str) -> dict[str, Any]:
 
 def raw_inventory_digest(entries: list[dict[str, Any]]) -> str:
     digest = hashlib.sha256()
-    for entry in sorted(entries, key=lambda item: item["path"]):
-        encoded = entry["path"].encode("utf-8")
-        digest.update(len(encoded).to_bytes(8, "big"))
-        digest.update(encoded)
-        digest.update(bytes.fromhex(entry["sha256"]))
+    for entry in sorted(entries, key=lambda item: (item["role"], item["path"])):
+        for field in ("role", "path", "sha256"):
+            encoded = str(entry[field]).encode("utf-8")
+            digest.update(len(encoded).to_bytes(8, "big"))
+            digest.update(encoded)
     return digest.hexdigest()
 
 
@@ -1538,14 +9532,16 @@ def paired_bootstrap_ratios(baseline: list[float], candidate: list[float], resam
     if any(value < 0 or not math.isfinite(value) for value in baseline + candidate):
         raise ValueError("ratio metrics must be finite and non-negative")
     pair_ratios = [stable_ratio(b, c) for b, c in zip(baseline, candidate)]
-    point = geometric_mean_ratio(pair_ratios)
+    point = stable_ratio(statistics.fmean(baseline), statistics.fmean(candidate))
     rng = random.Random(seed)
     count = len(pair_ratios)
     sampled = []
     for _ in range(resamples):
-        sampled.append(
-            geometric_mean_ratio([pair_ratios[rng.randrange(count)] for _ in range(count)])
-        )
+        indices = [rng.randrange(count) for _ in range(count)]
+        sampled.append(stable_ratio(
+            statistics.fmean(baseline[index] for index in indices),
+            statistics.fmean(candidate[index] for index in indices),
+        ))
     sampled.sort()
     upper_index = min(len(sampled) - 1, math.ceil(confidence * len(sampled)) - 1)
     return point, sampled[upper_index], pair_ratios
@@ -1569,14 +9565,868 @@ def geometric_mean_ratio(ratios: list[float]) -> float:
     return math.exp(statistics.fmean(math.log(value) for value in ratios))
 
 
+def cleanup_integration_self_test() -> None:
+    if os.name == "nt":
+        return
+    with tempfile.TemporaryDirectory(prefix="ytt-perf-cleanup-self-test-") as temporary:
+        root = Path(temporary)
+        identity_path = root / "process-identity.json"
+        mpv_link = root / "mpv"
+        mpv_link.symlink_to(Path(sys.executable).resolve())
+        child_script = (
+            "import signal,time;"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+            "time.sleep(60)"
+        )
+        detached_child_script = (
+            "import os,signal,time;os.setsid();"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+            "time.sleep(60)"
+        )
+        intermediate_script = (
+            "import os,subprocess;"
+            "p=subprocess.Popen([os.environ['MPV_LINK'],'-c',os.environ['DETACHED_CHILD_SCRIPT'],"
+            "'--input-ipc-server='+os.environ['DETACHED_ENDPOINT']]);"
+            "open(os.environ['DETACHED_PID_FILE'],'w').write(str(p.pid));"
+        )
+        owner_script = (
+            "import os,signal,subprocess,sys,time;"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+            "i=subprocess.Popen([sys.executable,'-c',os.environ['INTERMEDIATE_SCRIPT']]);"
+            "m=subprocess.Popen([os.environ['MPV_LINK'],'-c',os.environ['CHILD_SCRIPT'],"
+            "'--input-ipc-server='+os.environ['DIRECT_ENDPOINT']]);"
+            "o=subprocess.Popen([sys.executable,'-c',os.environ['CHILD_SCRIPT'],'other-child']);"
+            "open(os.environ['DIRECT_MPV_PID_FILE'],'w').write(str(m.pid));"
+            "open(os.environ['OTHER_PID_FILE'],'w').write(str(o.pid));"
+            "i.wait();"
+            "time.sleep(60)"
+        )
+        # This deliberately attempts a stale running write after cleanup_requested. The cleanup
+        # command must wait for/kill this TERM-ignoring producer and publish cleaned last.
+        producer_script = (
+            "import json,os,signal,subprocess,sys,time;os.setsid();"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+            "p=subprocess.Popen([sys.executable,'-c',os.environ['OWNER_SCRIPT']],"
+            "start_new_session=True);"
+            "open(os.environ['OWNER_PID_FILE'],'w').write(str(p.pid));"
+            "stale=False;"
+            "\nwhile True:\n"
+            " try:\n"
+            "  d=json.load(open(os.environ['IDENTITY_PATH']))\n"
+            "  if d.get('state')=='cleanup_requested' and not stale:\n"
+            "   d['state']='running';d['cleanup_proven']=False\n"
+            "   t=os.environ['IDENTITY_PATH']+'.producer-tmp'\n"
+            "   open(t,'w').write(json.dumps(d));os.replace(t,os.environ['IDENTITY_PATH']);stale=True\n"
+            " except Exception:\n"
+            "  pass\n"
+            " time.sleep(0.005)\n"
+        )
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "MPV_LINK": str(mpv_link),
+                "CHILD_SCRIPT": child_script,
+                "DETACHED_CHILD_SCRIPT": detached_child_script,
+                "INTERMEDIATE_SCRIPT": intermediate_script,
+                "OWNER_SCRIPT": owner_script,
+                "IDENTITY_PATH": str(identity_path),
+                "OWNER_PID_FILE": str(root / "owner.pid"),
+                "DETACHED_PID_FILE": str(root / "detached.pid"),
+                "DIRECT_MPV_PID_FILE": str(root / "direct-mpv.pid"),
+                "OTHER_PID_FILE": str(root / "other.pid"),
+                "DETACHED_ENDPOINT": str(root / "detached.sock"),
+                "DIRECT_ENDPOINT": str(root / "direct.sock"),
+            }
+        )
+        producer_process = subprocess.Popen(
+            [sys.executable, "-c", producer_script],
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        controller = subprocess.Popen(
+            [sys.executable, "-c", child_script],
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        expected_pid_files = [
+            root / "owner.pid",
+            root / "detached.pid",
+            root / "direct-mpv.pid",
+            root / "other.pid",
+        ]
+        try:
+            ready_deadline = time.monotonic() + 5
+            while time.monotonic() < ready_deadline and not all(
+                path.is_file() and path.read_text(encoding="utf-8").strip()
+                for path in expected_pid_files
+            ):
+                if producer_process.poll() is not None:
+                    raise AssertionError(
+                        f"cleanup producer helper exited: {producer_process.stderr.read()}"
+                    )
+                time.sleep(0.01)
+            if not all(path.is_file() for path in expected_pid_files):
+                raise AssertionError("cleanup helper topology did not become ready")
+            owner_pid, detached_pid, direct_mpv_pid, other_pid = [
+                int(path.read_text(encoding="utf-8")) for path in expected_pid_files
+            ]
+            observations: dict[int, dict[str, Any]] = {}
+            observation_deadline = time.monotonic() + 5
+            while time.monotonic() < observation_deadline:
+                observations = {
+                    pid: observation
+                    for pid in (
+                        producer_process.pid,
+                        owner_pid,
+                        detached_pid,
+                        direct_mpv_pid,
+                        other_pid,
+                    )
+                    if (observation := unix_process_observation(pid, hash_executable=True))
+                    is not None
+                }
+                detached = observations.get(detached_pid)
+                if len(observations) == 5 and detached is not None and detached["parent_pid"] != owner_pid:
+                    break
+                time.sleep(0.02)
+            if len(observations) != 5:
+                raise AssertionError("cleanup helper processes were not all observable")
+            producer_identity = {
+                field: observations[producer_process.pid][field]
+                for field in (
+                    "pid",
+                    "start_time_unix_s",
+                    "process_group_id",
+                    "executable",
+                    "executable_bytes",
+                    "executable_sha256",
+                )
+            }
+            owner_identity = {
+                field: observations[owner_pid][field]
+                for field in producer_identity
+            }
+            # Only the detached/reparented grandchild is pre-recorded. The direct mpv and other
+            # child exercise cleanup-time recursive/process-group discovery from an early abort.
+            retained = cleanup_descendant_identity(observations[detached_pid])
+            if retained["role"] != "mpv":
+                raise AssertionError("mpv symlink helper was not classified as mpv")
+            initial = {
+                "schema": "ytt.tui-perf.live-identity.v1",
+                "run_id": "cleanup-integration-self-test",
+                "state": "running",
+                "producer": producer_identity,
+                "owner": owner_identity,
+                "partial_owner": None,
+                "mpv": mpv_identities_from_descendants([retained]),
+                "descendants": [retained],
+                "cleanup_scope": CLEANUP_SCOPE,
+                "cleanup_proven": False,
+                "updated_unix_ns": time.time_ns(),
+            }
+            atomic_json(identity_path, initial)
+            command_cleanup(
+                argparse.Namespace(identity=identity_path, timeout_secs=8.0)
+            )
+            producer_process.wait(timeout=2)
+            cleaned = load_json_object(identity_path)
+            _producer, _owner, cleaned_mpv, cleaned_descendants = validated_live_identity(
+                cleaned, identity_path
+            )
+            require_artifact_value(identity_path, "cleanup state", cleaned["state"], "cleaned")
+            require_artifact_value(identity_path, "cleanup proof", cleaned["cleanup_proven"], True)
+            require_artifact_value(
+                identity_path, "cleanup scope", cleaned["cleanup_scope"], CLEANUP_SCOPE
+            )
+            cleaned_pids = {item["pid"] for item in cleaned_descendants}
+            if cleaned_pids != {detached_pid, direct_mpv_pid, other_pid}:
+                raise AssertionError(
+                    f"cleanup descendant inventory mismatch: {cleaned_pids}"
+                )
+            if {item["pid"] for item in cleaned_mpv} != {detached_pid, direct_mpv_pid}:
+                raise AssertionError("cleanup mpv inventory did not preserve/discover both mpv helpers")
+            for pid in (producer_process.pid, owner_pid, detached_pid, direct_mpv_pid, other_pid):
+                if unix_process_observation(pid, hash_executable=False) is not None:
+                    raise AssertionError(f"exact cleanup left helper PID {pid} alive")
+            if controller.poll() is not None:
+                raise AssertionError("separate controller process group was incorrectly targeted")
+            tampered = {**cleaned, "cleanup_scope": "all_host_processes"}
+            atomic_json(identity_path, tampered)
+            try:
+                validated_live_identity(tampered, identity_path)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("tampered cleanup scope must invalidate live identity")
+            atomic_json(identity_path, cleaned)
+            # Already-cleaned validation must also be idempotent.
+            command_cleanup(
+                argparse.Namespace(identity=identity_path, timeout_secs=1.0)
+            )
+        finally:
+            for process in (producer_process, controller):
+                if process.poll() is None:
+                    process.kill()
+                try:
+                    process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    pass
+
+
+def startup_cleanup_integration_self_test() -> None:
+    if os.name == "nt":
+        return
+    with tempfile.TemporaryDirectory(prefix="ytt-perf-startup-cleanup-self-test-") as temporary:
+        root = Path(temporary)
+        identity_path = root / "process-identity.json"
+        owner_pid_path = root / "owner.pid"
+        late_pid_path = root / "late.pid"
+        child_script = (
+            "import signal,time;"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+            "time.sleep(60)"
+        )
+        owner_script = (
+            "import os,signal,subprocess,sys,time;"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+            "p=subprocess.Popen([sys.executable,'-c',os.environ['CHILD_SCRIPT']],"
+            "start_new_session=True);"
+            "open(os.environ['LATE_PID_PATH'],'w').write(str(p.pid));"
+            "time.sleep(60)"
+        )
+        producer_script = (
+            "import os,signal,subprocess,sys,time;"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+            "p=subprocess.Popen([sys.executable,'-c',os.environ['OWNER_SCRIPT']],"
+            "start_new_session=True);"
+            "open(os.environ['OWNER_PID_PATH'],'w').write(str(p.pid));"
+            "time.sleep(60)"
+        )
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "CHILD_SCRIPT": child_script,
+                "OWNER_SCRIPT": owner_script,
+                "OWNER_PID_PATH": str(owner_pid_path),
+                "LATE_PID_PATH": str(late_pid_path),
+            }
+        )
+        producer = subprocess.Popen(
+            [sys.executable, "-c", producer_script],
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        unrelated = subprocess.Popen(
+            [sys.executable, "-c", child_script],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not (
+                owner_pid_path.is_file() and late_pid_path.is_file()
+            ):
+                if producer.poll() is not None:
+                    raise AssertionError("startup producer exited before publishing its children")
+                time.sleep(0.01)
+            if not owner_pid_path.is_file() or not late_pid_path.is_file():
+                raise AssertionError("startup cleanup topology did not become ready")
+            owner_pid = int(owner_pid_path.read_text(encoding="utf-8"))
+            late_pid = int(late_pid_path.read_text(encoding="utf-8"))
+            producer_observation = unix_process_observation(
+                producer.pid, hash_executable=True
+            )
+            if producer_observation is None:
+                raise AssertionError("startup producer was not observable")
+            producer_identity = {
+                field: producer_observation[field]
+                for field in (
+                    "pid",
+                    "start_time_unix_s",
+                    "process_group_id",
+                    "executable",
+                    "executable_bytes",
+                    "executable_sha256",
+                )
+            }
+            atomic_json(
+                identity_path,
+                {
+                    "schema": "ytt.tui-perf.live-identity.v1",
+                    "run_id": "startup-cleanup-integration-self-test",
+                    "state": "startup",
+                    "producer": producer_identity,
+                    "owner": None,
+                    "partial_owner": None,
+                    "mpv": [],
+                    "descendants": [],
+                    "cleanup_scope": CLEANUP_SCOPE,
+                    "cleanup_proven": False,
+                    "updated_unix_ns": time.time_ns(),
+                },
+            )
+            command_cleanup(
+                argparse.Namespace(identity=identity_path, timeout_secs=8.0)
+            )
+            producer.wait(timeout=2)
+            cleaned = load_json_object(identity_path)
+            _cleaned_producer, cleaned_owner, _cleaned_mpv, cleaned_descendants = (
+                validated_live_identity(cleaned, identity_path)
+            )
+            require_artifact_value(identity_path, "startup cleanup state", cleaned["state"], "cleaned")
+            require_artifact_value(
+                identity_path, "startup cleanup proof", cleaned["cleanup_proven"], True
+            )
+            require_artifact_value(
+                identity_path, "startup cleanup scope", cleaned["cleanup_scope"], CLEANUP_SCOPE
+            )
+            if cleaned_owner is None or cleaned_owner["pid"] != owner_pid:
+                raise AssertionError("startup cleanup did not bind the discovered dedicated owner")
+            cleaned_pids = {identity["pid"] for identity in cleaned_descendants}
+            if late_pid not in cleaned_pids or owner_pid in cleaned_pids:
+                raise AssertionError("startup cleanup did not inventory the late setsid descendant")
+            for pid in (producer.pid, owner_pid, late_pid):
+                if unix_process_observation(pid, hash_executable=False) is not None:
+                    raise AssertionError(f"startup cleanup left exact helper PID {pid} alive")
+            if unrelated.poll() is not None:
+                raise AssertionError("startup cleanup killed an unrelated same-shell helper")
+        finally:
+            for process in (producer, unrelated):
+                if process.poll() is None:
+                    process.kill()
+                try:
+                    process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    pass
+
+
+def run_contract_integration_self_test() -> None:
+    scenario_document, scenario_hash = load_scenarios(DEFAULT_SCENARIOS)
+    scenario = find_scenario(scenario_document, "render_and_interaction")
+    host_identity = stable_host_identity()
+    with tempfile.TemporaryDirectory(prefix="ytt-perf-run-contract-self-test-") as temporary:
+        evidence_root = Path(temporary).resolve()
+        baseline_runs: list[Path] = []
+        candidate_runs: list[Path] = []
+        with contextlib.redirect_stdout(io.StringIO()):
+            for pair_index in range(1, int(scenario["pairs"]) + 1):
+                order = (
+                    ("baseline", "candidate")
+                    if pair_index % 2 == 1
+                    else ("candidate", "baseline")
+                )
+                for role in order:
+                    run_path = evidence_root / f"pair-{pair_index:02d}" / role
+                    command_run_start(
+                        argparse.Namespace(
+                            scenarios=DEFAULT_SCENARIOS,
+                            scenario=scenario["id"],
+                            output=run_path / "run-contract.json",
+                            kind="paired",
+                            role=role,
+                            pair_index=pair_index,
+                            repeat_index=None,
+                        )
+                    )
+                    command_run_finish(
+                        argparse.Namespace(contract=run_path / "run-contract.json")
+                    )
+                baseline_runs.append(evidence_root / f"pair-{pair_index:02d}" / "baseline")
+                candidate_runs.append(evidence_root / f"pair-{pair_index:02d}" / "candidate")
+        compare_args = argparse.Namespace(
+            baseline_run=baseline_runs,
+            candidate_run=candidate_runs,
+            candidate_repeat_run=[],
+        )
+        _contracts, chronology = validate_run_contract_collection(
+            evidence_root,
+            compare_args,
+            scenario,
+            scenario_hash,
+            host_identity,
+        )
+        expected_roles = [
+            role
+            for pair_index in range(1, int(scenario["pairs"]) + 1)
+            for role in (
+                ("baseline", "candidate")
+                if pair_index % 2 == 1
+                else ("candidate", "baseline")
+            )
+        ]
+        assert [contract["role"] for contract in chronology] == expected_roles
+
+        if len(candidate_runs) > 1:
+            swapped_args = argparse.Namespace(
+                baseline_run=baseline_runs,
+                candidate_run=list(reversed(candidate_runs)),
+                candidate_repeat_run=[],
+            )
+            try:
+                validate_run_contract_collection(
+                    evidence_root,
+                    swapped_args,
+                    scenario,
+                    scenario_hash,
+                    host_identity,
+                )
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("swapped candidate pair list must be rejected")
+
+        first_path = evidence_root / "pair-01" / "baseline" / "run-contract.json"
+        second_path = evidence_root / "pair-01" / "candidate" / "run-contract.json"
+        first = load_json_object(first_path)
+        second = load_json_object(second_path)
+        tampered = dict(second)
+        tampered["started_monotonic_ns"] = first["finished_monotonic_ns"] - 1
+        tampered["started_unix_ns"] = first["finished_unix_ns"] - 1
+        tampered["duration_ns"] = (
+            tampered["finished_monotonic_ns"] - tampered["started_monotonic_ns"]
+        )
+        atomic_json(second_path, tampered)
+        try:
+            validate_run_contract_collection(
+                evidence_root,
+                compare_args,
+                scenario,
+                scenario_hash,
+                host_identity,
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("overlapping pair chronology must be rejected")
+        atomic_json(second_path, second)
+
+        tampered = dict(second)
+        tampered["host"] = {
+            **second["host"],
+            "boot_id_fingerprint": "sha256:" + "0" * 64,
+        }
+        atomic_json(second_path, tampered)
+        try:
+            validate_run_contract_collection(
+                evidence_root,
+                compare_args,
+                scenario,
+                scenario_hash,
+                host_identity,
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("cross-boot run contract must be rejected")
+        atomic_json(second_path, second)
+
+
+def multi_geometry_run_contract_integration_self_test() -> None:
+    scenario_document, scenario_hash = load_scenarios(DEFAULT_SCENARIOS)
+    scenario = find_scenario(scenario_document, "feature_regressions")
+    host_identity = stable_host_identity()
+    with tempfile.TemporaryDirectory(
+        prefix="ytt-perf-multi-geometry-contract-self-test-"
+    ) as temporary:
+        evidence_root = Path(temporary).resolve()
+        baseline_runs: list[Path] = []
+        candidate_runs: list[Path] = []
+        all_run_paths: list[Path] = []
+        with contextlib.redirect_stdout(io.StringIO()):
+            for pair_index in range(1, int(scenario["pairs"]) + 1):
+                order = (
+                    ("baseline", "candidate")
+                    if pair_index % 2 == 1
+                    else ("candidate", "baseline")
+                )
+                for role in order:
+                    run_path = evidence_root / f"pair-{pair_index:02d}" / role
+                    all_run_paths.append(run_path)
+                    for geometry_index, (width, height) in enumerate(scenario["geometry"]):
+                        geometry_path = run_path / f"geometry-{width}x{height}"
+                        command_run_start(
+                            argparse.Namespace(
+                                scenarios=DEFAULT_SCENARIOS,
+                                scenario=scenario["id"],
+                                output=geometry_path / "run-contract.json",
+                                kind="paired",
+                                role=role,
+                                pair_index=pair_index,
+                                repeat_index=None,
+                                geometry_index=geometry_index,
+                                width=width,
+                                height=height,
+                            )
+                        )
+                        command_run_finish(
+                            argparse.Namespace(
+                                contract=geometry_path / "run-contract.json"
+                            )
+                        )
+                baseline_runs.append(evidence_root / f"pair-{pair_index:02d}" / "baseline")
+                candidate_runs.append(
+                    evidence_root / f"pair-{pair_index:02d}" / "candidate"
+                )
+        if any((run_path / "run-contract.json").exists() for run_path in all_run_paths):
+            raise AssertionError("multi-geometry process run must not publish a root contract")
+        compare_args = argparse.Namespace(
+            baseline_run=baseline_runs,
+            candidate_run=candidate_runs,
+            candidate_repeat_run=[],
+        )
+        contracts, chronology = validate_run_contract_collection(
+            evidence_root,
+            compare_args,
+            scenario,
+            scenario_hash,
+            host_identity,
+        )
+        expected_order = [
+            (role, geometry_index)
+            for pair_index in range(1, int(scenario["pairs"]) + 1)
+            for role in (
+                ("baseline", "candidate")
+                if pair_index % 2 == 1
+                else ("candidate", "baseline")
+            )
+            for geometry_index in range(len(scenario["geometry"]))
+        ]
+        assert [
+            (contract["role"], contract["geometry_index"])
+            for contract in chronology
+        ] == expected_order
+
+        first_width, first_height = scenario["geometry"][0]
+        second_width, second_height = scenario["geometry"][1]
+        first_directory = (
+            evidence_root
+            / "pair-01"
+            / "baseline"
+            / f"geometry-{first_width}x{first_height}"
+        )
+        second_directory = (
+            evidence_root
+            / "pair-01"
+            / "baseline"
+            / f"geometry-{second_width}x{second_height}"
+        )
+        first_contract = contracts[first_directory.resolve()]
+        second_contract = contracts[second_directory.resolve()]
+        copied_sampler_record = {"terminal_geometry": scenario["geometry"][0]}
+        validate_sampler_terminal_geometry(
+            Path("<geometry-self-test>"),
+            copied_sampler_record,
+            copied_sampler_record,
+            first_contract,
+        )
+        try:
+            validate_sampler_terminal_geometry(
+                Path("<geometry-copy-self-test>"),
+                copied_sampler_record,
+                copied_sampler_record,
+                second_contract,
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("copied sampler geometry must be rejected")
+
+        first_path = first_directory / "run-contract.json"
+        second_path = second_directory / "run-contract.json"
+        original_second = second_path.read_bytes()
+        atomic_bytes(second_path, first_path.read_bytes())
+        try:
+            validate_run_contract_collection(
+                evidence_root,
+                compare_args,
+                scenario,
+                scenario_hash,
+                host_identity,
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("copied geometry contract must be rejected")
+        finally:
+            atomic_bytes(second_path, original_second)
+        validate_run_contract_collection(
+            evidence_root,
+            compare_args,
+            scenario,
+            scenario_hash,
+            host_identity,
+        )
+
+
+def toolchain_identity_self_test() -> None:
+    shim_source = r'''from pathlib import Path
+import json
+import os
+import sys
+
+
+def selected_toolchain():
+    current = Path.cwd().resolve()
+    while True:
+        for name in ("rust-toolchain.toml", "rust-toolchain"):
+            selector = current / name
+            if selector.is_file():
+                for line in selector.read_text(encoding="utf-8").splitlines():
+                    value = line.strip()
+                    if value and not value.startswith("#"):
+                        return value
+        if current.parent == current:
+            return "fake-default"
+        current = current.parent
+
+
+tool = sys.argv[1]
+arguments = sys.argv[2:]
+selected = selected_toolchain()
+if tool == "cargo" and arguments == ["-Vv"]:
+    print(f"cargo 1.0.0 ({selected})\\nrelease: 1.0.0\\nhost: fake-host")
+elif tool == "cargo" and arguments[:4] == [
+    "build", "--release", "--locked", "--message-format=json-render-diagnostics"
+]:
+    suffix = ".cmd" if sys.platform == "win32" else ""
+    expected_rustc = str((Path(sys.argv[0]).resolve().parent / f"rustc{suffix}").resolve())
+    if os.environ.get("RUSTC") != expected_rustc:
+        print("fake Cargo was not pinned to the captured absolute rustc", file=sys.stderr)
+        raise SystemExit(3)
+    if os.environ.get("RUSTC_WRAPPER") != "" or os.environ.get("RUSTC_WORKSPACE_WRAPPER") != "":
+        print("fake Cargo did not explicitly disable rustc wrappers", file=sys.stderr)
+        raise SystemExit(4)
+    target = Path(os.environ["CARGO_TARGET_DIR"]) / "release"
+    target.mkdir(parents=True, exist_ok=True)
+    executable_suffix = ".exe" if sys.platform == "win32" else ""
+    executable = target / f"fixture{executable_suffix}"
+    executable.write_bytes(f"fixture built by {selected}\\n".encode())
+    print(json.dumps({
+        "reason": "compiler-artifact",
+        "target": {"name": "fixture"},
+        "executable": str(executable),
+    }))
+elif tool == "rustc" and arguments == ["-vV"]:
+    print(f"rustc 1.0.0 ({selected})\\nbinary: rustc\\nhost: fake-host")
+elif tool == "rustup" and arguments == ["show", "active-toolchain"]:
+    print(f"{selected}-fake-host (fake selector)")
+elif tool == "rustup" and arguments == ["override", "list"]:
+    print("no overrides")
+elif tool == "rustup" and arguments == ["--version"]:
+    print("rustup 1.0.0 (fake)")
+elif tool == "rustup" and len(arguments) == 2 and arguments[0] == "which":
+    suffix = ".cmd" if sys.platform == "win32" else ""
+    print(Path(sys.argv[0]).resolve().parent / f"{arguments[1]}{suffix}")
+else:
+    print(f"unsupported fake tool invocation: {tool} {arguments}", file=sys.stderr)
+    raise SystemExit(2)
+'''
+    with tempfile.TemporaryDirectory(
+        prefix="ytt-perf-toolchain-identity-self-test-"
+    ) as temporary:
+        base = Path(temporary)
+        fake_bin = base / "bin"
+        fake_bin.mkdir()
+        shim = fake_bin / "tool-shim.py"
+        shim.write_text(shim_source, encoding="utf-8")
+        tool_paths: dict[str, Path] = {}
+        for name in ("cargo", "rustc", "rustup"):
+            if os.name == "nt":
+                path = fake_bin / f"{name}.cmd"
+                path.write_text(
+                    f'@"{sys.executable}" "{shim}" {name} %*\r\n',
+                    encoding="utf-8",
+                )
+            else:
+                path = fake_bin / name
+                path.write_text(
+                    "#!/bin/sh\n"
+                    f"exec {shlex.quote(sys.executable)} {shlex.quote(str(shim))} "
+                    f"{name} \"$@\"\n",
+                    encoding="utf-8",
+                )
+                path.chmod(0o755)
+            tool_paths[name] = path
+
+        baseline_parent = base / "baseline-parent"
+        candidate_parent = base / "candidate-parent"
+        baseline_root = baseline_parent / "source"
+        candidate_root = candidate_parent / "source"
+        baseline_root.mkdir(parents=True)
+        candidate_root.mkdir(parents=True)
+        (baseline_parent / "rust-toolchain").write_text(
+            "fake-ancestor\n", encoding="utf-8"
+        )
+        (candidate_parent / "rust-toolchain").write_text(
+            "fake-ancestor\n", encoding="utf-8"
+        )
+        hostile_wrapper = base / "hostile-rustc-wrapper"
+        hostile_wrapper.write_text("must never execute\n", encoding="utf-8")
+        for parent in (baseline_parent, candidate_parent):
+            cargo_dir = parent / ".cargo"
+            cargo_dir.mkdir()
+            (cargo_dir / "config.toml").write_text(
+                f'[build]\nrustc-wrapper = "{hostile_wrapper.as_posix()}"\n',
+                encoding="utf-8",
+            )
+        baseline_selector = baseline_root / "rust-toolchain.toml"
+        candidate_selector = candidate_root / "rust-toolchain.toml"
+        baseline_selector.write_text("fake-a\n", encoding="utf-8")
+        candidate_selector.write_text("fake-a\n", encoding="utf-8")
+        (candidate_root / ".gitignore").write_text(
+            "rust-toolchain.toml\n", encoding="utf-8"
+        )
+        environment = {
+            "PATH": str(fake_bin),
+            "HOME": str(base / "home"),
+            "CARGO_HOME": str(base / "cargo-home"),
+            "RUSTUP_HOME": str(base / "rustup-home"),
+            "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+        }
+        recorded = capture_build_toolchains(
+            baseline_root, candidate_root, environment
+        )
+        selector_scopes = [
+            (entry["scope"], entry["name"])
+            for entry in recorded["candidate"]["selector_chain"]
+        ]
+        if selector_scopes != [
+            ("source", "rust-toolchain.toml"),
+            ("ancestor", "rust-toolchain"),
+        ]:
+            raise AssertionError(
+                f"ignored/ancestor toolchain selector chain was not captured: {selector_scopes}"
+            )
+        parsed_overrides = relevant_rustup_overrides(
+            candidate_root,
+            f"{candidate_parent.resolve()}\tfake-a\n"
+            f"{(base / 'unrelated').resolve()}\tfake-z",
+        )
+        if len(parsed_overrides) != 1 or parsed_overrides[0]["ancestor_depth"] != 1:
+            raise AssertionError("relevant rustup directory override was not isolated")
+
+        candidate_selector.write_text("fake-b\n", encoding="utf-8")
+        try:
+            capture_build_toolchains(baseline_root, candidate_root, environment)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("different effective per-root toolchains must fail before build")
+
+        candidate_selector.write_text("fake-a\n# ignored semantic comment\n", encoding="utf-8")
+        try:
+            validate_recorded_build_toolchains(
+                recorded, baseline_root, candidate_root, environment
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("tampered ignored selector identity must invalidate the receipt")
+        candidate_selector.write_bytes(baseline_selector.read_bytes())
+        validate_recorded_build_toolchains(
+            recorded, baseline_root, candidate_root, environment
+        )
+
+        cargo_path = tool_paths["cargo"]
+        original_cargo = cargo_path.read_bytes()
+        cargo_path.write_bytes(
+            original_cargo
+            + (b"\r\nrem identity tamper\r\n" if os.name == "nt" else b"\n# identity tamper\n")
+        )
+        try:
+            validate_recorded_build_toolchains(
+                recorded, baseline_root, candidate_root, environment
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("tampered Cargo executable identity must invalidate the receipt")
+        cargo_path.write_bytes(original_cargo)
+        validate_recorded_build_toolchains(
+            recorded, baseline_root, candidate_root, environment
+        )
+        command, executables = run_fixed_cargo_build(
+            candidate_root,
+            base / "target",
+            ["--bin", "fixture"],
+            environment,
+            recorded["candidate"],
+        )
+        if command[-2:] != ["--bin", "fixture"] or set(executables) != {"fixture"}:
+            raise AssertionError("controlled fake Cargo build did not emit the targeted fixture")
+        binding = pinned_compiler_binding(recorded["candidate"])
+        if binding["environment"] != {
+            "RUSTC": str(tool_paths["rustc"].resolve()),
+            "RUSTC_WRAPPER": "",
+            "RUSTC_WORKSPACE_WRAPPER": "",
+        }:
+            raise AssertionError("controlled build compiler binding is not exact")
+
+
+def host_identity_privacy_self_test() -> None:
+    system = platform.system()
+    raw_identifiers = (
+        platform.node(),
+        stable_machine_id(system),
+        stable_boot_id(system),
+    )
+    identity = stable_host_identity()
+    serialized = json.dumps(identity, sort_keys=True)
+    for field in (
+        "node_fingerprint",
+        "machine_id_fingerprint",
+        "boot_id_fingerprint",
+    ):
+        value = identity[field]
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", value):
+            raise AssertionError(f"host identity {field} is not a SHA-256 fingerprint")
+    for raw in raw_identifiers:
+        if raw in serialized:
+            raise AssertionError("raw host identifier leaked into the serialized identity")
+        if ":" in raw and raw.split(":", 1)[1] in serialized:
+            raise AssertionError("raw host identifier payload leaked into the serialized identity")
+
+
 def command_self_test(_args: argparse.Namespace) -> int:
+    scenario_validation_self_test()
+    tree_digest_self_test()
+    effective_worktree_digest_self_test()
+    mpv_cache_argv_contract_self_test()
+    toolchain_identity_self_test()
+    cleanup_integration_self_test()
+    startup_cleanup_integration_self_test()
+    host_identity_privacy_self_test()
+    run_contract_integration_self_test()
+    multi_geometry_run_contract_integration_self_test()
+    launch_policy_self_test()
+    child_environment_policy_self_test()
+    materialized_session_self_test()
+    materialize_command_self_test()
+    seed_path_containment_self_test()
+    http_pacing_self_test()
+    http_server_shutdown_self_test()
+    control_operations_self_test()
+    sample_tree_topology_self_test()
     point, upper, ratios = paired_bootstrap_ratios([0.0, 0.0], [0.0, 0.0], 100, 7, 0.95)
     assert point == 1.0 and upper == 1.0 and ratios == [1.0, 1.0]
     point, upper, ratios = paired_bootstrap_ratios([1.0, 2.0], [0.0, 0.0], 100, 7, 0.95)
     assert point == 0.0 and upper == 0.0 and ratios == [0.0, 0.0]
     point, upper, ratios = paired_bootstrap_ratios([0.0, 1.0], [0.1, 1.0], 100, 7, 0.95)
-    assert point == RATIO_INFINITY and upper == RATIO_INFINITY
+    assert point == 1.1 and upper == RATIO_INFINITY
     assert ratios == [RATIO_INFINITY, 1.0]
+    point, upper, ratios = paired_bootstrap_ratios(
+        [1.0] * 7, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 100.0], 10_000, 7, 0.95
+    )
+    assert point > 10.0 and upper > 10.0
+    assert ratios == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 100.0]
     document = {"geometry": [[80, 24], [160, 50]]}
     assert dotted(document, "geometry.length") == 2
     assert dotted(document, "geometry.1.0") == 160
@@ -1602,10 +10452,16 @@ def command_self_test(_args: argparse.Namespace) -> int:
         raise AssertionError("duplicate scenario keys must be rejected")
     render_batch = {
         "draws": 200,
+        "total_ns": 2_000,
         "mean_draw_ns": 10,
-        "p95_draw_ns": 999,
+        "p50_draw_ns": 10,
+        "p95_draw_ns": 10,
+        "max_draw_ns": 10,
+        "latency_histogram": [{"ns": 10, "count": 200}],
         "allocations": 200,
+        "reallocations": 0,
         "allocated_bytes": 400,
+        "deallocated_bytes": 400,
         "retained_bytes_delta": 0,
         "peak_live_bytes_delta": 2,
     }
@@ -1615,15 +10471,28 @@ def command_self_test(_args: argparse.Namespace) -> int:
             "name": "pooled",
             "update_path": "app_update_msg_key",
             "measured_draws": 400,
-            "p95_draw_ns": 123,
+            "total_draw_ns": 4_000,
+            "mean_draw_ns": 10,
+            "p50_draw_ns": 10,
+            "p95_draw_ns": 10,
+            "max_draw_ns": 10,
+            "latency_histogram": [{"ns": 10, "count": 400}],
             "batches": [render_batch, render_batch],
             "buffer_style_digest": "buffer",
             "hit_map_digest": "hits",
         }],
     }
     render_metrics = render_metrics_from_document(render_document, Path("<self-test>"))
-    assert render_metrics["render.pooled.p95_draw_ns"] == 123
-    assert render_metrics["render.pooled.p95_reducer_input_to_draw_ns"] == 123
+    assert render_metrics["render.pooled.p95_draw_ns"] == 10
+    assert render_metrics["render.pooled.p95_reducer_input_to_draw_ns"] == 10
+    render_document["cases"][0]["p95_draw_ns"] = 11
+    try:
+        render_metrics_from_document(render_document, Path("<self-test>"))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("render p95 tampering must be rejected from raw histogram")
+    render_document["cases"][0]["p95_draw_ns"] = 10
     render_document["cases"][0]["measured_draws"] = 399
     try:
         render_metrics_from_document(render_document, Path("<self-test>"))
@@ -1631,6 +10500,15 @@ def command_self_test(_args: argparse.Namespace) -> int:
         pass
     else:
         raise AssertionError("render measured_draws mismatch must be rejected")
+    render_document["cases"][0]["measured_draws"] = 400
+    render_document["cases"][0]["batches"][0]["retained_bytes_delta"] = 1
+    try:
+        render_metrics_from_document(render_document, Path("<self-test>"))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("render allocator byte-conservation tampering must be rejected")
+    render_document["cases"][0]["batches"][0]["retained_bytes_delta"] = 0
     identity_scenario = {
         "id": "render_and_interaction",
         "warmup_draws": 2,
@@ -1648,17 +10526,50 @@ def command_self_test(_args: argparse.Namespace) -> int:
         "kind": "render_summary",
         "scenario_sha256": "scenario",
         "binary_sha256": "ab" * 32,
+        "run_id": "render:self-test",
+        "started_unix_ns": 200,
+        "finished_unix_ns": 300,
         "os": normalized_os(platform.system()),
         "batches_per_case": 1,
         "draws_per_batch": 3,
         "cases": [
             {
                 "name": "identity",
+                "update_path": "app_update_msg_key",
                 "warmup_draws": 2,
                 "measured_draws": 3,
-                "batches": [{"draws": 3}],
+                "total_draw_ns": 15,
+                "mean_draw_ns": 5,
+                "p50_draw_ns": 5,
+                "p95_draw_ns": 5,
+                "max_draw_ns": 5,
+                "latency_histogram": [{"ns": 5, "count": 3}],
+                "buffer_style_digest": "buffer",
+                "hit_map_digest": "hits",
+                "batches": [
+                    {
+                        "draws": 3,
+                        "total_ns": 15,
+                        "mean_draw_ns": 5,
+                        "p50_draw_ns": 5,
+                        "p95_draw_ns": 5,
+                        "max_draw_ns": 5,
+                        "latency_histogram": [{"ns": 5, "count": 3}],
+                        "allocations": 3,
+                        "reallocations": 0,
+                        "allocated_bytes": 30,
+                        "deallocated_bytes": 30,
+                        "retained_bytes_delta": 0,
+                        "peak_live_bytes_delta": 10,
+                    }
+                ],
             }
         ],
+    }
+    identity_run_contract = {
+        "run_id": "render:self-test",
+        "started_unix_ns": 100,
+        "finished_unix_ns": 400,
     }
     validate_render_document(
         identity_document,
@@ -1668,6 +10579,7 @@ def command_self_test(_args: argparse.Namespace) -> int:
         "scenario",
         normalized_os(platform.system()),
         identity_manifest,
+        identity_run_contract,
     )
     identity_document["binary_sha256"] = "00" * 32
     try:
@@ -1679,6 +10591,7 @@ def command_self_test(_args: argparse.Namespace) -> int:
             "scenario",
             normalized_os(platform.system()),
             identity_manifest,
+            identity_run_contract,
         )
     except ValueError:
         pass
@@ -1695,11 +10608,30 @@ def command_self_test(_args: argparse.Namespace) -> int:
             "scenario",
             normalized_os(platform.system()),
             identity_manifest,
+            identity_run_contract,
         )
     except ValueError:
         pass
     else:
         raise AssertionError("render scenario hash tampering must be rejected")
+    identity_document["scenario_sha256"] = "scenario"
+    identity_document["run_id"] = "swapped-run"
+    try:
+        validate_render_document(
+            identity_document,
+            Path("<identity-self-test>"),
+            "baseline",
+            identity_scenario,
+            "scenario",
+            normalized_os(platform.system()),
+            identity_manifest,
+            identity_run_contract,
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("render run ID tampering must be rejected")
+    identity_document["run_id"] = identity_run_contract["run_id"]
     with tempfile.TemporaryDirectory(prefix="ytt-perf-self-test-") as temporary:
         root = Path(temporary)
         raw = root / "raw.json"
@@ -1707,33 +10639,653 @@ def command_self_test(_args: argparse.Namespace) -> int:
         raw.write_text('{"value":1}\n', encoding="utf-8")
         assert write_checksums(root, sums) == 1
         assert verify_checksums(root, sums) == 1
+        shadow_dir = root / "nested"
+        shadow_dir.mkdir()
+        (shadow_dir / "SHA256SUMS.tmp").write_text("must be inventoried\n", encoding="utf-8")
+        assert write_checksums(root, sums) == 2
+        assert verify_checksums(root, sums) == 2
         raw.write_text('{"value":2}\n', encoding="utf-8")
+        sums_before = sha256_file(sums)
         try:
             verify_checksums(root, sums)
         except ValueError:
             pass
         else:
             raise AssertionError("raw artifact tampering must be rejected")
+        assert sha256_file(sums) == sums_before
+
+        base = root / "seed"
+        overlay = root / "overlay"
+        (base / "stores").mkdir(parents=True)
+        overlay.mkdir()
+        (base / "stores" / "state.json").write_text('{"old":true}\n', encoding="utf-8")
+        (overlay / "stores").mkdir()
+        (overlay / "stores" / "state.json").write_text('{"old":false}\n', encoding="utf-8")
+        overlay_digest, overlay_files = overlay_tree_identity(
+            base, overlay, ["stores/state.json"]
+        )
+        assert overlay_digest != sha256_tree(base)
+        assert overlay_files[0]["sha256"] == sha256_file(overlay / "stores" / "state.json")
+        try:
+            overlay_tree_identity(base, overlay, ["wrong.json"])
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("overlay path tampering must be rejected")
+
+        evidence = root / "evidence"
+        snapshot = evidence / "seed-template"
+        for store in ("config", "data", "cache"):
+            (snapshot / "stores" / store).mkdir(parents=True, exist_ok=True)
+        (snapshot / "stores" / "config" / "config.json").write_text(
+            '{"audio":{"mpv":{}}}\n', encoding="utf-8"
+        )
+        atomic_json(
+            snapshot / "stores" / "cache" / "session.json",
+            {
+                "schema_version": 2,
+                "app_version": project_package_version(),
+                "last_mode": "normal",
+                "normal_queue": {
+                    "songs": [{"local_path": "{{TUI_PERF_PLAYLIST}}"}],
+                    "order": [0],
+                    "cursor": 0,
+                },
+            },
+        )
+        seed_digest = sha256_tree(snapshot)
+        seed_scenario = {
+            "id": "seed-self-test",
+            "seed_contract": {
+                "require_identical_tree": True,
+                "require_identical_cache_policy": True,
+                "expected_cache_policy": None,
+            },
+        }
+        seed_manifest_path = evidence / "seed-contract.json"
+        seed_manifest = {
+            "schema": SEED_CONTRACT_SCHEMA,
+            "scenario": seed_scenario["id"],
+            "scenario_sha256": "seed-scenario",
+            "contract": seed_scenario["seed_contract"],
+            "source_tree_sha256": {
+                "baseline": seed_digest,
+                "candidate": seed_digest,
+            },
+            "cache_policy": seed_cache_policy(snapshot),
+            "playlist_placeholder_count": {"baseline": 1, "candidate": 1},
+            "active_playlist_contract": validate_active_session_playlist(
+                snapshot, "{{TUI_PERF_PLAYLIST}}"
+            ),
+            "snapshot": "seed-template",
+            "snapshot_tree_sha256": seed_digest,
+            "snapshot_files": tree_file_inventory(snapshot),
+        }
+        atomic_json(seed_manifest_path, seed_manifest)
+        validate_seed_contract_manifest(
+            seed_manifest_path, evidence, seed_scenario, "seed-scenario"
+        )
+        seed_manifest["cache_policy"] = {"config_present": False}
+        atomic_json(seed_manifest_path, seed_manifest)
+        try:
+            validate_seed_contract_manifest(
+                seed_manifest_path, evidence, seed_scenario, "seed-scenario"
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("seed cache-policy manifest tampering must be rejected")
+
+        def git_checked(cwd: Path, *arguments: str) -> None:
+            completed = subprocess.run(
+                ["git", "-C", str(cwd), *arguments],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            )
+            if completed.returncode != 0:
+                raise AssertionError(
+                    f"self-test git {' '.join(arguments)} failed: {completed.stderr.strip()}"
+                )
+
+        candidate_source = root / "candidate-source"
+        baseline_source = root / "baseline-source"
+        remote_source = root / "origin.git"
+        candidate_source.mkdir()
+        git_checked(candidate_source, "init", "--initial-branch=main")
+        git_checked(candidate_source, "config", "user.name", "tui-perf self-test")
+        git_checked(candidate_source, "config", "user.email", "tui-perf@example.invalid")
+        (candidate_source / "Cargo.lock").write_text("lock\n", encoding="utf-8")
+        (candidate_source / "Cargo.toml").write_text(
+            '[package]\nname = "tui-perf-self-test"\nversion = "0.0.1"\n',
+            encoding="utf-8",
+        )
+        (candidate_source / ".gitignore").write_text("/.cargo/\n", encoding="utf-8")
+        git_checked(candidate_source, "add", "Cargo.lock", "Cargo.toml", ".gitignore")
+        git_checked(candidate_source, "-c", "commit.gpgsign=false", "commit", "-m", "main")
+        remote_source.mkdir()
+        git_checked(remote_source, "init", "--bare", "--initial-branch=main")
+        git_checked(candidate_source, "remote", "add", "origin", str(remote_source))
+        git_checked(candidate_source, "push", "-u", "origin", "main")
+        git_checked(candidate_source, "switch", "-c", "candidate")
+        render_harness = candidate_source / "examples" / "tui_render_perf.rs"
+        render_harness.parent.mkdir()
+        render_harness.write_text("fn main() {}\n", encoding="utf-8")
+        git_checked(candidate_source, "add", "examples/tui_render_perf.rs")
+        git_checked(
+            candidate_source,
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-m",
+            "candidate",
+        )
+        completed = subprocess.run(
+            ["git", "clone", str(remote_source), str(baseline_source)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise AssertionError(f"self-test git clone failed: {completed.stderr.strip()}")
+        validate_source_contract(
+            baseline_source, candidate_source, render=True, refresh=True
+        )
+
+        (candidate_source / "Cargo.lock").write_text("dirty\n", encoding="utf-8")
+        try:
+            validate_source_contract(
+                baseline_source, candidate_source, render=True, refresh=False
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("dirty candidate source must be rejected")
+        (candidate_source / "Cargo.lock").write_text("lock\n", encoding="utf-8")
+
+        baseline_harness = baseline_source / "examples" / "tui_render_perf.rs"
+        baseline_harness.write_text("fn main() { panic!(); }\n", encoding="utf-8")
+        try:
+            validate_source_contract(
+                baseline_source, candidate_source, render=True, refresh=False
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("mismatched baseline render harness must be rejected")
+        baseline_harness.write_bytes(render_harness.read_bytes())
+
+        ignored_config = candidate_source / ".cargo" / "config.toml"
+        ignored_config.parent.mkdir()
+        ignored_config.write_text('[build]\nrustflags = ["-Ctarget-cpu=native"]\n', encoding="utf-8")
+        try:
+            validate_source_contract(
+                baseline_source, candidate_source, render=True, refresh=False
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("ignored candidate Cargo config difference must be rejected")
+        ignored_config.unlink()
+        ignored_config.parent.rmdir()
+
+        orphan_oid = str(
+            run_git(
+                candidate_source,
+                "-c",
+                "commit.gpgsign=false",
+                "commit-tree",
+                "HEAD^{tree}",
+                "-m",
+                "disconnected candidate",
+            )
+        )
+        git_checked(candidate_source, "switch", "--detach", orphan_oid)
+        try:
+            validate_source_contract(
+                baseline_source, candidate_source, render=True, refresh=False
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("candidate not descended from origin/main must be rejected")
+        git_checked(candidate_source, "switch", "candidate")
+
+        (baseline_source / "unexpected.txt").write_text("unexpected\n", encoding="utf-8")
+        try:
+            validate_source_contract(
+                baseline_source, candidate_source, render=True, refresh=False
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("unexpected baseline untracked files must be rejected")
+
+    measured_header = {
+        "root_pid": 100,
+        "binary_sha256": "ab" * 32,
+        "warmup_ms": 1_000,
+        "duration_ms": 2_000,
+        "cpu_accounting": CPU_ACCOUNTING_METHOD,
+        "cpu_window_start_ns": 1_000_000_000,
+        "cpu_window_end_ns": 3_000_000_000,
+        "interval_ms": 1_000,
+    }
+
+    def raw_sample(
+        elapsed_ms: int,
+        cpu_overlap_ms: int,
+        phase: str,
+        accumulated_ms: int,
+        cpu: float,
+        rss: int,
+    ) -> dict[str, Any]:
+        role = {"processes": 1, "cpu_percent": cpu, "rss_bytes": rss}
+        return {
+            "schema": "ytt.tui-perf.samples.v1",
+            "kind": "sample",
+            "elapsed_ms": elapsed_ms,
+            "observed_elapsed_ns": elapsed_ms * 1_000_000,
+            "cpu_interval_overlap_ns": cpu_overlap_ms * 1_000_000,
+            "phase": phase,
+            "mpv_present": False,
+            "mpv_all_silent_this_sample": False,
+            "roles": {"ytt": dict(role), "tree": dict(role)},
+            "processes": [
+                {
+                    "pid": 100,
+                    "parent_pid": 1,
+                    "role": "ytt",
+                    "name": "ytt",
+                    "start_time_unix_s": 50,
+                    "accumulated_cpu_ms": accumulated_ms,
+                    "cpu_percent": cpu,
+                    "rss_bytes": rss,
+                    "command": ["/tmp/ytt"],
+                    "executable": "/tmp/ytt",
+                    "executable_bytes": 1,
+                    "executable_sha256": "ab" * 32,
+                }
+            ],
+        }
+
+    measured_records = [
+        raw_sample(0, 0, "warmup", 0, 0.0, 50),
+        raw_sample(1_100, 100, "measure", 110, 10.0, 100),
+        raw_sample(1_900, 800, "measure", 270, 20.0, 200),
+        raw_sample(3_100, 1_100, "measure", 630, 30.0, 300),
+    ]
+    measured_summary = {
+        "cpu_accounting": CPU_ACCOUNTING_METHOD,
+        "cpu_window_start_ns": 1_000_000_000,
+        "cpu_window_end_ns": 3_000_000_000,
+        "roles": {
+            "ytt": {
+                "samples": 3,
+                "mean_cpu_percent": 25.0,
+                "mean_rss_bytes": 200,
+                "peak_rss_bytes": 300,
+            },
+            "tree": {
+                "samples": 3,
+                "mean_cpu_percent": 25.0,
+                "mean_rss_bytes": 200,
+                "peak_rss_bytes": 300,
+            }
+        },
+        "root_pid": 100,
+        "silent_mpv_proven": False,
+        "measured_mpv_proof": {
+            "samples": 3,
+            "samples_with_mpv": 0,
+            "samples_all_silent": 0,
+            "samples_all_cleanup_identified": 0,
+        },
+        "last_observed_mpv": [],
+    }
+    validate_measured_samples(
+        Path("<sample-self-test>"), measured_header, measured_summary, measured_records, False
+    )
+    measured_summary["roles"]["tree"]["mean_cpu_percent"] = 1.0
+    try:
+        validate_measured_samples(
+            Path("<sample-self-test>"), measured_header, measured_summary, measured_records, False
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("sampler summary tampering must be rejected")
+    measured_summary["roles"]["tree"]["mean_cpu_percent"] = 25.0
+    measured_records[2]["elapsed_ms"] = 1_001
+    try:
+        validate_measured_samples(
+            Path("<sample-self-test>"), measured_header, measured_summary, measured_records, False
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("sampler coverage tampering must be rejected")
+    measured_records[2]["elapsed_ms"] = 1_900
+
+    overlap_tamper = json.loads(json.dumps(measured_records))
+    overlap_tamper[-1]["cpu_interval_overlap_ns"] -= 1
+    try:
+        validate_measured_samples(
+            Path("<sample-self-test>"), measured_header, measured_summary, overlap_tamper, False
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("sampler CPU overlap tampering must be rejected")
+
+    try:
+        validate_measured_samples(
+            Path("<sample-self-test>"),
+            measured_header,
+            measured_summary,
+            measured_records[:-1],
+            False,
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("sampler omitted final CPU interval must be rejected")
+
+    control_records = [
+        {
+            "schema": "ytt.tui-perf.control.v1",
+            "kind": "mpv_event",
+            "elapsed_ns": 2_000_000,
+            "event": {
+                "event": "property-change",
+                "name": "paused-for-cache",
+                "data": True,
+            },
+        },
+        {
+            "schema": "ytt.tui-perf.control.v1",
+            "kind": "mpv_event",
+            "elapsed_ns": 7_000_000,
+            "event": {
+                "event": "property-change",
+                "name": "paused-for-cache",
+                "data": False,
+            },
+        },
+        {
+            "schema": "ytt.tui-perf.control.v1",
+            "kind": "mpv_event",
+            "elapsed_ns": 9_000_000,
+            "event": {
+                "event": "property-change",
+                "name": "paused-for-cache",
+                "data": True,
+            },
+        },
+        {
+            "schema": "ytt.tui-perf.control.v1",
+            "kind": "mpv_event",
+            "elapsed_ns": 11_000_000,
+            "event": {
+                "event": "property-change",
+                "name": "paused-for-cache",
+                "data": False,
+            },
+        },
+        {
+            "schema": "ytt.tui-perf.control.v1",
+            "kind": "mpv_event",
+            "elapsed_ns": 12_000_000,
+            "event": {
+                "event": "property-change",
+                "name": "paused-for-cache",
+                "data": True,
+            },
+        },
+    ]
+    control_summary = {
+        "schema": "ytt.tui-perf.control.v1",
+        "kind": "summary",
+        "elapsed_ns": 14_000_000,
+        "buffering_cutoff_ns": 10_000_000,
+        "buffering_events": 2,
+        "buffering_ms": 6,
+    }
+    validate_control_buffering(
+        Path("<control-self-test>"), control_records, control_summary
+    )
+    control_summary["buffering_ms"] = 7
+    try:
+        validate_control_buffering(
+            Path("<control-self-test>"), control_records, control_summary
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("controller buffering summary tampering must be rejected")
+
+    progress_records = [
+        {
+            "schema": "ytt.tui-perf.control.v1",
+            "kind": "mpv_event",
+            "elapsed_ns": elapsed_ns,
+            "event": {
+                "event": "property-change",
+                "name": "time-pos",
+                "data": position_s,
+            },
+        }
+        for elapsed_ns, position_s in (
+            (1_000_000_000, 5.0),
+            (79_000_000_000, 75.0),
+            (81_000_000_000, 999.0),
+        )
+    ]
+    progress_summary = {
+        "buffering_cutoff_ns": 80_000_000_000,
+        "cutoff_first_time_pos_ns": 1_000_000_000,
+        "cutoff_first_time_pos_s": 5.0,
+        "cutoff_last_time_pos_ns": 79_000_000_000,
+        "cutoff_last_time_pos_s": 75.0,
+    }
+    steady_scenario = {
+        "minimum_playback_progress_fraction": 0.8,
+        "time_pos_tail_tolerance_s": 2.0,
+    }
+    validate_steady_playback_progress(
+        Path("<control-progress-self-test>"),
+        progress_records,
+        progress_summary,
+        steady_scenario,
+    )
+    stalled_records = json.loads(json.dumps(progress_records))
+    stalled_records[1]["event"]["data"] = 5.01
+    stalled_summary = {
+        **progress_summary,
+        "cutoff_last_time_pos_s": 5.01,
+    }
+    try:
+        validate_steady_playback_progress(
+            Path("<control-progress-self-test>"),
+            stalled_records,
+            stalled_summary,
+            steady_scenario,
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("stalled steady playback must be rejected")
+
+    inventory_entry = {"role": "baseline", "path": "run/samples.ndjson", "sha256": "ab" * 32}
+    candidate_entry = {**inventory_entry, "role": "candidate"}
+    assert raw_inventory_digest([inventory_entry]) != raw_inventory_digest([candidate_entry])
     scenario_document, _ = load_scenarios(DEFAULT_SCENARIOS)
+    for replacement in (None, {}):
+        invalid = json.loads(json.dumps(scenario_document))
+        if replacement is None:
+            invalid["scenarios"][0].pop("metrics")
+        else:
+            invalid["scenarios"][0]["metrics"] = replacement
+        try:
+            validate_scenarios(invalid)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("missing or empty scenario metrics must be rejected")
+    playback_scenarios = [
+        scenario for scenario in scenario_document["scenarios"] if scenario["requires_mpv"]
+    ]
+    assert playback_scenarios and all(
+        scenario["expected_effective_mpv_cache_args"]
+        == REQUIRED_PLAYBACK_MPV_CACHE_ARGS
+        for scenario in playback_scenarios
+    )
+    missing_cache_contract = json.loads(json.dumps(scenario_document))
+    next(
+        scenario
+        for scenario in missing_cache_contract["scenarios"]
+        if scenario["requires_mpv"]
+    ).pop("expected_effective_mpv_cache_args")
+    try:
+        validate_scenarios(missing_cache_contract)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("missing playback mpv cache argv contract must be rejected")
     soak = find_scenario(scenario_document, "memory_soak")
     assert soak["pause_policy"] == "none" and soak["pause_hold_ms"] == 0
-    for wrapper_name in ("tui-perf.sh", "tui-perf.ps1"):
-        wrapper = Path(__file__).with_name(wrapper_name).read_text(encoding="utf-8")
-        for token in ("pause_policy", "pause_hold_ms", "--pause-hold-ms", "--no-pause"):
-            # PowerShell uses camelCase locals but still queries the exact snake_case key.
+    unix_wrapper = Path(__file__).with_name("tui-perf.sh").read_text(encoding="utf-8")
+    windows_wrapper = Path(__file__).with_name("tui-perf.ps1").read_text(encoding="utf-8")
+    for wrapper in (unix_wrapper, windows_wrapper):
+        for token in (
+            "--build-receipt",
+            "create-checksums",
+            "verify-checksums",
+            "baseline_render",
+            "candidate_render",
+            "run-start",
+            "run-finish",
+            "TUI_PERF_RUN_ID",
+        ):
             assert token in wrapper
+        for forbidden in (
+            "--baseline-binary",
+            "--candidate-binary",
+            "--baseline-build-command",
+            "--candidate-build-command",
+        ):
+            assert forbidden not in wrapper
+    for token in (
+        "--geometry-index",
+        "--width",
+        "--height",
+        '"$geometry_dir/run-contract.json"',
+        "if $is_render || ((geometry_count == 1)); then",
+    ):
+        assert token in unix_wrapper
+    for token in (
+        "pause_policy",
+        "pause_hold_ms",
+        "--pause-hold-ms",
+        "--no-pause",
+        "seed-contract",
+        "path-preflight",
+        "--input-snapshot",
+        "sampling.interval_ms",
+        "baseline_ytt",
+        "candidate_ytt",
+        "launch-policy",
+        "--identity-file",
+        " cleanup ",
+        "stop-server",
+        "--shutdown-token",
+    ):
+        assert token in unix_wrapper
+    assert unix_wrapper.index("path-preflight") < unix_wrapper.index('mkdir -p "$output"')
+    assert unix_wrapper.index("path-preflight") < unix_wrapper.index(
+        'python3 "$python_tool" validate'
+    )
+    assert '"--shutdown-token=$shutdown_token"' in unix_wrapper
+    assert '--shutdown-token "$shutdown_token"' not in unix_wrapper
+    assert 'kill "$active_server_pid"' not in unix_wrapper
+    for token in (
+        "off-screen ConPTY",
+        "controlled empty input",
+        "No process measurement was started and no output was created",
+        "if (-not $isRender) { Assert-WindowsProcessIsolation }",
+        "path-preflight",
+        "--output-root $Output",
+        "--protected-root $BaselineSourceRoot",
+        "--protected-root $CandidateSourceRoot",
+    ):
+        assert token in windows_wrapper
+    assert windows_wrapper.index("if (-not $isRender)") < windows_wrapper.index("$script:OutputRoot")
+    windows_preflight = windows_wrapper.index("$resolvedOutput = & python $PythonTool path-preflight")
+    windows_output_create = windows_wrapper.index(
+        "New-Item -ItemType Directory -Path $script:OutputRoot"
+    )
+    assert windows_preflight < windows_output_create
+    assert windows_preflight < windows_wrapper.index("$buildArgs = @(")
+    for forbidden in (
+        "Run-Process",
+        "Stop-RecordedYtt",
+        "RawUI",
+        "baseline_ytt",
+        "candidate_ytt",
+        'SetEnvironmentVariable("YTM_PERF", "1"',
+        '$env:YTM_PERF = "1"',
+    ):
+        assert forbidden not in windows_wrapper
+    parser = build_parser()
+    subcommands = next(
+        action
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    ).choices
+    assert "create-checksums" in subcommands
+    assert "verify-checksums" in subcommands
+    assert "checksums" not in subcommands
     print(
         json.dumps(
             {
                 "ok": True,
-                "zero_ratio_cases": 3,
+                "zero_ratio_cases": 4,
                 "geometry_variant_cases": 2,
+                "multi_geometry_contract_cases": 2,
                 "duplicate_key_cases": 1,
                 "aggregate_render_p95_cases": 2,
                 "render_identity_tamper_cases": 2,
                 "checksum_tamper_cases": 1,
+                "checksum_shadow_inventory_cases": 1,
+                "tree_digest_collision_cases": 1,
+                "tree_nonregular_rejection_cases": 1,
+                "effective_worktree_digest_collision_cases": 1,
+                "effective_worktree_digest_fail_closed_cases": 1,
+                "overlay_tamper_cases": 1,
+                "seed_manifest_tamper_cases": 1,
+                "seed_path_overlap_subprocess_cases": 2,
+                "sample_summary_tamper_cases": 1,
+                "sample_coverage_tamper_cases": 1,
+                "sample_cpu_window_tamper_cases": 2,
+                "sample_jitter_weighting_cases": 1,
+                "control_buffering_tamper_cases": 1,
+                "scenario_schema_tamper_cases": 33,
+                "control_operation_tamper_cases": 13,
+                "http_server_authenticated_shutdown_cases": 1,
+                "http_server_leading_dash_token_cases": 1,
+                "http_server_stale_pid_no_signal_cases": 1,
+                "sample_tree_topology_tamper_cases": 4,
+                "source_contract_tamper_cases": 3,
+                "toolchain_identity_tamper_cases": 3,
+                "cleanup_scope_tamper_cases": 1,
+                "raw_role_binding_cases": 1,
                 "steady_soak_pause_cases": 1,
                 "wrapper_pause_parity_cases": 2,
+                "wrapper_contract_parity_cases": 2,
+                "wrapper_shutdown_token_argv_cases": 2,
+                "checksum_command_split_cases": 1,
             }
         )
     )
@@ -1810,9 +11362,12 @@ def command_compare(args: argparse.Namespace) -> int:
         raise ValueError("--output-markdown must be directly inside the host-manifest directory")
     render = args.scenario == "render_and_interaction"
     host_manifest = validate_host_manifest(
-        args.host_manifest.resolve(), scenario, scenario_hash, render
+        args.host_manifest.resolve(), scenario, document, scenario_hash, render
     )
     host_os = normalized_os(host_manifest["host"]["system"])
+    host_identity = {
+        field: str(host_manifest["host"][field]) for field in HOST_IDENTITY_FIELDS
+    }
     if len(args.baseline_run) != len(args.candidate_run):
         raise ValueError("--baseline-run and --candidate-run counts must match")
     if len(args.baseline_run) != int(scenario["pairs"]):
@@ -1825,8 +11380,41 @@ def command_compare(args: argparse.Namespace) -> int:
             f"scenario {args.scenario} requires {expected_repeats} candidate repeats, "
             f"got {len(args.candidate_repeat_run)}"
         )
+    run_contracts, run_chronology = validate_run_contract_collection(
+        evidence_root, args, scenario, scenario_hash, host_identity
+    )
 
     inventory_paths: list[tuple[Path, str]] = []
+    inventory_paths.append(
+        (evidence_root / host_manifest["scenario_file"]["path"], "shared")
+    )
+    inventory_paths.append(
+        (evidence_root / host_manifest["build_receipt"]["path"], "shared")
+    )
+    inventory_paths.extend(
+        (Path(identity["path"]), "shared")
+        for identity in host_manifest["binaries"].values()
+    )
+    seed_context: tuple[dict[str, Any], Path] | None = None
+    if scenario["requires_mpv"]:
+        seed_manifest_path = evidence_root / "seed-contract.json"
+        seed_context = validate_seed_contract_manifest(
+            seed_manifest_path, evidence_root, scenario, scenario_hash
+        )
+        inventory_paths.append((seed_manifest_path, "shared"))
+        inventory_paths.extend(
+            (item, "shared")
+            for item in sorted(path for path in seed_context[1].rglob("*") if path.is_file())
+        )
+
+    all_run_paths = [
+        path.resolve()
+        for paths in (args.baseline_run, args.candidate_run, args.candidate_repeat_run)
+        for path in paths
+    ]
+    if len(all_run_paths) != len(set(all_run_paths)):
+        raise ValueError("run directories must be unique across baseline, candidate, and repeats")
+    mpv_run_provenance: list[dict[str, Any]] = []
     for role, paths in (
         ("baseline", args.baseline_run),
         ("candidate", args.candidate_run),
@@ -1840,18 +11428,41 @@ def command_compare(args: argparse.Namespace) -> int:
                 raise ValueError(
                     f"run directory must stay inside evidence root {evidence_root}: {resolved}"
                 ) from error
-            inventory_paths.extend(
-                (artifact, role)
-                for artifact in validate_run_artifacts(
-                    resolved,
-                    role,
-                    scenario,
-                    document,
-                    scenario_hash,
-                    host_os,
-                    host_manifest,
-                )
+            validated_artifacts = validate_run_artifacts(
+                resolved,
+                role,
+                scenario,
+                document,
+                scenario_hash,
+                host_os,
+                host_manifest,
+                seed_context,
+                run_contracts,
             )
+            inventory_paths.extend((artifact, role) for artifact in validated_artifacts)
+            if scenario["requires_mpv"]:
+                mpv_run_provenance.append(
+                    {
+                        "run_ids": [
+                            run_contracts[directory.resolve()]["run_id"]
+                            for directory in process_run_directories(resolved, scenario)
+                        ],
+                        "role": role,
+                        **measured_mpv_executable_provenance(resolved, scenario),
+                    }
+                )
+
+    if mpv_run_provenance:
+        executable_identities = {
+            (
+                item["executable"],
+                item["executable_bytes"],
+                item["executable_sha256"],
+            )
+            for item in mpv_run_provenance
+        }
+        if len(executable_identities) != 1:
+            raise ValueError("paired/repeat runs used different mpv executable identities")
 
     if scenario["requires_mpv"]:
         fixture_manifest_path = evidence_root / "fixture" / "manifest.json"
@@ -1880,6 +11491,7 @@ def command_compare(args: argparse.Namespace) -> int:
                     fixture_manifest.get("sha256"),
                 )
         inventory_paths.append((fixture_manifest_path, "shared"))
+        inventory_paths.append((fixture_path, "shared"))
 
     baseline_runs = [load_run(path) for path in args.baseline_run]
     candidate_runs = [load_run(path) for path in args.candidate_run]
@@ -1907,16 +11519,21 @@ def command_compare(args: argparse.Namespace) -> int:
             )
             for repeat, run in zip(repeat_metrics, candidate_repeat_runs):
                 repeat[name] = run[name]
+    if not results:
+        raise ValueError(f"scenario {args.scenario} produced no metric comparisons")
 
-    seen_artifacts: set[Path] = set()
+    seen_artifacts: dict[Path, str] = {}
     raw_artifacts = []
     for path, role in inventory_paths:
         resolved = path.resolve()
         if resolved in seen_artifacts:
-            continue
-        seen_artifacts.add(resolved)
+            raise ValueError(
+                f"raw artifact path collision: {resolved} is used as both "
+                f"{seen_artifacts[resolved]!r} and {role!r}"
+            )
+        seen_artifacts[resolved] = role
         raw_artifacts.append(relative_artifact(resolved, evidence_root, role))
-    raw_artifacts.sort(key=lambda item: item["path"])
+    raw_artifacts.sort(key=lambda item: (item["role"], item["path"]))
 
     def relative_run(path: Path) -> str:
         resolved = path.resolve()
@@ -1936,7 +11553,31 @@ def command_compare(args: argparse.Namespace) -> int:
         "baseline_runs": [relative_run(path) for path in args.baseline_run],
         "candidate_runs": [relative_run(path) for path in args.candidate_run],
         "candidate_repeat_runs": [relative_run(path) for path in args.candidate_repeat_run],
+        "run_chronology": [
+            {
+                field: contract[field]
+                for field in (
+                    "run_id",
+                    "kind",
+                    "role",
+                    "pair_index",
+                    "pair_order",
+                    "within_pair_ordinal",
+                    "repeat_index",
+                    "geometry_index",
+                    "terminal_geometry",
+                    "started_unix_ns",
+                    "finished_unix_ns",
+                    "started_monotonic_ns",
+                    "finished_monotonic_ns",
+                    "duration_ns",
+                )
+            }
+            for contract in run_chronology
+        ],
         "candidate_repeat_metrics": repeat_metrics,
+        "measurement_scope": document["sampling"],
+        "limitations": measurement_limitations(render),
         "evidence": {
             "host_manifest": relative_artifact(
                 args.host_manifest.resolve(), evidence_root, "shared"
@@ -1945,6 +11586,10 @@ def command_compare(args: argparse.Namespace) -> int:
             "binaries": host_manifest["binaries"],
             "raw_artifacts": raw_artifacts,
             "raw_set_sha256": raw_inventory_digest(raw_artifacts),
+            "mpv_executable_provenance": mpv_run_provenance,
+            "mpv_null_audio_zero_volume_proven": (
+                True if scenario["requires_mpv"] else None
+            ),
         },
         "required_runtime_checklist": document.get("required_runtime_checklist", []),
         "runtime_checklist_status": "not_run_by_performance_harness",
@@ -1980,8 +11625,13 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         f"Candidate diagnostic repeats: {len(report['candidate_repeat_runs'])}",
         "",
-        "Visual runtime checklist: **NOT RUN by this performance harness**",
+        "Measurement limitations:",
     ]
+    lines.extend(f"- {item}" for item in report["limitations"])
+    lines.extend([
+        "",
+        "Visual runtime checklist: **NOT RUN by this performance harness**",
+    ])
     lines.extend(f"- [ ] {item}" for item in report["required_runtime_checklist"])
     lines.extend([
         "",
@@ -2034,13 +11684,49 @@ def build_parser() -> argparse.ArgumentParser:
     setting.add_argument("--field", required=True)
     setting.set_defaults(handler=command_setting)
 
+    build = sub.add_parser(
+        "build", help="perform a fresh controlled source-bound release build"
+    )
+    build.add_argument("--scenarios", type=Path, default=DEFAULT_SCENARIOS)
+    build.add_argument("--scenario", required=True)
+    build.add_argument("--baseline-root", type=Path, required=True)
+    build.add_argument("--candidate-root", type=Path, required=True)
+    build.add_argument("--output", type=Path, required=True)
+    build.add_argument("--target-root", type=Path, required=True)
+    build.set_defaults(handler=command_build)
+
+    receipt = sub.add_parser("receipt", help="read one field from a controlled build receipt")
+    receipt.add_argument("--receipt", type=Path, required=True)
+    receipt.add_argument("--artifact", required=True)
+    receipt.add_argument("--field", required=True)
+    receipt.set_defaults(handler=command_receipt)
+
+    path_preflight = sub.add_parser(
+        "path-preflight",
+        help="resolve a new evidence root and reject source/seed containment",
+    )
+    path_preflight.add_argument("--output-root", type=Path, required=True)
+    path_preflight.add_argument(
+        "--protected-root", type=Path, action="append", required=True
+    )
+    path_preflight.set_defaults(handler=command_path_preflight)
+
+    seed_contract = sub.add_parser(
+        "seed-contract", help="validate identical role seeds and create an immutable snapshot"
+    )
+    seed_contract.add_argument("--scenarios", type=Path, default=DEFAULT_SCENARIOS)
+    seed_contract.add_argument("--scenario", required=True)
+    seed_contract.add_argument("--baseline-root", type=Path, required=True)
+    seed_contract.add_argument("--candidate-root", type=Path, required=True)
+    seed_contract.add_argument("--snapshot", type=Path, required=True)
+    seed_contract.add_argument("--output", type=Path, required=True)
+    seed_contract.set_defaults(handler=command_seed_contract)
+
     manifest = sub.add_parser("manifest", help="write OS, CPU, RAM, tool, and binary identity")
     manifest.add_argument("--scenarios", type=Path, default=DEFAULT_SCENARIOS)
     manifest.add_argument("--scenario", required=True)
     manifest.add_argument("--output", type=Path, required=True)
-    manifest.add_argument("--binary", action="append", default=[])
-    manifest.add_argument("--source-root", action="append", default=[])
-    manifest.add_argument("--build-command", action="append", default=[])
+    manifest.add_argument("--build-receipt", type=Path, required=True)
     manifest.set_defaults(handler=command_manifest)
 
     materialize = sub.add_parser(
@@ -2052,9 +11738,45 @@ def build_parser() -> argparse.ArgumentParser:
     materialize.add_argument(
         "--playlist-relative", type=Path, default=Path("fixture/tui-perf-stream.m3u")
     )
-    materialize.add_argument("--manifest", type=Path)
+    materialize.add_argument("--manifest", type=Path, required=True)
+    materialize.add_argument("--input-snapshot", type=Path, required=True)
     materialize.add_argument("--seed-label", default="unspecified")
     materialize.set_defaults(handler=command_materialize)
+
+    launch_policy = sub.add_parser(
+        "launch-policy", help="freeze background network/update work for a gating run"
+    )
+    launch_policy.add_argument("--root", type=Path, required=True)
+    launch_policy.add_argument("--output", type=Path, required=True)
+    launch_policy.set_defaults(handler=command_launch_policy)
+
+    run_start = sub.add_parser(
+        "run-start", help="atomically start one paired/repeat chronology contract"
+    )
+    run_start.add_argument("--scenarios", type=Path, default=DEFAULT_SCENARIOS)
+    run_start.add_argument("--scenario", required=True)
+    run_start.add_argument("--output", type=Path, required=True)
+    run_start.add_argument("--kind", choices=("paired", "candidate_repeat"), required=True)
+    run_start.add_argument("--role", choices=("baseline", "candidate"), required=True)
+    run_start.add_argument("--pair-index", type=int)
+    run_start.add_argument("--repeat-index", type=int)
+    run_start.add_argument("--geometry-index", type=int)
+    run_start.add_argument("--width", type=int)
+    run_start.add_argument("--height", type=int)
+    run_start.set_defaults(handler=command_run_start)
+
+    run_finish = sub.add_parser(
+        "run-finish", help="atomically close one chronology contract after all producers exit"
+    )
+    run_finish.add_argument("--contract", type=Path, required=True)
+    run_finish.set_defaults(handler=command_run_finish)
+
+    cleanup = sub.add_parser(
+        "cleanup", help="verify, terminate, wait for, and revalidate a live run identity"
+    )
+    cleanup.add_argument("--identity", type=Path, required=True)
+    cleanup.add_argument("--timeout-secs", type=float, default=10.0)
+    cleanup.set_defaults(handler=command_cleanup)
 
     fixture = sub.add_parser("fixture", help="create deterministic PCM WAV silence")
     fixture.add_argument("--output", type=Path, required=True)
@@ -2076,12 +11798,24 @@ def build_parser() -> argparse.ArgumentParser:
     serve.add_argument("--host", default="127.0.0.1")
     serve.add_argument("--port", type=int, default=0)
     serve.add_argument("--ready-file", type=Path)
+    serve.add_argument("--request-log", type=Path, required=True)
+    serve.add_argument("--run-id", required=True)
+    serve.add_argument("--shutdown-token", required=True)
     serve.add_argument("--throttle-bps", type=int, default=0)
     serve.add_argument("--outage-every-bytes", type=int, default=0)
     serve.add_argument("--outage-ms", type=int, default=0)
     serve.add_argument("--disconnect-every-bytes", type=int, default=0)
     serve.add_argument("--verbose", action="store_true")
     serve.set_defaults(handler=command_serve)
+
+    stop_server = sub.add_parser(
+        "stop-server",
+        help="authenticate, gracefully stop, and revalidate an exact fixture server",
+    )
+    stop_server.add_argument("--identity", type=Path, required=True)
+    stop_server.add_argument("--expected-run-id", required=True)
+    stop_server.add_argument("--timeout-secs", type=float, default=10.0)
+    stop_server.set_defaults(handler=command_stop_server)
 
     compare = sub.add_parser("compare", help="compare paired run directories and write reports")
     compare.add_argument("--scenarios", type=Path, default=DEFAULT_SCENARIOS)
@@ -2094,12 +11828,19 @@ def build_parser() -> argparse.ArgumentParser:
     compare.add_argument("--output-markdown", type=Path, required=True)
     compare.set_defaults(handler=command_compare)
 
-    checksums = sub.add_parser(
-        "checksums", help="write and immediately verify a portable SHA256SUMS inventory"
+    create_checksums = sub.add_parser(
+        "create-checksums",
+        help="create or overwrite and verify a portable SHA256SUMS inventory",
     )
-    checksums.add_argument("--root", type=Path, required=True)
-    checksums.add_argument("--output", type=Path, required=True)
-    checksums.set_defaults(handler=command_checksums)
+    create_checksums.add_argument("--root", type=Path, required=True)
+    create_checksums.add_argument("--output", type=Path, required=True)
+    create_checksums.set_defaults(handler=command_create_checksums)
+    verify = sub.add_parser(
+        "verify-checksums", help="read-only transport verification of an existing SHA256SUMS"
+    )
+    verify.add_argument("--root", type=Path, required=True)
+    verify.add_argument("--output", type=Path, required=True)
+    verify.set_defaults(handler=command_verify_checksums)
 
     self_test = sub.add_parser("self-test", help="run deterministic statistics edge-case checks")
     self_test.set_defaults(handler=command_self_test)

--- a/scripts/tui-perf.py
+++ b/scripts/tui-perf.py
@@ -1,0 +1,2120 @@
+#!/usr/bin/env python3
+"""Dependency-free orchestration/reporting helpers for the ytt TUI perf matrix.
+
+The Rust examples own native process and render measurements. This script owns the portable
+parts: deterministic silence fixtures, a Range-capable constrained HTTP server, scenario-file
+validation, paired fixed-seed bootstrap statistics, and merged JSON/Markdown reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import http.server
+import ipaddress
+import json
+import math
+import os
+import platform
+import random
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import wave
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlsplit
+
+
+SCHEMA = "ytt.tui-perf.report.v1"
+DEFAULT_SCENARIOS = Path(__file__).with_name("tui-perf-scenarios.json")
+RATIO_INFINITY = 1e300
+
+
+class DuplicateJsonKeyError(ValueError):
+    pass
+
+
+def reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise DuplicateJsonKeyError(f"duplicate JSON key {key!r}")
+        value[key] = item
+    return value
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sha256_tree(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run_git(root: Path, *arguments: str, binary: bool = False) -> str | bytes:
+    result = subprocess.run(
+        ["git", "-C", str(root), *arguments],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise ValueError(f"git {' '.join(arguments)} failed in {root}: {detail}")
+    if binary:
+        return result.stdout
+    return result.stdout.decode("utf-8", errors="strict").strip()
+
+
+def effective_worktree_digest(root: Path) -> tuple[str, int]:
+    raw = run_git(root, "ls-files", "-co", "--exclude-standard", "-z", binary=True)
+    assert isinstance(raw, bytes)
+    relative_paths = sorted(
+        (item.decode("utf-8", errors="surrogateescape") for item in raw.split(b"\0") if item),
+        key=lambda item: item.encode("utf-8", errors="surrogateescape"),
+    )
+    digest = hashlib.sha256()
+    for relative in relative_paths:
+        encoded = relative.encode("utf-8", errors="surrogateescape")
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+        path = root / relative
+        if path.is_symlink():
+            target = os.readlink(path).encode("utf-8", errors="surrogateescape")
+            digest.update(b"L")
+            digest.update(len(target).to_bytes(8, "big"))
+            digest.update(target)
+        elif path.is_file():
+            digest.update(b"F")
+            with path.open("rb") as stream:
+                for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                    digest.update(chunk)
+        else:
+            digest.update(b"M")
+    return digest.hexdigest(), len(relative_paths)
+
+
+def source_identity(root: Path, build_command: str) -> dict[str, Any]:
+    root = root.resolve()
+    if not root.is_dir():
+        raise ValueError(f"source root does not exist: {root}")
+    top_level = Path(str(run_git(root, "rev-parse", "--show-toplevel"))).resolve()
+    if top_level != root:
+        raise ValueError(f"source root must be the git top level: {root} (actual {top_level})")
+    lockfile = root / "Cargo.lock"
+    if not lockfile.is_file():
+        raise ValueError(f"source root has no Cargo.lock: {root}")
+    status = run_git(root, "status", "--porcelain=v1", "--untracked-files=all", "-z", binary=True)
+    assert isinstance(status, bytes)
+    effective_sha256, entry_count = effective_worktree_digest(root)
+    return {
+        "root": str(root),
+        "head": str(run_git(root, "rev-parse", "HEAD^{commit}")),
+        "tree": str(run_git(root, "rev-parse", "HEAD^{tree}")),
+        "dirty": bool(status),
+        "status_sha256": hashlib.sha256(status).hexdigest(),
+        "effective_worktree_sha256": effective_sha256,
+        "effective_worktree_entries": entry_count,
+        "cargo_lock": {
+            "path": "Cargo.lock",
+            "bytes": lockfile.stat().st_size,
+            "sha256": sha256_file(lockfile),
+        },
+        "build_command": build_command,
+    }
+
+
+def require_ignored_evidence_root(source_root: Path, evidence_root: Path) -> None:
+    source_root = source_root.resolve()
+    evidence_root = evidence_root.resolve()
+    try:
+        relative = evidence_root.relative_to(source_root).as_posix()
+    except ValueError:
+        return
+    result = subprocess.run(
+        ["git", "-C", str(source_root), "check-ignore", "-q", "--", relative],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode == 0:
+        return
+    if result.returncode != 1:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise ValueError(f"git check-ignore failed for evidence root {evidence_root}: {detail}")
+    raise ValueError(
+        f"evidence root inside source tree must be gitignored so measurements cannot alter "
+        f"the source digest: {evidence_root}"
+    )
+
+
+def seed_cache_policy(root: Path) -> dict[str, Any]:
+    path = root / "stores" / "config" / "config.json"
+    if not path.is_file():
+        return {"config_present": False}
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicate_json_keys
+        )
+    except (OSError, json.JSONDecodeError, DuplicateJsonKeyError) as error:
+        raise ValueError(f"cannot inspect seed cache policy at {path}: {error}") from error
+    mpv = document.get("audio", {}).get("mpv", {}) if isinstance(document, dict) else {}
+    if not isinstance(mpv, dict):
+        mpv = {}
+    fields = ("cache_forward", "cache_back", "_cache_defaults_revision")
+    return {
+        "config_present": True,
+        **{
+            field: {"present": field in mpv, "value": mpv.get(field)}
+            for field in fields
+        },
+    }
+
+
+def atomic_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def atomic_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    temporary.write_text(value, encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def checksum_targets(root: Path, output: Path) -> list[Path]:
+    root = root.resolve()
+    output = output.resolve()
+    return sorted(
+        (
+            path
+            for path in root.rglob("*")
+            if path.is_file()
+            and path.resolve() != output
+            and path.name != output.name + ".tmp"
+        ),
+        key=lambda path: path.relative_to(root).as_posix().encode("utf-8"),
+    )
+
+
+def write_checksums(root: Path, output: Path) -> int:
+    root = root.resolve()
+    output = output.resolve()
+    try:
+        output.relative_to(root)
+    except ValueError as error:
+        raise ValueError("checksum output must stay inside its root") from error
+    lines = []
+    for path in checksum_targets(root, output):
+        relative = path.relative_to(root).as_posix()
+        if "\n" in relative or "\r" in relative:
+            raise ValueError(f"checksum path contains a newline: {relative!r}")
+        lines.append(f"{sha256_file(path)}  {relative}")
+    atomic_text(output, "\n".join(lines) + "\n")
+    return len(lines)
+
+
+def verify_checksums(root: Path, output: Path) -> int:
+    root = root.resolve()
+    output = output.resolve()
+    if not output.is_file():
+        raise ValueError(f"checksum file does not exist: {output}")
+    expected_paths = {
+        path.relative_to(root).as_posix(): path for path in checksum_targets(root, output)
+    }
+    listed: dict[str, str] = {}
+    for number, line in enumerate(output.read_text(encoding="utf-8").splitlines(), start=1):
+        digest, separator, relative = line.partition("  ")
+        if (
+            not separator
+            or len(digest) != 64
+            or any(character not in "0123456789abcdef" for character in digest)
+            or not relative
+        ):
+            raise ValueError(f"{output}:{number}: malformed SHA256SUMS line")
+        if relative in listed:
+            raise ValueError(f"{output}:{number}: duplicate checksum path {relative!r}")
+        listed[relative] = digest
+    if set(listed) != set(expected_paths):
+        missing = sorted(set(expected_paths) - set(listed))
+        extra = sorted(set(listed) - set(expected_paths))
+        raise ValueError(f"checksum inventory mismatch; missing={missing}, extra={extra}")
+    for relative, expected in listed.items():
+        actual = sha256_file(expected_paths[relative])
+        if actual != expected:
+            raise ValueError(
+                f"checksum mismatch for {relative}: expected {expected}, actual {actual}"
+            )
+    return len(listed)
+
+
+def command_checksums(args: argparse.Namespace) -> int:
+    count = write_checksums(args.root, args.output)
+    verified = verify_checksums(args.root, args.output)
+    if verified != count:
+        raise ValueError("checksum write/verify count mismatch")
+    print(json.dumps({"ok": True, "output": str(args.output.resolve()), "files": count}))
+    return 0
+
+
+def load_scenarios(path: Path) -> tuple[dict[str, Any], str]:
+    try:
+        raw = path.read_bytes()
+        document = json.loads(raw, object_pairs_hook=reject_duplicate_json_keys)
+    except (OSError, json.JSONDecodeError, DuplicateJsonKeyError) as error:
+        raise ValueError(f"cannot read scenario file {path}: {error}") from error
+    validate_scenarios(document)
+    return document, hashlib.sha256(raw).hexdigest()
+
+
+def validate_scenarios(document: dict[str, Any]) -> None:
+    if document.get("schema") != "ytt.tui-perf.scenarios.v1":
+        raise ValueError("scenario schema must be ytt.tui-perf.scenarios.v1")
+    if document.get("version") != 1:
+        raise ValueError("scenario version must be 1")
+    stats = document.get("statistics")
+    if not isinstance(stats, dict) or int(stats.get("bootstrap_resamples", 0)) < 1:
+        raise ValueError("statistics.bootstrap_resamples must be positive")
+    traffic_profiles = document.get("traffic_profiles")
+    if not isinstance(traffic_profiles, dict) or not traffic_profiles:
+        raise ValueError("traffic_profiles must be a non-empty object")
+    for profile_name, profile in traffic_profiles.items():
+        if not isinstance(profile_name, str) or not isinstance(profile, dict):
+            raise ValueError("traffic profile names and values must be objects")
+        for field in (
+            "throttle_bps",
+            "outage_every_bytes",
+            "outage_ms",
+            "disconnect_every_bytes",
+        ):
+            value = profile.get(field)
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise ValueError(f"traffic_profiles.{profile_name}.{field} must be non-negative")
+    fixture = document.get("fixture")
+    if not isinstance(fixture, dict):
+        raise ValueError("fixture must be an object")
+    for field in ("duration_s", "sample_rate_hz", "margin_s"):
+        value = fixture.get(field)
+        if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+            raise ValueError(f"fixture.{field} must be positive")
+    scenarios = document.get("scenarios")
+    if not isinstance(scenarios, list) or not scenarios:
+        raise ValueError("scenarios must be a non-empty list")
+    seen: set[str] = set()
+    for scenario in scenarios:
+        if not isinstance(scenario, dict):
+            raise ValueError("each scenario must be an object")
+        name = scenario.get("id")
+        if not isinstance(name, str) or not name or name in seen:
+            raise ValueError(f"invalid or duplicate scenario id: {name!r}")
+        seen.add(name)
+        pairs = scenario.get("pairs")
+        if not isinstance(pairs, int) or isinstance(pairs, bool) or pairs < 1:
+            raise ValueError(f"{name}.pairs must be a positive integer")
+        repeats = scenario.get("candidate_repeats")
+        if not isinstance(repeats, int) or isinstance(repeats, bool) or repeats < 0:
+            raise ValueError(f"{name}.candidate_repeats must be a non-negative integer")
+        for field in ("warmup_s", "sample_s"):
+            value = scenario.get(field)
+            if (
+                not isinstance(value, (int, float))
+                or isinstance(value, bool)
+                or not math.isfinite(value)
+                or value < 0
+            ):
+                raise ValueError(f"{name}.{field} must be finite and non-negative")
+        geometry = scenario.get("geometry")
+        if not (
+            isinstance(geometry, list)
+            and geometry
+            and all(
+                isinstance(item, list)
+                and len(item) == 2
+                and all(isinstance(value, int) and value > 0 for value in item)
+                for item in geometry
+            )
+        ):
+            raise ValueError(f"{name}.geometry must contain positive [width,height] pairs")
+        profile = scenario.get("traffic_profile")
+        if profile not in traffic_profiles:
+            raise ValueError(f"{name}.traffic_profile references unknown profile {profile!r}")
+        requires_mpv = scenario.get("requires_mpv")
+        if not isinstance(requires_mpv, bool):
+            raise ValueError(f"{name}.requires_mpv must be boolean")
+        controller = scenario.get("controller")
+        if not isinstance(controller, bool):
+            raise ValueError(f"{name}.controller must be boolean")
+        pause_policy = scenario.get("pause_policy")
+        if pause_policy not in {"none", "pause-resume"}:
+            raise ValueError(f"{name}.pause_policy must be none or pause-resume")
+        pause_hold_ms = scenario.get("pause_hold_ms")
+        if not isinstance(pause_hold_ms, int) or isinstance(pause_hold_ms, bool):
+            raise ValueError(f"{name}.pause_hold_ms must be an integer")
+        if pause_policy == "none" and pause_hold_ms != 0:
+            raise ValueError(f"{name}.pause_policy none requires pause_hold_ms=0")
+        if pause_policy == "pause-resume":
+            if not controller:
+                raise ValueError(f"{name}.pause-resume requires controller=true")
+            if pause_hold_ms <= 0:
+                raise ValueError(f"{name}.pause-resume requires positive pause_hold_ms")
+        if controller and not requires_mpv:
+            raise ValueError(f"{name}.controller requires requires_mpv=true")
+        if controller:
+            if scenario.get("controller_load") not in {"none", "resume-session"}:
+                raise ValueError(f"{name}.controller_load is invalid")
+            seeks = scenario.get("seeks_s")
+            if not (
+                isinstance(seeks, list)
+                and all(
+                    isinstance(value, (int, float))
+                    and not isinstance(value, bool)
+                    and math.isfinite(value)
+                    and value >= 0
+                    for value in seeks
+                )
+            ):
+                raise ValueError(f"{name}.seeks_s must contain finite non-negative numbers")
+        if requires_mpv:
+            margin = float(fixture["margin_s"])
+            observation_end = float(scenario["warmup_s"]) + float(scenario["sample_s"])
+            furthest_seek = max((float(value) for value in scenario.get("seeks_s", [])), default=0.0)
+            required_duration = max(observation_end, furthest_seek) + margin
+            if float(fixture["duration_s"]) < required_duration:
+                raise ValueError(
+                    f"fixture.duration_s must be at least {required_duration:g} for {name}"
+                )
+        metrics = scenario.get("metrics", {})
+        if not isinstance(metrics, dict):
+            raise ValueError(f"{name}.metrics must be an object")
+        for metric, policy in metrics.items():
+            if not isinstance(metric, str) or not isinstance(policy, dict):
+                raise ValueError(f"{name}.metrics entries must be object policies")
+            comparison = policy.get("comparison", "ratio")
+            if comparison not in {"ratio", "latency", "no_increase", "exact"}:
+                raise ValueError(f"{name}.{metric}: unsupported comparison {comparison!r}")
+            if comparison in {"ratio", "latency"} and not isinstance(
+                policy.get("max_ratio"), (int, float)
+            ):
+                raise ValueError(f"{name}.{metric}: ratio policy needs max_ratio")
+            if comparison == "latency" and not isinstance(policy.get("max_delta"), (int, float)):
+                raise ValueError(f"{name}.{metric}: latency policy needs max_delta")
+
+
+def find_scenario(document: dict[str, Any], name: str) -> dict[str, Any]:
+    for scenario in document["scenarios"]:
+        if scenario["id"] == name:
+            return scenario
+    raise ValueError(f"unknown scenario {name!r}")
+
+
+def dotted(value: Any, path: str) -> Any:
+    current = value
+    for part in path.split("."):
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        elif isinstance(current, list) and part == "length":
+            current = len(current)
+        elif isinstance(current, list) and part.isdigit() and int(part) < len(current):
+            current = current[int(part)]
+        else:
+            raise ValueError(f"field {path!r} not found (missing {part!r})")
+    return current
+
+
+def command_validate(args: argparse.Namespace) -> int:
+    document, digest = load_scenarios(args.scenarios)
+    print(json.dumps({"ok": True, "sha256": digest, "scenario_count": len(document["scenarios"])}))
+    return 0
+
+
+def command_scenario(args: argparse.Namespace) -> int:
+    document, digest = load_scenarios(args.scenarios)
+    scenario = find_scenario(document, args.id)
+    if args.field == "sha256":
+        print(digest)
+    elif args.field:
+        value = dotted(scenario, args.field)
+        if isinstance(value, (dict, list)):
+            print(json.dumps(value, separators=(",", ":")))
+        elif isinstance(value, bool):
+            print("true" if value else "false")
+        else:
+            print(value)
+    else:
+        print(json.dumps({"scenario_sha256": digest, **scenario}, indent=2, sort_keys=True))
+    return 0
+
+
+def command_traffic(args: argparse.Namespace) -> int:
+    document, _ = load_scenarios(args.scenarios)
+    try:
+        profile = document["traffic_profiles"][args.name]
+    except KeyError as error:
+        raise ValueError(f"unknown traffic profile {args.name!r}") from error
+    value = dotted(profile, args.field) if args.field else profile
+    if isinstance(value, (dict, list)):
+        print(json.dumps(value, separators=(",", ":")))
+    else:
+        print(value)
+    return 0
+
+
+def command_setting(args: argparse.Namespace) -> int:
+    document, _ = load_scenarios(args.scenarios)
+    value = dotted(document, args.field)
+    if isinstance(value, (dict, list)):
+        print(json.dumps(value, separators=(",", ":")))
+    elif isinstance(value, bool):
+        print("true" if value else "false")
+    else:
+        print(value)
+    return 0
+
+
+def tool_version(command: list[str]) -> dict[str, Any]:
+    executable = shutil.which(command[0])
+    if not executable:
+        return {"available": False, "command": command}
+    try:
+        completed = subprocess.run(
+            [executable, *command[1:]],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return {
+            "available": True,
+            "path": executable,
+            "command": command,
+            "error": str(error),
+        }
+    output = (completed.stdout or completed.stderr).strip()
+    return {
+        "available": True,
+        "path": executable,
+        "command": command,
+        "exit_code": completed.returncode,
+        "version": output[:4096],
+    }
+
+
+def total_memory_bytes() -> int | None:
+    try:
+        pages = int(os.sysconf("SC_PHYS_PAGES"))
+        page_size = int(os.sysconf("SC_PAGE_SIZE"))
+        if pages > 0 and page_size > 0:
+            return pages * page_size
+    except (AttributeError, OSError, TypeError, ValueError):
+        pass
+    if os.name == "nt":
+        try:
+            import ctypes
+
+            class MemoryStatus(ctypes.Structure):
+                _fields_ = [
+                    ("length", ctypes.c_ulong),
+                    ("memory_load", ctypes.c_ulong),
+                    ("total_physical", ctypes.c_ulonglong),
+                    ("available_physical", ctypes.c_ulonglong),
+                    ("total_page_file", ctypes.c_ulonglong),
+                    ("available_page_file", ctypes.c_ulonglong),
+                    ("total_virtual", ctypes.c_ulonglong),
+                    ("available_virtual", ctypes.c_ulonglong),
+                    ("available_extended_virtual", ctypes.c_ulonglong),
+                ]
+
+            status = MemoryStatus()
+            status.length = ctypes.sizeof(status)
+            if ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(status)):
+                return int(status.total_physical)
+        except (AttributeError, OSError, ValueError):
+            pass
+    return None
+
+
+def cpu_model() -> str:
+    identifier = os.environ.get("PROCESSOR_IDENTIFIER", "").strip()
+    if identifier:
+        return identifier
+    cpuinfo = Path("/proc/cpuinfo")
+    if cpuinfo.is_file():
+        try:
+            for line in cpuinfo.read_text(encoding="utf-8", errors="replace").splitlines():
+                if line.lower().startswith(("model name", "hardware")) and ":" in line:
+                    return line.split(":", 1)[1].strip()
+        except OSError:
+            pass
+    if platform.system() == "Darwin":
+        version = tool_version(["sysctl", "-n", "machdep.cpu.brand_string"])
+        if version.get("exit_code") == 0 and version.get("version"):
+            return str(version["version"])
+    return platform.processor() or platform.machine()
+
+
+def labeled_specs(specs: list[str], option: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for spec in specs:
+        label, separator, value = spec.partition("=")
+        if not separator or not label or not value:
+            raise ValueError(f"{option} must use LABEL=VALUE")
+        if label in values:
+            raise ValueError(f"{option} repeats label {label!r}")
+        values[label] = value
+    return values
+
+
+def command_manifest(args: argparse.Namespace) -> int:
+    _, scenario_hash = load_scenarios(args.scenarios)
+    binaries: dict[str, Any] = {}
+    for label, raw_path in labeled_specs(args.binary, "--binary").items():
+        path = Path(raw_path)
+        if not path.is_file():
+            raise ValueError(f"manifest binary does not exist: {path}")
+        binaries[label] = {
+            "path": str(path.resolve()),
+            "bytes": path.stat().st_size,
+            "sha256": sha256_file(path),
+        }
+    source_roots = labeled_specs(args.source_root, "--source-root")
+    build_commands = labeled_specs(args.build_command, "--build-command")
+    required_sources = {"baseline", "candidate"}
+    if set(source_roots) != required_sources:
+        raise ValueError("--source-root requires exactly baseline=PATH and candidate=PATH")
+    if set(build_commands) != required_sources:
+        raise ValueError(
+            "--build-command requires exactly baseline=COMMAND and candidate=COMMAND"
+        )
+    evidence_root = args.output.resolve().parent
+    for source_root in source_roots.values():
+        require_ignored_evidence_root(Path(source_root), evidence_root)
+    sources = {
+        label: source_identity(Path(source_roots[label]), build_commands[label])
+        for label in sorted(required_sources)
+    }
+    tool_commands = {
+        "python": [sys.executable, "--version"],
+        "mpv_on_path": ["mpv", "--version"],
+        "yt_dlp_on_path": ["yt-dlp", "--version"],
+        "tmux": ["tmux", "-V"],
+        "rustc": ["rustc", "--version"],
+        "cargo": ["cargo", "--version"],
+    }
+    if os.name == "nt":
+        tool_commands["powershell"] = [
+            "powershell.exe",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$PSVersionTable.PSVersion.ToString()",
+        ]
+    manifest = {
+        "schema": "ytt.tui-perf.host.v1",
+        "scenario": args.scenario,
+        "scenario_sha256": scenario_hash,
+        "scenario_file": {
+            "path": str(args.scenarios.resolve()),
+            "bytes": args.scenarios.stat().st_size,
+            "sha256": scenario_hash,
+        },
+        "generated_unix_s": int(time.time()),
+        "host": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "version": platform.version(),
+            "machine": platform.machine(),
+            "cpu_model": cpu_model(),
+            "logical_cpu_count": os.cpu_count(),
+            "total_memory_bytes": total_memory_bytes(),
+        },
+        "tools": {name: tool_version(command) for name, command in tool_commands.items()},
+        "binaries": binaries,
+        "sources": sources,
+        "note": "actual mpv argv and executable are recorded in each sampler artifact",
+    }
+    atomic_json(args.output, manifest)
+    print(json.dumps({"ok": True, "output": str(args.output), "scenario_sha256": scenario_hash}))
+    return 0
+
+
+def command_materialize(args: argparse.Namespace) -> int:
+    if not args.root.is_dir():
+        raise ValueError(f"seed root does not exist: {args.root}")
+    root = args.root.resolve()
+    home = args.home.resolve()
+    seed_tree_sha256 = sha256_tree(root)
+    cache_policy = seed_cache_policy(root)
+    playlist = (root / args.playlist_relative).resolve()
+    try:
+        playlist.relative_to(root)
+    except ValueError as error:
+        raise ValueError("--playlist-relative must stay inside --root") from error
+
+    parsed_url = urlsplit(args.fixture_url)
+    try:
+        fixture_ip = ipaddress.ip_address(parsed_url.hostname or "")
+    except ValueError as error:
+        raise ValueError("--fixture-url host must be a loopback IP literal") from error
+    if parsed_url.scheme != "http" or not fixture_ip.is_loopback:
+        raise ValueError("--fixture-url must be an HTTP loopback URL")
+
+    replacements = {
+        "{{TUI_PERF_FIXTURE_URL}}": args.fixture_url,
+        "{{TUI_PERF_HOME}}": str(home),
+        "{{TUI_PERF_PLAYLIST}}": str(playlist),
+    }
+    seed_files: list[tuple[Path, str]] = []
+    playlist_references = 0
+    for path in sorted(item for item in args.root.rglob("*") if item.is_file()):
+        if path.resolve() == playlist:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if path.suffix.lower() == ".json" and "{{TUI_PERF_FIXTURE_URL}}" in text:
+            raise ValueError(
+                f"{path}: JSON must reference {{{{TUI_PERF_PLAYLIST}}}} as Song.local_path; "
+                "a direct loopback URL is rejected by the playback guard"
+            )
+        if path.suffix.lower() == ".json":
+            playlist_references += text.count("{{TUI_PERF_PLAYLIST}}")
+        seed_files.append((path, text))
+    if playlist_references == 0:
+        raise ValueError(
+            "seed JSON must reference {{TUI_PERF_PLAYLIST}} as the resumed Song.local_path"
+        )
+
+    atomic_text(
+        playlist,
+        f"#EXTM3U\n#EXTINF:-1,ytt deterministic performance fixture\n{args.fixture_url}\n",
+    )
+    changed = [str(playlist)]
+    for path, text in seed_files:
+        if not any(marker in text for marker in replacements):
+            continue
+        for marker, replacement in replacements.items():
+            encoded = json.dumps(replacement)[1:-1] if path.suffix.lower() == ".json" else replacement
+            text = text.replace(marker, encoded)
+        if path.suffix.lower() == ".json":
+            try:
+                json.loads(text, object_pairs_hook=reject_duplicate_json_keys)
+            except (json.JSONDecodeError, DuplicateJsonKeyError) as error:
+                raise ValueError(f"materialized JSON is invalid at {path}: {error}") from error
+        atomic_text(path, text)
+        changed.append(str(path))
+    manifest = {
+        "schema": "ytt.tui-perf.materialize.v1",
+        "changed": changed,
+        "fixture_url": args.fixture_url,
+        "fixture_host": str(fixture_ip),
+        "playlist": str(playlist),
+        "playback_target_mode": "local_m3u_indirection",
+        "external_dns_required": False,
+        "playlist_references": playlist_references,
+        "seed_label": args.seed_label,
+        "seed_tree_sha256": seed_tree_sha256,
+        "seed_cache_policy": cache_policy,
+    }
+    if args.manifest:
+        atomic_json(args.manifest, manifest)
+    print(json.dumps(manifest, sort_keys=True))
+    return 0
+
+
+def command_fixture(args: argparse.Namespace) -> int:
+    if args.seconds <= 0 or args.sample_rate <= 0:
+        raise ValueError("fixture duration and sample rate must be positive")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    frames = int(round(args.seconds * args.sample_rate))
+    chunk_frames = min(args.sample_rate, 65_536)
+    silence = b"\0\0" * chunk_frames
+    with wave.open(str(args.output), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(args.sample_rate)
+        remaining = frames
+        while remaining:
+            count = min(remaining, chunk_frames)
+            wav.writeframesraw(silence[: count * 2])
+            remaining -= count
+    manifest = {
+        "schema": "ytt.tui-perf.fixture.v1",
+        "path": str(args.output.resolve()),
+        "seconds": args.seconds,
+        "sample_rate_hz": args.sample_rate,
+        "channels": 1,
+        "sample_width_bytes": 2,
+        "frames": frames,
+        "bytes": args.output.stat().st_size,
+        "sha256": sha256_file(args.output),
+    }
+    if args.manifest:
+        atomic_json(args.manifest, manifest)
+    print(json.dumps(manifest, sort_keys=True))
+    return 0
+
+
+def command_check(args: argparse.Namespace) -> int:
+    records = read_ndjson(args.samples)
+    errors = [record for record in records if record.get("kind") == "error"]
+    if errors:
+        raise ValueError(f"sampler reported: {errors[-1].get('message')}")
+    headers = [record for record in records if record.get("kind") == "header"]
+    summaries = [record for record in records if record.get("kind") == "summary"]
+    measured = [
+        record
+        for record in records
+        if record.get("kind") == "sample" and record.get("phase") == "measure"
+    ]
+    if len(headers) != 1 or len(summaries) != 1 or not measured:
+        raise ValueError("samples need exactly one header/summary and at least one measured sample")
+    if args.scenario_sha256 and headers[0].get("scenario_sha256") != args.scenario_sha256:
+        raise ValueError("sample scenario SHA-256 does not match the selected scenario file")
+    if args.require_silent_mpv:
+        if not summaries[0].get("silent_mpv_proven"):
+            raise ValueError("sampler did not prove null audio and zero volume from measured argv")
+        if any(
+            record.get("mpv_present") is not True
+            or record.get("mpv_all_silent_this_sample") is not True
+            for record in measured
+        ):
+            raise ValueError("every measured sample must contain only effective null/zero mpv argv")
+        identities = summaries[0].get("last_observed_mpv")
+        if not isinstance(identities, list) or not identities:
+            raise ValueError("sampler did not retain an exact measured mpv cleanup identity")
+        for identity in identities:
+            if not (
+                isinstance(identity, dict)
+                and isinstance(identity.get("pid"), int)
+                and isinstance(identity.get("start_time_unix_s"), int)
+                and isinstance(identity.get("input_ipc_server_argv"), list)
+                and identity["input_ipc_server_argv"]
+            ):
+                raise ValueError("sampler mpv cleanup identity is incomplete")
+    if args.control:
+        control = read_ndjson(args.control)
+        control_summaries = [record for record in control if record.get("kind") == "summary"]
+        if len(control_summaries) != 1:
+            raise ValueError("control output needs exactly one summary")
+        if (
+            args.require_observer_close
+            and control_summaries[0].get("observation_end") != "mpv_ipc_closed"
+        ):
+            raise ValueError("controller did not observe the sampler-owned mpv IPC closing")
+        control_headers = [record for record in control if record.get("kind") == "header"]
+        if len(control_headers) != 1:
+            raise ValueError("control output needs exactly one header")
+        if args.scenario_sha256 and control_headers[0].get("scenario_sha256") != args.scenario_sha256:
+            raise ValueError("control scenario SHA-256 does not match the selected scenario file")
+    print(json.dumps({"ok": True, "measured_samples": len(measured)}))
+    return 0
+
+
+class FixtureServer(http.server.ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, address: tuple[str, int], handler: type[http.server.BaseHTTPRequestHandler],
+                 file: Path, throttle_bps: int, outage_every_bytes: int, outage_ms: int,
+                 disconnect_every_bytes: int):
+        super().__init__(address, handler)
+        self.fixture_file = file
+        self.throttle_bps = throttle_bps
+        self.outage_every_bytes = outage_every_bytes
+        self.outage_ms = outage_ms
+        self.disconnect_every_bytes = disconnect_every_bytes
+        self.transfer_lock = threading.Lock()
+        self.total_transferred = 0
+        self.next_outage = outage_every_bytes if outage_every_bytes else 0
+        self.next_disconnect = disconnect_every_bytes if disconnect_every_bytes else 0
+
+
+class RangeFixtureHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    @property
+    def perf_server(self) -> FixtureServer:
+        return self.server  # type: ignore[return-value]
+
+    def do_HEAD(self) -> None:  # noqa: N802 (BaseHTTPRequestHandler API)
+        self._serve(send_body=False)
+
+    def do_GET(self) -> None:  # noqa: N802 (BaseHTTPRequestHandler API)
+        self._serve(send_body=True)
+
+    def _serve(self, send_body: bool) -> None:
+        server = self.perf_server
+        if self.path.split("?", 1)[0] not in {"/fixture.wav", "/" + server.fixture_file.name}:
+            self.send_error(404)
+            return
+        size = server.fixture_file.stat().st_size
+        try:
+            start, end, partial = parse_range(self.headers.get("Range"), size)
+        except ValueError:
+            self.send_response(416)
+            self.send_header("Content-Range", f"bytes */{size}")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        length = end - start + 1
+        self.send_response(206 if partial else 200)
+        self.send_header("Accept-Ranges", "bytes")
+        self.send_header("Content-Type", "audio/wav")
+        self.send_header("Content-Length", str(length))
+        self.send_header("ETag", '"ytt-perf-silence-v1"')
+        if partial:
+            self.send_header("Content-Range", f"bytes {start}-{end}/{size}")
+        self.end_headers()
+        if not send_body:
+            return
+
+        remaining = length
+        with server.fixture_file.open("rb") as stream:
+            stream.seek(start)
+            while remaining:
+                chunk = stream.read(min(64 * 1024, remaining))
+                if not chunk:
+                    return
+                action = transfer_action(server, len(chunk))
+                if action == "outage":
+                    time.sleep(server.outage_ms / 1000.0)
+                elif action == "disconnect":
+                    self.close_connection = True
+                    return
+                started = time.monotonic()
+                try:
+                    self.wfile.write(chunk)
+                    self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    return
+                remaining -= len(chunk)
+                if server.throttle_bps:
+                    target = len(chunk) / server.throttle_bps
+                    delay = target - (time.monotonic() - started)
+                    if delay > 0:
+                        time.sleep(delay)
+
+    def log_message(self, fmt: str, *values: Any) -> None:
+        if getattr(self.server, "verbose", False):
+            super().log_message(fmt, *values)
+
+
+def parse_range(header: str | None, size: int) -> tuple[int, int, bool]:
+    if not header:
+        return 0, size - 1, False
+    if not header.startswith("bytes=") or "," in header:
+        raise ValueError("unsupported range")
+    first, last = header[6:].split("-", 1)
+    if not first:
+        suffix = int(last)
+        if suffix <= 0:
+            raise ValueError("invalid suffix")
+        return max(0, size - suffix), size - 1, True
+    start = int(first)
+    end = int(last) if last else size - 1
+    if start < 0 or start >= size or end < start:
+        raise ValueError("range outside file")
+    return start, min(end, size - 1), True
+
+
+def transfer_action(server: FixtureServer, count: int) -> str | None:
+    with server.transfer_lock:
+        server.total_transferred += count
+        if server.next_disconnect and server.total_transferred >= server.next_disconnect:
+            while server.next_disconnect <= server.total_transferred:
+                server.next_disconnect += server.disconnect_every_bytes
+            return "disconnect"
+        if server.next_outage and server.total_transferred >= server.next_outage:
+            while server.next_outage <= server.total_transferred:
+                server.next_outage += server.outage_every_bytes
+            return "outage"
+    return None
+
+
+def command_serve(args: argparse.Namespace) -> int:
+    if not args.file.is_file():
+        raise ValueError(f"fixture does not exist: {args.file}")
+    for name in ("throttle_bps", "outage_every_bytes", "outage_ms", "disconnect_every_bytes"):
+        if getattr(args, name) < 0:
+            raise ValueError(f"--{name.replace('_', '-')} must be non-negative")
+    server = FixtureServer(
+        (args.host, args.port),
+        RangeFixtureHandler,
+        args.file.resolve(),
+        args.throttle_bps,
+        args.outage_every_bytes,
+        args.outage_ms,
+        args.disconnect_every_bytes,
+    )
+    server.verbose = args.verbose  # type: ignore[attr-defined]
+    host, port = server.server_address[:2]
+    manifest = {
+        "schema": "ytt.tui-perf.http.v1",
+        "pid": os.getpid(),
+        "host": host,
+        "port": port,
+        "url": f"http://{host}:{port}/fixture.wav",
+        "fixture_sha256": sha256_file(args.file),
+        "throttle_bps": args.throttle_bps,
+        "outage_every_bytes": args.outage_every_bytes,
+        "outage_ms": args.outage_ms,
+        "disconnect_every_bytes": args.disconnect_every_bytes,
+        "bind_is_loopback": ipaddress.ip_address(host).is_loopback,
+        "playback_target_mode": "local_m3u_indirection",
+        "external_dns_required": False,
+    }
+    if args.ready_file:
+        atomic_json(args.ready_file, manifest)
+    print(json.dumps(manifest, sort_keys=True), flush=True)
+    try:
+        server.serve_forever(poll_interval=0.1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+def read_ndjson(path: Path) -> list[dict[str, Any]]:
+    records = []
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line, object_pairs_hook=reject_duplicate_json_keys)
+        except (json.JSONDecodeError, DuplicateJsonKeyError) as error:
+            raise ValueError(f"{path}:{number}: malformed NDJSON: {error}") from error
+        if not isinstance(record, dict):
+            raise ValueError(f"{path}:{number}: NDJSON record is not an object")
+        records.append(record)
+    return records
+
+
+def quantile(values: list[float], q: float) -> float:
+    if not values:
+        raise ValueError("cannot take a quantile of an empty list")
+    ordered = sorted(values)
+    index = math.ceil((len(ordered) - 1) * q)
+    return ordered[min(index, len(ordered) - 1)]
+
+
+def render_metrics_from_document(document: dict[str, Any], path: Path) -> dict[str, Any]:
+    metrics: dict[str, Any] = {}
+    for case in document.get("cases", []):
+        batches = case.get("batches", [])
+        if not batches:
+            raise ValueError(f"{path}: render case {case.get('name')} has no batches")
+        batch_draws = [batch.get("draws") for batch in batches]
+        if any(not isinstance(draws, int) or isinstance(draws, bool) or draws <= 0 for draws in batch_draws):
+            raise ValueError(f"{path}: render case {case.get('name')} has invalid batch draws")
+        measured_draws = case.get("measured_draws")
+        if measured_draws != sum(batch_draws):
+            raise ValueError(
+                f"{path}: render case {case.get('name')} measured_draws {measured_draws!r} "
+                f"does not match batch total {sum(batch_draws)}"
+            )
+        case_p95 = case.get("p95_draw_ns")
+        if (
+            not isinstance(case_p95, (int, float))
+            or isinstance(case_p95, bool)
+            or not math.isfinite(float(case_p95))
+            or float(case_p95) < 0
+        ):
+            raise ValueError(f"{path}: render case {case.get('name')} has invalid case p95")
+
+        prefix = f"render.{case['name']}"
+        for name in (
+            "mean_draw_ns",
+            "allocations",
+            "allocated_bytes",
+            "retained_bytes_delta",
+            "peak_live_bytes_delta",
+        ):
+            values = [float(batch[name]) for batch in batches]
+            value = statistics.fmean(values)
+            if name in {"allocations", "allocated_bytes"}:
+                value /= float(batches[0]["draws"])
+                name += "_per_draw"
+            metrics[f"{prefix}.{name}"] = value
+        metrics[f"{prefix}.p95_draw_ns"] = float(case_p95)
+        metrics[f"{prefix}.buffer_style_digest"] = case["buffer_style_digest"]
+        metrics[f"{prefix}.hit_map_digest"] = case["hit_map_digest"]
+        metrics[f"{prefix}.update_path"] = case["update_path"]
+        if case["update_path"] == "app_update_msg_key":
+            metrics[f"{prefix}.p95_reducer_input_to_draw_ns"] = float(case_p95)
+    return metrics
+
+
+def metrics_from_file(path: Path) -> dict[str, Any]:
+    metrics: dict[str, Any] = {}
+    if path.suffix == ".ndjson":
+        records = read_ndjson(path)
+        errors = [record for record in records if record.get("kind") == "error"]
+        if errors:
+            raise ValueError(f"{path}: harness error: {errors[-1].get('message')}")
+        for record in records:
+            if record.get("kind") == "summary" and isinstance(record.get("roles"), dict):
+                for role, values in record["roles"].items():
+                    if isinstance(values, dict):
+                        for name, value in values.items():
+                            metrics[f"{role}.{name}"] = value
+            if record.get("kind") == "summary" and "buffering_events" in record:
+                metrics["buffering_events"] = record["buffering_events"]
+                metrics["buffering_ms"] = record["buffering_ms"]
+        measured_samples = [
+            record
+            for record in records
+            if record.get("kind") == "sample" and record.get("phase") == "measure"
+        ]
+        role_names = {
+            role
+            for record in measured_samples
+            for role in record.get("roles", {})
+            if isinstance(record.get("roles", {}).get(role), dict)
+        }
+        for role in role_names:
+            points = [
+                (float(record["elapsed_ms"]) / 1_000.0, float(record["roles"][role]["rss_bytes"]))
+                for record in measured_samples
+                if role in record.get("roles", {})
+            ]
+            if len(points) >= 2:
+                metrics[f"{role}.rss_slope_bytes_per_s"] = linear_slope(points)
+        operations: dict[str, list[float]] = {}
+        for record in records:
+            if record.get("kind") == "operation":
+                operations.setdefault(str(record.get("operation")), []).append(float(record["latency_ms"]))
+        for name, values in operations.items():
+            metrics[f"operation.{name}.p95_ms"] = quantile(values, 0.95)
+            metrics[f"operation.{name}.mean_ms"] = statistics.fmean(values)
+        return metrics
+
+    document = json.loads(
+        path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicate_json_keys
+    )
+    if document.get("schema") == "ytt.tui-perf.render.v1":
+        return render_metrics_from_document(document, path)
+    return metrics
+
+
+def load_metric_files(path: Path) -> dict[str, Any]:
+    files = [path] if path.is_file() else sorted(
+        item
+        for item in path.iterdir()
+        if item.is_file() and item.suffix in {".json", ".ndjson"}
+    )
+    metrics: dict[str, Any] = {}
+    for file in files:
+        for name, value in metrics_from_file(file).items():
+            if name in metrics and metrics[name] != value:
+                raise ValueError(f"{path}: duplicate metric {name!r} disagrees across files")
+            metrics[name] = value
+    return metrics
+
+
+def load_run(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise ValueError(f"run path does not exist: {path}")
+    metrics = load_metric_files(path)
+    if path.is_dir():
+        geometry_dirs = sorted(
+            item
+            for item in path.iterdir()
+            if item.is_dir() and item.name.startswith("geometry-")
+        )
+        for directory in geometry_dirs:
+            geometry = directory.name.removeprefix("geometry-")
+            nested = load_metric_files(directory)
+            if not nested:
+                raise ValueError(f"{directory}: no recognized performance metrics")
+            for name, value in nested.items():
+                qualified = f"geometry.{geometry}.{name}"
+                if qualified in metrics:
+                    raise ValueError(f"{path}: duplicate metric {qualified!r}")
+                metrics[qualified] = value
+    if not metrics:
+        raise ValueError(f"{path}: no recognized performance metrics")
+    return metrics
+
+
+def load_json_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicate_json_keys
+        )
+    except (OSError, json.JSONDecodeError, DuplicateJsonKeyError) as error:
+        raise ValueError(f"cannot read JSON artifact {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"JSON artifact is not an object: {path}")
+    return value
+
+
+def normalized_os(value: Any) -> str:
+    name = str(value).strip().lower()
+    aliases = {
+        "darwin": "macos",
+        "macos": "macos",
+        "linux": "linux",
+        "windows": "windows",
+    }
+    return aliases.get(name, name)
+
+
+def require_artifact_value(path: Path, label: str, actual: Any, expected: Any) -> None:
+    if actual != expected:
+        raise ValueError(f"{path}: {label} is {actual!r}, expected {expected!r}")
+
+
+def validate_host_manifest(
+    path: Path,
+    scenario: dict[str, Any],
+    scenario_hash: str,
+    render: bool,
+) -> dict[str, Any]:
+    manifest = load_json_object(path)
+    require_artifact_value(path, "schema", manifest.get("schema"), "ytt.tui-perf.host.v1")
+    require_artifact_value(path, "scenario", manifest.get("scenario"), scenario["id"])
+    require_artifact_value(path, "scenario_sha256", manifest.get("scenario_sha256"), scenario_hash)
+    host = manifest.get("host")
+    if not isinstance(host, dict):
+        raise ValueError(f"{path}: host must be an object")
+    require_artifact_value(
+        path,
+        "host system",
+        normalized_os(host.get("system")),
+        normalized_os(platform.system()),
+    )
+
+    expected_binaries = (
+        {"baseline_render", "candidate_render"}
+        if render
+        else {"baseline_ytt", "candidate_ytt", "sampler", "controller"}
+    )
+    binaries = manifest.get("binaries")
+    binary_labels = set(binaries) if isinstance(binaries, dict) else set()
+    if not isinstance(binaries, dict) or not expected_binaries.issubset(binary_labels):
+        missing = sorted(expected_binaries - binary_labels)
+        raise ValueError(f"{path}: missing required binary identities: {missing}")
+    for label in sorted(expected_binaries):
+        identity = binaries[label]
+        if not isinstance(identity, dict):
+            raise ValueError(f"{path}: binary identity {label!r} must be an object")
+        binary = Path(str(identity.get("path", "")))
+        if not binary.is_file():
+            raise ValueError(f"{path}: manifested binary no longer exists: {binary}")
+        require_artifact_value(path, f"{label} bytes", binary.stat().st_size, identity.get("bytes"))
+        require_artifact_value(
+            path, f"{label} SHA-256", sha256_file(binary), identity.get("sha256")
+        )
+
+    sources = manifest.get("sources")
+    if not isinstance(sources, dict) or set(sources) != {"baseline", "candidate"}:
+        raise ValueError(f"{path}: sources must contain exactly baseline and candidate")
+    for label in ("baseline", "candidate"):
+        recorded = sources[label]
+        if not isinstance(recorded, dict):
+            raise ValueError(f"{path}: source identity {label!r} must be an object")
+        build_command = recorded.get("build_command")
+        if not isinstance(build_command, str) or not build_command.strip():
+            raise ValueError(f"{path}: source {label!r} has no build command")
+        current = source_identity(Path(str(recorded.get("root", ""))), build_command)
+        require_artifact_value(path, f"{label} source identity", current, recorded)
+    return manifest
+
+
+def validate_render_document(
+    document: dict[str, Any],
+    path: Path,
+    role: str,
+    scenario: dict[str, Any],
+    scenario_hash: str,
+    host_os: str,
+    manifest: dict[str, Any],
+) -> None:
+    require_artifact_value(path, "schema", document.get("schema"), "ytt.tui-perf.render.v1")
+    require_artifact_value(path, "kind", document.get("kind"), "render_summary")
+    require_artifact_value(path, "scenario SHA-256", document.get("scenario_sha256"), scenario_hash)
+    require_artifact_value(path, "OS", normalized_os(document.get("os")), host_os)
+    binary_label = f"{role}_render"
+    expected_binary = manifest["binaries"][binary_label]["sha256"]
+    require_artifact_value(
+        path, "executed binary SHA-256", document.get("binary_sha256"), expected_binary
+    )
+    require_artifact_value(path, "batches_per_case", document.get("batches_per_case"), scenario["batches"])
+    require_artifact_value(path, "draws_per_batch", document.get("draws_per_batch"), scenario["draws_per_batch"])
+    cases = document.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError(f"{path}: render cases must be a non-empty array")
+    names = [case.get("name") for case in cases if isinstance(case, dict)]
+    if len(names) != len(cases) or len(names) != len(set(names)):
+        raise ValueError(f"{path}: render case names must be unique objects")
+    expected_measured = int(scenario["batches"]) * int(scenario["draws_per_batch"])
+    for case in cases:
+        require_artifact_value(path, f"{case['name']} warmup", case.get("warmup_draws"), scenario["warmup_draws"])
+        require_artifact_value(path, f"{case['name']} measured draws", case.get("measured_draws"), expected_measured)
+        batches = case.get("batches")
+        if not isinstance(batches, list):
+            raise ValueError(f"{path}: {case['name']} batches must be an array")
+        require_artifact_value(path, f"{case['name']} batch count", len(batches), scenario["batches"])
+        for batch in batches:
+            if not isinstance(batch, dict):
+                raise ValueError(f"{path}: {case['name']} contains a non-object batch")
+            require_artifact_value(
+                path,
+                f"{case['name']} batch draws",
+                batch.get("draws"),
+                scenario["draws_per_batch"],
+            )
+
+
+def process_run_directories(path: Path, scenario: dict[str, Any]) -> list[Path]:
+    geometry = scenario["geometry"]
+    if len(geometry) == 1:
+        unexpected = sorted(item.name for item in path.glob("geometry-*") if item.is_dir())
+        if unexpected:
+            raise ValueError(f"{path}: single-geometry run has unexpected directories {unexpected}")
+        return [path]
+    expected = {f"geometry-{width}x{height}" for width, height in geometry}
+    actual = {item.name for item in path.glob("geometry-*") if item.is_dir()}
+    if actual != expected:
+        raise ValueError(
+            f"{path}: geometry directories are {sorted(actual)}, expected {sorted(expected)}"
+        )
+    return [path / name for name in sorted(expected)]
+
+
+def validate_process_directory(
+    path: Path,
+    role: str,
+    scenario: dict[str, Any],
+    scenario_document: dict[str, Any],
+    scenario_hash: str,
+    host_os: str,
+    manifest: dict[str, Any],
+) -> list[Path]:
+    samples_path = path / "samples.ndjson"
+    if not samples_path.is_file():
+        raise ValueError(f"{path}: missing samples.ndjson")
+    samples = read_ndjson(samples_path)
+    headers = [record for record in samples if record.get("kind") == "header"]
+    summaries = [record for record in samples if record.get("kind") == "summary"]
+    measured = [
+        record
+        for record in samples
+        if record.get("kind") == "sample" and record.get("phase") == "measure"
+    ]
+    if len(headers) != 1 or len(summaries) != 1 or not measured:
+        raise ValueError(f"{samples_path}: incomplete sampler header, summary, or measurements")
+    header = headers[0]
+    require_artifact_value(samples_path, "schema", header.get("schema"), "ytt.tui-perf.samples.v1")
+    require_artifact_value(samples_path, "scenario SHA-256", header.get("scenario_sha256"), scenario_hash)
+    require_artifact_value(samples_path, "OS", normalized_os(header.get("os")), host_os)
+    require_artifact_value(
+        samples_path,
+        "executed binary SHA-256",
+        header.get("binary_sha256"),
+        manifest["binaries"][f"{role}_ytt"]["sha256"],
+    )
+    require_artifact_value(
+        samples_path,
+        "warmup_ms",
+        header.get("warmup_ms"),
+        int(float(scenario["warmup_s"]) * 1000),
+    )
+    require_artifact_value(
+        samples_path,
+        "duration_ms",
+        header.get("duration_ms"),
+        int(float(scenario["sample_s"]) * 1000),
+    )
+    require_artifact_value(
+        samples_path,
+        "interval_ms",
+        header.get("interval_ms"),
+        scenario_document["sampling"]["interval_ms"],
+    )
+    require_artifact_value(
+        samples_path,
+        "silent mpv policy",
+        header.get("require_silent_mpv"),
+        scenario["requires_mpv"],
+    )
+    if any(record.get("kind") == "error" for record in samples):
+        raise ValueError(f"{samples_path}: sampler recorded an error")
+
+    artifacts = [samples_path]
+    if scenario["controller"]:
+        control_path = path / "control.ndjson"
+        if not control_path.is_file():
+            raise ValueError(f"{path}: missing control.ndjson")
+        control = read_ndjson(control_path)
+        control_headers = [record for record in control if record.get("kind") == "header"]
+        control_summaries = [record for record in control if record.get("kind") == "summary"]
+        if len(control_headers) != 1 or len(control_summaries) != 1:
+            raise ValueError(f"{control_path}: incomplete controller header or summary")
+        control_header = control_headers[0]
+        require_artifact_value(control_path, "schema", control_header.get("schema"), "ytt.tui-perf.control.v1")
+        require_artifact_value(control_path, "scenario SHA-256", control_header.get("scenario_sha256"), scenario_hash)
+        require_artifact_value(control_path, "OS", normalized_os(control_header.get("os")), host_os)
+        require_artifact_value(
+            control_path,
+            "pause policy",
+            control_header.get("pause_policy"),
+            scenario["pause_policy"],
+        )
+        expected_hold = scenario["pause_hold_ms"] if scenario["pause_policy"] == "pause-resume" else None
+        require_artifact_value(control_path, "pause hold", control_header.get("pause_hold_ms"), expected_hold)
+        require_artifact_value(
+            control_path,
+            "observation end",
+            control_summaries[0].get("observation_end"),
+            "mpv_ipc_closed",
+        )
+        operations = [record.get("operation") for record in control if record.get("kind") == "operation"]
+        expected_load = scenario.get("controller_load")
+        expected_load_operation = {"resume-session": "resume_session", "none": "ready"}.get(expected_load)
+        if expected_load_operation is None or operations.count(expected_load_operation) != 1:
+            raise ValueError(f"{control_path}: controller load operation does not match {expected_load!r}")
+        require_artifact_value(
+            control_path,
+            "seek operation count",
+            operations.count("seek"),
+            len(scenario.get("seeks_s", [])),
+        )
+        expected_pause_count = 1 if scenario["pause_policy"] == "pause-resume" else 0
+        require_artifact_value(control_path, "pause operation count", operations.count("pause"), expected_pause_count)
+        require_artifact_value(control_path, "resume operation count", operations.count("resume"), expected_pause_count)
+        artifacts.append(control_path)
+
+    if scenario["requires_mpv"]:
+        materialize_path = path / "materialize.json"
+        http_path = path / "http-ready.json"
+        for support in (materialize_path, http_path):
+            if not support.is_file():
+                raise ValueError(f"{path}: missing {support.name}")
+        materialize = load_json_object(materialize_path)
+        require_artifact_value(materialize_path, "schema", materialize.get("schema"), "ytt.tui-perf.materialize.v1")
+        require_artifact_value(materialize_path, "seed label", materialize.get("seed_label"), role)
+        require_artifact_value(
+            materialize_path,
+            "playback target",
+            materialize.get("playback_target_mode"),
+            "local_m3u_indirection",
+        )
+        require_artifact_value(materialize_path, "external DNS", materialize.get("external_dns_required"), False)
+        http = load_json_object(http_path)
+        require_artifact_value(http_path, "schema", http.get("schema"), "ytt.tui-perf.http.v1")
+        require_artifact_value(http_path, "loopback binding", http.get("bind_is_loopback"), True)
+        require_artifact_value(http_path, "playback target", http.get("playback_target_mode"), "local_m3u_indirection")
+        require_artifact_value(http_path, "external DNS", http.get("external_dns_required"), False)
+        profile = scenario_document["traffic_profiles"][scenario["traffic_profile"]]
+        for field in ("throttle_bps", "outage_every_bytes", "outage_ms", "disconnect_every_bytes"):
+            require_artifact_value(http_path, field, http.get(field), profile[field])
+        artifacts.extend((materialize_path, http_path))
+    return artifacts
+
+
+def validate_run_artifacts(
+    path: Path,
+    role: str,
+    scenario: dict[str, Any],
+    scenario_document: dict[str, Any],
+    scenario_hash: str,
+    host_os: str,
+    manifest: dict[str, Any],
+) -> list[Path]:
+    if scenario["id"] == "render_and_interaction":
+        render_path = path / "render.json"
+        if not render_path.is_file():
+            raise ValueError(f"{path}: missing render.json")
+        validate_render_document(
+            load_json_object(render_path),
+            render_path,
+            role,
+            scenario,
+            scenario_hash,
+            host_os,
+            manifest,
+        )
+        return [render_path]
+    artifacts: list[Path] = []
+    for directory in process_run_directories(path, scenario):
+        artifacts.extend(
+            validate_process_directory(
+                directory,
+                role,
+                scenario,
+                scenario_document,
+                scenario_hash,
+                host_os,
+                manifest,
+            )
+        )
+    return artifacts
+
+
+def relative_artifact(path: Path, root: Path, role: str) -> dict[str, Any]:
+    resolved = path.resolve()
+    try:
+        relative = resolved.relative_to(root).as_posix()
+    except ValueError as error:
+        raise ValueError(f"artifact must stay inside evidence root {root}: {resolved}") from error
+    return {
+        "role": role,
+        "path": relative,
+        "bytes": resolved.stat().st_size,
+        "sha256": sha256_file(resolved),
+    }
+
+
+def raw_inventory_digest(entries: list[dict[str, Any]]) -> str:
+    digest = hashlib.sha256()
+    for entry in sorted(entries, key=lambda item: item["path"]):
+        encoded = entry["path"].encode("utf-8")
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+        digest.update(bytes.fromhex(entry["sha256"]))
+    return digest.hexdigest()
+
+
+def expand_metric_names(metric: str, runs: list[dict[str, Any]]) -> list[str]:
+    if all(metric in run for run in runs):
+        return [metric]
+    suffix = f".{metric}"
+    variants = [
+        {name for name in run if name.startswith("geometry.") and name.endswith(suffix)}
+        for run in runs
+    ]
+    if variants and variants[0] and all(names == variants[0] for names in variants[1:]):
+        return sorted(variants[0])
+    missing = [index for index, names in enumerate(variants) if not names]
+    raise ValueError(
+        f"required metric {metric!r} is missing or has inconsistent geometry variants "
+        f"(empty run indexes: {missing})"
+    )
+
+
+def coefficient_of_variation(values: list[float]) -> float:
+    mean = statistics.fmean(values)
+    if mean == 0:
+        return 0.0 if all(value == 0 for value in values) else math.inf
+    return statistics.pstdev(values) / abs(mean)
+
+
+def linear_slope(points: list[tuple[float, float]]) -> float:
+    mean_x = statistics.fmean(point[0] for point in points)
+    mean_y = statistics.fmean(point[1] for point in points)
+    denominator = sum((x - mean_x) ** 2 for x, _ in points)
+    if denominator == 0:
+        return 0.0
+    return sum((x - mean_x) * (y - mean_y) for x, y in points) / denominator
+
+
+def paired_bootstrap_ratios(baseline: list[float], candidate: list[float], resamples: int,
+                            seed: int, confidence: float) -> tuple[float, float, list[float]]:
+    if len(baseline) != len(candidate) or not baseline:
+        raise ValueError("paired bootstrap needs equally sized non-empty inputs")
+    if any(value < 0 or not math.isfinite(value) for value in baseline + candidate):
+        raise ValueError("ratio metrics must be finite and non-negative")
+    pair_ratios = [stable_ratio(b, c) for b, c in zip(baseline, candidate)]
+    point = geometric_mean_ratio(pair_ratios)
+    rng = random.Random(seed)
+    count = len(pair_ratios)
+    sampled = []
+    for _ in range(resamples):
+        sampled.append(
+            geometric_mean_ratio([pair_ratios[rng.randrange(count)] for _ in range(count)])
+        )
+    sampled.sort()
+    upper_index = min(len(sampled) - 1, math.ceil(confidence * len(sampled)) - 1)
+    return point, sampled[upper_index], pair_ratios
+
+
+def stable_ratio(baseline: float, candidate: float) -> float:
+    if baseline == 0:
+        return 1.0 if candidate == 0 else RATIO_INFINITY
+    if candidate == 0:
+        return 0.0
+    return candidate / baseline
+
+
+def geometric_mean_ratio(ratios: list[float]) -> float:
+    # Conservative ordering for unresolved 0 * infinity products: a regression from an
+    # unmeasurably-idle baseline dominates a separate pair that reached exact zero.
+    if any(value >= RATIO_INFINITY for value in ratios):
+        return RATIO_INFINITY
+    if any(value == 0 for value in ratios):
+        return 0.0
+    return math.exp(statistics.fmean(math.log(value) for value in ratios))
+
+
+def command_self_test(_args: argparse.Namespace) -> int:
+    point, upper, ratios = paired_bootstrap_ratios([0.0, 0.0], [0.0, 0.0], 100, 7, 0.95)
+    assert point == 1.0 and upper == 1.0 and ratios == [1.0, 1.0]
+    point, upper, ratios = paired_bootstrap_ratios([1.0, 2.0], [0.0, 0.0], 100, 7, 0.95)
+    assert point == 0.0 and upper == 0.0 and ratios == [0.0, 0.0]
+    point, upper, ratios = paired_bootstrap_ratios([0.0, 1.0], [0.1, 1.0], 100, 7, 0.95)
+    assert point == RATIO_INFINITY and upper == RATIO_INFINITY
+    assert ratios == [RATIO_INFINITY, 1.0]
+    document = {"geometry": [[80, 24], [160, 50]]}
+    assert dotted(document, "geometry.length") == 2
+    assert dotted(document, "geometry.1.0") == 160
+    geometry_runs = [
+        {
+            "geometry.100x30.tree.mean_cpu_percent": 1.0,
+            "geometry.160x50.tree.mean_cpu_percent": 2.0,
+        },
+        {
+            "geometry.100x30.tree.mean_cpu_percent": 0.5,
+            "geometry.160x50.tree.mean_cpu_percent": 1.0,
+        },
+    ]
+    assert expand_metric_names("tree.mean_cpu_percent", geometry_runs) == [
+        "geometry.100x30.tree.mean_cpu_percent",
+        "geometry.160x50.tree.mean_cpu_percent",
+    ]
+    try:
+        json.loads('{"metric":1,"metric":2}', object_pairs_hook=reject_duplicate_json_keys)
+    except DuplicateJsonKeyError:
+        pass
+    else:
+        raise AssertionError("duplicate scenario keys must be rejected")
+    render_batch = {
+        "draws": 200,
+        "mean_draw_ns": 10,
+        "p95_draw_ns": 999,
+        "allocations": 200,
+        "allocated_bytes": 400,
+        "retained_bytes_delta": 0,
+        "peak_live_bytes_delta": 2,
+    }
+    render_document = {
+        "schema": "ytt.tui-perf.render.v1",
+        "cases": [{
+            "name": "pooled",
+            "update_path": "app_update_msg_key",
+            "measured_draws": 400,
+            "p95_draw_ns": 123,
+            "batches": [render_batch, render_batch],
+            "buffer_style_digest": "buffer",
+            "hit_map_digest": "hits",
+        }],
+    }
+    render_metrics = render_metrics_from_document(render_document, Path("<self-test>"))
+    assert render_metrics["render.pooled.p95_draw_ns"] == 123
+    assert render_metrics["render.pooled.p95_reducer_input_to_draw_ns"] == 123
+    render_document["cases"][0]["measured_draws"] = 399
+    try:
+        render_metrics_from_document(render_document, Path("<self-test>"))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("render measured_draws mismatch must be rejected")
+    identity_scenario = {
+        "id": "render_and_interaction",
+        "warmup_draws": 2,
+        "batches": 1,
+        "draws_per_batch": 3,
+    }
+    identity_manifest = {
+        "binaries": {
+            "baseline_render": {"sha256": "ab" * 32},
+            "candidate_render": {"sha256": "cd" * 32},
+        }
+    }
+    identity_document = {
+        "schema": "ytt.tui-perf.render.v1",
+        "kind": "render_summary",
+        "scenario_sha256": "scenario",
+        "binary_sha256": "ab" * 32,
+        "os": normalized_os(platform.system()),
+        "batches_per_case": 1,
+        "draws_per_batch": 3,
+        "cases": [
+            {
+                "name": "identity",
+                "warmup_draws": 2,
+                "measured_draws": 3,
+                "batches": [{"draws": 3}],
+            }
+        ],
+    }
+    validate_render_document(
+        identity_document,
+        Path("<identity-self-test>"),
+        "baseline",
+        identity_scenario,
+        "scenario",
+        normalized_os(platform.system()),
+        identity_manifest,
+    )
+    identity_document["binary_sha256"] = "00" * 32
+    try:
+        validate_render_document(
+            identity_document,
+            Path("<identity-self-test>"),
+            "baseline",
+            identity_scenario,
+            "scenario",
+            normalized_os(platform.system()),
+            identity_manifest,
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("render binary hash tampering must be rejected")
+    identity_document["binary_sha256"] = "ab" * 32
+    identity_document["scenario_sha256"] = "tampered"
+    try:
+        validate_render_document(
+            identity_document,
+            Path("<identity-self-test>"),
+            "baseline",
+            identity_scenario,
+            "scenario",
+            normalized_os(platform.system()),
+            identity_manifest,
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("render scenario hash tampering must be rejected")
+    with tempfile.TemporaryDirectory(prefix="ytt-perf-self-test-") as temporary:
+        root = Path(temporary)
+        raw = root / "raw.json"
+        sums = root / "SHA256SUMS"
+        raw.write_text('{"value":1}\n', encoding="utf-8")
+        assert write_checksums(root, sums) == 1
+        assert verify_checksums(root, sums) == 1
+        raw.write_text('{"value":2}\n', encoding="utf-8")
+        try:
+            verify_checksums(root, sums)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("raw artifact tampering must be rejected")
+    scenario_document, _ = load_scenarios(DEFAULT_SCENARIOS)
+    soak = find_scenario(scenario_document, "memory_soak")
+    assert soak["pause_policy"] == "none" and soak["pause_hold_ms"] == 0
+    for wrapper_name in ("tui-perf.sh", "tui-perf.ps1"):
+        wrapper = Path(__file__).with_name(wrapper_name).read_text(encoding="utf-8")
+        for token in ("pause_policy", "pause_hold_ms", "--pause-hold-ms", "--no-pause"):
+            # PowerShell uses camelCase locals but still queries the exact snake_case key.
+            assert token in wrapper
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "zero_ratio_cases": 3,
+                "geometry_variant_cases": 2,
+                "duplicate_key_cases": 1,
+                "aggregate_render_p95_cases": 2,
+                "render_identity_tamper_cases": 2,
+                "checksum_tamper_cases": 1,
+                "steady_soak_pause_cases": 1,
+                "wrapper_pause_parity_cases": 2,
+            }
+        )
+    )
+    return 0
+
+
+def compare_metric(name: str, policy: dict[str, Any], baseline: list[Any], candidate: list[Any],
+                   scenario: dict[str, Any], stats: dict[str, Any], seed_offset: int) -> dict[str, Any]:
+    comparison = policy.get("comparison", "ratio")
+    result: dict[str, Any] = {"metric": name, "comparison": comparison,
+                              "baseline": baseline, "candidate": candidate}
+    if comparison == "exact":
+        matches = [left == right for left, right in zip(baseline, candidate)]
+        result.update({"matches": matches, "pass": all(matches)})
+        return result
+
+    baseline_numbers = [float(value) for value in baseline]
+    candidate_numbers = [float(value) for value in candidate]
+    result["baseline_cv"] = coefficient_of_variation(baseline_numbers)
+    cv_limit = float(stats["baseline_cv_max"])
+    if comparison == "no_increase":
+        max_delta = float(policy.get("max_delta", 0))
+        deltas = [c - b for b, c in zip(baseline_numbers, candidate_numbers)]
+        result.update({"deltas": deltas, "max_delta": max_delta,
+                       "pass": all(delta <= max_delta for delta in deltas)})
+        return result
+
+    point, upper, pair_ratios = paired_bootstrap_ratios(
+        baseline_numbers,
+        candidate_numbers,
+        int(stats["bootstrap_resamples"]),
+        int(stats["seed"]) + seed_offset,
+        float(stats["one_sided_confidence"]),
+    )
+    max_ratio = float(policy["max_ratio"])
+    improved = sum(ratio < 1.0 for ratio in pair_ratios)
+    required_improved = int(
+        policy.get(
+            "min_improved_pairs",
+            scenario.get("min_improved_pairs", max(1, len(pair_ratios) - 1)),
+        )
+    )
+    passed = (
+        result["baseline_cv"] <= cv_limit
+        and point <= max_ratio
+        and upper <= max_ratio
+        and improved >= required_improved
+    )
+    if comparison == "latency":
+        max_delta = float(policy["max_delta"])
+        deltas = [c - b for b, c in zip(baseline_numbers, candidate_numbers)]
+        passed = passed and statistics.fmean(deltas) <= max_delta and max(deltas) <= max_delta
+        result.update({"deltas": deltas, "max_delta": max_delta})
+    result.update({
+        "point_ratio": point,
+        "upper_ratio": upper,
+        "max_ratio": max_ratio,
+        "pair_ratios": pair_ratios,
+        "improved_pairs": improved,
+        "required_improved_pairs": required_improved,
+        "baseline_cv_max": cv_limit,
+        "pass": passed,
+    })
+    return result
+
+
+def command_compare(args: argparse.Namespace) -> int:
+    document, scenario_hash = load_scenarios(args.scenarios)
+    scenario = find_scenario(document, args.scenario)
+    evidence_root = args.host_manifest.resolve().parent
+    if args.output_json.resolve().parent != evidence_root:
+        raise ValueError("--output-json must be directly inside the host-manifest directory")
+    if args.output_markdown.resolve().parent != evidence_root:
+        raise ValueError("--output-markdown must be directly inside the host-manifest directory")
+    render = args.scenario == "render_and_interaction"
+    host_manifest = validate_host_manifest(
+        args.host_manifest.resolve(), scenario, scenario_hash, render
+    )
+    host_os = normalized_os(host_manifest["host"]["system"])
+    if len(args.baseline_run) != len(args.candidate_run):
+        raise ValueError("--baseline-run and --candidate-run counts must match")
+    if len(args.baseline_run) != int(scenario["pairs"]):
+        raise ValueError(
+            f"scenario {args.scenario} requires {scenario['pairs']} pairs, got {len(args.baseline_run)}"
+        )
+    expected_repeats = int(scenario.get("candidate_repeats", 0))
+    if len(args.candidate_repeat_run) != expected_repeats:
+        raise ValueError(
+            f"scenario {args.scenario} requires {expected_repeats} candidate repeats, "
+            f"got {len(args.candidate_repeat_run)}"
+        )
+
+    inventory_paths: list[tuple[Path, str]] = []
+    for role, paths in (
+        ("baseline", args.baseline_run),
+        ("candidate", args.candidate_run),
+        ("candidate", args.candidate_repeat_run),
+    ):
+        for path in paths:
+            resolved = path.resolve()
+            try:
+                resolved.relative_to(evidence_root)
+            except ValueError as error:
+                raise ValueError(
+                    f"run directory must stay inside evidence root {evidence_root}: {resolved}"
+                ) from error
+            inventory_paths.extend(
+                (artifact, role)
+                for artifact in validate_run_artifacts(
+                    resolved,
+                    role,
+                    scenario,
+                    document,
+                    scenario_hash,
+                    host_os,
+                    host_manifest,
+                )
+            )
+
+    if scenario["requires_mpv"]:
+        fixture_manifest_path = evidence_root / "fixture" / "manifest.json"
+        fixture_manifest = load_json_object(fixture_manifest_path)
+        require_artifact_value(
+            fixture_manifest_path,
+            "schema",
+            fixture_manifest.get("schema"),
+            "ytt.tui-perf.fixture.v1",
+        )
+        fixture_path = Path(str(fixture_manifest.get("path", "")))
+        if not fixture_path.is_file():
+            raise ValueError(f"{fixture_manifest_path}: fixture no longer exists: {fixture_path}")
+        require_artifact_value(
+            fixture_manifest_path,
+            "fixture SHA-256",
+            sha256_file(fixture_path),
+            fixture_manifest.get("sha256"),
+        )
+        for artifact_path, _role in inventory_paths:
+            if artifact_path.name == "http-ready.json":
+                require_artifact_value(
+                    artifact_path,
+                    "served fixture SHA-256",
+                    load_json_object(artifact_path).get("fixture_sha256"),
+                    fixture_manifest.get("sha256"),
+                )
+        inventory_paths.append((fixture_manifest_path, "shared"))
+
+    baseline_runs = [load_run(path) for path in args.baseline_run]
+    candidate_runs = [load_run(path) for path in args.candidate_run]
+    candidate_repeat_runs = [load_run(path) for path in args.candidate_repeat_run]
+    policies = scenario.get("metrics", {})
+    results = []
+    repeat_metrics = [dict() for _ in candidate_repeat_runs]
+    for offset, (metric, policy) in enumerate(sorted(policies.items())):
+        names = expand_metric_names(
+            metric, baseline_runs + candidate_runs + candidate_repeat_runs
+        )
+        for variant_offset, name in enumerate(names):
+            baseline = [run[name] for run in baseline_runs]
+            candidate = [run[name] for run in candidate_runs]
+            results.append(
+                compare_metric(
+                    name,
+                    policy,
+                    baseline,
+                    candidate,
+                    scenario,
+                    document["statistics"],
+                    offset * 100 + variant_offset,
+                )
+            )
+            for repeat, run in zip(repeat_metrics, candidate_repeat_runs):
+                repeat[name] = run[name]
+
+    seen_artifacts: set[Path] = set()
+    raw_artifacts = []
+    for path, role in inventory_paths:
+        resolved = path.resolve()
+        if resolved in seen_artifacts:
+            continue
+        seen_artifacts.add(resolved)
+        raw_artifacts.append(relative_artifact(resolved, evidence_root, role))
+    raw_artifacts.sort(key=lambda item: item["path"])
+
+    def relative_run(path: Path) -> str:
+        resolved = path.resolve()
+        try:
+            return resolved.relative_to(evidence_root).as_posix()
+        except ValueError as error:
+            raise ValueError(f"run path escapes evidence root: {resolved}") from error
+
+    report = {
+        "schema": SCHEMA,
+        "kind": "paired_comparison",
+        "scenario": args.scenario,
+        "scenario_sha256": scenario_hash,
+        "generated_unix_s": int(time.time()),
+        "host": {"os": platform.system(), "release": platform.release(),
+                 "machine": platform.machine(), "python": platform.python_version()},
+        "baseline_runs": [relative_run(path) for path in args.baseline_run],
+        "candidate_runs": [relative_run(path) for path in args.candidate_run],
+        "candidate_repeat_runs": [relative_run(path) for path in args.candidate_repeat_run],
+        "candidate_repeat_metrics": repeat_metrics,
+        "evidence": {
+            "host_manifest": relative_artifact(
+                args.host_manifest.resolve(), evidence_root, "shared"
+            ),
+            "sources": host_manifest["sources"],
+            "binaries": host_manifest["binaries"],
+            "raw_artifacts": raw_artifacts,
+            "raw_set_sha256": raw_inventory_digest(raw_artifacts),
+        },
+        "required_runtime_checklist": document.get("required_runtime_checklist", []),
+        "runtime_checklist_status": "not_run_by_performance_harness",
+        "metrics": results,
+        "pass": all(result["pass"] for result in results),
+    }
+    atomic_json(args.output_json, report)
+    args.output_markdown.parent.mkdir(parents=True, exist_ok=True)
+    args.output_markdown.write_text(markdown_report(report), encoding="utf-8")
+    print(json.dumps({"pass": report["pass"], "json": str(args.output_json),
+                      "markdown": str(args.output_markdown), "scenario_sha256": scenario_hash}))
+    return 0 if report["pass"] else 1
+
+
+def markdown_report(report: dict[str, Any]) -> str:
+    lines = [
+        f"# TUI performance: `{report['scenario']}`",
+        "",
+        f"Overall: **{'PASS' if report['pass'] else 'FAIL'}**",
+        "",
+        f"Scenario SHA-256: `{report['scenario_sha256']}`",
+        "",
+        f"Host manifest SHA-256: `{report['evidence']['host_manifest']['sha256']}`",
+        "",
+        f"Raw artifact set SHA-256: `{report['evidence']['raw_set_sha256']}` "
+        f"({len(report['evidence']['raw_artifacts'])} files)",
+        "",
+        f"Baseline source: `{report['evidence']['sources']['baseline']['head']}` "
+        f"tree `{report['evidence']['sources']['baseline']['tree']}`",
+        "",
+        f"Candidate source: `{report['evidence']['sources']['candidate']['head']}` "
+        f"tree `{report['evidence']['sources']['candidate']['tree']}`",
+        "",
+        f"Candidate diagnostic repeats: {len(report['candidate_repeat_runs'])}",
+        "",
+        "Visual runtime checklist: **NOT RUN by this performance harness**",
+    ]
+    lines.extend(f"- [ ] {item}" for item in report["required_runtime_checklist"])
+    lines.extend([
+        "",
+        "| Metric | Policy | Result | Detail |",
+        "| --- | --- | --- | --- |",
+    ])
+    for metric in report["metrics"]:
+        if metric["comparison"] in {"ratio", "latency"}:
+            detail = (
+                f"ratio {metric['point_ratio']:.4f}; upper {metric['upper_ratio']:.4f}; "
+                f"limit {metric['max_ratio']:.4f}; CV {metric['baseline_cv']:.4f}; "
+                f"improved {metric['improved_pairs']}/{len(metric['pair_ratios'])}"
+            )
+            if metric["comparison"] == "latency":
+                detail += f"; deltas {metric['deltas']}; max +{metric['max_delta']}"
+        elif metric["comparison"] == "no_increase":
+            detail = f"deltas {metric['deltas']}; max allowed {metric['max_delta']}"
+        else:
+            detail = f"paired equality {metric['matches']}"
+        lines.append(
+            f"| `{metric['metric']}` | {metric['comparison']} | "
+            f"**{'PASS' if metric['pass'] else 'FAIL'}** | {detail} |"
+        )
+    lines.extend(["", "Generated from paired native-host artifacts; raw paths are retained in JSON.", ""])
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    validate = sub.add_parser("validate", help="validate the versioned scenario file")
+    validate.add_argument("--scenarios", type=Path, default=DEFAULT_SCENARIOS)
+    validate.set_defaults(handler=command_validate)
+
+    scenario = sub.add_parser("scenario", help="print one scenario or a dotted scalar field")
+    scenario.add_argument("--scenarios", type=Path, default=DEFAULT_SCENARIOS)
+    scenario.add_argument("--id", required=True)
+    scenario.add_argument("--field")
+    scenario.set_defaults(handler=command_scenario)
+
+    traffic = sub.add_parser("traffic", help="print a traffic profile or one scalar field")
+    traffic.add_argument("--scenarios", type=Path, default=DEFAULT_SCENARIOS)
+    traffic.add_argument("--name", required=True)
+    traffic.add_argument("--field")
+    traffic.set_defaults(handler=command_traffic)
+
+    setting = sub.add_parser("setting", help="print a dotted top-level scenario setting")
+    setting.add_argument("--scenarios", type=Path, default=DEFAULT_SCENARIOS)
+    setting.add_argument("--field", required=True)
+    setting.set_defaults(handler=command_setting)
+
+    manifest = sub.add_parser("manifest", help="write OS, CPU, RAM, tool, and binary identity")
+    manifest.add_argument("--scenarios", type=Path, default=DEFAULT_SCENARIOS)
+    manifest.add_argument("--scenario", required=True)
+    manifest.add_argument("--output", type=Path, required=True)
+    manifest.add_argument("--binary", action="append", default=[])
+    manifest.add_argument("--source-root", action="append", default=[])
+    manifest.add_argument("--build-command", action="append", default=[])
+    manifest.set_defaults(handler=command_manifest)
+
+    materialize = sub.add_parser(
+        "materialize", help="replace fixture/home placeholders in an isolated seed tree"
+    )
+    materialize.add_argument("--root", type=Path, required=True)
+    materialize.add_argument("--home", type=Path, required=True)
+    materialize.add_argument("--fixture-url", required=True)
+    materialize.add_argument(
+        "--playlist-relative", type=Path, default=Path("fixture/tui-perf-stream.m3u")
+    )
+    materialize.add_argument("--manifest", type=Path)
+    materialize.add_argument("--seed-label", default="unspecified")
+    materialize.set_defaults(handler=command_materialize)
+
+    fixture = sub.add_parser("fixture", help="create deterministic PCM WAV silence")
+    fixture.add_argument("--output", type=Path, required=True)
+    fixture.add_argument("--manifest", type=Path)
+    fixture.add_argument("--seconds", type=float, default=900.0)
+    fixture.add_argument("--sample-rate", type=int, default=8_000)
+    fixture.set_defaults(handler=command_fixture)
+
+    check = sub.add_parser("check", help="validate one sampler/control artifact set")
+    check.add_argument("--samples", type=Path, required=True)
+    check.add_argument("--control", type=Path)
+    check.add_argument("--scenario-sha256")
+    check.add_argument("--require-silent-mpv", action="store_true")
+    check.add_argument("--require-observer-close", action="store_true")
+    check.set_defaults(handler=command_check)
+
+    serve = sub.add_parser("serve", help="serve the fixture with Range/throttle/outage controls")
+    serve.add_argument("--file", type=Path, required=True)
+    serve.add_argument("--host", default="127.0.0.1")
+    serve.add_argument("--port", type=int, default=0)
+    serve.add_argument("--ready-file", type=Path)
+    serve.add_argument("--throttle-bps", type=int, default=0)
+    serve.add_argument("--outage-every-bytes", type=int, default=0)
+    serve.add_argument("--outage-ms", type=int, default=0)
+    serve.add_argument("--disconnect-every-bytes", type=int, default=0)
+    serve.add_argument("--verbose", action="store_true")
+    serve.set_defaults(handler=command_serve)
+
+    compare = sub.add_parser("compare", help="compare paired run directories and write reports")
+    compare.add_argument("--scenarios", type=Path, default=DEFAULT_SCENARIOS)
+    compare.add_argument("--scenario", required=True)
+    compare.add_argument("--host-manifest", type=Path, required=True)
+    compare.add_argument("--baseline-run", type=Path, action="append", required=True)
+    compare.add_argument("--candidate-run", type=Path, action="append", required=True)
+    compare.add_argument("--candidate-repeat-run", type=Path, action="append", default=[])
+    compare.add_argument("--output-json", type=Path, required=True)
+    compare.add_argument("--output-markdown", type=Path, required=True)
+    compare.set_defaults(handler=command_compare)
+
+    checksums = sub.add_parser(
+        "checksums", help="write and immediately verify a portable SHA256SUMS inventory"
+    )
+    checksums.add_argument("--root", type=Path, required=True)
+    checksums.add_argument("--output", type=Path, required=True)
+    checksums.set_defaults(handler=command_checksums)
+
+    self_test = sub.add_parser("self-test", help="run deterministic statistics edge-case checks")
+    self_test.set_defaults(handler=command_self_test)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return int(args.handler(args))
+    except (ValueError, OSError, json.JSONDecodeError) as error:
+        print(f"tui-perf.py: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tui-perf.sh
+++ b/scripts/tui-perf.sh
@@ -1,0 +1,465 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Native Unix launcher for paired ytt TUI performance runs. Real TUI binaries always run inside
+# a unique tmux server with a fake home and null audio, matching the repository verify contract.
+# Cleanup is confined to that tmux server and the exact PID recorded by the Rust sampler.
+
+repo_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+python_tool="$repo_dir/scripts/tui-perf.py"
+scenarios="$repo_dir/scripts/tui-perf-scenarios.json"
+scenario=""
+baseline_binary=""
+candidate_binary=""
+baseline_render=""
+candidate_render=""
+baseline_source_root=""
+candidate_source_root="$repo_dir"
+baseline_build_command=""
+candidate_build_command=""
+sampler="$repo_dir/target/release/examples/tui_perf_sampler"
+controller="$repo_dir/target/release/examples/tui_perf_control"
+output=""
+seed_home=""
+baseline_seed_home=""
+candidate_seed_home=""
+build_harness=true
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/tui-perf.sh --scenario ID --output DIR [options]
+
+Process-tree scenarios:
+  --baseline-binary PATH       Exact origin/main ytt binary
+  --candidate-binary PATH      Candidate ytt binary
+  --seed-home DIR              Isolated HOME template (required for playback scenarios).
+                               Persisted state must live under stores/{config,data,cache}.
+                               Resumed Song.local_path must be {{TUI_PERF_PLAYLIST}}.
+  --baseline-seed-home DIR     Baseline-specific template; falls back to --seed-home.
+  --candidate-seed-home DIR    Candidate-specific template; falls back to --seed-home.
+
+Render scenario:
+  --baseline-render PATH       Baseline tui_render_perf built from a throwaway harness copy
+  --candidate-render PATH      Candidate tui_render_perf (defaults to target/release/examples)
+  --baseline-source-root PATH  Git root used to build the baseline binary (auto-detected when possible)
+  --candidate-source-root PATH Git root used to build candidate binaries (defaults to this repo)
+  --baseline-build-command CMD Exact baseline build command recorded in evidence (required)
+  --candidate-build-command CMD Exact candidate build command recorded in evidence (required)
+
+Harness options:
+  --sampler PATH               Override tui_perf_sampler
+  --controller PATH            Override tui_perf_control
+  --scenarios PATH             Override scenario JSON
+  --no-build                   Use already-built harness examples
+
+The output directory retains every fake home, raw NDJSON, and paired report. Never point it at a
+real profile. The script alternates AB/BA order and never uses process-name-wide termination.
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --scenario) scenario=${2:?}; shift 2 ;;
+    --output) output=${2:?}; shift 2 ;;
+    --baseline-binary) baseline_binary=${2:?}; shift 2 ;;
+    --candidate-binary) candidate_binary=${2:?}; shift 2 ;;
+    --baseline-render) baseline_render=${2:?}; shift 2 ;;
+    --candidate-render) candidate_render=${2:?}; shift 2 ;;
+    --baseline-source-root) baseline_source_root=${2:?}; shift 2 ;;
+    --candidate-source-root) candidate_source_root=${2:?}; shift 2 ;;
+    --baseline-build-command) baseline_build_command=${2:?}; shift 2 ;;
+    --candidate-build-command) candidate_build_command=${2:?}; shift 2 ;;
+    --sampler) sampler=${2:?}; shift 2 ;;
+    --controller) controller=${2:?}; shift 2 ;;
+    --seed-home) seed_home=${2:?}; shift 2 ;;
+    --baseline-seed-home) baseline_seed_home=${2:?}; shift 2 ;;
+    --candidate-seed-home) candidate_seed_home=${2:?}; shift 2 ;;
+    --scenarios) scenarios=${2:?}; shift 2 ;;
+    --no-build) build_harness=false; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'tui-perf.sh: unknown argument %q\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$scenario" ]] || { echo "tui-perf.sh: --scenario is required" >&2; exit 2; }
+[[ -n "$output" ]] || { echo "tui-perf.sh: --output is required" >&2; exit 2; }
+[[ ! -e "$output" ]] || {
+  echo "tui-perf.sh: --output must name a new path; existing evidence is never reused" >&2
+  exit 2
+}
+[[ -n "$baseline_build_command" ]] || { echo "tui-perf.sh: --baseline-build-command is required" >&2; exit 2; }
+[[ -n "$candidate_build_command" ]] || { echo "tui-perf.sh: --candidate-build-command is required" >&2; exit 2; }
+command -v python3 >/dev/null || { echo "tui-perf.sh: python3 is required" >&2; exit 2; }
+python3 "$python_tool" validate --scenarios "$scenarios" >/dev/null
+scenario_hash=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field sha256)
+pairs=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field pairs)
+candidate_repeats=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field candidate_repeats)
+geometry_count=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field geometry.length)
+requires_mpv=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field requires_mpv)
+traffic_profile=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field traffic_profile)
+fixture_seconds=$(python3 "$python_tool" setting --scenarios "$scenarios" --field fixture.duration_s)
+fixture_sample_rate=$(python3 "$python_tool" setting --scenarios "$scenarios" --field fixture.sample_rate_hz)
+is_render=false
+[[ "$scenario" == "render_and_interaction" ]] && is_render=true
+baseline_seed_home=${baseline_seed_home:-$seed_home}
+candidate_seed_home=${candidate_seed_home:-$seed_home}
+
+if $build_harness; then
+  (
+    cd "$repo_dir"
+    cargo build --release \
+      --locked \
+      --example tui_perf_sampler \
+      --example tui_perf_control \
+      --example tui_render_perf
+  )
+fi
+
+if $is_render; then
+  candidate_render=${candidate_render:-$repo_dir/target/release/examples/tui_render_perf}
+  [[ -x "$baseline_render" ]] || {
+    echo "tui-perf.sh: --baseline-render must be an executable for render_and_interaction" >&2
+    exit 2
+  }
+  [[ -x "$candidate_render" ]] || { echo "tui-perf.sh: candidate render harness not executable" >&2; exit 2; }
+else
+  command -v tmux >/dev/null || { echo "tui-perf.sh: tmux is required for real TUI runs" >&2; exit 2; }
+  [[ -x "$baseline_binary" ]] || { echo "tui-perf.sh: --baseline-binary is not executable" >&2; exit 2; }
+  [[ -x "$candidate_binary" ]] || { echo "tui-perf.sh: --candidate-binary is not executable" >&2; exit 2; }
+  [[ -x "$sampler" ]] || { echo "tui-perf.sh: sampler is not executable" >&2; exit 2; }
+  [[ -x "$controller" ]] || { echo "tui-perf.sh: controller is not executable" >&2; exit 2; }
+  if [[ "$requires_mpv" == true ]]; then
+    for seed_role in baseline candidate; do
+      if [[ "$seed_role" == baseline ]]; then
+        role_seed_home=$baseline_seed_home
+      else
+        role_seed_home=$candidate_seed_home
+      fi
+      [[ -d "$role_seed_home" ]] || {
+        echo "tui-perf.sh: playback scenarios require a $seed_role seed home" >&2
+        exit 2
+      }
+      for store in config data cache; do
+        [[ -d "$role_seed_home/stores/$store" ]] || {
+          echo "tui-perf.sh: $seed_role seed home must contain stores/$store" >&2
+          exit 2
+        }
+      done
+    done
+  fi
+fi
+
+command -v git >/dev/null || { echo "tui-perf.sh: git is required for source identity" >&2; exit 2; }
+if [[ -z "$baseline_source_root" ]]; then
+  if $is_render; then
+    baseline_source_root=$(git -C "$(dirname -- "$baseline_render")" rev-parse --show-toplevel 2>/dev/null) || {
+      echo "tui-perf.sh: cannot infer --baseline-source-root from $baseline_render" >&2
+      exit 2
+    }
+  else
+    baseline_source_root=$(git -C "$(dirname -- "$baseline_binary")" rev-parse --show-toplevel 2>/dev/null) || {
+      echo "tui-perf.sh: cannot infer --baseline-source-root from $baseline_binary" >&2
+      exit 2
+    }
+  fi
+fi
+[[ -d "$baseline_source_root" ]] || { echo "tui-perf.sh: baseline source root is not a directory" >&2; exit 2; }
+[[ -d "$candidate_source_root" ]] || { echo "tui-perf.sh: candidate source root is not a directory" >&2; exit 2; }
+
+mkdir -p "$output"
+output=$(cd "$output" && pwd)
+active_socket=""
+active_server_pid=""
+fixture_file="$output/fixture/silence-${fixture_seconds}s.wav"
+if [[ "$requires_mpv" == true ]]; then
+  mkdir -p "$(dirname "$fixture_file")"
+  if [[ ! -f "$fixture_file" ]]; then
+    python3 "$python_tool" fixture \
+      --output "$fixture_file" \
+      --manifest "$output/fixture/manifest.json" \
+      --seconds "$fixture_seconds" \
+      --sample-rate "$fixture_sample_rate" >/dev/null
+  fi
+fi
+
+manifest_args=(
+  manifest
+  --scenarios "$scenarios"
+  --scenario "$scenario"
+  --output "$output/host-manifest.json"
+  --source-root "baseline=$baseline_source_root"
+  --source-root "candidate=$candidate_source_root"
+  --build-command "baseline=$baseline_build_command"
+  --build-command "candidate=$candidate_build_command"
+)
+if $is_render; then
+  manifest_args+=(--binary "baseline_render=$baseline_render")
+  manifest_args+=(--binary "candidate_render=$candidate_render")
+else
+  manifest_args+=(--binary "baseline_ytt=$baseline_binary")
+  manifest_args+=(--binary "candidate_ytt=$candidate_binary")
+  manifest_args+=(--binary "sampler=$sampler")
+  manifest_args+=(--binary "controller=$controller")
+fi
+python3 "$python_tool" "${manifest_args[@]}" >/dev/null
+
+cleanup() {
+  if [[ -n "$active_socket" ]]; then
+    tmux -S "$active_socket" kill-server 2>/dev/null || true
+  fi
+  if [[ -n "$active_server_pid" ]]; then
+    kill "$active_server_pid" 2>/dev/null || true
+    wait "$active_server_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+json_array_to_csv() {
+  python3 -c 'import json,sys; print(",".join(str(v) for v in json.loads(sys.argv[1])))' "$1"
+}
+
+run_render() {
+  local role=$1 binary=$2 run_dir=$3
+  mkdir -p "$run_dir"
+  TUI_PERF_SCENARIO_SHA256="$scenario_hash" \
+    "$binary" \
+      --output "$run_dir/render.json" \
+      --warmup "$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field warmup_draws)" \
+      --batches "$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field batches)" \
+      --draws "$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field draws_per_batch)"
+}
+
+run_process() {
+  local role=$1 binary=$2 run_root=$3 width=$4 height=$5 label=$6
+  local role_seed_home=$candidate_seed_home
+  [[ "$role" == baseline ]] && role_seed_home=$baseline_seed_home
+  local run_dir="$run_root"
+  if ((geometry_count > 1)); then
+    run_dir="$run_root/geometry-${width}x${height}"
+  fi
+  local home="$run_dir/home"
+  local runtime="$run_dir/runtime"
+  local tmp="$run_dir/tmp"
+  local config_store="$home/stores/config"
+  local data_store="$home/stores/data"
+  local cache_store="$home/stores/cache"
+  local samples="$run_dir/samples.ndjson"
+  local pid_file="$run_dir/ytt.pid"
+  local socket="$run_dir/tmux.sock"
+  mkdir -p "$home" "$runtime" "$tmp" "$config_store" "$data_store" "$cache_store"
+  chmod 700 "$runtime"
+  if [[ -n "$role_seed_home" ]]; then
+    cp -R "$role_seed_home"/. "$home"/
+  fi
+  if [[ "$requires_mpv" == true ]]; then
+    local ready_file="$run_dir/http-ready.json"
+    local throttle outage_every outage_ms disconnect_every fixture_url
+    rm -f -- "$ready_file"
+    throttle=$(python3 "$python_tool" traffic --scenarios "$scenarios" --name "$traffic_profile" --field throttle_bps)
+    outage_every=$(python3 "$python_tool" traffic --scenarios "$scenarios" --name "$traffic_profile" --field outage_every_bytes)
+    outage_ms=$(python3 "$python_tool" traffic --scenarios "$scenarios" --name "$traffic_profile" --field outage_ms)
+    disconnect_every=$(python3 "$python_tool" traffic --scenarios "$scenarios" --name "$traffic_profile" --field disconnect_every_bytes)
+    python3 "$python_tool" serve \
+      --file "$fixture_file" \
+      --ready-file "$ready_file" \
+      --throttle-bps "$throttle" \
+      --outage-every-bytes "$outage_every" \
+      --outage-ms "$outage_ms" \
+      --disconnect-every-bytes "$disconnect_every" \
+      >"$run_dir/http-server.log" 2>&1 &
+    active_server_pid=$!
+    local server_deadline=$((SECONDS + 10))
+    until [[ -s "$ready_file" ]]; do
+      if ((SECONDS >= server_deadline)) || ! kill -0 "$active_server_pid" 2>/dev/null; then
+        echo "tui-perf.sh: fixture server failed for $label" >&2
+        return 1
+      fi
+      sleep 0.05
+    done
+    fixture_url=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["url"])' "$ready_file")
+    python3 "$python_tool" materialize \
+      --root "$home" \
+      --home "$home" \
+      --fixture-url "$fixture_url" \
+      --seed-label "$role" \
+      --manifest "$run_dir/materialize.json" >/dev/null
+  fi
+  local warmup sample interval require_arg=""
+  warmup=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field warmup_s)
+  sample=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field sample_s)
+  interval=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["sampling"]["interval_ms"])' "$scenarios")
+  [[ "$requires_mpv" == true ]] && require_arg="--require-silent-mpv"
+
+  local -a isolated_env=(
+    "HOME=$home"
+    "XDG_CONFIG_HOME=$home/.config"
+    "XDG_DATA_HOME=$home/.local/share"
+    "XDG_CACHE_HOME=$home/.cache"
+    "XDG_STATE_HOME=$home/.local/state"
+    "XDG_RUNTIME_DIR=$runtime"
+    "YTM_CONFIG_DIR=$config_store"
+    "YTM_DATA_DIR=$data_store"
+    "YTM_CACHE_DIR=$cache_store"
+    "TMPDIR=$tmp"
+    "TEMP=$tmp"
+    "TMP=$tmp"
+    "TERM=xterm-256color"
+    "YTM_MPV_EXTRA=--ao=null --volume=0 --audio-display=no"
+    "YTM_PERF=1"
+    "TUI_PERF_SCENARIO_SHA256=$scenario_hash"
+  )
+  mkdir -p "$home/.config" "$home/.local/share" "$home/.cache" "$home/.local/state"
+
+  local -a sampler_cmd=(
+    env "${isolated_env[@]}" "$sampler"
+    --output "$samples"
+    --pid-file "$pid_file"
+    --binary "$binary"
+    --warmup-secs "$warmup"
+    --duration-secs "$sample"
+    --interval-ms "$interval"
+  )
+  [[ -n "$require_arg" ]] && sampler_cmd+=("$require_arg")
+  local controller_enabled
+  controller_enabled=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field controller)
+  # Non-controller runs do not need a discoverable primary endpoint. Controller runs omit
+  # --new-instance so ytt publishes its descriptor inside this run's unique XDG_RUNTIME_DIR;
+  # every other profile/runtime path is isolated above, so this cannot address the user's ytt.
+  if [[ "$controller_enabled" != true ]]; then
+    sampler_cmd+=(-- --new-instance)
+  fi
+  local shell_command
+  printf -v shell_command '%q ' "${sampler_cmd[@]}"
+  rm -f -- "$pid_file"
+  active_socket=$socket
+  tmux -S "$socket" new-session -d -x "$width" -y "$height" "$shell_command"
+
+  local ready_deadline=$((SECONDS + 30))
+  until [[ -s "$pid_file" ]]; do
+    if ((SECONDS >= ready_deadline)) || ! tmux -S "$socket" has-session 2>/dev/null; then
+      echo "tui-perf.sh: $label failed before publishing its PID" >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+
+  if [[ "$controller_enabled" == true ]]; then
+    local load seeks_json seeks_csv pause_policy pause_hold_ms
+    load=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field controller_load)
+    seeks_json=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field seeks_s)
+    seeks_csv=$(json_array_to_csv "$seeks_json")
+    pause_policy=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field pause_policy)
+    pause_hold_ms=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field pause_hold_ms)
+    local -a control_cmd=(
+      env "${isolated_env[@]}" "$controller"
+      --output "$run_dir/control.ndjson"
+      --wait-secs 45
+      --observe-secs "$(python3 -c 'import sys; print(float(sys.argv[1])+float(sys.argv[2]))' "$warmup" "$sample")"
+      --close-grace-secs 15
+      --load "$load"
+    )
+    [[ -n "$seeks_csv" ]] && control_cmd+=(--seeks "$seeks_csv")
+    if [[ "$pause_policy" == pause-resume ]]; then
+      control_cmd+=(--pause-hold-ms "$pause_hold_ms")
+    else
+      control_cmd+=(--no-pause)
+    fi
+    "${control_cmd[@]}"
+  fi
+
+  local finish_deadline
+  finish_deadline=$(python3 -c 'import math,sys; print(int(math.ceil(float(sys.argv[1])+float(sys.argv[2])+90)))' "$warmup" "$sample")
+  finish_deadline=$((SECONDS + finish_deadline))
+  while tmux -S "$socket" has-session 2>/dev/null; do
+    if ((SECONDS >= finish_deadline)); then
+      echo "tui-perf.sh: timed out waiting for $label" >&2
+      return 1
+    fi
+    sleep 1
+  done
+  active_socket=""
+  local -a check_args=(
+    check --samples "$samples" --scenario-sha256 "$scenario_hash"
+  )
+  [[ "$requires_mpv" == true ]] && check_args+=(--require-silent-mpv)
+  if [[ "$controller_enabled" == true ]]; then
+    check_args+=(--control "$run_dir/control.ndjson" --require-observer-close)
+  fi
+  python3 "$python_tool" "${check_args[@]}" >/dev/null
+  if [[ -n "$active_server_pid" ]]; then
+    kill "$active_server_pid" 2>/dev/null || true
+    wait "$active_server_pid" 2>/dev/null || true
+    active_server_pid=""
+  fi
+}
+
+run_process_geometries() {
+  local role=$1 binary=$2 run_root=$3 label=$4
+  local geometry_index width height
+  for ((geometry_index=0; geometry_index<geometry_count; geometry_index++)); do
+    width=$(python3 "$python_tool" scenario \
+      --scenarios "$scenarios" --id "$scenario" --field "geometry.$geometry_index.0")
+    height=$(python3 "$python_tool" scenario \
+      --scenarios "$scenarios" --id "$scenario" --field "geometry.$geometry_index.1")
+    run_process "$role" "$binary" "$run_root" "$width" "$height" \
+      "$label geometry ${width}x${height}"
+  done
+}
+
+baseline_runs=()
+candidate_runs=()
+for ((pair=1; pair<=pairs; pair++)); do
+  if ((pair % 2 == 1)); then
+    order=(baseline candidate)
+  else
+    order=(candidate baseline)
+  fi
+  for role in "${order[@]}"; do
+    if $is_render; then
+      [[ "$role" == baseline ]] && binary=$baseline_render || binary=$candidate_render
+      run_render "$role" "$binary" "$output/pair-$(printf '%02d' "$pair")/$role"
+    else
+      [[ "$role" == baseline ]] && binary=$baseline_binary || binary=$candidate_binary
+      run_process_geometries "$role" "$binary" \
+        "$output/pair-$(printf '%02d' "$pair")/$role" "$role pair $pair"
+    fi
+  done
+  baseline_runs+=(--baseline-run "$output/pair-$(printf '%02d' "$pair")/baseline")
+  candidate_runs+=(--candidate-run "$output/pair-$(printf '%02d' "$pair")/candidate")
+done
+
+candidate_repeat_runs=()
+for ((repeat=1; repeat<=candidate_repeats; repeat++)); do
+  repeat_dir="$output/candidate-repeat-$(printf '%02d' "$repeat")"
+  if $is_render; then
+    run_render candidate "$candidate_render" "$repeat_dir"
+  else
+    run_process_geometries candidate "$candidate_binary" "$repeat_dir" \
+      "candidate diagnostic repeat $repeat"
+  fi
+  candidate_repeat_runs+=(--candidate-repeat-run "$repeat_dir")
+done
+
+compare_args=(
+  compare
+  --scenarios "$scenarios"
+  --scenario "$scenario"
+  --host-manifest "$output/host-manifest.json"
+  "${baseline_runs[@]}"
+  "${candidate_runs[@]}"
+)
+# Bash 3.2 on macOS treats expansion of a declared-but-empty array as an unbound variable under
+# `set -u`. Only expand the diagnostic-repeat array when the scenario actually requested entries.
+if ((candidate_repeats > 0)); then
+  compare_args+=("${candidate_repeat_runs[@]}")
+fi
+compare_args+=(
+  --output-json "$output/report.json"
+  --output-markdown "$output/report.md"
+)
+compare_status=0
+python3 "$python_tool" "${compare_args[@]}" || compare_status=$?
+python3 "$python_tool" checksums \
+  --root "$output" \
+  --output "$output/SHA256SUMS" >/dev/null
+exit "$compare_status"

--- a/scripts/tui-perf.sh
+++ b/scripts/tui-perf.sh
@@ -1,56 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Performance evidence must describe the normal product. Never inherit the optional hot-path
+# instrumentation switch into the sampler, controller, or measured ytt process.
+unset YTM_PERF
+
 # Native Unix launcher for paired ytt TUI performance runs. Real TUI binaries always run inside
 # a unique tmux server with a fake home and null audio, matching the repository verify contract.
-# Cleanup is confined to that tmux server and the exact PID recorded by the Rust sampler.
+# Cleanup is confined to the exact owner/mpv live identities recorded by the Rust sampler and
+# completes before the unique tmux server may be stopped.
 
 repo_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 python_tool="$repo_dir/scripts/tui-perf.py"
 scenarios="$repo_dir/scripts/tui-perf-scenarios.json"
 scenario=""
-baseline_binary=""
-candidate_binary=""
-baseline_render=""
-candidate_render=""
 baseline_source_root=""
 candidate_source_root="$repo_dir"
-baseline_build_command=""
-candidate_build_command=""
-sampler="$repo_dir/target/release/examples/tui_perf_sampler"
-controller="$repo_dir/target/release/examples/tui_perf_control"
 output=""
 seed_home=""
 baseline_seed_home=""
 candidate_seed_home=""
-build_harness=true
 
 usage() {
   cat <<'EOF'
 Usage: scripts/tui-perf.sh --scenario ID --output DIR [options]
 
-Process-tree scenarios:
-  --baseline-binary PATH       Exact origin/main ytt binary
-  --candidate-binary PATH      Candidate ytt binary
+Required source inputs:
+  --baseline-source-root PATH  Clean worktree at candidate origin/main (required)
+  --candidate-source-root PATH Exact clean candidate HEAD (defaults to this repo)
+
+Playback scenarios:
   --seed-home DIR              Isolated HOME template (required for playback scenarios).
                                Persisted state must live under stores/{config,data,cache}.
                                Resumed Song.local_path must be {{TUI_PERF_PLAYLIST}}.
-  --baseline-seed-home DIR     Baseline-specific template; falls back to --seed-home.
-  --candidate-seed-home DIR    Candidate-specific template; falls back to --seed-home.
-
-Render scenario:
-  --baseline-render PATH       Baseline tui_render_perf built from a throwaway harness copy
-  --candidate-render PATH      Candidate tui_render_perf (defaults to target/release/examples)
-  --baseline-source-root PATH  Git root used to build the baseline binary (auto-detected when possible)
-  --candidate-source-root PATH Git root used to build candidate binaries (defaults to this repo)
-  --baseline-build-command CMD Exact baseline build command recorded in evidence (required)
-  --candidate-build-command CMD Exact candidate build command recorded in evidence (required)
+  --baseline-seed-home DIR     Baseline template; must hash-identically to candidate.
+  --candidate-seed-home DIR    Candidate template; must hash-identically to baseline.
 
 Harness options:
-  --sampler PATH               Override tui_perf_sampler
-  --controller PATH            Override tui_perf_control
   --scenarios PATH             Override scenario JSON
-  --no-build                   Use already-built harness examples
 
 The output directory retains every fake home, raw NDJSON, and paired report. Never point it at a
 real profile. The script alternates AB/BA order and never uses process-name-wide termination.
@@ -61,21 +48,12 @@ while (($#)); do
   case "$1" in
     --scenario) scenario=${2:?}; shift 2 ;;
     --output) output=${2:?}; shift 2 ;;
-    --baseline-binary) baseline_binary=${2:?}; shift 2 ;;
-    --candidate-binary) candidate_binary=${2:?}; shift 2 ;;
-    --baseline-render) baseline_render=${2:?}; shift 2 ;;
-    --candidate-render) candidate_render=${2:?}; shift 2 ;;
     --baseline-source-root) baseline_source_root=${2:?}; shift 2 ;;
     --candidate-source-root) candidate_source_root=${2:?}; shift 2 ;;
-    --baseline-build-command) baseline_build_command=${2:?}; shift 2 ;;
-    --candidate-build-command) candidate_build_command=${2:?}; shift 2 ;;
-    --sampler) sampler=${2:?}; shift 2 ;;
-    --controller) controller=${2:?}; shift 2 ;;
     --seed-home) seed_home=${2:?}; shift 2 ;;
     --baseline-seed-home) baseline_seed_home=${2:?}; shift 2 ;;
     --candidate-seed-home) candidate_seed_home=${2:?}; shift 2 ;;
     --scenarios) scenarios=${2:?}; shift 2 ;;
-    --no-build) build_harness=false; shift ;;
     -h|--help) usage; exit 0 ;;
     *) printf 'tui-perf.sh: unknown argument %q\n' "$1" >&2; usage >&2; exit 2 ;;
   esac
@@ -87,9 +65,16 @@ done
   echo "tui-perf.sh: --output must name a new path; existing evidence is never reused" >&2
   exit 2
 }
-[[ -n "$baseline_build_command" ]] || { echo "tui-perf.sh: --baseline-build-command is required" >&2; exit 2; }
-[[ -n "$candidate_build_command" ]] || { echo "tui-perf.sh: --candidate-build-command is required" >&2; exit 2; }
+[[ -n "$baseline_source_root" ]] || { echo "tui-perf.sh: --baseline-source-root is required" >&2; exit 2; }
 command -v python3 >/dev/null || { echo "tui-perf.sh: python3 is required" >&2; exit 2; }
+command -v git >/dev/null || { echo "tui-perf.sh: git is required for source identity" >&2; exit 2; }
+[[ -d "$baseline_source_root" ]] || { echo "tui-perf.sh: baseline source root is not a directory" >&2; exit 2; }
+[[ -d "$candidate_source_root" ]] || { echo "tui-perf.sh: candidate source root is not a directory" >&2; exit 2; }
+output=$(python3 "$python_tool" path-preflight \
+  --output-root "$output" \
+  --protected-root "$baseline_source_root" \
+  --protected-root "$candidate_source_root")
+
 python3 "$python_tool" validate --scenarios "$scenarios" >/dev/null
 scenario_hash=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field sha256)
 pairs=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field pairs)
@@ -104,72 +89,146 @@ is_render=false
 baseline_seed_home=${baseline_seed_home:-$seed_home}
 candidate_seed_home=${candidate_seed_home:-$seed_home}
 
-if $build_harness; then
-  (
-    cd "$repo_dir"
-    cargo build --release \
-      --locked \
-      --example tui_perf_sampler \
-      --example tui_perf_control \
-      --example tui_render_perf
-  )
+if [[ "$requires_mpv" == true ]]; then
+  [[ -d "$baseline_seed_home" ]] || { echo "tui-perf.sh: baseline seed home is required" >&2; exit 2; }
+  [[ -d "$candidate_seed_home" ]] || { echo "tui-perf.sh: candidate seed home is required" >&2; exit 2; }
+  python3 "$python_tool" path-preflight \
+    --output-root "$output" \
+    --protected-root "$baseline_seed_home" \
+    --protected-root "$candidate_seed_home" >/dev/null
 fi
-
-if $is_render; then
-  candidate_render=${candidate_render:-$repo_dir/target/release/examples/tui_render_perf}
-  [[ -x "$baseline_render" ]] || {
-    echo "tui-perf.sh: --baseline-render must be an executable for render_and_interaction" >&2
-    exit 2
-  }
-  [[ -x "$candidate_render" ]] || { echo "tui-perf.sh: candidate render harness not executable" >&2; exit 2; }
-else
+if ! $is_render; then
   command -v tmux >/dev/null || { echo "tui-perf.sh: tmux is required for real TUI runs" >&2; exit 2; }
-  [[ -x "$baseline_binary" ]] || { echo "tui-perf.sh: --baseline-binary is not executable" >&2; exit 2; }
-  [[ -x "$candidate_binary" ]] || { echo "tui-perf.sh: --candidate-binary is not executable" >&2; exit 2; }
-  [[ -x "$sampler" ]] || { echo "tui-perf.sh: sampler is not executable" >&2; exit 2; }
-  [[ -x "$controller" ]] || { echo "tui-perf.sh: controller is not executable" >&2; exit 2; }
-  if [[ "$requires_mpv" == true ]]; then
-    for seed_role in baseline candidate; do
-      if [[ "$seed_role" == baseline ]]; then
-        role_seed_home=$baseline_seed_home
-      else
-        role_seed_home=$candidate_seed_home
-      fi
-      [[ -d "$role_seed_home" ]] || {
-        echo "tui-perf.sh: playback scenarios require a $seed_role seed home" >&2
-        exit 2
-      }
-      for store in config data cache; do
-        [[ -d "$role_seed_home/stores/$store" ]] || {
-          echo "tui-perf.sh: $seed_role seed home must contain stores/$store" >&2
-          exit 2
-        }
-      done
-    done
-  fi
 fi
-
-command -v git >/dev/null || { echo "tui-perf.sh: git is required for source identity" >&2; exit 2; }
-if [[ -z "$baseline_source_root" ]]; then
-  if $is_render; then
-    baseline_source_root=$(git -C "$(dirname -- "$baseline_render")" rev-parse --show-toplevel 2>/dev/null) || {
-      echo "tui-perf.sh: cannot infer --baseline-source-root from $baseline_render" >&2
-      exit 2
-    }
-  else
-    baseline_source_root=$(git -C "$(dirname -- "$baseline_binary")" rev-parse --show-toplevel 2>/dev/null) || {
-      echo "tui-perf.sh: cannot infer --baseline-source-root from $baseline_binary" >&2
-      exit 2
-    }
-  fi
-fi
-[[ -d "$baseline_source_root" ]] || { echo "tui-perf.sh: baseline source root is not a directory" >&2; exit 2; }
-[[ -d "$candidate_source_root" ]] || { echo "tui-perf.sh: candidate source root is not a directory" >&2; exit 2; }
 
 mkdir -p "$output"
 output=$(cd "$output" && pwd)
+build_receipt="$output/build-receipt.json"
+build_args=(
+  build --scenarios "$scenarios" --scenario "$scenario"
+  --baseline-root "$baseline_source_root" --candidate-root "$candidate_source_root"
+  --output "$build_receipt"
+)
+build_target=$(mktemp -d "${TMPDIR:-/tmp}/ytt-perf-build.XXXXXX")
+rmdir "$build_target"
+build_args+=(--target-root "$build_target")
+if ! python3 "$python_tool" "${build_args[@]}" >/dev/null; then
+  [[ -z "$build_target" ]] || rm -rf -- "$build_target"
+  exit 2
+fi
+if [[ -n "$build_target" ]]; then
+  rm -rf -- "$build_target"
+fi
+
+receipt_field() {
+  python3 "$python_tool" receipt --receipt "$build_receipt" --artifact "$1" --field path
+}
+if $is_render; then
+  baseline_render=$(receipt_field baseline_render)
+  candidate_render=$(receipt_field candidate_render)
+else
+  baseline_binary=$(receipt_field baseline_ytt)
+  candidate_binary=$(receipt_field candidate_ytt)
+  sampler=$(receipt_field sampler)
+  controller=$(receipt_field controller)
+fi
+
+if [[ "$requires_mpv" == true ]]; then
+  python3 "$python_tool" seed-contract \
+    --scenarios "$scenarios" --scenario "$scenario" \
+    --baseline-root "$baseline_seed_home" --candidate-root "$candidate_seed_home" \
+    --snapshot "$output/seed-template" --output "$output/seed-contract.json" >/dev/null
+  baseline_seed_home="$output/seed-template"
+  candidate_seed_home="$output/seed-template"
+fi
+
 active_socket=""
+active_identity=""
 active_server_pid=""
+active_server_identity=""
+active_server_run_id=""
+socket_root=$(mktemp -d "${TMPDIR:-/tmp}/ytt-perf-tmux.XXXXXX")
+socket_counter=0
+
+cleanup_active_run() {
+  local cleanup_status=0
+  if [[ -n "$active_identity" ]]; then
+    if ! python3 "$python_tool" cleanup \
+      --identity "$active_identity" \
+      --timeout-secs 10; then
+      echo "tui-perf.sh: exact process cleanup/revalidation failed; refusing to kill the tmux server" >&2
+      cleanup_status=1
+    fi
+  fi
+  if [[ -n "$active_socket" ]] && tmux -S "$active_socket" has-session 2>/dev/null; then
+    if ((cleanup_status != 0)); then
+      return "$cleanup_status"
+    fi
+    if ! tmux -S "$active_socket" kill-server; then
+      echo "tui-perf.sh: failed to stop the isolated tmux server after exact process cleanup" >&2
+      cleanup_status=1
+    fi
+  fi
+  if ((cleanup_status == 0)); then
+    active_socket=""
+    active_identity=""
+  fi
+  return "$cleanup_status"
+}
+
+cleanup_server() {
+  [[ -n "$active_server_pid" ]] || return 0
+  if [[ -z "$active_server_identity" || -z "$active_server_run_id" ]]; then
+    echo "tui-perf.sh: fixture server has no exact shutdown identity; refusing to signal its numeric PID" >&2
+    return 1
+  fi
+  if ! python3 "$python_tool" stop-server \
+    --identity "$active_server_identity" \
+    --expected-run-id "$active_server_run_id" \
+    --timeout-secs 10 >/dev/null; then
+    echo "tui-perf.sh: exact authenticated fixture server shutdown failed; no PID signal was sent" >&2
+    return 1
+  fi
+  if ! wait "$active_server_pid"; then
+    echo "tui-perf.sh: fixture server exited unsuccessfully after exact shutdown" >&2
+    return 1
+  fi
+  active_server_pid=""
+  active_server_identity=""
+  active_server_run_id=""
+}
+
+server_child_is_running() {
+  local job_pid
+  while IFS= read -r job_pid; do
+    [[ "$job_pid" == "$active_server_pid" ]] && return 0
+  done <<<"$(jobs -pr)"
+  return 1
+}
+
+cleanup_on_exit() {
+  local exit_status=$?
+  local cleanup_status=0
+  trap - EXIT
+  # Once exact cleanup starts, a repeated terminal signal must not interrupt the
+  # terminate -> wait -> revalidate sequence and strand a measured descendant.
+  trap '' INT TERM
+  cleanup_active_run || cleanup_status=$?
+  if ! cleanup_server; then
+    cleanup_status=1
+  fi
+  if ((cleanup_status == 0)); then
+    rm -rf -- "$socket_root"
+  elif ((exit_status == 0)); then
+    exit_status=2
+  fi
+  exit "$exit_status"
+}
+
+trap cleanup_on_exit EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 fixture_file="$output/fixture/silence-${fixture_seconds}s.wav"
 if [[ "$requires_mpv" == true ]]; then
   mkdir -p "$(dirname "$fixture_file")"
@@ -187,41 +246,19 @@ manifest_args=(
   --scenarios "$scenarios"
   --scenario "$scenario"
   --output "$output/host-manifest.json"
-  --source-root "baseline=$baseline_source_root"
-  --source-root "candidate=$candidate_source_root"
-  --build-command "baseline=$baseline_build_command"
-  --build-command "candidate=$candidate_build_command"
+  --build-receipt "$build_receipt"
 )
-if $is_render; then
-  manifest_args+=(--binary "baseline_render=$baseline_render")
-  manifest_args+=(--binary "candidate_render=$candidate_render")
-else
-  manifest_args+=(--binary "baseline_ytt=$baseline_binary")
-  manifest_args+=(--binary "candidate_ytt=$candidate_binary")
-  manifest_args+=(--binary "sampler=$sampler")
-  manifest_args+=(--binary "controller=$controller")
-fi
 python3 "$python_tool" "${manifest_args[@]}" >/dev/null
-
-cleanup() {
-  if [[ -n "$active_socket" ]]; then
-    tmux -S "$active_socket" kill-server 2>/dev/null || true
-  fi
-  if [[ -n "$active_server_pid" ]]; then
-    kill "$active_server_pid" 2>/dev/null || true
-    wait "$active_server_pid" 2>/dev/null || true
-  fi
-}
-trap cleanup EXIT INT TERM
 
 json_array_to_csv() {
   python3 -c 'import json,sys; print(",".join(str(v) for v in json.loads(sys.argv[1])))' "$1"
 }
 
 run_render() {
-  local role=$1 binary=$2 run_dir=$3
+  local role=$1 binary=$2 run_dir=$3 run_id=$4
   mkdir -p "$run_dir"
   TUI_PERF_SCENARIO_SHA256="$scenario_hash" \
+  TUI_PERF_RUN_ID="$run_id" \
     "$binary" \
       --output "$run_dir/render.json" \
       --warmup "$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field warmup_draws)" \
@@ -230,7 +267,7 @@ run_render() {
 }
 
 run_process() {
-  local role=$1 binary=$2 run_root=$3 width=$4 height=$5 label=$6
+  local role=$1 binary=$2 run_root=$3 width=$4 height=$5 label=$6 run_id=$7
   local role_seed_home=$candidate_seed_home
   [[ "$role" == baseline ]] && role_seed_home=$baseline_seed_home
   local run_dir="$run_root"
@@ -245,7 +282,10 @@ run_process() {
   local cache_store="$home/stores/cache"
   local samples="$run_dir/samples.ndjson"
   local pid_file="$run_dir/ytt.pid"
-  local socket="$run_dir/tmux.sock"
+  local identity_file="$run_dir/process-identity.json"
+  local controller_ready_file="$run_dir/controller-ready.json"
+  ((socket_counter += 1))
+  local socket="$socket_root/s${socket_counter}.sock"
   mkdir -p "$home" "$runtime" "$tmp" "$config_store" "$data_store" "$cache_store"
   chmod 700 "$runtime"
   if [[ -n "$role_seed_home" ]]; then
@@ -253,15 +293,21 @@ run_process() {
   fi
   if [[ "$requires_mpv" == true ]]; then
     local ready_file="$run_dir/http-ready.json"
-    local throttle outage_every outage_ms disconnect_every fixture_url
+    local throttle outage_every outage_ms disconnect_every fixture_url shutdown_token
     rm -f -- "$ready_file"
     throttle=$(python3 "$python_tool" traffic --scenarios "$scenarios" --name "$traffic_profile" --field throttle_bps)
     outage_every=$(python3 "$python_tool" traffic --scenarios "$scenarios" --name "$traffic_profile" --field outage_every_bytes)
     outage_ms=$(python3 "$python_tool" traffic --scenarios "$scenarios" --name "$traffic_profile" --field outage_ms)
     disconnect_every=$(python3 "$python_tool" traffic --scenarios "$scenarios" --name "$traffic_profile" --field disconnect_every_bytes)
+    shutdown_token=$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')
+    active_server_identity=$ready_file
+    active_server_run_id=$run_id
     python3 "$python_tool" serve \
       --file "$fixture_file" \
       --ready-file "$ready_file" \
+      --request-log "$run_dir/http-requests.ndjson" \
+      --run-id "$run_id" \
+      "--shutdown-token=$shutdown_token" \
       --throttle-bps "$throttle" \
       --outage-every-bytes "$outage_every" \
       --outage-ms "$outage_ms" \
@@ -270,7 +316,13 @@ run_process() {
     active_server_pid=$!
     local server_deadline=$((SECONDS + 10))
     until [[ -s "$ready_file" ]]; do
-      if ((SECONDS >= server_deadline)) || ! kill -0 "$active_server_pid" 2>/dev/null; then
+      if ((SECONDS >= server_deadline)) || ! server_child_is_running; then
+        if ! server_child_is_running; then
+          wait "$active_server_pid" 2>/dev/null || true
+          active_server_pid=""
+          active_server_identity=""
+          active_server_run_id=""
+        fi
         echo "tui-perf.sh: fixture server failed for $label" >&2
         return 1
       fi
@@ -282,15 +334,21 @@ run_process() {
       --home "$home" \
       --fixture-url "$fixture_url" \
       --seed-label "$role" \
+      --input-snapshot "$run_dir/materialized-inputs" \
       --manifest "$run_dir/materialize.json" >/dev/null
   fi
+  python3 "$python_tool" launch-policy \
+    --root "$home" \
+    --output "$run_dir/launch-policy.json" >/dev/null
   local warmup sample interval require_arg=""
   warmup=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field warmup_s)
   sample=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field sample_s)
-  interval=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["sampling"]["interval_ms"])' "$scenarios")
+  interval=$(python3 "$python_tool" setting \
+    --scenarios "$scenarios" --field sampling.interval_ms)
   [[ "$requires_mpv" == true ]] && require_arg="--require-silent-mpv"
 
   local -a isolated_env=(
+    "PATH=$PATH"
     "HOME=$home"
     "XDG_CONFIG_HOME=$home/.config"
     "XDG_DATA_HOME=$home/.local/share"
@@ -305,15 +363,19 @@ run_process() {
     "TMP=$tmp"
     "TERM=xterm-256color"
     "YTM_MPV_EXTRA=--ao=null --volume=0 --audio-display=no"
-    "YTM_PERF=1"
     "TUI_PERF_SCENARIO_SHA256=$scenario_hash"
+    "TUI_PERF_RUN_ID=$run_id"
   )
+  [[ -n "${LANG:-}" ]] && isolated_env+=("LANG=$LANG")
+  [[ -n "${LC_ALL:-}" ]] && isolated_env+=("LC_ALL=$LC_ALL")
+  [[ -n "${LC_CTYPE:-}" ]] && isolated_env+=("LC_CTYPE=$LC_CTYPE")
   mkdir -p "$home/.config" "$home/.local/share" "$home/.cache" "$home/.local/state"
 
   local -a sampler_cmd=(
-    env "${isolated_env[@]}" "$sampler"
+    env -i "${isolated_env[@]}" "$sampler"
     --output "$samples"
     --pid-file "$pid_file"
+    --identity-file "$identity_file"
     --binary "$binary"
     --warmup-secs "$warmup"
     --duration-secs "$sample"
@@ -327,11 +389,14 @@ run_process() {
   # every other profile/runtime path is isolated above, so this cannot address the user's ytt.
   if [[ "$controller_enabled" != true ]]; then
     sampler_cmd+=(-- --new-instance)
+  else
+    sampler_cmd+=(--controller-ready-file "$controller_ready_file")
   fi
   local shell_command
   printf -v shell_command '%q ' "${sampler_cmd[@]}"
-  rm -f -- "$pid_file"
+  rm -f -- "$pid_file" "$identity_file" "$controller_ready_file"
   active_socket=$socket
+  active_identity=$identity_file
   tmux -S "$socket" new-session -d -x "$width" -y "$height" "$shell_command"
 
   local ready_deadline=$((SECONDS + 30))
@@ -351,8 +416,9 @@ run_process() {
     pause_policy=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field pause_policy)
     pause_hold_ms=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field pause_hold_ms)
     local -a control_cmd=(
-      env "${isolated_env[@]}" "$controller"
+      env -i "${isolated_env[@]}" "$controller"
       --output "$run_dir/control.ndjson"
+      --ready-file "$controller_ready_file"
       --wait-secs 45
       --observe-secs "$(python3 -c 'import sys; print(float(sys.argv[1])+float(sys.argv[2]))' "$warmup" "$sample")"
       --close-grace-secs 15
@@ -377,7 +443,7 @@ run_process() {
     fi
     sleep 1
   done
-  active_socket=""
+  cleanup_active_run
   local -a check_args=(
     check --samples "$samples" --scenario-sha256 "$scenario_hash"
   )
@@ -387,22 +453,46 @@ run_process() {
   fi
   python3 "$python_tool" "${check_args[@]}" >/dev/null
   if [[ -n "$active_server_pid" ]]; then
-    kill "$active_server_pid" 2>/dev/null || true
-    wait "$active_server_pid" 2>/dev/null || true
-    active_server_pid=""
+    cleanup_server
   fi
 }
 
 run_process_geometries() {
-  local role=$1 binary=$2 run_root=$3 label=$4
-  local geometry_index width height
+  local role=$1 binary=$2 run_root=$3 label=$4 kind=$5 run_index=$6 root_run_id=$7
+  local geometry_index width height geometry_dir geometry_run_id
   for ((geometry_index=0; geometry_index<geometry_count; geometry_index++)); do
     width=$(python3 "$python_tool" scenario \
       --scenarios "$scenarios" --id "$scenario" --field "geometry.$geometry_index.0")
     height=$(python3 "$python_tool" scenario \
       --scenarios "$scenarios" --id "$scenario" --field "geometry.$geometry_index.1")
+    geometry_dir="$run_root"
+    geometry_run_id=$root_run_id
+    if ((geometry_count > 1)); then
+      geometry_dir="$run_root/geometry-${width}x${height}"
+      local -a geometry_start_args=(
+        run-start
+        --scenarios "$scenarios"
+        --scenario "$scenario"
+        --output "$geometry_dir/run-contract.json"
+        --kind "$kind"
+        --role "$role"
+        --geometry-index "$geometry_index"
+        --width "$width"
+        --height "$height"
+      )
+      if [[ "$kind" == paired ]]; then
+        geometry_start_args+=(--pair-index "$run_index")
+      else
+        geometry_start_args+=(--repeat-index "$run_index")
+      fi
+      geometry_run_id=$(python3 "$python_tool" "${geometry_start_args[@]}")
+    fi
     run_process "$role" "$binary" "$run_root" "$width" "$height" \
-      "$label geometry ${width}x${height}"
+      "$label geometry ${width}x${height}" "$geometry_run_id"
+    if ((geometry_count > 1)); then
+      python3 "$python_tool" run-finish \
+        --contract "$geometry_dir/run-contract.json" >/dev/null
+    fi
   done
 }
 
@@ -415,13 +505,26 @@ for ((pair=1; pair<=pairs; pair++)); do
     order=(candidate baseline)
   fi
   for role in "${order[@]}"; do
+    run_root="$output/pair-$(printf '%02d' "$pair")/$role"
+    run_id=""
+    root_contract=false
+    if $is_render || ((geometry_count == 1)); then
+      root_contract=true
+      run_id=$(python3 "$python_tool" run-start \
+        --scenarios "$scenarios" --scenario "$scenario" \
+        --output "$run_root/run-contract.json" \
+        --kind paired --role "$role" --pair-index "$pair")
+    fi
     if $is_render; then
       [[ "$role" == baseline ]] && binary=$baseline_render || binary=$candidate_render
-      run_render "$role" "$binary" "$output/pair-$(printf '%02d' "$pair")/$role"
+      run_render "$role" "$binary" "$run_root" "$run_id"
     else
       [[ "$role" == baseline ]] && binary=$baseline_binary || binary=$candidate_binary
       run_process_geometries "$role" "$binary" \
-        "$output/pair-$(printf '%02d' "$pair")/$role" "$role pair $pair"
+        "$run_root" "$role pair $pair" paired "$pair" "$run_id"
+    fi
+    if $root_contract; then
+      python3 "$python_tool" run-finish --contract "$run_root/run-contract.json" >/dev/null
     fi
   done
   baseline_runs+=(--baseline-run "$output/pair-$(printf '%02d' "$pair")/baseline")
@@ -431,11 +534,23 @@ done
 candidate_repeat_runs=()
 for ((repeat=1; repeat<=candidate_repeats; repeat++)); do
   repeat_dir="$output/candidate-repeat-$(printf '%02d' "$repeat")"
+  run_id=""
+  root_contract=false
+  if $is_render || ((geometry_count == 1)); then
+    root_contract=true
+    run_id=$(python3 "$python_tool" run-start \
+      --scenarios "$scenarios" --scenario "$scenario" \
+      --output "$repeat_dir/run-contract.json" \
+      --kind candidate_repeat --role candidate --repeat-index "$repeat")
+  fi
   if $is_render; then
-    run_render candidate "$candidate_render" "$repeat_dir"
+    run_render candidate "$candidate_render" "$repeat_dir" "$run_id"
   else
     run_process_geometries candidate "$candidate_binary" "$repeat_dir" \
-      "candidate diagnostic repeat $repeat"
+      "candidate diagnostic repeat $repeat" candidate_repeat "$repeat" "$run_id"
+  fi
+  if $root_contract; then
+    python3 "$python_tool" run-finish --contract "$repeat_dir/run-contract.json" >/dev/null
   fi
   candidate_repeat_runs+=(--candidate-repeat-run "$repeat_dir")
 done
@@ -459,7 +574,8 @@ compare_args+=(
 )
 compare_status=0
 python3 "$python_tool" "${compare_args[@]}" || compare_status=$?
-python3 "$python_tool" checksums \
+python3 "$python_tool" create-checksums \
   --root "$output" \
   --output "$output/SHA256SUMS" >/dev/null
+echo "Transport verification: python3 $python_tool verify-checksums --root $output --output $output/SHA256SUMS"
 exit "$compare_status"

--- a/src/app/ai_reducer.rs
+++ b/src/app/ai_reducer.rs
@@ -251,6 +251,7 @@ impl App {
             let overflow = self.ai.messages.len() - AI_HISTORY_MAX;
             self.ai.messages.drain(0..overflow);
         }
+        self.ai.transcript_revision = self.ai.transcript_revision.wrapping_add(1);
         self.bridges.ai_transcript_scroll.scroll_to_end();
     }
 

--- a/src/app/artwork.rs
+++ b/src/app/artwork.rs
@@ -87,7 +87,7 @@ impl App {
     /// themselves (retro ASCII art) instead of through the terminal-graphics protocol.
     pub fn art_source_image(&self) -> Option<(&str, &DynamicImage)> {
         match (self.art.video_id.as_deref(), self.art.source.as_ref()) {
-            (Some(id), Some(img)) => Some((id, img)),
+            (Some(id), Some(img)) => Some((id, img.as_ref())),
             _ => None,
         }
     }
@@ -300,26 +300,70 @@ impl App {
 
     pub fn reset_animation_cadence(&mut self) {
         self.anim.anim_draw_credit = 0;
+        self.anim.anim_last_tick_fps = 0;
         self.anim.anim_last_draw_fps = 0;
     }
 
-    pub(in crate::app) fn advance_animation(&mut self) {
-        self.anim.anim_frame = self.anim.anim_frame.wrapping_add(1);
-
+    /// Logical ticks required for the next draw under the historical per-tick credit scheduler.
+    /// The runtime multiplies this by the same integer logical-tick period as `origin/main`, which
+    /// preserves both visible frame numbers and their original (possibly uneven) due times.
+    pub(crate) fn animation_ticks_until_next_draw(&self) -> u64 {
         let tick_fps = self.animation_tick_fps().max(1);
         let draw_fps = self.animation_draw_fps().clamp(1, tick_fps);
-        if self.anim.anim_last_draw_fps != draw_fps {
+        let credit = if self.anim.anim_last_tick_fps == tick_fps
+            && self.anim.anim_last_draw_fps == draw_fps
+        {
+            self.anim.anim_draw_credit
+        } else {
+            0
+        };
+        u64::from(tick_fps - credit).div_ceil(u64::from(draw_fps))
+    }
+
+    /// From all logical ticks whose legacy deadlines have elapsed, return the prefix ending on the
+    /// newest tick that would actually have dirtied the screen. This is the delayed-wake seam: one
+    /// reducer turn catches up to the exact buffer visible at that wall-clock checkpoint, while a
+    /// trailing non-draw logical tick is left for the next variable deadline.
+    pub(crate) fn animation_ticks_through_latest_draw(&self, available_ticks: u64) -> u64 {
+        let tick_fps = self.animation_tick_fps().max(1);
+        let draw_fps = self.animation_draw_fps().clamp(1, tick_fps);
+        let credit = if self.anim.anim_last_tick_fps == tick_fps
+            && self.anim.anim_last_draw_fps == draw_fps
+        {
+            self.anim.anim_draw_credit
+        } else {
+            0
+        };
+        let total_credit =
+            u128::from(credit).saturating_add(u128::from(available_ticks) * u128::from(draw_fps));
+        let draws_due = total_credit / u128::from(tick_fps);
+        if draws_due == 0 {
+            return 0;
+        }
+        let latest_draw_credit = draws_due * u128::from(tick_fps);
+        let ticks = (latest_draw_credit - u128::from(credit)).div_ceil(u128::from(draw_fps));
+        u64::try_from(ticks).unwrap_or(u64::MAX)
+    }
+
+    /// Apply batched legacy logical ticks. `logical_ticks` normally ends exactly on a draw-due
+    /// frame (as selected by [`Self::animation_ticks_through_latest_draw`]); applying the credit
+    /// in one multiplication is equivalent to running the old reducer once per logical tick.
+    pub(in crate::app) fn advance_animation(&mut self, logical_ticks: u64) {
+        let tick_fps = self.animation_tick_fps().max(1);
+        let draw_fps = self.animation_draw_fps().clamp(1, tick_fps);
+        if self.anim.anim_last_tick_fps != tick_fps || self.anim.anim_last_draw_fps != draw_fps {
+            self.anim.anim_last_tick_fps = tick_fps;
             self.anim.anim_last_draw_fps = draw_fps;
             self.anim.anim_draw_credit = 0;
         }
-        if draw_fps >= tick_fps {
-            self.dirty = true;
-            return;
-        }
 
-        self.anim.anim_draw_credit = self.anim.anim_draw_credit.saturating_add(draw_fps);
-        if self.anim.anim_draw_credit >= tick_fps {
-            self.anim.anim_draw_credit -= tick_fps;
+        let total_credit = u128::from(self.anim.anim_draw_credit)
+            .saturating_add(u128::from(logical_ticks) * u128::from(draw_fps));
+        self.anim.anim_frame = self.anim.anim_frame.wrapping_add(logical_ticks);
+        self.anim.anim_draw_credit = (total_credit % u128::from(tick_fps))
+            .try_into()
+            .unwrap_or(0);
+        if total_credit >= u128::from(tick_fps) {
             self.dirty = true;
         }
     }
@@ -676,11 +720,12 @@ impl App {
     pub(in crate::app) fn set_artwork(&mut self, video_id: String, image: Option<DynamicImage>) {
         match (image, self.art.picker.as_ref()) {
             (Some(img), Some(picker)) if self.art.resize_tx.is_some() => {
+                let img = Arc::new(img);
                 self.art.dims = (img.width(), img.height());
                 let tx = self.art.resize_tx.as_ref().expect("checked above").clone();
                 *self.art.protocol.borrow_mut() = Some(ThreadProtocol::new(
                     tx,
-                    Some(picker.new_resize_protocol(img.clone())),
+                    Some(picker.new_resize_protocol_shared(Arc::clone(&img))),
                 ));
                 self.art.source = Some(img);
                 self.art.video_id = Some(video_id);

--- a/src/app/artwork.rs
+++ b/src/app/artwork.rs
@@ -300,70 +300,26 @@ impl App {
 
     pub fn reset_animation_cadence(&mut self) {
         self.anim.anim_draw_credit = 0;
-        self.anim.anim_last_tick_fps = 0;
         self.anim.anim_last_draw_fps = 0;
     }
 
-    /// Logical ticks required for the next draw under the historical per-tick credit scheduler.
-    /// The runtime multiplies this by the same integer logical-tick period as `origin/main`, which
-    /// preserves both visible frame numbers and their original (possibly uneven) due times.
-    pub(crate) fn animation_ticks_until_next_draw(&self) -> u64 {
-        let tick_fps = self.animation_tick_fps().max(1);
-        let draw_fps = self.animation_draw_fps().clamp(1, tick_fps);
-        let credit = if self.anim.anim_last_tick_fps == tick_fps
-            && self.anim.anim_last_draw_fps == draw_fps
-        {
-            self.anim.anim_draw_credit
-        } else {
-            0
-        };
-        u64::from(tick_fps - credit).div_ceil(u64::from(draw_fps))
-    }
+    pub(in crate::app) fn advance_animation(&mut self) {
+        self.anim.anim_frame = self.anim.anim_frame.wrapping_add(1);
 
-    /// From all logical ticks whose legacy deadlines have elapsed, return the prefix ending on the
-    /// newest tick that would actually have dirtied the screen. This is the delayed-wake seam: one
-    /// reducer turn catches up to the exact buffer visible at that wall-clock checkpoint, while a
-    /// trailing non-draw logical tick is left for the next variable deadline.
-    pub(crate) fn animation_ticks_through_latest_draw(&self, available_ticks: u64) -> u64 {
         let tick_fps = self.animation_tick_fps().max(1);
         let draw_fps = self.animation_draw_fps().clamp(1, tick_fps);
-        let credit = if self.anim.anim_last_tick_fps == tick_fps
-            && self.anim.anim_last_draw_fps == draw_fps
-        {
-            self.anim.anim_draw_credit
-        } else {
-            0
-        };
-        let total_credit =
-            u128::from(credit).saturating_add(u128::from(available_ticks) * u128::from(draw_fps));
-        let draws_due = total_credit / u128::from(tick_fps);
-        if draws_due == 0 {
-            return 0;
-        }
-        let latest_draw_credit = draws_due * u128::from(tick_fps);
-        let ticks = (latest_draw_credit - u128::from(credit)).div_ceil(u128::from(draw_fps));
-        u64::try_from(ticks).unwrap_or(u64::MAX)
-    }
-
-    /// Apply batched legacy logical ticks. `logical_ticks` normally ends exactly on a draw-due
-    /// frame (as selected by [`Self::animation_ticks_through_latest_draw`]); applying the credit
-    /// in one multiplication is equivalent to running the old reducer once per logical tick.
-    pub(in crate::app) fn advance_animation(&mut self, logical_ticks: u64) {
-        let tick_fps = self.animation_tick_fps().max(1);
-        let draw_fps = self.animation_draw_fps().clamp(1, tick_fps);
-        if self.anim.anim_last_tick_fps != tick_fps || self.anim.anim_last_draw_fps != draw_fps {
-            self.anim.anim_last_tick_fps = tick_fps;
+        if self.anim.anim_last_draw_fps != draw_fps {
             self.anim.anim_last_draw_fps = draw_fps;
             self.anim.anim_draw_credit = 0;
         }
+        if draw_fps >= tick_fps {
+            self.dirty = true;
+            return;
+        }
 
-        let total_credit = u128::from(self.anim.anim_draw_credit)
-            .saturating_add(u128::from(logical_ticks) * u128::from(draw_fps));
-        self.anim.anim_frame = self.anim.anim_frame.wrapping_add(logical_ticks);
-        self.anim.anim_draw_credit = (total_credit % u128::from(tick_fps))
-            .try_into()
-            .unwrap_or(0);
-        if total_credit >= u128::from(tick_fps) {
+        self.anim.anim_draw_credit = self.anim.anim_draw_credit.saturating_add(draw_fps);
+        if self.anim.anim_draw_credit >= tick_fps {
+            self.anim.anim_draw_credit -= tick_fps;
             self.dirty = true;
         }
     }

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -42,6 +42,8 @@ impl App {
                 available: false,
                 model: GeminiModel::default(),
                 messages: Vec::new(),
+                transcript_revision: 0,
+                transcript_cache_token: Arc::new(()),
                 input: String::new(),
                 select_all: false,
                 thinking: false,

--- a/src/app/library_reducer.rs
+++ b/src/app/library_reducer.rs
@@ -19,12 +19,28 @@ impl App {
     /// resolves to exactly one row; see [`Self::rows_from_slots`]). Called on every library
     /// nav key and wheel-scroll, so this must stay O(1) on a cache hit rather than rebuilding
     /// and throwing away a full row vector just to read its length.
-    fn library_rows_len(&self) -> usize {
+    pub(crate) fn library_rows_len(&self) -> usize {
         let tab = self.effective_library_tab();
-        // Playlist drill-down rows are built uncached (an open playlist is small); count them
-        // the same way `library_rows` builds them, so the two never disagree.
+        // Playlist drill-down rows are built uncached because the playlist store has no cheap
+        // revision key. Count directly so rendering does not first allocate a full `Vec<&Song>`.
         if matches!(tab, LibraryTab::Playlists) {
-            return self.apply_library_filter(self.open_playlist_rows()).len();
+            let Some(playlist) = self
+                .library_ui
+                .open_playlist
+                .as_ref()
+                .and_then(|key| self.playlists.find(key))
+            else {
+                return 0;
+            };
+            let needle = self.library_ui.filter_query.trim().to_lowercase();
+            if needle.is_empty() {
+                return playlist.songs.len();
+            }
+            return playlist
+                .songs
+                .iter()
+                .filter(|song| self.song_matches_filter(song, &needle))
+                .count();
         }
         let key = self.library_rows_key(tab);
         if let Some(cache) = self.library_rows_cache.borrow().as_ref()
@@ -38,6 +54,64 @@ impl App {
         let n = slots.len();
         *self.library_rows_cache.borrow_mut() = Some(LibraryRowsCache { key, slots });
         n
+    }
+
+    /// Resolve one visible window of already-filtered library rows for rendering.
+    ///
+    /// Non-playlist tabs slice the cached `RowSlot` vector. An opened playlist scans its
+    /// source at most once through the requested window instead of restarting a filtered
+    /// `.nth(index)` search for every visible row. `Option` preserves the old behavior for a
+    /// hypothetically stale cached slot: that logical row remains blank rather than shifting
+    /// every following row and its mouse target upward.
+    pub(crate) fn library_render_window(&self, start: usize, visible: usize) -> Vec<Option<&Song>> {
+        if visible == 0 {
+            return Vec::new();
+        }
+        let tab = self.effective_library_tab();
+        if matches!(tab, LibraryTab::Playlists) {
+            let Some(playlist) = self
+                .library_ui
+                .open_playlist
+                .as_ref()
+                .and_then(|key| self.playlists.find(key))
+            else {
+                return Vec::new();
+            };
+            let needle = self.library_ui.filter_query.trim().to_lowercase();
+            if needle.is_empty() {
+                return playlist
+                    .songs
+                    .iter()
+                    .skip(start)
+                    .take(visible)
+                    .map(Some)
+                    .collect();
+            }
+            return playlist
+                .songs
+                .iter()
+                .filter(|song| self.song_matches_filter(song, &needle))
+                .skip(start)
+                .take(visible)
+                .map(Some)
+                .collect();
+        }
+
+        // Populate or refresh the slot cache on a miss. `library_rows_len` does not allocate
+        // the resolved row vector and leaves the cache ready for the window lookup below.
+        self.library_rows_len();
+        let cache = self.library_rows_cache.borrow();
+        let Some(cache) = cache.as_ref() else {
+            return Vec::new();
+        };
+        cache
+            .slots
+            .iter()
+            .skip(start)
+            .take(visible)
+            .copied()
+            .map(|slot| self.resolve_row_slot(slot))
+            .collect()
     }
 
     pub fn library_count_for(&self, tab: LibraryTab) -> usize {
@@ -138,18 +212,20 @@ impl App {
     fn rows_from_slots(&self, slots: &[RowSlot]) -> Vec<&Song> {
         slots
             .iter()
-            .filter_map(|slot| {
-                let song = match *slot {
-                    RowSlot::Fav(i) => self.library.favorites.get(i as usize),
-                    RowSlot::Hist(i) => self.library.history.get(i as usize),
-                    RowSlot::RadioFav(i) => self.library.radio_favorites.get(i as usize),
-                    RowSlot::RadioRecent(i) => self.library.radios.get(i as usize),
-                    RowSlot::Down(i) => self.library_ui.downloaded.get(i as usize),
-                };
-                debug_assert!(song.is_some(), "stale library row slot {slot:?}");
-                song
-            })
+            .filter_map(|slot| self.resolve_row_slot(*slot))
             .collect()
+    }
+
+    fn resolve_row_slot(&self, slot: RowSlot) -> Option<&Song> {
+        let song = match slot {
+            RowSlot::Fav(i) => self.library.favorites.get(i as usize),
+            RowSlot::Hist(i) => self.library.history.get(i as usize),
+            RowSlot::RadioFav(i) => self.library.radio_favorites.get(i as usize),
+            RowSlot::RadioRecent(i) => self.library.radios.get(i as usize),
+            RowSlot::Down(i) => self.library_ui.downloaded.get(i as usize),
+        };
+        debug_assert!(song.is_some(), "stale library row slot {slot:?}");
+        song
     }
 
     /// The uncached row computation: per-tab source selection (+ the All-tab dedup),
@@ -244,13 +320,7 @@ impl App {
         let needle = self.library_ui.filter_query.trim().to_lowercase();
         if !needle.is_empty() {
             let matches = |slot: &RowSlot| -> bool {
-                let song = match *slot {
-                    RowSlot::Fav(i) => self.library.favorites.get(i as usize),
-                    RowSlot::Hist(i) => self.library.history.get(i as usize),
-                    RowSlot::RadioFav(i) => self.library.radio_favorites.get(i as usize),
-                    RowSlot::RadioRecent(i) => self.library.radios.get(i as usize),
-                    RowSlot::Down(i) => self.library_ui.downloaded.get(i as usize),
-                };
+                let song = self.resolve_row_slot(*slot);
                 song.is_some_and(|s| self.song_matches_filter(s, &needle))
             };
             slots.retain(matches);

--- a/src/app/local.rs
+++ b/src/app/local.rs
@@ -4,8 +4,14 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use super::local_format::*;
+
+mod import_fingerprint;
+mod rows_cache;
+
 use super::*;
 use crate::util::query::{MAX_FILTER_QUERY_BYTES, try_push_query_char};
+pub(in crate::app) use import_fingerprint::LocalImportFilesFingerprintCache;
+pub(in crate::app) use rows_cache::{LocalRowsCache, LocalRowsData};
 
 impl App {
     pub(in crate::app) fn request_local_mode_switch(&mut self) -> Vec<Cmd> {
@@ -97,7 +103,7 @@ impl App {
     }
 
     pub fn local_rows_len(&self) -> usize {
-        self.local_visible_rows().len()
+        self.local_rows_snapshot().rows().len()
     }
 
     pub(in crate::app) fn on_key_local(&mut self, k: KeyEvent) -> Vec<Cmd> {
@@ -366,8 +372,8 @@ impl App {
     fn local_download_visible(&mut self) -> Vec<Cmd> {
         let songs = self
             .local_visible_rows()
-            .into_iter()
-            .flat_map(|row| self.local_downloadable_songs_for_row(&row))
+            .iter()
+            .flat_map(|row| self.local_downloadable_songs_for_row(row))
             .collect();
         self.open_confirm_download(songs)
     }
@@ -401,6 +407,7 @@ impl App {
                 self.local_mode.index.progress = None;
                 self.local_mode.index.load_errors = warnings;
                 self.local_mode.index.errors.clear();
+                self.invalidate_local_rows();
                 self.clamp_local_after_index_change();
                 self.dirty = true;
                 if !self.local_mode.index.load_errors.is_empty() {
@@ -426,6 +433,7 @@ impl App {
                 self.local_mode.index.progress = None;
                 self.local_mode.index.last_summary = Some(result.summary.clone());
                 self.local_mode.index.errors = result.errors;
+                self.invalidate_local_rows();
                 self.clamp_local_after_index_change();
                 self.status.kind = if self.local_mode.index.errors.is_empty() {
                     StatusKind::Info
@@ -467,13 +475,22 @@ impl App {
                 action,
                 result,
                 elapsed_ms: _,
-            } => self.apply_local_import_review_finished(op_id, session_id, action, result),
+            } => {
+                let cmds =
+                    self.apply_local_import_review_finished(op_id, session_id, action, result);
+                self.invalidate_local_rows();
+                cmds
+            }
             LocalMsg::ImportReviewAcceptAllFinished {
                 op_id,
                 session_id,
                 result,
                 elapsed_ms: _,
-            } => self.apply_local_import_accept_all_finished(op_id, session_id, result),
+            } => {
+                let cmds = self.apply_local_import_accept_all_finished(op_id, session_id, result);
+                self.invalidate_local_rows();
+                cmds
+            }
         }
     }
 
@@ -514,6 +531,7 @@ impl App {
         self.local_mode.index.scanning = true;
         self.local_mode.index.progress = Some(crate::local::LocalScanProgress::default());
         self.local_mode.index.errors.clear();
+        self.invalidate_local_rows();
         self.status.kind = StatusKind::Info;
         self.status.text = t!("Scanning local music...", "로컬 음악 스캔 중...").to_owned();
         self.dirty = true;
@@ -626,12 +644,11 @@ impl App {
         self.request_local_mode_switch()
     }
 
-    pub(crate) fn local_visible_rows(&self) -> Vec<crate::local::LocalRowId> {
-        self.local_rows_for_query(self.local_mode.ui.filter_query.as_str())
-    }
-
-    pub(crate) fn local_total_rows_len(&self) -> usize {
-        self.local_rows_for_query("").len()
+    fn invalidate_local_rows(&self) {
+        self.local_mode
+            .rows_revision
+            .set(self.local_mode.rows_revision.get().wrapping_add(1));
+        self.local_mode.rows_cache.borrow_mut().take();
     }
 
     pub(crate) fn local_scan_progress_text(&self) -> Option<String> {
@@ -658,6 +675,39 @@ impl App {
             LocalSection::ImportSessions => self.local_import_session_rows_for_query(query),
             LocalSection::Inbox => self.local_inbox_rows_for_query(query),
         }
+    }
+
+    fn local_smart_track_count(
+        &self,
+        smart: crate::local::LocalSmartList,
+        download_dir: &Path,
+    ) -> usize {
+        self.local_mode
+            .index
+            .index
+            .tracks()
+            .iter()
+            .filter(|track| match smart {
+                crate::local::LocalSmartList::RecentlyAdded => true,
+                crate::local::LocalSmartList::DownloadedFromYoutubeMusic => {
+                    track.linked_video_id.is_some() || track.path.starts_with(download_dir)
+                }
+                crate::local::LocalSmartList::LocalOnly => track.linked_video_id.is_none(),
+                crate::local::LocalSmartList::MissingArtist => track.artist.is_empty(),
+                crate::local::LocalSmartList::MissingAlbum => track
+                    .album
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|album| !album.is_empty())
+                    .is_none(),
+                crate::local::LocalSmartList::NoEmbeddedCover => track.embedded_art_key.is_none(),
+                crate::local::LocalSmartList::LargeFiles => track.file_size >= 50 * 1024 * 1024,
+                crate::local::LocalSmartList::Lossless => matches!(
+                    track.format,
+                    Some(crate::local::AudioFormat::Flac | crate::local::AudioFormat::Wav)
+                ),
+            })
+            .count()
     }
 
     fn local_drill_rows(&self, drill: &LocalDrill, query: &str) -> Vec<crate::local::LocalRowId> {
@@ -1047,114 +1097,6 @@ impl App {
             LocalDrill::Smart(smart) => smart.label().to_owned(),
             LocalDrill::ImportSession(session_id) => session_id.clone(),
         }
-    }
-
-    pub(crate) fn local_row_text(&self, row: &crate::local::LocalRowId) -> String {
-        match row {
-            crate::local::LocalRowId::Track(id) => self
-                .local_track_by_id(id)
-                .map(|track| local_track_text(self, track))
-                .unwrap_or_else(|| t!("Missing track", "없는 곡").to_owned()),
-            crate::local::LocalRowId::DownloadSeed(index) => self
-                .library_ui
-                .downloaded
-                .get(*index)
-                .map(|song| local_song_text(self, song))
-                .unwrap_or_else(|| t!("Missing track", "없는 곡").to_owned()),
-            crate::local::LocalRowId::Album(id) => self
-                .local_album_by_id(id)
-                .map(|album| {
-                    let duration = album.duration_ms.map(format_local_duration_ms);
-                    let year = album.year.map(|year| year.to_string()).unwrap_or_default();
-                    let suffix = match (year.is_empty(), duration) {
-                        (false, Some(duration)) => format!("  {year} - {duration}"),
-                        (false, None) => format!("  {year}"),
-                        (true, Some(duration)) => format!("  {duration}"),
-                        (true, None) => String::new(),
-                    };
-                    format!(
-                        "{} - {}  ({} {}){}",
-                        album.title,
-                        album.album_artist,
-                        album.track_count,
-                        t!("tracks", "곡"),
-                        suffix
-                    )
-                })
-                .unwrap_or_else(|| t!("Missing album", "없는 앨범").to_owned()),
-            crate::local::LocalRowId::Artist(id) => self
-                .local_artist_by_id(id)
-                .map(|artist| {
-                    format!(
-                        "{}  ({} {}, {} {})",
-                        artist.name,
-                        artist.album_ids.len(),
-                        t!("albums", "앨범"),
-                        artist.track_ids.len(),
-                        t!("tracks", "곡")
-                    )
-                })
-                .unwrap_or_else(|| t!("Missing artist", "없는 아티스트").to_owned()),
-            crate::local::LocalRowId::Genre(genre) => {
-                let count = self.local_tracks_for_genre(genre).len();
-                format!("{genre}  ({count} {})", t!("tracks", "곡"))
-            }
-            crate::local::LocalRowId::Folder(folder) => {
-                let count = self.local_tracks_for_folder(folder).len();
-                format!("{}  ({count} {})", folder.display(), t!("tracks", "곡"))
-            }
-            crate::local::LocalRowId::Smart(smart) => {
-                let count = self.local_tracks_for_smart(*smart).len();
-                format!("{}  ({count} {})", smart.label(), t!("tracks", "곡"))
-            }
-            crate::local::LocalRowId::ImportSession(session_id) => local_import_session_text(
-                session_id,
-                self.local_tracks_for_import_session(session_id).len(),
-            ),
-            crate::local::LocalRowId::ImportSessionRow {
-                session_id,
-                source_order,
-            } => self.local_import_session_row_text(session_id, *source_order),
-            crate::local::LocalRowId::ScanError(index) => self
-                .local_scan_issue(*index)
-                .map(|error| format!("{} - {}", error.path.display(), error.message))
-                .unwrap_or_else(|| t!("Missing scan error", "없는 스캔 오류").to_owned()),
-        }
-    }
-
-    pub(crate) fn local_details_lines(&self) -> Vec<String> {
-        let mut lines = Vec::new();
-        lines.push(t!("Selected", "선택").to_owned());
-        let selected = self
-            .local_visible_rows()
-            .get(self.local_mode.ui.selected)
-            .cloned();
-        if let Some(row) = selected {
-            self.push_local_row_details(&mut lines, &row);
-        } else {
-            lines.push(t!("No local item selected.", "선택된 로컬 항목이 없습니다.").to_owned());
-        }
-
-        lines.push(String::new());
-        self.push_local_queue_details(&mut lines);
-        lines
-    }
-
-    pub(crate) fn local_details_summary(&self) -> String {
-        let selected = self
-            .local_visible_rows()
-            .get(self.local_mode.ui.selected)
-            .map(|row| self.local_row_text(row))
-            .unwrap_or_else(|| t!("No selection", "선택 없음").to_owned());
-        let Some(current) = self.queue.current() else {
-            return format!("{}: {selected}", t!("Selected", "선택"));
-        };
-        format!(
-            "{}: {selected}  |  {}: {}",
-            t!("Selected", "선택"),
-            t!("Now", "재생 중"),
-            local_song_text(self, current)
-        )
     }
 
     fn push_local_row_details(&self, lines: &mut Vec<String>, row: &crate::local::LocalRowId) {

--- a/src/app/local.rs
+++ b/src/app/local.rs
@@ -11,6 +11,10 @@ mod rows_cache;
 use super::*;
 use crate::util::query::{MAX_FILTER_QUERY_BYTES, try_push_query_char};
 pub(in crate::app) use import_fingerprint::LocalImportFilesFingerprintCache;
+#[cfg(test)]
+pub(in crate::app) use import_fingerprint::{
+    local_import_files_fingerprint_for_test, stable_import_cache_key_for_test,
+};
 pub(in crate::app) use rows_cache::{LocalRowsCache, LocalRowsData};
 
 impl App {

--- a/src/app/local/import_fingerprint.rs
+++ b/src/app/local/import_fingerprint.rs
@@ -1,0 +1,493 @@
+//! Bounded filesystem fingerprints for Local Deck import artifacts.
+
+use std::collections::{HashMap, hash_map::DefaultHasher};
+use std::hash::{Hash, Hasher};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+/// Enough for hundreds of import sessions while keeping retained path/signature state below a
+/// small, fixed ceiling even if the transfers directory is unexpectedly large.
+const LOCAL_IMPORT_CONTENT_CACHE_CAP: usize = 4096;
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+enum ImportModifiedTimeSignature {
+    SinceEpoch { secs: u64, nanos: u32 },
+    BeforeEpoch { secs: u64, nanos: u32 },
+    Unavailable(std::io::ErrorKind),
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+struct ImportPlatformMetadataSignature {
+    device: u64,
+    inode: u64,
+    mode: u32,
+    links: u64,
+    changed_secs: i64,
+    changed_nanos: i64,
+}
+
+#[cfg(windows)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+struct ImportPlatformMetadataSignature {
+    attributes: u32,
+    creation_time: u64,
+    last_write_time: u64,
+}
+
+#[cfg(not(any(unix, windows)))]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+struct ImportPlatformMetadataSignature;
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+struct ImportFileMetadataSignature {
+    len: u64,
+    is_file: bool,
+    is_dir: bool,
+    readonly: bool,
+    modified: ImportModifiedTimeSignature,
+    platform: ImportPlatformMetadataSignature,
+}
+
+struct CachedImportFileDigest {
+    metadata: ImportFileMetadataSignature,
+    content_digest: u64,
+    seen_generation: u64,
+}
+
+/// Persistent metadata-to-content-digest memoization owned by one `LocalMode`. Metadata is still
+/// sampled on every import render; only files whose signatures changed are opened and re-hashed.
+pub(in crate::app) struct LocalImportFilesFingerprintCache {
+    files: HashMap<PathBuf, CachedImportFileDigest>,
+    generation: u64,
+    capacity: usize,
+    #[cfg(test)]
+    content_open_attempts: u64,
+    #[cfg(test)]
+    content_bytes_read: u64,
+}
+
+impl Default for LocalImportFilesFingerprintCache {
+    fn default() -> Self {
+        Self {
+            files: HashMap::new(),
+            generation: 0,
+            capacity: LOCAL_IMPORT_CONTENT_CACHE_CAP,
+            #[cfg(test)]
+            content_open_attempts: 0,
+            #[cfg(test)]
+            content_bytes_read: 0,
+        }
+    }
+}
+
+impl LocalImportFilesFingerprintCache {
+    fn begin_scan(&mut self) {
+        if self.generation == u64::MAX {
+            for cached in self.files.values_mut() {
+                cached.seen_generation = 0;
+            }
+            self.generation = 1;
+        } else {
+            self.generation += 1;
+        }
+    }
+
+    fn finish_scan(&mut self) {
+        let generation = self.generation;
+        self.files
+            .retain(|_, cached| cached.seen_generation == generation);
+    }
+
+    fn reusable_digest(
+        &mut self,
+        path: &Path,
+        metadata: ImportFileMetadataSignature,
+    ) -> Option<u64> {
+        let cached = self.files.get_mut(path)?;
+        if cached.metadata != metadata {
+            return None;
+        }
+        cached.seen_generation = self.generation;
+        Some(cached.content_digest)
+    }
+
+    fn remove(&mut self, path: &Path) {
+        self.files.remove(path);
+    }
+
+    fn store(&mut self, path: PathBuf, metadata: ImportFileMetadataSignature, content_digest: u64) {
+        if self.capacity == 0 {
+            return;
+        }
+        if self.files.len() >= self.capacity
+            && let Some(stale) = self.files.iter().find_map(|(path, cached)| {
+                (cached.seen_generation != self.generation).then(|| path.clone())
+            })
+        {
+            self.files.remove(&stale);
+        }
+        if self.files.len() < self.capacity {
+            self.files.insert(
+                path,
+                CachedImportFileDigest {
+                    metadata,
+                    content_digest,
+                    seen_generation: self.generation,
+                },
+            );
+        }
+    }
+
+    fn record_content_open(&mut self) {
+        #[cfg(test)]
+        {
+            self.content_open_attempts = self.content_open_attempts.wrapping_add(1);
+        }
+    }
+
+    fn record_content_bytes(&mut self, bytes: usize) {
+        #[cfg(not(test))]
+        let _ = bytes;
+        #[cfg(test)]
+        {
+            self.content_bytes_read = self.content_bytes_read.wrapping_add(bytes as u64);
+        }
+    }
+
+    #[cfg(test)]
+    fn set_capacity(&mut self, capacity: usize) {
+        self.capacity = capacity;
+        while self.files.len() > capacity {
+            let Some(path) = self.files.keys().next().cloned() else {
+                break;
+            };
+            self.files.remove(&path);
+        }
+    }
+}
+
+pub(super) fn local_import_files_fingerprint(cache: &mut LocalImportFilesFingerprintCache) -> u64 {
+    let Some(data_dir) = crate::paths::data_dir() else {
+        return fingerprint_import_directories(std::iter::empty::<&Path>(), cache);
+    };
+    let transfers = data_dir.join("transfers");
+    let sessions = transfers.join("sessions");
+    fingerprint_import_directories([transfers.as_path(), sessions.as_path()], cache)
+}
+
+fn fingerprint_import_directories<'a>(
+    paths: impl IntoIterator<Item = &'a Path>,
+    cache: &mut LocalImportFilesFingerprintCache,
+) -> u64 {
+    cache.begin_scan();
+    let mut hasher = DefaultHasher::new();
+    for path in paths {
+        hash_import_directory(path, &mut hasher, cache);
+    }
+    cache.finish_scan();
+    hasher.finish()
+}
+
+fn hash_import_directory(
+    path: &Path,
+    hasher: &mut impl Hasher,
+    cache: &mut LocalImportFilesFingerprintCache,
+) {
+    path.hash(hasher);
+    let Ok(entries) = std::fs::read_dir(path) else {
+        0_u8.hash(hasher);
+        return;
+    };
+    let mut entry_count = 0_u64;
+    let mut entry_sum = 0_u64;
+    let mut entry_xor = 0_u64;
+    for entry in entries.flatten() {
+        let mut entry_hasher = DefaultHasher::new();
+        entry.file_name().hash(&mut entry_hasher);
+        match entry.metadata() {
+            Ok(metadata) => {
+                let metadata_signature = import_file_metadata_signature(&metadata);
+                metadata_signature.hash(&mut entry_hasher);
+                if metadata.is_file() {
+                    let entry_path = entry.path();
+                    if let Some(content_digest) =
+                        cache.reusable_digest(&entry_path, metadata_signature)
+                    {
+                        2_u8.hash(&mut entry_hasher);
+                        content_digest.hash(&mut entry_hasher);
+                    } else {
+                        // Failed opens/reads are deliberately not memoized: an unchanged metadata
+                        // signature must not hide recovery from a transient permission or I/O error.
+                        cache.remove(&entry_path);
+                        match read_import_file_digest(&entry_path, cache) {
+                            ImportFileDigestRead::Complete(content_digest) => {
+                                2_u8.hash(&mut entry_hasher);
+                                content_digest.hash(&mut entry_hasher);
+                                cache.store(entry_path, metadata_signature, content_digest);
+                            }
+                            ImportFileDigestRead::ReadError {
+                                partial_digest,
+                                kind,
+                            } => {
+                                2_u8.hash(&mut entry_hasher);
+                                partial_digest.hash(&mut entry_hasher);
+                                3_u8.hash(&mut entry_hasher);
+                                kind.hash(&mut entry_hasher);
+                            }
+                            ImportFileDigestRead::OpenError(kind) => {
+                                4_u8.hash(&mut entry_hasher);
+                                kind.hash(&mut entry_hasher);
+                            }
+                        }
+                    }
+                }
+            }
+            Err(error) => {
+                error.kind().hash(&mut entry_hasher);
+            }
+        }
+        let fingerprint = entry_hasher.finish();
+        entry_count += 1;
+        entry_sum = entry_sum.wrapping_add(fingerprint);
+        entry_xor ^= fingerprint.rotate_left((fingerprint & 63) as u32);
+    }
+    entry_count.hash(hasher);
+    entry_sum.hash(hasher);
+    entry_xor.hash(hasher);
+}
+
+fn import_file_metadata_signature(metadata: &std::fs::Metadata) -> ImportFileMetadataSignature {
+    let modified = match metadata.modified() {
+        Ok(modified) => match modified.duration_since(UNIX_EPOCH) {
+            Ok(duration) => ImportModifiedTimeSignature::SinceEpoch {
+                secs: duration.as_secs(),
+                nanos: duration.subsec_nanos(),
+            },
+            Err(error) => ImportModifiedTimeSignature::BeforeEpoch {
+                secs: error.duration().as_secs(),
+                nanos: error.duration().subsec_nanos(),
+            },
+        },
+        Err(error) => ImportModifiedTimeSignature::Unavailable(error.kind()),
+    };
+    ImportFileMetadataSignature {
+        len: metadata.len(),
+        is_file: metadata.is_file(),
+        is_dir: metadata.is_dir(),
+        readonly: metadata.permissions().readonly(),
+        modified,
+        platform: import_platform_metadata_signature(metadata),
+    }
+}
+
+#[cfg(unix)]
+fn import_platform_metadata_signature(
+    metadata: &std::fs::Metadata,
+) -> ImportPlatformMetadataSignature {
+    use std::os::unix::fs::MetadataExt;
+
+    ImportPlatformMetadataSignature {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        mode: metadata.mode(),
+        links: metadata.nlink(),
+        changed_secs: metadata.ctime(),
+        changed_nanos: metadata.ctime_nsec(),
+    }
+}
+
+#[cfg(windows)]
+fn import_platform_metadata_signature(
+    metadata: &std::fs::Metadata,
+) -> ImportPlatformMetadataSignature {
+    use std::os::windows::fs::MetadataExt;
+
+    ImportPlatformMetadataSignature {
+        attributes: metadata.file_attributes(),
+        creation_time: metadata.creation_time(),
+        last_write_time: metadata.last_write_time(),
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn import_platform_metadata_signature(
+    _metadata: &std::fs::Metadata,
+) -> ImportPlatformMetadataSignature {
+    ImportPlatformMetadataSignature
+}
+
+enum ImportFileDigestRead {
+    Complete(u64),
+    ReadError {
+        partial_digest: u64,
+        kind: std::io::ErrorKind,
+    },
+    OpenError(std::io::ErrorKind),
+}
+
+fn read_import_file_digest(
+    path: &Path,
+    cache: &mut LocalImportFilesFingerprintCache,
+) -> ImportFileDigestRead {
+    cache.record_content_open();
+    let mut file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) => return ImportFileDigestRead::OpenError(error.kind()),
+    };
+    let mut content_hasher = DefaultHasher::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        match file.read(&mut buffer) {
+            Ok(0) => return ImportFileDigestRead::Complete(content_hasher.finish()),
+            Ok(read) => {
+                cache.record_content_bytes(read);
+                content_hasher.write(&buffer[..read]);
+            }
+            Err(error) => {
+                return ImportFileDigestRead::ReadError {
+                    partial_digest: content_hasher.finish(),
+                    kind: error.kind(),
+                };
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            let sequence = NEXT_TEST_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "yututui-import-fingerprint-{}-{sequence}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&path).expect("create import fingerprint test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn fingerprint(path: &Path, cache: &mut LocalImportFilesFingerprintCache) -> u64 {
+        fingerprint_import_directories([path], cache)
+    }
+
+    #[test]
+    fn unchanged_import_artifact_reuses_digest_with_zero_content_io() {
+        let directory = TestDirectory::new();
+        let artifact = directory.path().join("session.report.json");
+        let initial = vec![b'a'; 16_385];
+        std::fs::write(&artifact, &initial).expect("write initial artifact");
+        let mut cache = LocalImportFilesFingerprintCache::default();
+
+        let first = fingerprint(directory.path(), &mut cache);
+        assert_eq!(cache.content_open_attempts, 1);
+        assert_eq!(cache.content_bytes_read, initial.len() as u64);
+        assert_eq!(cache.files.len(), 1);
+        let io_after_first_scan = (cache.content_open_attempts, cache.content_bytes_read);
+
+        let unchanged = fingerprint(directory.path(), &mut cache);
+        assert_eq!(unchanged, first);
+        assert_eq!(
+            (cache.content_open_attempts, cache.content_bytes_read),
+            io_after_first_scan,
+            "an unchanged metadata signature must cause zero opens and zero content bytes read"
+        );
+
+        let modified = vec![b'b'; initial.len() + 1];
+        std::fs::write(&artifact, &modified).expect("modify artifact");
+        let after_modify = fingerprint(directory.path(), &mut cache);
+        assert_ne!(after_modify, unchanged);
+        assert_eq!(cache.content_open_attempts, io_after_first_scan.0 + 1);
+        assert_eq!(
+            cache.content_bytes_read,
+            io_after_first_scan.1 + modified.len() as u64
+        );
+
+        let io_after_modify = (cache.content_open_attempts, cache.content_bytes_read);
+        assert_eq!(fingerprint(directory.path(), &mut cache), after_modify);
+        assert_eq!(
+            (cache.content_open_attempts, cache.content_bytes_read),
+            io_after_modify,
+            "the digest recalculated after a modification must also be reusable"
+        );
+
+        std::fs::remove_file(&artifact).expect("delete artifact");
+        assert_ne!(fingerprint(directory.path(), &mut cache), after_modify);
+        assert!(cache.files.is_empty(), "deleted artifacts must be pruned");
+        assert_eq!(
+            (cache.content_open_attempts, cache.content_bytes_read),
+            io_after_modify,
+            "deletion invalidation only needs directory metadata, not a content read"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_change_identity_catches_same_size_rewrite_with_restored_mtime() {
+        let directory = TestDirectory::new();
+        let artifact = directory.path().join("session.report.json");
+        std::fs::write(&artifact, b"{}").expect("write initial artifact");
+        let mut cache = LocalImportFilesFingerprintCache::default();
+        let before = fingerprint(directory.path(), &mut cache);
+        let original_modified = std::fs::metadata(&artifact)
+            .and_then(|metadata| metadata.modified())
+            .expect("read original timestamp");
+
+        std::fs::write(&artifact, b"[]").expect("rewrite artifact at the same size");
+        std::fs::File::options()
+            .write(true)
+            .open(&artifact)
+            .and_then(|file| {
+                file.set_times(std::fs::FileTimes::new().set_modified(original_modified))
+            })
+            .expect("restore original mtime");
+
+        let after = fingerprint(directory.path(), &mut cache);
+        assert_ne!(after, before);
+        assert_eq!(cache.content_open_attempts, 2);
+        assert_eq!(cache.content_bytes_read, 4);
+    }
+
+    #[test]
+    fn import_digest_cache_is_bounded_and_prunes_unseen_paths() {
+        let directory = TestDirectory::new();
+        for index in 0..3 {
+            std::fs::write(
+                directory.path().join(format!("{index}.json")),
+                [index as u8],
+            )
+            .expect("write bounded-cache artifact");
+        }
+        let mut cache = LocalImportFilesFingerprintCache::default();
+        cache.set_capacity(2);
+
+        fingerprint(directory.path(), &mut cache);
+        assert_eq!(cache.files.len(), 2);
+
+        for index in 0..3 {
+            std::fs::remove_file(directory.path().join(format!("{index}.json")))
+                .expect("remove bounded-cache artifact");
+        }
+        fingerprint(directory.path(), &mut cache);
+        assert!(cache.files.is_empty());
+    }
+}

--- a/src/app/local/import_fingerprint.rs
+++ b/src/app/local/import_fingerprint.rs
@@ -1,14 +1,126 @@
-//! Bounded filesystem fingerprints for Local Deck import artifacts.
+//! Metadata-only invalidation for persisted Local Deck import projections.
 
-use std::collections::{HashMap, hash_map::DefaultHasher};
+use std::collections::hash_map::DefaultHasher;
+use std::ffi::OsStr;
 use std::hash::{Hash, Hasher};
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-/// Enough for hundreds of import sessions while keeping retained path/signature state below a
-/// small, fixed ceiling even if the transfers directory is unexpectedly large.
-const LOCAL_IMPORT_CONTENT_CACHE_CAP: usize = 4096;
+const LOCAL_IMPORT_RETAINED_PATH_CAP: usize = 4096;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct LocalImportFilesFingerprint {
+    digest: u64,
+    reliable: bool,
+}
+
+impl LocalImportFilesFingerprint {
+    pub(super) fn digest(self) -> u64 {
+        self.digest
+    }
+
+    pub(super) fn reliable(self) -> bool {
+        self.reliable
+    }
+}
+
+pub(super) fn stable_import_cache_key(
+    before: Option<LocalImportFilesFingerprint>,
+    after: Option<LocalImportFilesFingerprint>,
+) -> Option<Option<u64>> {
+    match (before, after) {
+        (None, None) => Some(None),
+        (Some(before), Some(after))
+            if before.reliable && after.reliable && before.digest == after.digest =>
+        {
+            Some(Some(after.digest))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(in crate::app) struct LocalImportFingerprintProbe {
+    pub directory_metadata_stats: u64,
+    pub directory_generation_queries: u64,
+    pub read_dir_calls: u64,
+    pub read_dir_errors: u64,
+    pub directory_entries_visited: u64,
+    pub artifact_metadata_stats: u64,
+}
+
+#[derive(Default)]
+struct CachedImportDirectory {
+    path: Option<PathBuf>,
+    metadata: Option<ImportMetadataState>,
+    retained_paths: Vec<PathBuf>,
+    recognized_count: usize,
+    membership_valid: bool,
+    overflow: bool,
+    #[cfg(windows)]
+    directory_change_time: Option<i64>,
+    #[cfg(test)]
+    next_read_dir_error: Option<std::io::ErrorKind>,
+}
+
+/// One LocalMode-owned cache. Directory membership is retained only while it is reliable and
+/// bounded; overflow/error states deliberately rescan on every lookup rather than missing writes.
+#[derive(Default)]
+pub(in crate::app) struct LocalImportFilesFingerprintCache {
+    transfers: CachedImportDirectory,
+    sessions: CachedImportDirectory,
+    force_full_scan: bool,
+    #[cfg(test)]
+    probe: LocalImportFingerprintProbe,
+    #[cfg(test)]
+    data_dir_override: Option<PathBuf>,
+}
+
+impl LocalImportFilesFingerprintCache {
+    #[cfg(test)]
+    pub(in crate::app) fn set_data_dir_for_test(&mut self, data_dir: PathBuf) {
+        *self = Self {
+            data_dir_override: Some(data_dir),
+            ..Self::default()
+        };
+    }
+
+    #[cfg(test)]
+    pub(in crate::app) fn reset_probe(&mut self) {
+        self.probe = LocalImportFingerprintProbe::default();
+    }
+
+    #[cfg(test)]
+    pub(in crate::app) fn probe(&self) -> LocalImportFingerprintProbe {
+        self.probe
+    }
+
+    #[cfg(test)]
+    pub(in crate::app) fn fail_next_transfers_read_dir_for_test(
+        &mut self,
+        kind: std::io::ErrorKind,
+    ) {
+        self.transfers.membership_valid = false;
+        self.transfers.next_read_dir_error = Some(kind);
+    }
+
+    #[cfg(test)]
+    pub(in crate::app) fn retained_path_count_for_test(&self) -> usize {
+        self.transfers.retained_paths.len() + self.sessions.retained_paths.len()
+    }
+
+    #[cfg(test)]
+    pub(in crate::app) fn retained_path_capacity_for_test(&self) -> usize {
+        self.transfers.retained_paths.capacity() + self.sessions.retained_paths.capacity()
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ImportArtifactDirectory {
+    Transfers,
+    Sessions,
+}
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 enum ImportModifiedTimeSignature {
@@ -34,6 +146,7 @@ struct ImportPlatformMetadataSignature {
     attributes: u32,
     creation_time: u64,
     last_write_time: u64,
+    artifact_change_time: Option<i64>,
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -41,224 +154,397 @@ struct ImportPlatformMetadataSignature {
 struct ImportPlatformMetadataSignature;
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-struct ImportFileMetadataSignature {
+struct ImportMetadataSignature {
     len: u64,
     is_file: bool,
     is_dir: bool,
+    is_symlink: bool,
     readonly: bool,
     modified: ImportModifiedTimeSignature,
     platform: ImportPlatformMetadataSignature,
 }
 
-struct CachedImportFileDigest {
-    metadata: ImportFileMetadataSignature,
-    content_digest: u64,
-    seen_generation: u64,
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+enum ImportMetadataState {
+    Present(ImportMetadataSignature),
+    Error(std::io::ErrorKind),
 }
 
-/// Persistent metadata-to-content-digest memoization owned by one `LocalMode`. Metadata is still
-/// sampled on every import render; only files whose signatures changed are opened and re-hashed.
-pub(in crate::app) struct LocalImportFilesFingerprintCache {
-    files: HashMap<PathBuf, CachedImportFileDigest>,
-    generation: u64,
-    capacity: usize,
+#[derive(Default)]
+struct ImportEntryAccumulator {
+    count: u64,
+    sum: u64,
+    xor: u64,
+}
+
+impl ImportEntryAccumulator {
+    fn push(&mut self, value: u64) {
+        self.count = self.count.wrapping_add(1);
+        self.sum = self.sum.wrapping_add(value);
+        self.xor ^= value.rotate_left((value & 63) as u32);
+    }
+
+    fn hash_into(&self, hasher: &mut impl Hasher) {
+        self.count.hash(hasher);
+        self.sum.hash(hasher);
+        self.xor.hash(hasher);
+    }
+}
+
+pub(super) fn local_import_files_fingerprint(
+    cache: &mut LocalImportFilesFingerprintCache,
+) -> LocalImportFilesFingerprint {
     #[cfg(test)]
-    content_open_attempts: u64,
-    #[cfg(test)]
-    content_bytes_read: u64,
-}
-
-impl Default for LocalImportFilesFingerprintCache {
-    fn default() -> Self {
-        Self {
-            files: HashMap::new(),
-            generation: 0,
-            capacity: LOCAL_IMPORT_CONTENT_CACHE_CAP,
-            #[cfg(test)]
-            content_open_attempts: 0,
-            #[cfg(test)]
-            content_bytes_read: 0,
-        }
-    }
-}
-
-impl LocalImportFilesFingerprintCache {
-    fn begin_scan(&mut self) {
-        if self.generation == u64::MAX {
-            for cached in self.files.values_mut() {
-                cached.seen_generation = 0;
-            }
-            self.generation = 1;
-        } else {
-            self.generation += 1;
-        }
-    }
-
-    fn finish_scan(&mut self) {
-        let generation = self.generation;
-        self.files
-            .retain(|_, cached| cached.seen_generation == generation);
-    }
-
-    fn reusable_digest(
-        &mut self,
-        path: &Path,
-        metadata: ImportFileMetadataSignature,
-    ) -> Option<u64> {
-        let cached = self.files.get_mut(path)?;
-        if cached.metadata != metadata {
-            return None;
-        }
-        cached.seen_generation = self.generation;
-        Some(cached.content_digest)
-    }
-
-    fn remove(&mut self, path: &Path) {
-        self.files.remove(path);
-    }
-
-    fn store(&mut self, path: PathBuf, metadata: ImportFileMetadataSignature, content_digest: u64) {
-        if self.capacity == 0 {
-            return;
-        }
-        if self.files.len() >= self.capacity
-            && let Some(stale) = self.files.iter().find_map(|(path, cached)| {
-                (cached.seen_generation != self.generation).then(|| path.clone())
-            })
-        {
-            self.files.remove(&stale);
-        }
-        if self.files.len() < self.capacity {
-            self.files.insert(
-                path,
-                CachedImportFileDigest {
-                    metadata,
-                    content_digest,
-                    seen_generation: self.generation,
-                },
-            );
-        }
-    }
-
-    fn record_content_open(&mut self) {
-        #[cfg(test)]
-        {
-            self.content_open_attempts = self.content_open_attempts.wrapping_add(1);
-        }
-    }
-
-    fn record_content_bytes(&mut self, bytes: usize) {
-        #[cfg(not(test))]
-        let _ = bytes;
-        #[cfg(test)]
-        {
-            self.content_bytes_read = self.content_bytes_read.wrapping_add(bytes as u64);
-        }
-    }
-
-    #[cfg(test)]
-    fn set_capacity(&mut self, capacity: usize) {
-        self.capacity = capacity;
-        while self.files.len() > capacity {
-            let Some(path) = self.files.keys().next().cloned() else {
-                break;
-            };
-            self.files.remove(&path);
-        }
-    }
-}
-
-pub(super) fn local_import_files_fingerprint(cache: &mut LocalImportFilesFingerprintCache) -> u64 {
-    let Some(data_dir) = crate::paths::data_dir() else {
-        return fingerprint_import_directories(std::iter::empty::<&Path>(), cache);
+    let data_dir = cache
+        .data_dir_override
+        .clone()
+        .or_else(crate::paths::data_dir);
+    #[cfg(not(test))]
+    let data_dir = crate::paths::data_dir();
+    let Some(data_dir) = data_dir else {
+        return LocalImportFilesFingerprint {
+            digest: 0,
+            reliable: true,
+        };
     };
     let transfers = data_dir.join("transfers");
     let sessions = transfers.join("sessions");
-    fingerprint_import_directories([transfers.as_path(), sessions.as_path()], cache)
-}
-
-fn fingerprint_import_directories<'a>(
-    paths: impl IntoIterator<Item = &'a Path>,
-    cache: &mut LocalImportFilesFingerprintCache,
-) -> u64 {
-    cache.begin_scan();
+    let force_full_scan = cache.force_full_scan;
+    let transfers_budget =
+        LOCAL_IMPORT_RETAINED_PATH_CAP.saturating_sub(cache.sessions.retained_paths.len());
+    let transfers_fingerprint = fingerprint_import_directory(
+        &transfers,
+        ImportArtifactDirectory::Transfers,
+        &mut cache.transfers,
+        transfers_budget,
+        force_full_scan,
+        #[cfg(test)]
+        &mut cache.probe,
+    );
+    let sessions_budget =
+        LOCAL_IMPORT_RETAINED_PATH_CAP.saturating_sub(cache.transfers.retained_paths.len());
+    let sessions_fingerprint = fingerprint_import_directory(
+        &sessions,
+        ImportArtifactDirectory::Sessions,
+        &mut cache.sessions,
+        sessions_budget,
+        force_full_scan,
+        #[cfg(test)]
+        &mut cache.probe,
+    );
+    let combined_count = cache
+        .transfers
+        .recognized_count
+        .saturating_add(cache.sessions.recognized_count);
+    let global_overflow = combined_count > LOCAL_IMPORT_RETAINED_PATH_CAP;
+    cache.force_full_scan = global_overflow || cache.transfers.overflow || cache.sessions.overflow;
     let mut hasher = DefaultHasher::new();
-    for path in paths {
-        hash_import_directory(path, &mut hasher, cache);
+    0_u8.hash(&mut hasher);
+    transfers_fingerprint.digest.hash(&mut hasher);
+    1_u8.hash(&mut hasher);
+    sessions_fingerprint.digest.hash(&mut hasher);
+    LocalImportFilesFingerprint {
+        digest: hasher.finish(),
+        reliable: transfers_fingerprint.reliable
+            && sessions_fingerprint.reliable
+            && !global_overflow,
     }
-    cache.finish_scan();
-    hasher.finish()
 }
 
-fn hash_import_directory(
-    path: &Path,
-    hasher: &mut impl Hasher,
+#[cfg(test)]
+pub(in crate::app) fn local_import_files_fingerprint_for_test(
     cache: &mut LocalImportFilesFingerprintCache,
-) {
-    path.hash(hasher);
-    let Ok(entries) = std::fs::read_dir(path) else {
-        0_u8.hash(hasher);
-        return;
+) -> (u64, bool) {
+    let fingerprint = local_import_files_fingerprint(cache);
+    (fingerprint.digest, fingerprint.reliable)
+}
+
+#[cfg(test)]
+pub(in crate::app) fn stable_import_cache_key_for_test(
+    before: Option<(u64, bool)>,
+    after: Option<(u64, bool)>,
+) -> Option<Option<u64>> {
+    let fingerprint = |(digest, reliable)| LocalImportFilesFingerprint { digest, reliable };
+    stable_import_cache_key(before.map(fingerprint), after.map(fingerprint))
+}
+
+fn fingerprint_import_directory(
+    path: &Path,
+    kind: ImportArtifactDirectory,
+    cache: &mut CachedImportDirectory,
+    retained_path_budget: usize,
+    force_scan: bool,
+    #[cfg(test)] probe: &mut LocalImportFingerprintProbe,
+) -> LocalImportFilesFingerprint {
+    let metadata = directory_metadata_state(
+        path,
+        #[cfg(test)]
+        probe,
+    );
+    let path_changed = cache.path.as_deref() != Some(path);
+    let metadata_changed = cache.metadata != Some(metadata);
+    if path_changed {
+        *cache = CachedImportDirectory::default();
+        cache.path = Some(path.to_path_buf());
+    }
+    cache.metadata = Some(metadata);
+
+    let ImportMetadataState::Present(signature) = metadata else {
+        cache.retained_paths = Vec::new();
+        cache.recognized_count = 0;
+        cache.membership_valid = matches!(
+            metadata,
+            ImportMetadataState::Error(std::io::ErrorKind::NotFound)
+        );
+        cache.overflow = false;
+        #[cfg(windows)]
+        {
+            cache.directory_change_time = None;
+        }
+        return hash_import_directory_state(
+            path,
+            &ImportEntryAccumulator::default(),
+            cache.membership_valid,
+        );
     };
-    let mut entry_count = 0_u64;
-    let mut entry_sum = 0_u64;
-    let mut entry_xor = 0_u64;
-    for entry in entries.flatten() {
-        let mut entry_hasher = DefaultHasher::new();
-        entry.file_name().hash(&mut entry_hasher);
-        match entry.metadata() {
-            Ok(metadata) => {
-                let metadata_signature = import_file_metadata_signature(&metadata);
-                metadata_signature.hash(&mut entry_hasher);
-                if metadata.is_file() {
-                    let entry_path = entry.path();
-                    if let Some(content_digest) =
-                        cache.reusable_digest(&entry_path, metadata_signature)
-                    {
-                        2_u8.hash(&mut entry_hasher);
-                        content_digest.hash(&mut entry_hasher);
-                    } else {
-                        // Failed opens/reads are deliberately not memoized: an unchanged metadata
-                        // signature must not hide recovery from a transient permission or I/O error.
-                        cache.remove(&entry_path);
-                        match read_import_file_digest(&entry_path, cache) {
-                            ImportFileDigestRead::Complete(content_digest) => {
-                                2_u8.hash(&mut entry_hasher);
-                                content_digest.hash(&mut entry_hasher);
-                                cache.store(entry_path, metadata_signature, content_digest);
-                            }
-                            ImportFileDigestRead::ReadError {
-                                partial_digest,
-                                kind,
-                            } => {
-                                2_u8.hash(&mut entry_hasher);
-                                partial_digest.hash(&mut entry_hasher);
-                                3_u8.hash(&mut entry_hasher);
-                                kind.hash(&mut entry_hasher);
-                            }
-                            ImportFileDigestRead::OpenError(kind) => {
-                                4_u8.hash(&mut entry_hasher);
-                                kind.hash(&mut entry_hasher);
-                            }
-                        }
-                    }
-                }
+    if !signature.is_dir {
+        cache.retained_paths = Vec::new();
+        cache.recognized_count = 0;
+        cache.membership_valid = true;
+        cache.overflow = false;
+        #[cfg(windows)]
+        {
+            cache.directory_change_time = None;
+        }
+        return hash_import_directory_state(path, &ImportEntryAccumulator::default(), true);
+    }
+
+    #[cfg(windows)]
+    let (membership_changed, generation_reliable) = {
+        if metadata_changed {
+            cache.directory_change_time = None;
+        }
+        match windows_directory_change_time(
+            path,
+            #[cfg(test)]
+            probe,
+        ) {
+            Ok(change_time) => {
+                let previous = cache.directory_change_time.replace(change_time);
+                (previous != Some(change_time), true)
             }
-            Err(error) => {
-                error.kind().hash(&mut entry_hasher);
+            Err(_) => {
+                cache.directory_change_time = None;
+                (true, false)
             }
         }
-        let fingerprint = entry_hasher.finish();
-        entry_count += 1;
-        entry_sum = entry_sum.wrapping_add(fingerprint);
-        entry_xor ^= fingerprint.rotate_left((fingerprint & 63) as u32);
-    }
-    entry_count.hash(hasher);
-    entry_sum.hash(hasher);
-    entry_xor.hash(hasher);
+    };
+    #[cfg(not(windows))]
+    let (membership_changed, generation_reliable) = (metadata_changed, true);
+
+    let mut fingerprint = if force_scan
+        || path_changed
+        || membership_changed
+        || !cache.membership_valid
+        || cache.overflow
+    {
+        scan_import_directory(
+            path,
+            kind,
+            cache,
+            retained_path_budget,
+            #[cfg(test)]
+            probe,
+        )
+    } else {
+        fingerprint_retained_import_paths(
+            path,
+            cache,
+            #[cfg(test)]
+            probe,
+        )
+    };
+    fingerprint.reliable &= generation_reliable;
+    fingerprint
 }
 
-fn import_file_metadata_signature(metadata: &std::fs::Metadata) -> ImportFileMetadataSignature {
+fn scan_import_directory(
+    path: &Path,
+    kind: ImportArtifactDirectory,
+    cache: &mut CachedImportDirectory,
+    retained_path_budget: usize,
+    #[cfg(test)] probe: &mut LocalImportFingerprintProbe,
+) -> LocalImportFilesFingerprint {
+    #[cfg(test)]
+    {
+        probe.read_dir_calls = probe.read_dir_calls.wrapping_add(1);
+    }
+    #[cfg(test)]
+    let read_dir = match cache.next_read_dir_error.take() {
+        Some(kind) => Err(std::io::Error::from(kind)),
+        None => std::fs::read_dir(path),
+    };
+    #[cfg(not(test))]
+    let read_dir = std::fs::read_dir(path);
+    let entries = match read_dir {
+        Ok(entries) => entries,
+        Err(error) => {
+            #[cfg(test)]
+            {
+                probe.read_dir_errors = probe.read_dir_errors.wrapping_add(1);
+            }
+            cache.retained_paths = Vec::new();
+            cache.recognized_count = 0;
+            cache.membership_valid = false;
+            cache.overflow = false;
+            let mut accumulator = ImportEntryAccumulator::default();
+            accumulator.push(hash_value(&(0_u8, error.kind())));
+            return hash_import_directory_state(path, &accumulator, false);
+        }
+    };
+
+    let mut accumulator = ImportEntryAccumulator::default();
+    let mut retained = Vec::new();
+    let mut recognized_count = 0_usize;
+    let mut overflow = false;
+    let mut reliable = true;
+    for entry in entries {
+        #[cfg(test)]
+        {
+            probe.directory_entries_visited = probe.directory_entries_visited.wrapping_add(1);
+        }
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                reliable = false;
+                accumulator.push(hash_value(&(1_u8, error.kind())));
+                continue;
+            }
+        };
+        let file_name = entry.file_name();
+        if !is_recognized_import_artifact(&file_name, kind) {
+            continue;
+        }
+        recognized_count = recognized_count.saturating_add(1);
+        let entry_path = entry.path();
+        let artifact_metadata = artifact_metadata_state(
+            &entry_path,
+            #[cfg(test)]
+            probe,
+        );
+        if matches!(artifact_metadata, ImportMetadataState::Error(_)) {
+            reliable = false;
+        }
+        accumulator.push(hash_import_entry(&file_name, artifact_metadata));
+        if !overflow && retained.len() < retained_path_budget {
+            retained.push(entry_path);
+        } else {
+            overflow = true;
+            retained = Vec::new();
+        }
+    }
+    retained.sort_unstable();
+    cache.retained_paths = retained;
+    cache.recognized_count = recognized_count;
+    cache.membership_valid = reliable;
+    cache.overflow = overflow;
+    hash_import_directory_state(path, &accumulator, reliable && !overflow)
+}
+
+fn fingerprint_retained_import_paths(
+    path: &Path,
+    cache: &mut CachedImportDirectory,
+    #[cfg(test)] probe: &mut LocalImportFingerprintProbe,
+) -> LocalImportFilesFingerprint {
+    let mut accumulator = ImportEntryAccumulator::default();
+    let mut reliable = true;
+    for entry_path in &cache.retained_paths {
+        let metadata = artifact_metadata_state(
+            entry_path,
+            #[cfg(test)]
+            probe,
+        );
+        if matches!(metadata, ImportMetadataState::Error(_)) {
+            reliable = false;
+        }
+        let Some(file_name) = entry_path.file_name() else {
+            reliable = false;
+            continue;
+        };
+        accumulator.push(hash_import_entry(file_name, metadata));
+    }
+    if !reliable {
+        cache.membership_valid = false;
+    } else {
+        cache.recognized_count = cache.retained_paths.len();
+    }
+    hash_import_directory_state(path, &accumulator, reliable)
+}
+
+fn hash_import_directory_state(
+    path: &Path,
+    entries: &ImportEntryAccumulator,
+    reliable: bool,
+) -> LocalImportFilesFingerprint {
+    let mut hasher = DefaultHasher::new();
+    path.hash(&mut hasher);
+    entries.hash_into(&mut hasher);
+    LocalImportFilesFingerprint {
+        digest: hasher.finish(),
+        reliable,
+    }
+}
+
+fn directory_metadata_state(
+    path: &Path,
+    #[cfg(test)] probe: &mut LocalImportFingerprintProbe,
+) -> ImportMetadataState {
+    #[cfg(test)]
+    {
+        probe.directory_metadata_stats = probe.directory_metadata_stats.wrapping_add(1);
+    }
+    metadata_state(std::fs::metadata(path))
+}
+
+fn artifact_metadata_state(
+    path: &Path,
+    #[cfg(test)] probe: &mut LocalImportFingerprintProbe,
+) -> ImportMetadataState {
+    #[cfg(test)]
+    {
+        probe.artifact_metadata_stats = probe.artifact_metadata_stats.wrapping_add(1);
+    }
+    let metadata = std::fs::symlink_metadata(path);
+    #[cfg(windows)]
+    {
+        match metadata {
+            Ok(metadata) => match crate::util::safe_fs::windows_file_change_time(path) {
+                Ok(change_time) => ImportMetadataState::Present(import_metadata_signature(
+                    &metadata,
+                    Some(change_time),
+                )),
+                Err(error) => ImportMetadataState::Error(error.kind()),
+            },
+            Err(error) => ImportMetadataState::Error(error.kind()),
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        metadata_state(metadata)
+    }
+}
+
+fn metadata_state(result: std::io::Result<std::fs::Metadata>) -> ImportMetadataState {
+    match result {
+        Ok(metadata) => ImportMetadataState::Present(import_metadata_signature(&metadata, None)),
+        Err(error) => ImportMetadataState::Error(error.kind()),
+    }
+}
+
+fn import_metadata_signature(
+    metadata: &std::fs::Metadata,
+    artifact_change_time: Option<i64>,
+) -> ImportMetadataSignature {
     let modified = match metadata.modified() {
         Ok(modified) => match modified.duration_since(UNIX_EPOCH) {
             Ok(duration) => ImportModifiedTimeSignature::SinceEpoch {
@@ -272,19 +558,21 @@ fn import_file_metadata_signature(metadata: &std::fs::Metadata) -> ImportFileMet
         },
         Err(error) => ImportModifiedTimeSignature::Unavailable(error.kind()),
     };
-    ImportFileMetadataSignature {
+    ImportMetadataSignature {
         len: metadata.len(),
         is_file: metadata.is_file(),
         is_dir: metadata.is_dir(),
+        is_symlink: metadata.file_type().is_symlink(),
         readonly: metadata.permissions().readonly(),
         modified,
-        platform: import_platform_metadata_signature(metadata),
+        platform: import_platform_metadata_signature(metadata, artifact_change_time),
     }
 }
 
 #[cfg(unix)]
 fn import_platform_metadata_signature(
     metadata: &std::fs::Metadata,
+    _artifact_change_time: Option<i64>,
 ) -> ImportPlatformMetadataSignature {
     use std::os::unix::fs::MetadataExt;
 
@@ -301,6 +589,7 @@ fn import_platform_metadata_signature(
 #[cfg(windows)]
 fn import_platform_metadata_signature(
     metadata: &std::fs::Metadata,
+    artifact_change_time: Option<i64>,
 ) -> ImportPlatformMetadataSignature {
     use std::os::windows::fs::MetadataExt;
 
@@ -308,186 +597,44 @@ fn import_platform_metadata_signature(
         attributes: metadata.file_attributes(),
         creation_time: metadata.creation_time(),
         last_write_time: metadata.last_write_time(),
+        artifact_change_time,
     }
 }
 
 #[cfg(not(any(unix, windows)))]
 fn import_platform_metadata_signature(
     _metadata: &std::fs::Metadata,
+    _artifact_change_time: Option<i64>,
 ) -> ImportPlatformMetadataSignature {
     ImportPlatformMetadataSignature
 }
 
-enum ImportFileDigestRead {
-    Complete(u64),
-    ReadError {
-        partial_digest: u64,
-        kind: std::io::ErrorKind,
-    },
-    OpenError(std::io::ErrorKind),
-}
-
-fn read_import_file_digest(
-    path: &Path,
-    cache: &mut LocalImportFilesFingerprintCache,
-) -> ImportFileDigestRead {
-    cache.record_content_open();
-    let mut file = match std::fs::File::open(path) {
-        Ok(file) => file,
-        Err(error) => return ImportFileDigestRead::OpenError(error.kind()),
+fn is_recognized_import_artifact(name: &OsStr, kind: ImportArtifactDirectory) -> bool {
+    let Some(name) = name.to_str() else {
+        return false;
     };
-    let mut content_hasher = DefaultHasher::new();
-    let mut buffer = [0_u8; 8192];
-    loop {
-        match file.read(&mut buffer) {
-            Ok(0) => return ImportFileDigestRead::Complete(content_hasher.finish()),
-            Ok(read) => {
-                cache.record_content_bytes(read);
-                content_hasher.write(&buffer[..read]);
-            }
-            Err(error) => {
-                return ImportFileDigestRead::ReadError {
-                    partial_digest: content_hasher.finish(),
-                    kind: error.kind(),
-                };
-            }
-        }
-    }
+    name.ends_with(".json")
+        || matches!(kind, ImportArtifactDirectory::Transfers) && name.ends_with(".journal.jsonl")
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::atomic::{AtomicU64, Ordering};
+fn hash_import_entry(name: &OsStr, metadata: ImportMetadataState) -> u64 {
+    hash_value(&(name, metadata))
+}
 
-    static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
-
-    struct TestDirectory(PathBuf);
-
-    impl TestDirectory {
-        fn new() -> Self {
-            let sequence = NEXT_TEST_DIRECTORY.fetch_add(1, Ordering::Relaxed);
-            let path = std::env::temp_dir().join(format!(
-                "yututui-import-fingerprint-{}-{sequence}",
-                std::process::id()
-            ));
-            std::fs::create_dir_all(&path).expect("create import fingerprint test directory");
-            Self(path)
-        }
-
-        fn path(&self) -> &Path {
-            &self.0
-        }
+#[cfg(windows)]
+fn windows_directory_change_time(
+    path: &Path,
+    #[cfg(test)] probe: &mut LocalImportFingerprintProbe,
+) -> std::io::Result<i64> {
+    #[cfg(test)]
+    {
+        probe.directory_generation_queries = probe.directory_generation_queries.wrapping_add(1);
     }
+    crate::util::safe_fs::windows_directory_change_time(path)
+}
 
-    impl Drop for TestDirectory {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.0);
-        }
-    }
-
-    fn fingerprint(path: &Path, cache: &mut LocalImportFilesFingerprintCache) -> u64 {
-        fingerprint_import_directories([path], cache)
-    }
-
-    #[test]
-    fn unchanged_import_artifact_reuses_digest_with_zero_content_io() {
-        let directory = TestDirectory::new();
-        let artifact = directory.path().join("session.report.json");
-        let initial = vec![b'a'; 16_385];
-        std::fs::write(&artifact, &initial).expect("write initial artifact");
-        let mut cache = LocalImportFilesFingerprintCache::default();
-
-        let first = fingerprint(directory.path(), &mut cache);
-        assert_eq!(cache.content_open_attempts, 1);
-        assert_eq!(cache.content_bytes_read, initial.len() as u64);
-        assert_eq!(cache.files.len(), 1);
-        let io_after_first_scan = (cache.content_open_attempts, cache.content_bytes_read);
-
-        let unchanged = fingerprint(directory.path(), &mut cache);
-        assert_eq!(unchanged, first);
-        assert_eq!(
-            (cache.content_open_attempts, cache.content_bytes_read),
-            io_after_first_scan,
-            "an unchanged metadata signature must cause zero opens and zero content bytes read"
-        );
-
-        let modified = vec![b'b'; initial.len() + 1];
-        std::fs::write(&artifact, &modified).expect("modify artifact");
-        let after_modify = fingerprint(directory.path(), &mut cache);
-        assert_ne!(after_modify, unchanged);
-        assert_eq!(cache.content_open_attempts, io_after_first_scan.0 + 1);
-        assert_eq!(
-            cache.content_bytes_read,
-            io_after_first_scan.1 + modified.len() as u64
-        );
-
-        let io_after_modify = (cache.content_open_attempts, cache.content_bytes_read);
-        assert_eq!(fingerprint(directory.path(), &mut cache), after_modify);
-        assert_eq!(
-            (cache.content_open_attempts, cache.content_bytes_read),
-            io_after_modify,
-            "the digest recalculated after a modification must also be reusable"
-        );
-
-        std::fs::remove_file(&artifact).expect("delete artifact");
-        assert_ne!(fingerprint(directory.path(), &mut cache), after_modify);
-        assert!(cache.files.is_empty(), "deleted artifacts must be pruned");
-        assert_eq!(
-            (cache.content_open_attempts, cache.content_bytes_read),
-            io_after_modify,
-            "deletion invalidation only needs directory metadata, not a content read"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn unix_change_identity_catches_same_size_rewrite_with_restored_mtime() {
-        let directory = TestDirectory::new();
-        let artifact = directory.path().join("session.report.json");
-        std::fs::write(&artifact, b"{}").expect("write initial artifact");
-        let mut cache = LocalImportFilesFingerprintCache::default();
-        let before = fingerprint(directory.path(), &mut cache);
-        let original_modified = std::fs::metadata(&artifact)
-            .and_then(|metadata| metadata.modified())
-            .expect("read original timestamp");
-
-        std::fs::write(&artifact, b"[]").expect("rewrite artifact at the same size");
-        std::fs::File::options()
-            .write(true)
-            .open(&artifact)
-            .and_then(|file| {
-                file.set_times(std::fs::FileTimes::new().set_modified(original_modified))
-            })
-            .expect("restore original mtime");
-
-        let after = fingerprint(directory.path(), &mut cache);
-        assert_ne!(after, before);
-        assert_eq!(cache.content_open_attempts, 2);
-        assert_eq!(cache.content_bytes_read, 4);
-    }
-
-    #[test]
-    fn import_digest_cache_is_bounded_and_prunes_unseen_paths() {
-        let directory = TestDirectory::new();
-        for index in 0..3 {
-            std::fs::write(
-                directory.path().join(format!("{index}.json")),
-                [index as u8],
-            )
-            .expect("write bounded-cache artifact");
-        }
-        let mut cache = LocalImportFilesFingerprintCache::default();
-        cache.set_capacity(2);
-
-        fingerprint(directory.path(), &mut cache);
-        assert_eq!(cache.files.len(), 2);
-
-        for index in 0..3 {
-            std::fs::remove_file(directory.path().join(format!("{index}.json")))
-                .expect("remove bounded-cache artifact");
-        }
-        fingerprint(directory.path(), &mut cache);
-        assert!(cache.files.is_empty());
-    }
+fn hash_value(value: &impl Hash) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
 }

--- a/src/app/local/rows_cache.rs
+++ b/src/app/local/rows_cache.rs
@@ -1,6 +1,6 @@
 //! Cached Local Deck row projections and sparse formatted values.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet, hash_map::DefaultHasher};
 use std::hash::{Hash, Hasher};
 use std::path::Path;
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use super::super::local_format::*;
 use super::super::local_import_helpers::import_session_row_status_label;
 use super::super::*;
-use super::import_fingerprint::local_import_files_fingerprint;
+use super::import_fingerprint::{local_import_files_fingerprint, stable_import_cache_key};
 
 const MISSING_LOCAL_TRACK_INDEX: usize = usize::MAX;
 const LOCAL_VISIBLE_VALUE_CACHE_CAP: usize = 512;
@@ -96,6 +96,8 @@ pub(in crate::app) struct LocalRowsCache {
     config: u64,
     romanize: u64,
     import_files: Option<u64>,
+    /// Set only after a full terminal draw successfully presented this exact cached projection.
+    rendered: Cell<bool>,
     data: Rc<LocalRowsData>,
     total_len: usize,
 }
@@ -106,6 +108,11 @@ impl App {
         let section = self.local_mode.ui.section;
         let drill = self.local_mode.ui.drill.as_slice();
         let query = self.local_mode.ui.filter_query.as_str();
+        let import_before = local_rows_read_import_files(section, drill.last()).then(|| {
+            local_import_files_fingerprint(
+                &mut self.local_mode.import_files_fingerprint_cache.borrow_mut(),
+            )
+        });
         let korean = crate::i18n::is_korean();
         let index = local_index_rows_fingerprint(&self.local_mode.index.index);
         let downloads = local_download_rows_fingerprint(
@@ -118,12 +125,6 @@ impl App {
         );
         let config = local_config_rows_fingerprint(&self.config);
         let romanize = self.romanization.cache.rev();
-        let reads_import_files = local_rows_read_import_files(section, drill.last());
-        let import_files = reads_import_files.then(|| {
-            local_import_files_fingerprint(
-                &mut self.local_mode.import_files_fingerprint_cache.borrow_mut(),
-            )
-        });
 
         if let Some(cache) = self.local_mode.rows_cache.borrow().as_ref()
             && cache.revision == revision
@@ -136,7 +137,8 @@ impl App {
             && cache.errors == errors
             && cache.config == config
             && cache.romanize == romanize
-            && cache.import_files == import_files
+            && import_before.is_none_or(|fingerprint| fingerprint.reliable())
+            && cache.import_files == import_before.map(|fingerprint| fingerprint.digest())
         {
             return LocalRowsSnapshot {
                 data: Rc::clone(&cache.data),
@@ -144,28 +146,16 @@ impl App {
             };
         }
 
-        let rows = self.local_rows_for_query(query);
-        let total_len = if query.is_empty() {
-            rows.len()
-        } else {
-            self.local_rows_for_query("").len()
-        };
-        let kind = self.local_rows_kind(&rows);
-        let data = Rc::new(LocalRowsData {
-            rows: Arc::from(rows),
-            kind,
-            row_text: RefCell::new(HashMap::new()),
-            row_details: RefCell::new(HashMap::new()),
-            import_deletable: RefCell::new(HashMap::new()),
-            import_action_hint: RefCell::new(HashMap::new()),
-        });
-        // A recovering import read can atomically rewrite a session while constructing rows. Store
-        // the post-build filesystem signature so the freshly built entry is not needlessly stale.
-        let import_files = reads_import_files.then(|| {
+        let snapshot = self.build_local_rows_snapshot(query);
+        let import_after = import_before.map(|_| {
             local_import_files_fingerprint(
                 &mut self.local_mode.import_files_fingerprint_cache.borrow_mut(),
             )
         });
+        let Some(import_files) = stable_import_cache_key(import_before, import_after) else {
+            self.local_mode.rows_cache.borrow_mut().take();
+            return snapshot;
+        };
         *self.local_mode.rows_cache.borrow_mut() = Some(LocalRowsCache {
             revision,
             section,
@@ -178,10 +168,110 @@ impl App {
             config,
             romanize,
             import_files,
-            data: Rc::clone(&data),
-            total_len,
+            rendered: Cell::new(false),
+            data: Rc::clone(&snapshot.data),
+            total_len: snapshot.total_len,
         });
-        LocalRowsSnapshot { data, total_len }
+        snapshot
+    }
+
+    /// Record that the current import-backed Local rows cache reached the terminal in a successful
+    /// full draw. This intentionally does not touch the filesystem again: the fast-path freshness
+    /// probe compares the recorded cache digest with a new reliable fingerprint immediately before
+    /// every scrub, catching writes performed later in the same render (such as action hints).
+    pub(crate) fn mark_local_rows_rendered(&self) {
+        if !self.local_import_rows_view_active() {
+            return;
+        }
+        let cache = self.local_mode.rows_cache.borrow();
+        let Some(cache) = cache.as_ref() else {
+            return;
+        };
+        if cache.import_files.is_some()
+            && self.local_rows_cache_matches_current_state(cache, cache.import_files)
+        {
+            cache.rendered.set(true);
+        }
+    }
+
+    /// Whether terminal-only IME scrubbing may reuse the currently displayed Local projection.
+    /// Import artifacts are external mutable state, so this fails closed unless a reliable current
+    /// fingerprint matches a row cache that a successful full draw has already presented. The
+    /// runner calls this only after its reducer-turn/dirty/clear gates prove owner-loop state could
+    /// not have changed, avoiding repeated in-memory projection fingerprints on the 80 ms clock.
+    pub(crate) fn ime_scrub_local_projection_fresh(&self) -> bool {
+        if !self.local_import_rows_view_active() {
+            return true;
+        }
+        let fingerprint = local_import_files_fingerprint(
+            &mut self.local_mode.import_files_fingerprint_cache.borrow_mut(),
+        );
+        if !fingerprint.reliable() {
+            return false;
+        }
+        self.local_mode
+            .rows_cache
+            .borrow()
+            .as_ref()
+            .is_some_and(|cache| {
+                cache.rendered.get() && cache.import_files == Some(fingerprint.digest())
+            })
+    }
+
+    fn local_import_rows_view_active(&self) -> bool {
+        self.local_dedicated_mode
+            && self.mode == Mode::Library
+            && local_rows_read_import_files(
+                self.local_mode.ui.section,
+                self.local_mode.ui.drill.last(),
+            )
+    }
+
+    fn local_rows_cache_matches_current_state(
+        &self,
+        cache: &LocalRowsCache,
+        import_files: Option<u64>,
+    ) -> bool {
+        cache.revision == self.local_mode.rows_revision.get()
+            && cache.section == self.local_mode.ui.section
+            && cache.drill.as_slice() == self.local_mode.ui.drill.as_slice()
+            && cache.query == self.local_mode.ui.filter_query
+            && cache.korean == crate::i18n::is_korean()
+            && cache.index == local_index_rows_fingerprint(&self.local_mode.index.index)
+            && cache.downloads
+                == local_download_rows_fingerprint(
+                    self.library_ui.downloaded_rev,
+                    &self.library_ui.downloaded,
+                )
+            && cache.errors
+                == local_error_rows_fingerprint(
+                    &self.local_mode.index.load_errors,
+                    &self.local_mode.index.errors,
+                )
+            && cache.config == local_config_rows_fingerprint(&self.config)
+            && cache.romanize == self.romanization.cache.rev()
+            && cache.import_files == import_files
+    }
+
+    fn build_local_rows_snapshot(&self, query: &str) -> LocalRowsSnapshot {
+        let rows = self.local_rows_for_query(query);
+        let total_len = if query.is_empty() {
+            rows.len()
+        } else {
+            self.local_rows_for_query("").len()
+        };
+        let kind = self.local_rows_kind(&rows);
+        LocalRowsSnapshot {
+            data: Rc::new(LocalRowsData {
+                rows: Arc::from(rows),
+                kind,
+                row_text: RefCell::new(HashMap::new()),
+                row_details: RefCell::new(HashMap::new()),
+                import_deletable: RefCell::new(HashMap::new()),
+                import_action_hint: RefCell::new(HashMap::new()),
+            }),
+            total_len,
+        }
     }
 
     pub(crate) fn local_visible_rows(&self) -> Arc<[crate::local::LocalRowId]> {

--- a/src/app/local/rows_cache.rs
+++ b/src/app/local/rows_cache.rs
@@ -1,0 +1,1015 @@
+//! Cached Local Deck row projections and sparse formatted values.
+
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet, hash_map::DefaultHasher};
+use std::hash::{Hash, Hasher};
+use std::path::Path;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use super::super::local_format::*;
+use super::super::local_import_helpers::import_session_row_status_label;
+use super::super::*;
+use super::import_fingerprint::local_import_files_fingerprint;
+
+const MISSING_LOCAL_TRACK_INDEX: usize = usize::MAX;
+const LOCAL_VISIBLE_VALUE_CACHE_CAP: usize = 512;
+const LOCAL_SELECTED_VALUE_CACHE_CAP: usize = 64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct LocalIndexRowsFingerprint {
+    updated_at: i64,
+    len: usize,
+    representative: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct LocalDownloadRowsFingerprint {
+    revision: u64,
+    len: usize,
+    representative: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct LocalErrorRowsFingerprint {
+    load_len: usize,
+    scan_len: usize,
+    representative: u64,
+}
+
+struct LocalAlbumDisplay {
+    title: String,
+    album_artist: String,
+    year: Option<i32>,
+    track_count: usize,
+    duration_ms: Option<u64>,
+    embedded_cover_count: usize,
+}
+
+struct LocalArtistDisplay {
+    name: String,
+    album_count: usize,
+    track_count: usize,
+}
+
+struct LocalImportRowDisplay {
+    status: &'static str,
+    title: String,
+    artists: Vec<String>,
+}
+
+enum LocalRowsKind {
+    Empty,
+    Tracks(Box<[usize]>),
+    DownloadSeeds,
+    Albums(Box<[Option<LocalAlbumDisplay>]>),
+    Artists(Box<[Option<LocalArtistDisplay>]>),
+    Counted(Box<[usize]>),
+    ImportSessions(Box<[usize]>),
+    ImportRows(Box<[Option<LocalImportRowDisplay>]>),
+    ScanErrors,
+}
+
+/// Immutable row ids + compact data needed to format them without rebuilding the LocalIndex's
+/// album/artist/group projections. String/detail caches are sparse: only rows that actually become
+/// visible (or selected) allocate formatted output.
+pub(in crate::app) struct LocalRowsData {
+    pub(in crate::app) rows: Arc<[crate::local::LocalRowId]>,
+    kind: LocalRowsKind,
+    row_text: RefCell<HashMap<usize, Arc<str>>>,
+    row_details: RefCell<HashMap<usize, Arc<[String]>>>,
+    import_deletable: RefCell<HashMap<usize, bool>>,
+    import_action_hint: RefCell<HashMap<usize, Option<Arc<str>>>>,
+}
+
+/// The Local Deck only renders one section/query/drill path at a time, so retaining one entry keeps
+/// memory bounded while making all repeated reads in that state O(1).
+pub(in crate::app) struct LocalRowsCache {
+    revision: u64,
+    section: LocalSection,
+    drill: Vec<LocalDrill>,
+    query: String,
+    korean: bool,
+    index: LocalIndexRowsFingerprint,
+    downloads: LocalDownloadRowsFingerprint,
+    errors: LocalErrorRowsFingerprint,
+    config: u64,
+    romanize: u64,
+    import_files: Option<u64>,
+    data: Rc<LocalRowsData>,
+    total_len: usize,
+}
+
+impl App {
+    pub(crate) fn local_rows_snapshot(&self) -> LocalRowsSnapshot {
+        let revision = self.local_mode.rows_revision.get();
+        let section = self.local_mode.ui.section;
+        let drill = self.local_mode.ui.drill.as_slice();
+        let query = self.local_mode.ui.filter_query.as_str();
+        let korean = crate::i18n::is_korean();
+        let index = local_index_rows_fingerprint(&self.local_mode.index.index);
+        let downloads = local_download_rows_fingerprint(
+            self.library_ui.downloaded_rev,
+            &self.library_ui.downloaded,
+        );
+        let errors = local_error_rows_fingerprint(
+            &self.local_mode.index.load_errors,
+            &self.local_mode.index.errors,
+        );
+        let config = local_config_rows_fingerprint(&self.config);
+        let romanize = self.romanization.cache.rev();
+        let reads_import_files = local_rows_read_import_files(section, drill.last());
+        let import_files = reads_import_files.then(|| {
+            local_import_files_fingerprint(
+                &mut self.local_mode.import_files_fingerprint_cache.borrow_mut(),
+            )
+        });
+
+        if let Some(cache) = self.local_mode.rows_cache.borrow().as_ref()
+            && cache.revision == revision
+            && cache.section == section
+            && cache.drill.as_slice() == drill
+            && cache.query == query
+            && cache.korean == korean
+            && cache.index == index
+            && cache.downloads == downloads
+            && cache.errors == errors
+            && cache.config == config
+            && cache.romanize == romanize
+            && cache.import_files == import_files
+        {
+            return LocalRowsSnapshot {
+                data: Rc::clone(&cache.data),
+                total_len: cache.total_len,
+            };
+        }
+
+        let rows = self.local_rows_for_query(query);
+        let total_len = if query.is_empty() {
+            rows.len()
+        } else {
+            self.local_rows_for_query("").len()
+        };
+        let kind = self.local_rows_kind(&rows);
+        let data = Rc::new(LocalRowsData {
+            rows: Arc::from(rows),
+            kind,
+            row_text: RefCell::new(HashMap::new()),
+            row_details: RefCell::new(HashMap::new()),
+            import_deletable: RefCell::new(HashMap::new()),
+            import_action_hint: RefCell::new(HashMap::new()),
+        });
+        // A recovering import read can atomically rewrite a session while constructing rows. Store
+        // the post-build filesystem signature so the freshly built entry is not needlessly stale.
+        let import_files = reads_import_files.then(|| {
+            local_import_files_fingerprint(
+                &mut self.local_mode.import_files_fingerprint_cache.borrow_mut(),
+            )
+        });
+        *self.local_mode.rows_cache.borrow_mut() = Some(LocalRowsCache {
+            revision,
+            section,
+            drill: drill.to_vec(),
+            query: query.to_owned(),
+            korean,
+            index,
+            downloads,
+            errors,
+            config,
+            romanize,
+            import_files,
+            data: Rc::clone(&data),
+            total_len,
+        });
+        LocalRowsSnapshot { data, total_len }
+    }
+
+    pub(crate) fn local_visible_rows(&self) -> Arc<[crate::local::LocalRowId]> {
+        Arc::clone(&self.local_rows_snapshot().data.rows)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn local_uncached_rows_snapshot(&self) -> LocalRowsSnapshot {
+        let query = self.local_mode.ui.filter_query.as_str();
+        let rows = self.local_rows_for_query(query);
+        let total_len = if query.is_empty() {
+            rows.len()
+        } else {
+            self.local_rows_for_query("").len()
+        };
+        LocalRowsSnapshot {
+            data: Rc::new(LocalRowsData {
+                rows: Arc::from(rows),
+                // Empty deliberately routes formatting/details through the exact legacy lookup
+                // paths; equivalence tests compare that surface with the cached projections.
+                kind: LocalRowsKind::Empty,
+                row_text: RefCell::new(HashMap::new()),
+                row_details: RefCell::new(HashMap::new()),
+                import_deletable: RefCell::new(HashMap::new()),
+                import_action_hint: RefCell::new(HashMap::new()),
+            }),
+            total_len,
+        }
+    }
+
+    fn local_rows_kind(&self, rows: &[crate::local::LocalRowId]) -> LocalRowsKind {
+        let Some(first) = rows.first() else {
+            return LocalRowsKind::Empty;
+        };
+        match first {
+            crate::local::LocalRowId::Track(_) => {
+                let positions: HashMap<_, _> = self
+                    .local_mode
+                    .index
+                    .index
+                    .tracks()
+                    .iter()
+                    .enumerate()
+                    .map(|(index, track)| (&track.id, index))
+                    .collect();
+                let indices = rows
+                    .iter()
+                    .map(|row| match row {
+                        crate::local::LocalRowId::Track(id) => positions
+                            .get(id)
+                            .copied()
+                            .unwrap_or(MISSING_LOCAL_TRACK_INDEX),
+                        _ => MISSING_LOCAL_TRACK_INDEX,
+                    })
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice();
+                LocalRowsKind::Tracks(indices)
+            }
+            crate::local::LocalRowId::DownloadSeed(_) => LocalRowsKind::DownloadSeeds,
+            crate::local::LocalRowId::Album(_) => {
+                let covered: HashSet<_> = self
+                    .local_mode
+                    .index
+                    .index
+                    .tracks()
+                    .iter()
+                    .filter(|track| track.embedded_art_key.is_some())
+                    .map(|track| track.id.as_str())
+                    .collect();
+                let mut albums: HashMap<_, _> = self
+                    .local_mode
+                    .index
+                    .index
+                    .albums()
+                    .into_iter()
+                    .map(|album| {
+                        let embedded_cover_count = album
+                            .track_ids
+                            .iter()
+                            .filter(|id| covered.contains(id.as_str()))
+                            .count();
+                        (
+                            album.id,
+                            LocalAlbumDisplay {
+                                title: album.title,
+                                album_artist: album.album_artist,
+                                year: album.year,
+                                track_count: album.track_count,
+                                duration_ms: album.duration_ms,
+                                embedded_cover_count,
+                            },
+                        )
+                    })
+                    .collect();
+                let albums = rows
+                    .iter()
+                    .map(|row| match row {
+                        crate::local::LocalRowId::Album(id) => albums.remove(id),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice();
+                LocalRowsKind::Albums(albums)
+            }
+            crate::local::LocalRowId::Artist(_) => {
+                let mut artists: HashMap<_, _> = self
+                    .local_mode
+                    .index
+                    .index
+                    .artists()
+                    .into_iter()
+                    .map(|artist| {
+                        (
+                            artist.id,
+                            LocalArtistDisplay {
+                                name: artist.name,
+                                album_count: artist.album_ids.len(),
+                                track_count: artist.track_ids.len(),
+                            },
+                        )
+                    })
+                    .collect();
+                let artists = rows
+                    .iter()
+                    .map(|row| match row {
+                        crate::local::LocalRowId::Artist(id) => artists.remove(id),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice();
+                LocalRowsKind::Artists(artists)
+            }
+            crate::local::LocalRowId::Genre(_) => {
+                let mut counts = HashMap::<String, usize>::new();
+                for track in self.local_mode.index.index.tracks() {
+                    let mut seen = HashSet::new();
+                    for genre in &track.genre {
+                        let genre = genre.trim();
+                        if !genre.is_empty() {
+                            let key = crate::local::model::normalize_key(genre);
+                            if seen.insert(key.clone()) {
+                                *counts.entry(key).or_default() += 1;
+                            }
+                        }
+                    }
+                }
+                LocalRowsKind::Counted(
+                    rows.iter()
+                        .map(|row| match row {
+                            crate::local::LocalRowId::Genre(genre) => counts
+                                .get(&crate::local::model::normalize_key(genre))
+                                .copied()
+                                .unwrap_or_default(),
+                            _ => 0,
+                        })
+                        .collect::<Vec<_>>()
+                        .into_boxed_slice(),
+                )
+            }
+            crate::local::LocalRowId::Folder(_) => {
+                let mut counts = HashMap::<&Path, usize>::new();
+                for track in self.local_mode.index.index.tracks() {
+                    if let Some(parent) = track.path.parent() {
+                        *counts.entry(parent).or_default() += 1;
+                    }
+                }
+                LocalRowsKind::Counted(
+                    rows.iter()
+                        .map(|row| match row {
+                            crate::local::LocalRowId::Folder(folder) => {
+                                counts.get(folder.as_path()).copied().unwrap_or_default()
+                            }
+                            _ => 0,
+                        })
+                        .collect::<Vec<_>>()
+                        .into_boxed_slice(),
+                )
+            }
+            crate::local::LocalRowId::Smart(_) => {
+                let download_dir = self.config.effective_download_dir();
+                LocalRowsKind::Counted(
+                    rows.iter()
+                        .map(|row| match row {
+                            crate::local::LocalRowId::Smart(smart) => {
+                                self.local_smart_track_count(*smart, &download_dir)
+                            }
+                            _ => 0,
+                        })
+                        .collect::<Vec<_>>()
+                        .into_boxed_slice(),
+                )
+            }
+            crate::local::LocalRowId::ImportSession(_) => {
+                let mut counts = HashMap::<&str, usize>::new();
+                for track in self.local_mode.index.index.tracks() {
+                    if let Some(session_id) = track.import_session_id.as_deref() {
+                        *counts.entry(session_id).or_default() += 1;
+                    }
+                }
+                LocalRowsKind::ImportSessions(
+                    rows.iter()
+                        .map(|row| match row {
+                            crate::local::LocalRowId::ImportSession(session_id) => {
+                                counts.get(session_id.as_str()).copied().unwrap_or_default()
+                            }
+                            _ => 0,
+                        })
+                        .collect::<Vec<_>>()
+                        .into_boxed_slice(),
+                )
+            }
+            crate::local::LocalRowId::ImportSessionRow { .. } => {
+                LocalRowsKind::ImportRows(self.local_import_row_displays(rows))
+            }
+            crate::local::LocalRowId::ScanError(_) => LocalRowsKind::ScanErrors,
+        }
+    }
+
+    fn local_import_row_displays(
+        &self,
+        rows: &[crate::local::LocalRowId],
+    ) -> Box<[Option<LocalImportRowDisplay>]> {
+        let mut needed = HashMap::<String, HashSet<u32>>::new();
+        for row in rows {
+            if let crate::local::LocalRowId::ImportSessionRow {
+                session_id,
+                source_order,
+            } = row
+            {
+                needed
+                    .entry(session_id.clone())
+                    .or_default()
+                    .insert(*source_order);
+            }
+        }
+        let mut displays = HashMap::<String, HashMap<u32, LocalImportRowDisplay>>::new();
+        for (session_id, orders) in needed {
+            let Ok(session) = crate::transfer::session::ImportSession::load(&session_id) else {
+                continue;
+            };
+            let by_order = session
+                .rows
+                .into_iter()
+                .filter(|row| orders.contains(&row.source_order))
+                .map(|row| {
+                    let source_order = row.source_order;
+                    let status = import_session_row_status_label(&row);
+                    (
+                        source_order,
+                        LocalImportRowDisplay {
+                            status,
+                            title: row.title,
+                            artists: row.artists,
+                        },
+                    )
+                })
+                .collect();
+            displays.insert(session_id, by_order);
+        }
+        rows.iter()
+            .map(|row| match row {
+                crate::local::LocalRowId::ImportSessionRow {
+                    session_id,
+                    source_order,
+                } => displays
+                    .get_mut(session_id)
+                    .and_then(|rows| rows.remove(source_order)),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice()
+    }
+
+    pub(crate) fn local_row_text_at(&self, snapshot: &LocalRowsSnapshot, index: usize) -> Arc<str> {
+        if let Some(text) = snapshot.data.row_text.borrow().get(&index).cloned() {
+            return text;
+        }
+        let Some(row) = snapshot.rows().get(index) else {
+            return Arc::from("");
+        };
+        let text = self.local_row_text_from_snapshot(snapshot, index, row);
+        let text: Arc<str> = Arc::from(text);
+        insert_bounded_local_value(
+            &snapshot.data.row_text,
+            index,
+            Arc::clone(&text),
+            LOCAL_VISIBLE_VALUE_CACHE_CAP,
+        );
+        text
+    }
+
+    fn local_row_text_from_snapshot(
+        &self,
+        snapshot: &LocalRowsSnapshot,
+        index: usize,
+        row: &crate::local::LocalRowId,
+    ) -> String {
+        match (&snapshot.data.kind, row) {
+            (LocalRowsKind::Tracks(indices), crate::local::LocalRowId::Track(_)) => indices
+                .get(index)
+                .and_then(|track_index| self.local_mode.index.index.tracks().get(*track_index))
+                .map(|track| local_track_text(self, track))
+                .unwrap_or_else(|| self.local_row_text_uncached(row)),
+            (
+                LocalRowsKind::DownloadSeeds,
+                crate::local::LocalRowId::DownloadSeed(download_index),
+            ) => self
+                .library_ui
+                .downloaded
+                .get(*download_index)
+                .map(|song| local_song_text(self, song))
+                .unwrap_or_else(|| t!("Missing track", "없는 곡").to_owned()),
+            (LocalRowsKind::Albums(albums), crate::local::LocalRowId::Album(_)) => albums
+                .get(index)
+                .and_then(Option::as_ref)
+                .map(|album| {
+                    let duration = album.duration_ms.map(format_local_duration_ms);
+                    let year = album.year.map(|year| year.to_string()).unwrap_or_default();
+                    let suffix = match (year.is_empty(), duration) {
+                        (false, Some(duration)) => format!("  {year} - {duration}"),
+                        (false, None) => format!("  {year}"),
+                        (true, Some(duration)) => format!("  {duration}"),
+                        (true, None) => String::new(),
+                    };
+                    format!(
+                        "{} - {}  ({} {}){}",
+                        album.title,
+                        album.album_artist,
+                        album.track_count,
+                        t!("tracks", "곡"),
+                        suffix
+                    )
+                })
+                .unwrap_or_else(|| t!("Missing album", "없는 앨범").to_owned()),
+            (LocalRowsKind::Artists(artists), crate::local::LocalRowId::Artist(_)) => artists
+                .get(index)
+                .and_then(Option::as_ref)
+                .map(|artist| {
+                    format!(
+                        "{}  ({} {}, {} {})",
+                        artist.name,
+                        artist.album_count,
+                        t!("albums", "앨범"),
+                        artist.track_count,
+                        t!("tracks", "곡")
+                    )
+                })
+                .unwrap_or_else(|| t!("Missing artist", "없는 아티스트").to_owned()),
+            (LocalRowsKind::Counted(counts), crate::local::LocalRowId::Genre(genre)) => {
+                let count = counts.get(index).copied().unwrap_or_default();
+                format!("{genre}  ({count} {})", t!("tracks", "곡"))
+            }
+            (LocalRowsKind::Counted(counts), crate::local::LocalRowId::Folder(folder)) => {
+                let count = counts.get(index).copied().unwrap_or_default();
+                format!("{}  ({count} {})", folder.display(), t!("tracks", "곡"))
+            }
+            (LocalRowsKind::Counted(counts), crate::local::LocalRowId::Smart(smart)) => {
+                let count = counts.get(index).copied().unwrap_or_default();
+                format!("{}  ({count} {})", smart.label(), t!("tracks", "곡"))
+            }
+            (
+                LocalRowsKind::ImportSessions(track_counts),
+                crate::local::LocalRowId::ImportSession(session_id),
+            ) => local_import_session_text(
+                session_id,
+                track_counts.get(index).copied().unwrap_or_default(),
+            ),
+            (
+                LocalRowsKind::ImportRows(displays),
+                crate::local::LocalRowId::ImportSessionRow { source_order, .. },
+            ) => displays
+                .get(index)
+                .and_then(Option::as_ref)
+                .map(|display| {
+                    let artist = if display.artists.is_empty() {
+                        t!("Local file", "로컬 파일").to_owned()
+                    } else {
+                        display.artists.join(", ")
+                    };
+                    let title = display.title.trim();
+                    if title.is_empty() {
+                        format!("#{source_order} {} - {artist}", display.status)
+                    } else {
+                        format!("#{source_order} {} {title} - {artist}", display.status)
+                    }
+                })
+                .unwrap_or_else(|| self.local_row_text_uncached(row)),
+            (LocalRowsKind::ScanErrors, crate::local::LocalRowId::ScanError(issue_index)) => self
+                .local_scan_issue(*issue_index)
+                .map(|error| format!("{} - {}", error.path.display(), error.message))
+                .unwrap_or_else(|| t!("Missing scan error", "없는 스캔 오류").to_owned()),
+            _ => self.local_row_text_uncached(row),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn local_row_text(&self, row: &crate::local::LocalRowId) -> String {
+        let snapshot = self.local_rows_snapshot();
+        if let Some(index) = snapshot
+            .rows()
+            .iter()
+            .position(|candidate| candidate == row)
+        {
+            return self.local_row_text_at(&snapshot, index).to_string();
+        }
+        self.local_row_text_uncached(row)
+    }
+
+    fn local_row_text_uncached(&self, row: &crate::local::LocalRowId) -> String {
+        match row {
+            crate::local::LocalRowId::Track(id) => self
+                .local_track_by_id(id)
+                .map(|track| local_track_text(self, track))
+                .unwrap_or_else(|| t!("Missing track", "없는 곡").to_owned()),
+            crate::local::LocalRowId::DownloadSeed(index) => self
+                .library_ui
+                .downloaded
+                .get(*index)
+                .map(|song| local_song_text(self, song))
+                .unwrap_or_else(|| t!("Missing track", "없는 곡").to_owned()),
+            crate::local::LocalRowId::Album(id) => self
+                .local_album_by_id(id)
+                .map(|album| {
+                    let duration = album.duration_ms.map(format_local_duration_ms);
+                    let year = album.year.map(|year| year.to_string()).unwrap_or_default();
+                    let suffix = match (year.is_empty(), duration) {
+                        (false, Some(duration)) => format!("  {year} - {duration}"),
+                        (false, None) => format!("  {year}"),
+                        (true, Some(duration)) => format!("  {duration}"),
+                        (true, None) => String::new(),
+                    };
+                    format!(
+                        "{} - {}  ({} {}){}",
+                        album.title,
+                        album.album_artist,
+                        album.track_count,
+                        t!("tracks", "곡"),
+                        suffix
+                    )
+                })
+                .unwrap_or_else(|| t!("Missing album", "없는 앨범").to_owned()),
+            crate::local::LocalRowId::Artist(id) => self
+                .local_artist_by_id(id)
+                .map(|artist| {
+                    format!(
+                        "{}  ({} {}, {} {})",
+                        artist.name,
+                        artist.album_ids.len(),
+                        t!("albums", "앨범"),
+                        artist.track_ids.len(),
+                        t!("tracks", "곡")
+                    )
+                })
+                .unwrap_or_else(|| t!("Missing artist", "없는 아티스트").to_owned()),
+            crate::local::LocalRowId::Genre(genre) => {
+                let count = self.local_tracks_for_genre(genre).len();
+                format!("{genre}  ({count} {})", t!("tracks", "곡"))
+            }
+            crate::local::LocalRowId::Folder(folder) => {
+                let count = self.local_tracks_for_folder(folder).len();
+                format!("{}  ({count} {})", folder.display(), t!("tracks", "곡"))
+            }
+            crate::local::LocalRowId::Smart(smart) => {
+                let count = self.local_tracks_for_smart(*smart).len();
+                format!("{}  ({count} {})", smart.label(), t!("tracks", "곡"))
+            }
+            crate::local::LocalRowId::ImportSession(session_id) => local_import_session_text(
+                session_id,
+                self.local_tracks_for_import_session(session_id).len(),
+            ),
+            crate::local::LocalRowId::ImportSessionRow {
+                session_id,
+                source_order,
+            } => self.local_import_session_row_text(session_id, *source_order),
+            crate::local::LocalRowId::ScanError(index) => self
+                .local_scan_issue(*index)
+                .map(|error| format!("{} - {}", error.path.display(), error.message))
+                .unwrap_or_else(|| t!("Missing scan error", "없는 스캔 오류").to_owned()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn local_details_lines(&self) -> Vec<String> {
+        let snapshot = self.local_rows_snapshot();
+        self.local_details_lines_for_snapshot(&snapshot)
+    }
+
+    pub(crate) fn local_details_lines_for_snapshot(
+        &self,
+        snapshot: &LocalRowsSnapshot,
+    ) -> Vec<String> {
+        let mut lines = Vec::new();
+        lines.push(t!("Selected", "선택").to_owned());
+        if snapshot.rows().get(self.local_mode.ui.selected).is_some() {
+            lines.extend(
+                self.local_row_details_at(snapshot, self.local_mode.ui.selected)
+                    .iter()
+                    .cloned(),
+            );
+        } else {
+            lines.push(t!("No local item selected.", "선택된 로컬 항목이 없습니다.").to_owned());
+        }
+
+        lines.push(String::new());
+        self.push_local_queue_details(&mut lines);
+        lines
+    }
+
+    pub(crate) fn local_details_summary_for_snapshot(
+        &self,
+        snapshot: &LocalRowsSnapshot,
+    ) -> String {
+        let selected = if snapshot.rows().get(self.local_mode.ui.selected).is_some() {
+            self.local_row_text_at(snapshot, self.local_mode.ui.selected)
+                .to_string()
+        } else {
+            t!("No selection", "선택 없음").to_owned()
+        };
+        let Some(current) = self.queue.current() else {
+            return format!("{}: {selected}", t!("Selected", "선택"));
+        };
+        format!(
+            "{}: {selected}  |  {}: {}",
+            t!("Selected", "선택"),
+            t!("Now", "재생 중"),
+            local_song_text(self, current)
+        )
+    }
+
+    fn local_row_details_at(&self, snapshot: &LocalRowsSnapshot, index: usize) -> Arc<[String]> {
+        if let Some(lines) = snapshot.data.row_details.borrow().get(&index).cloned() {
+            return lines;
+        }
+        let Some(row) = snapshot.rows().get(index) else {
+            return Arc::from(Vec::<String>::new());
+        };
+        let mut lines = Vec::new();
+        match (&snapshot.data.kind, row) {
+            (LocalRowsKind::Tracks(indices), crate::local::LocalRowId::Track(_)) => {
+                if let Some(track) = indices
+                    .get(index)
+                    .and_then(|track_index| self.local_mode.index.index.tracks().get(*track_index))
+                {
+                    self.push_local_track_details(&mut lines, track);
+                } else {
+                    self.push_local_row_details(&mut lines, row);
+                }
+            }
+            (
+                LocalRowsKind::DownloadSeeds,
+                crate::local::LocalRowId::DownloadSeed(download_index),
+            ) => {
+                if let Some(song) = self.library_ui.downloaded.get(*download_index) {
+                    self.push_local_song_details(&mut lines, song);
+                }
+            }
+            (LocalRowsKind::Albums(albums), crate::local::LocalRowId::Album(_)) => {
+                if let Some(album) = albums.get(index).and_then(Option::as_ref) {
+                    push_detail_line(&mut lines, t!("Album", "앨범"), &album.title);
+                    push_detail_line(&mut lines, t!("Artist", "아티스트"), &album.album_artist);
+                    if let Some(year) = album.year {
+                        push_detail_line(&mut lines, t!("Year", "연도"), year.to_string());
+                    }
+                    push_detail_line(
+                        &mut lines,
+                        t!("Tracks", "곡"),
+                        format!("{} {}", album.track_count, t!("tracks", "곡")),
+                    );
+                    if let Some(duration) = album.duration_ms {
+                        push_detail_line(
+                            &mut lines,
+                            t!("Duration", "길이"),
+                            format_local_duration_ms(duration),
+                        );
+                    }
+                    push_detail_line(
+                        &mut lines,
+                        t!("Cover", "커버"),
+                        format_embedded_cover_count(album.embedded_cover_count),
+                    );
+                }
+            }
+            (LocalRowsKind::Artists(artists), crate::local::LocalRowId::Artist(_)) => {
+                if let Some(artist) = artists.get(index).and_then(Option::as_ref) {
+                    push_detail_line(&mut lines, t!("Artist", "아티스트"), &artist.name);
+                    push_detail_line(
+                        &mut lines,
+                        t!("Albums", "앨범"),
+                        format!("{} {}", artist.album_count, t!("albums", "앨범")),
+                    );
+                    push_detail_line(
+                        &mut lines,
+                        t!("Tracks", "곡"),
+                        format!("{} {}", artist.track_count, t!("tracks", "곡")),
+                    );
+                }
+            }
+            (LocalRowsKind::Counted(counts), crate::local::LocalRowId::Genre(genre)) => {
+                push_detail_line(&mut lines, t!("Genre", "장르"), genre);
+                push_detail_line(
+                    &mut lines,
+                    t!("Tracks", "곡"),
+                    format!(
+                        "{} {}",
+                        counts.get(index).copied().unwrap_or_default(),
+                        t!("tracks", "곡")
+                    ),
+                );
+            }
+            (LocalRowsKind::Counted(counts), crate::local::LocalRowId::Folder(folder)) => {
+                push_detail_line(
+                    &mut lines,
+                    t!("Folder", "폴더"),
+                    folder.display().to_string(),
+                );
+                push_detail_line(
+                    &mut lines,
+                    t!("Tracks", "곡"),
+                    format!(
+                        "{} {}",
+                        counts.get(index).copied().unwrap_or_default(),
+                        t!("tracks", "곡")
+                    ),
+                );
+            }
+            (LocalRowsKind::Counted(counts), crate::local::LocalRowId::Smart(smart)) => {
+                push_detail_line(&mut lines, t!("Smart list", "스마트 목록"), smart.label());
+                push_detail_line(
+                    &mut lines,
+                    t!("Tracks", "곡"),
+                    format!(
+                        "{} {}",
+                        counts.get(index).copied().unwrap_or_default(),
+                        t!("tracks", "곡")
+                    ),
+                );
+            }
+            _ => self.push_local_row_details(&mut lines, row),
+        }
+        let lines: Arc<[String]> = Arc::from(lines);
+        insert_bounded_local_value(
+            &snapshot.data.row_details,
+            index,
+            Arc::clone(&lines),
+            LOCAL_SELECTED_VALUE_CACHE_CAP,
+        );
+        lines
+    }
+
+    pub(crate) fn local_import_record_deletable_at(
+        &self,
+        snapshot: &LocalRowsSnapshot,
+        index: usize,
+    ) -> bool {
+        if let Some(deletable) = snapshot.data.import_deletable.borrow().get(&index) {
+            return *deletable;
+        }
+        let deletable = snapshot
+            .rows()
+            .get(index)
+            .is_some_and(|row| self.local_import_record_deletable(row));
+        insert_bounded_local_value(
+            &snapshot.data.import_deletable,
+            index,
+            deletable,
+            LOCAL_VISIBLE_VALUE_CACHE_CAP,
+        );
+        deletable
+    }
+
+    pub(crate) fn local_import_action_hint_for_snapshot(
+        &self,
+        snapshot: &LocalRowsSnapshot,
+    ) -> Option<String> {
+        let index = self.local_mode.ui.selected;
+        snapshot.rows().get(index)?;
+        if let Some(hint) = snapshot.data.import_action_hint.borrow().get(&index) {
+            return hint.as_ref().map(|hint| hint.to_string());
+        }
+        let hint = self.local_import_action_hint();
+        insert_bounded_local_value(
+            &snapshot.data.import_action_hint,
+            index,
+            hint.as_deref().map(Arc::<str>::from),
+            LOCAL_SELECTED_VALUE_CACHE_CAP,
+        );
+        hint
+    }
+}
+
+fn local_rows_read_import_files(section: LocalSection, drill: Option<&LocalDrill>) -> bool {
+    match drill {
+        Some(LocalDrill::ImportSession(_)) => true,
+        Some(_) => false,
+        None => matches!(section, LocalSection::ImportSessions | LocalSection::Inbox),
+    }
+}
+
+fn insert_bounded_local_value<T>(
+    cache: &RefCell<HashMap<usize, T>>,
+    index: usize,
+    value: T,
+    capacity: usize,
+) {
+    let mut cache = cache.borrow_mut();
+    if cache.len() >= capacity && !cache.contains_key(&index) {
+        cache.clear();
+    }
+    cache.insert(index, value);
+}
+
+fn local_index_rows_fingerprint(index: &crate::local::LocalIndex) -> LocalIndexRowsFingerprint {
+    let tracks = index.tracks();
+    let mut hasher = DefaultHasher::new();
+    for sample in representative_indices(tracks.len()).into_iter().flatten() {
+        sample.hash(&mut hasher);
+        hash_local_track(&tracks[sample], &mut hasher);
+    }
+    LocalIndexRowsFingerprint {
+        updated_at: index.updated_at,
+        len: tracks.len(),
+        representative: hasher.finish(),
+    }
+}
+
+fn local_download_rows_fingerprint(revision: u64, songs: &[Song]) -> LocalDownloadRowsFingerprint {
+    let mut hasher = DefaultHasher::new();
+    for sample in representative_indices(songs.len()).into_iter().flatten() {
+        sample.hash(&mut hasher);
+        let song = &songs[sample];
+        song.video_id.hash(&mut hasher);
+        song.title.hash(&mut hasher);
+        song.artist.hash(&mut hasher);
+        song.artists.hash(&mut hasher);
+        song.duration.hash(&mut hasher);
+        song.album.hash(&mut hasher);
+        song.album_artist.hash(&mut hasher);
+        song.local_path.hash(&mut hasher);
+        song.import_session_id.hash(&mut hasher);
+        song.import_source_order.hash(&mut hasher);
+    }
+    LocalDownloadRowsFingerprint {
+        revision,
+        len: songs.len(),
+        representative: hasher.finish(),
+    }
+}
+
+fn local_error_rows_fingerprint(
+    load_errors: &[crate::local::ScanError],
+    scan_errors: &[crate::local::ScanError],
+) -> LocalErrorRowsFingerprint {
+    let mut hasher = DefaultHasher::new();
+    for (tag, errors) in [(0_u8, load_errors), (1_u8, scan_errors)] {
+        tag.hash(&mut hasher);
+        for sample in representative_indices(errors.len()).into_iter().flatten() {
+            sample.hash(&mut hasher);
+            errors[sample].path.hash(&mut hasher);
+            errors[sample].message.hash(&mut hasher);
+        }
+    }
+    LocalErrorRowsFingerprint {
+        load_len: load_errors.len(),
+        scan_len: scan_errors.len(),
+        representative: hasher.finish(),
+    }
+}
+
+fn local_config_rows_fingerprint(config: &crate::config::Config) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    config.download_dir.hash(&mut hasher);
+    config.romanized_titles.hash(&mut hasher);
+    config.local.include_download_dir.hash(&mut hasher);
+    config.local.roots.len().hash(&mut hasher);
+    for root in &config.local.roots {
+        root.path.hash(&mut hasher);
+        root.enabled.hash(&mut hasher);
+        root.recursive.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+fn representative_indices(len: usize) -> [Option<usize>; 3] {
+    match len {
+        0 => [None, None, None],
+        1 => [Some(0), None, None],
+        2 => [Some(0), Some(1), None],
+        _ => [Some(0), Some(len / 2), Some(len - 1)],
+    }
+}
+
+fn hash_local_track(track: &crate::local::LocalTrack, hasher: &mut impl Hasher) {
+    track.id.hash(hasher);
+    track.path.hash(hasher);
+    track.title.hash(hasher);
+    track.artist.hash(hasher);
+    track.album.hash(hasher);
+    track.album_artist.hash(hasher);
+    track.genre.hash(hasher);
+    track.year.hash(hasher);
+    track.disc_no.hash(hasher);
+    track.track_no.hash(hasher);
+    track.isrc.hash(hasher);
+    track.duration_ms.hash(hasher);
+    match &track.format {
+        None => 0_u8.hash(hasher),
+        Some(crate::local::AudioFormat::Aac) => 1_u8.hash(hasher),
+        Some(crate::local::AudioFormat::Flac) => 2_u8.hash(hasher),
+        Some(crate::local::AudioFormat::M4a) => 3_u8.hash(hasher),
+        Some(crate::local::AudioFormat::Mp3) => 4_u8.hash(hasher),
+        Some(crate::local::AudioFormat::Ogg) => 5_u8.hash(hasher),
+        Some(crate::local::AudioFormat::Opus) => 6_u8.hash(hasher),
+        Some(crate::local::AudioFormat::Wav) => 7_u8.hash(hasher),
+        Some(crate::local::AudioFormat::Wma) => 8_u8.hash(hasher),
+        Some(crate::local::AudioFormat::Other(value)) => {
+            9_u8.hash(hasher);
+            value.hash(hasher);
+        }
+    }
+    track.bitrate.hash(hasher);
+    track.sample_rate.hash(hasher);
+    track.file_size.hash(hasher);
+    track.modified_at.hash(hasher);
+    track.fingerprint.stable_hash().hash(hasher);
+    track.embedded_art_key.hash(hasher);
+    track.linked_video_id.hash(hasher);
+    track.origin_key.hash(hasher);
+    track.origin_url.hash(hasher);
+    track.import_session_id.hash(hasher);
+    track.import_source_order.hash(hasher);
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8,6 +8,7 @@
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};

--- a/src/app/reducer.rs
+++ b/src/app/reducer.rs
@@ -113,10 +113,11 @@ impl App {
                     self.dirty = true;
                 }
             }
-            Msg::AnimTick(logical_ticks) => {
-                // One reducer turn per actual draw. The variable timer batches exactly the legacy
-                // logical ticks ending at the newest draw-due frame.
-                self.advance_animation(logical_ticks);
+            Msg::AnimTick => {
+                // Advance the logical animation phase on every configured tick, but only request
+                // an actual terminal redraw when the active effect mix is due. This keeps visual
+                // timing stable while cutting the expensive render/terminal/compositor path.
+                self.advance_animation();
             }
             Msg::Focus(f) => {
                 // Terminal focus toggled. `animation_active()` reads `focused` to park the ~30 fps

--- a/src/app/reducer.rs
+++ b/src/app/reducer.rs
@@ -113,11 +113,10 @@ impl App {
                     self.dirty = true;
                 }
             }
-            Msg::AnimTick => {
-                // Advance the logical animation phase on every configured tick, but only request
-                // an actual terminal redraw when the active effect mix is due. This keeps visual
-                // timing stable while cutting the expensive render/terminal/compositor path.
-                self.advance_animation();
+            Msg::AnimTick(logical_ticks) => {
+                // One reducer turn per actual draw. The variable timer batches exactly the legacy
+                // logical ticks ending at the newest draw-due frame.
+                self.advance_animation(logical_ticks);
             }
             Msg::Focus(f) => {
                 // Terminal focus toggled. `animation_active()` reads `focused` to park the ~30 fps
@@ -139,11 +138,15 @@ impl App {
                     if t > 0.0 {
                         self.consecutive_play_errors = 0;
                     }
-                    // Redraw at most once per second; mpv emits `time-pos` far more often.
+                    // Keep the whole-second anchor current in every mode, but only redraw when
+                    // the Player view that renders the scalar is visible. Navigation back to the
+                    // Player already requests a frame, which reads the latest stored position.
                     let sec = t as i64;
                     if sec != self.anim.last_shown_sec {
                         self.anim.last_shown_sec = sec;
-                        self.dirty = true;
+                        if matches!(self.mode, Mode::Player) {
+                            self.dirty = true;
+                        }
                         tracing::debug!(time_pos = t, "progress");
                     }
                 }
@@ -156,12 +159,14 @@ impl App {
                     let had = self.playback.cache_time.is_some();
                     self.playback.cache_time = t;
                     self.playback.cache_time_at = t.map(|_| Instant::now());
-                    // Redraw at most once per second (mpv reports far more often), plus on
-                    // Some↔None transitions so the live-sync glyph never shows stale state.
+                    // Track whole seconds and Some↔None transitions in every mode. Only the
+                    // Player renders the live-sync state, and returning there requests a frame.
                     let sec = t.map_or(-1, |v| v as i64);
                     if sec != self.anim.last_shown_cache_sec || had != t.is_some() {
                         self.anim.last_shown_cache_sec = sec;
-                        self.dirty = true;
+                        if matches!(self.mode, Mode::Player) {
+                            self.dirty = true;
+                        }
                     }
                 }
                 PlayerMsg::AudioCodec(codec) => {

--- a/src/app/remote_reducer.rs
+++ b/src/app/remote_reducer.rs
@@ -447,9 +447,9 @@ impl App {
                 .playback
                 .stream_now_playing
                 .as_ref()
-                .map(|now| now.label()),
+                .map(|now| std::borrow::Cow::Owned(now.label())),
             owner_mode: InstanceMode::StandaloneTui,
-            eq_preset: self.audio.preset.label().to_string(),
+            eq_preset: self.audio.preset.label(),
             eq_bands: self.audio.bands,
             eq_normalize: self.audio.normalize,
             config: &self.config,
@@ -458,9 +458,9 @@ impl App {
                 self.media_art
                     .as_ref()
                     .filter(|art| art.key == song.video_id)
-                    .map(|art| ArtworkRef {
-                        key: art.key.clone(),
-                        path: Some(art.path.to_string_lossy().into_owned()),
+                    .map(|art| crate::remote::publish::CoreArtwork {
+                        key: &art.key,
+                        path: Some(art.path.as_path()),
                         mime: None,
                     })
             }),

--- a/src/app/settings_reducer.rs
+++ b/src/app/settings_reducer.rs
@@ -1910,13 +1910,13 @@ impl App {
                 self.status.text = t!("Settings saved", "설정을 저장했어요").to_owned();
             }
             Field::AudioMpvCacheForward => {
-                self.config.audio.mpv.cache_forward = settings::blank_to_none(&value)
-                    .unwrap_or_else(|| crate::config::MPV_CACHE_FORWARD_DEFAULT.to_owned());
+                let mpv = &mut self.config.audio.mpv;
+                mpv.set_cache_forward(settings::blank_to_none(&value));
                 self.status.text = t!("Settings saved", "설정을 저장했어요").to_owned();
             }
             Field::AudioMpvCacheBack => {
-                self.config.audio.mpv.cache_back = settings::blank_to_none(&value)
-                    .unwrap_or_else(|| crate::config::MPV_CACHE_BACK_DEFAULT.to_owned());
+                let mpv = &mut self.config.audio.mpv;
+                mpv.set_cache_back(settings::blank_to_none(&value));
                 self.status.text = t!("Settings saved", "설정을 저장했어요").to_owned();
             }
             Field::ApiKey => {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -816,20 +816,18 @@ pub struct LocalMode {
     pub(in crate::app) next_import_review_op_id: u64,
 }
 
-/// Animation clock and redraw-coalescing counters: the monotonic logical frame counter that drives
-/// every effect's phase, the legacy fractional draw-credit scheduler, and the last whole second /
-/// cache second rendered (so sub-second mpv position spam is coalesced). The one-shot [`FxState`]
-/// feedback and the `focused` gate live separately on [`App`].
+/// Animation clock and redraw-coalescing counters: the monotonic frame counter that drives every
+/// effect's phase, the fractional draw-credit scheduler and its last cadence, and the last whole
+/// second / cache second rendered (so sub-second mpv position spam is coalesced). The one-shot
+/// [`FxState`] feedback and the `focused` gate live separately on [`App`].
 pub struct Animation {
-    /// Monotonic logical animation frame counter. A variable-wake [`Msg::AnimTick`] can advance it
-    /// by multiple configured-FPS ticks at once. Drives every effect's phase; wraps harmlessly.
-    /// `0` at rest.
+    /// Monotonic animation frame counter, bumped on each [`Msg::AnimTick`] (~30 fps) while
+    /// animations are active. Drives every effect's phase; wraps harmlessly. `0` at rest.
     pub(in crate::app) anim_frame: u64,
-    /// Fractional redraw scheduler in logical-frame units. It preserves the exact historical
-    /// visible frame sequence when one draw-cadence wake replaces several logical ticks.
+    /// Fractional redraw scheduler for animation frames. The phase can advance at the configured
+    /// FPS while heavyweight effects redraw at a lower cadence, preserving motion timing without
+    /// forcing the terminal compositor to repaint every logical tick.
     pub(in crate::app) anim_draw_credit: u16,
-    /// Last logical cadence used to interpret [`Self::anim_draw_credit`].
-    pub(in crate::app) anim_last_tick_fps: u16,
     /// Last draw cadence used to interpret [`Self::anim_draw_credit`]. Reset when the active effect
     /// mix moves between cheap element effects, canvas effects, and the DJ Gem mascot.
     pub(in crate::app) anim_last_draw_fps: u16,
@@ -846,7 +844,6 @@ impl Default for Animation {
         Self {
             anim_frame: 0,
             anim_draw_credit: 0,
-            anim_last_tick_fps: 0,
             anim_last_draw_fps: 0,
             last_shown_sec: -1,
             last_shown_cache_sec: -1,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -49,7 +49,7 @@ pub struct RenderBridges {
     pub ai_transcript_scroll: crate::ui::scroll::ScrollState,
     /// Last rendered DJ Gem transcript visual lines, after wrapping and prefix indentation.
     /// Mouse-drag copy uses these exact rows so the copied text matches what was selected.
-    pub ai_transcript_copy_lines: RefCell<Arc<[String]>>,
+    pub ai_transcript_copy_lines: RefCell<Arc<[Arc<str>]>>,
     pub ai_scroll: crate::ui::scroll::ScrollState,
     /// The Settings field list keeps its own persistent offset too, so a mouse click on a
     /// visible row focuses it in place instead of letting ratatui re-derive the offset from 0
@@ -800,9 +800,8 @@ pub struct LocalMode {
     /// A single entry is enough: only the active section/query/drill path is rendered, and
     /// replacing it promptly releases potentially large row/id and derived-metadata arrays.
     pub(in crate::app) rows_cache: RefCell<Option<super::local::LocalRowsCache>>,
-    /// Import artifact metadata and content digests persist independently of the one-row-projection
-    /// entry so unchanged files are never opened from the render path. The cache prunes missing
-    /// paths after each scan and enforces a fixed entry ceiling.
+    /// Recognized import-artifact paths and metadata used to invalidate the row cache without
+    /// opening persisted JSON or rescanning unchanged directories from the render path.
     pub(in crate::app) import_files_fingerprint_cache:
         RefCell<super::local::LocalImportFilesFingerprintCache>,
     pub(in crate::app) normal_mode_queue: Option<QueueSnapshot>,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -49,7 +49,7 @@ pub struct RenderBridges {
     pub ai_transcript_scroll: crate::ui::scroll::ScrollState,
     /// Last rendered DJ Gem transcript visual lines, after wrapping and prefix indentation.
     /// Mouse-drag copy uses these exact rows so the copied text matches what was selected.
-    pub ai_transcript_copy_lines: RefCell<Vec<String>>,
+    pub ai_transcript_copy_lines: RefCell<Arc<[String]>>,
     pub ai_scroll: crate::ui::scroll::ScrollState,
     /// The Settings field list keeps its own persistent offset too, so a mouse click on a
     /// visible row focuses it in place instead of letting ratatui re-derive the offset from 0
@@ -418,6 +418,12 @@ pub struct AiState {
     pub model: GeminiModel,
     /// The chat transcript (user prompts, assistant replies, errors).
     pub messages: Vec<AiMessage>,
+    /// Production mutation generation for the wrapped-transcript render cache. Every reducer
+    /// append (including history trimming) advances it exactly once.
+    pub(crate) transcript_revision: u64,
+    /// Stable owner identity prevents a thread-local cache entry from one `App` being reused by a
+    /// different instance that happens to have the same revision and presentation settings.
+    pub(crate) transcript_cache_token: Arc<()>,
     /// The DJ Gem prompt being typed.
     pub input: String,
     /// Whether Ctrl+A has selected the whole DJ Gem prompt (next edit replaces/clears it).
@@ -461,7 +467,7 @@ pub struct ArtState {
     pub(in crate::app) resize_tx: Option<tokio::sync::mpsc::Sender<ResizeRequest>>,
     /// The decoded source image kept alongside the protocol for stale-result checks and future
     /// resize/protocol rebuilds. Reducer-only (was a private App field) — `pub(in crate::app)`.
-    pub(in crate::app) source: Option<DynamicImage>,
+    pub(in crate::app) source: Option<Arc<DynamicImage>>,
     /// Source pixel dimensions of the held art, for centering it within its panel.
     pub dims: (u32, u32),
     /// `video_id` the held art belongs to (guards against a stale image lingering).
@@ -763,6 +769,25 @@ pub struct LocalIndexRuntime {
     pub errors: Vec<crate::local::ScanError>,
 }
 
+/// One immutable view of the Local Deck rows used by a render pass. The backing row slice and
+/// its compact derived metadata are shared with the single-entry cache, so the header, body, and
+/// details panes never rebuild (or independently clone) the same row set within a frame.
+#[derive(Clone)]
+pub(crate) struct LocalRowsSnapshot {
+    pub(in crate::app) data: std::rc::Rc<super::local::LocalRowsData>,
+    pub(in crate::app) total_len: usize,
+}
+
+impl LocalRowsSnapshot {
+    pub(crate) fn rows(&self) -> &[crate::local::LocalRowId] {
+        self.data.rows.as_ref()
+    }
+
+    pub(crate) fn total_len(&self) -> usize {
+        self.total_len
+    }
+}
+
 /// Dedicated Local Deck state. The active `local_dedicated_mode` flag stays flat on
 /// [`App`], mirroring Radio mode, while this struct owns shell-local UI state and the
 /// pending enter/leave confirmation.
@@ -770,6 +795,16 @@ pub struct LocalIndexRuntime {
 pub struct LocalMode {
     pub ui: LocalUi,
     pub index: LocalIndexRuntime,
+    /// Explicit production mutation generation for the Local Deck derived-row cache.
+    pub(in crate::app) rows_revision: Cell<u64>,
+    /// A single entry is enough: only the active section/query/drill path is rendered, and
+    /// replacing it promptly releases potentially large row/id and derived-metadata arrays.
+    pub(in crate::app) rows_cache: RefCell<Option<super::local::LocalRowsCache>>,
+    /// Import artifact metadata and content digests persist independently of the one-row-projection
+    /// entry so unchanged files are never opened from the render path. The cache prunes missing
+    /// paths after each scan and enforces a fixed entry ceiling.
+    pub(in crate::app) import_files_fingerprint_cache:
+        RefCell<super::local::LocalImportFilesFingerprintCache>,
     pub(in crate::app) normal_mode_queue: Option<QueueSnapshot>,
     pub(in crate::app) local_mode_queue: Option<QueueSnapshot>,
     pub pending_confirm: Option<LocalModeConfirm>,
@@ -782,18 +817,20 @@ pub struct LocalMode {
     pub(in crate::app) next_import_review_op_id: u64,
 }
 
-/// Animation clock and redraw-coalescing counters: the monotonic frame counter that drives every
-/// effect's phase, the fractional draw-credit scheduler and its last cadence, and the last whole
-/// second / cache second rendered (so sub-second mpv position spam is coalesced). The one-shot
-/// [`FxState`] feedback and the `focused` gate live separately on [`App`].
+/// Animation clock and redraw-coalescing counters: the monotonic logical frame counter that drives
+/// every effect's phase, the legacy fractional draw-credit scheduler, and the last whole second /
+/// cache second rendered (so sub-second mpv position spam is coalesced). The one-shot [`FxState`]
+/// feedback and the `focused` gate live separately on [`App`].
 pub struct Animation {
-    /// Monotonic animation frame counter, bumped on each [`Msg::AnimTick`] (~30 fps) while
-    /// animations are active. Drives every effect's phase; wraps harmlessly. `0` at rest.
+    /// Monotonic logical animation frame counter. A variable-wake [`Msg::AnimTick`] can advance it
+    /// by multiple configured-FPS ticks at once. Drives every effect's phase; wraps harmlessly.
+    /// `0` at rest.
     pub(in crate::app) anim_frame: u64,
-    /// Fractional redraw scheduler for animation frames. The phase can advance at the configured
-    /// FPS while heavyweight effects redraw at a lower cadence, preserving motion timing without
-    /// forcing the terminal compositor to repaint every logical tick.
+    /// Fractional redraw scheduler in logical-frame units. It preserves the exact historical
+    /// visible frame sequence when one draw-cadence wake replaces several logical ticks.
     pub(in crate::app) anim_draw_credit: u16,
+    /// Last logical cadence used to interpret [`Self::anim_draw_credit`].
+    pub(in crate::app) anim_last_tick_fps: u16,
     /// Last draw cadence used to interpret [`Self::anim_draw_credit`]. Reset when the active effect
     /// mix moves between cheap element effects, canvas effects, and the DJ Gem mascot.
     pub(in crate::app) anim_last_draw_fps: u16,
@@ -810,6 +847,7 @@ impl Default for Animation {
         Self {
             anim_frame: 0,
             anim_draw_credit: 0,
+            anim_last_tick_fps: 0,
             anim_last_draw_fps: 0,
             last_shown_sec: -1,
             last_shown_cache_sec: -1,

--- a/src/app/tests/animations.rs
+++ b/src/app/tests/animations.rs
@@ -179,7 +179,7 @@ fn all_animations_on_render_every_view_without_panic() {
             app.fx.list = Some((0, mode));
             for _ in 0..4 {
                 // A few frames into every window (advances anim_frame via the real tick).
-                app.update(Msg::AnimTick(1));
+                app.update(Msg::AnimTick);
                 let _ = render_app_buffer(&app, 80, 24);
                 let _ = render_app_buffer(&app, 34, 10);
                 let _ = render_app_buffer(&app, 12, 4);
@@ -333,7 +333,7 @@ fn volume_edge_flash_blinks_color_without_moving_cells() {
         app.fx.volume = Some(app.anim_frame());
         let start = snapshot(&app);
         for _ in 0..app.anim_ms_frames(crate::ui::anim::fx_window::VOLUME_MS) / 2 {
-            app.update(Msg::AnimTick(1));
+            app.update(Msg::AnimTick);
         }
         let peak = snapshot(&app);
         assert_eq!(start.0, peak.0, "volume overlay moved at {volume}%");
@@ -357,7 +357,7 @@ fn volume_edge_flash_blinks_color_without_moving_cells() {
     app.fx.volume = Some(app.anim_frame());
     let start = snapshot(&app);
     for _ in 0..app.anim_ms_frames(crate::ui::anim::fx_window::VOLUME_MS) / 2 {
-        app.update(Msg::AnimTick(1));
+        app.update(Msg::AnimTick);
     }
     assert_eq!(
         start,
@@ -505,7 +505,7 @@ fn ambient_effects_draw_at_a_lower_cadence_than_one_shots() {
 }
 
 #[test]
-fn canvas_variable_wakes_preserve_30_to_20_legacy_due_times_and_frames() {
+fn canvas_animation_advances_phase_every_tick_but_caps_redraws() {
     let mut app = app_playing(1, 0);
     app.playback.paused = false;
     app.config.animations.master = true;
@@ -515,21 +515,18 @@ fn canvas_variable_wakes_preserve_30_to_20_legacy_due_times_and_frames() {
     assert_eq!(app.animation_tick_fps(), 30);
     assert_eq!(app.animation_draw_fps(), 20);
 
-    let mut due_ms = 0;
-    let expected = [(66, 2), (99, 3), (165, 5), (198, 6), (264, 8), (297, 9)];
-    for (expected_due_ms, expected_frame) in expected {
-        let logical_ticks = app.animation_ticks_until_next_draw();
-        due_ms += logical_ticks * 33;
+    let mut redraws = 0;
+    for expected_frame in 1..=30 {
         app.dirty = false;
-        app.update(Msg::AnimTick(logical_ticks));
-        assert_eq!(due_ms, expected_due_ms);
+        app.update(Msg::AnimTick);
         assert_eq!(app.anim.anim_frame, expected_frame);
-        assert!(app.dirty, "every timer wake must be an actual draw");
+        redraws += usize::from(app.dirty);
     }
+    assert_eq!(redraws, 20);
 }
 
 #[test]
-fn mascot_and_marquee_wakes_keep_their_legacy_integer_due_times() {
+fn ai_mascot_animation_redraws_only_when_pose_can_change() {
     let mut app = app_playing(1, 0);
     app.mode = Mode::Ai;
     app.playback.paused = false;
@@ -540,130 +537,122 @@ fn mascot_and_marquee_wakes_keep_their_legacy_integer_due_times() {
     assert_eq!(app.animation_tick_fps(), 30);
     assert_eq!(app.animation_draw_fps(), 3);
 
-    let mut due_ms = 0;
-    for (expected_due_ms, expected_frame) in [(330, 10), (660, 20), (990, 30)] {
-        let logical_ticks = app.animation_ticks_until_next_draw();
-        due_ms += logical_ticks * 33;
+    let mut redraws = 0;
+    for _ in 0..30 {
         app.dirty = false;
-        app.update(Msg::AnimTick(logical_ticks));
-        assert_eq!(due_ms, expected_due_ms);
-        assert_eq!(app.anim.anim_frame, expected_frame);
-        assert!(app.dirty);
+        app.update(Msg::AnimTick);
+        redraws += usize::from(app.dirty);
     }
+    assert_eq!(redraws, 3);
+}
 
+#[test]
+fn marquee_animation_advances_every_tick_but_redraws_only_on_steps() {
     let mut marquee = App::new(100);
     marquee.config.animations.fps = 30;
     marquee.bridges.marquee_ran.set(true);
     assert_eq!(marquee.animation_draw_fps(), 5);
-    let mut due_ms = 0;
-    for (expected_due_ms, expected_frame) in [(198, 6), (396, 12), (594, 18)] {
-        let logical_ticks = marquee.animation_ticks_until_next_draw();
-        due_ms += logical_ticks * 33;
+
+    let mut redraws = 0;
+    for expected_frame in 1..=30 {
         marquee.dirty = false;
-        marquee.update(Msg::AnimTick(logical_ticks));
-        assert_eq!(due_ms, expected_due_ms);
+        marquee.update(Msg::AnimTick);
         assert_eq!(marquee.anim_frame(), expected_frame);
-        assert!(marquee.dirty);
+        redraws += usize::from(marquee.dirty);
     }
+    assert_eq!(redraws, 5);
 }
 
 #[test]
-fn ambient_draw_sequences_stay_stable_at_5_30_and_60_configured_fps() {
-    for (fps, expected_frames) in [
-        (5, vec![1, 2, 3, 4, 5]),
-        (30, vec![3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]),
-        (60, vec![5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]),
-    ] {
+fn inactive_to_active_transition_retains_fractional_draw_credit() {
+    let mut app = App::new(100);
+    app.mode = Mode::Search;
+    app.config.animations.master = true;
+    app.config.animations.caret = true;
+    app.config.animations.fps = 30;
+    assert_eq!(app.animation_draw_fps(), 12);
+
+    // Two delivered ticks leave 24/30 credit without drawing.
+    for _ in 0..2 {
+        app.dirty = false;
+        app.update(Msg::AnimTick);
+        assert!(!app.dirty);
+    }
+    assert_eq!(app.anim.anim_draw_credit, 24);
+
+    // Focus parking is only an Interval polling gate. It must not reset the reducer's cadence.
+    app.update(Msg::Focus(false));
+    app.update(Msg::Focus(true));
+    app.dirty = false;
+    app.update(Msg::AnimTick);
+    assert_eq!(app.anim_frame(), 3);
+    assert_eq!(app.anim.anim_draw_credit, 6);
+    assert!(app.dirty, "the retained 24/30 credit makes tick three draw");
+}
+
+#[tokio::test]
+async fn delayed_interval_skip_matches_one_tick_oracle_for_canvas_marquee_and_fx() {
+    async fn assert_matches_one_tick(mut actual: App, mut oracle: App, label: &str) {
+        oracle.dirty = false;
+        oracle.update(Msg::AnimTick);
+        let oracle_dirty = oracle.dirty;
+        let oracle_frame = oracle.anim_frame();
+        let oracle_buffer = render_app_buffer(&oracle, 80, 24);
+
+        let period = std::time::Duration::from_millis(33);
+        let first_due = tokio::time::Instant::now() - std::time::Duration::from_millis(200);
+        let mut interval = tokio::time::interval_at(first_due, period);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        actual.dirty = false;
+        let delivered_due = interval.tick().await;
+        assert_eq!(delivered_due, first_due, "{label}: overdue first deadline");
+        actual.update(Msg::AnimTick);
+
+        assert_eq!(actual.anim_frame(), oracle_frame, "{label}: frame");
+        assert_eq!(actual.dirty, oracle_dirty, "{label}: draw credit");
+        assert_eq!(
+            render_app_buffer(&actual, 80, 24),
+            oracle_buffer,
+            "{label}: rendered buffer"
+        );
+    }
+
+    fn canvas_app() -> App {
+        let mut app = app_playing(1, 0);
+        app.playback.paused = false;
+        app.config.animations.master = true;
+        app.config.animations.rain = true;
+        app.config.animations.fps = 30;
+        assert_eq!(app.animation_draw_fps(), 20);
+        app
+    }
+
+    fn marquee_app() -> App {
+        let mut app = App::new(100);
+        app.config.animations.fps = 30;
+        app.bridges.marquee_ran.set(true);
+        assert_eq!(app.animation_draw_fps(), 5);
+        app
+    }
+
+    fn fx_app() -> App {
         let mut app = App::new(100);
         app.mode = Mode::Search;
         app.config.animations.master = true;
-        app.config.animations.caret = true;
-        app.config.animations.fps = fps;
-        for expected_frame in expected_frames {
-            let logical_ticks = app.animation_ticks_until_next_draw();
-            app.dirty = false;
-            app.update(Msg::AnimTick(logical_ticks));
-            assert_eq!(app.anim.anim_frame, expected_frame, "configured fps {fps}");
-            assert!(app.dirty);
-        }
+        app.config.animations.toast = true;
+        app.update(Msg::ApiModeResolved {
+            mode: ApiMode::Anonymous,
+            had_cookie: true,
+        });
+        assert!(app.fx_active());
+        assert_eq!(app.animation_draw_fps(), app.animation_tick_fps());
+        app
     }
-}
 
-#[test]
-fn delayed_wake_catches_up_to_latest_visible_phase_without_backlog_draws() {
-    let mut between_draws = app_playing(1, 0);
-    between_draws.playback.paused = false;
-    between_draws.config.animations.master = true;
-    between_draws.config.animations.rain = true;
-    between_draws.config.animations.fps = 30;
-
-    // Four logical deadlines have elapsed at 150 ms (33/66/99/132), but frame 4 was not a
-    // legacy draw. One wake must land on frame 3, the newest actually-visible phase.
-    let logical_ticks = between_draws.animation_ticks_through_latest_draw(150 / 33);
-    assert_eq!(logical_ticks, 3);
-    between_draws.dirty = false;
-    between_draws.update(Msg::AnimTick(logical_ticks));
-    assert_eq!(between_draws.anim_frame(), 3);
-    assert!(between_draws.dirty);
-    assert_eq!(between_draws.animation_ticks_until_next_draw(), 2);
-    assert_eq!(3 * 33 + 2 * 33, 165);
-
-    // A 200 ms stall crosses four draw deadlines. Catch up all four in the same reducer turn and
-    // render only the newest frame, then continue on the legacy grid at 264 ms.
-    let mut many_draws = app_playing(1, 0);
-    many_draws.playback.paused = false;
-    many_draws.config.animations.master = true;
-    many_draws.config.animations.rain = true;
-    many_draws.config.animations.fps = 30;
-    let logical_ticks = many_draws.animation_ticks_through_latest_draw(200 / 33);
-    assert_eq!(logical_ticks, 6);
-    many_draws.dirty = false;
-    many_draws.update(Msg::AnimTick(logical_ticks));
-    assert_eq!(many_draws.anim_frame(), 6);
-    assert!(many_draws.dirty);
-    assert_eq!(many_draws.animation_ticks_until_next_draw(), 2);
-    assert_eq!(6 * 33 + 2 * 33, 264);
-}
-
-#[test]
-fn variable_wakes_match_legacy_visible_buffers_at_fixed_wall_clock_checkpoints() {
-    for checkpoint_ms in [
-        0_u64, 32, 33, 65, 66, 98, 99, 131, 132, 150, 164, 165, 197, 198, 231, 990, 1024,
-    ] {
-        let mut legacy = app_playing(1, 0);
-        legacy.playback.paused = false;
-        legacy.config.animations.master = true;
-        legacy.config.animations.rain = true;
-        legacy.config.animations.fps = 30;
-        let mut legacy_visible = render_app_buffer(&legacy, 80, 24);
-        legacy.dirty = false;
-        for _ in 0..checkpoint_ms / 33 {
-            legacy.update(Msg::AnimTick(1));
-            if legacy.dirty {
-                legacy_visible = render_app_buffer(&legacy, 80, 24);
-                legacy.dirty = false;
-            }
-        }
-
-        let mut variable = app_playing(1, 0);
-        variable.playback.paused = false;
-        variable.config.animations.master = true;
-        variable.config.animations.rain = true;
-        variable.config.animations.fps = 30;
-        let mut variable_visible = render_app_buffer(&variable, 80, 24);
-        variable.dirty = false;
-        let logical_ticks = variable.animation_ticks_through_latest_draw(checkpoint_ms / 33);
-        if logical_ticks > 0 {
-            variable.update(Msg::AnimTick(logical_ticks));
-            assert!(variable.dirty);
-            variable_visible = render_app_buffer(&variable, 80, 24);
-        }
-
-        assert_eq!(
-            variable_visible, legacy_visible,
-            "visible buffer diverged at {checkpoint_ms} ms"
-        );
-    }
+    assert_matches_one_tick(canvas_app(), canvas_app(), "canvas").await;
+    assert_matches_one_tick(marquee_app(), marquee_app(), "marquee").await;
+    assert_matches_one_tick(fx_app(), fx_app(), "one-shot fx").await;
 }
 
 #[test]

--- a/src/app/tests/animations.rs
+++ b/src/app/tests/animations.rs
@@ -123,7 +123,8 @@ fn all_animations_on_render_every_view_without_panic() {
                 time: f64::from(i) * 5.0,
                 text: format!("line {i}"),
             })
-            .collect(),
+            .collect::<Vec<_>>()
+            .into(),
     });
     app.downloads
         .active
@@ -178,7 +179,7 @@ fn all_animations_on_render_every_view_without_panic() {
             app.fx.list = Some((0, mode));
             for _ in 0..4 {
                 // A few frames into every window (advances anim_frame via the real tick).
-                app.update(Msg::AnimTick);
+                app.update(Msg::AnimTick(1));
                 let _ = render_app_buffer(&app, 80, 24);
                 let _ = render_app_buffer(&app, 34, 10);
                 let _ = render_app_buffer(&app, 12, 4);
@@ -332,7 +333,7 @@ fn volume_edge_flash_blinks_color_without_moving_cells() {
         app.fx.volume = Some(app.anim_frame());
         let start = snapshot(&app);
         for _ in 0..app.anim_ms_frames(crate::ui::anim::fx_window::VOLUME_MS) / 2 {
-            app.update(Msg::AnimTick);
+            app.update(Msg::AnimTick(1));
         }
         let peak = snapshot(&app);
         assert_eq!(start.0, peak.0, "volume overlay moved at {volume}%");
@@ -356,7 +357,7 @@ fn volume_edge_flash_blinks_color_without_moving_cells() {
     app.fx.volume = Some(app.anim_frame());
     let start = snapshot(&app);
     for _ in 0..app.anim_ms_frames(crate::ui::anim::fx_window::VOLUME_MS) / 2 {
-        app.update(Msg::AnimTick);
+        app.update(Msg::AnimTick(1));
     }
     assert_eq!(
         start,
@@ -504,7 +505,7 @@ fn ambient_effects_draw_at_a_lower_cadence_than_one_shots() {
 }
 
 #[test]
-fn canvas_animation_advances_phase_every_tick_but_caps_redraws() {
+fn canvas_variable_wakes_preserve_30_to_20_legacy_due_times_and_frames() {
     let mut app = app_playing(1, 0);
     app.playback.paused = false;
     app.config.animations.master = true;
@@ -514,18 +515,21 @@ fn canvas_animation_advances_phase_every_tick_but_caps_redraws() {
     assert_eq!(app.animation_tick_fps(), 30);
     assert_eq!(app.animation_draw_fps(), 20);
 
-    let mut redraws = 0;
-    for expected_frame in 1..=30 {
+    let mut due_ms = 0;
+    let expected = [(66, 2), (99, 3), (165, 5), (198, 6), (264, 8), (297, 9)];
+    for (expected_due_ms, expected_frame) in expected {
+        let logical_ticks = app.animation_ticks_until_next_draw();
+        due_ms += logical_ticks * 33;
         app.dirty = false;
-        app.update(Msg::AnimTick);
+        app.update(Msg::AnimTick(logical_ticks));
+        assert_eq!(due_ms, expected_due_ms);
         assert_eq!(app.anim.anim_frame, expected_frame);
-        redraws += usize::from(app.dirty);
+        assert!(app.dirty, "every timer wake must be an actual draw");
     }
-    assert_eq!(redraws, 20);
 }
 
 #[test]
-fn ai_mascot_animation_redraws_only_when_pose_can_change() {
+fn mascot_and_marquee_wakes_keep_their_legacy_integer_due_times() {
     let mut app = app_playing(1, 0);
     app.mode = Mode::Ai;
     app.playback.paused = false;
@@ -536,13 +540,130 @@ fn ai_mascot_animation_redraws_only_when_pose_can_change() {
     assert_eq!(app.animation_tick_fps(), 30);
     assert_eq!(app.animation_draw_fps(), 3);
 
-    let mut redraws = 0;
-    for _ in 0..30 {
+    let mut due_ms = 0;
+    for (expected_due_ms, expected_frame) in [(330, 10), (660, 20), (990, 30)] {
+        let logical_ticks = app.animation_ticks_until_next_draw();
+        due_ms += logical_ticks * 33;
         app.dirty = false;
-        app.update(Msg::AnimTick);
-        redraws += usize::from(app.dirty);
+        app.update(Msg::AnimTick(logical_ticks));
+        assert_eq!(due_ms, expected_due_ms);
+        assert_eq!(app.anim.anim_frame, expected_frame);
+        assert!(app.dirty);
     }
-    assert_eq!(redraws, 3);
+
+    let mut marquee = App::new(100);
+    marquee.config.animations.fps = 30;
+    marquee.bridges.marquee_ran.set(true);
+    assert_eq!(marquee.animation_draw_fps(), 5);
+    let mut due_ms = 0;
+    for (expected_due_ms, expected_frame) in [(198, 6), (396, 12), (594, 18)] {
+        let logical_ticks = marquee.animation_ticks_until_next_draw();
+        due_ms += logical_ticks * 33;
+        marquee.dirty = false;
+        marquee.update(Msg::AnimTick(logical_ticks));
+        assert_eq!(due_ms, expected_due_ms);
+        assert_eq!(marquee.anim_frame(), expected_frame);
+        assert!(marquee.dirty);
+    }
+}
+
+#[test]
+fn ambient_draw_sequences_stay_stable_at_5_30_and_60_configured_fps() {
+    for (fps, expected_frames) in [
+        (5, vec![1, 2, 3, 4, 5]),
+        (30, vec![3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]),
+        (60, vec![5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]),
+    ] {
+        let mut app = App::new(100);
+        app.mode = Mode::Search;
+        app.config.animations.master = true;
+        app.config.animations.caret = true;
+        app.config.animations.fps = fps;
+        for expected_frame in expected_frames {
+            let logical_ticks = app.animation_ticks_until_next_draw();
+            app.dirty = false;
+            app.update(Msg::AnimTick(logical_ticks));
+            assert_eq!(app.anim.anim_frame, expected_frame, "configured fps {fps}");
+            assert!(app.dirty);
+        }
+    }
+}
+
+#[test]
+fn delayed_wake_catches_up_to_latest_visible_phase_without_backlog_draws() {
+    let mut between_draws = app_playing(1, 0);
+    between_draws.playback.paused = false;
+    between_draws.config.animations.master = true;
+    between_draws.config.animations.rain = true;
+    between_draws.config.animations.fps = 30;
+
+    // Four logical deadlines have elapsed at 150 ms (33/66/99/132), but frame 4 was not a
+    // legacy draw. One wake must land on frame 3, the newest actually-visible phase.
+    let logical_ticks = between_draws.animation_ticks_through_latest_draw(150 / 33);
+    assert_eq!(logical_ticks, 3);
+    between_draws.dirty = false;
+    between_draws.update(Msg::AnimTick(logical_ticks));
+    assert_eq!(between_draws.anim_frame(), 3);
+    assert!(between_draws.dirty);
+    assert_eq!(between_draws.animation_ticks_until_next_draw(), 2);
+    assert_eq!(3 * 33 + 2 * 33, 165);
+
+    // A 200 ms stall crosses four draw deadlines. Catch up all four in the same reducer turn and
+    // render only the newest frame, then continue on the legacy grid at 264 ms.
+    let mut many_draws = app_playing(1, 0);
+    many_draws.playback.paused = false;
+    many_draws.config.animations.master = true;
+    many_draws.config.animations.rain = true;
+    many_draws.config.animations.fps = 30;
+    let logical_ticks = many_draws.animation_ticks_through_latest_draw(200 / 33);
+    assert_eq!(logical_ticks, 6);
+    many_draws.dirty = false;
+    many_draws.update(Msg::AnimTick(logical_ticks));
+    assert_eq!(many_draws.anim_frame(), 6);
+    assert!(many_draws.dirty);
+    assert_eq!(many_draws.animation_ticks_until_next_draw(), 2);
+    assert_eq!(6 * 33 + 2 * 33, 264);
+}
+
+#[test]
+fn variable_wakes_match_legacy_visible_buffers_at_fixed_wall_clock_checkpoints() {
+    for checkpoint_ms in [
+        0_u64, 32, 33, 65, 66, 98, 99, 131, 132, 150, 164, 165, 197, 198, 231, 990, 1024,
+    ] {
+        let mut legacy = app_playing(1, 0);
+        legacy.playback.paused = false;
+        legacy.config.animations.master = true;
+        legacy.config.animations.rain = true;
+        legacy.config.animations.fps = 30;
+        let mut legacy_visible = render_app_buffer(&legacy, 80, 24);
+        legacy.dirty = false;
+        for _ in 0..checkpoint_ms / 33 {
+            legacy.update(Msg::AnimTick(1));
+            if legacy.dirty {
+                legacy_visible = render_app_buffer(&legacy, 80, 24);
+                legacy.dirty = false;
+            }
+        }
+
+        let mut variable = app_playing(1, 0);
+        variable.playback.paused = false;
+        variable.config.animations.master = true;
+        variable.config.animations.rain = true;
+        variable.config.animations.fps = 30;
+        let mut variable_visible = render_app_buffer(&variable, 80, 24);
+        variable.dirty = false;
+        let logical_ticks = variable.animation_ticks_through_latest_draw(checkpoint_ms / 33);
+        if logical_ticks > 0 {
+            variable.update(Msg::AnimTick(logical_ticks));
+            assert!(variable.dirty);
+            variable_visible = render_app_buffer(&variable, 80, 24);
+        }
+
+        assert_eq!(
+            variable_visible, legacy_visible,
+            "visible buffer diverged at {checkpoint_ms} ms"
+        );
+    }
 }
 
 #[test]

--- a/src/app/tests/library_core.rs
+++ b/src/app/tests/library_core.rs
@@ -1,5 +1,90 @@
 use super::*;
 
+fn render_window_ids(app: &App, start: usize, visible: usize) -> Vec<String> {
+    app.library_render_window(start, visible)
+        .into_iter()
+        .flatten()
+        .map(|song| song.video_id.clone())
+        .collect()
+}
+
+#[test]
+fn cached_library_render_windows_match_action_rows() {
+    let mut app = App::new(100);
+    for song in songs(8) {
+        app.library.record_play(&song);
+        if song.video_id.ends_with('2') || song.video_id.ends_with('5') {
+            app.library.toggle_favorite(&song);
+        }
+    }
+    app.mode = Mode::Library;
+
+    for tab in [LibraryTab::All, LibraryTab::Favorites, LibraryTab::History] {
+        app.library_ui.tab = tab;
+        for filter in ["", "title 2", "artist"] {
+            app.library_ui.filter_query = filter.to_owned();
+            let action_ids: Vec<_> = app
+                .library_rows()
+                .into_iter()
+                .map(|song| song.video_id.clone())
+                .collect();
+            let render_ids = render_window_ids(&app, 0, app.library_rows_len());
+            assert_eq!(render_ids, action_ids, "tab={tab:?}, filter={filter:?}");
+        }
+    }
+}
+
+#[test]
+fn playlist_render_window_handles_empty_and_small_lists() {
+    let mut app = App::new(100);
+    let empty_id = app.playlists.create("Empty").unwrap();
+    app.mode = Mode::Library;
+    app.library_ui.tab = LibraryTab::Playlists;
+    app.library_ui.open_playlist = Some(empty_id.clone());
+
+    assert_eq!(app.library_rows_len(), 0);
+    assert!(app.library_render_window(0, 8).is_empty());
+
+    app.playlists
+        .add(&empty_id, fsong("first", "First", "Artist"));
+    app.playlists
+        .add(&empty_id, fsong("second", "Second", "Artist"));
+    assert_eq!(app.library_rows_len(), 2);
+    assert_eq!(
+        render_window_ids(&app, 0, 8),
+        vec!["first".to_owned(), "second".to_owned()]
+    );
+    assert!(app.library_render_window(2, 8).is_empty());
+}
+
+#[test]
+fn playlist_render_window_preserves_filtered_bottom_offsets() {
+    let mut app = App::new(100);
+    let playlist_id = app.playlists.create("Window").unwrap();
+    for i in 0..12 {
+        let title = if i % 2 == 0 {
+            format!("Keep {i}")
+        } else {
+            format!("Skip {i}")
+        };
+        app.playlists.add(
+            &playlist_id,
+            Song::remote(format!("id{i}"), title, "Artist", "0:10"),
+        );
+    }
+    app.mode = Mode::Library;
+    app.library_ui.tab = LibraryTab::Playlists;
+    app.library_ui.open_playlist = Some(playlist_id);
+    app.library_ui.filter_query = "  kEeP  ".to_owned();
+
+    assert_eq!(app.library_rows_len(), 6);
+    assert_eq!(
+        render_window_ids(&app, 4, 20),
+        vec!["id8".to_owned(), "id10".to_owned()]
+    );
+    assert!(app.library_render_window(6, 20).is_empty());
+}
+
 #[test]
 fn f_toggles_favorite_of_current_track() {
     let mut app = app_playing(3, 0); // playing "id0"

--- a/src/app/tests/local.rs
+++ b/src/app/tests/local.rs
@@ -50,6 +50,36 @@ fn app_with_local_deck_index(tracks: Vec<crate::local::LocalTrack>) -> App {
     app
 }
 
+fn render_local_snapshot(
+    app: &App,
+    snapshot: &LocalRowsSnapshot,
+    width: u16,
+    height: u16,
+) -> (ratatui::buffer::Buffer, Vec<MouseButtonRegion>) {
+    app.clear_mouse_regions();
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            let area = frame.area();
+            crate::ui::views::local::render_test_snapshot(frame, app, area, snapshot);
+        })
+        .unwrap();
+    let buffer = terminal.backend().buffer().clone();
+    let hits = app.hits.regions().clone();
+    (buffer, hits)
+}
+
+fn assert_local_cached_render_matches_legacy(app: &App, width: u16, height: u16) {
+    let legacy = app.local_uncached_rows_snapshot();
+    let cached = app.local_rows_snapshot();
+    assert_eq!(legacy.rows(), cached.rows());
+    assert_eq!(legacy.total_len(), cached.total_len());
+    let legacy_render = render_local_snapshot(app, &legacy, width, height);
+    let cached_render = render_local_snapshot(app, &cached, width, height);
+    assert_eq!(legacy_render, cached_render);
+}
+
 #[test]
 fn double_click_library_nav_confirms_local_deck_shell() {
     let mut app = App::new(100);
@@ -724,6 +754,184 @@ fn local_deck_render_expands_details_then_collapses_to_summary() {
 
     let medium = render_app_buffer(&app, 90, 24);
     assert!(buffer_contains(&medium, "Selected: Palette - IU"));
+}
+
+#[test]
+fn local_rows_cache_reuses_arc_and_invalidates_for_revision_query_locale_and_fixture_content() {
+    let _language_guard = crate::i18n::lock_for_test();
+    let mut app = app_with_local_deck_index(vec![
+        local_deck_track(
+            "/tmp/music/a.flac",
+            "Alpha",
+            &["Artist"],
+            Some("Album"),
+            Some("Artist"),
+            &["Rock"],
+            1,
+        ),
+        local_deck_track(
+            "/tmp/music/b.flac",
+            "Beta",
+            &["Artist"],
+            Some("Album"),
+            Some("Artist"),
+            &["Rock"],
+            2,
+        ),
+        local_deck_track(
+            "/tmp/music/c.flac",
+            "Gamma",
+            &["Artist"],
+            Some("Album"),
+            Some("Artist"),
+            &["Rock"],
+            3,
+        ),
+    ]);
+
+    let first = app.local_visible_rows();
+    let second = app.local_visible_rows();
+    assert!(std::sync::Arc::ptr_eq(&first, &second));
+
+    app.local_mode.ui.filter_query = "beta".to_owned();
+    let filtered = app.local_visible_rows();
+    assert!(!std::sync::Arc::ptr_eq(&first, &filtered));
+    assert_eq!(filtered.len(), 1);
+
+    app.local_mode.ui.filter_query.clear();
+    let before_direct_fixture_edit = app.local_visible_rows();
+    let updated_at = app.local_mode.index.index.updated_at;
+    app.local_mode.index.index.tracks[1].title = "Fixture changed".to_owned();
+    assert_eq!(app.local_mode.index.index.updated_at, updated_at);
+    let after_direct_fixture_edit = app.local_visible_rows();
+    assert!(!std::sync::Arc::ptr_eq(
+        &before_direct_fixture_edit,
+        &after_direct_fixture_edit
+    ));
+
+    app.local_mode
+        .ui
+        .drill
+        .push(LocalDrill::Genre("Rock".to_owned()));
+    let drilled = app.local_visible_rows();
+    assert!(!std::sync::Arc::ptr_eq(
+        &after_direct_fixture_edit,
+        &drilled
+    ));
+    app.local_mode.ui.drill.clear();
+
+    let before_production_revision = app.local_visible_rows();
+    let same_index = app.local_mode.index.index.clone();
+    app.update(Msg::Local(LocalMsg::ScanFinished {
+        index_path: None,
+        result: crate::local::LocalScanResult {
+            summary: crate::local::LocalScanSummary {
+                indexed: same_index.tracks().len(),
+                ..crate::local::LocalScanSummary::default()
+            },
+            index: same_index,
+            errors: Vec::new(),
+        },
+    }));
+    let after_production_revision = app.local_visible_rows();
+    assert!(!std::sync::Arc::ptr_eq(
+        &before_production_revision,
+        &after_production_revision
+    ));
+
+    let old_language = crate::i18n::current();
+    crate::i18n::set_language(crate::i18n::Language::Korean);
+    let korean = app.local_visible_rows();
+    assert!(!std::sync::Arc::ptr_eq(&after_production_revision, &korean));
+    crate::i18n::set_language(old_language);
+}
+
+#[test]
+fn local_rows_cache_guards_direct_download_and_error_fixture_mutations() {
+    let mut downloads = App::new(100);
+    downloads.mode = Mode::Library;
+    downloads.library_ui.downloaded = vec![
+        local_song("download-a"),
+        local_song("download-b"),
+        local_song("download-c"),
+    ];
+    downloads.apply_local_mode_confirm(LocalModeConfirm::Enter);
+    let before_download_edit = downloads.local_visible_rows();
+    downloads.library_ui.downloaded[1].title = "Changed fixture title".to_owned();
+    let after_download_edit = downloads.local_visible_rows();
+    assert!(!std::sync::Arc::ptr_eq(
+        &before_download_edit,
+        &after_download_edit
+    ));
+    downloads.library_ui.downloaded_rev = downloads.library_ui.downloaded_rev.wrapping_add(1);
+    let after_download_revision = downloads.local_visible_rows();
+    assert!(!std::sync::Arc::ptr_eq(
+        &after_download_edit,
+        &after_download_revision
+    ));
+
+    let mut errors = app_with_local_deck_index(Vec::new());
+    errors.local_mode.index.errors = vec![crate::local::ScanError {
+        path: PathBuf::from("/tmp/broken.flac"),
+        message: "first fixture error".to_owned(),
+    }];
+    errors.switch_local_section(LocalSection::ScanErrors);
+    let before_error_edit = errors.local_visible_rows();
+    errors.local_mode.index.errors[0].message = "changed fixture error".to_owned();
+    let after_error_edit = errors.local_visible_rows();
+    assert!(!std::sync::Arc::ptr_eq(
+        &before_error_edit,
+        &after_error_edit
+    ));
+}
+
+#[test]
+fn local_cached_and_legacy_buffers_and_hits_match_across_layout_filter_scroll_and_locale() {
+    let _language_guard = crate::i18n::lock_for_test();
+    let tracks = (0..180)
+        .map(|index| {
+            let path = format!(
+                "/tmp/music/Artist {}/Album {}/track {index:03}.flac",
+                index % 9,
+                index % 13
+            );
+            let title = if index % 17 == 0 {
+                format!("Needle track {index:03}")
+            } else {
+                format!("Track {index:03}")
+            };
+            local_deck_track(
+                &path,
+                &title,
+                &["Test Artist"],
+                Some("Test Album"),
+                Some("Test Artist"),
+                &["Rock"],
+                index,
+            )
+        })
+        .collect();
+    let mut app = app_with_local_deck_index(tracks);
+
+    assert_local_cached_render_matches_legacy(&app, 120, 30);
+    app.local_mode.ui.selected = usize::MAX;
+    assert_local_cached_render_matches_legacy(&app, 60, 16);
+
+    app.local_mode.ui.selected = 0;
+    app.local_mode.ui.filter_query = "needle".to_owned();
+    assert_local_cached_render_matches_legacy(&app, 90, 24);
+
+    app.local_mode.ui.filter_query.clear();
+    app.local_mode.ui.selected = 140;
+    assert_local_cached_render_matches_legacy(&app, 72, 18);
+
+    let old_language = crate::i18n::current();
+    crate::i18n::set_language(crate::i18n::Language::Korean);
+    assert_local_cached_render_matches_legacy(&app, 110, 24);
+    crate::i18n::set_language(old_language);
+
+    let empty = app_with_local_deck_index(Vec::new());
+    assert_local_cached_render_matches_legacy(&empty, 60, 16);
 }
 
 #[test]

--- a/src/app/tests/local_import.rs
+++ b/src/app/tests/local_import.rs
@@ -870,7 +870,7 @@ fn orphan_report_without_session_document_is_visible_and_deletable() {
 }
 
 #[test]
-fn external_import_artifact_change_invalidates_cached_rows_without_changing_membership() {
+fn external_import_artifact_change_is_immediately_visible_without_changing_membership() {
     let session_id = "sp2yt-local-cache-external-change";
     let report_path = crate::transfer::checkpoint::report_path(session_id).expect("report path");
     std::fs::create_dir_all(report_path.parent().expect("report parent"))

--- a/src/app/tests/local_import.rs
+++ b/src/app/tests/local_import.rs
@@ -851,10 +851,11 @@ fn orphan_report_without_session_document_is_visible_and_deletable() {
     app.update(Msg::Key(key(KeyCode::Char('9'))));
     app.local_mode.ui.filter_query = session_id.to_owned();
     assert_eq!(
-        app.local_visible_rows(),
-        vec![crate::local::LocalRowId::ImportSession(
+        app.local_visible_rows().as_ref(),
+        [crate::local::LocalRowId::ImportSession(
             session_id.to_owned()
         )]
+        .as_slice()
     );
     assert!(
         app.local_import_record_deletable(&crate::local::LocalRowId::ImportSession(
@@ -866,6 +867,45 @@ fn orphan_report_without_session_document_is_visible_and_deletable() {
     app.apply_local_import_record_delete(session_id.to_owned());
     assert!(!report_path.exists());
     assert!(app.local_visible_rows().is_empty());
+}
+
+#[test]
+fn external_import_artifact_change_invalidates_cached_rows_without_changing_membership() {
+    let session_id = "sp2yt-local-cache-external-change";
+    let report_path = crate::transfer::checkpoint::report_path(session_id).expect("report path");
+    std::fs::create_dir_all(report_path.parent().expect("report parent"))
+        .expect("create transfers dir");
+    std::fs::write(&report_path, b"{}").expect("write orphan report");
+
+    let mut app = app_with_local_deck_index(Vec::new());
+    app.update(Msg::Key(key(KeyCode::Char('9'))));
+    app.local_mode.ui.filter_query = session_id.to_owned();
+    let before = app.local_visible_rows();
+    assert_eq!(before.len(), 1);
+
+    #[cfg(unix)]
+    {
+        let original_modified = std::fs::metadata(&report_path)
+            .and_then(|metadata| metadata.modified())
+            .expect("read original report timestamp");
+        std::fs::write(&report_path, b"[]").expect("externally update orphan report in place");
+        std::fs::File::options()
+            .write(true)
+            .open(&report_path)
+            .and_then(|file| {
+                file.set_times(std::fs::FileTimes::new().set_modified(original_modified))
+            })
+            .expect("restore original report timestamp");
+    }
+    #[cfg(not(unix))]
+    std::fs::write(&report_path, b"[ ]")
+        .expect("externally update orphan report with a normal metadata change");
+    let after = app.local_visible_rows();
+    assert_eq!(before.as_ref(), after.as_ref());
+    assert!(!std::sync::Arc::ptr_eq(&before, &after));
+
+    crate::transfer::session::ImportSession::delete_record(session_id)
+        .expect("clean external-change fixture");
 }
 
 #[test]

--- a/src/app/tests/local_import_rows_cache.rs
+++ b/src/app/tests/local_import_rows_cache.rs
@@ -1,0 +1,722 @@
+use super::*;
+use crate::app::local::{
+    LocalImportFilesFingerprintCache, local_import_files_fingerprint_for_test,
+    stable_import_cache_key_for_test,
+};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::{fs, io};
+
+static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+struct TestImportData {
+    root: PathBuf,
+    transfers: PathBuf,
+    sessions: PathBuf,
+}
+
+impl TestImportData {
+    fn new() -> Self {
+        let sequence = NEXT_TEST_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "yututui-import-row-cache-{}-{sequence}",
+            std::process::id()
+        ));
+        let transfers = root.join("transfers");
+        let sessions = transfers.join("sessions");
+        fs::create_dir_all(&sessions).expect("create isolated import data directories");
+        Self {
+            root,
+            transfers,
+            sessions,
+        }
+    }
+
+    fn cache(&self) -> LocalImportFilesFingerprintCache {
+        let mut cache = LocalImportFilesFingerprintCache::default();
+        cache.set_data_dir_for_test(self.root.clone());
+        cache
+    }
+
+    fn write_transfer(&self, name: &str, bytes: &[u8]) -> PathBuf {
+        let path = self.transfers.join(name);
+        fs::write(&path, bytes).expect("write isolated transfer artifact");
+        path
+    }
+
+    fn write_session(&self, name: &str, bytes: &[u8]) -> PathBuf {
+        let path = self.sessions.join(name);
+        fs::write(&path, bytes).expect("write isolated session artifact");
+        path
+    }
+
+    fn create_hard_link_set(&self, suffix: &str, count: usize) {
+        let backing = self.write_transfer("hard-link-backing.scratch", b"x");
+        self.create_hard_link_range(&backing, &self.transfers, "artifact", suffix, 0..count);
+    }
+
+    fn create_hard_link_range(
+        &self,
+        backing: &Path,
+        directory: &Path,
+        prefix: &str,
+        suffix: &str,
+        indices: std::ops::Range<usize>,
+    ) {
+        for index in indices {
+            let path = directory.join(format!("{prefix}-{index:04}{suffix}"));
+            if fs::hard_link(backing, &path).is_err() {
+                fs::write(path, b"x").expect("write import artifact fallback");
+            }
+        }
+    }
+}
+
+impl Drop for TestImportData {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+struct MirroredArtifact {
+    fingerprint_path: PathBuf,
+    projection_path: PathBuf,
+}
+
+impl MirroredArtifact {
+    fn create(fingerprint_path: PathBuf, projection_path: PathBuf, bytes: &[u8]) -> Self {
+        fs::create_dir_all(
+            projection_path
+                .parent()
+                .expect("mirrored artifact has parent"),
+        )
+        .expect("create projection artifact directory");
+        let artifact = Self {
+            fingerprint_path,
+            projection_path,
+        };
+        artifact.write(bytes);
+        artifact
+    }
+
+    fn write(&self, bytes: &[u8]) {
+        fs::write(&self.fingerprint_path, bytes).expect("write fingerprint artifact");
+        fs::write(&self.projection_path, bytes).expect("write projection artifact");
+    }
+
+    fn remove(&self) {
+        for path in [&self.fingerprint_path, &self.projection_path] {
+            match fs::remove_file(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => panic!("remove mirrored artifact {}: {error}", path.display()),
+            }
+        }
+    }
+}
+
+impl Drop for MirroredArtifact {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.projection_path);
+    }
+}
+
+fn projection_transfers_dir() -> PathBuf {
+    crate::paths::data_dir()
+        .expect("test platform has app data directory")
+        .join("transfers")
+}
+
+fn app_with_fingerprint_data(data: &TestImportData) -> App {
+    let mut app = App::new(100);
+    app.mode = Mode::Library;
+    app.apply_local_mode_confirm(LocalModeConfirm::Enter);
+    app.update(Msg::Local(LocalMsg::ScanFinished {
+        index_path: None,
+        result: crate::local::LocalScanResult {
+            summary: crate::local::LocalScanSummary::default(),
+            index: crate::local::LocalIndex::default(),
+            errors: Vec::new(),
+        },
+    }));
+    app.local_mode
+        .import_files_fingerprint_cache
+        .borrow_mut()
+        .set_data_dir_for_test(data.root.clone());
+    app
+}
+
+#[test]
+fn ime_scrub_requires_a_matching_successfully_rendered_import_projection() {
+    let data = TestImportData::new();
+    let mut app = app_with_fingerprint_data(&data);
+    app.switch_local_section(LocalSection::ImportSessions);
+    app.local_mode.ui.filter_query = "ime-fast-path".to_owned();
+
+    assert!(!app.ime_scrub_local_projection_fresh());
+    let _snapshot = app.local_rows_snapshot();
+    assert!(
+        !app.ime_scrub_local_projection_fresh(),
+        "building a cache is not proof that it reached the terminal"
+    );
+
+    app.local_mode.ui.filter_query.push_str("-changed");
+    app.mark_local_rows_rendered();
+    app.local_mode.ui.filter_query = "ime-fast-path".to_owned();
+    assert!(
+        !app.ime_scrub_local_projection_fresh(),
+        "a full draw may only mark the row cache matching the rendered view"
+    );
+    app.mark_local_rows_rendered();
+    assert!(app.ime_scrub_local_projection_fresh());
+
+    app.switch_local_section(LocalSection::Tracks);
+    assert!(
+        app.ime_scrub_local_projection_fresh(),
+        "Local views that do not read import artifacts need no external fingerprint"
+    );
+}
+
+#[test]
+fn ime_scrub_rejects_changed_or_unreliable_import_fingerprints() {
+    let data = TestImportData::new();
+    let mut app = app_with_fingerprint_data(&data);
+    app.switch_local_section(LocalSection::ImportSessions);
+    app.local_mode.ui.filter_query = "ime-external-change".to_owned();
+    let _snapshot = app.local_rows_snapshot();
+    app.mark_local_rows_rendered();
+    assert!(app.ime_scrub_local_projection_fresh());
+
+    data.write_transfer("ime-external-change.report.json", b"{}");
+    assert!(
+        !app.ime_scrub_local_projection_fresh(),
+        "recognized external writes must invalidate before the next scrub"
+    );
+
+    let _snapshot = app.local_rows_snapshot();
+    app.mark_local_rows_rendered();
+    assert!(app.ime_scrub_local_projection_fresh());
+    app.local_mode
+        .import_files_fingerprint_cache
+        .borrow_mut()
+        .fail_next_transfers_read_dir_for_test(io::ErrorKind::PermissionDenied);
+    assert!(
+        !app.ime_scrub_local_projection_fresh(),
+        "an unreliable filesystem observation must fail closed"
+    );
+}
+
+fn fingerprint(cache: &mut LocalImportFilesFingerprintCache) -> (u64, bool) {
+    local_import_files_fingerprint_for_test(cache)
+}
+
+#[test]
+fn import_projection_is_cached_only_for_a_stable_reliable_pre_post_fingerprint() {
+    assert_eq!(
+        stable_import_cache_key_for_test(Some((7, true)), Some((7, true))),
+        Some(Some(7))
+    );
+    assert_eq!(
+        stable_import_cache_key_for_test(Some((7, true)), Some((8, true))),
+        None
+    );
+    assert_eq!(
+        stable_import_cache_key_for_test(Some((7, false)), Some((7, true))),
+        None
+    );
+    assert_eq!(
+        stable_import_cache_key_for_test(Some((7, true)), Some((7, false))),
+        None
+    );
+    assert_eq!(
+        stable_import_cache_key_for_test(None, Some((7, true))),
+        None
+    );
+    assert_eq!(
+        stable_import_cache_key_for_test(Some((7, true)), None),
+        None
+    );
+    assert_eq!(stable_import_cache_key_for_test(None, None), Some(None));
+}
+
+#[test]
+fn fingerprint_implementation_forbids_content_read_apis() {
+    let source = include_str!("../local/import_fingerprint.rs");
+    for forbidden in [
+        "std::fs::File",
+        "OpenOptions",
+        "std::io::Read",
+        "std::fs::read(",
+        "std::fs::read_to_string(",
+        "BufReader",
+        ".read_exact(",
+        ".read_to_end(",
+        ".read_to_string(",
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "metadata-only fingerprint must not use content API {forbidden}"
+        );
+    }
+    assert!(
+        !source.contains("directory_change_handle"),
+        "Windows directory generations must reopen the current path instead of retaining a stale handle"
+    );
+    let safe_fs = include_str!("../../util/safe_fs.rs");
+    assert!(
+        safe_fs.contains("pub(crate) fn windows_directory_change_time(path: &Path)"),
+        "Windows directory generation must use the transient current-path helper"
+    );
+}
+
+fn import_session(
+    session_id: &str,
+    status: crate::transfer::session::ImportSessionRowStatus,
+    title: &str,
+) -> crate::transfer::session::ImportSession {
+    crate::transfer::session::ImportSession {
+        schema_version: 1,
+        session_id: session_id.to_owned(),
+        job_id: session_id.to_owned(),
+        updated_at: 10,
+        rows: vec![crate::transfer::session::ImportSessionRow {
+            row_id: "row-1".to_owned(),
+            source_order: 1,
+            status,
+            title: title.to_owned(),
+            artists: vec!["Artist".to_owned()],
+            source_key: "source:row-1".to_owned(),
+            ..crate::transfer::session::ImportSessionRow::default()
+        }],
+        ..crate::transfer::session::ImportSession::default()
+    }
+}
+
+fn session_bytes(session: &crate::transfer::session::ImportSession) -> Vec<u8> {
+    serde_json::to_vec(session).expect("serialize import session fixture")
+}
+
+#[test]
+fn cold_large_unrecognized_file_has_zero_content_or_artifact_io_on_warm_lookup() {
+    let data = TestImportData::new();
+    let path = data.transfers.join("cold-32mib.scratch");
+    let file = fs::File::create(path).expect("create cold sparse artifact");
+    file.set_len(32 * 1024 * 1024)
+        .expect("size cold sparse artifact");
+    drop(file);
+    let mut cache = data.cache();
+
+    let first = fingerprint(&mut cache);
+    assert!(first.1);
+    assert_eq!(cache.probe().read_dir_calls, 2);
+    assert_eq!(cache.probe().artifact_metadata_stats, 0);
+
+    cache.reset_probe();
+    assert_eq!(fingerprint(&mut cache), first);
+    let warm = cache.probe();
+    assert_eq!(warm.directory_metadata_stats, 2);
+    assert_eq!(warm.read_dir_calls, 0);
+    assert_eq!(warm.directory_entries_visited, 0);
+    assert_eq!(warm.artifact_metadata_stats, 0);
+}
+
+#[test]
+fn over_legacy_cap_unrecognized_files_do_not_overflow_or_rescan() {
+    let data = TestImportData::new();
+    data.create_hard_link_set(".scratch", 4097);
+    let mut cache = data.cache();
+    let first = fingerprint(&mut cache);
+    assert!(first.1);
+
+    cache.reset_probe();
+    assert_eq!(fingerprint(&mut cache), first);
+    assert_eq!(fingerprint(&mut cache), first);
+    let warm = cache.probe();
+    assert_eq!(warm.read_dir_calls, 0);
+    assert_eq!(warm.directory_entries_visited, 0);
+    assert_eq!(warm.artifact_metadata_stats, 0);
+}
+
+#[test]
+fn recognized_artifacts_are_metadata_statted_without_content_reads() {
+    let data = TestImportData::new();
+    data.write_transfer("checkpoint.json", b"checkpoint");
+    data.write_transfer("report.report.json", b"report");
+    data.write_transfer("journal.journal.jsonl", b"journal");
+    data.write_session("UPPER_name.json", b"session");
+    data.write_session("summary.summary.json", b"summary");
+    data.write_transfer("ignored.scratch", b"ignored");
+    let mut cache = data.cache();
+    assert!(fingerprint(&mut cache).1);
+
+    cache.reset_probe();
+    assert!(fingerprint(&mut cache).1);
+    let warm = cache.probe();
+    assert_eq!(warm.read_dir_calls, 0);
+    assert_eq!(warm.artifact_metadata_stats, 5);
+}
+
+#[test]
+fn recognized_cap_overflow_and_shrink_preserve_the_bounded_cache_contract() {
+    let data = TestImportData::new();
+    data.create_hard_link_set(".json", 4096);
+    let mut cache = data.cache();
+    let at_cap = fingerprint(&mut cache);
+    assert!(at_cap.1);
+
+    cache.reset_probe();
+    assert_eq!(fingerprint(&mut cache), at_cap);
+    let at_cap_warm = cache.probe();
+    assert_eq!(at_cap_warm.read_dir_calls, 0);
+    assert_eq!(at_cap_warm.artifact_metadata_stats, 4096);
+
+    let trailing = data.write_transfer("artifact-4096.json", b"x");
+    let first_overflow = fingerprint(&mut cache);
+    assert!(!first_overflow.1);
+
+    cache.reset_probe();
+    let unchanged_overflow = fingerprint(&mut cache);
+    assert_eq!(unchanged_overflow.0, first_overflow.0);
+    assert!(!unchanged_overflow.1);
+    let overflow = cache.probe();
+    assert_eq!(overflow.read_dir_calls, 2);
+    assert_eq!(overflow.artifact_metadata_stats, 4097);
+
+    fs::write(&trailing, b"changed trailing artifact")
+        .expect("rewrite artifact beyond retained-path cap");
+    cache.reset_probe();
+    let changed_overflow = fingerprint(&mut cache);
+    assert_ne!(changed_overflow.0, unchanged_overflow.0);
+    assert!(!changed_overflow.1);
+    assert_eq!(cache.probe().read_dir_calls, 2);
+    assert_eq!(cache.probe().artifact_metadata_stats, 4097);
+
+    fs::remove_file(&trailing).expect("shrink recognized artifacts back to cap");
+    let recovered = fingerprint(&mut cache);
+    assert!(recovered.1);
+    assert_eq!(recovered.0, at_cap.0);
+    cache.reset_probe();
+    assert_eq!(fingerprint(&mut cache), recovered);
+    assert_eq!(cache.probe().read_dir_calls, 0);
+    assert_eq!(cache.probe().artifact_metadata_stats, 4096);
+
+    data.write_transfer("artifact-4096.json", b"overflow again");
+    let mut app = app_with_fingerprint_data(&data);
+    app.switch_local_section(LocalSection::ImportSessions);
+    app.local_mode.ui.filter_query = "no-overflow-row".to_owned();
+    let first_snapshot = app.local_rows_snapshot();
+    let second_snapshot = app.local_rows_snapshot();
+    assert!(!std::rc::Rc::ptr_eq(
+        &first_snapshot.data,
+        &second_snapshot.data
+    ));
+    assert!(app.local_mode.rows_cache.borrow().is_none());
+}
+
+#[test]
+fn recognized_path_cap_is_global_across_transfers_and_sessions() {
+    let data = TestImportData::new();
+    data.create_hard_link_set(".json", 2048);
+    let backing = data.transfers.join("hard-link-backing.scratch");
+    data.create_hard_link_range(
+        &backing,
+        &data.sessions,
+        "session-artifact",
+        ".json",
+        0..2048,
+    );
+    let mut cache = data.cache();
+    let at_cap = fingerprint(&mut cache);
+    assert!(at_cap.1);
+    assert_eq!(cache.retained_path_count_for_test(), 4096);
+    assert!(cache.retained_path_capacity_for_test() <= 4096);
+
+    cache.reset_probe();
+    assert_eq!(fingerprint(&mut cache), at_cap);
+    assert_eq!(cache.probe().read_dir_calls, 0);
+    assert_eq!(cache.probe().artifact_metadata_stats, 4096);
+
+    data.create_hard_link_range(
+        &backing,
+        &data.sessions,
+        "session-artifact",
+        ".json",
+        2048..2049,
+    );
+    assert!(!fingerprint(&mut cache).1);
+    assert!(cache.retained_path_count_for_test() <= 4096);
+    assert!(cache.retained_path_capacity_for_test() <= 4096);
+    cache.reset_probe();
+    assert!(!fingerprint(&mut cache).1);
+    assert_eq!(cache.probe().read_dir_calls, 2);
+    assert_eq!(cache.probe().artifact_metadata_stats, 4097);
+
+    data.create_hard_link_range(&backing, &data.transfers, "artifact", ".json", 2048..3000);
+    data.create_hard_link_range(
+        &backing,
+        &data.sessions,
+        "session-artifact",
+        ".json",
+        2049..3000,
+    );
+    assert!(!fingerprint(&mut cache).1);
+    assert!(cache.retained_path_count_for_test() <= 4096);
+    assert!(cache.retained_path_capacity_for_test() <= 4096);
+    cache.reset_probe();
+    assert!(!fingerprint(&mut cache).1);
+    assert_eq!(cache.probe().read_dir_calls, 2);
+    assert_eq!(cache.probe().artifact_metadata_stats, 6000);
+
+    for index in 2048..3000 {
+        fs::remove_file(data.transfers.join(format!("artifact-{index:04}.json")))
+            .expect("shrink transfer artifacts to the global cap split");
+        fs::remove_file(
+            data.sessions
+                .join(format!("session-artifact-{index:04}.json")),
+        )
+        .expect("shrink session artifacts to the global cap split");
+    }
+    let recovered = fingerprint(&mut cache);
+    assert!(recovered.1);
+    assert_eq!(cache.retained_path_count_for_test(), 4096);
+    assert!(cache.retained_path_capacity_for_test() <= 4096);
+    cache.reset_probe();
+    assert_eq!(fingerprint(&mut cache), recovered);
+    assert_eq!(cache.probe().read_dir_calls, 0);
+    assert_eq!(cache.probe().artifact_metadata_stats, 4096);
+}
+
+#[test]
+fn unrelated_membership_churn_rescans_but_keeps_the_semantic_row_cache_key() {
+    let data = TestImportData::new();
+    let mut app = app_with_fingerprint_data(&data);
+    app.switch_local_section(LocalSection::ImportSessions);
+    app.local_mode.ui.filter_query = "unrelated-churn-missing".to_owned();
+    let before = app.local_rows_snapshot();
+
+    let scratch = data.write_transfer("external.scratch", b"ignored");
+    app.local_mode
+        .import_files_fingerprint_cache
+        .borrow_mut()
+        .reset_probe();
+    let after_add = app.local_rows_snapshot();
+    assert!(std::rc::Rc::ptr_eq(&before.data, &after_add.data));
+    let add_probe = app
+        .local_mode
+        .import_files_fingerprint_cache
+        .borrow()
+        .probe();
+    assert_eq!(add_probe.read_dir_calls, 1);
+    assert_eq!(add_probe.artifact_metadata_stats, 0);
+
+    fs::remove_file(scratch).expect("remove unrelated scratch artifact");
+    let after_remove = app.local_rows_snapshot();
+    assert!(std::rc::Rc::ptr_eq(&before.data, &after_remove.data));
+}
+
+#[test]
+fn read_dir_error_is_volatile_and_recovery_redetects_membership() {
+    let data = TestImportData::new();
+    let session_id = format!("read-dir-recovery-{}", std::process::id());
+    let mut app = app_with_fingerprint_data(&data);
+    app.switch_local_section(LocalSection::ImportSessions);
+    app.local_mode.ui.filter_query = session_id.clone();
+    let before = app.local_rows_snapshot();
+    assert!(before.rows().is_empty());
+
+    let _artifact = MirroredArtifact::create(
+        data.transfers.join(format!("{session_id}.report.json")),
+        projection_transfers_dir().join(format!("{session_id}.report.json")),
+        b"{}",
+    );
+    {
+        let mut fingerprint_cache = app.local_mode.import_files_fingerprint_cache.borrow_mut();
+        fingerprint_cache.reset_probe();
+        fingerprint_cache.fail_next_transfers_read_dir_for_test(io::ErrorKind::PermissionDenied);
+    }
+
+    let during_error = app.local_rows_snapshot();
+    assert!(!std::rc::Rc::ptr_eq(&before.data, &during_error.data));
+    assert_eq!(
+        during_error.rows(),
+        [crate::local::LocalRowId::ImportSession(session_id)].as_slice()
+    );
+    assert!(app.local_mode.rows_cache.borrow().is_none());
+    let error_probe = app
+        .local_mode
+        .import_files_fingerprint_cache
+        .borrow()
+        .probe();
+    assert_eq!(error_probe.read_dir_errors, 1);
+    assert_eq!(error_probe.read_dir_calls, 2);
+
+    let recovered = app.local_rows_snapshot();
+    assert!(!std::rc::Rc::ptr_eq(&during_error.data, &recovered.data));
+    assert!(app.local_mode.rows_cache.borrow().is_some());
+    let cached = app.local_rows_snapshot();
+    assert!(std::rc::Rc::ptr_eq(&recovered.data, &cached.data));
+}
+
+#[test]
+fn recognized_add_and_delete_invalidate_membership_at_the_next_lookup() {
+    let data = TestImportData::new();
+    let session_id = format!("metadata-membership-{}", std::process::id());
+    let mut app = app_with_fingerprint_data(&data);
+    app.switch_local_section(LocalSection::ImportSessions);
+    app.local_mode.ui.filter_query = session_id.clone();
+    let before = app.local_rows_snapshot();
+    assert!(before.rows().is_empty());
+
+    let artifact = MirroredArtifact::create(
+        data.transfers.join(format!("{session_id}.report.json")),
+        projection_transfers_dir().join(format!("{session_id}.report.json")),
+        b"{}",
+    );
+    let after_add = app.local_rows_snapshot();
+    assert!(!std::rc::Rc::ptr_eq(&before.data, &after_add.data));
+    assert_eq!(
+        after_add.rows(),
+        [crate::local::LocalRowId::ImportSession(session_id)].as_slice()
+    );
+
+    artifact.remove();
+    let after_delete = app.local_rows_snapshot();
+    assert!(!std::rc::Rc::ptr_eq(&after_add.data, &after_delete.data));
+    assert!(after_delete.rows().is_empty());
+}
+
+#[test]
+fn restored_mtime_status_rewrite_invalidates_from_platform_change_identity() {
+    let data = TestImportData::new();
+    let session_id = format!("metadata-status-{}", std::process::id());
+    let mut session = import_session(
+        &session_id,
+        crate::transfer::session::ImportSessionRowStatus::Ambiguous,
+        "Review",
+    );
+    let initial = session_bytes(&session);
+    let artifact = MirroredArtifact::create(
+        data.sessions.join(format!("{session_id}.json")),
+        projection_transfers_dir()
+            .join("sessions")
+            .join(format!("{session_id}.json")),
+        &initial,
+    );
+    let mut app = app_with_fingerprint_data(&data);
+    app.switch_local_section(LocalSection::ImportSessions);
+    app.local_mode
+        .ui
+        .drill
+        .push(LocalDrill::ImportSession(session_id));
+    let before = app.local_rows_snapshot();
+    assert!(app.local_row_text_at(&before, 0).contains("review Review"));
+
+    let original_modified = fs::metadata(&artifact.fingerprint_path)
+        .and_then(|metadata| metadata.modified())
+        .expect("read original fingerprint timestamp");
+    session.rows[0].status = crate::transfer::session::ImportSessionRowStatus::NotFound;
+    session.rows[0].title = "Absent".to_owned();
+    #[cfg(not(any(unix, windows)))]
+    session.rows[0]
+        .warnings
+        .push("normal metadata-length change".to_owned());
+    let changed = session_bytes(&session);
+    #[cfg(any(unix, windows))]
+    assert_eq!(initial.len(), changed.len());
+    artifact.write(&changed);
+    #[cfg(any(unix, windows))]
+    fs::File::options()
+        .write(true)
+        .open(&artifact.fingerprint_path)
+        .and_then(|file| file.set_times(fs::FileTimes::new().set_modified(original_modified)))
+        .expect("restore original fingerprint mtime");
+
+    let after = app.local_rows_snapshot();
+    assert!(!std::rc::Rc::ptr_eq(&before.data, &after.data));
+    assert!(app.local_row_text_at(&after, 0).contains("missing Absent"));
+}
+
+#[test]
+fn nonsafe_utf8_json_candidate_is_tracked_and_invalidated() {
+    let data = TestImportData::new();
+    let session_id = format!("UPPER_name_{}", std::process::id());
+    let mut session = import_session(
+        &session_id,
+        crate::transfer::session::ImportSessionRowStatus::Matched,
+        "Unsafe Name",
+    );
+    let artifact = MirroredArtifact::create(
+        data.sessions.join(format!("{session_id}.json")),
+        projection_transfers_dir()
+            .join("sessions")
+            .join(format!("{session_id}.json")),
+        &session_bytes(&session),
+    );
+    let mut app = app_with_fingerprint_data(&data);
+    app.switch_local_section(LocalSection::ImportSessions);
+    app.local_mode.ui.filter_query = session_id.clone();
+    let before = app.local_rows_snapshot();
+    assert_eq!(
+        before.rows(),
+        [crate::local::LocalRowId::ImportSession(session_id)].as_slice()
+    );
+
+    session.source.label = Some("externally changed non-safe candidate".repeat(2));
+    artifact.write(&session_bytes(&session));
+    let after = app.local_rows_snapshot();
+    assert!(!std::rc::Rc::ptr_eq(&before.data, &after.data));
+    assert_eq!(before.rows(), after.rows());
+}
+
+#[test]
+fn stable_import_snapshot_reuses_and_memoizes_its_action_hint() {
+    let data = TestImportData::new();
+    let session_id = format!("metadata-hint-{}", std::process::id());
+    let session = import_session(
+        &session_id,
+        crate::transfer::session::ImportSessionRowStatus::Ambiguous,
+        "Review",
+    );
+    let _artifact = MirroredArtifact::create(
+        data.sessions.join(format!("{session_id}.json")),
+        projection_transfers_dir()
+            .join("sessions")
+            .join(format!("{session_id}.json")),
+        &session_bytes(&session),
+    );
+    let mut app = app_with_fingerprint_data(&data);
+    app.switch_local_section(LocalSection::ImportSessions);
+    app.local_mode
+        .ui
+        .drill
+        .push(LocalDrill::ImportSession(session_id));
+    let snapshot = app.local_rows_snapshot();
+    let cached = app.local_rows_snapshot();
+    assert!(std::rc::Rc::ptr_eq(&snapshot.data, &cached.data));
+
+    app.local_mode
+        .import_files_fingerprint_cache
+        .borrow_mut()
+        .reset_probe();
+    let first_hint = app
+        .local_import_action_hint_for_snapshot(&snapshot)
+        .expect("ambiguous row has action hint");
+    assert!(first_hint.contains("a accept"));
+    let after_first = app
+        .local_mode
+        .import_files_fingerprint_cache
+        .borrow()
+        .probe();
+    let second_hint = app
+        .local_import_action_hint_for_snapshot(&snapshot)
+        .expect("memoized ambiguous-row hint");
+    assert_eq!(second_hint, first_hint);
+    assert_eq!(
+        app.local_mode
+            .import_files_fingerprint_cache
+            .borrow()
+            .probe(),
+        after_first,
+        "memoized hint must not trigger a second filesystem projection lookup"
+    );
+}

--- a/src/app/tests/lyrics_art_download.rs
+++ b/src/app/tests/lyrics_art_download.rs
@@ -19,9 +19,10 @@ fn shift_l_toggles_lyrics_and_fetches_on_open() {
 #[test]
 fn lyrics_result_stored_only_for_current_track() {
     let mut app = app_playing(3, 0); // current id0
+    let lines = lyric_lines();
     app.update(Msg::LyricsResult {
         video_id: "id0".to_owned(),
-        lines: lyric_lines(),
+        lines: std::sync::Arc::clone(&lines),
     });
     assert!(
         app.lyrics
@@ -29,6 +30,10 @@ fn lyrics_result_stored_only_for_current_track() {
             .as_ref()
             .is_some_and(|l| l.lines.len() == 2)
     );
+    assert!(std::sync::Arc::ptr_eq(
+        &lines,
+        &app.lyrics.track.as_ref().unwrap().lines
+    ));
     // A late result for a different track is ignored.
     app.update(Msg::LyricsResult {
         video_id: "stale".to_owned(),
@@ -89,6 +94,57 @@ fn album_art_on_fetches_remote_then_builds_protocol() {
     assert!(!app.art.loading);
     assert!(app.art_active());
     assert_eq!(app.art.dims, (120, 120));
+    assert_eq!(
+        std::sync::Arc::strong_count(app.art.source.as_ref().expect("held decoded art")),
+        2,
+        "App and the resize protocol should share one decoded pixel allocation"
+    );
+}
+
+#[test]
+fn owned_and_shared_album_art_protocols_render_identically() {
+    use image::imageops::FilterType;
+    use image::{DynamicImage, Rgba, RgbaImage};
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use ratatui_image::{Resize, ResizeEncodeRender};
+
+    let mut pixels = RgbaImage::new(17, 11);
+    for (x, y, pixel) in pixels.enumerate_pixels_mut() {
+        *pixel = Rgba([
+            (x * 31 + y * 7) as u8,
+            (x * 11 + y * 37) as u8,
+            (x * 19 + y * 13) as u8,
+            if (x + y) % 3 == 0 { 96 } else { 255 },
+        ]);
+    }
+    let image = DynamicImage::ImageRgba8(pixels);
+
+    for background in [None, Some(Rgba([20, 30, 40, 255]))] {
+        let mut picker = Picker::halfblocks();
+        picker.set_background_color(background);
+        for area in [Rect::new(0, 0, 5, 3), Rect::new(0, 0, 9, 4)] {
+            let mut owned = picker.new_resize_protocol(image.clone());
+            let mut shared = picker.new_resize_protocol_shared(std::sync::Arc::new(image.clone()));
+            let mut owned_buffer = Buffer::empty(area);
+            let mut shared_buffer = Buffer::empty(area);
+
+            owned.resize_encode_render(
+                &Resize::Scale(Some(FilterType::Triangle)),
+                area,
+                &mut owned_buffer,
+            );
+            shared.resize_encode_render(
+                &Resize::Scale(Some(FilterType::Triangle)),
+                area,
+                &mut shared_buffer,
+            );
+
+            assert_eq!(owned_buffer, shared_buffer, "background={background:?}");
+            assert!(owned.last_encoding_result().unwrap().is_ok());
+            assert!(shared.last_encoding_result().unwrap().is_ok());
+        }
+    }
 }
 
 #[test]

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -23,6 +23,7 @@ mod library_filter;
 mod library_queue_actions;
 mod local;
 mod local_import;
+mod local_import_rows_cache;
 mod lyrics_art_download;
 mod mouse_player;
 mod nav_mouse;

--- a/src/app/tests/radio_sync.rs
+++ b/src/app/tests/radio_sync.rs
@@ -26,6 +26,65 @@ fn cache_time_updates_playback_and_coalesces_redraws() {
 }
 
 #[test]
+fn offscreen_progress_updates_state_without_redrawing_or_bumping_epoch() {
+    for mode in [Mode::Search, Mode::Library, Mode::Ai, Mode::Settings] {
+        let mut app = radio_playing("groove");
+        app.mode = mode;
+        app.dirty = false;
+        let epoch = app.playback.position_epoch;
+
+        app.update(PlayerMsg::TimePos(75.4));
+        assert_eq!(app.playback.time_pos, Some(75.4), "mode={mode:?}");
+        assert!(app.playback.time_pos_at.is_some(), "mode={mode:?}");
+        assert!(!app.dirty, "offscreen time-pos redrew mode={mode:?}");
+
+        app.update(PlayerMsg::CacheTime(Some(135.9)));
+        assert_eq!(app.playback.cache_time, Some(135.9), "mode={mode:?}");
+        assert!(app.playback.cache_time_at.is_some(), "mode={mode:?}");
+        assert_eq!(
+            app.radio_behind_secs().map(|behind| behind as i64),
+            Some(60),
+            "mode={mode:?}"
+        );
+        assert_eq!(app.media_snapshot().position, 75.4, "mode={mode:?}");
+        assert!(
+            app.core_view()
+                .elapsed_ms
+                .is_some_and(|elapsed| elapsed >= 75_400),
+            "remote observer did not see latest position in mode={mode:?}"
+        );
+        assert!(app.media_scrobble_heartbeat_active(), "mode={mode:?}");
+        assert!(!app.dirty, "offscreen cache-time redrew mode={mode:?}");
+
+        app.update(PlayerMsg::CacheTime(None));
+        assert_eq!(app.playback.cache_time, None, "mode={mode:?}");
+        assert!(app.playback.cache_time_at.is_none(), "mode={mode:?}");
+        assert_eq!(app.radio_live_synced(), None, "mode={mode:?}");
+        assert!(!app.dirty, "offscreen cache Some→None redrew mode={mode:?}");
+        assert_eq!(app.playback.position_epoch, epoch, "mode={mode:?}");
+    }
+}
+
+#[test]
+fn returning_to_player_renders_latest_offscreen_progress() {
+    let mut app = radio_playing("groove");
+    app.mode = Mode::Search;
+    app.dirty = false;
+
+    app.update(PlayerMsg::TimePos(75.4));
+    app.update(PlayerMsg::CacheTime(Some(135.9)));
+    assert!(!app.dirty);
+
+    assert!(app.navigate_to(Mode::Player).is_empty());
+    assert!(app.dirty, "mode transition must request the catch-up frame");
+    let buffer = render_app_buffer(&app, 100, 30);
+    assert!(
+        buffer_contains(&buffer, "1:15 · -60s"),
+        "Player did not render the latest offscreen time/cache state"
+    );
+}
+
+#[test]
 fn radio_live_sync_verdict_follows_behind_distance() {
     let mut app = radio_playing("groove");
     app.update(PlayerMsg::TimePos(100.0));

--- a/src/app/tests/scrollbars_layout.rs
+++ b/src/app/tests/scrollbars_layout.rs
@@ -144,6 +144,82 @@ fn dragging_search_scrollbar_moves_the_viewport() {
 }
 
 #[test]
+fn scrolled_search_rows_keep_absolute_hit_indices() {
+    let mut app = App::new(100);
+    app.mode = Mode::Search;
+    app.search.results = songs(40);
+    app.search.selected = 0;
+
+    let backend = TestBackend::new(80, 20);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
+    app.bridges
+        .search_scroll
+        .wheel(false, 8, app.search.results.len());
+    terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
+
+    let offset = app.bridges.search_scroll.offset();
+    assert!(offset > 0);
+    let mut visible_rows: Vec<_> = app
+        .hits
+        .regions()
+        .iter()
+        .filter_map(|region| match region.target {
+            MouseTarget::ListRow(index) => Some(index),
+            _ => None,
+        })
+        .collect();
+    visible_rows.sort_unstable();
+    visible_rows.dedup();
+    assert_eq!(visible_rows.first().copied(), Some(offset));
+    assert!(!visible_rows.contains(&0));
+}
+
+#[test]
+fn filtered_playlist_bottom_window_keeps_absolute_hit_indices() {
+    let mut app = App::new(100);
+    let playlist_id = app.playlists.create("Window").unwrap();
+    for i in 0..40 {
+        let title = if i % 2 == 0 {
+            format!("Keep {i}")
+        } else {
+            format!("Skip {i}")
+        };
+        app.playlists.add(
+            &playlist_id,
+            Song::remote(format!("id{i}"), title, "Artist", "0:10"),
+        );
+    }
+    app.mode = Mode::Library;
+    app.library_ui.tab = LibraryTab::Playlists;
+    app.library_ui.open_playlist = Some(playlist_id);
+    app.library_ui.filter_query = "keep".to_owned();
+
+    let backend = TestBackend::new(80, 20);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
+    let len = app.library_len();
+    app.bridges.library_scroll.wheel(false, 999, len);
+    terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
+
+    let offset = app.bridges.library_scroll.offset();
+    assert!(offset > 0);
+    let mut visible_rows: Vec<_> = app
+        .hits
+        .regions()
+        .iter()
+        .filter_map(|region| match region.target {
+            MouseTarget::ListRow(index) => Some(index),
+            _ => None,
+        })
+        .collect();
+    visible_rows.sort_unstable();
+    visible_rows.dedup();
+    assert_eq!(visible_rows.first().copied(), Some(offset));
+    assert_eq!(visible_rows.last().copied(), Some(len - 1));
+}
+
+#[test]
 fn ai_suggestions_scrollbar_renders_inside_borderless_list() {
     let mut app = App::new(100);
     app.mode = Mode::Ai;

--- a/src/app/tests/settings_ui.rs
+++ b/src/app/tests/settings_ui.rs
@@ -1381,3 +1381,54 @@ fn reset_all_re_enables_ai() {
         "reset returns DJ Gem to its default (enabled)"
     );
 }
+
+#[test]
+fn reset_all_preserves_tui_mpv_output_device_and_cache_like_origin_main() {
+    // This is intentionally different from the daemon GUI's full-Config reset. The terminal
+    // Settings reset has never included the mpv output/device/cache draft fields; keep that exact
+    // behavior unless the user explicitly approves the visible settings-semantics change.
+    let mut app = app_playing(1, 0);
+    app.config.audio.mpv.output = Some("pipewire".to_owned());
+    app.config.audio.mpv.device = Some("alsa/custom".to_owned());
+    app.config.audio.mpv.cache_forward = "64MiB".to_owned();
+    app.config.audio.mpv.cache_back = "12MiB".to_owned();
+    app.config.audio.mpv.cache_defaults_revision = u64::MAX;
+
+    app.update(Msg::Key(key(KeyCode::Char('o'))));
+    app.settings_reset_all();
+
+    let draft = &app.settings.as_ref().unwrap().draft;
+    assert_eq!(draft.audio_mpv_output, "pipewire");
+    assert_eq!(draft.audio_mpv_device, "alsa/custom");
+    assert_eq!(draft.audio_mpv_cache_forward, "64MiB");
+    assert_eq!(draft.audio_mpv_cache_back, "12MiB");
+
+    let cmds = app.update(Msg::Key(key(KeyCode::Char('q'))));
+    let saved = save_config(&cmds).unwrap();
+    assert_eq!(saved.audio.mpv.output.as_deref(), Some("pipewire"));
+    assert_eq!(saved.audio.mpv.device.as_deref(), Some("alsa/custom"));
+    assert_eq!(saved.audio.mpv.cache_forward, "64MiB");
+    assert_eq!(saved.audio.mpv.cache_back, "12MiB");
+    assert_eq!(saved.audio.mpv.cache_defaults_revision, u64::MAX);
+}
+
+#[test]
+fn direct_tui_cache_edits_mark_current_without_lowering_future_revision() {
+    let mut app = app_playing(1, 0);
+    app.config.audio.mpv.cache_defaults_revision = 0;
+    app.update(Msg::Key(key(KeyCode::Char('o'))));
+
+    app.settings.as_mut().unwrap().draft.audio_mpv_cache_forward = "48MiB".to_owned();
+    app.settings_persist_text_field(Field::AudioMpvCacheForward);
+    assert_eq!(app.config.audio.mpv.cache_forward, "48MiB");
+    assert_eq!(
+        app.config.audio.mpv.cache_defaults_revision,
+        crate::config::MPV_CACHE_DEFAULTS_REVISION
+    );
+
+    app.config.audio.mpv.cache_defaults_revision = u64::MAX;
+    app.settings.as_mut().unwrap().draft.audio_mpv_cache_back = "6MiB".to_owned();
+    app.settings_persist_text_field(Field::AudioMpvCacheBack);
+    assert_eq!(app.config.audio.mpv.cache_back, "6MiB");
+    assert_eq!(app.config.audio.mpv.cache_defaults_revision, u64::MAX);
+}

--- a/src/app/tests/support.rs
+++ b/src/app/tests/support.rs
@@ -426,7 +426,7 @@ pub(super) fn open_library_tab(app: &mut App, tab: LibraryTab) {
     }
 }
 
-pub(super) fn lyric_lines() -> Vec<LyricLine> {
+pub(super) fn lyric_lines() -> std::sync::Arc<[LyricLine]> {
     vec![
         LyricLine {
             time: 0.0,
@@ -437,6 +437,7 @@ pub(super) fn lyric_lines() -> Vec<LyricLine> {
             text: "two".to_owned(),
         },
     ]
+    .into()
 }
 
 pub(super) fn resolve_cmd<'a>(cmds: &'a [Cmd], id: &str) -> Option<&'a str> {

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -73,11 +73,11 @@ pub enum Msg {
     /// Periodic wake-up (driven by the main loop only while a transient `status` is showing)
     /// that lets the reducer expire the status after [`STATUS_TTL`] and restore the title.
     StatusTick,
-    /// Animation frame tick (~30 fps), driven by the main loop **only** while
-    /// [`App::animation_active`] holds — i.e. on the player view, master on, a track playing,
-    /// and at least one effect enabled. Advances `anim_frame` and forces a redraw. When all
-    /// animation toggles are off the main loop never arms this, so it costs literally nothing.
-    AnimTick,
+    /// Animation draw wake, driven by the main loop **only** while [`App::animation_active`]
+    /// holds. The payload is the number of legacy configured-FPS logical ticks ending at the
+    /// newest draw-due frame. A delayed wake can therefore catch up phase in one reducer turn
+    /// without replaying intermediate draws. When no effect is visible the timer is fully parked.
+    AnimTick(u64),
     /// A player/playback runtime message — mpv property changes (position, duration, pause,
     /// volume, metadata, cache-time, codec, format), EOF, playback errors, and video-overlay
     /// IPC events. See [`PlayerMsg`].
@@ -119,7 +119,7 @@ pub enum Msg {
     /// Synced lyrics for `video_id` (empty `lines` = none found).
     LyricsResult {
         video_id: String,
-        lines: Vec<LyricLine>,
+        lines: std::sync::Arc<[LyricLine]>,
     },
     /// Decoded album art / thumbnail for `video_id` (`None` = none found / fetch failed).
     ArtworkResult {
@@ -805,7 +805,7 @@ pub enum Mode {
 /// Synced lyrics for one track (held while it's the current track).
 pub struct TrackLyrics {
     pub video_id: String,
-    pub lines: Vec<LyricLine>,
+    pub lines: std::sync::Arc<[LyricLine]>,
 }
 
 /// The lists in the library view.

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -73,11 +73,11 @@ pub enum Msg {
     /// Periodic wake-up (driven by the main loop only while a transient `status` is showing)
     /// that lets the reducer expire the status after [`STATUS_TTL`] and restore the title.
     StatusTick,
-    /// Animation draw wake, driven by the main loop **only** while [`App::animation_active`]
-    /// holds. The payload is the number of legacy configured-FPS logical ticks ending at the
-    /// newest draw-due frame. A delayed wake can therefore catch up phase in one reducer turn
-    /// without replaying intermediate draws. When no effect is visible the timer is fully parked.
-    AnimTick(u64),
+    /// Animation frame tick (~30 fps), driven by the main loop **only** while
+    /// [`App::animation_active`] holds — i.e. on the player view, master on, a track playing,
+    /// and at least one effect enabled. Advances `anim_frame` and forces a redraw. When all
+    /// animation toggles are off the main loop never arms this, so it costs literally nothing.
+    AnimTick,
     /// A player/playback runtime message — mpv property changes (position, duration, pause,
     /// volume, metadata, cache-time, codec, format), EOF, playback errors, and video-overlay
     /// IPC events. See [`PlayerMsg`].

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,8 @@ mod recovery;
 mod spotify;
 pub use audio::{
     AudioBackend, AudioConfig, AudioRuntimeConfig, MPV_CACHE_BACK_DEFAULT,
-    MPV_CACHE_FORWARD_DEFAULT, MpvAudioConfig, MpvAudioRuntimeConfig,
+    MPV_CACHE_BACK_LEGACY_DEFAULT, MPV_CACHE_DEFAULTS_REVISION, MPV_CACHE_FORWARD_DEFAULT,
+    MPV_CACHE_FORWARD_LEGACY_DEFAULT, MpvAudioConfig, MpvAudioRuntimeConfig,
 };
 pub use spotify::SpotifyImportMode;
 
@@ -1460,6 +1461,8 @@ fn parse_netscape_cookies(content: &str) -> String {
 }
 
 #[cfg(test)]
+mod cache_policy_tests;
+#[cfg(test)]
 mod hardening_tests;
 
 #[cfg(test)]
@@ -1714,6 +1717,7 @@ mod tests {
             audio: AudioConfig {
                 backend: AudioBackend::Mpv,
                 mpv: MpvAudioConfig {
+                    cache_defaults_revision: MPV_CACHE_DEFAULTS_REVISION,
                     output: Some("pipewire".to_owned()),
                     device: Some("alsa/default".to_owned()),
                     cache_forward: "64MiB".to_owned(),

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -1,7 +1,25 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+/// Defaults shipped before cache-default migrations were revisioned.
+pub const MPV_CACHE_FORWARD_LEGACY_DEFAULT: &str = "32MiB";
+pub const MPV_CACHE_BACK_LEGACY_DEFAULT: &str = "8MiB";
+/// Keep the migration policy dormant until every native OS selects the same smaller cache pair.
+/// Revision zero is never persisted, so today's 32/8 users remain eligible for that future move.
+pub const MPV_CACHE_DEFAULTS_REVISION: u64 = 0;
+
+// Keep the runtime defaults at the legacy pair until the cross-platform benchmark selects a
+// smaller common winner. Migration code below deliberately treats these as independent constants
+// so changing only this pair later activates the already-tested exact-pair migration.
 pub const MPV_CACHE_FORWARD_DEFAULT: &str = "32MiB";
 pub const MPV_CACHE_BACK_DEFAULT: &str = "8MiB";
+
+const fn unrevisioned_cache_defaults() -> u64 {
+    0
+}
+
+const fn is_zero(value: &u64) -> bool {
+    *value == 0
+}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum AudioBackend {
@@ -68,6 +86,13 @@ impl AudioConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct MpvAudioConfig {
+    /// Private persisted migration marker. Missing in pre-revision configs means revision 0.
+    #[serde(
+        rename = "_cache_defaults_revision",
+        default = "unrevisioned_cache_defaults",
+        skip_serializing_if = "is_zero"
+    )]
+    pub(crate) cache_defaults_revision: u64,
     /// mpv audio output driver (`--ao`). `None`, blank, and `auto` leave mpv on its default.
     pub output: Option<String>,
     /// mpv audio device (`--audio-device`). `None`, blank, and `auto` leave mpv on its default.
@@ -85,6 +110,7 @@ pub struct MpvAudioConfig {
 impl Default for MpvAudioConfig {
     fn default() -> Self {
         Self {
+            cache_defaults_revision: MPV_CACHE_DEFAULTS_REVISION,
             output: None,
             device: None,
             cache_forward: MPV_CACHE_FORWARD_DEFAULT.to_owned(),
@@ -95,6 +121,59 @@ impl Default for MpvAudioConfig {
 }
 
 impl MpvAudioConfig {
+    pub(crate) fn set_cache_forward(&mut self, value: Option<String>) {
+        self.cache_forward = value.unwrap_or_else(|| MPV_CACHE_FORWARD_DEFAULT.to_owned());
+        self.mark_cache_defaults_current();
+    }
+
+    pub(crate) fn set_cache_back(&mut self, value: Option<String>) {
+        self.cache_back = value.unwrap_or_else(|| MPV_CACHE_BACK_DEFAULT.to_owned());
+        self.mark_cache_defaults_current();
+    }
+
+    /// Mark an explicit user edit or reset as belonging to the current defaults policy. Never
+    /// lower a marker written by a future version of the application.
+    pub(crate) fn mark_cache_defaults_current(&mut self) {
+        self.mark_cache_defaults_revision(MPV_CACHE_DEFAULTS_REVISION);
+    }
+
+    fn mark_cache_defaults_revision(&mut self, target_revision: u64) {
+        if self.cache_defaults_revision < target_revision {
+            self.cache_defaults_revision = target_revision;
+        }
+    }
+
+    /// Defensive typed fallback after raw migration and lenient schema recovery. Raw migration is
+    /// preferred because it preserves unknown JSON fields; keeping the exact-pair rule here makes
+    /// the in-memory result safe even when an unfamiliar raw marker shape cannot be patched.
+    pub(super) fn migrate_cache_defaults(&mut self) -> bool {
+        self.migrate_cache_defaults_to(
+            MPV_CACHE_FORWARD_DEFAULT,
+            MPV_CACHE_BACK_DEFAULT,
+            MPV_CACHE_DEFAULTS_REVISION,
+        )
+    }
+
+    fn migrate_cache_defaults_to(
+        &mut self,
+        target_forward: &str,
+        target_back: &str,
+        target_revision: u64,
+    ) -> bool {
+        if target_revision == 0 || self.cache_defaults_revision >= target_revision {
+            return false;
+        }
+        if self.cache_defaults_revision == 0
+            && self.cache_forward == MPV_CACHE_FORWARD_LEGACY_DEFAULT
+            && self.cache_back == MPV_CACHE_BACK_LEGACY_DEFAULT
+        {
+            self.cache_forward = target_forward.to_owned();
+            self.cache_back = target_back.to_owned();
+        }
+        self.cache_defaults_revision = target_revision;
+        true
+    }
+
     pub fn effective(&self) -> MpvAudioRuntimeConfig {
         MpvAudioRuntimeConfig {
             output: normalize_optional(&self.output),
@@ -111,6 +190,81 @@ impl MpvAudioConfig {
                 .collect(),
         }
     }
+}
+
+/// Patch an existing raw `Config` JSON value without round-tripping it through the typed schema.
+/// This retains unknown keys and custom cache values while adding the private revision marker.
+pub(super) fn migrate_cache_defaults_json(value: &mut serde_json::Value) -> bool {
+    migrate_cache_defaults_json_to(
+        value,
+        MPV_CACHE_FORWARD_DEFAULT,
+        MPV_CACHE_BACK_DEFAULT,
+        MPV_CACHE_DEFAULTS_REVISION,
+    )
+}
+
+fn migrate_cache_defaults_json_to(
+    value: &mut serde_json::Value,
+    target_forward: &str,
+    target_back: &str,
+    target_revision: u64,
+) -> bool {
+    const REVISION_KEY: &str = "_cache_defaults_revision";
+
+    if target_revision == 0 {
+        return false;
+    }
+
+    let Some(mpv) = value
+        .get_mut("audio")
+        .and_then(|audio| audio.get_mut("mpv"))
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return false;
+    };
+
+    let revision = match mpv.get(REVISION_KEY) {
+        None => 0,
+        Some(value) => match value.as_u64() {
+            Some(revision) => revision,
+            // An unknown marker shape may belong to a newer schema. Preserve it instead of
+            // guessing and potentially rewriting intentional user values.
+            None => return false,
+        },
+    };
+    if revision >= target_revision {
+        return false;
+    }
+
+    let exact_legacy_pair = mpv.get("cache_forward").and_then(serde_json::Value::as_str)
+        == Some(MPV_CACHE_FORWARD_LEGACY_DEFAULT)
+        && mpv.get("cache_back").and_then(serde_json::Value::as_str)
+            == Some(MPV_CACHE_BACK_LEGACY_DEFAULT);
+    if revision == 0 && exact_legacy_pair {
+        mpv.insert(
+            "cache_forward".to_owned(),
+            serde_json::Value::String(target_forward.to_owned()),
+        );
+        mpv.insert(
+            "cache_back".to_owned(),
+            serde_json::Value::String(target_back.to_owned()),
+        );
+    }
+    mpv.insert(
+        REVISION_KEY.to_owned(),
+        serde_json::Value::from(target_revision),
+    );
+    true
+}
+
+#[cfg(test)]
+pub(super) fn migrate_cache_defaults_json_to_for_test(
+    value: &mut serde_json::Value,
+    target_forward: &str,
+    target_back: &str,
+    target_revision: u64,
+) -> bool {
+    migrate_cache_defaults_json_to(value, target_forward, target_back, target_revision)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -185,6 +339,7 @@ mod tests {
         let cfg = AudioConfig::default();
         let runtime = cfg.runtime();
 
+        assert_eq!(cfg.mpv.cache_defaults_revision, MPV_CACHE_DEFAULTS_REVISION);
         assert_eq!(runtime.backend, AudioBackend::Mpv);
         assert_eq!(runtime.mpv.output, None);
         assert_eq!(runtime.mpv.device, None);
@@ -195,6 +350,7 @@ mod tests {
     #[test]
     fn mpv_audio_runtime_normalizes_auto_blank_cache_and_args() {
         let cfg = MpvAudioConfig {
+            cache_defaults_revision: MPV_CACHE_DEFAULTS_REVISION,
             output: Some(" auto ".to_owned()),
             device: Some(" pipewire/thing ".to_owned()),
             cache_forward: "bad".to_owned(),
@@ -215,5 +371,165 @@ mod tests {
     fn unknown_backend_deserializes_as_mpv() {
         let backend: AudioBackend = serde_json::from_str(r#""native""#).unwrap();
         assert_eq!(backend, AudioBackend::Mpv);
+    }
+
+    #[test]
+    fn revision_zero_is_absent_for_legacy_and_fresh_configs_until_selection() {
+        let old: MpvAudioConfig =
+            serde_json::from_str(r#"{"cache_forward":"32MiB","cache_back":"8MiB"}"#).unwrap();
+        assert_eq!(old.cache_defaults_revision, 0);
+
+        let fresh = MpvAudioConfig::default();
+        assert_eq!(fresh.cache_defaults_revision, MPV_CACHE_DEFAULTS_REVISION);
+        let json = serde_json::to_value(fresh).unwrap();
+        assert!(json.get("_cache_defaults_revision").is_none());
+    }
+
+    #[test]
+    fn dormant_production_policy_does_not_mark_or_rewrite_unrevisioned_values() {
+        for mpv in [
+            serde_json::json!({"cache_forward": "32MiB", "cache_back": "8MiB"}),
+            serde_json::json!({"cache_forward": "64MiB", "cache_back": "3MiB"}),
+            serde_json::json!({"cache_forward": "32MiB"}),
+        ] {
+            let mut value = serde_json::json!({"audio": {"mpv": mpv}});
+            let before = value.clone();
+            assert!(!migrate_cache_defaults_json(&mut value));
+            assert_eq!(value, before);
+        }
+
+        let mut typed: MpvAudioConfig =
+            serde_json::from_str(r#"{"cache_forward":"32MiB","cache_back":"8MiB"}"#).unwrap();
+        assert!(!typed.migrate_cache_defaults());
+        assert_eq!(typed.cache_defaults_revision, 0);
+    }
+
+    #[test]
+    fn raw_exact_legacy_pair_migrates_to_future_selected_pair_atomically() {
+        let mut value = serde_json::json!({
+            "unknown_top": {"keep": [1, 2, 3]},
+            "audio": {
+                "unknown_audio": true,
+                "mpv": {
+                    "cache_forward": "32MiB",
+                    "cache_back": "8MiB",
+                    "unknown_mpv": {"keep": "exactly"}
+                }
+            }
+        });
+
+        assert!(migrate_cache_defaults_json_to(
+            &mut value, "16MiB", "4MiB", 1
+        ));
+        assert_eq!(value["audio"]["mpv"]["cache_forward"], "16MiB");
+        assert_eq!(value["audio"]["mpv"]["cache_back"], "4MiB");
+        assert_eq!(value["audio"]["mpv"]["_cache_defaults_revision"], 1);
+        assert_eq!(value["unknown_top"], serde_json::json!({"keep": [1, 2, 3]}));
+        assert_eq!(value["audio"]["unknown_audio"], true);
+        assert_eq!(
+            value["audio"]["mpv"]["unknown_mpv"],
+            serde_json::json!({"keep": "exactly"})
+        );
+    }
+
+    #[test]
+    fn raw_custom_partial_and_non_exact_pairs_are_only_marked() {
+        for (forward, back) in [
+            (Some("64MiB"), Some("8MiB")),
+            (Some("32MiB"), None),
+            (None, Some("8MiB")),
+            (Some(" 32MiB"), Some("8MiB")),
+            (Some("32MiB"), Some("8MiB ")),
+            (Some("32mib"), Some("8MiB")),
+            (Some("32MiB"), Some("8mib")),
+        ] {
+            let mut mpv = serde_json::Map::new();
+            if let Some(forward) = forward {
+                mpv.insert(
+                    "cache_forward".to_owned(),
+                    serde_json::Value::String(forward.to_owned()),
+                );
+            }
+            if let Some(back) = back {
+                mpv.insert(
+                    "cache_back".to_owned(),
+                    serde_json::Value::String(back.to_owned()),
+                );
+            }
+            mpv.insert("unknown".to_owned(), serde_json::json!(["still", "here"]));
+            let before_forward = mpv.get("cache_forward").cloned();
+            let before_back = mpv.get("cache_back").cloned();
+            let mut value = serde_json::json!({"audio": {"mpv": mpv}});
+
+            assert!(migrate_cache_defaults_json_to(
+                &mut value, "16MiB", "4MiB", 1
+            ));
+            assert_eq!(
+                value["audio"]["mpv"].get("cache_forward"),
+                before_forward.as_ref()
+            );
+            assert_eq!(
+                value["audio"]["mpv"].get("cache_back"),
+                before_back.as_ref()
+            );
+            assert_eq!(value["audio"]["mpv"]["_cache_defaults_revision"], 1);
+            assert_eq!(
+                value["audio"]["mpv"]["unknown"],
+                serde_json::json!(["still", "here"])
+            );
+        }
+    }
+
+    #[test]
+    fn raw_current_future_and_unknown_revisions_are_never_lowered_or_rewritten() {
+        for revision in [
+            serde_json::json!(1),
+            serde_json::json!(u64::MAX),
+            serde_json::json!("future-schema"),
+        ] {
+            let mut value = serde_json::json!({
+                "audio": {"mpv": {
+                    "_cache_defaults_revision": revision,
+                    "cache_forward": "32MiB",
+                    "cache_back": "8MiB"
+                }}
+            });
+            let before = value.clone();
+            assert!(!migrate_cache_defaults_json_to(
+                &mut value, "16MiB", "4MiB", 1
+            ));
+            assert_eq!(value, before);
+        }
+    }
+
+    #[test]
+    fn simulated_typed_policy_marks_custom_pair_without_replacing_it() {
+        let mut cfg: MpvAudioConfig =
+            serde_json::from_str(r#"{"cache_forward":"64MiB","cache_back":"3MiB"}"#).unwrap();
+        assert!(cfg.migrate_cache_defaults_to("16MiB", "4MiB", 1));
+        assert_eq!(cfg.cache_forward, "64MiB");
+        assert_eq!(cfg.cache_back, "3MiB");
+        assert_eq!(cfg.cache_defaults_revision, 1);
+    }
+
+    #[test]
+    fn typed_config_preserves_a_numeric_future_revision_across_edit_and_round_trip() {
+        let mut cfg: MpvAudioConfig = serde_json::from_value(serde_json::json!({
+            "_cache_defaults_revision": u64::MAX,
+            "cache_forward": "96MiB",
+            "cache_back": "12MiB"
+        }))
+        .unwrap();
+
+        cfg.mark_cache_defaults_current();
+
+        assert_eq!(cfg.cache_defaults_revision, u64::MAX);
+        assert_eq!(cfg.cache_forward, "96MiB");
+        assert_eq!(cfg.cache_back, "12MiB");
+        let encoded = serde_json::to_value(cfg).unwrap();
+        assert_eq!(
+            encoded["_cache_defaults_revision"],
+            serde_json::json!(u64::MAX)
+        );
     }
 }

--- a/src/config/cache_policy_tests.rs
+++ b/src/config/cache_policy_tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+#[test]
+fn dormant_cache_policy_preserves_unknown_raw_json_without_rewrite() {
+    let dir = std::env::temp_dir().join(format!("ytm-cache-dormant-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("config.json");
+    let original = serde_json::to_vec_pretty(&serde_json::json!({
+        "volume": 55,
+        "unknown_top": {"future": [1, 2, 3]},
+        "audio": {
+            "unknown_audio": "keep",
+            "mpv": {
+                "cache_forward": MPV_CACHE_FORWARD_LEGACY_DEFAULT,
+                "cache_back": MPV_CACHE_BACK_LEGACY_DEFAULT,
+                "unknown_mpv": {"also": "keep"}
+            }
+        }
+    }))
+    .unwrap();
+    std::fs::write(&path, &original).unwrap();
+
+    let cfg = Config::load_from(&path);
+    assert_eq!(cfg.volume, 55);
+    assert_eq!(cfg.audio.mpv.cache_defaults_revision, 0);
+    assert_eq!(cfg.audio.mpv.cache_forward, MPV_CACHE_FORWARD_DEFAULT);
+    assert_eq!(cfg.audio.mpv.cache_back, MPV_CACHE_BACK_DEFAULT);
+    assert_eq!(std::fs::read(&path).unwrap(), original);
+
+    let disk: serde_json::Value = serde_json::from_slice(&original).unwrap();
+    assert!(
+        disk["audio"]["mpv"]
+            .get("_cache_defaults_revision")
+            .is_none()
+    );
+    assert_eq!(
+        disk["unknown_top"],
+        serde_json::json!({"future": [1, 2, 3]})
+    );
+    assert_eq!(disk["audio"]["unknown_audio"], "keep");
+    assert_eq!(
+        disk["audio"]["mpv"]["unknown_mpv"],
+        serde_json::json!({"also": "keep"})
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn replayed_cache_snapshot_is_installed_without_premature_marker() {
+    let dir = std::env::temp_dir().join(format!("ytm-cache-replay-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("config.json");
+    std::fs::write(
+        &path,
+        serde_json::to_vec_pretty(&Config::default()).unwrap(),
+    )
+    .unwrap();
+
+    let mut replay = serde_json::to_value(Config::default()).unwrap();
+    replay["volume"] = serde_json::json!(42);
+    replay["unknown_journal"] = serde_json::json!({"survives": true});
+    replay["audio"]["mpv"]["unknown_journal_mpv"] = serde_json::json!([1, 2, 3]);
+    replay["audio"]["mpv"]
+        .as_object_mut()
+        .unwrap()
+        .remove("_cache_defaults_revision");
+    replay["audio"]["mpv"]["cache_forward"] = serde_json::json!("64MiB");
+    replay["audio"]["mpv"]["cache_back"] = serde_json::json!("3MiB");
+    crate::persist::write_test_journaled_snapshot(
+        crate::persist::StoreKind::Config,
+        path.clone(),
+        serde_json::to_vec_pretty(&replay).unwrap(),
+    )
+    .unwrap();
+
+    let cfg = Config::load_from(&path);
+    assert_eq!(cfg.volume, 42);
+    assert_eq!(cfg.audio.mpv.cache_forward, "64MiB");
+    assert_eq!(cfg.audio.mpv.cache_back, "3MiB");
+    assert_eq!(cfg.audio.mpv.cache_defaults_revision, 0);
+    assert!(!crate::persist::test_journal_exists(&path));
+
+    let installed_bytes = std::fs::read(&path).unwrap();
+    let installed: Config = serde_json::from_slice(&installed_bytes).unwrap();
+    assert_eq!(installed.volume, 42);
+    assert_eq!(installed.audio.mpv.cache_defaults_revision, 0);
+    let raw: serde_json::Value = serde_json::from_slice(&installed_bytes).unwrap();
+    assert!(
+        raw["audio"]["mpv"]
+            .get("_cache_defaults_revision")
+            .is_none()
+    );
+    assert_eq!(
+        raw["unknown_journal"],
+        serde_json::json!({"survives": true})
+    );
+    assert_eq!(
+        raw["audio"]["mpv"]["unknown_journal_mpv"],
+        serde_json::json!([1, 2, 3])
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/src/config/recovery.rs
+++ b/src/config/recovery.rs
@@ -4,24 +4,8 @@ pub(super) fn load_from_path(path: &std::path::Path) -> Config {
     let can_persist_default = match safe_fs::read_no_symlink_limited(path, MAX_CONFIG_BYTES) {
         Ok(bytes) => match String::from_utf8(bytes) {
             Ok(text) => {
-                // Fast path: schema unchanged since this file was written.
-                if let Ok(cfg) = serde_json::from_str::<Config>(&text) {
-                    return crate::persist::replay_journaled_snapshot(
-                        crate::persist::StoreKind::Config,
-                        path,
-                        cfg,
-                        MAX_CONFIG_BYTES,
-                    );
-                }
-                // Schema drifted: keep every field that still fits instead of resetting.
                 if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
-                    let cfg = safe_fs::recover_lenient::<Config>(value);
-                    return crate::persist::replay_journaled_snapshot(
-                        crate::persist::StoreKind::Config,
-                        path,
-                        cfg,
-                        MAX_CONFIG_BYTES,
-                    );
+                    return recover_value(path, value, false, true);
                 }
                 safe_fs::backup_aside_secret(path).is_ok()
             }
@@ -38,19 +22,254 @@ pub(super) fn load_from_path(path: &std::path::Path) -> Config {
     if let Some(old) = old_config_path() {
         import_old_from(&old, &mut cfg);
     }
-    cfg = crate::persist::replay_journaled_snapshot(
-        crate::persist::StoreKind::Config,
-        path,
-        cfg,
-        MAX_CONFIG_BYTES,
-    );
+    let value = match serde_json::to_value(&cfg) {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::error!(
+                error = %error,
+                "failed to encode recovered config; keeping the in-memory recovery"
+            );
+            return cfg;
+        }
+    };
     if can_persist_default {
-        let _ = cfg.save_to(path);
+        cfg = recover_value(path, value, true, true);
     } else {
+        cfg = recover_value(path, value, false, false);
         tracing::error!(
             path = %path.display(),
             "refusing to overwrite unreadable/corrupt config because recovery backup failed"
         );
     }
     cfg
+}
+
+/// Replay as raw JSON, then migrate before typed recovery. This preserves unknown keys in both the
+/// primary config and a pending sidecar. A replay is cleared only after its effective raw object is
+/// atomically installed; any failed write leaves the old marker/journal available for retry.
+fn recover_value(
+    path: &std::path::Path,
+    value: serde_json::Value,
+    install_base: bool,
+    allow_persist: bool,
+) -> Config {
+    recover_value_with_writer(
+        path,
+        value,
+        install_base,
+        allow_persist,
+        safe_fs::write_private_atomic_json,
+    )
+}
+
+fn recover_value_with_writer(
+    path: &std::path::Path,
+    base_value: serde_json::Value,
+    install_base: bool,
+    allow_persist: bool,
+    write: impl Fn(&std::path::Path, &serde_json::Value) -> std::io::Result<()>,
+) -> Config {
+    recover_value_with_migration_and_writer(
+        path,
+        base_value,
+        install_base,
+        allow_persist,
+        super::audio::migrate_cache_defaults_json,
+        write,
+    )
+}
+
+fn recover_value_with_migration_and_writer(
+    path: &std::path::Path,
+    base_value: serde_json::Value,
+    install_base: bool,
+    allow_persist: bool,
+    migrate: impl Fn(&mut serde_json::Value) -> bool,
+    write: impl Fn(&std::path::Path, &serde_json::Value) -> std::io::Result<()>,
+) -> Config {
+    let (replayed_value, replayed) = crate::persist::replay_journaled_snapshot_with_status(
+        crate::persist::StoreKind::Config,
+        path,
+        base_value.clone(),
+        MAX_CONFIG_BYTES,
+    );
+    // Replaying as `Value` is what retains unknown future fields, but it also accepts scalar and
+    // array JSON that the former typed replay correctly rejected. Never replace a valid config or
+    // clear its recovery intent unless the replay at least has the Config root shape.
+    let (mut value, replayed) = if replayed && !replayed_value.is_object() {
+        tracing::warn!("refusing non-object pending config snapshot");
+        (base_value, false)
+    } else {
+        (replayed_value, replayed)
+    };
+    let migrated = migrate(&mut value);
+
+    if allow_persist && (replayed || install_base || migrated) {
+        match write(path, &value) {
+            Ok(()) => {
+                if replayed {
+                    crate::persist::clear_journaled_snapshot(path);
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "failed to install recovered config snapshot; will retry"
+                );
+            }
+        }
+    }
+
+    // Fast path when the schema is current; otherwise keep every field that still fits instead of
+    // resetting the whole config. The typed fallback mirrors the raw rule defensively for a value
+    // whose marker shape could not be interpreted above.
+    let mut cfg = serde_json::from_value::<Config>(value.clone())
+        .unwrap_or_else(|_| safe_fs::recover_lenient::<Config>(value));
+    cfg.audio.mpv.migrate_cache_defaults();
+    cfg
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let mut random = [0u8; 8];
+        getrandom::fill(&mut random).unwrap();
+        let suffix = random
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        std::env::temp_dir()
+            .join(format!("yututui-config-recovery-{name}-{suffix}"))
+            .join("config.json")
+    }
+
+    fn write_pending(path: &std::path::Path, value: &serde_json::Value) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        crate::persist::write_test_journaled_snapshot(
+            crate::persist::StoreKind::Config,
+            path.to_owned(),
+            serde_json::to_vec_pretty(value).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn migrate_selected_cache(value: &mut serde_json::Value) -> bool {
+        super::super::audio::migrate_cache_defaults_json_to_for_test(value, "16MiB", "4MiB", 1)
+    }
+
+    #[test]
+    fn failed_replay_install_retains_intent_then_retries_and_clears() {
+        let path = temp_path("write-failure");
+        let mut base = serde_json::to_value(Config::default()).unwrap();
+        base["volume"] = serde_json::json!(17);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        safe_fs::write_private_atomic_json(&path, &base).unwrap();
+
+        let mut pending = base.clone();
+        pending["volume"] = serde_json::json!(73);
+        pending["unknown_pending"] = serde_json::json!({"keep": true});
+        write_pending(&path, &pending);
+
+        let recovered = recover_value_with_writer(&path, base.clone(), false, true, |_, _| {
+            Err(std::io::Error::other("injected install failure"))
+        });
+        assert_eq!(recovered.volume, 73, "valid pending state remains usable");
+        assert!(crate::persist::test_journal_exists(&path));
+        let disk: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(disk["volume"], 17, "failed install cannot replace the base");
+
+        let recovered = recover_value(&path, disk, false, true);
+        assert_eq!(recovered.volume, 73);
+        assert!(!crate::persist::test_journal_exists(&path));
+        let installed: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(installed["volume"], 73);
+        assert_eq!(
+            installed["unknown_pending"],
+            serde_json::json!({"keep": true})
+        );
+
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn failed_simulated_future_migration_leaves_the_unmarked_source_retryable() {
+        let path = temp_path("migration-write-failure");
+        let mut base = serde_json::to_value(Config::default()).unwrap();
+        base["audio"]["mpv"]
+            .as_object_mut()
+            .unwrap()
+            .remove("_cache_defaults_revision");
+        base["unknown_primary"] = serde_json::json!({"keep": [1, 2, 3]});
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        safe_fs::write_private_atomic_json(&path, &base).unwrap();
+
+        let recovered = recover_value_with_migration_and_writer(
+            &path,
+            base.clone(),
+            false,
+            true,
+            migrate_selected_cache,
+            |_, _| Err(std::io::Error::other("injected migration failure")),
+        );
+        assert_eq!(recovered.audio.mpv.cache_defaults_revision, 1);
+        assert_eq!(recovered.audio.mpv.cache_forward, "16MiB");
+        assert_eq!(recovered.audio.mpv.cache_back, "4MiB");
+        let disk: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert!(
+            disk["audio"]["mpv"]
+                .get("_cache_defaults_revision")
+                .is_none()
+        );
+
+        assert_eq!(disk["audio"]["mpv"]["cache_forward"], "32MiB");
+        assert_eq!(disk["audio"]["mpv"]["cache_back"], "8MiB");
+
+        let recovered = recover_value_with_migration_and_writer(
+            &path,
+            disk,
+            false,
+            true,
+            migrate_selected_cache,
+            safe_fs::write_private_atomic_json,
+        );
+        assert_eq!(recovered.audio.mpv.cache_defaults_revision, 1);
+        assert_eq!(recovered.audio.mpv.cache_forward, "16MiB");
+        assert_eq!(recovered.audio.mpv.cache_back, "4MiB");
+        let installed: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(installed["audio"]["mpv"]["_cache_defaults_revision"], 1);
+        assert_eq!(installed["audio"]["mpv"]["cache_forward"], "16MiB");
+        assert_eq!(installed["audio"]["mpv"]["cache_back"], "4MiB");
+        assert_eq!(
+            installed["unknown_primary"],
+            serde_json::json!({"keep": [1, 2, 3]})
+        );
+
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn non_object_replay_is_neither_installed_nor_cleared() {
+        let path = temp_path("invalid-root");
+        let mut base = serde_json::to_value(Config::default()).unwrap();
+        base["volume"] = serde_json::json!(29);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        safe_fs::write_private_atomic_json(&path, &base).unwrap();
+        write_pending(&path, &serde_json::json!(["not", "a", "config"]));
+
+        let recovered = recover_value(&path, base.clone(), false, true);
+
+        assert_eq!(recovered.volume, 29);
+        assert!(crate::persist::test_journal_exists(&path));
+        let disk: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(disk, base);
+
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
 }

--- a/src/daemon/engine.rs
+++ b/src/daemon/engine.rs
@@ -32,6 +32,8 @@ use crate::playback_policy::{
     STREAMING_FALLBACK_COUNT, STREAMING_POOL_COUNT, VOLUME_MAX, VOLUME_STEP,
 };
 
+mod media_projection;
+
 const SESSION_EVENTS_CAP: usize = 20;
 
 pub struct EngineOptions {
@@ -575,8 +577,10 @@ impl DaemonEngine {
             },
             ("audio", "mpv_cache_forward") => match as_str() {
                 Some(value) => {
-                    self.config.audio.mpv.cache_forward = crate::settings::blank_to_none(&value)
-                        .unwrap_or_else(|| crate::config::MPV_CACHE_FORWARD_DEFAULT.to_owned());
+                    self.config
+                        .audio
+                        .mpv
+                        .set_cache_forward(crate::settings::blank_to_none(&value));
                     self.save_config("daemon mpv forward-cache setting");
                     ok(self)
                 }
@@ -584,8 +588,10 @@ impl DaemonEngine {
             },
             ("audio", "mpv_cache_back") => match as_str() {
                 Some(value) => {
-                    self.config.audio.mpv.cache_back = crate::settings::blank_to_none(&value)
-                        .unwrap_or_else(|| crate::config::MPV_CACHE_BACK_DEFAULT.to_owned());
+                    self.config
+                        .audio
+                        .mpv
+                        .set_cache_back(crate::settings::blank_to_none(&value));
                     self.save_config("daemon mpv back-cache setting");
                     ok(self)
                 }
@@ -1371,7 +1377,7 @@ impl DaemonEngine {
             radio_mode: self.last_mode == LastMode::Radio,
             stream_now_playing: None,
             owner_mode: crate::remote::proto::InstanceMode::Daemon,
-            eq_preset: self.config.eq_preset.label().to_string(),
+            eq_preset: self.config.eq_preset.label(),
             eq_bands: self.config.effective_eq_bands(),
             eq_normalize: self.config.effective_normalize(),
             config: &self.config,
@@ -1381,9 +1387,9 @@ impl DaemonEngine {
                 self.media_art
                     .as_ref()
                     .filter(|art| art.key == song.video_id)
-                    .map(|art| ArtworkRef {
-                        key: art.key.clone(),
-                        path: Some(art.path.to_string_lossy().into_owned()),
+                    .map(|art| crate::remote::publish::CoreArtwork {
+                        key: &art.key,
+                        path: Some(art.path.as_path()),
                         mime: None,
                     })
             }),
@@ -2415,6 +2421,8 @@ mod tests {
 
     use serde_json::json;
 
+    mod perf;
+
     fn song(id: &str) -> Song {
         Song::remote(id, format!("title-{id}"), "artist".to_owned(), "3:00")
     }
@@ -2541,6 +2549,20 @@ mod tests {
         assert_eq!(engine.config.media_controls, Some(false));
         assert_eq!(engine.playback.volume, VOLUME_MAX);
         assert!(engine.queue.shuffle);
+
+        engine.config.audio.mpv.cache_defaults_revision = 0;
+        apply_gui_ok(&mut engine, "audio", "mpv_cache_forward", json!("64MiB"));
+        apply_gui_ok(&mut engine, "audio", "mpv_cache_back", json!("16MiB"));
+        assert_eq!(engine.config.audio.mpv.cache_forward, "64MiB");
+        assert_eq!(engine.config.audio.mpv.cache_back, "16MiB");
+        assert_eq!(
+            engine.config.audio.mpv.cache_defaults_revision,
+            crate::config::MPV_CACHE_DEFAULTS_REVISION
+        );
+        engine.config.audio.mpv.cache_defaults_revision = u64::MAX;
+        apply_gui_ok(&mut engine, "audio", "mpv_cache_forward", json!("80MiB"));
+        assert_eq!(engine.config.audio.mpv.cache_forward, "80MiB");
+        assert_eq!(engine.config.audio.mpv.cache_defaults_revision, u64::MAX);
 
         apply_gui_ok(&mut engine, "eq", "preset", json!("rock"));
         apply_gui_ok(
@@ -2726,6 +2748,7 @@ mod tests {
     #[tokio::test]
     async fn player_events_normalize_transport_state_without_player_runtime() {
         let mut engine = engine_with_queue(&["seed"]);
+        let epoch = engine.playback.position_epoch;
 
         assert!(
             engine
@@ -2734,6 +2757,10 @@ mod tests {
                 .is_empty()
         );
         assert_eq!(engine.playback.time_pos, Some(0.0));
+        assert_eq!(
+            engine.playback.position_epoch, epoch,
+            "ordinary progress must not masquerade as a seek discontinuity"
+        );
         engine
             .handle_player_event(PlayerEvent::Duration(Some(f64::INFINITY)))
             .await;
@@ -2753,6 +2780,7 @@ mod tests {
         engine
             .handle_player_event(PlayerEvent::CacheTime(None))
             .await;
+        assert_eq!(engine.playback.position_epoch, epoch);
         engine
             .handle_player_event(PlayerEvent::AudioCodec(Some("aac".to_owned())))
             .await;
@@ -2891,10 +2919,7 @@ mod tests {
         assert_eq!(core.position_epoch, 7);
         assert!(core.streaming);
         assert_eq!(core.owner_mode, InstanceMode::Daemon);
-        assert_eq!(
-            core.artwork.as_ref().map(|art| art.key.as_str()),
-            Some("seed")
-        );
+        assert_eq!(core.artwork.as_ref().map(|art| art.key), Some("seed"));
 
         let media = engine.media_snapshot();
         assert_eq!(media.status, crate::media::MediaPlaybackStatus::Playing);

--- a/src/daemon/engine/media_projection.rs
+++ b/src/daemon/engine/media_projection.rs
@@ -1,0 +1,64 @@
+use std::hash::{Hash, Hasher};
+use std::time::Instant;
+
+use super::DaemonEngine;
+
+impl DaemonEngine {
+    /// Whether the scrobble observer needs a periodic playback heartbeat.
+    pub fn media_scrobble_heartbeat_active(&self) -> bool {
+        self.queue.current().is_some() && !self.playback.paused && self.loaded_video_id.is_some()
+    }
+
+    /// Latest normalized mpv clock without constructing the owned OS-media projection.
+    pub fn media_position_update(&self) -> Option<(f64, Instant)> {
+        Some((self.playback.time_pos?, self.playback.time_pos_at?))
+    }
+
+    /// Allocation-free fingerprint of every daemon field projected by [`Self::media_snapshot`],
+    /// excluding ordinary position/time-anchor progress. The owner loop uses this to avoid
+    /// rebuilding a tree of owned strings and paths after unrelated remote/API events.
+    pub fn media_fingerprint(&self) -> u64 {
+        let mut hash = std::collections::hash_map::DefaultHasher::new();
+        let current = self.queue.current();
+        current.map(|song| song.video_id.as_str()).hash(&mut hash);
+        self.playback.paused.hash(&mut hash);
+        self.loaded_video_id.is_some().hash(&mut hash);
+        self.playback.volume.hash(&mut hash);
+        self.playback.speed.to_bits().hash(&mut hash);
+        self.playback.position_epoch.hash(&mut hash);
+        self.playback.duration.map(f64::to_bits).hash(&mut hash);
+        self.queue.shuffle.hash(&mut hash);
+        match self.queue.repeat {
+            crate::queue::Repeat::Off => 0u8,
+            crate::queue::Repeat::All => 1,
+            crate::queue::Repeat::One => 2,
+        }
+        .hash(&mut hash);
+        self.queue.len().hash(&mut hash);
+        self.queue.position().hash(&mut hash);
+        self.queue
+            .peek_next()
+            .map(|song| song.video_id.as_str())
+            .hash(&mut hash);
+        self.media_can_seek().hash(&mut hash);
+
+        if let Some(song) = current {
+            song.title.hash(&mut hash);
+            song.artist.hash(&mut hash);
+            song.album.hash(&mut hash);
+            song.duration.hash(&mut hash);
+            song.is_radio_station().hash(&mut hash);
+            song.youtube_id().hash(&mut hash);
+            song.local_path.hash(&mut hash);
+            self.library.is_favorite(&song.video_id).hash(&mut hash);
+            self.signals.is_disliked(&song.video_id).hash(&mut hash);
+            self.media_art
+                .as_ref()
+                .filter(|art| art.key == song.video_id)
+                .map(|art| (&art.key, &art.path))
+                .hash(&mut hash);
+        }
+
+        hash.finish()
+    }
+}

--- a/src/daemon/engine/tests/perf.rs
+++ b/src/daemon/engine/tests/perf.rs
@@ -1,0 +1,70 @@
+use super::*;
+
+#[test]
+fn configured_cache_values_flow_to_remote_projection_and_player_argv() {
+    let mut engine = engine_with_queue(&["seed"]);
+    engine.config.audio.mpv.output = Some(" pipewire ".to_owned());
+    engine.config.audio.mpv.device = Some(" alsa/custom ".to_owned());
+    engine.config.audio.mpv.cache_forward = "64MiB".to_owned();
+    engine.config.audio.mpv.cache_back = "12MiB".to_owned();
+
+    let settings = crate::remote::publish::settings_model(&engine.core_view(), 9);
+    assert_eq!(settings.audio.mpv_output.as_deref(), Some("pipewire"));
+    assert_eq!(settings.audio.mpv_device.as_deref(), Some("alsa/custom"));
+    assert_eq!(settings.audio.mpv_cache_forward, "64MiB");
+    assert_eq!(settings.audio.mpv_cache_back, "12MiB");
+
+    let runtime = engine.config.player_runtime(None);
+    assert_eq!(
+        crate::player::mpv::structured_audio_args(&runtime.audio.mpv),
+        [
+            "--ao=pipewire",
+            "--audio-device=alsa/custom",
+            "--demuxer-max-bytes=64MiB",
+            "--demuxer-max-back-bytes=12MiB",
+        ]
+    );
+}
+
+#[test]
+fn media_fingerprint_ignores_progress_but_tracks_projected_facets() {
+    let mut engine = engine_with_queue(&["seed", "next"]);
+    engine.loaded_video_id = Some("seed".to_owned());
+    engine.playback.paused = false;
+    engine.playback.time_pos = Some(1.0);
+    engine.playback.time_pos_at = Some(Instant::now());
+    let baseline = engine.media_fingerprint();
+
+    engine.playback.time_pos = Some(42.0);
+    engine.playback.time_pos_at = Some(Instant::now() - Duration::from_secs(1));
+    assert_eq!(engine.media_fingerprint(), baseline);
+
+    engine.playback.paused = true;
+    assert_ne!(engine.media_fingerprint(), baseline);
+    engine.playback.paused = false;
+    assert_eq!(engine.media_fingerprint(), baseline);
+
+    engine.library.toggle_favorite(&song("seed"));
+    assert_ne!(engine.media_fingerprint(), baseline);
+}
+
+#[tokio::test]
+async fn daemon_reset_all_keeps_its_origin_main_full_config_semantics() {
+    let mut engine = engine_with_queue(&["seed"]);
+    engine.config.audio.mpv.output = Some("pipewire".to_owned());
+    engine.config.audio.mpv.device = Some("alsa/custom".to_owned());
+    engine.config.audio.mpv.cache_forward = "64MiB".to_owned();
+    engine.config.audio.mpv.cache_back = "12MiB".to_owned();
+    engine.config.audio.mpv.cache_defaults_revision = u64::MAX;
+
+    let (response, shutdown, effects) = engine.handle_remote(RemoteCommand::ResetAllSettings).await;
+
+    assert!(response.ok);
+    assert!(!shutdown);
+    assert!(effects.is_empty());
+    assert_eq!(engine.config.audio.mpv, Config::default().audio.mpv);
+    assert_eq!(
+        engine.config.audio.mpv.cache_defaults_revision,
+        crate::config::MPV_CACHE_DEFAULTS_REVISION
+    );
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -21,6 +21,7 @@ use crate::util::process::{self, ProcessProfile};
 
 mod engine;
 mod must_deliver;
+mod observer_plan;
 #[cfg(test)]
 mod parity_tests;
 
@@ -556,6 +557,7 @@ async fn serve(_from_tray: bool, resume: bool) -> i32 {
             pending_events.extend(event_tx.drain_coalesced());
             continue;
         }
+        let (observer_plan, media_position_turn, media_before) = event.observer_context(&engine);
         match event {
             DaemonEvent::Remote(RemoteEvent::Command(command, reply)) => {
                 let (response, shutdown, effects) = engine.handle_remote(command).await;
@@ -613,12 +615,30 @@ async fn serve(_from_tray: bool, resume: bool) -> i32 {
             DaemonEvent::Signal => break,
             DaemonEvent::TelemetryWake => unreachable!("telemetry wake is handled before dispatch"),
         }
-        // Mirror the post-event state to the OS session (diff-based inside); the
-        // scrobbler taps the same snapshot first (it ignores media-controls enablement).
-        let snapshot = engine.media_snapshot();
-        scrobble.observe(&snapshot);
-        media.publish(snapshot);
-        // v8 push: fingerprint-diffed; time-tick events change nothing it watches.
+        // Preserve origin/main's platform-clock correction cadence on progress turns.
+        let media_progress_publish_due = media_position_turn
+            && engine
+                .media_position_update()
+                .is_some_and(|(position, captured_at)| {
+                    media.rebase_position(position, captured_at)
+                });
+
+        // Build the owned OS/scrobble projection only when a projected facet changed or the
+        // active scrobble clock needs its ~1 Hz heartbeat. Ordinary API/remote events and
+        // high-rate telemetry otherwise stay allocation-free here.
+        let media_changed = media_before.is_some_and(|before| before != engine.media_fingerprint());
+        let scrobble_due = observer_plan.drive_scrobble_heartbeat
+            && engine.media_scrobble_heartbeat_active()
+            && scrobble.heartbeat_due();
+        if media_changed || scrobble_due || media_progress_publish_due {
+            let snapshot = engine.media_snapshot();
+            scrobble.observe(&snapshot);
+            if media_changed || media_progress_publish_due {
+                media.publish(snapshot);
+            }
+        }
+        // Preserve origin's baseline-refresh/event ordering on every dispatched daemon event.
+        // The view is borrowed and unchanged topics do not allocate or serialize models.
         publisher.observe(&engine.core_view());
     }
     // A `Signal`/media-quit exit reaches here without the remote-Quit goodbye above;

--- a/src/daemon/observer_plan.rs
+++ b/src/daemon/observer_plan.rs
@@ -1,0 +1,79 @@
+use super::engine::DaemonEngine;
+use super::{DaemonEvent, RemoteEvent};
+
+/// Expensive post-event owner projections are unnecessary for ordinary playback clocks. Keep the
+/// scrobble heartbeat independent so a progress-only workload still advances listening time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ObserverPlan {
+    pub(super) project_state: bool,
+    pub(super) drive_scrobble_heartbeat: bool,
+}
+
+impl ObserverPlan {
+    const INERT: Self = Self {
+        project_state: false,
+        drive_scrobble_heartbeat: false,
+    };
+    const PROGRESS: Self = Self {
+        project_state: false,
+        drive_scrobble_heartbeat: true,
+    };
+    const PROJECTED: Self = Self {
+        project_state: true,
+        drive_scrobble_heartbeat: true,
+    };
+}
+
+impl DaemonEvent {
+    pub(super) fn observer_plan(&self) -> ObserverPlan {
+        match self {
+            DaemonEvent::Player(
+                crate::player::PlayerEvent::TimePos(_) | crate::player::PlayerEvent::CacheTime(_),
+            ) => ObserverPlan::PROGRESS,
+            DaemonEvent::Remote(RemoteEvent::SessionSubscribe { .. })
+            | DaemonEvent::Signal
+            | DaemonEvent::TelemetryWake => ObserverPlan::INERT,
+            _ => ObserverPlan::PROJECTED,
+        }
+    }
+
+    pub(super) fn observer_context(
+        &self,
+        engine: &DaemonEngine,
+    ) -> (ObserverPlan, bool, Option<u64>) {
+        let plan = self.observer_plan();
+        let position_turn = matches!(
+            self,
+            DaemonEvent::Player(crate::player::PlayerEvent::TimePos(_))
+        );
+        let fingerprint = plan.project_state.then(|| engine.media_fingerprint());
+        (plan, position_turn, fingerprint)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn progress_events_skip_owner_projections_but_keep_scrobble_heartbeat() {
+        for event in [
+            DaemonEvent::Player(crate::player::PlayerEvent::TimePos(7.0)),
+            DaemonEvent::Player(crate::player::PlayerEvent::CacheTime(Some(9.0))),
+        ] {
+            let plan = event.observer_plan();
+            assert!(!plan.project_state, "progress must skip projection");
+            assert!(
+                plan.drive_scrobble_heartbeat,
+                "progress must retain the 1 Hz scrobble clock"
+            );
+        }
+
+        assert_eq!(
+            DaemonEvent::Player(crate::player::PlayerEvent::Duration(Some(180.0))).observer_plan(),
+            ObserverPlan::PROJECTED,
+            "a real media facet still runs media/remote observers"
+        );
+        assert_eq!(DaemonEvent::Signal.observer_plan(), ObserverPlan::INERT);
+    }
+}

--- a/src/library.rs
+++ b/src/library.rs
@@ -8,7 +8,8 @@
 //! sessions) and de-duplicated by `video_id`. Persistence mirrors [`crate::config`]:
 //! pretty JSON written atomically (temp file + rename).
 
-use std::collections::VecDeque;
+use std::cell::RefCell;
+use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -24,6 +25,9 @@ const RADIO_FAVORITES_MAX: usize = 999;
 const RADIOS_MAX: usize = 999;
 const DOWNLOADS_MAX: usize = 999;
 const AUDIO_EXTENSIONS: &[&str] = &["aac", "flac", "m4a", "mp3", "ogg", "opus", "wav", "wma"];
+/// Linear scans beat hashing for the small favorite collections common on fresh installs while
+/// the lazy membership index keeps large library renders from becoming quadratic.
+const FAVORITE_MEMBERSHIP_LINEAR_LIMIT: usize = 8;
 
 #[derive(Debug, Clone, Default)]
 pub struct DownloadScan {
@@ -33,7 +37,7 @@ pub struct DownloadScan {
 }
 
 /// Saved tracks and play history, persisted to `<data dir>/library.json`.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Library {
     /// Saved tracks, most-recently-favorited first.
@@ -49,6 +53,37 @@ pub struct Library {
     /// caches also keying on collection lengths.
     #[serde(skip)]
     pub(crate) rev: u64,
+    /// Lazily rebuilt membership sets for the render/media hot paths. The persisted vectors remain
+    /// authoritative; this cache is skipped by serde and invalidated by every production mutation.
+    /// Lengths are part of the key so direct test-fixture pushes also rebuild on first lookup.
+    #[serde(skip)]
+    pub(crate) favorite_membership: RefCell<FavoriteMembership>,
+}
+
+impl Clone for Library {
+    fn clone(&self) -> Self {
+        Self {
+            favorites: self.favorites.clone(),
+            history: self.history.clone(),
+            radio_favorites: self.radio_favorites.clone(),
+            radios: self.radios.clone(),
+            rev: self.rev,
+            // This is a derived hot-path cache, not persisted state. Persist snapshots clone the
+            // Library frequently, so copying up to ~2,000 owned IDs and both hash tables would
+            // turn the optimization into extra work. The clone rebuilds lazily if queried.
+            favorite_membership: RefCell::default(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct FavoriteMembership {
+    favorites_len: usize,
+    radio_favorites_len: usize,
+    initialized: bool,
+    /// `false` is a normal track and `true` is a radio station. A single map avoids retaining a
+    /// second copy of every radio ID while still answering both membership queries in O(1).
+    entries: HashMap<String, bool>,
 }
 
 impl Library {
@@ -81,20 +116,75 @@ impl Library {
     }
 
     pub fn is_favorite(&self, video_id: &str) -> bool {
-        self.favorites.iter().any(|s| s.video_id == video_id) || self.is_radio_favorite(video_id)
+        let favorite_count = self.favorites.len() + self.radio_favorites.len();
+        if favorite_count == 0 {
+            return false;
+        }
+        if favorite_count <= FAVORITE_MEMBERSHIP_LINEAR_LIMIT {
+            return self.favorites.iter().any(|song| song.video_id == video_id)
+                || self
+                    .radio_favorites
+                    .iter()
+                    .any(|song| song.video_id == video_id);
+        }
+        self.indexed_favorite_kind(video_id).is_some()
     }
 
     pub fn is_radio_favorite(&self, video_id: &str) -> bool {
-        self.radio_favorites.iter().any(|s| s.video_id == video_id)
+        if self.radio_favorites.is_empty() {
+            return false;
+        }
+        if self.radio_favorites.len() <= FAVORITE_MEMBERSHIP_LINEAR_LIMIT {
+            return self
+                .radio_favorites
+                .iter()
+                .any(|song| song.video_id == video_id);
+        }
+        self.indexed_favorite_kind(video_id).unwrap_or(false)
+    }
+
+    fn indexed_favorite_kind(&self, video_id: &str) -> Option<bool> {
+        {
+            let membership = self.favorite_membership.borrow();
+            if membership.initialized
+                && membership.favorites_len == self.favorites.len()
+                && membership.radio_favorites_len == self.radio_favorites.len()
+            {
+                return membership.entries.get(video_id).copied();
+            }
+        }
+
+        let mut membership = self.favorite_membership.borrow_mut();
+        membership.entries.clear();
+        membership
+            .entries
+            .reserve(self.favorites.len() + self.radio_favorites.len());
+        membership.entries.extend(
+            self.favorites
+                .iter()
+                .map(|song| (song.video_id.clone(), false)),
+        );
+        for song in &self.radio_favorites {
+            membership.entries.insert(song.video_id.clone(), true);
+        }
+        membership.favorites_len = self.favorites.len();
+        membership.radio_favorites_len = self.radio_favorites.len();
+        membership.initialized = true;
+        membership.entries.get(video_id).copied()
     }
 
     fn touch(&mut self) {
         self.rev = self.rev.wrapping_add(1);
     }
 
+    fn touch_favorites(&mut self) {
+        self.touch();
+        self.favorite_membership.get_mut().initialized = false;
+    }
+
     /// Toggle `song`'s favorite status. Returns `true` if it is now a favorite.
     pub fn toggle_favorite(&mut self, song: &Song) -> bool {
-        self.touch();
+        self.touch_favorites();
         if song.is_radio_station() {
             return self.toggle_radio_favorite(song);
         }
@@ -114,7 +204,7 @@ impl Library {
 
     /// Toggle a live radio station's favorite status, separate from track favorites.
     pub fn toggle_radio_favorite(&mut self, song: &Song) -> bool {
-        self.touch();
+        self.touch_favorites();
         if !song.is_radio_station() {
             return false;
         }
@@ -136,7 +226,7 @@ impl Library {
     /// Remove the favorite at `index` (position in [`Self::favorites`]). Returns whether a
     /// track was removed — `false` for an out-of-range index. Powers the library's delete.
     pub fn remove_favorite_at(&mut self, index: usize) -> bool {
-        self.touch();
+        self.touch_favorites();
         if index < self.favorites.len() {
             self.favorites.remove(index);
             true
@@ -154,7 +244,7 @@ impl Library {
 
     /// Remove a station from radio favorites only, leaving its recent-play entry intact.
     pub fn remove_radio_favorite_by_id(&mut self, video_id: &str) -> bool {
-        self.touch();
+        self.touch_favorites();
         let before = self.radio_favorites.len();
         self.radio_favorites.retain(|s| s.video_id != video_id);
         self.radio_favorites.len() != before
@@ -185,7 +275,7 @@ impl Library {
 
     /// Record a live radio station in its own list, de-duped by id and kept out of song lists.
     pub fn record_radio(&mut self, song: &Song) {
-        self.touch();
+        self.touch_favorites();
         if !song.is_radio_station() {
             return;
         }
@@ -400,6 +490,69 @@ mod tests {
         lib.toggle_favorite(&song("b"));
         assert_eq!(lib.favorites[0].video_id, "b");
         assert_eq!(lib.favorites[1].video_id, "a");
+    }
+
+    #[test]
+    fn favorite_membership_rebuilds_after_mutation_and_direct_fixture_push() {
+        let mut lib = Library::default();
+        assert!(!lib.is_favorite("a")); // prime the empty membership cache
+
+        assert!(lib.toggle_favorite(&song("a")));
+        assert!(lib.is_favorite("a"));
+        assert!(!lib.is_radio_favorite("a"));
+
+        let station = radio("direct");
+        let station_id = station.video_id.clone();
+        lib.radio_favorites.push(station); // test fixtures sometimes mutate public vectors
+        assert!(lib.is_favorite(&station_id));
+        assert!(lib.is_radio_favorite(&station_id));
+
+        assert!(!lib.toggle_favorite(&song("a")));
+        assert!(!lib.is_favorite("a"));
+        assert!(lib.is_favorite(&station_id));
+    }
+
+    #[test]
+    fn cloning_library_does_not_deep_clone_derived_membership_cache() {
+        let mut lib = Library::default();
+        for index in 0..=FAVORITE_MEMBERSHIP_LINEAR_LIMIT {
+            assert!(lib.toggle_favorite(&song(&format!("favorite-{index}"))));
+        }
+        assert!(lib.is_favorite("favorite-0"));
+        assert!(lib.favorite_membership.borrow().initialized);
+
+        let cloned = lib.clone();
+        assert!(!cloned.favorite_membership.borrow().initialized);
+        assert!(cloned.favorite_membership.borrow().entries.is_empty());
+        assert!(cloned.is_favorite("favorite-0"));
+    }
+
+    #[test]
+    fn small_favorite_collections_skip_the_membership_index() {
+        let mut lib = Library::default();
+        for index in 0..FAVORITE_MEMBERSHIP_LINEAR_LIMIT {
+            assert!(lib.toggle_favorite(&song(&format!("favorite-{index}"))));
+        }
+
+        assert!(lib.is_favorite("favorite-0"));
+        assert!(!lib.is_favorite("missing"));
+        assert!(!lib.favorite_membership.borrow().initialized);
+    }
+
+    #[test]
+    fn history_only_mutations_preserve_large_favorite_membership_index() {
+        let mut lib = Library::default();
+        for index in 0..=FAVORITE_MEMBERSHIP_LINEAR_LIMIT {
+            assert!(lib.toggle_favorite(&song(&format!("favorite-{index}"))));
+        }
+        assert!(lib.is_favorite("favorite-0"));
+        assert!(lib.favorite_membership.borrow().initialized);
+
+        lib.record_play(&song("history"));
+        assert!(lib.favorite_membership.borrow().initialized);
+        assert!(lib.is_favorite("favorite-0"));
+        assert!(lib.remove_history_at(0));
+        assert!(lib.favorite_membership.borrow().initialized);
     }
 
     #[test]

--- a/src/library.rs
+++ b/src/library.rs
@@ -8,8 +8,7 @@
 //! sessions) and de-duplicated by `video_id`. Persistence mirrors [`crate::config`]:
 //! pretty JSON written atomically (temp file + rename).
 
-use std::cell::RefCell;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -25,9 +24,23 @@ const RADIO_FAVORITES_MAX: usize = 999;
 const RADIOS_MAX: usize = 999;
 const DOWNLOADS_MAX: usize = 999;
 const AUDIO_EXTENSIONS: &[&str] = &["aac", "flac", "m4a", "mp3", "ogg", "opus", "wav", "wma"];
-/// Linear scans beat hashing for the small favorite collections common on fresh installs while
-/// the lazy membership index keeps large library renders from becoming quadratic.
-const FAVORITE_MEMBERSHIP_LINEAR_LIMIT: usize = 8;
+const FAVORITE_LOOKUP_LINEAR_LIMIT: usize = 32;
+
+/// One-render borrowed favorite membership lookup. Large Library/Search frames build this once
+/// from the authoritative public vectors; no owned ids or stale state survive the render.
+pub(crate) struct FavoriteLookup<'a> {
+    library: &'a Library,
+    ids: Option<HashSet<&'a str>>,
+}
+
+impl FavoriteLookup<'_> {
+    pub(crate) fn is_favorite(&self, video_id: &str) -> bool {
+        self.ids.as_ref().map_or_else(
+            || self.library.is_favorite(video_id),
+            |ids| ids.contains(video_id),
+        )
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct DownloadScan {
@@ -37,7 +50,7 @@ pub struct DownloadScan {
 }
 
 /// Saved tracks and play history, persisted to `<data dir>/library.json`.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Library {
     /// Saved tracks, most-recently-favorited first.
@@ -49,41 +62,10 @@ pub struct Library {
     /// Recently played live radio stations, most-recent first; capped at [`RADIOS_MAX`].
     pub radios: VecDeque<Song>,
     /// Mutation counter for downstream caches (library row cache, id-recovery memo).
-    /// Every `&mut self` method bumps it; direct field mutation (tests) is covered by the
-    /// caches also keying on collection lengths.
+    /// Every production `&mut self` method bumps it. Favorite membership never relies on this
+    /// counter: its render-local borrowed lookup is exact even for direct fixture replacement.
     #[serde(skip)]
     pub(crate) rev: u64,
-    /// Lazily rebuilt membership sets for the render/media hot paths. The persisted vectors remain
-    /// authoritative; this cache is skipped by serde and invalidated by every production mutation.
-    /// Lengths are part of the key so direct test-fixture pushes also rebuild on first lookup.
-    #[serde(skip)]
-    pub(crate) favorite_membership: RefCell<FavoriteMembership>,
-}
-
-impl Clone for Library {
-    fn clone(&self) -> Self {
-        Self {
-            favorites: self.favorites.clone(),
-            history: self.history.clone(),
-            radio_favorites: self.radio_favorites.clone(),
-            radios: self.radios.clone(),
-            rev: self.rev,
-            // This is a derived hot-path cache, not persisted state. Persist snapshots clone the
-            // Library frequently, so copying up to ~2,000 owned IDs and both hash tables would
-            // turn the optimization into extra work. The clone rebuilds lazily if queried.
-            favorite_membership: RefCell::default(),
-        }
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-pub(crate) struct FavoriteMembership {
-    favorites_len: usize,
-    radio_favorites_len: usize,
-    initialized: bool,
-    /// `false` is a normal track and `true` is a radio station. A single map avoids retaining a
-    /// second copy of every radio ID while still answering both membership queries in O(1).
-    entries: HashMap<String, bool>,
 }
 
 impl Library {
@@ -116,75 +98,35 @@ impl Library {
     }
 
     pub fn is_favorite(&self, video_id: &str) -> bool {
-        let favorite_count = self.favorites.len() + self.radio_favorites.len();
-        if favorite_count == 0 {
-            return false;
-        }
-        if favorite_count <= FAVORITE_MEMBERSHIP_LINEAR_LIMIT {
-            return self.favorites.iter().any(|song| song.video_id == video_id)
-                || self
-                    .radio_favorites
-                    .iter()
-                    .any(|song| song.video_id == video_id);
-        }
-        self.indexed_favorite_kind(video_id).is_some()
+        self.favorites.iter().any(|s| s.video_id == video_id) || self.is_radio_favorite(video_id)
     }
 
     pub fn is_radio_favorite(&self, video_id: &str) -> bool {
-        if self.radio_favorites.is_empty() {
-            return false;
-        }
-        if self.radio_favorites.len() <= FAVORITE_MEMBERSHIP_LINEAR_LIMIT {
-            return self
-                .radio_favorites
-                .iter()
-                .any(|song| song.video_id == video_id);
-        }
-        self.indexed_favorite_kind(video_id).unwrap_or(false)
+        self.radio_favorites.iter().any(|s| s.video_id == video_id)
     }
 
-    fn indexed_favorite_kind(&self, video_id: &str) -> Option<bool> {
-        {
-            let membership = self.favorite_membership.borrow();
-            if membership.initialized
-                && membership.favorites_len == self.favorites.len()
-                && membership.radio_favorites_len == self.radio_favorites.len()
-            {
-                return membership.entries.get(video_id).copied();
-            }
-        }
-
-        let mut membership = self.favorite_membership.borrow_mut();
-        membership.entries.clear();
-        membership
-            .entries
-            .reserve(self.favorites.len() + self.radio_favorites.len());
-        membership.entries.extend(
+    pub(crate) fn favorite_lookup(&self) -> FavoriteLookup<'_> {
+        let total = self
+            .favorites
+            .len()
+            .saturating_add(self.radio_favorites.len());
+        let ids = (total > FAVORITE_LOOKUP_LINEAR_LIMIT).then(|| {
             self.favorites
                 .iter()
-                .map(|song| (song.video_id.clone(), false)),
-        );
-        for song in &self.radio_favorites {
-            membership.entries.insert(song.video_id.clone(), true);
-        }
-        membership.favorites_len = self.favorites.len();
-        membership.radio_favorites_len = self.radio_favorites.len();
-        membership.initialized = true;
-        membership.entries.get(video_id).copied()
+                .chain(&self.radio_favorites)
+                .map(|song| song.video_id.as_str())
+                .collect()
+        });
+        FavoriteLookup { library: self, ids }
     }
 
     fn touch(&mut self) {
         self.rev = self.rev.wrapping_add(1);
     }
 
-    fn touch_favorites(&mut self) {
-        self.touch();
-        self.favorite_membership.get_mut().initialized = false;
-    }
-
     /// Toggle `song`'s favorite status. Returns `true` if it is now a favorite.
     pub fn toggle_favorite(&mut self, song: &Song) -> bool {
-        self.touch_favorites();
+        self.touch();
         if song.is_radio_station() {
             return self.toggle_radio_favorite(song);
         }
@@ -204,7 +146,7 @@ impl Library {
 
     /// Toggle a live radio station's favorite status, separate from track favorites.
     pub fn toggle_radio_favorite(&mut self, song: &Song) -> bool {
-        self.touch_favorites();
+        self.touch();
         if !song.is_radio_station() {
             return false;
         }
@@ -226,7 +168,7 @@ impl Library {
     /// Remove the favorite at `index` (position in [`Self::favorites`]). Returns whether a
     /// track was removed — `false` for an out-of-range index. Powers the library's delete.
     pub fn remove_favorite_at(&mut self, index: usize) -> bool {
-        self.touch_favorites();
+        self.touch();
         if index < self.favorites.len() {
             self.favorites.remove(index);
             true
@@ -244,7 +186,7 @@ impl Library {
 
     /// Remove a station from radio favorites only, leaving its recent-play entry intact.
     pub fn remove_radio_favorite_by_id(&mut self, video_id: &str) -> bool {
-        self.touch_favorites();
+        self.touch();
         let before = self.radio_favorites.len();
         self.radio_favorites.retain(|s| s.video_id != video_id);
         self.radio_favorites.len() != before
@@ -275,7 +217,7 @@ impl Library {
 
     /// Record a live radio station in its own list, de-duped by id and kept out of song lists.
     pub fn record_radio(&mut self, song: &Song) {
-        self.touch_favorites();
+        self.touch();
         if !song.is_radio_station() {
             return;
         }
@@ -493,66 +435,71 @@ mod tests {
     }
 
     #[test]
-    fn favorite_membership_rebuilds_after_mutation_and_direct_fixture_push() {
-        let mut lib = Library::default();
-        assert!(!lib.is_favorite("a")); // prime the empty membership cache
+    fn favorite_membership_tracks_same_length_public_vector_replacement() {
+        let mut lib = Library {
+            favorites: (0..64).map(|index| song(&format!("old-{index}"))).collect(),
+            ..Library::default()
+        };
+        assert!(lib.favorite_lookup().is_favorite("old-0"));
 
-        assert!(lib.toggle_favorite(&song("a")));
-        assert!(lib.is_favorite("a"));
-        assert!(!lib.is_radio_favorite("a"));
-
-        let station = radio("direct");
-        let station_id = station.video_id.clone();
-        lib.radio_favorites.push(station); // test fixtures sometimes mutate public vectors
-        assert!(lib.is_favorite(&station_id));
-        assert!(lib.is_radio_favorite(&station_id));
-
-        assert!(!lib.toggle_favorite(&song("a")));
-        assert!(!lib.is_favorite("a"));
-        assert!(lib.is_favorite(&station_id));
+        lib.favorites = (0..64).map(|index| song(&format!("new-{index}"))).collect();
+        let lookup = lib.favorite_lookup();
+        assert!(lookup.ids.is_some());
+        assert!(!lookup.is_favorite("old-0"));
+        assert!(lookup.is_favorite("new-0"));
     }
 
     #[test]
-    fn cloning_library_does_not_deep_clone_derived_membership_cache() {
-        let mut lib = Library::default();
-        for index in 0..=FAVORITE_MEMBERSHIP_LINEAR_LIMIT {
-            assert!(lib.toggle_favorite(&song(&format!("favorite-{index}"))));
-        }
-        assert!(lib.is_favorite("favorite-0"));
-        assert!(lib.favorite_membership.borrow().initialized);
+    fn favorite_membership_tracks_same_length_cross_kind_public_mutation() {
+        let mut lib = Library {
+            favorites: (0..20)
+                .map(|index| song(&format!("track-{index}")))
+                .collect(),
+            radio_favorites: (0..20)
+                .map(|index| radio(&format!("station-{index}")))
+                .collect(),
+            ..Library::default()
+        };
+        let track = lib.favorites[0].clone();
+        let station = lib.radio_favorites[0].clone();
+        assert!(!lib.is_radio_favorite(&track.video_id));
+        assert!(lib.is_radio_favorite(&station.video_id));
 
-        let cloned = lib.clone();
-        assert!(!cloned.favorite_membership.borrow().initialized);
-        assert!(cloned.favorite_membership.borrow().entries.is_empty());
-        assert!(cloned.is_favorite("favorite-0"));
+        lib.favorites[0] = station.clone();
+        lib.radio_favorites[0] = track.clone();
+
+        let lookup = lib.favorite_lookup();
+        assert!(lookup.ids.is_some());
+        assert!(lookup.is_favorite(&track.video_id));
+        assert!(lib.is_radio_favorite(&track.video_id));
+        assert!(lookup.is_favorite(&station.video_id));
+        assert!(!lib.is_radio_favorite(&station.video_id));
     }
 
     #[test]
-    fn small_favorite_collections_skip_the_membership_index() {
-        let mut lib = Library::default();
-        for index in 0..FAVORITE_MEMBERSHIP_LINEAR_LIMIT {
-            assert!(lib.toggle_favorite(&song(&format!("favorite-{index}"))));
-        }
+    fn large_favorite_lookup_borrows_one_exact_id_set_for_the_render() {
+        let lib = Library {
+            favorites: (0..64)
+                .map(|index| song(&format!("track-{index}")))
+                .collect(),
+            radio_favorites: (0..64)
+                .map(|index| radio(&format!("station-{index}")))
+                .collect(),
+            ..Library::default()
+        };
 
-        assert!(lib.is_favorite("favorite-0"));
-        assert!(!lib.is_favorite("missing"));
-        assert!(!lib.favorite_membership.borrow().initialized);
-    }
-
-    #[test]
-    fn history_only_mutations_preserve_large_favorite_membership_index() {
-        let mut lib = Library::default();
-        for index in 0..=FAVORITE_MEMBERSHIP_LINEAR_LIMIT {
-            assert!(lib.toggle_favorite(&song(&format!("favorite-{index}"))));
-        }
-        assert!(lib.is_favorite("favorite-0"));
-        assert!(lib.favorite_membership.borrow().initialized);
-
-        lib.record_play(&song("history"));
-        assert!(lib.favorite_membership.borrow().initialized);
-        assert!(lib.is_favorite("favorite-0"));
-        assert!(lib.remove_history_at(0));
-        assert!(lib.favorite_membership.borrow().initialized);
+        let lookup = lib.favorite_lookup();
+        let ids = lookup.ids.as_ref().expect("large lookup must be indexed");
+        assert_eq!(ids.len(), 128);
+        assert!(lookup.is_favorite("track-63"));
+        assert!(lookup.is_favorite(&lib.radio_favorites[63].video_id));
+        assert!(!lookup.is_favorite("missing"));
+        assert!(ids.iter().all(|id| {
+            lib.favorites
+                .iter()
+                .chain(&lib.radio_favorites)
+                .any(|song| std::ptr::eq(id.as_ptr(), song.video_id.as_ptr()))
+        }));
     }
 
     #[test]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -4,9 +4,16 @@
 //! and stops the background writer.
 
 use std::path::Path;
+use std::sync::OnceLock;
 
-use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::non_blocking::{ErrorCounter, NonBlocking, NonBlockingBuilder, WorkerGuard};
 use tracing_subscriber::EnvFilter;
+
+/// The upstream default is 128,000 lines, which can retain a large burst indefinitely. Logging is
+/// diagnostic and must never apply backpressure to the reducer, so keep a much smaller lossy queue.
+const BUFFERED_LINES_LIMIT: usize = 8_192;
+
+static DROPPED_LINES: OnceLock<ErrorCounter> = OnceLock::new();
 
 pub fn init(dir: &Path) -> Option<WorkerGuard> {
     init_named(dir, "yututui.log")
@@ -25,7 +32,8 @@ pub fn init_named(dir: &Path, file_name: &str) -> Option<WorkerGuard> {
         .max_log_files(7)
         .build(dir)
         .ok()?;
-    let (writer, guard) = tracing_appender::non_blocking(appender);
+    let (writer, guard) = non_blocking_writer(appender);
+    let error_counter = writer.error_counter();
 
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
@@ -37,5 +45,82 @@ pub fn init_named(dir: &Path, file_name: &str) -> Option<WorkerGuard> {
         .try_init()
         .is_ok();
 
-    ok.then_some(guard)
+    if ok {
+        let _ = DROPPED_LINES.set(error_counter);
+        Some(guard)
+    } else {
+        None
+    }
+}
+
+/// Total log lines dropped after the bounded lossy queue filled. This is intentionally a polling
+/// diagnostic (used by `YTM_PERF`) rather than another log event, which could itself be dropped.
+pub fn dropped_lines() -> usize {
+    DROPPED_LINES.get().map_or(0, ErrorCounter::dropped_lines)
+}
+
+fn non_blocking_writer<T>(writer: T) -> (NonBlocking, WorkerGuard)
+where
+    T: std::io::Write + Send + 'static,
+{
+    NonBlockingBuilder::default()
+        .buffered_lines_limit(BUFFERED_LINES_LIMIT)
+        .lossy(true)
+        .finish(writer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::{Arc, Condvar, Mutex, mpsc};
+    use std::time::Duration;
+
+    struct StalledWriter {
+        entered: mpsc::SyncSender<()>,
+        released: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl Write for StalledWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let _ = self.entered.try_send(());
+            let (lock, ready) = &*self.released;
+            let mut released = lock.lock().unwrap();
+            while !*released {
+                released = ready.wait(released).unwrap();
+            }
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn stalled_writer_drops_after_bounded_queue_without_blocking_producer() {
+        let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+        let released = Arc::new((Mutex::new(false), Condvar::new()));
+        let (mut writer, guard) = non_blocking_writer(StalledWriter {
+            entered: entered_tx,
+            released: Arc::clone(&released),
+        });
+        let dropped = writer.error_counter();
+
+        // Let the worker consume one line and stall inside the sink. The producer can then fill
+        // the exact bounded channel and cross the limit without ever waiting on that sink.
+        writer.write_all(b"worker-stalls-here\n").unwrap();
+        entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("logging worker entered the stalled sink");
+        for _ in 0..=BUFFERED_LINES_LIMIT {
+            writer.write_all(b"queued\n").unwrap();
+        }
+        assert_eq!(dropped.dropped_lines(), 1);
+
+        let (lock, ready) = &*released;
+        *lock.lock().unwrap() = true;
+        ready.notify_all();
+        drop(guard);
+    }
 }

--- a/src/lyrics.rs
+++ b/src/lyrics.rs
@@ -7,6 +7,7 @@
 //! (or replaying) costs no network.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use serde::Deserialize;
@@ -14,8 +15,10 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use crate::util::{http, sanitize};
 
-/// Session cache cap (bounded memory; cleared wholesale when exceeded).
-const CACHE_MAX: usize = 999;
+/// Session cache bounds. Found lyric payloads count their slice storage plus every retained
+/// `String` capacity; empty results and transient failures still count toward the entry bound.
+const CACHE_MAX_ENTRIES: usize = 64;
+const CACHE_MAX_PAYLOAD_BYTES: usize = 8 * 1024 * 1024;
 const LYRICS_JSON_MAX: usize = 512 * 1024;
 /// Per-request timeout so a hung lrclib connection can't wedge the actor indefinitely.
 const LYRICS_TIMEOUT: Duration = Duration::from_secs(8);
@@ -26,9 +29,114 @@ const NEGATIVE_TTL: Duration = Duration::from_secs(120);
 
 /// A per-track cache entry: a resolved result (kept for the session, even when empty — the
 /// track genuinely has no synced lyrics) versus a transient failure retried after a cooldown.
-enum CacheEntry {
-    Found(Vec<LyricLine>),
+enum CacheValue {
+    Found(Arc<[LyricLine]>),
     Failed(Instant),
+}
+
+struct CacheEntry {
+    value: CacheValue,
+    payload_bytes: usize,
+    last_used: u64,
+}
+
+/// Small dependency-free LRU. A monotonic touch stamp avoids a second owned copy of every video
+/// id; finding the oldest entry is O(64), bounded by [`CACHE_MAX_ENTRIES`].
+#[derive(Default)]
+struct LyricsCache {
+    entries: HashMap<String, CacheEntry>,
+    payload_bytes: usize,
+    clock: u64,
+}
+
+impl LyricsCache {
+    fn get(&mut self, video_id: &str, now: Instant) -> Option<Arc<[LyricLine]>> {
+        let stamp = self.next_stamp();
+        let entry = self.entries.get_mut(video_id)?;
+        entry.last_used = stamp;
+        match &entry.value {
+            CacheValue::Found(lines) => Some(Arc::clone(lines)),
+            CacheValue::Failed(at) if now.saturating_duration_since(*at) < NEGATIVE_TTL => {
+                Some(Arc::from([]))
+            }
+            CacheValue::Failed(_) => {
+                self.remove(video_id);
+                None
+            }
+        }
+    }
+
+    fn insert_found(&mut self, video_id: String, lines: Arc<[LyricLine]>) {
+        let payload_bytes = lyrics_payload_bytes(&lines);
+        self.remove(&video_id);
+
+        // A single pathological response is still delivered to the current track, but retaining
+        // it would make the byte cap meaningless. It can be fetched again if revisited.
+        if payload_bytes > CACHE_MAX_PAYLOAD_BYTES {
+            return;
+        }
+
+        let last_used = self.next_stamp();
+        self.payload_bytes = self.payload_bytes.saturating_add(payload_bytes);
+        self.entries.insert(
+            video_id,
+            CacheEntry {
+                value: CacheValue::Found(lines),
+                payload_bytes,
+                last_used,
+            },
+        );
+        self.evict_to_bounds();
+    }
+
+    fn insert_failed(&mut self, video_id: String, at: Instant) {
+        self.remove(&video_id);
+        let last_used = self.next_stamp();
+        self.entries.insert(
+            video_id,
+            CacheEntry {
+                value: CacheValue::Failed(at),
+                payload_bytes: 0,
+                last_used,
+            },
+        );
+        self.evict_to_bounds();
+    }
+
+    fn remove(&mut self, video_id: &str) {
+        if let Some(old) = self.entries.remove(video_id) {
+            self.payload_bytes = self.payload_bytes.saturating_sub(old.payload_bytes);
+        }
+    }
+
+    fn evict_to_bounds(&mut self) {
+        while self.entries.len() > CACHE_MAX_ENTRIES || self.payload_bytes > CACHE_MAX_PAYLOAD_BYTES
+        {
+            let Some(oldest) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_used)
+                .map(|(video_id, _)| video_id.clone())
+            else {
+                break;
+            };
+            self.remove(&oldest);
+        }
+    }
+
+    fn next_stamp(&mut self) -> u64 {
+        self.clock = self.clock.saturating_add(1);
+        self.clock
+    }
+}
+
+fn lyrics_payload_bytes(lines: &[LyricLine]) -> usize {
+    std::mem::size_of_val(lines).saturating_add(
+        lines
+            .iter()
+            .map(|line| line.text.capacity())
+            .fold(0usize, usize::saturating_add),
+    )
 }
 
 /// One timed lyric line.
@@ -103,7 +211,7 @@ pub enum LyricsCmd {
 pub enum LyricsEvent {
     Result {
         video_id: String,
-        lines: Vec<LyricLine>,
+        lines: Arc<[LyricLine]>,
     },
 }
 
@@ -150,7 +258,7 @@ where
         .timeout(LYRICS_TIMEOUT)
         .build()
         .unwrap_or_else(|_| reqwest::Client::new());
-    let mut cache: HashMap<String, CacheEntry> = HashMap::new();
+    let mut cache = LyricsCache::default();
 
     while let Some(cmd) = rx.recv().await {
         // Latest-only: rapid track-skips queue several fetches, but only the current track's
@@ -163,25 +271,19 @@ where
         } = take_latest(cmd, &mut rx);
         // A resolved result (even empty) is reused; a transient failure is reused only until
         // its cooldown expires, after which we re-fetch instead of showing "no lyrics" forever.
-        let cached = match cache.get(&video_id) {
-            Some(CacheEntry::Found(lines)) => Some(lines.clone()),
-            Some(CacheEntry::Failed(at)) if at.elapsed() < NEGATIVE_TTL => Some(Vec::new()),
-            _ => None,
-        };
+        let cached = cache.get(&video_id, Instant::now());
         let lines = if let Some(lines) = cached {
             lines
         } else {
-            if cache.len() >= CACHE_MAX {
-                cache.clear();
-            }
             match fetch(&client, &artist, &title).await {
                 Ok(fetched) => {
-                    cache.insert(video_id.clone(), CacheEntry::Found(fetched.clone()));
+                    let fetched: Arc<[LyricLine]> = fetched.into();
+                    cache.insert_found(video_id.clone(), Arc::clone(&fetched));
                     fetched
                 }
                 Err(()) => {
-                    cache.insert(video_id.clone(), CacheEntry::Failed(Instant::now()));
-                    Vec::new()
+                    cache.insert_failed(video_id.clone(), Instant::now());
+                    Arc::from([])
                 }
             }
         };
@@ -277,5 +379,126 @@ mod tests {
     fn empty_is_handled() {
         assert!(parse_lrc("").is_empty());
         assert_eq!(current_index(&[], 5.0), None);
+    }
+
+    fn retained_lines(text_capacity: usize) -> Arc<[LyricLine]> {
+        let mut text = String::with_capacity(text_capacity);
+        text.push('x');
+        vec![LyricLine { time: 0.0, text }].into()
+    }
+
+    #[test]
+    fn cache_hits_share_the_same_lyric_payload() {
+        let mut cache = LyricsCache::default();
+        let lines = retained_lines(128);
+        cache.insert_found("track".to_owned(), Arc::clone(&lines));
+
+        let hit = cache.get("track", Instant::now()).unwrap();
+        assert!(Arc::ptr_eq(&lines, &hit));
+        assert_eq!(cache.payload_bytes, lyrics_payload_bytes(&lines));
+    }
+
+    #[test]
+    fn cache_evicts_least_recently_used_at_entry_bound() {
+        let mut cache = LyricsCache::default();
+        let now = Instant::now();
+        for i in 0..CACHE_MAX_ENTRIES {
+            cache.insert_found(format!("track-{i}"), Arc::from([]));
+        }
+        assert_eq!(cache.entries.len(), CACHE_MAX_ENTRIES);
+
+        // Keep the original oldest entry hot, making track-1 the eviction candidate.
+        assert!(cache.get("track-0", now).is_some());
+        cache.insert_found("newest".to_owned(), Arc::from([]));
+
+        assert_eq!(cache.entries.len(), CACHE_MAX_ENTRIES);
+        assert!(cache.entries.contains_key("track-0"));
+        assert!(!cache.entries.contains_key("track-1"));
+        assert!(cache.entries.contains_key("newest"));
+    }
+
+    #[test]
+    fn negative_cache_hits_are_touched_for_lru_eviction() {
+        let mut cache = LyricsCache::default();
+        let now = Instant::now();
+        cache.insert_failed("failed".to_owned(), now);
+        for i in 0..CACHE_MAX_ENTRIES - 1 {
+            cache.insert_found(format!("track-{i}"), Arc::from([]));
+        }
+
+        assert!(cache.get("failed", now).is_some());
+        cache.insert_found("newest".to_owned(), Arc::from([]));
+
+        assert!(cache.entries.contains_key("failed"));
+        assert!(!cache.entries.contains_key("track-0"));
+        assert!(cache.entries.contains_key("newest"));
+    }
+
+    #[test]
+    fn cache_evicts_by_retained_payload_bytes() {
+        let mut cache = LyricsCache::default();
+        let each = CACHE_MAX_PAYLOAD_BYTES / 2 + 1024;
+        let first = retained_lines(each);
+        let second = retained_lines(each);
+
+        cache.insert_found("first".to_owned(), first);
+        cache.insert_found("second".to_owned(), Arc::clone(&second));
+
+        assert!(!cache.entries.contains_key("first"));
+        assert!(cache.entries.contains_key("second"));
+        assert_eq!(cache.payload_bytes, lyrics_payload_bytes(&second));
+        assert!(cache.payload_bytes <= CACHE_MAX_PAYLOAD_BYTES);
+    }
+
+    #[test]
+    fn replacement_updates_payload_accounting() {
+        let mut cache = LyricsCache::default();
+        cache.insert_found("track".to_owned(), retained_lines(128));
+        let replacement = retained_lines(4096);
+        cache.insert_found("track".to_owned(), Arc::clone(&replacement));
+
+        assert_eq!(cache.entries.len(), 1);
+        assert_eq!(cache.payload_bytes, lyrics_payload_bytes(&replacement));
+    }
+
+    #[test]
+    fn empty_and_negative_entries_count_but_not_toward_payload() {
+        let mut cache = LyricsCache::default();
+        let now = Instant::now();
+        cache.insert_found("empty".to_owned(), Arc::from([]));
+        cache.insert_failed("failed".to_owned(), now);
+
+        assert_eq!(cache.entries.len(), 2);
+        assert_eq!(cache.payload_bytes, 0);
+        assert!(cache.get("empty", now).unwrap().is_empty());
+        assert!(cache.get("failed", now).unwrap().is_empty());
+    }
+
+    #[test]
+    fn transient_failure_expires_after_existing_ttl() {
+        let mut cache = LyricsCache::default();
+        let at = Instant::now();
+        cache.insert_failed("failed".to_owned(), at);
+
+        assert!(
+            cache
+                .get("failed", at + NEGATIVE_TTL - Duration::from_millis(1))
+                .is_some()
+        );
+        assert!(cache.get("failed", at + NEGATIVE_TTL).is_none());
+        assert!(!cache.entries.contains_key("failed"));
+    }
+
+    #[test]
+    fn oversized_payload_is_delivered_by_caller_but_not_retained() {
+        let mut cache = LyricsCache::default();
+        let oversized = retained_lines(CACHE_MAX_PAYLOAD_BYTES);
+        assert!(lyrics_payload_bytes(&oversized) > CACHE_MAX_PAYLOAD_BYTES);
+
+        cache.insert_found("huge".to_owned(), Arc::clone(&oversized));
+
+        assert!(!oversized.is_empty());
+        assert!(cache.entries.is_empty());
+        assert_eq!(cache.payload_bytes, 0);
     }
 }

--- a/src/media/delivery.rs
+++ b/src/media/delivery.rs
@@ -1,10 +1,16 @@
-//! Bounded latest-state delivery shared by the Linux and Windows media workers.
+//! Bounded ordered media-event delivery shared by Linux and Windows workers.
 //!
-//! Ordinary progress replaces one scalar clock slot, while metadata-bearing state
-//! replaces one snapshot slot and ORs its [`MediaChanges`]. Position discontinuities
-//! are different: every epoch is retained in a compact bounded queue. If that queue
-//! fills, the producer applies backpressure instead of losing a `Seeked`/timeline
-//! event or growing memory without bound.
+//! Metadata, status, option, capability, feedback, and position-discontinuity
+//! publications retain a complete snapshot in FIFO order. Pure playback progress
+//! replaces one compact scalar clock. Both platforms bound total pending work
+//! (ordered events plus the progress slot) at 256 items.
+//!
+//! If the ordered FIFO is full, a newer ordered publication replaces the tail
+//! snapshot and ORs its changed facets into that tail. This bounded coalescing may
+//! omit intermediate events, but it always retains a coherent newest external
+//! state without waiting for a future progress publication. A receiver removes
+//! one item per lock acquisition, so producer contention is independent of queue
+//! length.
 
 #![cfg_attr(not(any(target_os = "linux", windows)), allow(dead_code))]
 
@@ -14,62 +20,32 @@ use std::time::Instant;
 
 use super::{MediaChanges, MediaPlaybackStatus, MediaSnapshot};
 
-/// Compact discontinuity capacity. This matches the old Linux snapshot-channel
-/// depth while retaining only scalar clocks (rather than up to 256 full metadata
-/// snapshots); normal state/progress always occupies one latest-value slot.
-pub(super) const MAX_PENDING_DISCONTINUITIES: usize = 256;
+/// Total pending-work capacity for both platform workers.
+pub(super) const MAX_PENDING_UPDATES: usize = 256;
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct PositionClock {
-    #[cfg(any(windows, test))]
-    sequence: u64,
     pub(super) position_epoch: u64,
     position: f64,
     captured_at: Instant,
     rate: f64,
     volume: f64,
     status: MediaPlaybackStatus,
-    duration: Option<f64>,
-    #[cfg(windows)]
-    is_live: bool,
 }
 
 impl PositionClock {
-    fn from_snapshot(snapshot: &MediaSnapshot, sequence: u64) -> Self {
-        #[cfg(not(any(windows, test)))]
-        let _ = sequence;
+    fn from_snapshot(snapshot: &MediaSnapshot) -> Self {
         Self {
-            #[cfg(any(windows, test))]
-            sequence,
             position_epoch: snapshot.position_epoch,
             position: snapshot.position,
             captured_at: snapshot.captured_at,
             rate: snapshot.rate,
             volume: snapshot.volume,
             status: snapshot.status,
-            duration: snapshot.track.as_ref().and_then(|track| track.duration),
-            #[cfg(windows)]
-            is_live: snapshot.track.as_ref().is_some_and(|track| track.is_live),
         }
     }
 
-    pub(super) fn position_now(self) -> f64 {
-        let mut position = self.position;
-        if self.status == MediaPlaybackStatus::Playing {
-            position += self.captured_at.elapsed().as_secs_f64() * self.rate;
-        }
-        if let Some(duration) = self.duration {
-            position = position.min(duration);
-        }
-        position.max(0.0)
-    }
-
-    #[cfg(windows)]
-    pub(super) fn timeline_duration(self) -> Option<f64> {
-        self.duration.filter(|_| !self.is_live)
-    }
-
-    fn apply_to(self, snapshot: &mut MediaSnapshot) {
+    pub(super) fn apply_to(self, snapshot: &mut MediaSnapshot) {
         snapshot.position = self.position;
         snapshot.captured_at = self.captured_at;
         snapshot.rate = self.rate;
@@ -79,52 +55,32 @@ impl PositionClock {
     }
 }
 
+/// One logical non-progress publication. Snapshot and changes remain coupled so
+/// metadata and position can never come from different core publications.
 #[derive(Debug)]
-pub(super) struct DeliveryBatch {
-    /// Present only when a non-position facet changed. Progress-only publications
-    /// therefore never clone track strings or paths.
-    pub(super) snapshot: Option<MediaSnapshot>,
-    pub(super) clock: PositionClock,
+pub(super) struct OrderedMediaEvent {
+    pub(super) snapshot: MediaSnapshot,
     pub(super) changes: MediaChanges,
-    /// Every position discontinuity, in publication order.
-    pub(super) discontinuities: Vec<PositionClock>,
-    /// Sequence of the newest coalesced update that requires an immediate SMTC
-    /// timeline push for reasons other than a discontinuity (status/options/track).
-    #[cfg(any(windows, test))]
-    timeline_sequence: Option<u64>,
 }
 
-impl DeliveryBatch {
-    /// Install the newest scalar clock into the optional full snapshot before a
-    /// consumer publishes it or moves it into its shared current-state slot.
-    pub(super) fn prepare_snapshot(&mut self) {
-        if let Some(snapshot) = self.snapshot.as_mut() {
-            self.clock.apply_to(snapshot);
-        }
-    }
-
-    pub(super) fn apply_clock_to(&self, snapshot: &mut MediaSnapshot) {
-        self.clock.apply_to(snapshot);
-    }
-
-    /// SMTC pushes every discontinuity. A separate final push is needed only when
-    /// a later coalesced status/options update occurred after the last one.
-    #[cfg(any(windows, test))]
-    pub(super) fn needs_final_timeline(&self) -> bool {
-        self.timeline_sequence.is_some_and(|sequence| {
-            self.discontinuities
-                .last()
-                .is_none_or(|position| sequence > position.sequence)
-        })
-    }
+/// Exactly one item crosses the receiver lock per call. This enum deliberately
+/// keeps the hot ordered event inline: boxing every event would add one allocation
+/// merely to silence a size lint, while at most one item is in flight.
+#[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
+pub(super) enum DeliveryItem {
+    Ordered(OrderedMediaEvent),
+    Progress(PositionClock),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum SubmitOutcome {
-    /// The pending slot was empty; the platform worker must be woken.
+    /// Pending work was previously empty and fully observed; wake the worker.
     Wake,
-    /// A wake is already pending; this update was coalesced into it.
+    /// The worker is already awake or has not yet observed the queue as empty.
     Coalesced,
+    /// A pure-progress update could not claim a new slot at total capacity.
+    Dropped,
     /// The receiver has gone away or this sender was closed.
     Closed,
 }
@@ -140,50 +96,37 @@ pub(super) struct LatestMediaReceiver {
 struct Inner {
     pending: Mutex<Pending>,
     ready: Condvar,
-    space: Condvar,
-    discontinuity_capacity: usize,
+    capacity: usize,
 }
 
 struct Pending {
-    snapshot: Option<MediaSnapshot>,
-    clock: Option<PositionClock>,
-    /// A platform wake has been requested for the current pending slot. This is separate from
-    /// `clock`: a consumer clears it when taking a batch, and Windows can clear it after a failed
-    /// `PostThreadMessageW` so the next update retries instead of coalescing forever.
+    events: VecDeque<OrderedMediaEvent>,
+    progress: Option<PositionClock>,
+    /// One platform wake covers all work until the receiver observes the queue
+    /// completely empty while holding this mutex.
     wake_pending: bool,
-    changes: MediaChanges,
-    discontinuities: VecDeque<PositionClock>,
-    #[cfg(any(windows, test))]
-    timeline_sequence: Option<u64>,
-    next_sequence: u64,
     sender_open: bool,
     receiver_open: bool,
 }
 
-pub(super) fn latest_media_channel() -> (LatestMediaSender, LatestMediaReceiver) {
-    latest_media_channel_with_capacity(MAX_PENDING_DISCONTINUITIES)
+/// Both platform workers use the same bounded total-work policy.
+pub(super) fn latest_media_channel_bounded() -> (LatestMediaSender, LatestMediaReceiver) {
+    latest_media_channel_with_capacity(MAX_PENDING_UPDATES)
 }
 
-fn latest_media_channel_with_capacity(
-    discontinuity_capacity: usize,
-) -> (LatestMediaSender, LatestMediaReceiver) {
-    assert!(discontinuity_capacity > 0);
+fn latest_media_channel_with_capacity(capacity: usize) -> (LatestMediaSender, LatestMediaReceiver) {
+    assert!(capacity > 0);
     let inner = Arc::new(Inner {
         pending: Mutex::new(Pending {
-            snapshot: None,
-            clock: None,
+            // Do not reserve 256 large snapshot slots for the common one-item case.
+            events: VecDeque::new(),
+            progress: None,
             wake_pending: false,
-            changes: MediaChanges::default(),
-            discontinuities: VecDeque::with_capacity(discontinuity_capacity),
-            #[cfg(any(windows, test))]
-            timeline_sequence: None,
-            next_sequence: 1,
             sender_open: true,
             receiver_open: true,
         }),
         ready: Condvar::new(),
-        space: Condvar::new(),
-        discontinuity_capacity,
+        capacity,
     });
     (
         LatestMediaSender {
@@ -194,59 +137,62 @@ fn latest_media_channel_with_capacity(
 }
 
 impl LatestMediaSender {
-    /// Publish one logical media update. Only a full-queue discontinuity can block:
-    /// scalar progress and metadata always replace their single latest-value slots.
+    /// Publish one logical media update without waiting for consumer capacity.
     pub(super) fn submit(&self, snapshot: &MediaSnapshot, changes: MediaChanges) -> SubmitOutcome {
         let mut pending = self.inner.lock();
-        while changes.position
-            && pending.discontinuities.len() == self.inner.discontinuity_capacity
-            && pending.sender_open
-            && pending.receiver_open
-        {
-            pending = self
-                .inner
-                .space
-                .wait(pending)
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-        }
         if !pending.sender_open || !pending.receiver_open {
             return SubmitOutcome::Closed;
         }
 
         let needs_wake = !pending.wake_pending;
+        if changes == MediaChanges::default() {
+            if pending.progress.is_none() && pending.len() >= self.inner.capacity {
+                // The new progress value is dropped, but after a failed platform
+                // wake this submit must still re-arm delivery of existing work.
+                if needs_wake {
+                    pending.wake_pending = true;
+                    drop(pending);
+                    self.inner.ready.notify_one();
+                    return SubmitOutcome::Wake;
+                }
+                return SubmitOutcome::Dropped;
+            }
+            pending.progress = Some(PositionClock::from_snapshot(snapshot));
+        } else {
+            // The complete ordered snapshot is newer than any scalar progress and
+            // can reuse that slot before checking the ordered capacity.
+            pending.progress = None;
+            if pending.events.len() >= self.inner.capacity {
+                let tail = pending
+                    .events
+                    .back_mut()
+                    .expect("positive capacity and a full queue imply a tail");
+                tail.snapshot = snapshot.clone();
+                merge_changes(&mut tail.changes, changes);
+            } else {
+                pending.events.push_back(OrderedMediaEvent {
+                    snapshot: snapshot.clone(),
+                    changes,
+                });
+            }
+        }
+
         pending.wake_pending = true;
-        let sequence = pending.next_sequence;
-        pending.next_sequence = pending.next_sequence.wrapping_add(1);
-        let clock = PositionClock::from_snapshot(snapshot, sequence);
-
-        if requires_snapshot(changes) {
-            pending.snapshot = Some(snapshot.clone());
-        }
-        pending.clock = Some(clock);
-        merge_changes(&mut pending.changes, changes);
-        if changes.position {
-            pending.discontinuities.push_back(clock);
-        }
-        #[cfg(any(windows, test))]
-        if changes.track || changes.status || changes.options {
-            pending.timeline_sequence = Some(sequence);
-        }
         drop(pending);
-        self.inner.ready.notify_one();
-
         if needs_wake {
+            self.inner.ready.notify_one();
             SubmitOutcome::Wake
         } else {
             SubmitOutcome::Coalesced
         }
     }
 
-    /// Re-arm wake delivery after a platform notification failed. Pending state remains intact;
-    /// a later publication will return [`SubmitOutcome::Wake`] and retry the platform signal.
+    /// Re-arm wake delivery after a platform notification failed. Pending work
+    /// remains intact; a later publication requests another platform wake.
     #[cfg(any(windows, test))]
     pub(super) fn wake_failed(&self) {
         let mut pending = self.inner.lock();
-        if pending.clock.is_some() {
+        if pending.has_work() {
             pending.wake_pending = false;
         }
     }
@@ -259,7 +205,6 @@ impl LatestMediaSender {
         pending.sender_open = false;
         drop(pending);
         self.inner.ready.notify_all();
-        self.inner.space.notify_all();
     }
 }
 
@@ -270,47 +215,48 @@ impl Drop for LatestMediaSender {
 }
 
 impl LatestMediaReceiver {
-    pub(super) fn try_take(&self) -> Option<DeliveryBatch> {
-        let mut pending = self.inner.lock();
-        take_batch(&mut pending).inspect(|_| self.inner.space.notify_all())
+    pub(super) fn try_take(&self) -> Option<DeliveryItem> {
+        take_next(&mut self.inner.lock())
     }
 
     #[cfg(target_os = "linux")]
     pub(super) fn is_closed(&self) -> bool {
         let pending = self.inner.lock();
-        !pending.sender_open && pending.clock.is_none()
+        !pending.sender_open && !pending.has_work()
     }
 
     #[cfg(test)]
-    fn recv_blocking(&self) -> Option<DeliveryBatch> {
+    fn recv_blocking(&self) -> Option<DeliveryItem> {
         let mut pending = self.inner.lock();
-        while pending.clock.is_none() && pending.sender_open {
+        loop {
+            if let Some(item) = take_next(&mut pending) {
+                return Some(item);
+            }
+            if !pending.sender_open {
+                return None;
+            }
             pending = self
                 .inner
                 .ready
                 .wait(pending)
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
         }
-        take_batch(&mut pending).inspect(|_| self.inner.space.notify_all())
     }
 
     #[cfg(test)]
-    fn pending_shape(&self) -> (bool, bool, usize) {
+    fn pending_shape(&self) -> PendingShape {
         let pending = self.inner.lock();
-        (
-            pending.snapshot.is_some(),
-            pending.clock.is_some(),
-            pending.discontinuities.len(),
-        )
+        PendingShape {
+            events: pending.events.len(),
+            progress: pending.progress.is_some(),
+            wake_pending: pending.wake_pending,
+        }
     }
 }
 
 impl Drop for LatestMediaReceiver {
     fn drop(&mut self) {
-        let mut pending = self.inner.lock();
-        pending.receiver_open = false;
-        drop(pending);
-        self.inner.space.notify_all();
+        self.inner.lock().receiver_open = false;
     }
 }
 
@@ -322,26 +268,28 @@ impl Inner {
     }
 }
 
-fn take_batch(pending: &mut Pending) -> Option<DeliveryBatch> {
-    let clock = pending.clock.take()?;
-    pending.wake_pending = false;
-    Some(DeliveryBatch {
-        snapshot: pending.snapshot.take(),
-        clock,
-        changes: std::mem::take(&mut pending.changes),
-        discontinuities: pending.discontinuities.drain(..).collect(),
-        #[cfg(any(windows, test))]
-        timeline_sequence: pending.timeline_sequence.take(),
-    })
+impl Pending {
+    fn has_work(&self) -> bool {
+        !self.events.is_empty() || self.progress.is_some()
+    }
+
+    fn len(&self) -> usize {
+        self.events.len() + usize::from(self.progress.is_some())
+    }
 }
 
-fn requires_snapshot(changes: MediaChanges) -> bool {
-    changes.track
-        || changes.artwork
-        || changes.status
-        || changes.options
-        || changes.caps
-        || changes.feedback
+/// Pop exactly one item while holding the mutex. `wake_pending` deliberately
+/// remains set after the last item is removed: a submit racing before the next
+/// empty observation coalesces into the worker that is already draining.
+fn take_next(pending: &mut Pending) -> Option<DeliveryItem> {
+    if let Some(event) = pending.events.pop_front() {
+        return Some(DeliveryItem::Ordered(event));
+    }
+    if let Some(progress) = pending.progress.take() {
+        return Some(DeliveryItem::Progress(progress));
+    }
+    pending.wake_pending = false;
+    None
 }
 
 fn merge_changes(into: &mut MediaChanges, update: MediaChanges) {
@@ -355,19 +303,28 @@ fn merge_changes(into: &mut MediaChanges, update: MediaChanges) {
 }
 
 #[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PendingShape {
+    events: usize,
+    progress: bool,
+    wake_pending: bool,
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::media::{MediaCaps, MediaTrack};
     use crate::queue::Repeat;
+    use std::time::Duration;
 
     fn snapshot(title: &str, epoch: u64) -> MediaSnapshot {
         MediaSnapshot {
             track: Some(MediaTrack {
-                key: "track".to_owned(),
+                key: format!("track-{title}"),
                 title: title.to_owned(),
-                artist: "artist".to_owned(),
-                album: None,
-                duration: Some(180.0),
+                artist: format!("artist-{title}"),
+                album: Some(format!("album-{title}")),
+                duration: Some(180.0 + epoch as f64),
                 is_live: false,
                 url: None,
                 art_remote_url: None,
@@ -388,56 +345,52 @@ mod tests {
         }
     }
 
-    #[test]
-    fn slow_consumer_gets_newest_metadata_and_every_aggregated_facet() {
-        let (sender, receiver) = latest_media_channel_with_capacity(4);
-        let facets = [
-            MediaChanges {
-                track: true,
-                position: true,
-                ..MediaChanges::default()
-            },
-            MediaChanges {
-                artwork: true,
-                status: true,
-                ..MediaChanges::default()
-            },
-            MediaChanges {
-                options: true,
-                caps: true,
-                feedback: true,
-                ..MediaChanges::default()
-            },
-        ];
+    fn track_seek() -> MediaChanges {
+        MediaChanges {
+            track: true,
+            position: true,
+            ..MediaChanges::default()
+        }
+    }
 
-        assert_eq!(
-            sender.submit(&snapshot("old", 1), facets[0]),
-            SubmitOutcome::Wake
-        );
-        assert_eq!(
-            sender.submit(&snapshot("middle", 1), facets[1]),
-            SubmitOutcome::Coalesced
-        );
-        assert_eq!(
-            sender.submit(&snapshot("newest", 1), facets[2]),
-            SubmitOutcome::Coalesced
-        );
+    fn ordered(item: DeliveryItem) -> OrderedMediaEvent {
+        match item {
+            DeliveryItem::Ordered(event) => event,
+            DeliveryItem::Progress(_) => panic!("expected ordered event"),
+        }
+    }
 
-        let mut batch = receiver.try_take().expect("one coalesced batch");
-        batch.prepare_snapshot();
-        let state = batch.snapshot.expect("metadata-bearing latest snapshot");
-        assert_eq!(state.track.as_ref().unwrap().title, "newest");
-        assert_eq!(batch.changes, MediaChanges::all());
-        assert_eq!(batch.discontinuities.len(), 1);
+    fn progress(item: DeliveryItem) -> PositionClock {
+        match item {
+            DeliveryItem::Progress(clock) => clock,
+            DeliveryItem::Ordered(_) => panic!("expected scalar progress"),
+        }
     }
 
     #[test]
-    fn scalar_progress_occupies_one_slot_and_never_clones_full_state() {
-        let (sender, receiver) = latest_media_channel_with_capacity(2);
+    fn slow_consumer_keeps_uncoalesced_track_and_seek_events_in_exact_order() {
+        let (sender, receiver) = latest_media_channel_with_capacity(4);
+        sender.submit(&snapshot("A", 11), track_seek());
+        sender.submit(&snapshot("A-progress", 12), MediaChanges::default());
+        sender.submit(&snapshot("B", 21), track_seek());
+
+        let a = ordered(receiver.try_take().unwrap());
+        let b = ordered(receiver.try_take().unwrap());
+        assert_eq!(a.snapshot.track.as_ref().unwrap().title, "A");
+        assert_eq!(a.snapshot.position_epoch, 11);
+        assert_eq!(a.changes, track_seek());
+        assert_eq!(b.snapshot.track.as_ref().unwrap().title, "B");
+        assert_eq!(b.snapshot.position_epoch, 21);
+        assert_eq!(b.changes, track_seek());
+        assert!(receiver.try_take().is_none());
+    }
+
+    #[test]
+    fn scalar_progress_occupies_one_slot_for_fifty_thousand_updates() {
+        let (sender, receiver) = latest_media_channel_with_capacity(1);
         for epoch in 0..50_000 {
-            let outcome = sender.submit(&snapshot("unchanged", epoch), MediaChanges::default());
             assert_eq!(
-                outcome,
+                sender.submit(&snapshot("unchanged", epoch), MediaChanges::default()),
                 if epoch == 0 {
                     SubmitOutcome::Wake
                 } else {
@@ -445,183 +398,276 @@ mod tests {
                 }
             );
         }
-        assert_eq!(receiver.pending_shape(), (false, true, 0));
-
-        let batch = receiver.try_take().expect("latest scalar clock");
-        assert!(batch.snapshot.is_none());
-        assert_eq!(batch.clock.position_epoch, 49_999);
-        assert_eq!(batch.changes, MediaChanges::default());
-    }
-
-    #[test]
-    fn failed_platform_wake_is_retried_without_losing_pending_state() {
-        let (sender, receiver) = latest_media_channel_with_capacity(2);
         assert_eq!(
-            sender.submit(&snapshot("first", 1), MediaChanges::default()),
-            SubmitOutcome::Wake
-        );
-
-        // Model a failed Windows PostThreadMessageW. The first snapshot stays pending, but the
-        // next publication must request another wake instead of being coalesced into a wake that
-        // never reached the worker.
-        sender.wake_failed();
-        assert_eq!(
-            sender.submit(&snapshot("latest", 2), MediaChanges::default()),
-            SubmitOutcome::Wake
-        );
-
-        let batch = receiver
-            .try_take()
-            .expect("latest state remains deliverable");
-        assert_eq!(batch.clock.position_epoch, 2);
-        assert!(receiver.try_take().is_none());
-
-        assert_eq!(
-            sender.submit(&snapshot("after-drain", 3), MediaChanges::default()),
-            SubmitOutcome::Wake,
-            "taking a batch also re-arms the next platform wake"
-        );
-    }
-
-    #[test]
-    fn bounded_slow_consumer_preserves_every_discontinuity_in_order() {
-        let (sender, receiver) = latest_media_channel_with_capacity(2);
-        let (filled_tx, filled_rx) = std::sync::mpsc::channel();
-        let (continue_tx, continue_rx) = std::sync::mpsc::channel();
-        let producer = std::thread::spawn(move || {
-            for epoch in 1..=20 {
-                assert_ne!(
-                    sender.submit(
-                        &snapshot("same", epoch),
-                        MediaChanges {
-                            position: true,
-                            ..MediaChanges::default()
-                        }
-                    ),
-                    SubmitOutcome::Closed
-                );
-                if epoch == 2 {
-                    filled_tx.send(()).unwrap();
-                    continue_rx.recv().unwrap();
-                }
+            receiver.pending_shape(),
+            PendingShape {
+                events: 0,
+                progress: true,
+                wake_pending: true,
             }
-        });
-
-        filled_rx.recv().unwrap();
-        assert_eq!(receiver.pending_shape(), (false, true, 2));
-        continue_tx.send(()).unwrap();
-
-        let mut epochs = Vec::new();
-        while let Some(batch) = receiver.recv_blocking() {
-            assert!(batch.discontinuities.len() <= 2);
-            epochs.extend(
-                batch
-                    .discontinuities
-                    .into_iter()
-                    .map(|clock| clock.position_epoch),
-            );
-        }
-        producer.join().unwrap();
-        assert_eq!(epochs, (1..=20).collect::<Vec<_>>());
+        );
+        assert_eq!(
+            progress(receiver.try_take().unwrap()).position_epoch,
+            49_999
+        );
     }
 
     #[test]
-    fn dedicated_consumer_releases_backpressure_from_a_current_thread_runtime() {
-        let (sender, receiver) = latest_media_channel_with_capacity(1);
-        let (first_pending_tx, first_pending_rx) = std::sync::mpsc::channel();
-        let (drained_tx, drained_rx) = std::sync::mpsc::channel();
+    fn total_capacity_counts_events_and_progress_but_allows_progress_replacement() {
+        let (sender, receiver) = latest_media_channel_with_capacity(2);
+        sender.submit(&snapshot("A", 1), track_seek());
+        sender.submit(&snapshot("A", 2), MediaChanges::default());
+        assert_eq!(
+            receiver.pending_shape(),
+            PendingShape {
+                events: 1,
+                progress: true,
+                wake_pending: true,
+            }
+        );
+        assert_eq!(
+            sender.submit(&snapshot("A", 3), MediaChanges::default()),
+            SubmitOutcome::Coalesced
+        );
+        assert_eq!(receiver.pending_shape().events, 1);
+        assert!(receiver.pending_shape().progress);
+    }
 
-        // Mirrors MPRIS's dedicated worker: it can drain independently even while the daemon's
-        // single-thread runtime is synchronously submitting the second lossless discontinuity.
-        let consumer = std::thread::spawn(move || {
-            first_pending_rx.recv().unwrap();
-            let batch = receiver.recv_blocking().expect("first discontinuity");
-            assert_eq!(batch.discontinuities[0].position_epoch, 1);
-            drained_tx.send(()).unwrap();
-            receiver
-        });
-
+    #[test]
+    fn progress_at_full_capacity_drops_without_waiting() {
+        let (sender, _receiver) = latest_media_channel_with_capacity(1);
+        sender.submit(&snapshot("A", 1), track_seek());
         let (done_tx, done_rx) = std::sync::mpsc::channel();
         let producer = std::thread::spawn(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
+            done_tx
+                .send(sender.submit(&snapshot("progress", 2), MediaChanges::default()))
                 .unwrap();
-            runtime.block_on(async move {
-                let position_change = MediaChanges {
-                    position: true,
-                    ..MediaChanges::default()
-                };
-                assert_eq!(
-                    sender.submit(&snapshot("same", 1), position_change),
-                    SubmitOutcome::Wake
-                );
-                first_pending_tx.send(()).unwrap();
-                assert_ne!(
-                    sender.submit(&snapshot("same", 2), position_change),
-                    SubmitOutcome::Closed
-                );
-                done_tx.send(()).unwrap();
-            });
         });
-
-        done_rx
-            .recv_timeout(std::time::Duration::from_secs(1))
-            .expect("dedicated consumer must prevent single-thread runtime deadlock");
-        drained_rx.recv().unwrap();
-        producer.join().unwrap();
-        let receiver = consumer.join().unwrap();
         assert_eq!(
-            receiver
-                .try_take()
-                .expect("second discontinuity remains pending")
-                .discontinuities[0]
-                .position_epoch,
-            2
+            done_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            SubmitOutcome::Dropped
         );
+        producer.join().unwrap();
     }
 
     #[test]
-    fn final_timeline_is_needed_only_after_the_last_discontinuity() {
-        let (sender, receiver) = latest_media_channel_with_capacity(4);
+    fn capacity_one_coalesces_a_into_coherent_newest_b() {
+        let (sender, receiver) = latest_media_channel_with_capacity(1);
+        let a_changes = MediaChanges {
+            track: true,
+            position: true,
+            ..MediaChanges::default()
+        };
+        let b_changes = MediaChanges {
+            status: true,
+            options: true,
+            caps: true,
+            ..MediaChanges::default()
+        };
+        sender.submit(&snapshot("A", 1), a_changes);
+        sender.submit(&snapshot("B", 2), b_changes);
+
+        let event = ordered(receiver.try_take().unwrap());
+        assert_eq!(event.snapshot.track.as_ref().unwrap().title, "B");
+        assert_eq!(event.snapshot.position_epoch, 2);
+        assert_eq!(
+            event.changes,
+            MediaChanges {
+                track: true,
+                status: true,
+                position: true,
+                options: true,
+                caps: true,
+                ..MediaChanges::default()
+            }
+        );
+        assert!(receiver.try_take().is_none());
+    }
+
+    #[test]
+    fn full_queue_retains_final_ordered_snapshot_without_a_future_submit() {
+        let (sender, receiver) = latest_media_channel_with_capacity(3);
+        for epoch in 0..3 {
+            sender.submit(&snapshot(&format!("old-{epoch}"), epoch), track_seek());
+        }
+        let final_changes = MediaChanges {
+            status: true,
+            options: true,
+            ..MediaChanges::default()
+        };
+        sender.submit(&snapshot("final-B", 99), final_changes);
+
+        assert_eq!(
+            ordered(receiver.try_take().unwrap())
+                .snapshot
+                .position_epoch,
+            0
+        );
+        assert_eq!(
+            ordered(receiver.try_take().unwrap())
+                .snapshot
+                .position_epoch,
+            1
+        );
+        let final_event = ordered(receiver.try_take().unwrap());
+        assert_eq!(
+            final_event.snapshot.track.as_ref().unwrap().title,
+            "final-B"
+        );
+        assert_eq!(final_event.snapshot.position_epoch, 99);
+        assert!(final_event.changes.track);
+        assert!(final_event.changes.position);
+        assert!(final_event.changes.status);
+        assert!(final_event.changes.options);
+        assert!(receiver.try_take().is_none());
+    }
+
+    #[test]
+    fn accepted_ordered_event_clears_older_progress_and_uses_its_slot() {
+        let (sender, receiver) = latest_media_channel_with_capacity(2);
+        sender.submit(&snapshot("A", 1), track_seek());
+        sender.submit(&snapshot("A", 2), MediaChanges::default());
         sender.submit(
-            &snapshot("same", 1),
+            &snapshot("C", 3),
             MediaChanges {
                 status: true,
                 ..MediaChanges::default()
             },
         );
-        sender.submit(
-            &snapshot("same", 2),
-            MediaChanges {
-                position: true,
-                ..MediaChanges::default()
-            },
+        assert_eq!(
+            receiver.pending_shape(),
+            PendingShape {
+                events: 2,
+                progress: false,
+                wake_pending: true,
+            }
         );
-        assert!(!receiver.try_take().unwrap().needs_final_timeline());
-
-        sender.submit(
-            &snapshot("same", 3),
-            MediaChanges {
-                position: true,
-                ..MediaChanges::default()
-            },
+        assert_eq!(
+            ordered(receiver.try_take().unwrap())
+                .snapshot
+                .position_epoch,
+            1
         );
-        sender.submit(
-            &snapshot("same", 3),
-            MediaChanges {
-                options: true,
-                ..MediaChanges::default()
-            },
+        assert_eq!(
+            ordered(receiver.try_take().unwrap())
+                .snapshot
+                .position_epoch,
+            3
         );
-        assert!(receiver.try_take().unwrap().needs_final_timeline());
     }
 
     #[test]
-    fn close_wakes_a_blocking_receiver_without_fabricating_state() {
+    fn shared_default_capacity_never_exceeds_256_total_items() {
+        let (sender, receiver) = latest_media_channel_bounded();
+        for epoch in 0..(MAX_PENDING_UPDATES - 1) as u64 {
+            sender.submit(&snapshot("accepted", epoch), track_seek());
+        }
+        sender.submit(&snapshot("progress", 999), MediaChanges::default());
+        assert_eq!(receiver.pending_shape().events, MAX_PENDING_UPDATES - 1);
+        assert!(receiver.pending_shape().progress);
+
+        // Ordered work reuses the progress slot, reaching exactly 256 events.
+        sender.submit(&snapshot("ordered", 1_000), track_seek());
+        assert_eq!(receiver.pending_shape().events, MAX_PENDING_UPDATES);
+        assert!(!receiver.pending_shape().progress);
+        // A further ordered event replaces the tail instead of growing the queue.
+        sender.submit(&snapshot("tail", 1_001), track_seek());
+        assert_eq!(receiver.pending_shape().events, MAX_PENDING_UPDATES);
+    }
+
+    #[test]
+    fn submit_after_last_take_coalesces_until_empty_is_observed() {
+        let (sender, receiver) = latest_media_channel_with_capacity(1);
+        assert_eq!(
+            sender.submit(&snapshot("first", 1), MediaChanges::default()),
+            SubmitOutcome::Wake
+        );
+        assert_eq!(progress(receiver.try_take().unwrap()).position_epoch, 1);
+        assert_eq!(
+            sender.submit(&snapshot("racing", 2), MediaChanges::default()),
+            SubmitOutcome::Coalesced
+        );
+        assert_eq!(progress(receiver.try_take().unwrap()).position_epoch, 2);
+    }
+
+    #[test]
+    fn submit_after_empty_observation_requests_a_new_wake() {
+        let (sender, receiver) = latest_media_channel_with_capacity(1);
+        sender.submit(&snapshot("first", 1), MediaChanges::default());
+        let _ = receiver.try_take().unwrap();
+        assert!(receiver.try_take().is_none());
+        assert_eq!(
+            sender.submit(&snapshot("after-empty", 2), MediaChanges::default()),
+            SubmitOutcome::Wake
+        );
+    }
+
+    #[test]
+    fn failed_platform_wake_is_retried_without_losing_pending_work() {
+        let (sender, receiver) = latest_media_channel_with_capacity(2);
+        sender.submit(&snapshot("first", 1), track_seek());
+        sender.wake_failed();
+        assert_eq!(
+            sender.submit(&snapshot("latest", 2), MediaChanges::default()),
+            SubmitOutcome::Wake
+        );
+        assert_eq!(
+            ordered(receiver.try_take().unwrap())
+                .snapshot
+                .position_epoch,
+            1
+        );
+        assert_eq!(progress(receiver.try_take().unwrap()).position_epoch, 2);
+        assert!(receiver.try_take().is_none());
+    }
+
+    #[test]
+    fn full_queue_failed_wake_is_rearmed_even_when_progress_drops() {
+        let (sender, receiver) = latest_media_channel_with_capacity(1);
+        sender.submit(&snapshot("pending", 1), track_seek());
+        sender.wake_failed();
+        assert_eq!(
+            sender.submit(&snapshot("dropped-progress", 2), MediaChanges::default()),
+            SubmitOutcome::Wake
+        );
+        let event = ordered(receiver.try_take().unwrap());
+        assert_eq!(event.snapshot.track.unwrap().title, "pending");
+        assert!(receiver.try_take().is_none());
+    }
+
+    #[test]
+    fn close_drains_every_item_before_reporting_closed() {
+        let (sender, receiver) = latest_media_channel_with_capacity(2);
+        sender.submit(&snapshot("pending", 1), track_seek());
+        sender.submit(&snapshot("pending", 2), MediaChanges::default());
+        sender.close();
+
+        assert!(matches!(
+            receiver.recv_blocking(),
+            Some(DeliveryItem::Ordered(_))
+        ));
+        assert!(matches!(
+            receiver.recv_blocking(),
+            Some(DeliveryItem::Progress(_))
+        ));
+        assert!(receiver.recv_blocking().is_none());
+    }
+
+    #[test]
+    fn close_wakes_blocking_receiver_without_fabricating_work() {
         let (sender, receiver) = latest_media_channel_with_capacity(1);
         let waiter = std::thread::spawn(move || receiver.recv_blocking().is_none());
         sender.close();
         assert!(waiter.join().unwrap());
+    }
+
+    #[test]
+    fn receiver_close_makes_later_submit_nonblocking_and_closed() {
+        let (sender, receiver) = latest_media_channel_with_capacity(1);
+        drop(receiver);
+        assert_eq!(
+            sender.submit(&snapshot("closed", 1), track_seek()),
+            SubmitOutcome::Closed
+        );
     }
 }

--- a/src/media/delivery.rs
+++ b/src/media/delivery.rs
@@ -1,0 +1,627 @@
+//! Bounded latest-state delivery shared by the Linux and Windows media workers.
+//!
+//! Ordinary progress replaces one scalar clock slot, while metadata-bearing state
+//! replaces one snapshot slot and ORs its [`MediaChanges`]. Position discontinuities
+//! are different: every epoch is retained in a compact bounded queue. If that queue
+//! fills, the producer applies backpressure instead of losing a `Seeked`/timeline
+//! event or growing memory without bound.
+
+#![cfg_attr(not(any(target_os = "linux", windows)), allow(dead_code))]
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::time::Instant;
+
+use super::{MediaChanges, MediaPlaybackStatus, MediaSnapshot};
+
+/// Compact discontinuity capacity. This matches the old Linux snapshot-channel
+/// depth while retaining only scalar clocks (rather than up to 256 full metadata
+/// snapshots); normal state/progress always occupies one latest-value slot.
+pub(super) const MAX_PENDING_DISCONTINUITIES: usize = 256;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct PositionClock {
+    #[cfg(any(windows, test))]
+    sequence: u64,
+    pub(super) position_epoch: u64,
+    position: f64,
+    captured_at: Instant,
+    rate: f64,
+    volume: f64,
+    status: MediaPlaybackStatus,
+    duration: Option<f64>,
+    #[cfg(windows)]
+    is_live: bool,
+}
+
+impl PositionClock {
+    fn from_snapshot(snapshot: &MediaSnapshot, sequence: u64) -> Self {
+        #[cfg(not(any(windows, test)))]
+        let _ = sequence;
+        Self {
+            #[cfg(any(windows, test))]
+            sequence,
+            position_epoch: snapshot.position_epoch,
+            position: snapshot.position,
+            captured_at: snapshot.captured_at,
+            rate: snapshot.rate,
+            volume: snapshot.volume,
+            status: snapshot.status,
+            duration: snapshot.track.as_ref().and_then(|track| track.duration),
+            #[cfg(windows)]
+            is_live: snapshot.track.as_ref().is_some_and(|track| track.is_live),
+        }
+    }
+
+    pub(super) fn position_now(self) -> f64 {
+        let mut position = self.position;
+        if self.status == MediaPlaybackStatus::Playing {
+            position += self.captured_at.elapsed().as_secs_f64() * self.rate;
+        }
+        if let Some(duration) = self.duration {
+            position = position.min(duration);
+        }
+        position.max(0.0)
+    }
+
+    #[cfg(windows)]
+    pub(super) fn timeline_duration(self) -> Option<f64> {
+        self.duration.filter(|_| !self.is_live)
+    }
+
+    fn apply_to(self, snapshot: &mut MediaSnapshot) {
+        snapshot.position = self.position;
+        snapshot.captured_at = self.captured_at;
+        snapshot.rate = self.rate;
+        snapshot.volume = self.volume;
+        snapshot.status = self.status;
+        snapshot.copy_delivery_clock_from_core(self.position_epoch);
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct DeliveryBatch {
+    /// Present only when a non-position facet changed. Progress-only publications
+    /// therefore never clone track strings or paths.
+    pub(super) snapshot: Option<MediaSnapshot>,
+    pub(super) clock: PositionClock,
+    pub(super) changes: MediaChanges,
+    /// Every position discontinuity, in publication order.
+    pub(super) discontinuities: Vec<PositionClock>,
+    /// Sequence of the newest coalesced update that requires an immediate SMTC
+    /// timeline push for reasons other than a discontinuity (status/options/track).
+    #[cfg(any(windows, test))]
+    timeline_sequence: Option<u64>,
+}
+
+impl DeliveryBatch {
+    /// Install the newest scalar clock into the optional full snapshot before a
+    /// consumer publishes it or moves it into its shared current-state slot.
+    pub(super) fn prepare_snapshot(&mut self) {
+        if let Some(snapshot) = self.snapshot.as_mut() {
+            self.clock.apply_to(snapshot);
+        }
+    }
+
+    pub(super) fn apply_clock_to(&self, snapshot: &mut MediaSnapshot) {
+        self.clock.apply_to(snapshot);
+    }
+
+    /// SMTC pushes every discontinuity. A separate final push is needed only when
+    /// a later coalesced status/options update occurred after the last one.
+    #[cfg(any(windows, test))]
+    pub(super) fn needs_final_timeline(&self) -> bool {
+        self.timeline_sequence.is_some_and(|sequence| {
+            self.discontinuities
+                .last()
+                .is_none_or(|position| sequence > position.sequence)
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SubmitOutcome {
+    /// The pending slot was empty; the platform worker must be woken.
+    Wake,
+    /// A wake is already pending; this update was coalesced into it.
+    Coalesced,
+    /// The receiver has gone away or this sender was closed.
+    Closed,
+}
+
+pub(super) struct LatestMediaSender {
+    inner: Arc<Inner>,
+}
+
+pub(super) struct LatestMediaReceiver {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    pending: Mutex<Pending>,
+    ready: Condvar,
+    space: Condvar,
+    discontinuity_capacity: usize,
+}
+
+struct Pending {
+    snapshot: Option<MediaSnapshot>,
+    clock: Option<PositionClock>,
+    /// A platform wake has been requested for the current pending slot. This is separate from
+    /// `clock`: a consumer clears it when taking a batch, and Windows can clear it after a failed
+    /// `PostThreadMessageW` so the next update retries instead of coalescing forever.
+    wake_pending: bool,
+    changes: MediaChanges,
+    discontinuities: VecDeque<PositionClock>,
+    #[cfg(any(windows, test))]
+    timeline_sequence: Option<u64>,
+    next_sequence: u64,
+    sender_open: bool,
+    receiver_open: bool,
+}
+
+pub(super) fn latest_media_channel() -> (LatestMediaSender, LatestMediaReceiver) {
+    latest_media_channel_with_capacity(MAX_PENDING_DISCONTINUITIES)
+}
+
+fn latest_media_channel_with_capacity(
+    discontinuity_capacity: usize,
+) -> (LatestMediaSender, LatestMediaReceiver) {
+    assert!(discontinuity_capacity > 0);
+    let inner = Arc::new(Inner {
+        pending: Mutex::new(Pending {
+            snapshot: None,
+            clock: None,
+            wake_pending: false,
+            changes: MediaChanges::default(),
+            discontinuities: VecDeque::with_capacity(discontinuity_capacity),
+            #[cfg(any(windows, test))]
+            timeline_sequence: None,
+            next_sequence: 1,
+            sender_open: true,
+            receiver_open: true,
+        }),
+        ready: Condvar::new(),
+        space: Condvar::new(),
+        discontinuity_capacity,
+    });
+    (
+        LatestMediaSender {
+            inner: Arc::clone(&inner),
+        },
+        LatestMediaReceiver { inner },
+    )
+}
+
+impl LatestMediaSender {
+    /// Publish one logical media update. Only a full-queue discontinuity can block:
+    /// scalar progress and metadata always replace their single latest-value slots.
+    pub(super) fn submit(&self, snapshot: &MediaSnapshot, changes: MediaChanges) -> SubmitOutcome {
+        let mut pending = self.inner.lock();
+        while changes.position
+            && pending.discontinuities.len() == self.inner.discontinuity_capacity
+            && pending.sender_open
+            && pending.receiver_open
+        {
+            pending = self
+                .inner
+                .space
+                .wait(pending)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+        if !pending.sender_open || !pending.receiver_open {
+            return SubmitOutcome::Closed;
+        }
+
+        let needs_wake = !pending.wake_pending;
+        pending.wake_pending = true;
+        let sequence = pending.next_sequence;
+        pending.next_sequence = pending.next_sequence.wrapping_add(1);
+        let clock = PositionClock::from_snapshot(snapshot, sequence);
+
+        if requires_snapshot(changes) {
+            pending.snapshot = Some(snapshot.clone());
+        }
+        pending.clock = Some(clock);
+        merge_changes(&mut pending.changes, changes);
+        if changes.position {
+            pending.discontinuities.push_back(clock);
+        }
+        #[cfg(any(windows, test))]
+        if changes.track || changes.status || changes.options {
+            pending.timeline_sequence = Some(sequence);
+        }
+        drop(pending);
+        self.inner.ready.notify_one();
+
+        if needs_wake {
+            SubmitOutcome::Wake
+        } else {
+            SubmitOutcome::Coalesced
+        }
+    }
+
+    /// Re-arm wake delivery after a platform notification failed. Pending state remains intact;
+    /// a later publication will return [`SubmitOutcome::Wake`] and retry the platform signal.
+    #[cfg(any(windows, test))]
+    pub(super) fn wake_failed(&self) {
+        let mut pending = self.inner.lock();
+        if pending.clock.is_some() {
+            pending.wake_pending = false;
+        }
+    }
+
+    pub(super) fn close(&self) {
+        let mut pending = self.inner.lock();
+        if !pending.sender_open {
+            return;
+        }
+        pending.sender_open = false;
+        drop(pending);
+        self.inner.ready.notify_all();
+        self.inner.space.notify_all();
+    }
+}
+
+impl Drop for LatestMediaSender {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+impl LatestMediaReceiver {
+    pub(super) fn try_take(&self) -> Option<DeliveryBatch> {
+        let mut pending = self.inner.lock();
+        take_batch(&mut pending).inspect(|_| self.inner.space.notify_all())
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(super) fn is_closed(&self) -> bool {
+        let pending = self.inner.lock();
+        !pending.sender_open && pending.clock.is_none()
+    }
+
+    #[cfg(test)]
+    fn recv_blocking(&self) -> Option<DeliveryBatch> {
+        let mut pending = self.inner.lock();
+        while pending.clock.is_none() && pending.sender_open {
+            pending = self
+                .inner
+                .ready
+                .wait(pending)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+        take_batch(&mut pending).inspect(|_| self.inner.space.notify_all())
+    }
+
+    #[cfg(test)]
+    fn pending_shape(&self) -> (bool, bool, usize) {
+        let pending = self.inner.lock();
+        (
+            pending.snapshot.is_some(),
+            pending.clock.is_some(),
+            pending.discontinuities.len(),
+        )
+    }
+}
+
+impl Drop for LatestMediaReceiver {
+    fn drop(&mut self) {
+        let mut pending = self.inner.lock();
+        pending.receiver_open = false;
+        drop(pending);
+        self.inner.space.notify_all();
+    }
+}
+
+impl Inner {
+    fn lock(&self) -> MutexGuard<'_, Pending> {
+        self.pending
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+fn take_batch(pending: &mut Pending) -> Option<DeliveryBatch> {
+    let clock = pending.clock.take()?;
+    pending.wake_pending = false;
+    Some(DeliveryBatch {
+        snapshot: pending.snapshot.take(),
+        clock,
+        changes: std::mem::take(&mut pending.changes),
+        discontinuities: pending.discontinuities.drain(..).collect(),
+        #[cfg(any(windows, test))]
+        timeline_sequence: pending.timeline_sequence.take(),
+    })
+}
+
+fn requires_snapshot(changes: MediaChanges) -> bool {
+    changes.track
+        || changes.artwork
+        || changes.status
+        || changes.options
+        || changes.caps
+        || changes.feedback
+}
+
+fn merge_changes(into: &mut MediaChanges, update: MediaChanges) {
+    into.track |= update.track;
+    into.artwork |= update.artwork;
+    into.status |= update.status;
+    into.position |= update.position;
+    into.options |= update.options;
+    into.caps |= update.caps;
+    into.feedback |= update.feedback;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::{MediaCaps, MediaTrack};
+    use crate::queue::Repeat;
+
+    fn snapshot(title: &str, epoch: u64) -> MediaSnapshot {
+        MediaSnapshot {
+            track: Some(MediaTrack {
+                key: "track".to_owned(),
+                title: title.to_owned(),
+                artist: "artist".to_owned(),
+                album: None,
+                duration: Some(180.0),
+                is_live: false,
+                url: None,
+                art_remote_url: None,
+                art_file: None,
+                art_query: None,
+                liked: false,
+                disliked: false,
+            }),
+            status: MediaPlaybackStatus::Playing,
+            position: epoch as f64,
+            captured_at: Instant::now(),
+            rate: 1.0,
+            shuffle: false,
+            repeat: Repeat::Off,
+            volume: 0.5,
+            caps: MediaCaps::default(),
+            position_epoch: epoch,
+        }
+    }
+
+    #[test]
+    fn slow_consumer_gets_newest_metadata_and_every_aggregated_facet() {
+        let (sender, receiver) = latest_media_channel_with_capacity(4);
+        let facets = [
+            MediaChanges {
+                track: true,
+                position: true,
+                ..MediaChanges::default()
+            },
+            MediaChanges {
+                artwork: true,
+                status: true,
+                ..MediaChanges::default()
+            },
+            MediaChanges {
+                options: true,
+                caps: true,
+                feedback: true,
+                ..MediaChanges::default()
+            },
+        ];
+
+        assert_eq!(
+            sender.submit(&snapshot("old", 1), facets[0]),
+            SubmitOutcome::Wake
+        );
+        assert_eq!(
+            sender.submit(&snapshot("middle", 1), facets[1]),
+            SubmitOutcome::Coalesced
+        );
+        assert_eq!(
+            sender.submit(&snapshot("newest", 1), facets[2]),
+            SubmitOutcome::Coalesced
+        );
+
+        let mut batch = receiver.try_take().expect("one coalesced batch");
+        batch.prepare_snapshot();
+        let state = batch.snapshot.expect("metadata-bearing latest snapshot");
+        assert_eq!(state.track.as_ref().unwrap().title, "newest");
+        assert_eq!(batch.changes, MediaChanges::all());
+        assert_eq!(batch.discontinuities.len(), 1);
+    }
+
+    #[test]
+    fn scalar_progress_occupies_one_slot_and_never_clones_full_state() {
+        let (sender, receiver) = latest_media_channel_with_capacity(2);
+        for epoch in 0..50_000 {
+            let outcome = sender.submit(&snapshot("unchanged", epoch), MediaChanges::default());
+            assert_eq!(
+                outcome,
+                if epoch == 0 {
+                    SubmitOutcome::Wake
+                } else {
+                    SubmitOutcome::Coalesced
+                }
+            );
+        }
+        assert_eq!(receiver.pending_shape(), (false, true, 0));
+
+        let batch = receiver.try_take().expect("latest scalar clock");
+        assert!(batch.snapshot.is_none());
+        assert_eq!(batch.clock.position_epoch, 49_999);
+        assert_eq!(batch.changes, MediaChanges::default());
+    }
+
+    #[test]
+    fn failed_platform_wake_is_retried_without_losing_pending_state() {
+        let (sender, receiver) = latest_media_channel_with_capacity(2);
+        assert_eq!(
+            sender.submit(&snapshot("first", 1), MediaChanges::default()),
+            SubmitOutcome::Wake
+        );
+
+        // Model a failed Windows PostThreadMessageW. The first snapshot stays pending, but the
+        // next publication must request another wake instead of being coalesced into a wake that
+        // never reached the worker.
+        sender.wake_failed();
+        assert_eq!(
+            sender.submit(&snapshot("latest", 2), MediaChanges::default()),
+            SubmitOutcome::Wake
+        );
+
+        let batch = receiver
+            .try_take()
+            .expect("latest state remains deliverable");
+        assert_eq!(batch.clock.position_epoch, 2);
+        assert!(receiver.try_take().is_none());
+
+        assert_eq!(
+            sender.submit(&snapshot("after-drain", 3), MediaChanges::default()),
+            SubmitOutcome::Wake,
+            "taking a batch also re-arms the next platform wake"
+        );
+    }
+
+    #[test]
+    fn bounded_slow_consumer_preserves_every_discontinuity_in_order() {
+        let (sender, receiver) = latest_media_channel_with_capacity(2);
+        let (filled_tx, filled_rx) = std::sync::mpsc::channel();
+        let (continue_tx, continue_rx) = std::sync::mpsc::channel();
+        let producer = std::thread::spawn(move || {
+            for epoch in 1..=20 {
+                assert_ne!(
+                    sender.submit(
+                        &snapshot("same", epoch),
+                        MediaChanges {
+                            position: true,
+                            ..MediaChanges::default()
+                        }
+                    ),
+                    SubmitOutcome::Closed
+                );
+                if epoch == 2 {
+                    filled_tx.send(()).unwrap();
+                    continue_rx.recv().unwrap();
+                }
+            }
+        });
+
+        filled_rx.recv().unwrap();
+        assert_eq!(receiver.pending_shape(), (false, true, 2));
+        continue_tx.send(()).unwrap();
+
+        let mut epochs = Vec::new();
+        while let Some(batch) = receiver.recv_blocking() {
+            assert!(batch.discontinuities.len() <= 2);
+            epochs.extend(
+                batch
+                    .discontinuities
+                    .into_iter()
+                    .map(|clock| clock.position_epoch),
+            );
+        }
+        producer.join().unwrap();
+        assert_eq!(epochs, (1..=20).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn dedicated_consumer_releases_backpressure_from_a_current_thread_runtime() {
+        let (sender, receiver) = latest_media_channel_with_capacity(1);
+        let (first_pending_tx, first_pending_rx) = std::sync::mpsc::channel();
+        let (drained_tx, drained_rx) = std::sync::mpsc::channel();
+
+        // Mirrors MPRIS's dedicated worker: it can drain independently even while the daemon's
+        // single-thread runtime is synchronously submitting the second lossless discontinuity.
+        let consumer = std::thread::spawn(move || {
+            first_pending_rx.recv().unwrap();
+            let batch = receiver.recv_blocking().expect("first discontinuity");
+            assert_eq!(batch.discontinuities[0].position_epoch, 1);
+            drained_tx.send(()).unwrap();
+            receiver
+        });
+
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let producer = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            runtime.block_on(async move {
+                let position_change = MediaChanges {
+                    position: true,
+                    ..MediaChanges::default()
+                };
+                assert_eq!(
+                    sender.submit(&snapshot("same", 1), position_change),
+                    SubmitOutcome::Wake
+                );
+                first_pending_tx.send(()).unwrap();
+                assert_ne!(
+                    sender.submit(&snapshot("same", 2), position_change),
+                    SubmitOutcome::Closed
+                );
+                done_tx.send(()).unwrap();
+            });
+        });
+
+        done_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("dedicated consumer must prevent single-thread runtime deadlock");
+        drained_rx.recv().unwrap();
+        producer.join().unwrap();
+        let receiver = consumer.join().unwrap();
+        assert_eq!(
+            receiver
+                .try_take()
+                .expect("second discontinuity remains pending")
+                .discontinuities[0]
+                .position_epoch,
+            2
+        );
+    }
+
+    #[test]
+    fn final_timeline_is_needed_only_after_the_last_discontinuity() {
+        let (sender, receiver) = latest_media_channel_with_capacity(4);
+        sender.submit(
+            &snapshot("same", 1),
+            MediaChanges {
+                status: true,
+                ..MediaChanges::default()
+            },
+        );
+        sender.submit(
+            &snapshot("same", 2),
+            MediaChanges {
+                position: true,
+                ..MediaChanges::default()
+            },
+        );
+        assert!(!receiver.try_take().unwrap().needs_final_timeline());
+
+        sender.submit(
+            &snapshot("same", 3),
+            MediaChanges {
+                position: true,
+                ..MediaChanges::default()
+            },
+        );
+        sender.submit(
+            &snapshot("same", 3),
+            MediaChanges {
+                options: true,
+                ..MediaChanges::default()
+            },
+        );
+        assert!(receiver.try_take().unwrap().needs_final_timeline());
+    }
+
+    #[test]
+    fn close_wakes_a_blocking_receiver_without_fabricating_state() {
+        let (sender, receiver) = latest_media_channel_with_capacity(1);
+        let waiter = std::thread::spawn(move || receiver.recv_blocking().is_none());
+        sender.close();
+        assert!(waiter.join().unwrap());
+    }
+}

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -1,9 +1,11 @@
 //! OS media-session integration: macOS Now Playing, Windows SMTC, Linux MPRIS.
 //!
 //! This is the platform-independent layer. The core (TUI reducer or headless daemon
-//! engine) stays the single source of truth: it builds a [`MediaSnapshot`] after every
-//! state change and hands it to [`MediaSession::publish`], which diffs against the last
-//! published snapshot and forwards only the changed facets to the platform backend.
+//! engine) stays the single source of truth: it builds a [`MediaSnapshot`] after projected
+//! state changes and hands it to [`MediaSession::publish`], which diffs against the last
+//! published snapshot and forwards only the changed facets to the platform backend. Ordinary
+//! playback progress uses [`MediaSession::rebase_position`] so platform clocks retain the exact
+//! pre-optimization correction cadence without rebuilding metadata-bearing snapshots.
 //! Inbound OS events (media keys, widget buttons, scrubber drags, AirPods gestures)
 //! arrive as [`MediaCommand`]s through the sink given at construction and flow through
 //! the normal reducer/engine paths — the backend never mutates state optimistically.
@@ -13,6 +15,9 @@
 
 pub mod artwork;
 pub mod identity;
+
+#[cfg(any(target_os = "linux", windows, test))]
+mod delivery;
 
 #[cfg(target_os = "macos")]
 mod macos;
@@ -169,6 +174,14 @@ impl MediaSnapshot {
             pos = pos.min(len);
         }
         pos.max(0.0)
+    }
+
+    /// Copy the core-authored discontinuity token into a backend's retained
+    /// position clock. This never advances the epoch; App/daemon bump helpers
+    /// remain the only writers that create a new discontinuity.
+    #[cfg(any(target_os = "linux", windows, test))]
+    pub(super) fn copy_delivery_clock_from_core(&mut self, core_position_epoch: u64) {
+        self.position_epoch = core_position_epoch;
     }
 }
 
@@ -442,6 +455,32 @@ impl MediaSession {
         self.last = Some(snapshot);
     }
 
+    /// Rebase only the scalar playback clock after a `time-pos` update.
+    ///
+    /// `origin/main` handed every progress snapshot to the platform backend even though the
+    /// snapshot diff had no changed facets. Linux and Windows used those calls to correct their
+    /// interpolated clocks. Keep that observable cadence while reusing the retained metadata, so
+    /// a progress turn neither rebuilds nor clones track strings, paths, artwork, or capabilities.
+    /// Returns `true` only when the platform has not activated yet and the caller must publish one
+    /// full current snapshot. This preserves lazy first-play activation on macOS/Windows.
+    pub fn rebase_position(&mut self, position: f64, captured_at: Instant) -> bool {
+        if !self.enabled || self.failed {
+            return false;
+        }
+        if !self.activated {
+            return true;
+        }
+        let Some(snapshot) = self.last.as_mut() else {
+            return true;
+        };
+        snapshot.position = position;
+        snapshot.captured_at = captured_at;
+        if let Some(backend) = self.backend.as_mut() {
+            backend.apply(snapshot, MediaChanges::default());
+        }
+        false
+    }
+
     /// Kick the async artwork fetch when a new track appears; the result comes back
     /// through the core (as a message) and lands in a later snapshot's `art_file`.
     fn request_artwork(&mut self, snapshot: &MediaSnapshot) {
@@ -614,6 +653,13 @@ mod tests {
     }
 
     #[test]
+    fn delivery_clock_copies_core_epoch_without_bumping_again() {
+        let mut delivered = snap(Some("a"));
+        delivered.copy_delivery_clock_from_core(7);
+        assert_eq!(delivered.position_epoch, 7);
+    }
+
+    #[test]
     fn artwork_arrival_marks_artwork_only() {
         let a = snap(Some("a"));
         let mut b = a.clone();
@@ -665,5 +711,30 @@ mod tests {
         let mut s = snap(Some("a"));
         s.position = 500.0; // past the 180s duration
         assert!((s.position_now() - 180.0).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn scalar_rebase_updates_retained_clock_without_rebuilding_metadata() {
+        let mut session = MediaSession::new(false, |_| {}, |_| {});
+        session.enabled = true;
+        session.activated = true;
+        session.last = Some(snap(Some("same-track")));
+        let track_before = session.last.as_ref().unwrap().track.clone();
+        let captured_at = Instant::now();
+
+        assert!(!session.rebase_position(47.5, captured_at));
+
+        let retained = session.last.as_ref().unwrap();
+        assert_eq!(retained.position, 47.5);
+        assert_eq!(retained.captured_at, captured_at);
+        assert_eq!(retained.track, track_before);
+        assert_eq!(retained.position_epoch, 1);
+    }
+
+    #[tokio::test]
+    async fn first_progress_requests_lazy_platform_activation_snapshot() {
+        let mut session = MediaSession::new(false, |_| {}, |_| {});
+        session.enabled = true;
+        assert!(session.rebase_position(1.0, Instant::now()));
     }
 }

--- a/src/media/mpris.rs
+++ b/src/media/mpris.rs
@@ -1,13 +1,14 @@
 //! Linux MPRIS adapter (`org.mpris.MediaPlayer2.ytmtui` on the session bus), per
 //! the media-controls spec §3, built on `mpris-server` (zbus).
 //!
-//! The D-Bus server runs on its own tokio task: the facade forwards diffed
-//! snapshots over a channel; the task keeps the latest snapshot in shared state
+//! The D-Bus server runs on its own small-stack worker thread and current-thread
+//! runtime: the facade forwards diffed snapshots over a channel; the worker keeps
+//! the latest snapshot in shared state
 //! (so property *reads* — including the un-signalled, interpolated `Position` —
-//! answer instantly), batches changed properties into a single
-//! `PropertiesChanged` per logical event (L-6/S-4), and emits `Seeked` exactly on
-//! position discontinuities (L-7). Inbound calls only forward a [`MediaCommand`]
-//! and return (C-1).
+//! answer instantly), coalesces changed properties into one `PropertiesChanged`
+//! per worker wake (L-6/S-4), and emits `Seeked` once for every position
+//! discontinuity (L-7). Inbound calls only forward a [`MediaCommand`] and return
+//! (C-1).
 //!
 //! No session bus (SSH/headless/container) is non-fatal: the facade logs one
 //! warning and the app runs without media controls (spec A-2).
@@ -20,8 +21,11 @@ use mpris_server::{
     Volume,
     zbus::{self, fdo},
 };
-use tokio::sync::mpsc;
+use tokio::sync::Notify;
 
+use super::delivery::{
+    DeliveryBatch, LatestMediaReceiver, LatestMediaSender, SubmitOutcome, latest_media_channel,
+};
 use super::{CommandSink, MediaChanges, MediaCommand, MediaPlaybackStatus, MediaSnapshot};
 use crate::config::{SPEED_MAX, SPEED_MIN};
 use crate::queue::Repeat;
@@ -35,27 +39,59 @@ pub const EAGER: bool = true;
 const BUS_SUFFIX: &str = "ytmtui";
 
 pub struct Backend {
-    tx: mpsc::Sender<(MediaSnapshot, MediaChanges)>,
+    updates: LatestMediaSender,
+    wake: Arc<Notify>,
+    _worker: std::thread::JoinHandle<()>,
 }
 
 impl Backend {
     pub fn new(sink: CommandSink) -> Result<Self> {
-        // Bounded with a generous cap; the zbus server task drains it. A permanently stalled
-        // D-Bus consumer drops new snapshots (`try_send` in `apply`) instead of growing the
-        // queue without bound — snapshots are frequent, so the next one re-conveys state.
-        let (tx, rx) = mpsc::channel(256);
-        tokio::spawn(run_server(rx, sink));
-        Ok(Self { tx })
+        let (updates, rx) = latest_media_channel();
+        let wake = Arc::new(Notify::new());
+        let worker_wake = Arc::clone(&wake);
+        // `submit` applies bounded backpressure only after 256 retained discontinuities. The
+        // daemon uses a single-thread Tokio runtime, so this consumer must not share that runtime:
+        // otherwise a full queue could block the only thread capable of making queue space.
+        let worker = std::thread::Builder::new()
+            .name("mpris-worker".to_owned())
+            .stack_size(1024 * 1024)
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        tracing::warn!(error = %error, "media controls: MPRIS runtime failed");
+                        return;
+                    }
+                };
+                runtime.block_on(run_server(rx, worker_wake, sink));
+            })?;
+        Ok(Self {
+            updates,
+            wake,
+            _worker: worker,
+        })
     }
 
     pub fn apply(&mut self, snapshot: &MediaSnapshot, changes: MediaChanges) {
-        // Dropping the Backend closes the channel; the server task then winds down
-        // and releases the bus name (no ghost player in desktop widgets).
-        let _ = self.tx.try_send((snapshot.clone(), changes));
+        if self.updates.submit(snapshot, changes) == SubmitOutcome::Wake {
+            self.wake.notify_one();
+        }
     }
 }
 
-async fn run_server(mut rx: mpsc::Receiver<(MediaSnapshot, MediaChanges)>, sink: CommandSink) {
+impl Drop for Backend {
+    fn drop(&mut self) {
+        // Wake the task after closing so it releases the bus name even when no
+        // media update is pending (no ghost player in desktop widgets).
+        self.updates.close();
+        self.wake.notify_one();
+    }
+}
+
+async fn run_server(rx: LatestMediaReceiver, wake: Arc<Notify>, sink: CommandSink) {
     let state = Arc::new(Mutex::new(MediaSnapshot::idle()));
     // Bus-name collision (a second instance) retries with a PID-qualified suffix,
     // as the MPRIS spec prescribes (spec L-2).
@@ -94,49 +130,82 @@ async fn run_server(mut rx: mpsc::Receiver<(MediaSnapshot, MediaChanges)>, sink:
     };
     tracing::info!(bus_name = %server.bus_name(), "media controls: MPRIS session ready");
 
-    while let Some((snapshot, changes)) = rx.recv().await {
-        *state.lock().unwrap() = snapshot.clone();
-        let mut properties = Vec::new();
-        if changes.track || changes.artwork {
-            properties.push(Property::Metadata(build_metadata(&snapshot)));
+    loop {
+        while let Some(batch) = rx.try_take() {
+            apply_batch(&server, &state, batch).await;
         }
-        if changes.status {
-            properties.push(Property::PlaybackStatus(playback_status(&snapshot)));
+        if rx.is_closed() {
+            break;
         }
-        if changes.options {
-            properties.push(Property::Rate(snapshot.rate));
-            properties.push(Property::Volume(snapshot.volume));
-            properties.push(Property::Shuffle(snapshot.shuffle));
-            properties.push(Property::LoopStatus(loop_status(snapshot.repeat)));
-        }
-        if changes.caps {
-            properties.push(Property::CanGoNext(snapshot.caps.can_next));
-            properties.push(Property::CanGoPrevious(snapshot.caps.can_previous));
-            properties.push(Property::CanPlay(snapshot.caps.can_play));
-            properties.push(Property::CanPause(snapshot.caps.can_pause));
-            properties.push(Property::CanSeek(snapshot.caps.can_seek));
-        }
-        // One PropertiesChanged per logical event (L-6/S-4).
-        if !properties.is_empty()
-            && let Err(e) = server.properties_changed(properties).await
-        {
-            tracing::debug!(error = %e, "MPRIS properties_changed failed");
-        }
-        // Seeked fires on every discontinuity — user seek, SetPosition, and track
-        // (re)starts as Seeked(0) (L-7); never on plain progress (L-8).
-        if changes.position
-            && let Err(e) = server
-                .emit(Signal::Seeked {
-                    position: Time::from_micros((snapshot.position_now() * 1e6) as i64),
-                })
-                .await
-        {
-            tracing::debug!(error = %e, "MPRIS Seeked emit failed");
-        }
+        wake.notified().await;
     }
     // Facade dropped the sender (disable/quit): release the bus name explicitly so
     // desktop widgets drop the entry immediately (L-3).
     let _ = server.release_bus_name().await;
+}
+
+async fn apply_batch(
+    server: &Server<Player>,
+    state: &Arc<Mutex<MediaSnapshot>>,
+    mut batch: DeliveryBatch,
+) {
+    batch.prepare_snapshot();
+    let properties = batch
+        .snapshot
+        .as_ref()
+        .map(|snapshot| changed_properties(snapshot, batch.changes))
+        .unwrap_or_default();
+
+    // Move metadata-bearing state into the property-read slot. Progress-only
+    // updates mutate scalar fields and never clone track strings a second time.
+    if let Some(snapshot) = batch.snapshot.take() {
+        *state.lock().unwrap() = snapshot;
+    } else {
+        batch.apply_clock_to(&mut state.lock().unwrap());
+    }
+
+    // One PropertiesChanged per drained/coalesced logical batch (L-6/S-4).
+    if !properties.is_empty()
+        && let Err(e) = server.properties_changed(properties).await
+    {
+        tracing::debug!(error = %e, "MPRIS properties_changed failed");
+    }
+    // Every compact discontinuity survives coalescing — user seeks, SetPosition,
+    // and track (re)starts each emit their own Seeked signal (L-7/L-8).
+    for position in batch.discontinuities {
+        if let Err(e) = server
+            .emit(Signal::Seeked {
+                position: Time::from_micros((position.position_now() * 1e6) as i64),
+            })
+            .await
+        {
+            tracing::debug!(error = %e, "MPRIS Seeked emit failed");
+        }
+    }
+}
+
+fn changed_properties(snapshot: &MediaSnapshot, changes: MediaChanges) -> Vec<Property> {
+    let mut properties = Vec::new();
+    if changes.track || changes.artwork {
+        properties.push(Property::Metadata(build_metadata(snapshot)));
+    }
+    if changes.status {
+        properties.push(Property::PlaybackStatus(playback_status(snapshot)));
+    }
+    if changes.options {
+        properties.push(Property::Rate(snapshot.rate));
+        properties.push(Property::Volume(snapshot.volume));
+        properties.push(Property::Shuffle(snapshot.shuffle));
+        properties.push(Property::LoopStatus(loop_status(snapshot.repeat)));
+    }
+    if changes.caps {
+        properties.push(Property::CanGoNext(snapshot.caps.can_next));
+        properties.push(Property::CanGoPrevious(snapshot.caps.can_previous));
+        properties.push(Property::CanPlay(snapshot.caps.can_play));
+        properties.push(Property::CanPause(snapshot.caps.can_pause));
+        properties.push(Property::CanSeek(snapshot.caps.can_seek));
+    }
+    properties
 }
 
 /// `Arc`-clone helper so each `Server::new` attempt gets its own `Player`.

--- a/src/media/mpris.rs
+++ b/src/media/mpris.rs
@@ -5,10 +5,10 @@
 //! runtime: the facade forwards diffed snapshots over a channel; the worker keeps
 //! the latest snapshot in shared state
 //! (so property *reads* — including the un-signalled, interpolated `Position` —
-//! answer instantly), coalesces changed properties into one `PropertiesChanged`
-//! per worker wake (L-6/S-4), and emits `Seeked` once for every position
-//! discontinuity (L-7). Inbound calls only forward a [`MediaCommand`] and return
-//! (C-1).
+//! answer instantly), applies retained logical events in publication order, and
+//! emits `Seeked` for retained position discontinuities (L-7). At the shared
+//! bounded-delivery limit, the newest complete state is coalesced into the FIFO
+//! tail. Inbound calls only forward a [`MediaCommand`] and return (C-1).
 //!
 //! No session bus (SSH/headless/container) is non-fatal: the facade logs one
 //! warning and the app runs without media controls (spec A-2).
@@ -24,7 +24,8 @@ use mpris_server::{
 use tokio::sync::Notify;
 
 use super::delivery::{
-    DeliveryBatch, LatestMediaReceiver, LatestMediaSender, SubmitOutcome, latest_media_channel,
+    DeliveryItem, LatestMediaReceiver, LatestMediaSender, SubmitOutcome,
+    latest_media_channel_bounded,
 };
 use super::{CommandSink, MediaChanges, MediaCommand, MediaPlaybackStatus, MediaSnapshot};
 use crate::config::{SPEED_MAX, SPEED_MIN};
@@ -46,12 +47,12 @@ pub struct Backend {
 
 impl Backend {
     pub fn new(sink: CommandSink) -> Result<Self> {
-        let (updates, rx) = latest_media_channel();
+        let (updates, rx) = latest_media_channel_bounded();
         let wake = Arc::new(Notify::new());
         let worker_wake = Arc::clone(&wake);
-        // `submit` applies bounded backpressure only after 256 retained discontinuities. The
-        // daemon uses a single-thread Tokio runtime, so this consumer must not share that runtime:
-        // otherwise a full queue could block the only thread capable of making queue space.
+        // Keep zbus on a dedicated small-stack worker. Submission never waits:
+        // the shared delivery queue bounds total pending work and coalesces a
+        // saturated ordered tail to retain the newest complete external state.
         let worker = std::thread::Builder::new()
             .name("mpris-worker".to_owned())
             .stack_size(1024 * 1024)
@@ -131,8 +132,8 @@ async fn run_server(rx: LatestMediaReceiver, wake: Arc<Notify>, sink: CommandSin
     tracing::info!(bus_name = %server.bus_name(), "media controls: MPRIS session ready");
 
     loop {
-        while let Some(batch) = rx.try_take() {
-            apply_batch(&server, &state, batch).await;
+        while let Some(item) = rx.try_take() {
+            apply_item(&server, &state, item).await;
         }
         if rx.is_closed() {
             break;
@@ -144,38 +145,45 @@ async fn run_server(rx: LatestMediaReceiver, wake: Arc<Notify>, sink: CommandSin
     let _ = server.release_bus_name().await;
 }
 
-async fn apply_batch(
+async fn apply_item(
     server: &Server<Player>,
     state: &Arc<Mutex<MediaSnapshot>>,
-    mut batch: DeliveryBatch,
+    item: DeliveryItem,
 ) {
-    batch.prepare_snapshot();
-    let properties = batch
-        .snapshot
-        .as_ref()
-        .map(|snapshot| changed_properties(snapshot, batch.changes))
-        .unwrap_or_default();
-
-    // Move metadata-bearing state into the property-read slot. Progress-only
-    // updates mutate scalar fields and never clone track strings a second time.
-    if let Some(snapshot) = batch.snapshot.take() {
-        *state.lock().unwrap() = snapshot;
-    } else {
-        batch.apply_clock_to(&mut state.lock().unwrap());
+    match item {
+        DeliveryItem::Ordered(event) => {
+            apply_snapshot_event(server, state, event.snapshot, event.changes).await;
+        }
+        DeliveryItem::Progress(progress) => {
+            progress.apply_to(&mut state.lock().unwrap());
+        }
     }
+}
 
-    // One PropertiesChanged per drained/coalesced logical batch (L-6/S-4).
+async fn apply_snapshot_event(
+    server: &Server<Player>,
+    state: &Arc<Mutex<MediaSnapshot>>,
+    snapshot: MediaSnapshot,
+    changes: MediaChanges,
+) {
+    let properties = changed_properties(&snapshot, changes);
+    let seeked = changes.position;
+
+    // Install event A before emitting any facet of A. The receiver does not
+    // expose B until this call returns, preserving logical order.
+    *state.lock().unwrap() = snapshot;
     if !properties.is_empty()
         && let Err(e) = server.properties_changed(properties).await
     {
         tracing::debug!(error = %e, "MPRIS properties_changed failed");
     }
-    // Every compact discontinuity survives coalescing — user seeks, SetPosition,
-    // and track (re)starts each emit their own Seeked signal (L-7/L-8).
-    for position in batch.discontinuities {
+    if seeked {
+        // Match origin timing: interpolate after PropertiesChanged completes
+        // while state still contains this exact event.
+        let position = state.lock().unwrap().position_now();
         if let Err(e) = server
             .emit(Signal::Seeked {
-                position: Time::from_micros((position.position_now() * 1e6) as i64),
+                position: Time::from_micros((position * 1e6) as i64),
             })
             .await
         {
@@ -517,6 +525,7 @@ impl mpris_server::PlayerInterface for Player {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::media::{MediaCaps, MediaTrack};
 
     #[test]
     fn track_id_escapes_per_spec() {
@@ -541,5 +550,84 @@ mod tests {
                 assert_eq!(track_key_from_path(&path).as_deref(), Some(key));
             }
         }
+    }
+
+    #[test]
+    fn coalesced_facets_map_to_all_external_mpris_properties() {
+        let mut snapshot = MediaSnapshot::idle();
+        snapshot.track = Some(MediaTrack {
+            key: "track-key".to_owned(),
+            title: "Title".to_owned(),
+            artist: "Artist".to_owned(),
+            album: Some("Album".to_owned()),
+            duration: Some(180.0),
+            is_live: false,
+            url: Some("https://music.youtube.com/watch?v=track-key".to_owned()),
+            art_remote_url: None,
+            art_file: None,
+            art_query: None,
+            liked: false,
+            disliked: false,
+        });
+        snapshot.status = MediaPlaybackStatus::Playing;
+        snapshot.rate = 1.25;
+        snapshot.volume = 0.75;
+        snapshot.shuffle = true;
+        snapshot.repeat = Repeat::All;
+        snapshot.caps = MediaCaps {
+            can_next: true,
+            can_previous: true,
+            can_seek: true,
+            can_play: true,
+            can_pause: true,
+        };
+
+        let properties = changed_properties(
+            &snapshot,
+            MediaChanges {
+                track: true,
+                status: true,
+                options: true,
+                caps: true,
+                ..MediaChanges::default()
+            },
+        );
+
+        assert_eq!(properties.len(), 11);
+        assert!(
+            properties
+                .iter()
+                .any(|p| matches!(p, Property::Metadata(_)))
+        );
+        assert!(
+            properties
+                .iter()
+                .any(|p| matches!(p, Property::PlaybackStatus(_)))
+        );
+        assert!(properties.iter().any(|p| matches!(p, Property::Rate(_))));
+        assert!(properties.iter().any(|p| matches!(p, Property::Volume(_))));
+        assert!(properties.iter().any(|p| matches!(p, Property::Shuffle(_))));
+        assert!(
+            properties
+                .iter()
+                .any(|p| matches!(p, Property::LoopStatus(_)))
+        );
+        assert!(
+            properties
+                .iter()
+                .any(|p| matches!(p, Property::CanGoNext(_)))
+        );
+        assert!(
+            properties
+                .iter()
+                .any(|p| matches!(p, Property::CanGoPrevious(_)))
+        );
+        assert!(properties.iter().any(|p| matches!(p, Property::CanPlay(_))));
+        assert!(
+            properties
+                .iter()
+                .any(|p| matches!(p, Property::CanPause(_)))
+        );
+        assert!(properties.iter().any(|p| matches!(p, Property::CanSeek(_))));
     }
 }

--- a/src/media/smtc.rs
+++ b/src/media/smtc.rs
@@ -5,10 +5,10 @@
 //! (`ISystemMediaTransportControlsInterop::GetForWindow`) requires one owned by the
 //! calling thread — so a dedicated "smtc-worker" thread creates an invisible
 //! top-level window (a real one, not message-only, which has known compatibility
-//! problems) and runs the message pump SMTC needs. Snapshot diffs coalesce in a
-//! bounded latest-state slot (the pump is woken with a posted thread message);
-//! WinRT event handlers only forward a [`MediaCommand`] through the sink and return
-//! (spec C-1).
+//! problems) and runs the message pump SMTC needs. Complete snapshot diffs retain
+//! publication order while pure progress coalesces to one scalar clock (the pump
+//! is woken with a posted thread message); WinRT event handlers only forward a
+//! [`MediaCommand`] through the sink and return (spec C-1).
 //!
 //! SMTC does not interpolate playback position: the worker re-pushes timeline
 //! properties every ~5s while playing (spec W-3) from the snapshot's position
@@ -46,8 +46,8 @@ use windows::Win32::UI::WindowsAndMessaging::{
 use windows::core::{HSTRING, w};
 
 use super::delivery::{
-    DeliveryBatch, LatestMediaReceiver, LatestMediaSender, PositionClock, SubmitOutcome,
-    latest_media_channel,
+    DeliveryItem, LatestMediaReceiver, LatestMediaSender, SubmitOutcome,
+    latest_media_channel_bounded,
 };
 use super::{
     CommandSink, MediaChanges, MediaCommand, MediaPlaybackStatus as Status, MediaSnapshot,
@@ -72,7 +72,7 @@ pub struct Backend {
 
 impl Backend {
     pub fn new(sink: CommandSink) -> Result<Self> {
-        let (updates, rx) = latest_media_channel();
+        let (updates, rx) = latest_media_channel_bounded();
         let (ready_tx, ready_rx) = mpsc::channel::<std::result::Result<u32, String>>();
         let join = std::thread::Builder::new()
             .name("smtc-worker".to_owned())
@@ -167,8 +167,8 @@ fn worker(
             if msg.hwnd == HWND::default() {
                 match msg.message {
                     WM_APP_UPDATE => {
-                        while let Some(batch) = rx.try_take() {
-                            session.apply(batch);
+                        while let Some(item) = rx.try_take() {
+                            session.apply(item);
                         }
                         continue;
                     }
@@ -353,29 +353,30 @@ fn init_session(sink: &CommandSink) -> Result<Session> {
 }
 
 impl Session {
-    fn apply(&mut self, mut batch: DeliveryBatch) {
-        batch.prepare_snapshot();
-        if let Some(snapshot) = batch.snapshot.take() {
-            self.snapshot = snapshot;
-        } else {
-            batch.apply_clock_to(&mut self.snapshot);
-        }
-        let needs_final_timeline = batch.needs_final_timeline();
-        if let Err(e) = self.apply_facets(batch.changes) {
-            tracing::debug!(error = %e, "SMTC update failed");
-        }
-        // Keep every position epoch even when metadata/progress coalesced while the
-        // message pump was busy. Each clock also retains its own track duration/live
-        // semantics, so a rapid track transition cannot reuse the newest duration.
-        for position in batch.discontinuities {
-            if let Err(e) = self.push_timeline_clock(position) {
-                tracing::debug!(error = %e, epoch = position.position_epoch, "SMTC discontinuity timeline update failed");
+    fn apply(&mut self, item: DeliveryItem) {
+        match item {
+            DeliveryItem::Ordered(event) => {
+                self.snapshot = event.snapshot;
+                if let Err(e) = self.apply_event(event.changes) {
+                    tracing::debug!(error = %e, "SMTC update failed");
+                }
+            }
+            DeliveryItem::Progress(progress) => {
+                progress.apply_to(&mut self.snapshot);
+                self.manage_timer();
             }
         }
-        if needs_final_timeline && let Err(e) = self.push_timeline() {
-            tracing::debug!(error = %e, "SMTC final timeline update failed");
+    }
+
+    /// Apply one logical event completely before the next snapshot is installed.
+    /// The facet/timeline/timer order mirrors `origin/main`'s `apply_inner`.
+    fn apply_event(&mut self, changes: MediaChanges) -> windows::core::Result<()> {
+        self.apply_facets(changes)?;
+        if changes.track || changes.position || changes.status || changes.options {
+            self.push_timeline()?;
         }
         self.manage_timer();
+        Ok(())
     }
 
     fn apply_facets(&mut self, changes: MediaChanges) -> windows::core::Result<()> {
@@ -463,10 +464,6 @@ impl Session {
             .and_then(|t| t.duration)
             .filter(|_| !track.is_some_and(|t| t.is_live));
         self.update_timeline(duration, self.snapshot.position_now())
-    }
-
-    fn push_timeline_clock(&self, clock: PositionClock) -> windows::core::Result<()> {
-        self.update_timeline(clock.timeline_duration(), clock.position_now())
     }
 
     fn update_timeline(&self, duration: Option<f64>, position: f64) -> windows::core::Result<()> {

--- a/src/media/smtc.rs
+++ b/src/media/smtc.rs
@@ -5,9 +5,10 @@
 //! (`ISystemMediaTransportControlsInterop::GetForWindow`) requires one owned by the
 //! calling thread — so a dedicated "smtc-worker" thread creates an invisible
 //! top-level window (a real one, not message-only, which has known compatibility
-//! problems) and runs the message pump SMTC needs. Snapshot diffs arrive over a
-//! channel (the pump is woken with a posted thread message); WinRT event handlers
-//! only forward a [`MediaCommand`] through the sink and return (spec C-1).
+//! problems) and runs the message pump SMTC needs. Snapshot diffs coalesce in a
+//! bounded latest-state slot (the pump is woken with a posted thread message);
+//! WinRT event handlers only forward a [`MediaCommand`] through the sink and return
+//! (spec C-1).
 //!
 //! SMTC does not interpolate playback position: the worker re-pushes timeline
 //! properties every ~5s while playing (spec W-3) from the snapshot's position
@@ -44,6 +45,10 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 use windows::core::{HSTRING, w};
 
+use super::delivery::{
+    DeliveryBatch, LatestMediaReceiver, LatestMediaSender, PositionClock, SubmitOutcome,
+    latest_media_channel,
+};
 use super::{
     CommandSink, MediaChanges, MediaCommand, MediaPlaybackStatus as Status, MediaSnapshot,
 };
@@ -60,14 +65,14 @@ const WM_APP_UPDATE: u32 = WM_APP + 1;
 const TIMELINE_REFRESH_MS: u32 = 5_000;
 
 pub struct Backend {
-    tx: mpsc::Sender<(MediaSnapshot, MediaChanges)>,
+    updates: LatestMediaSender,
     worker_thread_id: u32,
     join: Option<std::thread::JoinHandle<()>>,
 }
 
 impl Backend {
     pub fn new(sink: CommandSink) -> Result<Self> {
-        let (tx, rx) = mpsc::channel::<(MediaSnapshot, MediaChanges)>();
+        let (updates, rx) = latest_media_channel();
         let (ready_tx, ready_rx) = mpsc::channel::<std::result::Result<u32, String>>();
         let join = std::thread::Builder::new()
             .name("smtc-worker".to_owned())
@@ -77,7 +82,7 @@ impl Backend {
             Ok(Ok(worker_thread_id)) => {
                 tracing::info!("media controls: Windows SMTC session ready");
                 Ok(Self {
-                    tx,
+                    updates,
                     worker_thread_id,
                     join: Some(join),
                 })
@@ -91,12 +96,15 @@ impl Backend {
     }
 
     pub fn apply(&mut self, snapshot: &MediaSnapshot, changes: MediaChanges) {
-        if self.tx.send((snapshot.clone(), changes)).is_ok() {
-            // SAFETY: `worker_thread_id` was captured from the live SMTC worker after
-            // its message queue was created; a failed post only drops this wake-up.
-            unsafe {
-                let _ =
-                    PostThreadMessageW(self.worker_thread_id, WM_APP_UPDATE, WPARAM(0), LPARAM(0));
+        if self.updates.submit(snapshot, changes) == SubmitOutcome::Wake {
+            // SAFETY: `worker_thread_id` was captured from the live SMTC worker after its message
+            // queue was created. If the post fails, re-arm the delivery slot: otherwise every
+            // later update would coalesce behind a wake that never reached the worker.
+            if let Err(error) = unsafe {
+                PostThreadMessageW(self.worker_thread_id, WM_APP_UPDATE, WPARAM(0), LPARAM(0))
+            } {
+                self.updates.wake_failed();
+                tracing::debug!(%error, "SMTC worker wake failed");
             }
         }
     }
@@ -104,6 +112,7 @@ impl Backend {
 
 impl Drop for Backend {
     fn drop(&mut self) {
+        self.updates.close();
         // SAFETY: best-effort shutdown post to the worker thread id captured at
         // startup; failure is harmless because join handles already-ended threads.
         unsafe {
@@ -131,7 +140,7 @@ struct Session {
 }
 
 fn worker(
-    rx: mpsc::Receiver<(MediaSnapshot, MediaChanges)>,
+    rx: LatestMediaReceiver,
     sink: CommandSink,
     ready_tx: mpsc::Sender<std::result::Result<u32, String>>,
 ) {
@@ -158,8 +167,8 @@ fn worker(
             if msg.hwnd == HWND::default() {
                 match msg.message {
                     WM_APP_UPDATE => {
-                        while let Ok((snapshot, changes)) = rx.try_recv() {
-                            session.apply(snapshot, changes);
+                        while let Some(batch) = rx.try_take() {
+                            session.apply(batch);
                         }
                         continue;
                     }
@@ -344,14 +353,32 @@ fn init_session(sink: &CommandSink) -> Result<Session> {
 }
 
 impl Session {
-    fn apply(&mut self, snapshot: MediaSnapshot, changes: MediaChanges) {
-        self.snapshot = snapshot;
-        if let Err(e) = self.apply_inner(changes) {
+    fn apply(&mut self, mut batch: DeliveryBatch) {
+        batch.prepare_snapshot();
+        if let Some(snapshot) = batch.snapshot.take() {
+            self.snapshot = snapshot;
+        } else {
+            batch.apply_clock_to(&mut self.snapshot);
+        }
+        let needs_final_timeline = batch.needs_final_timeline();
+        if let Err(e) = self.apply_facets(batch.changes) {
             tracing::debug!(error = %e, "SMTC update failed");
         }
+        // Keep every position epoch even when metadata/progress coalesced while the
+        // message pump was busy. Each clock also retains its own track duration/live
+        // semantics, so a rapid track transition cannot reuse the newest duration.
+        for position in batch.discontinuities {
+            if let Err(e) = self.push_timeline_clock(position) {
+                tracing::debug!(error = %e, epoch = position.position_epoch, "SMTC discontinuity timeline update failed");
+            }
+        }
+        if needs_final_timeline && let Err(e) = self.push_timeline() {
+            tracing::debug!(error = %e, "SMTC final timeline update failed");
+        }
+        self.manage_timer();
     }
 
-    fn apply_inner(&mut self, changes: MediaChanges) -> windows::core::Result<()> {
+    fn apply_facets(&mut self, changes: MediaChanges) -> windows::core::Result<()> {
         if changes.track || changes.artwork {
             self.update_display()?;
         }
@@ -382,10 +409,6 @@ impl Session {
             // using this rate, and RateChangeRequested never fires until it's seeded.
             self.smtc.SetPlaybackRate(self.snapshot.rate)?;
         }
-        if changes.track || changes.position || changes.status || changes.options {
-            self.push_timeline()?;
-        }
-        self.manage_timer();
         Ok(())
     }
 
@@ -435,17 +458,25 @@ impl Session {
     /// Push the current timeline (start/end/seek range/position). Live streams get
     /// a default (cleared) timeline so no scrubber is shown (spec W-4).
     fn push_timeline(&self) -> windows::core::Result<()> {
-        let props = SystemMediaTransportControlsTimelineProperties::new()?;
         let track = self.snapshot.track.as_ref();
         let duration = track
             .and_then(|t| t.duration)
             .filter(|_| !track.is_some_and(|t| t.is_live));
+        self.update_timeline(duration, self.snapshot.position_now())
+    }
+
+    fn push_timeline_clock(&self, clock: PositionClock) -> windows::core::Result<()> {
+        self.update_timeline(clock.timeline_duration(), clock.position_now())
+    }
+
+    fn update_timeline(&self, duration: Option<f64>, position: f64) -> windows::core::Result<()> {
+        let props = SystemMediaTransportControlsTimelineProperties::new()?;
         if let Some(duration) = duration {
             props.SetStartTime(timespan(0.0))?;
             props.SetMinSeekTime(timespan(0.0))?;
             props.SetEndTime(timespan(duration))?;
             props.SetMaxSeekTime(timespan(duration))?;
-            props.SetPosition(timespan(self.snapshot.position_now()))?;
+            props.SetPosition(timespan(position))?;
         }
         self.smtc.UpdateTimelineProperties(&props)
     }

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -459,19 +459,27 @@ fn write_journal_intent(intent: &JournalIntent) -> std::io::Result<()> {
     let Some(sidecar_path) = intent_sidecar_path(&intent.path) else {
         return Ok(());
     };
-    crate::util::safe_fs::write_private_atomic(&sidecar_path, &intent.bytes)?;
     let sidecar = sidecar_path
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| std::io::Error::other("invalid intent sidecar name"))?;
-    let record = serde_json::json!({
+    let record = journal_record(intent.kind, sidecar, &intent.bytes);
+    // Append the durable record before replacing the shared latest sidecar. If the process dies
+    // between these two operations, replay skips the new record's checksum mismatch and can still
+    // use the previous record with the previous sidecar. Replacing the sidecar first would make
+    // every older committed record mismatch during that crash window.
+    crate::util::safe_fs::append_private_jsonl_durable(&journal_path, &record.to_string())?;
+    crate::util::safe_fs::write_private_atomic(&sidecar_path, &intent.bytes)
+}
+
+fn journal_record(kind: StoreKind, sidecar: &str, bytes: &[u8]) -> serde_json::Value {
+    serde_json::json!({
         "v": 1,
         "op": "replace",
-        "kind": intent.kind.label(),
+        "kind": kind.label(),
         "sidecar": sidecar,
-        "sha256": sha256_hex(&intent.bytes),
-    });
-    crate::util::safe_fs::append_private_jsonl_durable(&journal_path, &record.to_string())
+        "sha256": sha256_hex(bytes),
+    })
 }
 
 fn clear_store_journal_for_kind(kind: StoreKind) {
@@ -518,16 +526,31 @@ pub(crate) fn replay_journaled_snapshot<T>(
 where
     T: DeserializeOwned,
 {
+    replay_journaled_snapshot_with_status(kind, path, current, max_bytes).0
+}
+
+/// Replay the newest valid intent and report whether the returned value came from its sidecar.
+/// Config recovery uses the status to atomically install a migrated replay before clearing the
+/// journal; all other stores keep the existing value-only interface above.
+pub(crate) fn replay_journaled_snapshot_with_status<T>(
+    kind: StoreKind,
+    path: &Path,
+    current: T,
+    max_bytes: u64,
+) -> (T, bool)
+where
+    T: DeserializeOwned,
+{
     let Some(journal_path) = intent_journal_path(path) else {
-        return current;
+        return (current, false);
     };
     let Ok(bytes) =
         crate::util::safe_fs::read_no_symlink_limited(&journal_path, INTENT_JOURNAL_MAX_BYTES)
     else {
-        return current;
+        return (current, false);
     };
     let Ok(text) = String::from_utf8(bytes) else {
-        return current;
+        return (current, false);
     };
     for line in text.lines().rev() {
         let Ok(record) = serde_json::from_str::<serde_json::Value>(line) else {
@@ -563,7 +586,7 @@ where
         match serde_json::from_slice::<T>(&snapshot_bytes) {
             Ok(snapshot) => {
                 tracing::info!(store = kind.label(), "replayed pending persistence intent");
-                return snapshot;
+                return (snapshot, true);
             }
             Err(error) => {
                 tracing::warn!(
@@ -574,7 +597,27 @@ where
             }
         }
     }
-    current
+    (current, false)
+}
+
+/// Remove a replayed intent only after its snapshot has been successfully installed at `path`.
+pub(crate) fn clear_journaled_snapshot(path: &Path) {
+    clear_store_journal(path);
+}
+
+#[cfg(test)]
+pub(crate) fn write_test_journaled_snapshot(
+    kind: StoreKind,
+    path: PathBuf,
+    bytes: Vec<u8>,
+) -> std::io::Result<()> {
+    write_journal_intent(&JournalIntent { kind, path, bytes })
+}
+
+#[cfg(test)]
+pub(crate) fn test_journal_exists(path: &Path) -> bool {
+    intent_journal_path(path).is_some_and(|journal| journal.exists())
+        || intent_sidecar_path(path).is_some_and(|sidecar| sidecar.exists())
 }
 
 fn intent_journal_path(path: &Path) -> Option<PathBuf> {
@@ -789,12 +832,81 @@ mod tests {
         })
         .unwrap();
 
-        let replayed = replay_journaled_snapshot(StoreKind::Config, &path, Tiny { value: 1 }, 1024);
+        let (replayed, from_journal) = replay_journaled_snapshot_with_status(
+            StoreKind::Config,
+            &path,
+            Tiny { value: 1 },
+            1024,
+        );
+        assert_eq!(replayed, Tiny { value: 7 });
+        assert!(from_journal);
+        assert!(test_journal_exists(&path));
+
+        clear_journaled_snapshot(&path);
+        let (replayed, from_journal) = replay_journaled_snapshot_with_status(
+            StoreKind::Config,
+            &path,
+            Tiny { value: 1 },
+            1024,
+        );
+        assert_eq!(replayed, Tiny { value: 1 });
+        assert!(!from_journal);
+        assert!(!test_journal_exists(&path));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn sidecar_replacement_crash_windows_keep_the_last_committed_intent() {
+        #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+        struct Tiny {
+            value: u8,
+        }
+
+        let dir = temp_dir("intent-replace-order");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("tiny.json");
+        let old_bytes = serde_json::to_vec_pretty(&Tiny { value: 7 }).unwrap();
+        write_journal_intent(&JournalIntent {
+            kind: StoreKind::Config,
+            path: path.clone(),
+            bytes: old_bytes,
+        })
+        .unwrap();
+
+        let journal_path = intent_journal_path(&path).unwrap();
+        let sidecar_path = intent_sidecar_path(&path).unwrap();
+        let sidecar_name = sidecar_path.file_name().unwrap().to_str().unwrap();
+        let new_bytes = serde_json::to_vec_pretty(&Tiny { value: 9 }).unwrap();
+        let new_record = journal_record(StoreKind::Config, sidecar_name, &new_bytes);
+
+        // Crash after the new record is durable but before its sidecar replacement: the newest
+        // checksum mismatches, so replay must fall back to the older committed pair.
+        crate::util::safe_fs::append_private_jsonl_durable(&journal_path, &new_record.to_string())
+            .unwrap();
+        let (replayed, from_journal) = replay_journaled_snapshot_with_status(
+            StoreKind::Config,
+            &path,
+            Tiny { value: 1 },
+            1024,
+        );
+        assert!(from_journal);
         assert_eq!(replayed, Tiny { value: 7 });
 
-        clear_store_journal(&path);
-        let replayed = replay_journaled_snapshot(StoreKind::Config, &path, Tiny { value: 1 }, 1024);
-        assert_eq!(replayed, Tiny { value: 1 });
+        // Once the atomic sidecar replacement lands, the same durable record becomes the newest
+        // valid pair. Replaying it repeatedly is safe until the installed store is cleared.
+        crate::util::safe_fs::write_private_atomic(&sidecar_path, &new_bytes).unwrap();
+        for _ in 0..2 {
+            let (replayed, from_journal) = replay_journaled_snapshot_with_status(
+                StoreKind::Config,
+                &path,
+                Tiny { value: 1 },
+                1024,
+            );
+            assert!(from_journal);
+            assert_eq!(replayed, Tiny { value: 9 });
+        }
+
+        clear_journaled_snapshot(&path);
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/src/player/ipc.rs
+++ b/src/player/ipc.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashMap;
 use std::io;
+use std::time::Instant;
 
 use interprocess::local_socket::GenericFilePath;
 use interprocess::local_socket::tokio::Stream;
@@ -31,6 +32,100 @@ struct DispatchState {
     /// keeping repeated nulls (a stream that never had one) silent.
     duration_known: bool,
     pending: HashMap<u64, String>,
+    /// Raw mpv numeric-property traffic for the opt-in `YTM_PERF` trace. Kept behind an
+    /// `Option` so normal runs pay only one predictable branch per incoming IPC line.
+    numeric_perf: Option<NumericPerfWindow>,
+}
+
+struct NumericPerfWindow {
+    started: Instant,
+    raw_time_pos: u64,
+    raw_cache_time: u64,
+    borrowed_fast_path: u64,
+    generic_fallback: u64,
+    forwarded_time_pos: u64,
+    forwarded_cache_time: u64,
+}
+
+impl NumericPerfWindow {
+    fn new() -> Self {
+        Self {
+            started: Instant::now(),
+            raw_time_pos: 0,
+            raw_cache_time: 0,
+            borrowed_fast_path: 0,
+            generic_fallback: 0,
+            forwarded_time_pos: 0,
+            forwarded_cache_time: 0,
+        }
+    }
+
+    fn reset(&mut self, now: Instant) {
+        self.started = now;
+        self.raw_time_pos = 0;
+        self.raw_cache_time = 0;
+        self.borrowed_fast_path = 0;
+        self.generic_fallback = 0;
+        self.forwarded_time_pos = 0;
+        self.forwarded_cache_time = 0;
+    }
+}
+
+const NUMERIC_PERF_WINDOW: Duration = Duration::from_secs(5);
+
+fn record_numeric_input(state: &mut DispatchState, name: &str, borrowed: bool) {
+    let Some(perf) = state.numeric_perf.as_mut() else {
+        return;
+    };
+    match name {
+        "time-pos" => perf.raw_time_pos += 1,
+        "demuxer-cache-time" => perf.raw_cache_time += 1,
+        _ => return,
+    }
+    if borrowed {
+        perf.borrowed_fast_path += 1;
+    } else {
+        perf.generic_fallback += 1;
+    }
+}
+
+fn record_numeric_forward(state: &mut DispatchState, name: &str) {
+    let Some(perf) = state.numeric_perf.as_mut() else {
+        return;
+    };
+    match name {
+        "time-pos" => perf.forwarded_time_pos += 1,
+        "demuxer-cache-time" => perf.forwarded_cache_time += 1,
+        _ => {}
+    }
+}
+
+fn log_numeric_perf(state: &mut DispatchState, force: bool) {
+    let Some(perf) = state.numeric_perf.as_mut() else {
+        return;
+    };
+    let now = Instant::now();
+    let elapsed = now.saturating_duration_since(perf.started);
+    if !force && elapsed < NUMERIC_PERF_WINDOW {
+        return;
+    }
+    let raw_total = perf.raw_time_pos + perf.raw_cache_time;
+    if raw_total > 0 {
+        let seconds = elapsed.as_secs_f64().max(f64::EPSILON);
+        tracing::info!(
+            target: "ytt::perf",
+            window_ms = elapsed.as_millis() as u64,
+            raw_time_pos_lines = perf.raw_time_pos,
+            raw_cache_time_lines = perf.raw_cache_time,
+            raw_numeric_hz = raw_total as f64 / seconds,
+            borrowed_numeric_lines = perf.borrowed_fast_path,
+            generic_numeric_lines = perf.generic_fallback,
+            forwarded_time_pos = perf.forwarded_time_pos,
+            forwarded_cache_time = perf.forwarded_cache_time,
+            "mpv numeric IPC window"
+        );
+    }
+    perf.reset(now);
 }
 
 /// Clear the per-file dedup/latch state when a file ends for ANY reason, so the next
@@ -77,6 +172,9 @@ pub async fn run_actor(
     emit: EventSink,
 ) {
     let mut state = DispatchState::default();
+    if std::env::var_os("YTM_PERF").is_some() {
+        state.numeric_perf = Some(NumericPerfWindow::new());
+    }
 
     // Subscribe to the properties the player view needs. IDs are arbitrary but stable.
     for (id, prop) in [
@@ -135,6 +233,7 @@ pub async fn run_actor(
             },
         }
     }
+    log_numeric_perf(&mut state, true);
 }
 
 async fn dispatch_command(
@@ -216,34 +315,64 @@ pub(super) async fn write_json(conn: &Stream, json: &str) -> io::Result<()> {
     writer.flush().await
 }
 
-/// Borrowed view of the one high-rate mpv line: a `time-pos` property-change. Parsing
-/// into this (zero-copy `&str` fields, `data` as a plain number) skips the full
-/// `serde_json::Value` tree that `proto::parse_line` builds — and time-pos arrives many
-/// times a second during playback, then is deduped to 1/sec anyway.
+/// Borrowed view of the two high-rate numeric mpv properties. Parsing into this (zero-copy
+/// `&str` fields, `data` as a plain optional number) skips the full `serde_json::Value` tree that
+/// `proto::parse_line` builds. `None` deliberately covers both JSON null and a missing `data`
+/// field, matching the general parser's `Value::Null` fallback.
 #[derive(serde::Deserialize)]
-struct TimePosLine<'a> {
+struct NumericPropertyLine<'a> {
     event: &'a str,
     name: &'a str,
-    data: f64,
+    data: Option<f64>,
 }
 
 /// Translate one mpv line into a player event for the runtime.
 fn dispatch_incoming(line: &str, emit: &EventSink, state: &mut DispatchState) {
-    // Fast path: dedup time-pos before allocating anything. A borrow-mode parse fails on
-    // any other event shape (missing fields, null/escaped data) and falls through to the
-    // general path below, so behavior is unchanged — e.g. `data:null` still ends up in
-    // the `as_f64() == None` arm there and emits nothing.
-    if let Ok(tp) = serde_json::from_str::<TimePosLine>(line.trim())
-        && tp.event == "property-change"
-        && tp.name == "time-pos"
+    // Flush the previous complete measurement window before accounting this line, so forwarded
+    // counts and raw counts always describe the same set of fully-dispatched events.
+    log_numeric_perf(state, false);
+    // Fast path: normalize and dedup the two high-rate progress properties before allocating.
+    // Other property shapes fail or fall through to the general parser unchanged.
+    if let Ok(property) = serde_json::from_str::<NumericPropertyLine>(line.trim())
+        && property.event == "property-change"
     {
-        let t = crate::playback_policy::norm_position(tp.data);
-        let sec = t as i64;
-        if state.last_sent_time_sec != Some(sec) {
-            state.last_sent_time_sec = Some(sec);
-            emit(PlayerEvent::TimePos(t));
+        match property.name {
+            "time-pos" => {
+                record_numeric_input(state, property.name, true);
+                if let Some(t) = property.data {
+                    let t = crate::playback_policy::norm_position(t);
+                    let sec = t as i64;
+                    if state.last_sent_time_sec != Some(sec) {
+                        state.last_sent_time_sec = Some(sec);
+                        emit(PlayerEvent::TimePos(t));
+                        record_numeric_forward(state, property.name);
+                    }
+                }
+                return;
+            }
+            "demuxer-cache-time" => {
+                record_numeric_input(state, property.name, true);
+                match property.data {
+                    Some(t) => {
+                        let t = crate::playback_policy::norm_position(t);
+                        let sec = t as i64;
+                        if state.last_sent_cache_sec != Some(sec) {
+                            state.last_sent_cache_sec = Some(sec);
+                            emit(PlayerEvent::CacheTime(Some(t)));
+                            record_numeric_forward(state, property.name);
+                        }
+                    }
+                    None => {
+                        if state.last_sent_cache_sec.take().is_some() {
+                            emit(PlayerEvent::CacheTime(None));
+                            record_numeric_forward(state, property.name);
+                        }
+                    }
+                }
+                return;
+            }
+            _ => {}
         }
-        return;
     }
     let Some(incoming) = proto::parse_line(line) else {
         return;
@@ -251,12 +380,14 @@ fn dispatch_incoming(line: &str, emit: &EventSink, state: &mut DispatchState) {
     match incoming {
         MpvIncoming::PropertyChange { name, value, .. } => match name.as_str() {
             "time-pos" => {
+                record_numeric_input(state, &name, false);
                 if let Some(t) = value.as_f64() {
                     let t = crate::playback_policy::norm_position(t);
                     let sec = t as i64;
                     if state.last_sent_time_sec != Some(sec) {
                         state.last_sent_time_sec = Some(sec);
                         emit(PlayerEvent::TimePos(t));
+                        record_numeric_forward(state, &name);
                     }
                 }
             }
@@ -297,18 +428,22 @@ fn dispatch_incoming(line: &str, emit: &EventSink, state: &mut DispatchState) {
             "demuxer-cache-time" => match value.as_f64() {
                 // High-rate like time-pos → dedup to whole seconds.
                 Some(t) => {
+                    record_numeric_input(state, &name, false);
                     let t = crate::playback_policy::norm_position(t);
                     let sec = t as i64;
                     if state.last_sent_cache_sec != Some(sec) {
                         state.last_sent_cache_sec = Some(sec);
                         emit(PlayerEvent::CacheTime(Some(t)));
+                        record_numeric_forward(state, &name);
                     }
                 }
                 // Unlike time-pos, a null here is a signal the reducer needs: the
                 // property became unavailable (stream teardown, cache-less demuxer).
                 None => {
+                    record_numeric_input(state, &name, false);
                     if state.last_sent_cache_sec.take().is_some() {
                         emit(PlayerEvent::CacheTime(None));
+                        record_numeric_forward(state, &name);
                     }
                 }
             },
@@ -402,6 +537,43 @@ mod tests {
         assert!(matches!(rx.try_recv(), Ok(PlayerEvent::TimePos(t)) if t == 1.1));
         assert!(matches!(rx.try_recv(), Ok(PlayerEvent::TimePos(t)) if t == 2.0));
         assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn numeric_perf_window_counts_raw_fast_fallback_and_forwarded_lines() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let emit: EventSink = std::sync::Arc::new(move |event| {
+            let _ = tx.try_send(event);
+        });
+        let mut state = DispatchState {
+            numeric_perf: Some(NumericPerfWindow::new()),
+            ..DispatchState::default()
+        };
+
+        for line in [
+            r#"{"event":"property-change","name":"time-pos","data":1.1}"#,
+            r#"{"event":"property-change","name":"time-pos","data":1.8}"#,
+            r#"{"event":"property-change","name":"demuxer-cache-time","data":100.2}"#,
+            r#"{"event":"property-change","name":"demuxer-cache-time","data":null}"#,
+            // An escaped property name cannot be borrowed by the fast-path struct, but the
+            // allocating generic parser still recognizes it and must be represented in stats.
+            r#"{"event":"property-change","name":"time-\u0070os","data":2.0}"#,
+        ] {
+            dispatch_incoming(line, &emit, &mut state);
+        }
+
+        let perf = state.numeric_perf.as_ref().expect("perf counters enabled");
+        assert_eq!(perf.raw_time_pos, 3);
+        assert_eq!(perf.raw_cache_time, 2);
+        assert_eq!(perf.borrowed_fast_path, 4);
+        assert_eq!(perf.generic_fallback, 1);
+        assert_eq!(perf.forwarded_time_pos, 2);
+        assert_eq!(perf.forwarded_cache_time, 2);
+        let mut forwarded = 0;
+        while rx.try_recv().is_ok() {
+            forwarded += 1;
+        }
+        assert_eq!(forwarded, 4);
     }
 
     #[test]

--- a/src/remote/publish.rs
+++ b/src/remote/publish.rs
@@ -1,12 +1,13 @@
 //! The v8 Publisher: turns owner-state changes into session push events without ever
 //! touching the reducer (docs/gui/02 §14).
 //!
-//! Both owner hosts call [`Publisher::observe`] once per turn on the owner-loop thread,
-//! right next to their existing `media.publish(..)` post-turn observers, passing a
-//! [`CoreView`] borrow of current state. Change detection is fingerprint-based and
-//! cheap; models are built and serialized only when something changed AND someone is
-//! subscribed, and the serialized payload fans out by `Arc` (the per-session envelope is
-//! spliced at write time by the session writer).
+//! Both owner hosts call [`Publisher::observe`] after turns that can change a projected
+//! facet, on the owner-loop thread next to their existing `media.publish(..)` observers,
+//! passing a [`CoreView`] borrow of current state. Ordinary position/cache clocks bypass
+//! the view entirely because elapsed is deliberately not pushed. Change detection is
+//! fingerprint-based; models are built and serialized only when something changed AND
+//! someone is subscribed, and the serialized payload fans out by `Arc` (the per-session
+//! envelope is spliced at write time by the session writer).
 //!
 //! Frozen rule (docs/gui/02 §14, tested here): the 1 Hz `PlayerTimePos` tick while
 //! playing changes only `elapsed_ms`, which is deliberately **outside** the player
@@ -16,6 +17,8 @@
 //! message types stay out of `src/remote` entirely (`scripts/check-architecture.sh`
 //! enforces that boundary).
 
+use std::borrow::Cow;
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::api::Song;
@@ -41,9 +44,9 @@ pub struct CoreView<'a> {
     pub position_epoch: u64,
     pub streaming: bool,
     pub radio_mode: bool,
-    pub stream_now_playing: Option<String>,
+    pub stream_now_playing: Option<Cow<'a, str>>,
     pub owner_mode: InstanceMode,
-    pub eq_preset: String,
+    pub eq_preset: &'a str,
     pub eq_bands: [f64; 10],
     pub eq_normalize: bool,
     /// The live config, projected into the `settings` topic model.
@@ -51,12 +54,29 @@ pub struct CoreView<'a> {
     /// The media-art cache's resolved file for the CURRENT track (already gated by the
     /// host — stale art from a previous track never appears here). Rides the player
     /// snapshot so the GUI can fetch `ytm://app/art/<key>`.
-    pub artwork: Option<super::proto::ArtworkRef>,
+    pub artwork: Option<CoreArtwork<'a>>,
+}
+
+/// Borrowed current-art projection. It is converted to the owned wire type only when a player
+/// snapshot is actually emitted, rather than cloning the key/path on every observer turn.
+pub struct CoreArtwork<'a> {
+    pub key: &'a str,
+    pub path: Option<&'a Path>,
+    pub mime: Option<&'a str>,
+}
+
+impl CoreArtwork<'_> {
+    fn to_wire(&self) -> super::proto::ArtworkRef {
+        super::proto::ArtworkRef {
+            key: self.key.to_owned(),
+            path: self.path.map(|path| path.to_string_lossy().into_owned()),
+            mime: self.mime.map(str::to_owned),
+        }
+    }
 }
 
 /// The player-topic change fingerprint. **`elapsed_ms` is deliberately absent** — see
 /// the module docs. `duration_ms` is included (it changes on track load, not per tick).
-#[derive(PartialEq, Clone)]
 struct PlayerFingerprint {
     video_id: Option<String>,
     paused: bool,
@@ -74,9 +94,7 @@ struct PlayerFingerprint {
     eq_normalize: bool,
     queue_pos: usize,
     queue_len: usize,
-    /// Art resolves ~1–2 s AFTER a track starts (async cache fetch); keying on it makes
-    /// that arrival its own push, or the GUI would show the placeholder until the next
-    /// unrelated change.
+    /// Art resolves ~1–2 s after track start, so its arrival must produce its own push.
     artwork_key: Option<String>,
 }
 
@@ -84,7 +102,7 @@ impl PlayerFingerprint {
     fn of(view: &CoreView<'_>) -> Self {
         let (pos, len) = view.queue.position();
         Self {
-            video_id: view.queue.current().map(|s| s.video_id.clone()),
+            video_id: view.queue.current().map(|song| song.video_id.clone()),
             paused: view.paused,
             volume: view.volume,
             speed_tenths: view.speed_tenths,
@@ -94,14 +112,38 @@ impl PlayerFingerprint {
             repeat: view.queue.repeat,
             streaming: view.streaming,
             radio_mode: view.radio_mode,
-            stream_now_playing: view.stream_now_playing.clone(),
-            eq_preset: view.eq_preset.clone(),
+            stream_now_playing: view.stream_now_playing.as_deref().map(str::to_owned),
+            eq_preset: view.eq_preset.to_owned(),
             eq_bands: view.eq_bands,
             eq_normalize: view.eq_normalize,
             queue_pos: if len == 0 { 0 } else { pos.saturating_sub(1) },
             queue_len: len,
-            artwork_key: view.artwork.as_ref().map(|art| art.key.clone()),
+            artwork_key: view.artwork.as_ref().map(|art| art.key.to_owned()),
         }
+    }
+
+    /// Compare the current borrowed projection against the retained exact snapshot. Owned strings
+    /// are allocated only after a real change; unchanged observer turns stay allocation-free
+    /// without relying on a lossy hash that could suppress a required remote update.
+    fn matches(&self, view: &CoreView<'_>) -> bool {
+        let (pos, len) = view.queue.position();
+        self.video_id.as_deref() == view.queue.current().map(|song| song.video_id.as_str())
+            && self.paused == view.paused
+            && self.volume == view.volume
+            && self.speed_tenths == view.speed_tenths
+            && self.position_epoch == view.position_epoch
+            && self.duration_ms == view.duration_ms
+            && self.shuffle == view.queue.shuffle
+            && self.repeat == view.queue.repeat
+            && self.streaming == view.streaming
+            && self.radio_mode == view.radio_mode
+            && self.stream_now_playing.as_deref() == view.stream_now_playing.as_deref()
+            && self.eq_preset == view.eq_preset
+            && self.eq_bands == view.eq_bands
+            && self.eq_normalize == view.eq_normalize
+            && self.queue_pos == if len == 0 { 0 } else { pos.saturating_sub(1) }
+            && self.queue_len == len
+            && self.artwork_key.as_deref() == view.artwork.as_ref().map(|art| art.key)
     }
 }
 
@@ -109,12 +151,23 @@ impl PlayerFingerprint {
 pub struct Publisher {
     hub: Arc<RemoteSessionHub>,
     last_player: Option<PlayerFingerprint>,
-    last_queue_rev: u64,
+    last_queue_rev: Option<u64>,
     /// Serialized settings model (rev 0) from the last turn — the settings fingerprint.
     /// Byte comparison over a ~2 KB projection per event turn is comfortably cheap and
     /// immune to forgotten-field drift, unlike a hand-listed fingerprint struct.
     last_settings: Option<Vec<u8>>,
     settings_rev: u64,
+    #[cfg(test)]
+    last_projection_work: ProjectionWork,
+}
+
+/// Test-only record of the concrete projection work performed by [`Publisher::observe`].
+#[cfg(test)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct ProjectionWork {
+    player_fingerprint: bool,
+    queue_revision: bool,
+    settings_model: bool,
 }
 
 impl Publisher {
@@ -122,19 +175,34 @@ impl Publisher {
         Self {
             hub,
             last_player: None,
-            last_queue_rev: 0,
+            last_queue_rev: None,
             last_settings: None,
             settings_rev: 0,
+            #[cfg(test)]
+            last_projection_work: ProjectionWork::default(),
         }
     }
 
-    /// Called once per owner-loop turn. O(fingerprint) when nothing changed; builds and
-    /// serializes a model only for a changed topic that has subscribers.
-    pub fn observe(&mut self, view: &CoreView<'_>) {
-        let player_now = PlayerFingerprint::of(view);
-        if self.last_player.as_ref() != Some(&player_now) {
-            self.last_player = Some(player_now);
-            if self.hub.any_subscribed(Topic::Player) {
+    /// Called after owner-loop turns selected by each host. Player and queue retain their historical
+    /// cheap baseline comparisons even without subscribers, so a later subscription cannot perturb
+    /// the established event sequence. Owned models are still built only for changed subscribed
+    /// topics, and the substantially more expensive Settings projection remains subscriber-gated.
+    pub(crate) fn observe(&mut self, view: &CoreView<'_>) {
+        #[cfg(test)]
+        let mut work = ProjectionWork::default();
+
+        let player_subscribed = self.hub.any_subscribed(Topic::Player);
+        #[cfg(test)]
+        {
+            work.player_fingerprint = true;
+        }
+        if self
+            .last_player
+            .as_ref()
+            .is_none_or(|last| !last.matches(view))
+        {
+            self.last_player = Some(PlayerFingerprint::of(view));
+            if player_subscribed {
                 let payload = event_payload(&PushEvent::PlayerSnapshot {
                     model: Box::new(player_model(view)),
                 });
@@ -142,10 +210,15 @@ impl Publisher {
             }
         }
 
+        let queue_subscribed = self.hub.any_subscribed(Topic::Queue);
+        #[cfg(test)]
+        {
+            work.queue_revision = true;
+        }
         let queue_rev = view.queue.rev();
-        if self.last_queue_rev != queue_rev {
-            self.last_queue_rev = queue_rev;
-            if self.hub.any_subscribed(Topic::Queue) {
+        if self.last_queue_rev != Some(queue_rev) {
+            self.last_queue_rev = Some(queue_rev);
+            if queue_subscribed {
                 let payload = event_payload(&PushEvent::QueueSnapshot {
                     model: queue_model(view),
                 });
@@ -162,7 +235,12 @@ impl Publisher {
         // freezes and no bytes are produced; `handle_subscribe` sends a full *current* snapshot
         // on connect, so a subscriber that joins after a change never misses it (test:
         // `late_settings_subscriber_still_sees_changes`).
-        if self.hub.any_subscribed(Topic::Settings) || self.last_settings.is_none() {
+        let settings_subscribed = self.hub.any_subscribed(Topic::Settings);
+        if settings_subscribed || self.last_settings.is_none() {
+            #[cfg(test)]
+            {
+                work.settings_model = true;
+            }
             let mut settings_now = settings_model(view, 0);
             let settings_bytes = serde_json::to_vec(&settings_now).unwrap_or_default();
             if self.last_settings.as_deref() != Some(settings_bytes.as_slice()) {
@@ -171,7 +249,7 @@ impl Publisher {
                 self.settings_rev += 1;
                 // The very first observe primes the baseline (nothing changed yet) —
                 // matching how the player/queue baselines behave before any subscriber.
-                if primed && self.hub.any_subscribed(Topic::Settings) {
+                if primed && settings_subscribed {
                     settings_now.rev = self.settings_rev;
                     let payload = event_payload(&PushEvent::SettingsSnapshot {
                         model: Box::new(settings_now),
@@ -180,12 +258,23 @@ impl Publisher {
                 }
             }
         }
+
+        #[cfg(test)]
+        {
+            self.last_projection_work = work;
+        }
+    }
+
+    #[cfg(test)]
+    fn observe_work(&mut self, view: &CoreView<'_>) -> ProjectionWork {
+        self.observe(view);
+        self.last_projection_work
     }
 
     pub fn should_observe(&self, state_changed: bool) -> bool {
         state_changed
             || self.last_player.is_none()
-            || self.last_queue_rev == 0
+            || self.last_queue_rev.is_none_or(|revision| revision == 0)
             || self.last_settings.is_none()
             || self.hub.any_subscribed(Topic::Player)
             || self.hub.any_subscribed(Topic::Queue)
@@ -282,7 +371,7 @@ pub(crate) fn player_model(view: &CoreView<'_>) -> PlayerModel {
     PlayerModel {
         track: view.queue.current().map(|song| {
             let mut track = track_model(song);
-            track.artwork = view.artwork.clone();
+            track.artwork = view.artwork.as_ref().map(CoreArtwork::to_wire);
             track
         }),
         paused: view.paused,
@@ -295,10 +384,10 @@ pub(crate) fn player_model(view: &CoreView<'_>) -> PlayerModel {
         repeat: view.queue.repeat,
         streaming: view.streaming,
         radio_mode: view.radio_mode,
-        stream_now_playing: view.stream_now_playing.clone(),
+        stream_now_playing: view.stream_now_playing.as_deref().map(str::to_owned),
         owner_mode: view.owner_mode,
         eq: EqModel {
-            preset: view.eq_preset.clone(),
+            preset: view.eq_preset.to_owned(),
             bands: view.eq_bands,
             normalize: view.eq_normalize,
         },
@@ -347,7 +436,7 @@ pub(crate) fn settings_model(view: &CoreView<'_>, rev: u64) -> super::proto::Set
             repeat: view.queue.repeat,
         },
         eq: EqModel {
-            preset: view.eq_preset.clone(),
+            preset: view.eq_preset.to_owned(),
             bands: view.eq_bands,
             normalize: view.eq_normalize,
         },
@@ -515,7 +604,7 @@ pub(crate) fn test_view(queue: &Queue) -> CoreView<'_> {
         radio_mode: false,
         stream_now_playing: None,
         owner_mode: InstanceMode::StandaloneTui,
-        eq_preset: "Flat".to_string(),
+        eq_preset: "Flat",
         eq_bands: [0.0; 10],
         eq_normalize: false,
         config: Box::leak(Box::new(crate::config::Config::default())),
@@ -561,6 +650,22 @@ mod tests {
             .collect()
     }
 
+    fn settings_revs(lines: &[SessionLine]) -> Vec<u64> {
+        lines
+            .iter()
+            .filter_map(|line| match line {
+                SessionLine::Event {
+                    topic: Topic::Settings,
+                    payload,
+                    ..
+                } => serde_json::from_slice::<serde_json::Value>(payload)
+                    .ok()
+                    .and_then(|event| event["model"]["rev"].as_u64()),
+                _ => None,
+            })
+            .collect()
+    }
+
     #[test]
     fn subscribe_emits_snapshots_before_reply_and_only_for_new_topics() {
         let (hub, session, mut rx) = test_register(SessionTuning::default());
@@ -585,6 +690,98 @@ mod tests {
         publisher.handle_subscribe(&view(&queue), &session, 2, &[Topic::Player]);
         let lines = drain(&mut rx);
         assert_eq!(kinds(&lines), vec!["raw:frame"]);
+    }
+
+    #[test]
+    fn owner_can_park_projection_work_without_model_subscribers() {
+        let (hub, session, mut rx) = test_register(SessionTuning::default());
+        let mut publisher = Publisher::new(hub);
+        let mut queue = Queue::default();
+        queue.set(vec![song("baseline")], 0);
+
+        assert!(
+            publisher.should_observe(false),
+            "first turn primes baselines"
+        );
+        publisher.observe(&view(&queue));
+        assert!(
+            !publisher.should_observe(false),
+            "standalone idle turns park"
+        );
+
+        publisher.handle_subscribe(&view(&queue), &session, 1, &[Topic::Player]);
+        drain(&mut rx);
+        assert!(
+            publisher.should_observe(false),
+            "active model subscriber stays observed"
+        );
+    }
+
+    #[test]
+    fn cheap_baselines_refresh_while_settings_projection_stays_subscriber_gated() {
+        let queue = Queue::default();
+
+        let (hub, session, mut rx) = test_register(SessionTuning::default());
+        let mut publisher = Publisher::new(hub);
+        assert_eq!(
+            publisher.observe_work(&view(&queue)),
+            ProjectionWork {
+                player_fingerprint: true,
+                queue_revision: true,
+                settings_model: true,
+            },
+            "the first owner turn primes each baseline exactly once"
+        );
+        assert_eq!(
+            publisher.observe_work(&view(&queue)),
+            ProjectionWork {
+                player_fingerprint: true,
+                queue_revision: true,
+                settings_model: false,
+            },
+            "origin-compatible cheap baselines refresh without rebuilding settings"
+        );
+        publisher.handle_subscribe(&view(&queue), &session, 1, &[Topic::Settings]);
+        drain(&mut rx);
+        assert_eq!(
+            publisher.observe_work(&view(&queue)),
+            ProjectionWork {
+                settings_model: true,
+                player_fingerprint: true,
+                queue_revision: true,
+            },
+            "settings projection is added only for a settings subscriber"
+        );
+
+        let (hub, session, mut rx) = test_register(SessionTuning::default());
+        let mut publisher = Publisher::new(hub);
+        publisher.observe(&view(&queue));
+        publisher.handle_subscribe(&view(&queue), &session, 1, &[Topic::Player]);
+        drain(&mut rx);
+        assert_eq!(
+            publisher.observe_work(&view(&queue)),
+            ProjectionWork {
+                player_fingerprint: true,
+                queue_revision: true,
+                settings_model: false,
+            },
+            "a player-only client does not build settings"
+        );
+
+        let (hub, session, mut rx) = test_register(SessionTuning::default());
+        let mut publisher = Publisher::new(hub);
+        publisher.observe(&view(&queue));
+        publisher.handle_subscribe(&view(&queue), &session, 1, &[Topic::Queue]);
+        drain(&mut rx);
+        assert_eq!(
+            publisher.observe_work(&view(&queue)),
+            ProjectionWork {
+                player_fingerprint: true,
+                queue_revision: true,
+                settings_model: false,
+            },
+            "a queue-only client does not build settings"
+        );
     }
 
     #[test]
@@ -678,7 +875,7 @@ mod tests {
         // A setting changes while nobody is subscribed: the gate skips the serialize and pushes
         // nothing, but the change must not be lost to a future subscriber.
         let mut v = view(&queue);
-        v.eq_preset = "Rock".to_string();
+        v.eq_preset = "Rock";
         publisher.observe(&v);
         assert!(
             drain(&mut rx).is_empty(),
@@ -687,18 +884,32 @@ mod tests {
 
         // Subscriber connects: `handle_subscribe` sends the current settings snapshot.
         publisher.handle_subscribe(&v, &session, 1, &[Topic::Settings]);
+        let initial = drain(&mut rx);
         assert!(
-            kinds(&drain(&mut rx)).contains(&"event:settings".to_string()),
+            kinds(&initial).contains(&"event:settings".to_string()),
             "a new Settings subscriber receives the current snapshot despite the serialize gate"
         );
+        assert_eq!(
+            settings_revs(&initial),
+            vec![1],
+            "subscribe reports the existing owner revision without mutating observer baselines"
+        );
+
+        // Preserve the established wire sequence: subscription itself never advances the parked
+        // observer baseline, so the next owner observation publishes the already-current model.
+        publisher.observe(&v);
+        let follow_up = drain(&mut rx);
+        assert_eq!(settings_revs(&follow_up), vec![2]);
 
         // A further change while subscribed still pushes a settings snapshot.
-        v.eq_preset = "Jazz".to_string();
+        v.eq_preset = "Jazz";
         publisher.observe(&v);
+        let changed = drain(&mut rx);
         assert!(
-            kinds(&drain(&mut rx)).contains(&"event:settings".to_string()),
+            kinds(&changed).contains(&"event:settings".to_string()),
             "a subscribed settings change still pushes"
         );
+        assert_eq!(settings_revs(&changed), vec![3]);
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -330,7 +330,7 @@ fn app_msg_policy(msg: &Msg) -> EventPolicy {
         Msg::ResolveFailed { .. } => EventPolicy::DropIfStale {
             stale_key: Key::ResolverVideo,
         },
-        Msg::Noop | Msg::StatusTick | Msg::AnimTick | Msg::RecordingTick => {
+        Msg::Noop | Msg::StatusTick | Msg::AnimTick(_) | Msg::RecordingTick => {
             EventPolicy::BestEffort {
                 reason: "loop-owned ticks and inert messages are redraw/status hints",
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -330,7 +330,7 @@ fn app_msg_policy(msg: &Msg) -> EventPolicy {
         Msg::ResolveFailed { .. } => EventPolicy::DropIfStale {
             stale_key: Key::ResolverVideo,
         },
-        Msg::Noop | Msg::StatusTick | Msg::AnimTick(_) | Msg::RecordingTick => {
+        Msg::Noop | Msg::StatusTick | Msg::AnimTick | Msg::RecordingTick => {
             EventPolicy::BestEffort {
                 reason: "loop-owned ticks and inert messages are redraw/status hints",
             }

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -252,7 +252,7 @@ fn runtime_event_policy_covers_leaf_event_classes() {
     assert_policy(
         RuntimeEvent::Lyrics(crate::lyrics::LyricsEvent::Result {
             video_id: "v".to_owned(),
-            lines: Vec::new(),
+            lines: Vec::new().into(),
         }),
         EventPolicy::DropIfStale {
             stale_key: EventKey::LyricsVideo,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1192,6 +1192,7 @@ impl SettingsDraft {
             .unwrap_or_else(|| MPV_CACHE_FORWARD_DEFAULT.to_owned());
         cfg.audio.mpv.cache_back = blank_to_none(&self.audio_mpv_cache_back)
             .unwrap_or_else(|| MPV_CACHE_BACK_DEFAULT.to_owned());
+        cfg.audio.mpv.mark_cache_defaults_current();
         // Radio recording. Keep max strictly above min so the two sliders can't invert.
         cfg.recording.mode = self.recording_mode;
         cfg.recording.min_duration_secs = self.recording_min_seconds;

--- a/src/terminal_runtime/art.rs
+++ b/src/terminal_runtime/art.rs
@@ -93,8 +93,7 @@ fn store_halfblocks_art_picker_cache() {
 }
 
 fn art_picker_cache_path() -> Option<std::path::PathBuf> {
-    directories::ProjectDirs::from("", "", "yututui")
-        .map(|dirs| dirs.cache_dir().join("art-picker.cache"))
+    crate::paths::cache_dir().map(|dir| dir.join("art-picker.cache"))
 }
 
 fn terminal_probe_cache_key() -> u64 {

--- a/src/terminal_runtime/runner.rs
+++ b/src/terminal_runtime/runner.rs
@@ -20,73 +20,43 @@ use crate::{
 use super::art::log_art_picker;
 use super::startup::StartupTrace;
 
-/// The historical logical animation-tick period. Keep the integer-millisecond division from
-/// `origin/main`: visible phase was defined on this grid (`30 fps` means 33 ms logical ticks).
+/// The animation tick period for a given frame rate. `fps` is expected pre-clamped (via
+/// [`config::AnimationsConfig::effective_fps`]); the `.max(1)` is a divide-by-zero guard only.
 fn anim_tick_period(fps: u16) -> Duration {
     Duration::from_millis((1000 / u64::from(fps.max(1))).max(1))
 }
 
-fn logical_tick_span(period: Duration, ticks: u64) -> Duration {
-    const NANOS_PER_SECOND: u128 = 1_000_000_000;
-    let total_nanos = period.as_nanos().saturating_mul(u128::from(ticks));
-    let seconds = total_nanos / NANOS_PER_SECOND;
-    let Ok(seconds) = u64::try_from(seconds) else {
-        return Duration::MAX;
-    };
-    let nanos = u32::try_from(total_nanos % NANOS_PER_SECOND).unwrap_or(0);
-    Duration::new(seconds, nanos)
+/// Build the animation tick for `fps`. The first tick is scheduled one full period out (via
+/// `interval_at`) instead of firing immediately, so rebuilding the interval when the rate changes
+/// in Settings doesn't emit a spurious extra frame on the very next loop iteration. `Skip` drops
+/// missed frames so a busy moment can't back up a redraw backlog.
+fn anim_interval(fps: u16) -> tokio::time::Interval {
+    let period = anim_tick_period(fps);
+    anim_interval_at(tokio::time::Instant::now() + period, fps)
 }
 
-/// Variable animation deadline anchored to the legacy logical-tick grid. Only draw-due logical
-/// ticks become timer wakes; the ticks between them exist as time/credit math, not reducer turns.
-struct AnimationSchedule {
-    tick_period: Duration,
-    last_applied_tick_due: Instant,
-    next_draw_due: Instant,
+fn anim_interval_at(first_tick: tokio::time::Instant, fps: u16) -> tokio::time::Interval {
+    let mut tick = tokio::time::interval_at(first_tick, anim_tick_period(fps));
+    tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    tick
 }
 
-impl AnimationSchedule {
-    fn new(now: Instant, tick_fps: u16, ticks_until_draw: u64) -> Self {
-        let mut schedule = Self {
-            tick_period: anim_tick_period(tick_fps),
-            last_applied_tick_due: now,
-            next_draw_due: now,
-        };
-        schedule.arm_next(ticks_until_draw);
-        schedule
+/// Rebuild the long-lived interval only when the configured logical FPS changes. Animation
+/// activation and draw-cadence changes deliberately do not call this path, preserving the
+/// existing timer grid and reducer draw credit across a guarded (inactive) period.
+fn sync_animation_interval(
+    app: &mut App,
+    anim_fps: &mut u16,
+    anim_tick: &mut tokio::time::Interval,
+) -> bool {
+    let new_fps = app.animation_tick_fps();
+    if new_fps == *anim_fps {
+        return false;
     }
-
-    fn reset(&mut self, now: Instant, tick_fps: u16, ticks_until_draw: u64) {
-        self.tick_period = anim_tick_period(tick_fps);
-        self.last_applied_tick_due = now;
-        self.arm_next(ticks_until_draw);
-    }
-
-    fn deadline(&self) -> Instant {
-        self.next_draw_due
-    }
-
-    /// Logical deadlines elapsed since the newest logical tick already applied to `App`.
-    fn available_ticks(&self, now: Instant) -> u64 {
-        let elapsed = now.saturating_duration_since(self.last_applied_tick_due);
-        let ticks = elapsed.as_nanos() / self.tick_period.as_nanos();
-        u64::try_from(ticks).unwrap_or(u64::MAX)
-    }
-
-    fn consume_ticks(&mut self, ticks: u64) {
-        let advanced = self
-            .last_applied_tick_due
-            .checked_add(logical_tick_span(self.tick_period, ticks));
-        self.last_applied_tick_due = advanced.unwrap_or(self.next_draw_due);
-    }
-
-    fn arm_next(&mut self, ticks_until_draw: u64) {
-        let span = logical_tick_span(self.tick_period, ticks_until_draw.max(1));
-        self.next_draw_due = self
-            .last_applied_tick_due
-            .checked_add(span)
-            .unwrap_or(self.last_applied_tick_due);
-    }
+    *anim_fps = new_fps;
+    app.reset_animation_cadence();
+    *anim_tick = anim_interval(new_fps);
+    true
 }
 
 const IME_SCRUB_PERIOD: Duration = Duration::from_millis(80);
@@ -149,7 +119,7 @@ impl ObserverPlan {
         };
         if progress(first) && paired.is_none_or(progress) {
             Self::PROGRESS
-        } else if paired.is_none() && matches!(first, Msg::AnimTick(_) | Msg::StatusTick) {
+        } else if paired.is_none() && matches!(first, Msg::AnimTick | Msg::StatusTick) {
             Self::INERT
         } else {
             Self::PROJECTED
@@ -702,17 +672,15 @@ pub async fn run(
     // ticks). Drives the max-duration force-split.
     let mut recording_tick = tokio::time::interval(Duration::from_secs(1));
     recording_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
-    // Drive optional animations only at the historical draw-due logical ticks. The deadline moves
-    // by a variable number of the original integer logical periods, so canvas/ambient/mascot/
-    // marquee modes avoid intermediate wakes without changing visible due times or phase.
-    let mut anim_tick_fps = app.animation_tick_fps();
-    let mut anim_draw_fps = app.animation_draw_fps();
-    let mut anim_schedule = AnimationSchedule::new(
-        Instant::now(),
-        anim_tick_fps,
-        app.animation_ticks_until_next_draw(),
-    );
-    let mut anim_was_active = false;
+    // Drives the optional player-view animations at the configured frame rate - but only ticks
+    // while `app.animation_active()` holds (player view, master + an effect enabled, a track
+    // playing, focused unless the user opted out of focus-pausing). With every animation toggle
+    // off (the default) the guard is false, this timer never wakes, and the loop stays exactly as
+    // light as before.
+    // `Skip` drops missed frames so a busy moment can't build up a backlog of redraws. The period
+    // is rebuilt below whenever the user changes the rate in Settings.
+    let mut anim_fps = app.animation_tick_fps();
+    let mut anim_tick = anim_interval(anim_fps);
     // Every actor is up and the reducer loop is one statement away from draining `worker_rx`:
     // now start the control server and publish the instance descriptor. Doing it here (rather
     // than during setup) means a `ytt -r` that discovers the descriptor is guaranteed something
@@ -734,7 +702,7 @@ pub async fn run(
     // terminal matches all reducer-owned state, the IME clock must take the normal draw path.
     let mut reducer_turn_unrendered = true;
 
-    'main_loop: while !app.should_quit {
+    while !app.should_quit {
         if app.dirty {
             draw_full_app_frame(terminal, &mut app, &mut perf, &mut reducer_turn_unrendered)?;
             perf.maybe_log(&app);
@@ -742,30 +710,6 @@ pub async fn run(
                 continue;
             }
         }
-
-        // A render can start/stop a selected-row marquee, and reducer turns can change the active
-        // effect mix or configured FPS. Activation/tick-rate changes start a new logical grid;
-        // draw-rate changes keep that grid and only reset credit. The common active path is three
-        // scalar comparisons, and the inactive path never polls the timer.
-        let animation_active = app.animation_active();
-        let new_tick_fps = app.animation_tick_fps();
-        let new_draw_fps = app.animation_draw_fps();
-        if animation_active && (!anim_was_active || new_tick_fps != anim_tick_fps) {
-            app.reset_animation_cadence();
-            anim_schedule.reset(
-                Instant::now(),
-                new_tick_fps,
-                app.animation_ticks_until_next_draw(),
-            );
-        } else if animation_active && new_draw_fps != anim_draw_fps {
-            // The legacy logical timer did not move when the active effect mix changed its draw
-            // credit. Reset only that credit and keep the next wake on the existing tick grid.
-            app.reset_animation_cadence();
-            anim_schedule.arm_next(app.animation_ticks_until_next_draw());
-        }
-        anim_was_active = animation_active;
-        anim_tick_fps = new_tick_fps;
-        anim_draw_fps = new_draw_fps;
 
         // Mostly blocks until input or a worker message arrives. Outside text-entry fields,
         // a low-rate redraw scrubs IME preedit text that some terminals paint without
@@ -868,26 +812,7 @@ pub async fn run(
                     continue;
                 },
                 _ = status_tick.tick(), if app.status_visible() => Msg::StatusTick,
-                _ = tokio::time::sleep_until(tokio::time::Instant::from_std(anim_schedule.deadline())),
-                    if app.animation_active() => {
-                    let now = Instant::now();
-                    let available = anim_schedule.available_ticks(now);
-                    let logical_ticks = app.animation_ticks_through_latest_draw(available);
-                    if logical_ticks == 0 {
-                        // `sleep_until` cannot normally complete early. If the platform clock
-                        // conversion ever rounds across the boundary, re-arm instead of drawing a
-                        // phase that was not visible on the legacy logical-tick grid.
-                        app.reset_animation_cadence();
-                        anim_schedule.reset(
-                            now,
-                            app.animation_tick_fps(),
-                            app.animation_ticks_until_next_draw(),
-                        );
-                        continue 'main_loop;
-                    }
-                    anim_schedule.consume_ticks(logical_ticks);
-                    Msg::AnimTick(logical_ticks)
-                },
+                _ = anim_tick.tick(), if app.animation_active() => Msg::AnimTick,
                 _ = recording_tick.tick(), if app.recorder_active() => Msg::RecordingTick,
                 _ = media_pump.tick(), if media.wants_pump() => {
                     media.pump();
@@ -896,19 +821,6 @@ pub async fn run(
             }
         };
 
-        let animation_wake = matches!(&msg, Msg::AnimTick(_));
-        if !animation_wake && animation_active {
-            // The old loop advanced logical phase even on ticks that did not redraw. Lazily apply
-            // those elapsed ticks before an unrelated event can trigger a render or arm an FX;
-            // this adds no timer wake and keeps interaction-time phase/duration unchanged.
-            let available = anim_schedule.available_ticks(Instant::now());
-            if available > 0 {
-                let cmds = app.update(Msg::AnimTick(available));
-                debug_assert!(cmds.is_empty(), "animation phase sync emitted commands");
-                anim_schedule.consume_ticks(available);
-                anim_schedule.arm_next(app.animation_ticks_until_next_draw());
-            }
-        }
         let paired_progress = take_adjacent_player_progress_pair(&msg, &mut pending_worker_msgs);
         let observer_plan = ObserverPlan::for_messages(&msg, paired_progress.as_ref());
 
@@ -931,12 +843,15 @@ pub async fn run(
                 handles.dispatch(&mut app, cmd);
             }
         }
-        if animation_wake {
-            anim_schedule.arm_next(app.animation_ticks_until_next_draw());
-        }
         if resized_artwork {
             perf.record_art_resize();
         }
+
+        // The frame rate may have changed in Settings (committed to `config.animations` on close).
+        // Rebuild the tick so the new rate applies without a relaunch - only when it actually
+        // changed, so the common path costs one `u16` compare. Kept before the draw so the new
+        // cadence is in force for this iteration.
+        let _fps_changed = sync_animation_interval(&mut app, &mut anim_fps, &mut anim_tick);
 
         // Draw first, so the keypress lands on screen with the least latency. Everything below
         // is pure output bookkeeping - it reads post-update state but feeds no rendering - so
@@ -1027,7 +942,9 @@ mod tests {
     use std::collections::VecDeque;
     use std::time::{Duration, Instant};
 
-    use crate::app::{App, Msg, PlayerMsg};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    use crate::app::{App, Mode, Msg, PlayerMsg};
 
     use super::*;
 
@@ -1068,47 +985,135 @@ mod tests {
         assert_eq!(stats.ime_fast_scrubs, 0);
     }
 
-    #[test]
-    fn animation_schedule_uses_the_legacy_integer_tick_grid() {
+    #[tokio::test]
+    async fn animation_interval_uses_the_legacy_period_and_skip_policy() {
         assert_eq!(anim_tick_period(0), Duration::from_millis(1000));
         assert_eq!(anim_tick_period(1), Duration::from_millis(1000));
         assert_eq!(anim_tick_period(60), Duration::from_millis(16));
         assert_eq!(anim_tick_period(2_000), Duration::from_millis(1));
 
-        let base = Instant::now();
-        let mut schedule = AnimationSchedule::new(base, 30, 2);
+        let interval = anim_interval(30);
+        assert_eq!(interval.period(), Duration::from_millis(33));
         assert_eq!(
-            schedule.deadline().saturating_duration_since(base),
-            Duration::from_millis(66)
-        );
-        assert_eq!(
-            schedule.available_ticks(base + Duration::from_millis(65)),
-            1
-        );
-        assert_eq!(
-            schedule.available_ticks(base + Duration::from_millis(66)),
-            2
+            interval.missed_tick_behavior(),
+            MissedTickBehavior::Skip,
+            "busy periods must collapse into one delivered tick"
         );
 
-        schedule.consume_ticks(2);
-        schedule.arm_next(1);
-        assert_eq!(
-            schedule.deadline().saturating_duration_since(base),
-            Duration::from_millis(99)
+        // A 1 Hz interval whose first deadline is 2.5 s overdue has two missed deadlines behind
+        // it. Skip delivers the first poll immediately, then jumps to the next future grid point;
+        // Burst would make this second poll immediately ready too.
+        let first_due = tokio::time::Instant::now() - Duration::from_millis(2_500);
+        let mut delayed = anim_interval_at(first_due, 1);
+        assert_eq!(delayed.tick().await, first_due);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), delayed.tick())
+                .await
+                .is_err(),
+            "Skip must drop the overdue backlog instead of replaying a second tick"
         );
+    }
 
-        // If that wake is delivered at 150 ms, the app selects frame 3 as the newest visible
-        // phase. Consuming its three logical ticks and re-arming two more stays on 165 ms.
-        let mut delayed = AnimationSchedule::new(base, 30, 2);
+    #[tokio::test]
+    async fn delayed_200ms_first_poll_advances_exactly_one_frame() {
+        let first_due = tokio::time::Instant::now() - Duration::from_millis(200);
+        let mut interval = anim_interval_at(first_due, 30);
+        let mut app = App::new(100);
+
+        let delivered_due = interval.tick().await;
+        assert_eq!(delivered_due, first_due);
+        app.update(Msg::AnimTick);
+
         assert_eq!(
-            delayed.available_ticks(base + Duration::from_millis(150)),
-            4
+            app.anim_frame(),
+            1,
+            "missed deadlines are never batch-applied"
         );
-        delayed.consume_ticks(3);
-        delayed.arm_next(2);
+    }
+
+    fn ambient_animation_app() -> App {
+        let mut app = App::new(100);
+        app.mode = Mode::Search;
+        app.config.animations.master = true;
+        app.config.animations.caret = true;
+        app.config.animations.fps = 30;
+        app
+    }
+
+    #[tokio::test]
+    async fn inactive_overdue_tick_is_immediate_and_retains_draw_credit() {
+        let mut app = ambient_animation_app();
+        assert!(app.animation_active());
+        assert_eq!(app.animation_draw_fps(), 12);
+
+        // At 30→12 fps, two delivered ticks bank 24/30 credit without redrawing.
+        for _ in 0..2 {
+            app.dirty = false;
+            app.update(Msg::AnimTick);
+            assert!(!app.dirty);
+        }
+
+        // Construct one already-overdue interval before parking. The exact same object survives
+        // both focus transitions and is polled only after reactivation.
+        let first_due = tokio::time::Instant::now() - Duration::from_millis(2_500);
+        let mut interval = anim_interval_at(first_due, 30);
+        app.update(Msg::Focus(false));
+        assert!(!app.animation_active());
+
+        // The interval remained overdue while its select branch was guarded. Reactivation polls
+        // the same interval and therefore gets exactly one immediate Skip tick on existing state.
+        app.update(Msg::Focus(true));
+        app.dirty = false;
+        let delivered_due = tokio::time::timeout(Duration::from_millis(50), interval.tick())
+            .await
+            .expect("an overdue interval tick must be immediately ready");
+        assert_eq!(delivered_due, first_due);
+        app.update(Msg::AnimTick);
+
+        assert_eq!(app.anim_frame(), 3);
+        assert!(app.dirty, "retained 24/30 credit makes the third tick draw");
+    }
+
+    #[tokio::test]
+    async fn reactivation_before_deadline_keeps_the_existing_interval_grid() {
+        let mut app = ambient_animation_app();
+        // A distant first deadline makes this structural test independent of wall-clock load.
+        let first_due = tokio::time::Instant::now() + Duration::from_secs(3_600);
+        let mut interval = anim_interval_at(first_due, 30);
+        let mut fps = 30;
+
+        app.update(Msg::Focus(false));
+        assert!(!sync_animation_interval(&mut app, &mut fps, &mut interval));
+        app.update(Msg::Focus(true));
+        assert!(!sync_animation_interval(&mut app, &mut fps, &mut interval));
+        assert_eq!(interval.period(), Duration::from_millis(33));
+        assert_eq!(app.anim_frame(), 0);
+
+        // The same synchronization seam does rebuild on the sole approved trigger.
+        app.config.animations.fps = 60;
+        assert!(sync_animation_interval(&mut app, &mut fps, &mut interval));
+        assert_eq!(fps, 60);
+        assert_eq!(interval.period(), Duration::from_millis(16));
+    }
+
+    #[tokio::test]
+    async fn input_without_a_delivered_timer_does_not_advance_animation() {
+        let mut app = ambient_animation_app();
+        let before = app.anim_frame();
+        // Even an overdue clock has no reducer effect until its `tick()` future is delivered by
+        // select. This is the exact ordering that the removed input-time phase sync violated.
+        let _undelivered_interval =
+            anim_interval_at(tokio::time::Instant::now() - Duration::from_millis(200), 30);
+
+        app.update(Msg::Key(KeyEvent::new(
+            KeyCode::Char('x'),
+            KeyModifiers::NONE,
+        )));
+
         assert_eq!(
-            delayed.deadline().saturating_duration_since(base),
-            Duration::from_millis(165)
+            app.anim_frame(),
+            before,
+            "input handling must not pre-apply elapsed animation ticks"
         );
     }
 

--- a/src/terminal_runtime/runner.rs
+++ b/src/terminal_runtime/runner.rs
@@ -2,8 +2,8 @@ use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use crossterm::event::EventStream;
-use futures::StreamExt;
+use crossterm::event::{Event as TerminalEvent, EventStream};
+use futures::{FutureExt, StreamExt};
 use ratatui_image::thread::ResizeRequest;
 use tokio::sync::mpsc;
 use tokio::time::MissedTickBehavior;
@@ -20,21 +20,190 @@ use crate::{
 use super::art::log_art_picker;
 use super::startup::StartupTrace;
 
-/// The animation tick period for a given frame rate. `fps` is expected pre-clamped (via
-/// [`config::AnimationsConfig::effective_fps`]); the `.max(1)` is a divide-by-zero guard only.
+/// The historical logical animation-tick period. Keep the integer-millisecond division from
+/// `origin/main`: visible phase was defined on this grid (`30 fps` means 33 ms logical ticks).
 fn anim_tick_period(fps: u16) -> Duration {
     Duration::from_millis((1000 / u64::from(fps.max(1))).max(1))
 }
 
-/// Build the animation tick for `fps`. The first tick is scheduled one full period out (via
-/// `interval_at`) instead of firing immediately, so rebuilding the interval when the rate changes
-/// in Settings doesn't emit a spurious extra frame on the very next loop iteration. `Skip` drops
-/// missed frames so a busy moment can't back up a redraw backlog.
-fn anim_interval(fps: u16) -> tokio::time::Interval {
-    let period = anim_tick_period(fps);
-    let mut tick = tokio::time::interval_at(tokio::time::Instant::now() + period, period);
-    tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
-    tick
+fn logical_tick_span(period: Duration, ticks: u64) -> Duration {
+    const NANOS_PER_SECOND: u128 = 1_000_000_000;
+    let total_nanos = period.as_nanos().saturating_mul(u128::from(ticks));
+    let seconds = total_nanos / NANOS_PER_SECOND;
+    let Ok(seconds) = u64::try_from(seconds) else {
+        return Duration::MAX;
+    };
+    let nanos = u32::try_from(total_nanos % NANOS_PER_SECOND).unwrap_or(0);
+    Duration::new(seconds, nanos)
+}
+
+/// Variable animation deadline anchored to the legacy logical-tick grid. Only draw-due logical
+/// ticks become timer wakes; the ticks between them exist as time/credit math, not reducer turns.
+struct AnimationSchedule {
+    tick_period: Duration,
+    last_applied_tick_due: Instant,
+    next_draw_due: Instant,
+}
+
+impl AnimationSchedule {
+    fn new(now: Instant, tick_fps: u16, ticks_until_draw: u64) -> Self {
+        let mut schedule = Self {
+            tick_period: anim_tick_period(tick_fps),
+            last_applied_tick_due: now,
+            next_draw_due: now,
+        };
+        schedule.arm_next(ticks_until_draw);
+        schedule
+    }
+
+    fn reset(&mut self, now: Instant, tick_fps: u16, ticks_until_draw: u64) {
+        self.tick_period = anim_tick_period(tick_fps);
+        self.last_applied_tick_due = now;
+        self.arm_next(ticks_until_draw);
+    }
+
+    fn deadline(&self) -> Instant {
+        self.next_draw_due
+    }
+
+    /// Logical deadlines elapsed since the newest logical tick already applied to `App`.
+    fn available_ticks(&self, now: Instant) -> u64 {
+        let elapsed = now.saturating_duration_since(self.last_applied_tick_due);
+        let ticks = elapsed.as_nanos() / self.tick_period.as_nanos();
+        u64::try_from(ticks).unwrap_or(u64::MAX)
+    }
+
+    fn consume_ticks(&mut self, ticks: u64) {
+        let advanced = self
+            .last_applied_tick_due
+            .checked_add(logical_tick_span(self.tick_period, ticks));
+        self.last_applied_tick_due = advanced.unwrap_or(self.next_draw_due);
+    }
+
+    fn arm_next(&mut self, ticks_until_draw: u64) {
+        let span = logical_tick_span(self.tick_period, ticks_until_draw.max(1));
+        self.next_draw_due = self
+            .last_applied_tick_due
+            .checked_add(span)
+            .unwrap_or(self.last_applied_tick_due);
+    }
+}
+
+const IME_SCRUB_PERIOD: Duration = Duration::from_millis(80);
+const IME_SCRUB_TICKS: u8 = 8;
+
+/// A short, event-triggered repaint window that clears terminal-owned IME preedit text.
+///
+/// Some terminals paint preedit text without sending it through the application's buffer. A
+/// repaint removes that residue, but polling forever at 12.5 fps burns CPU while the UI is idle.
+/// Re-arm this burst for terminal activity that can leave preedit behind; after eight 80 ms ticks
+/// (640 ms) the interval is parked again.
+struct ImeScrubBurst {
+    interval: tokio::time::Interval,
+    remaining: u8,
+}
+
+impl ImeScrubBurst {
+    fn new() -> Self {
+        let mut interval = tokio::time::interval_at(
+            tokio::time::Instant::now() + IME_SCRUB_PERIOD,
+            IME_SCRUB_PERIOD,
+        );
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        Self {
+            interval,
+            remaining: 0,
+        }
+    }
+
+    fn arm(&mut self) {
+        self.remaining = IME_SCRUB_TICKS;
+        self.interval
+            .reset_at(tokio::time::Instant::now() + IME_SCRUB_PERIOD);
+    }
+
+    fn active(&self) -> bool {
+        self.remaining > 0
+    }
+
+    async fn tick(&mut self) {
+        self.interval.tick().await;
+    }
+
+    fn consume_tick(&mut self) {
+        self.remaining = self.remaining.saturating_sub(1);
+    }
+}
+
+/// Terminal activity that can leave terminal-owned preedit outside an application text field.
+/// Focus gain and resize always arm a cleanup window; keyboard/mouse/paste activity does so only
+/// when the application is not deliberately displaying editable text.
+fn terminal_event_arms_ime_scrub(event: &TerminalEvent, outside_text_entry: bool) -> bool {
+    matches!(
+        event,
+        TerminalEvent::FocusGained | TerminalEvent::Resize(_, _)
+    ) || (outside_text_entry
+        && matches!(
+            event,
+            TerminalEvent::Key(_) | TerminalEvent::Mouse(_) | TerminalEvent::Paste(_)
+        ))
+}
+
+/// Take only an immediately-adjacent time/cache pair. Both messages still pass through
+/// `App::update` in their original order; sharing the post-update draw/observer work is safe while
+/// skipping over any intervening message would not be.
+fn take_adjacent_player_progress_pair(first: &Msg, pending: &mut VecDeque<Msg>) -> Option<Msg> {
+    let complementary = matches!(
+        (first, pending.front()),
+        (
+            Msg::Player(app::PlayerMsg::TimePos(_)),
+            Some(Msg::Player(app::PlayerMsg::CacheTime(_)))
+        ) | (
+            Msg::Player(app::PlayerMsg::CacheTime(_)),
+            Some(Msg::Player(app::PlayerMsg::TimePos(_)))
+        )
+    );
+    complementary.then(|| pending.pop_front().expect("front checked above"))
+}
+
+/// Post-reducer observer work for one owner-loop turn. Progress is deliberately separate: mpv's
+/// high-rate clocks still feed the 1 Hz scrobbler, but elapsed time is not an OS/remote change and
+/// must not trigger media fingerprints, `CoreView`, topic hashes, models, or serialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ObserverPlan {
+    project_state: bool,
+    drive_scrobble_heartbeat: bool,
+}
+
+impl ObserverPlan {
+    const INERT: Self = Self {
+        project_state: false,
+        drive_scrobble_heartbeat: false,
+    };
+    const PROGRESS: Self = Self {
+        project_state: false,
+        drive_scrobble_heartbeat: true,
+    };
+    const PROJECTED: Self = Self {
+        project_state: true,
+        drive_scrobble_heartbeat: true,
+    };
+
+    fn for_messages(first: &Msg, paired: Option<&Msg>) -> Self {
+        let progress = |msg: &Msg| {
+            matches!(
+                msg,
+                Msg::Player(app::PlayerMsg::TimePos(_)) | Msg::Player(app::PlayerMsg::CacheTime(_))
+            )
+        };
+        if progress(first) && paired.is_none_or(progress) {
+            Self::PROGRESS
+        } else if paired.is_none() && matches!(first, Msg::AnimTick(_) | Msg::StatusTick) {
+            Self::INERT
+        } else {
+            Self::PROJECTED
+        }
+    }
 }
 
 struct PerfStats {
@@ -107,6 +276,7 @@ impl PerfStats {
             avg_draw_ms,
             max_draw_ms = self.draw_max.as_secs_f64() * 1000.0,
             art_resizes = self.art_resizes,
+            dropped_log_lines = logging::dropped_lines(),
             active_effects,
             tick_fps = app.animation_tick_fps(),
             draw_fps = app.animation_draw_fps(),
@@ -174,16 +344,16 @@ pub async fn run(
     zoom: zoom::ZoomHandle,
     current_version: &'static str,
 ) -> Result<()> {
-    // Resolve cross-platform dirs; logging + PID registry degrade gracefully if absent.
-    let dirs = directories::ProjectDirs::from("", "", "yututui");
-    let _log_guard = dirs.as_ref().and_then(|d| {
-        let dir = d.cache_dir();
+    // Use the centralized paths so verification/perf runs honor YTM_* overrides all the way
+    // through logging and the mpv lifetime registry. Both degrade gracefully if unavailable.
+    let cache_dir = crate::paths::cache_dir();
+    let _log_guard = cache_dir.as_ref().and_then(|dir| {
         std::fs::create_dir_all(dir).ok()?;
         logging::init(dir)
     });
     startup.mark("logging_init_called");
     startup.enable_logging();
-    let data_dir = dirs.as_ref().map(|d| d.data_dir().to_path_buf());
+    let data_dir = crate::paths::data_dir();
     if let Some(dir) = &data_dir {
         let _ = std::fs::create_dir_all(dir);
         // Reap any mpv leaked by a prior run that died uncatchably (SIGKILL/power loss).
@@ -232,8 +402,8 @@ pub async fn run(
     // render (`recorder.supported` is only consulted when the user opens/uses the recorder),
     // and the probe is an `mpv --version` fork/exec (~40-60ms) that must run *after*
     // `tools::init` sets `mpv_program()`, so it probes the selected mpv, not the fallback.
-    if let Some(d) = dirs.as_ref() {
-        app.recorder.temp_dir = d.cache_dir().join("recordings");
+    if let Some(dir) = cache_dir.as_ref() {
+        app.recorder.temp_dir = dir.join("recordings");
     }
     // Zoom wiring before `apply_config`, which restores the persisted scale (the handle
     // carries the probed mode, so an unsupported terminal never sees a scale above 1).
@@ -316,7 +486,7 @@ pub async fn run(
     // Runs after `tools::init` so the capability probe hits the *selected* mpv (via
     // `mpv_program()`), and before the event loop starts, so a recording (an explicit user
     // action) can never race the temp-dir wipe.
-    if dirs.is_some() {
+    if cache_dir.is_some() {
         let temp_dir = app.recorder.temp_dir.clone();
         let _ = std::fs::remove_dir_all(&temp_dir);
         let _ = std::fs::create_dir_all(&temp_dir);
@@ -514,8 +684,7 @@ pub async fn run(
 
     let mut events = EventStream::new();
     let mut input = event::Translator::default();
-    let mut ime_scrub = tokio::time::interval(Duration::from_millis(80));
-    ime_scrub.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    let mut ime_scrub = ImeScrubBurst::new();
     // Only polled while a transient status is covering the song title; lets the reducer
     // expire it (and restore the title) ~3s after it was shown. Idle otherwise.
     let mut status_tick = tokio::time::interval(Duration::from_millis(250));
@@ -525,15 +694,17 @@ pub async fn run(
     // ticks). Drives the max-duration force-split.
     let mut recording_tick = tokio::time::interval(Duration::from_secs(1));
     recording_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
-    // Drives the optional player-view animations at the configured frame rate - but only ticks
-    // while `app.animation_active()` holds (player view, master + an effect enabled, a track
-    // playing, focused unless the user opted out of focus-pausing). With every animation toggle
-    // off (the default) the guard is false, this timer never wakes, and the loop stays exactly as
-    // light as before.
-    // `Skip` drops missed frames so a busy moment can't build up a backlog of redraws. The period
-    // is rebuilt below whenever the user changes the rate in Settings.
-    let mut anim_fps = app.animation_tick_fps();
-    let mut anim_tick = anim_interval(anim_fps);
+    // Drive optional animations only at the historical draw-due logical ticks. The deadline moves
+    // by a variable number of the original integer logical periods, so canvas/ambient/mascot/
+    // marquee modes avoid intermediate wakes without changing visible due times or phase.
+    let mut anim_tick_fps = app.animation_tick_fps();
+    let mut anim_draw_fps = app.animation_draw_fps();
+    let mut anim_schedule = AnimationSchedule::new(
+        Instant::now(),
+        anim_tick_fps,
+        app.animation_ticks_until_next_draw(),
+    );
+    let mut anim_was_active = false;
     // Every actor is up and the reducer loop is one statement away from draining `worker_rx`:
     // now start the control server and publish the instance descriptor. Doing it here (rather
     // than during setup) means a `ytt -r` that discovers the descriptor is guaranteed something
@@ -552,7 +723,7 @@ pub async fn run(
 
     let mut pending_worker_msgs: VecDeque<Msg> = VecDeque::new();
 
-    while !app.should_quit {
+    'main_loop: while !app.should_quit {
         if app.dirty {
             if draw_app_frame(terminal, &mut app, &mut perf)? {
                 finish_draw_cycle(&mut app);
@@ -563,18 +734,53 @@ pub async fn run(
             }
         }
 
-        // Mostly blocks until input or a worker message arrives. Outside text-entry fields,
-        // a low-rate redraw scrubs IME preedit text that some terminals paint without
-        // sending an input event to the app.
+        // A render can start/stop a selected-row marquee, and reducer turns can change the active
+        // effect mix or configured FPS. Activation/tick-rate changes start a new logical grid;
+        // draw-rate changes keep that grid and only reset credit. The common active path is three
+        // scalar comparisons, and the inactive path never polls the timer.
+        let animation_active = app.animation_active();
+        let new_tick_fps = app.animation_tick_fps();
+        let new_draw_fps = app.animation_draw_fps();
+        if animation_active && (!anim_was_active || new_tick_fps != anim_tick_fps) {
+            app.reset_animation_cadence();
+            anim_schedule.reset(
+                Instant::now(),
+                new_tick_fps,
+                app.animation_ticks_until_next_draw(),
+            );
+        } else if animation_active && new_draw_fps != anim_draw_fps {
+            // The legacy logical timer did not move when the active effect mix changed its draw
+            // credit. Reset only that credit and keep the next wake on the existing tick grid.
+            app.reset_animation_cadence();
+            anim_schedule.arm_next(app.animation_ticks_until_next_draw());
+        }
+        anim_was_active = animation_active;
+        anim_tick_fps = new_tick_fps;
+        anim_draw_fps = new_draw_fps;
+
+        // Mostly blocks until input or a worker message arrives. A bounded repaint burst after
+        // relevant terminal activity scrubs IME preedit text that some terminals paint without
+        // sending it through the app, then parks completely at idle.
         let msg = if !pending_worker_msgs.is_empty() {
-            let mut polled_input = None;
-            match event::poll_terminal_input_now(&mut events, &mut input, &zoom, &mut polled_input)
-            {
-                event::InputPoll::Ready => polled_input.expect("ready input message"),
-                event::InputPoll::Empty => pending_worker_msgs
-                    .pop_front()
-                    .expect("pending worker message"),
-                event::InputPoll::Closed => break,
+            loop {
+                match events.next().now_or_never() {
+                    Some(Some(Ok(ev))) => {
+                        if terminal_event_arms_ime_scrub(&ev, app.should_scrub_ime_preedit()) {
+                            ime_scrub.arm();
+                        }
+                        let (cs, rs) = zoom.mouse_scale();
+                        if let Some(msg) = input.translate(ev, cs, rs) {
+                            break msg;
+                        }
+                    }
+                    Some(Some(Err(_))) => continue,
+                    Some(None) => break 'main_loop,
+                    None => {
+                        break pending_worker_msgs
+                            .pop_front()
+                            .expect("pending worker message");
+                    }
+                }
             }
         } else {
             tokio::select! {
@@ -583,6 +789,12 @@ pub async fn run(
                     // virtual grid, so hit-testing (and double-click identity) stay correct
                     // while the UI is scaled.
                     Some(Ok(ev)) => {
+                        if terminal_event_arms_ime_scrub(
+                            &ev,
+                            app.should_scrub_ime_preedit(),
+                        ) {
+                            ime_scrub.arm();
+                        }
                         let (cs, rs) = zoom.mouse_scale();
                         match input.translate(ev, cs, rs) {
                             Some(m) => m,
@@ -623,7 +835,8 @@ pub async fn run(
                     }
                     continue;
                 },
-                _ = ime_scrub.tick(), if app.should_scrub_ime_preedit() => {
+                _ = ime_scrub.tick(), if ime_scrub.active() && app.should_scrub_ime_preedit() => {
+                    ime_scrub.consume_tick();
                     if draw_app_frame(terminal, &mut app, &mut perf)? {
                         finish_draw_cycle(&mut app);
                     }
@@ -631,7 +844,26 @@ pub async fn run(
                     continue;
                 },
                 _ = status_tick.tick(), if app.status_visible() => Msg::StatusTick,
-                _ = anim_tick.tick(), if app.animation_active() => Msg::AnimTick,
+                _ = tokio::time::sleep_until(tokio::time::Instant::from_std(anim_schedule.deadline())),
+                    if app.animation_active() => {
+                    let now = Instant::now();
+                    let available = anim_schedule.available_ticks(now);
+                    let logical_ticks = app.animation_ticks_through_latest_draw(available);
+                    if logical_ticks == 0 {
+                        // `sleep_until` cannot normally complete early. If the platform clock
+                        // conversion ever rounds across the boundary, re-arm instead of drawing a
+                        // phase that was not visible on the legacy logical-tick grid.
+                        app.reset_animation_cadence();
+                        anim_schedule.reset(
+                            now,
+                            app.animation_tick_fps(),
+                            app.animation_ticks_until_next_draw(),
+                        );
+                        continue 'main_loop;
+                    }
+                    anim_schedule.consume_ticks(logical_ticks);
+                    Msg::AnimTick(logical_ticks)
+                },
                 _ = recording_tick.tick(), if app.recorder_active() => Msg::RecordingTick,
                 _ = media_pump.tick(), if media.wants_pump() => {
                     media.pump();
@@ -640,35 +872,49 @@ pub async fn run(
             }
         };
 
-        let resized_artwork = matches!(&msg, Msg::ArtworkResized(_));
-        // AnimTick/StatusTick only advance animations / expire the toast - they can't touch
-        // anything a media snapshot reads, so skip rebuilding it (snapshot construction
-        // allocates ~10 Strings, and AnimTick fires at up to the configured FPS).
-        let media_inert = matches!(&msg, Msg::AnimTick | Msg::StatusTick);
-        let media_before = (!media_inert).then(|| app.media_fingerprint());
-        for cmd in app.update(msg) {
-            // Desktop notifications are handled here (not in `RuntimeHandles`) because the OSC
-            // path writes to the terminal's stdout, which this scope owns; do it between frames
-            // (before the draw below) so it never interleaves with a partial frame.
-            if let Cmd::DesktopNotify { title, body } = cmd {
-                notifier.emit(&title, &body);
-                continue;
+        let animation_wake = matches!(&msg, Msg::AnimTick(_));
+        if !animation_wake && animation_active {
+            // The old loop advanced logical phase even on ticks that did not redraw. Lazily apply
+            // those elapsed ticks before an unrelated event can trigger a render or arm an FX;
+            // this adds no timer wake and keeps interaction-time phase/duration unchanged.
+            let available = anim_schedule.available_ticks(Instant::now());
+            if available > 0 {
+                let cmds = app.update(Msg::AnimTick(available));
+                debug_assert!(cmds.is_empty(), "animation phase sync emitted commands");
+                anim_schedule.consume_ticks(available);
+                anim_schedule.arm_next(app.animation_ticks_until_next_draw());
             }
-            handles.dispatch(&mut app, cmd);
+        }
+        let paired_progress = take_adjacent_player_progress_pair(&msg, &mut pending_worker_msgs);
+        let observer_plan = ObserverPlan::for_messages(&msg, paired_progress.as_ref());
+        let was_in_text_entry = !app.should_scrub_ime_preedit();
+
+        let resized_artwork = matches!(&msg, Msg::ArtworkResized(_))
+            || matches!(&paired_progress, Some(Msg::ArtworkResized(_)));
+        // Progress updates only interpolation/live-sync clocks. Neither clock is a projected
+        // facet: OS media and remote clients interpolate elapsed independently, while seeks bump
+        // `position_epoch` through a different message. Skip both hashes on this high-rate path.
+        let media_before = observer_plan.project_state.then(|| app.media_fingerprint());
+        for msg in std::iter::once(msg).chain(paired_progress) {
+            for cmd in app.update(msg) {
+                // Desktop notifications are handled here (not in `RuntimeHandles`) because the
+                // OSC path writes to the terminal's stdout, which this scope owns; do it between
+                // frames (before the draw below) so it never interleaves with a partial frame.
+                if let Cmd::DesktopNotify { title, body } = cmd {
+                    notifier.emit(&title, &body);
+                    continue;
+                }
+                handles.dispatch(&mut app, cmd);
+            }
+        }
+        if animation_wake {
+            anim_schedule.arm_next(app.animation_ticks_until_next_draw());
+        }
+        if was_in_text_entry && app.should_scrub_ime_preedit() {
+            ime_scrub.arm();
         }
         if resized_artwork {
             perf.record_art_resize();
-        }
-
-        // The frame rate may have changed in Settings (committed to `config.animations` on close).
-        // Rebuild the tick so the new rate applies without a relaunch - only when it actually
-        // changed, so the common path costs one `u16` compare. Kept before the draw so the new
-        // cadence is in force for this iteration.
-        let new_fps = app.animation_tick_fps();
-        if new_fps != anim_fps {
-            anim_fps = new_fps;
-            app.reset_animation_cadence();
-            anim_tick = anim_interval(anim_fps);
         }
 
         // Draw first, so the keypress lands on screen with the least latency. Everything below
@@ -679,21 +925,22 @@ pub async fn run(
             finish_draw_cycle(&mut app);
         }
 
-        // Mirror the post-update state to the OS media session: the facade diffs, so
-        // this is one comparison when nothing media-visible changed. The enabled flag
-        // tracks the Settings toggle live. The scrobbler taps the same snapshot first -
-        // it must keep working when media controls are disabled (publish early-returns).
-        // Scrobble cadence is unaffected by the inert skip: elapsed time is credited from
-        // the 1 Hz PlayerTimePos observations, which always take this path.
-        let media_enabled = app.config.effective_media_controls();
-        let media_enabled_changed = media.set_enabled(media_enabled);
-        let media_observed_turn = media_before.is_some();
+        // Only a turn that can mutate projected state may toggle/rebuild OS metadata. Progress
+        // still checks the independent heartbeat gate below, so scrobbling remains ~1 Hz even
+        // when media controls are disabled or no remote topic is subscribed.
+        let (media_enabled_changed, media_enable_publish_due) = if observer_plan.project_state {
+            let media_enabled = app.config.effective_media_controls();
+            let changed = media.set_enabled(media_enabled);
+            (changed, changed && media_enabled)
+        } else {
+            (false, false)
+        };
         let media_changed = media_before.is_some_and(|before| before != app.media_fingerprint());
-        let scrobble_due = media_observed_turn
+        let scrobble_due = observer_plan.drive_scrobble_heartbeat
             && app.media_scrobble_heartbeat_active()
             && handles.scrobble_heartbeat_due();
-        let publish_due = media_changed || (media_enabled_changed && media_enabled);
-        if media_changed || scrobble_due || publish_due {
+        let publish_due = media_changed || media_enable_publish_due;
+        if scrobble_due || publish_due {
             let snapshot = app.media_snapshot();
             if media_changed || scrobble_due {
                 handles.scrobble_observe(&snapshot);
@@ -702,9 +949,10 @@ pub async fn run(
                 media.publish(snapshot);
             }
         }
-        // v8 push: fingerprint-diffed internally. Avoid building the borrowed core view
-        // on idle standalone turns after the publisher has primed its baselines.
-        if !media_inert
+        // Remote elapsed remains outside the player fingerprint. Match origin's observer call
+        // gates so late subscriptions and follow-up snapshot ordering stay byte-for-byte stable;
+        // unchanged turns perform only borrowed comparisons and never build owned models.
+        if observer_plan != ObserverPlan::INERT
             && let Some(publisher) = publisher.as_mut()
             && publisher.should_observe(media_changed || media_enabled_changed)
         {
@@ -755,9 +1003,12 @@ pub async fn run(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
     use std::time::{Duration, Instant};
 
-    use crate::app::App;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    use crate::app::{App, Msg, PlayerMsg};
 
     use super::*;
 
@@ -792,15 +1043,155 @@ mod tests {
         assert_eq!(stats.art_resizes, 0);
     }
 
-    #[tokio::test]
-    async fn animation_tick_period_clamps_extreme_frame_rates() {
+    #[test]
+    fn animation_schedule_uses_the_legacy_integer_tick_grid() {
         assert_eq!(anim_tick_period(0), Duration::from_millis(1000));
         assert_eq!(anim_tick_period(1), Duration::from_millis(1000));
         assert_eq!(anim_tick_period(60), Duration::from_millis(16));
         assert_eq!(anim_tick_period(2_000), Duration::from_millis(1));
 
-        let interval = anim_interval(30);
-        assert_eq!(interval.period(), Duration::from_millis(33));
+        let base = Instant::now();
+        let mut schedule = AnimationSchedule::new(base, 30, 2);
+        assert_eq!(
+            schedule.deadline().saturating_duration_since(base),
+            Duration::from_millis(66)
+        );
+        assert_eq!(
+            schedule.available_ticks(base + Duration::from_millis(65)),
+            1
+        );
+        assert_eq!(
+            schedule.available_ticks(base + Duration::from_millis(66)),
+            2
+        );
+
+        schedule.consume_ticks(2);
+        schedule.arm_next(1);
+        assert_eq!(
+            schedule.deadline().saturating_duration_since(base),
+            Duration::from_millis(99)
+        );
+
+        // If that wake is delivered at 150 ms, the app selects frame 3 as the newest visible
+        // phase. Consuming its three logical ticks and re-arming two more stays on 165 ms.
+        let mut delayed = AnimationSchedule::new(base, 30, 2);
+        assert_eq!(
+            delayed.available_ticks(base + Duration::from_millis(150)),
+            4
+        );
+        delayed.consume_ticks(3);
+        delayed.arm_next(2);
+        assert_eq!(
+            delayed.deadline().saturating_duration_since(base),
+            Duration::from_millis(165)
+        );
+    }
+
+    #[tokio::test]
+    async fn ime_scrub_burst_parks_after_exactly_640_ms_worth_of_ticks() {
+        assert_eq!(
+            IME_SCRUB_PERIOD * u32::from(IME_SCRUB_TICKS),
+            Duration::from_millis(640)
+        );
+
+        let mut burst = ImeScrubBurst::new();
+        assert!(!burst.active());
+        assert_eq!(burst.interval.period(), IME_SCRUB_PERIOD);
+
+        burst.arm();
+        for _ in 0..IME_SCRUB_TICKS - 1 {
+            assert!(burst.active());
+            burst.consume_tick();
+        }
+        assert!(burst.active());
+        burst.consume_tick();
+        assert!(!burst.active());
+
+        // A new terminal event restores the whole window rather than continuing a stale one.
+        burst.arm();
+        assert_eq!(burst.remaining, IME_SCRUB_TICKS);
+    }
+
+    #[test]
+    fn ime_scrub_arming_events_respect_text_entry() {
+        let key = TerminalEvent::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        let paste = TerminalEvent::Paste("x".to_owned());
+        let resize = TerminalEvent::Resize(120, 40);
+
+        assert!(terminal_event_arms_ime_scrub(&key, true));
+        assert!(!terminal_event_arms_ime_scrub(&key, false));
+        assert!(terminal_event_arms_ime_scrub(&paste, true));
+        assert!(!terminal_event_arms_ime_scrub(&paste, false));
+        assert!(terminal_event_arms_ime_scrub(&resize, false));
+        assert!(terminal_event_arms_ime_scrub(
+            &TerminalEvent::FocusGained,
+            false
+        ));
+        assert!(!terminal_event_arms_ime_scrub(
+            &TerminalEvent::FocusLost,
+            true
+        ));
+    }
+
+    #[test]
+    fn only_adjacent_time_and_cache_messages_share_an_owner_turn() {
+        let first = Msg::Player(PlayerMsg::TimePos(7.0));
+        let mut adjacent = VecDeque::from([Msg::Player(PlayerMsg::CacheTime(Some(9.0)))]);
+        assert!(matches!(
+            take_adjacent_player_progress_pair(&first, &mut adjacent),
+            Some(Msg::Player(PlayerMsg::CacheTime(Some(9.0))))
+        ));
+        assert!(adjacent.is_empty());
+
+        let mut intervening = VecDeque::from([
+            Msg::Player(PlayerMsg::Duration(Some(180.0))),
+            Msg::Player(PlayerMsg::CacheTime(Some(9.0))),
+        ]);
+        assert!(take_adjacent_player_progress_pair(&first, &mut intervening).is_none());
+        assert!(matches!(
+            intervening.front(),
+            Some(Msg::Player(PlayerMsg::Duration(Some(180.0))))
+        ));
+
+        let reverse = Msg::Player(PlayerMsg::CacheTime(Some(9.0)));
+        let mut adjacent = VecDeque::from([Msg::Player(PlayerMsg::TimePos(7.0))]);
+        assert!(matches!(
+            take_adjacent_player_progress_pair(&reverse, &mut adjacent),
+            Some(Msg::Player(PlayerMsg::TimePos(7.0)))
+        ));
+    }
+
+    #[test]
+    fn progress_turns_skip_media_and_remote_projection_but_keep_scrobble_heartbeat() {
+        for first in [
+            Msg::Player(PlayerMsg::TimePos(7.0)),
+            Msg::Player(PlayerMsg::CacheTime(Some(9.0))),
+        ] {
+            let plan = ObserverPlan::for_messages(&first, None);
+            assert!(!plan.project_state, "progress must skip projection");
+            assert!(
+                plan.drive_scrobble_heartbeat,
+                "progress must retain the 1 Hz scrobble clock"
+            );
+        }
+
+        let first = Msg::Player(PlayerMsg::TimePos(7.0));
+        let paired = Msg::Player(PlayerMsg::CacheTime(Some(9.0)));
+        assert_eq!(
+            ObserverPlan::for_messages(&first, Some(&paired)),
+            ObserverPlan::PROGRESS,
+            "coalescing the two clocks must not re-enable projection"
+        );
+
+        assert_eq!(
+            ObserverPlan::for_messages(&Msg::StatusTick, None),
+            ObserverPlan::INERT
+        );
+        assert_eq!(
+            ObserverPlan::for_messages(&Msg::Player(PlayerMsg::Duration(Some(180.0))), None,),
+            ObserverPlan::PROJECTED,
+            "a real media facet still runs media/remote observers"
+        );
     }
 
     #[test]

--- a/src/terminal_runtime/runner.rs
+++ b/src/terminal_runtime/runner.rs
@@ -2,8 +2,8 @@ use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use crossterm::event::{Event as TerminalEvent, EventStream};
-use futures::{FutureExt, StreamExt};
+use crossterm::event::EventStream;
+use futures::StreamExt;
 use ratatui_image::thread::ResizeRequest;
 use tokio::sync::mpsc;
 use tokio::time::MissedTickBehavior;
@@ -90,63 +90,14 @@ impl AnimationSchedule {
 }
 
 const IME_SCRUB_PERIOD: Duration = Duration::from_millis(80);
-const IME_SCRUB_TICKS: u8 = 8;
 
-/// A short, event-triggered repaint window that clears terminal-owned IME preedit text.
-///
-/// Some terminals paint preedit text without sending it through the application's buffer. A
-/// repaint removes that residue, but polling forever at 12.5 fps burns CPU while the UI is idle.
-/// Re-arm this burst for terminal activity that can leave preedit behind; after eight 80 ms ticks
-/// (640 ms) the interval is parked again.
-struct ImeScrubBurst {
-    interval: tokio::time::Interval,
-    remaining: u8,
-}
-
-impl ImeScrubBurst {
-    fn new() -> Self {
-        let mut interval = tokio::time::interval_at(
-            tokio::time::Instant::now() + IME_SCRUB_PERIOD,
-            IME_SCRUB_PERIOD,
-        );
-        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-        Self {
-            interval,
-            remaining: 0,
-        }
-    }
-
-    fn arm(&mut self) {
-        self.remaining = IME_SCRUB_TICKS;
-        self.interval
-            .reset_at(tokio::time::Instant::now() + IME_SCRUB_PERIOD);
-    }
-
-    fn active(&self) -> bool {
-        self.remaining > 0
-    }
-
-    async fn tick(&mut self) {
-        self.interval.tick().await;
-    }
-
-    fn consume_tick(&mut self) {
-        self.remaining = self.remaining.saturating_sub(1);
-    }
-}
-
-/// Terminal activity that can leave terminal-owned preedit outside an application text field.
-/// Focus gain and resize always arm a cleanup window; keyboard/mouse/paste activity does so only
-/// when the application is not deliberately displaying editable text.
-fn terminal_event_arms_ime_scrub(event: &TerminalEvent, outside_text_entry: bool) -> bool {
-    matches!(
-        event,
-        TerminalEvent::FocusGained | TerminalEvent::Resize(_, _)
-    ) || (outside_text_entry
-        && matches!(
-            event,
-            TerminalEvent::Key(_) | TerminalEvent::Mouse(_) | TerminalEvent::Paste(_)
-        ))
+/// Permanent low-rate repaint clock for terminal-owned IME preedit text. The select branch is
+/// guarded while an application text field is active, but the clock itself never expires: some
+/// terminals repaint preedit without sending any event that could re-arm a bounded timer.
+fn ime_scrub_interval() -> tokio::time::Interval {
+    let mut interval = tokio::time::interval(IME_SCRUB_PERIOD);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    interval
 }
 
 /// Take only an immediately-adjacent time/cache pair. Both messages still pass through
@@ -210,6 +161,7 @@ struct PerfStats {
     enabled: bool,
     last_log: Instant,
     frames: u64,
+    ime_fast_scrubs: u64,
     draw_total: Duration,
     draw_max: Duration,
     art_resizes: u64,
@@ -222,6 +174,7 @@ impl PerfStats {
             enabled,
             last_log: Instant::now(),
             frames: 0,
+            ime_fast_scrubs: 0,
             draw_total: Duration::ZERO,
             draw_max: Duration::ZERO,
             art_resizes: 0,
@@ -240,6 +193,12 @@ impl PerfStats {
     fn record_art_resize(&mut self) {
         if self.enabled {
             self.art_resizes += 1;
+        }
+    }
+
+    fn record_ime_fast_scrub(&mut self) {
+        if self.enabled {
+            self.ime_fast_scrubs += 1;
         }
     }
 
@@ -272,7 +231,8 @@ impl PerfStats {
         .count();
         tracing::info!(
             target: "ytt::perf",
-            frames = self.frames,
+            full_frames = self.frames,
+            ime_fast_scrubs = self.ime_fast_scrubs,
             avg_draw_ms,
             max_draw_ms = self.draw_max.as_secs_f64() * 1000.0,
             art_resizes = self.art_resizes,
@@ -285,6 +245,7 @@ impl PerfStats {
         );
         self.last_log = Instant::now();
         self.frames = 0;
+        self.ime_fast_scrubs = 0;
         self.draw_total = Duration::ZERO;
         self.draw_max = Duration::ZERO;
         self.art_resizes = 0;
@@ -302,6 +263,7 @@ fn draw_app_frame(
     let res = tui::draw_frame(terminal, synchronized, clear_before, |f| ui::render(f, app));
     match res {
         Ok(()) => {
+            app.mark_local_rows_rendered();
             if let Some(start) = start {
                 perf.record_draw(start.elapsed());
             }
@@ -321,6 +283,52 @@ fn draw_app_frame(
 
 fn finish_draw_cycle(app: &mut App) {
     app.dirty = app.clear_before_draw_pending();
+}
+
+/// Attempt the normal render lifecycle while keeping IME freshness fail-closed. A transient full
+/// draw failure may clear `app.dirty`, so the separate flag is set before touching the terminal and
+/// is cleared only after both a successful draw and the normal finish step.
+fn draw_full_app_frame(
+    terminal: &mut tui::AppTerminal,
+    app: &mut App,
+    perf: &mut PerfStats,
+    reducer_turn_unrendered: &mut bool,
+) -> std::io::Result<bool> {
+    *reducer_turn_unrendered = true;
+    let rendered = draw_app_frame(terminal, app, perf)?;
+    if rendered {
+        finish_draw_cycle(app);
+        *reducer_turn_unrendered = false;
+    }
+    Ok(rendered)
+}
+
+fn ime_scrub_state_requires_full_draw(
+    reducer_turn_unrendered: bool,
+    dirty: bool,
+    clear_before_draw_pending: bool,
+    animation_active: bool,
+    radio_stream_active: bool,
+) -> bool {
+    reducer_turn_unrendered
+        || dirty
+        || clear_before_draw_pending
+        || animation_active
+        || radio_stream_active
+}
+
+fn ime_scrub_requires_full_draw(app: &App, reducer_turn_unrendered: bool) -> bool {
+    ime_scrub_state_requires_full_draw(
+        reducer_turn_unrendered,
+        app.dirty,
+        app.clear_before_draw_pending(),
+        // Active animation renders can depend on wall-clock interpolation between reducer ticks.
+        // Keep origin's 80 ms full redraw in those windows so visible timing remains exact.
+        app.animation_active(),
+        // Live-radio rendering reads `cache_time_at.elapsed()` for its stale-edge verdict, even
+        // when the stream was started outside dedicated Radio mode.
+        app.current_is_radio_stream(),
+    ) || !app.ime_scrub_local_projection_fresh()
 }
 
 #[cfg(windows)]
@@ -684,7 +692,7 @@ pub async fn run(
 
     let mut events = EventStream::new();
     let mut input = event::Translator::default();
-    let mut ime_scrub = ImeScrubBurst::new();
+    let mut ime_scrub = ime_scrub_interval();
     // Only polled while a transient status is covering the song title; lets the reducer
     // expire it (and restore the title) ~3s after it was shown. Idle otherwise.
     let mut status_tick = tokio::time::interval(Duration::from_millis(250));
@@ -722,12 +730,13 @@ pub async fn run(
     };
 
     let mut pending_worker_msgs: VecDeque<Msg> = VecDeque::new();
+    // Startup mutates App after the first paint. Until a later successful full render proves the
+    // terminal matches all reducer-owned state, the IME clock must take the normal draw path.
+    let mut reducer_turn_unrendered = true;
 
     'main_loop: while !app.should_quit {
         if app.dirty {
-            if draw_app_frame(terminal, &mut app, &mut perf)? {
-                finish_draw_cycle(&mut app);
-            }
+            draw_full_app_frame(terminal, &mut app, &mut perf, &mut reducer_turn_unrendered)?;
             perf.maybe_log(&app);
             if app.dirty {
                 continue;
@@ -758,29 +767,18 @@ pub async fn run(
         anim_tick_fps = new_tick_fps;
         anim_draw_fps = new_draw_fps;
 
-        // Mostly blocks until input or a worker message arrives. A bounded repaint burst after
-        // relevant terminal activity scrubs IME preedit text that some terminals paint without
-        // sending it through the app, then parks completely at idle.
+        // Mostly blocks until input or a worker message arrives. Outside text-entry fields,
+        // a low-rate redraw scrubs IME preedit text that some terminals paint without
+        // sending an input event to the app.
         let msg = if !pending_worker_msgs.is_empty() {
-            loop {
-                match events.next().now_or_never() {
-                    Some(Some(Ok(ev))) => {
-                        if terminal_event_arms_ime_scrub(&ev, app.should_scrub_ime_preedit()) {
-                            ime_scrub.arm();
-                        }
-                        let (cs, rs) = zoom.mouse_scale();
-                        if let Some(msg) = input.translate(ev, cs, rs) {
-                            break msg;
-                        }
-                    }
-                    Some(Some(Err(_))) => continue,
-                    Some(None) => break 'main_loop,
-                    None => {
-                        break pending_worker_msgs
-                            .pop_front()
-                            .expect("pending worker message");
-                    }
-                }
+            let mut polled_input = None;
+            match event::poll_terminal_input_now(&mut events, &mut input, &zoom, &mut polled_input)
+            {
+                event::InputPoll::Ready => polled_input.expect("ready input message"),
+                event::InputPoll::Empty => pending_worker_msgs
+                    .pop_front()
+                    .expect("pending worker message"),
+                event::InputPoll::Closed => break,
             }
         } else {
             tokio::select! {
@@ -789,12 +787,6 @@ pub async fn run(
                     // virtual grid, so hit-testing (and double-click identity) stay correct
                     // while the UI is scaled.
                     Some(Ok(ev)) => {
-                        if terminal_event_arms_ime_scrub(
-                            &ev,
-                            app.should_scrub_ime_preedit(),
-                        ) {
-                            ime_scrub.arm();
-                        }
                         let (cs, rs) = zoom.mouse_scale();
                         match input.translate(ev, cs, rs) {
                             Some(m) => m,
@@ -827,18 +819,50 @@ pub async fn run(
                 },
                 Some(result) = player_ready_rx.recv() => {
                     handles.handle_player_ready(result, &player_runtime, &mut app);
+                    reducer_turn_unrendered = true;
                     if app.dirty {
-                        if draw_app_frame(terminal, &mut app, &mut perf)? {
-                            finish_draw_cycle(&mut app);
-                        }
+                        draw_full_app_frame(
+                            terminal,
+                            &mut app,
+                            &mut perf,
+                            &mut reducer_turn_unrendered,
+                        )?;
                         perf.maybe_log(&app);
                     }
                     continue;
                 },
-                _ = ime_scrub.tick(), if ime_scrub.active() && app.should_scrub_ime_preedit() => {
-                    ime_scrub.consume_tick();
-                    if draw_app_frame(terminal, &mut app, &mut perf)? {
-                        finish_draw_cycle(&mut app);
+                _ = ime_scrub.tick(), if app.should_scrub_ime_preedit() => {
+                    let fast_succeeded = if ime_scrub_requires_full_draw(
+                        &app,
+                        reducer_turn_unrendered,
+                    ) {
+                        false
+                    } else {
+                        match tui::scrub_ime_preedit(
+                            terminal,
+                            app.synchronized_draw_active(),
+                        ) {
+                            Ok(tui::ImeScrubResult::Fast) => {
+                                perf.record_ime_fast_scrub();
+                                true
+                            }
+                            Ok(tui::ImeScrubResult::Resized) => false,
+                            Err(error) => {
+                                tracing::warn!(
+                                    error = %error,
+                                    "IME terminal scrub failed; retrying with a full draw"
+                                );
+                                false
+                            }
+                        }
+                    };
+                    if !fast_succeeded {
+                        draw_full_app_frame(
+                            terminal,
+                            &mut app,
+                            &mut perf,
+                            &mut reducer_turn_unrendered,
+                        )?;
                     }
                     perf.maybe_log(&app);
                     continue;
@@ -887,7 +911,6 @@ pub async fn run(
         }
         let paired_progress = take_adjacent_player_progress_pair(&msg, &mut pending_worker_msgs);
         let observer_plan = ObserverPlan::for_messages(&msg, paired_progress.as_ref());
-        let was_in_text_entry = !app.should_scrub_ime_preedit();
 
         let resized_artwork = matches!(&msg, Msg::ArtworkResized(_))
             || matches!(&paired_progress, Some(Msg::ArtworkResized(_)));
@@ -895,6 +918,7 @@ pub async fn run(
         // facet: OS media and remote clients interpolate elapsed independently, while seeks bump
         // `position_epoch` through a different message. Skip both hashes on this high-rate path.
         let media_before = observer_plan.project_state.then(|| app.media_fingerprint());
+        reducer_turn_unrendered = true;
         for msg in std::iter::once(msg).chain(paired_progress) {
             for cmd in app.update(msg) {
                 // Desktop notifications are handled here (not in `RuntimeHandles`) because the
@@ -910,9 +934,6 @@ pub async fn run(
         if animation_wake {
             anim_schedule.arm_next(app.animation_ticks_until_next_draw());
         }
-        if was_in_text_entry && app.should_scrub_ime_preedit() {
-            ime_scrub.arm();
-        }
         if resized_artwork {
             perf.record_art_resize();
         }
@@ -921,8 +942,8 @@ pub async fn run(
         // is pure output bookkeeping - it reads post-update state but feeds no rendering - so
         // running it *after* the frame lags the OS/remote surfaces by well under one frame while
         // leaving the resting on-screen output identical.
-        if app.dirty && draw_app_frame(terminal, &mut app, &mut perf)? {
-            finish_draw_cycle(&mut app);
+        if app.dirty {
+            draw_full_app_frame(terminal, &mut app, &mut perf, &mut reducer_turn_unrendered)?;
         }
 
         // Only a turn that can mutate projected state may toggle/rebuild OS metadata. Progress
@@ -1006,8 +1027,6 @@ mod tests {
     use std::collections::VecDeque;
     use std::time::{Duration, Instant};
 
-    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-
     use crate::app::{App, Msg, PlayerMsg};
 
     use super::*;
@@ -1018,29 +1037,35 @@ mod tests {
             enabled: false,
             last_log: Instant::now() - Duration::from_secs(10),
             frames: 0,
+            ime_fast_scrubs: 0,
             draw_total: Duration::ZERO,
             draw_max: Duration::ZERO,
             art_resizes: 0,
         };
         stats.record_draw(Duration::from_millis(7));
         stats.record_art_resize();
+        stats.record_ime_fast_scrub();
         assert_eq!(stats.frames, 0);
         assert_eq!(stats.art_resizes, 0);
+        assert_eq!(stats.ime_fast_scrubs, 0);
 
         stats.enabled = true;
         stats.record_draw(Duration::from_millis(7));
         stats.record_draw(Duration::from_millis(11));
         stats.record_art_resize();
+        stats.record_ime_fast_scrub();
         assert_eq!(stats.frames, 2);
         assert_eq!(stats.draw_total, Duration::from_millis(18));
         assert_eq!(stats.draw_max, Duration::from_millis(11));
         assert_eq!(stats.art_resizes, 1);
+        assert_eq!(stats.ime_fast_scrubs, 1);
 
         stats.maybe_log(&App::new(100));
         assert_eq!(stats.frames, 0);
         assert_eq!(stats.draw_total, Duration::ZERO);
         assert_eq!(stats.draw_max, Duration::ZERO);
         assert_eq!(stats.art_resizes, 0);
+        assert_eq!(stats.ime_fast_scrubs, 0);
     }
 
     #[test]
@@ -1088,49 +1113,69 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ime_scrub_burst_parks_after_exactly_640_ms_worth_of_ticks() {
-        assert_eq!(
-            IME_SCRUB_PERIOD * u32::from(IME_SCRUB_TICKS),
-            Duration::from_millis(640)
-        );
+    async fn ime_scrub_clock_retains_the_permanent_origin_period() {
+        let mut interval = ime_scrub_interval();
+        assert_eq!(IME_SCRUB_PERIOD, Duration::from_millis(80));
+        assert_eq!(interval.period(), Duration::from_millis(80));
 
-        let mut burst = ImeScrubBurst::new();
-        assert!(!burst.active());
-        assert_eq!(burst.interval.period(), IME_SCRUB_PERIOD);
-
-        burst.arm();
-        for _ in 0..IME_SCRUB_TICKS - 1 {
-            assert!(burst.active());
-            burst.consume_tick();
+        // The removed burst stopped after eight ticks. Reaching ten ticks without any event-based
+        // re-arming proves the scrub clock remains capable of repainting terminal-owned preedit.
+        for _ in 0..10 {
+            tokio::time::timeout(Duration::from_millis(250), interval.tick())
+                .await
+                .expect("permanent IME scrub clock must not expire");
         }
-        assert!(burst.active());
-        burst.consume_tick();
-        assert!(!burst.active());
-
-        // A new terminal event restores the whole window rather than continuing a stale one.
-        burst.arm();
-        assert_eq!(burst.remaining, IME_SCRUB_TICKS);
     }
 
     #[test]
-    fn ime_scrub_arming_events_respect_text_entry() {
-        let key = TerminalEvent::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
-        let paste = TerminalEvent::Paste("x".to_owned());
-        let resize = TerminalEvent::Resize(120, 40);
+    fn ime_scrub_gate_fails_closed_for_state_and_wall_clock_rendering() {
+        assert!(!ime_scrub_state_requires_full_draw(
+            false, false, false, false, false
+        ));
+        assert!(ime_scrub_state_requires_full_draw(
+            true, false, false, false, false
+        ));
+        assert!(ime_scrub_state_requires_full_draw(
+            false, true, false, false, false
+        ));
+        assert!(
+            ime_scrub_state_requires_full_draw(false, false, true, false, false),
+            "a pending native-image clear must go through the consuming full-draw path"
+        );
+        assert!(
+            ime_scrub_state_requires_full_draw(false, false, false, true, false),
+            "animation-active views retain origin's wall-clock full draws"
+        );
+        assert!(
+            ime_scrub_state_requires_full_draw(false, false, false, false, true),
+            "live-radio stale-edge rendering retains origin's wall-clock full draws"
+        );
+    }
 
-        assert!(terminal_event_arms_ime_scrub(&key, true));
-        assert!(!terminal_event_arms_ime_scrub(&key, false));
-        assert!(terminal_event_arms_ime_scrub(&paste, true));
-        assert!(!terminal_event_arms_ime_scrub(&paste, false));
-        assert!(terminal_event_arms_ime_scrub(&resize, false));
-        assert!(terminal_event_arms_ime_scrub(
-            &TerminalEvent::FocusGained,
-            false
-        ));
-        assert!(!terminal_event_arms_ime_scrub(
-            &TerminalEvent::FocusLost,
-            true
-        ));
+    #[test]
+    fn reducer_turn_gate_catches_visible_updates_that_do_not_set_dirty() {
+        let mut app = App::new(100);
+        app.dirty = false;
+        let status = crate::update::UpdateStatus {
+            current: "1.0.0".to_owned(),
+            latest: "v1.0.1".to_owned(),
+            available: true,
+            first_seen: false,
+            method: crate::update::InstallMethod::Cargo,
+        };
+
+        let _ = app.update(Msg::UpdateChecked(status));
+
+        assert!(
+            !app.dirty,
+            "this persistent surface update intentionally skips dirty"
+        );
+        assert!(app.overlays.update_status.is_some());
+        assert!(ime_scrub_requires_full_draw(&app, true));
+        assert!(
+            !ime_scrub_requires_full_draw(&app, false),
+            "after a successful full draw the same stable non-Local state may use the fast path"
+        );
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -4,7 +4,7 @@
 //! The panic hook is additionally wrapped in `player::lifetime` to kill mpv on a
 //! crash before the terminal is restored.
 
-use std::io;
+use std::io::{self, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crossterm::event::{
@@ -22,6 +22,15 @@ use crate::zoom::{ZoomBackend, ZoomHandle};
 /// At zoom 1 (always, on terminals without the text sizing protocol) the wrapper is a
 /// transparent pass-through of ratatui's `DefaultTerminal`.
 pub type AppTerminal = Terminal<ZoomBackend<io::Stdout>>;
+
+/// Outcome of the low-cost terminal-owned IME preedit scrub.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ImeScrubResult {
+    /// The unchanged terminal apply sequence completed successfully.
+    Fast,
+    /// The backend size differs from ratatui's current frame; render a full frame immediately.
+    Resized,
+}
 
 static KEYBOARD_ENHANCEMENT_ENABLED: AtomicBool = AtomicBool::new(false);
 
@@ -70,10 +79,7 @@ pub fn draw_synced<F>(terminal: &mut AppTerminal, render: F) -> io::Result<()>
 where
     F: FnOnce(&mut Frame),
 {
-    let _ = execute!(io::stdout(), BeginSynchronizedUpdate);
-    let res = terminal.draw(render);
-    let _ = execute!(io::stdout(), EndSynchronizedUpdate);
-    res.map(|_| ())
+    with_synchronized_update(&mut io::stdout(), |_| draw_frame_inner(terminal, render))
 }
 
 /// Draw one frame, using synchronized update only when the caller expects large image/canvas
@@ -87,34 +93,117 @@ pub fn draw_frame<F>(
 where
     F: FnOnce(&mut Frame),
 {
+    draw_frame_with_output(
+        terminal,
+        &mut io::stdout(),
+        synchronized,
+        clear_before,
+        render,
+    )
+}
+
+fn draw_frame_with_output<B, W, F>(
+    terminal: &mut Terminal<B>,
+    output: &mut W,
+    synchronized: bool,
+    clear_before: bool,
+    render: F,
+) -> io::Result<()>
+where
+    B: Backend<Error = io::Error>,
+    W: Write,
+    F: FnOnce(&mut Frame),
+{
     if synchronized {
         if !clear_before {
-            return draw_synced(terminal, render);
+            return with_synchronized_update(output, |_| draw_frame_inner(terminal, render));
         }
-        let _ = execute!(io::stdout(), BeginSynchronizedUpdate);
-        let res = (|| {
-            write_vt_clear_for_native_images()?;
+        return with_synchronized_update(output, |output| {
+            write_vt_clear_for_native_images(output)?;
             draw_frame_after_explicit_clear(terminal, render)
-        })();
-        let _ = execute!(io::stdout(), EndSynchronizedUpdate);
-        return res;
+        });
     }
     if clear_before {
-        write_vt_clear_for_native_images()?;
+        write_vt_clear_for_native_images(output)?;
         return draw_frame_after_explicit_clear(terminal, render);
     }
     draw_frame_inner(terminal, render)
 }
 
-fn write_vt_clear_for_native_images() -> io::Result<()> {
-    use io::Write;
-
+fn write_vt_clear_for_native_images(output: &mut impl Write) -> io::Result<()> {
     // Clear native terminal graphics directly. We deliberately do not use `Terminal::clear()` for
     // this path: ratatui preserves the cursor by querying crossterm's cursor position, which can
     // race the event stream on Unix and fail after a 2s ESC[6n timeout during image-heavy redraws.
-    let mut stdout = io::stdout().lock();
-    stdout.write_all(b"\x1b[2J\x1b[H")?;
-    stdout.flush()
+    output.write_all(b"\x1b[2J\x1b[H")?;
+    output.flush()
+}
+
+fn with_synchronized_update<W, T>(
+    output: &mut W,
+    operation: impl FnOnce(&mut W) -> io::Result<T>,
+) -> io::Result<T>
+where
+    W: Write,
+{
+    let _ = execute!(output, BeginSynchronizedUpdate);
+    let result = operation(output);
+    let _ = execute!(output, EndSynchronizedUpdate);
+    result
+}
+
+/// Re-emit ratatui's exact successful unchanged-frame terminal sequence without invoking the UI
+/// render callback or swapping its buffers. In particular, this deliberately does not call
+/// `Terminal::flush()`: after a successful full draw ratatui's current buffer is the reset/blank
+/// one, so diffing it against the displayed previous buffer can emit cells that erase the UI.
+fn scrub_unchanged_terminal<B>(terminal: &mut Terminal<B>) -> Result<(), B::Error>
+where
+    B: Backend,
+{
+    terminal.backend_mut().draw(std::iter::empty())?;
+    terminal.hide_cursor()?;
+    terminal.backend_mut().flush()
+}
+
+fn fullscreen_size_changed<B>(terminal: &mut Terminal<B>) -> Result<bool, B::Error>
+where
+    B: Backend,
+{
+    Ok(terminal.size()? != terminal.get_frame().area().as_size())
+}
+
+fn scrub_ime_preedit_with_output<B, W>(
+    terminal: &mut Terminal<B>,
+    output: &mut W,
+    synchronized: bool,
+    fullscreen: bool,
+) -> io::Result<ImeScrubResult>
+where
+    B: Backend<Error = io::Error>,
+    W: Write,
+{
+    // `Terminal::autoresize()` can clear and flush the visible surface. Merely observe the
+    // backend here; the immediately-following normal full draw performs autoresize inside its
+    // synchronized-update wrapper. Fixed viewports deliberately opt out, matching ratatui.
+    if fullscreen && fullscreen_size_changed(terminal)? {
+        return Ok(ImeScrubResult::Resized);
+    }
+    if synchronized {
+        with_synchronized_update(output, |_| scrub_unchanged_terminal(terminal))?;
+    } else {
+        scrub_unchanged_terminal(terminal)?;
+    }
+    Ok(ImeScrubResult::Fast)
+}
+
+/// Scrub terminal-owned IME preedit while preserving the exact output stream of an unchanged full
+/// draw. A detected resize is reported before any fast-path output so the caller can immediately
+/// perform the normal full render.
+pub fn scrub_ime_preedit(
+    terminal: &mut AppTerminal,
+    synchronized: bool,
+) -> io::Result<ImeScrubResult> {
+    // `init` always constructs this AppTerminal with ratatui's fullscreen viewport.
+    scrub_ime_preedit_with_output(terminal, &mut io::stdout(), synchronized, true)
 }
 
 fn draw_frame_inner<B, F>(terminal: &mut Terminal<B>, render: F) -> Result<(), B::Error>
@@ -228,13 +317,304 @@ fn should_probe_keyboard_enhancement() -> bool {
 #[cfg(test)]
 mod tests {
     use std::convert::Infallible;
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
 
-    use ratatui::backend::{Backend, ClearType, TestBackend, WindowSize};
+    use ratatui::backend::{Backend, ClearType, CrosstermBackend, TestBackend, WindowSize};
     use ratatui::buffer::Cell;
-    use ratatui::layout::{Position, Size};
+    use ratatui::layout::{Position, Rect, Size};
     use ratatui::widgets::Paragraph;
+    use ratatui::{Terminal, TerminalOptions, Viewport};
 
-    use super::{draw_frame_after_explicit_clear, draw_frame_inner};
+    use super::{
+        ImeScrubResult, draw_frame_after_explicit_clear, draw_frame_inner, draw_frame_with_output,
+        scrub_ime_preedit_with_output, scrub_unchanged_terminal,
+    };
+    use crate::zoom::{ZoomBackend, ZoomHandle, ZoomMode};
+
+    /// Shared byte sink: the terminal backend and synchronized-update writer use clones so tests
+    /// observe their real interleaving in one stream.
+    #[derive(Clone, Default)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl CaptureWriter {
+        fn clear(&self) {
+            self.0.lock().unwrap().clear();
+        }
+
+        fn bytes(&self) -> Vec<u8> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    impl Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct IoTestBackend {
+        inner: TestBackend,
+        draw_calls: usize,
+        clear_calls: usize,
+        flush_calls: usize,
+    }
+
+    impl IoTestBackend {
+        fn new(width: u16, height: u16) -> Self {
+            Self {
+                inner: TestBackend::new(width, height),
+                draw_calls: 0,
+                clear_calls: 0,
+                flush_calls: 0,
+            }
+        }
+
+        fn resize(&mut self, width: u16, height: u16) {
+            self.inner.resize(width, height);
+        }
+
+        fn reset_operations(&mut self) {
+            self.draw_calls = 0;
+            self.clear_calls = 0;
+            self.flush_calls = 0;
+        }
+
+        fn into_io<T>(result: Result<T, Infallible>) -> io::Result<T> {
+            match result {
+                Ok(value) => Ok(value),
+                Err(error) => match error {},
+            }
+        }
+    }
+
+    impl Backend for IoTestBackend {
+        type Error = io::Error;
+
+        fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
+        where
+            I: Iterator<Item = (u16, u16, &'a Cell)>,
+        {
+            self.draw_calls += 1;
+            Self::into_io(self.inner.draw(content))
+        }
+
+        fn hide_cursor(&mut self) -> io::Result<()> {
+            Self::into_io(self.inner.hide_cursor())
+        }
+
+        fn show_cursor(&mut self) -> io::Result<()> {
+            Self::into_io(self.inner.show_cursor())
+        }
+
+        fn get_cursor_position(&mut self) -> io::Result<Position> {
+            Self::into_io(self.inner.get_cursor_position())
+        }
+
+        fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+            Self::into_io(self.inner.set_cursor_position(position))
+        }
+
+        fn clear(&mut self) -> io::Result<()> {
+            self.clear_calls += 1;
+            Self::into_io(self.inner.clear())
+        }
+
+        fn clear_region(&mut self, clear_type: ClearType) -> io::Result<()> {
+            self.clear_calls += 1;
+            Self::into_io(self.inner.clear_region(clear_type))
+        }
+
+        fn size(&self) -> io::Result<Size> {
+            Self::into_io(self.inner.size())
+        }
+
+        fn window_size(&mut self) -> io::Result<WindowSize> {
+            Self::into_io(self.inner.window_size())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.flush_calls += 1;
+            Self::into_io(self.inner.flush())
+        }
+    }
+
+    fn capture_terminal(percent: u16) -> (Terminal<ZoomBackend<CaptureWriter>>, CaptureWriter) {
+        let sink = CaptureWriter::default();
+        let zoom = ZoomHandle::default();
+        zoom.set_mode(ZoomMode::Osc66);
+        zoom.set(percent);
+        let backend = ZoomBackend::new(CrosstermBackend::new(sink.clone()), zoom);
+        let terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Fixed(Rect::new(0, 0, 5, 1)),
+            },
+        )
+        .unwrap();
+        (terminal, sink)
+    }
+
+    fn render_text(frame: &mut ratatui::Frame, text: &'static str) {
+        frame.render_widget(Paragraph::new(text), frame.area());
+    }
+
+    #[test]
+    fn ime_fast_path_matches_unchanged_full_draw_bytes_with_and_without_sync() {
+        for (percent, synchronized) in [100, 200]
+            .into_iter()
+            .flat_map(|percent| [false, true].map(move |synchronized| (percent, synchronized)))
+        {
+            let (mut full, full_sink) = capture_terminal(percent);
+            let mut full_output = full_sink.clone();
+            draw_frame_with_output(&mut full, &mut full_output, false, false, |frame| {
+                render_text(frame, "abc");
+            })
+            .unwrap();
+            full_sink.clear();
+            draw_frame_with_output(&mut full, &mut full_output, synchronized, false, |frame| {
+                render_text(frame, "abc")
+            })
+            .unwrap();
+            let expected = full_sink.bytes();
+
+            let (mut fast, fast_sink) = capture_terminal(percent);
+            let mut fast_output = fast_sink.clone();
+            draw_frame_with_output(&mut fast, &mut fast_output, false, false, |frame| {
+                render_text(frame, "abc");
+            })
+            .unwrap();
+            fast_sink.clear();
+            assert_eq!(
+                scrub_ime_preedit_with_output(&mut fast, &mut fast_output, synchronized, false,)
+                    .unwrap(),
+                ImeScrubResult::Fast
+            );
+            let actual = fast_sink.bytes();
+
+            assert!(!expected.is_empty());
+            assert_eq!(
+                actual, expected,
+                "percent={percent}, synchronized={synchronized}"
+            );
+        }
+    }
+
+    #[test]
+    fn fast_scrubs_preserve_the_next_changed_frame_buffer_result() {
+        let mut fast = Terminal::new(TestBackend::new(5, 1)).unwrap();
+        let mut full = Terminal::new(TestBackend::new(5, 1)).unwrap();
+        for terminal in [&mut fast, &mut full] {
+            draw_frame_inner(terminal, |frame| render_text(frame, "A")).unwrap();
+        }
+
+        for _ in 0..4 {
+            scrub_unchanged_terminal(&mut fast).unwrap();
+            draw_frame_inner(&mut full, |frame| render_text(frame, "A")).unwrap();
+        }
+        draw_frame_inner(&mut fast, |frame| render_text(frame, "B")).unwrap();
+        draw_frame_inner(&mut full, |frame| render_text(frame, "B")).unwrap();
+
+        assert_eq!(fast.backend().buffer(), full.backend().buffer());
+        fast.backend().assert_buffer_lines(["B    "]);
+    }
+
+    #[test]
+    fn fast_scrubs_preserve_the_next_changed_frame_byte_stream() {
+        for percent in [100, 200] {
+            let (mut fast, fast_sink) = capture_terminal(percent);
+            let (mut full, full_sink) = capture_terminal(percent);
+            let mut fast_output = fast_sink.clone();
+            let mut full_output = full_sink.clone();
+            for (terminal, output) in [(&mut fast, &mut fast_output), (&mut full, &mut full_output)]
+            {
+                draw_frame_with_output(terminal, output, false, false, |frame| {
+                    render_text(frame, "A")
+                })
+                .unwrap();
+            }
+
+            for _ in 0..4 {
+                scrub_ime_preedit_with_output(&mut fast, &mut fast_output, false, false).unwrap();
+                draw_frame_with_output(&mut full, &mut full_output, false, false, |frame| {
+                    render_text(frame, "A")
+                })
+                .unwrap();
+            }
+
+            fast_sink.clear();
+            full_sink.clear();
+            draw_frame_with_output(&mut fast, &mut fast_output, false, false, |frame| {
+                render_text(frame, "B")
+            })
+            .unwrap();
+            draw_frame_with_output(&mut full, &mut full_output, false, false, |frame| {
+                render_text(frame, "B")
+            })
+            .unwrap();
+
+            assert_eq!(fast_sink.bytes(), full_sink.bytes(), "percent={percent}");
+        }
+    }
+
+    #[test]
+    fn resize_is_reported_without_output_before_synced_full_draw_autoresizes() {
+        let mut terminal = Terminal::new(IoTestBackend::new(5, 1)).unwrap();
+        draw_frame_inner(&mut terminal, |frame| render_text(frame, "abc")).unwrap();
+        terminal.backend_mut().resize(7, 2);
+        terminal.backend_mut().reset_operations();
+        let area_before = terminal.get_frame().area();
+        let mut output = Vec::new();
+
+        assert_eq!(
+            scrub_ime_preedit_with_output(&mut terminal, &mut output, true, true).unwrap(),
+            ImeScrubResult::Resized
+        );
+        assert!(output.is_empty());
+        assert_eq!(terminal.get_frame().area(), area_before);
+        assert_eq!(terminal.backend().draw_calls, 0);
+        assert_eq!(terminal.backend().clear_calls, 0);
+        assert_eq!(terminal.backend().flush_calls, 0);
+
+        draw_frame_with_output(&mut terminal, &mut output, true, false, |frame| {
+            render_text(frame, "changed")
+        })
+        .unwrap();
+        assert_eq!(terminal.get_frame().area(), Rect::new(0, 0, 7, 2));
+        assert_eq!(terminal.backend().clear_calls, 1);
+        assert!(terminal.backend().draw_calls > 0);
+        assert!(terminal.backend().flush_calls > 0);
+        assert_eq!(output, b"\x1b[?2026h\x1b[?2026l");
+    }
+
+    #[test]
+    fn fixed_viewport_fast_scrub_ignores_backend_size_changes() {
+        let fixed = Rect::new(1, 0, 3, 1);
+        let mut terminal = Terminal::with_options(
+            IoTestBackend::new(5, 1),
+            TerminalOptions {
+                viewport: Viewport::Fixed(fixed),
+            },
+        )
+        .unwrap();
+        draw_frame_inner(&mut terminal, |frame| render_text(frame, "abc")).unwrap();
+        terminal.backend_mut().resize(7, 2);
+        terminal.backend_mut().reset_operations();
+
+        assert_eq!(
+            scrub_ime_preedit_with_output(&mut terminal, &mut Vec::new(), false, false).unwrap(),
+            ImeScrubResult::Fast
+        );
+        assert_eq!(terminal.get_frame().area(), fixed);
+        assert_eq!(terminal.backend().clear_calls, 0);
+        assert_eq!(terminal.backend().draw_calls, 1);
+        assert_eq!(terminal.backend().flush_calls, 1);
+    }
 
     #[test]
     fn clear_before_draw_forces_unchanged_cells_to_redraw() {

--- a/src/ui/anim.rs
+++ b/src/ui/anim.rs
@@ -1302,7 +1302,7 @@ mod tests {
 
     fn advance_frames(app: &mut App, frames: u64) {
         for _ in 0..frames {
-            app.update(Msg::AnimTick);
+            app.update(Msg::AnimTick(1));
         }
     }
 

--- a/src/ui/anim.rs
+++ b/src/ui/anim.rs
@@ -1302,7 +1302,7 @@ mod tests {
 
     fn advance_frames(app: &mut App, frames: u64) {
         for _ in 0..frames {
-            app.update(Msg::AnimTick(1));
+            app.update(Msg::AnimTick);
         }
     }
 

--- a/src/ui/ascii_art.rs
+++ b/src/ui/ascii_art.rs
@@ -43,13 +43,19 @@ thread_local! {
 /// Draw `img` as ASCII art filling `rect`. `id` names the image (track id, asset name); the
 /// cell grid is rebuilt only when it or the rect size changes.
 pub fn render_image(frame: &mut Frame, slot: Slot, id: &str, img: &DynamicImage, rect: Rect) {
-    render_cached(frame, slot, id, rect, || Some(img.clone()));
+    render_cached(frame, slot, id, rect, || {
+        Some(build(img, rect.width, rect.height))
+    });
 }
 
 /// Like [`render_image`], but decodes `png` lazily — only when the cache slot is stale — so
 /// an embedded asset isn't re-decoded per frame.
 pub fn render_png(frame: &mut Frame, slot: Slot, id: &str, png: &[u8], rect: Rect) {
-    render_cached(frame, slot, id, rect, || image::load_from_memory(png).ok());
+    render_cached(frame, slot, id, rect, || {
+        image::load_from_memory(png)
+            .ok()
+            .map(|img| build(&img, rect.width, rect.height))
+    });
 }
 
 fn render_cached(
@@ -57,7 +63,7 @@ fn render_cached(
     slot: Slot,
     id: &str,
     rect: Rect,
-    source: impl FnOnce() -> Option<DynamicImage>,
+    source: impl FnOnce() -> Option<Vec<(char, Color)>>,
 ) {
     if rect.width == 0 || rect.height == 0 {
         return;
@@ -68,7 +74,7 @@ fn render_cached(
             .get(&slot)
             .is_none_or(|c| c.id != id || c.width != rect.width || c.height != rect.height);
         if stale {
-            let Some(img) = source() else {
+            let Some(cells) = source() else {
                 return;
             };
             cache.insert(
@@ -77,7 +83,7 @@ fn render_cached(
                     id: id.to_owned(),
                     width: rect.width,
                     height: rect.height,
-                    cells: build(&img, rect.width, rect.height),
+                    cells,
                 },
             );
         }

--- a/src/ui/views/ai.rs
+++ b/src/ui/views/ai.rs
@@ -223,12 +223,12 @@ fn render_transcript(frame: &mut Frame, app: &App, area: Rect) {
         .map(|(vis, line)| {
             let abs = offset + vis;
             if selected.is_some_and(|(start, end)| abs >= start && abs <= end) {
-                Line::from(line.copy.as_str()).style(selection_style)
+                Line::from(line.text.as_ref()).style(selection_style)
             } else {
                 Line::from(
-                    line.spans
+                    line.styles
                         .iter()
-                        .map(|(text, style)| Span::styled(text.as_str(), *style))
+                        .map(|range| Span::styled(&line.text[range.start..range.end], range.style))
                         .collect::<Vec<Span>>(),
                 )
             }
@@ -255,11 +255,23 @@ fn render_transcript(frame: &mut Frame, app: &App, area: Rect) {
 
 #[derive(Debug, Clone)]
 struct TranscriptLine {
-    /// The plain rendered text — markdown markers already stripped — so drag-copy and
-    /// the selection highlight yield exactly what's on screen.
-    copy: String,
-    /// The same text split into styled runs (their concatenation equals `copy`).
-    spans: Vec<(String, Style)>,
+    /// The only retained copy of this rendered row. Markdown markers are already
+    /// stripped; rendering, selection highlighting, and drag-copy all share it.
+    text: Arc<str>,
+    /// Styled runs as UTF-8 byte ranges into `text`, never duplicated strings.
+    styles: Vec<StyleRange>,
+}
+
+#[derive(Debug, Clone)]
+struct StyleRange {
+    start: usize,
+    end: usize,
+    style: Style,
+}
+
+struct TranscriptLineBuilder {
+    text: String,
+    styles: Vec<StyleRange>,
 }
 
 struct TranscriptCache {
@@ -272,7 +284,7 @@ struct TranscriptCache {
     #[cfg(test)]
     fixture_messages: Vec<(AiRole, String)>,
     lines: Arc<[TranscriptLine]>,
-    copy_lines: Arc<[String]>,
+    copy_lines: Arc<[Arc<str>]>,
 }
 
 thread_local! {
@@ -282,15 +294,53 @@ thread_local! {
 impl TranscriptLine {
     fn blank() -> Self {
         Self {
-            copy: String::new(),
-            spans: Vec::new(),
+            text: Arc::from(""),
+            styles: Vec::new(),
         }
     }
 
     fn plain(text: String, style: Style) -> Self {
+        let mut line = TranscriptLineBuilder::new(text.len());
+        line.push_str(&text, style);
+        line.finish()
+    }
+}
+
+impl TranscriptLineBuilder {
+    fn new(text_capacity: usize) -> Self {
         Self {
-            spans: vec![(text.clone(), style)],
-            copy: text,
+            text: String::with_capacity(text_capacity),
+            styles: Vec::new(),
+        }
+    }
+
+    fn push_str(&mut self, text: &str, style: Style) {
+        if text.is_empty() {
+            return;
+        }
+        let start = self.text.len();
+        self.text.push_str(text);
+        self.extend_style(start, style);
+    }
+
+    fn push_char(&mut self, ch: char, style: Style) {
+        let start = self.text.len();
+        self.text.push(ch);
+        self.extend_style(start, style);
+    }
+
+    fn extend_style(&mut self, start: usize, style: Style) {
+        let end = self.text.len();
+        match self.styles.last_mut() {
+            Some(range) if range.end == start && range.style == style => range.end = end,
+            _ => self.styles.push(StyleRange { start, end, style }),
+        }
+    }
+
+    fn finish(self) -> TranscriptLine {
+        TranscriptLine {
+            text: Arc::from(self.text),
+            styles: self.styles,
         }
     }
 }
@@ -359,7 +409,7 @@ fn transcript_thinking_text(app: &App) -> Option<String> {
     })
 }
 
-fn cached_transcript_lines(app: &App, width: usize) -> (Arc<[TranscriptLine]>, Arc<[String]>) {
+fn cached_transcript_lines(app: &App, width: usize) -> (Arc<[TranscriptLine]>, Arc<[Arc<str>]>) {
     let thinking_text = transcript_thinking_text(app);
     let korean = crate::i18n::is_korean();
     let styles = [
@@ -394,9 +444,9 @@ fn cached_transcript_lines(app: &App, width: usize) -> (Arc<[TranscriptLine]>, A
         }
 
         let lines = build_transcript_lines_with_thinking(app, width, thinking_text.as_deref());
-        let copy_lines: Arc<[String]> = lines
+        let copy_lines: Arc<[Arc<str>]> = lines
             .iter()
-            .map(|line| line.copy.clone())
+            .map(|line| Arc::clone(&line.text))
             .collect::<Vec<_>>()
             .into();
         let lines: Arc<[TranscriptLine]> = lines.into();
@@ -452,34 +502,23 @@ fn push_wrapped_styled(
     let chip_style = prefix_style.add_modifier(Modifier::REVERSED | Modifier::BOLD);
     let mut first = true;
     for segment in wrap_styled_cells(chars, body_w) {
-        let mut spans: Vec<(String, Style)> = Vec::with_capacity(4);
+        let mut line = TranscriptLineBuilder::new(prefix.len() + segment.len());
         if first {
             if !chip.is_empty() {
-                spans.push((chip.to_owned(), chip_style));
+                line.push_str(chip, chip_style);
             }
             if !pad.is_empty() {
-                spans.push((pad.to_owned(), prefix_style));
+                line.push_str(pad, prefix_style);
             }
         } else {
-            spans.push((indent.clone(), prefix_style));
+            line.push_str(&indent, prefix_style);
         }
-        spans.extend(group_style_runs(&segment));
-        let copy: String = spans.iter().map(|(text, _)| text.as_str()).collect();
-        out.push(TranscriptLine { copy, spans });
+        for &(ch, style) in &segment {
+            line.push_char(ch, style);
+        }
+        out.push(line.finish());
         first = false;
     }
-}
-
-/// Collapse per-char styles into contiguous `(text, style)` runs.
-fn group_style_runs(chars: &[(char, Style)]) -> Vec<(String, Style)> {
-    let mut out: Vec<(String, Style)> = Vec::new();
-    for &(c, style) in chars {
-        match out.last_mut() {
-            Some((text, s)) if *s == style => text.push(c),
-            _ => out.push((c.to_string(), style)),
-        }
-    }
-    out
 }
 
 /// Markdown-lite styling for assistant replies — the subset Gemini actually emits:
@@ -906,6 +945,21 @@ mod tests {
     }
 
     #[test]
+    fn copy_bridge_shares_every_transcript_line_payload_arc() {
+        let mut app = App::new(100);
+        app.ai.messages.push(AiMessage {
+            role: AiRole::Ai,
+            text: "**shared** UTF-8 줄 with enough words to wrap".to_owned(),
+        });
+
+        let (lines, copy_lines) = cached_transcript_lines(&app, 16);
+        assert_eq!(lines.len(), copy_lines.len());
+        for (line, copy) in lines.iter().zip(copy_lines.iter()) {
+            assert!(Arc::ptr_eq(&line.text, copy));
+        }
+    }
+
+    #[test]
     fn reducer_append_advances_revision_and_rebuilds_cached_transcript() {
         let mut app = App::new(100);
         let before_revision = app.ai.transcript_revision;
@@ -1001,31 +1055,34 @@ mod tests {
 
         // Message, blank separator, message.
         assert_eq!(lines.len(), 3);
-        assert!(lines[1].copy.is_empty() && lines[1].spans.is_empty());
+        assert!(lines[1].text.is_empty() && lines[1].styles.is_empty());
 
         // The role tag renders as a reversed chip; its text stays in the copy line.
-        assert_eq!(lines[0].copy, "you who sings this?");
-        assert_eq!(lines[0].spans[0].0, "you");
-        assert!(
-            lines[0].spans[0]
-                .1
-                .add_modifier
-                .contains(Modifier::REVERSED)
-        );
+        assert_eq!(lines[0].text.as_ref(), "you who sings this?");
+        let first_range = &lines[0].styles[0];
+        assert_eq!(&lines[0].text[first_range.start..first_range.end], "you");
+        assert!(first_range.style.add_modifier.contains(Modifier::REVERSED));
 
         // Markdown markers are stripped from both the render and the drag-copy text.
-        assert_eq!(lines[2].copy, "Gem It's YOASOBI.");
-        assert!(
-            lines[2]
-                .spans
-                .iter()
-                .any(|(text, style)| text.contains("YOASOBI")
-                    && style.add_modifier.contains(Modifier::BOLD))
-        );
-        // Spans always reassemble exactly into the copy text.
+        assert_eq!(lines[2].text.as_ref(), "Gem It's YOASOBI.");
+        assert!(lines[2].styles.iter().any(|range| {
+            lines[2].text[range.start..range.end].contains("YOASOBI")
+                && range.style.add_modifier.contains(Modifier::BOLD)
+        }));
+        // Byte ranges are contiguous, valid UTF-8 slices, and cover the one text payload.
         for line in &lines {
-            let joined: String = line.spans.iter().map(|(t, _)| t.as_str()).collect();
-            assert_eq!(joined, line.copy);
+            let mut next = 0;
+            let joined: String = line
+                .styles
+                .iter()
+                .map(|range| {
+                    assert_eq!(range.start, next);
+                    next = range.end;
+                    &line.text[range.start..range.end]
+                })
+                .collect();
+            assert_eq!(next, line.text.len());
+            assert_eq!(joined, line.text.as_ref());
         }
     }
 
@@ -1039,7 +1096,7 @@ mod tests {
         // Width 14 = 4 ("Gem " chip+pad) + 10 body cells: the bold pair fills line one,
         // and the continuation hang-indents under the body, not under the chip.
         let lines = build_transcript_lines(&app, 14);
-        assert_eq!(lines[0].copy, "Gem alpha beta");
-        assert_eq!(lines[1].copy, "    gamma");
+        assert_eq!(lines[0].text.as_ref(), "Gem alpha beta");
+        assert_eq!(lines[1].text.as_ref(), "    gamma");
     }
 }

--- a/src/ui/views/ai.rs
+++ b/src/ui/views/ai.rs
@@ -4,6 +4,9 @@
 //! When no API key is configured the transcript area shows an onboarding block instead;
 //! the input still works (submitting yields an inline error pointing at settings).
 
+use std::cell::RefCell;
+use std::sync::Arc;
+
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style, Stylize};
@@ -184,7 +187,7 @@ fn render_transcript(frame: &mut Frame, app: &App, area: Rect) {
             ))
             .style(app.theme.style(R::TextMuted)),
         ];
-        app.bridges.ai_transcript_copy_lines.borrow_mut().clear();
+        *app.bridges.ai_transcript_copy_lines.borrow_mut() = Arc::default();
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), padded);
         return;
     }
@@ -193,8 +196,7 @@ fn render_transcript(frame: &mut Frame, app: &App, area: Rect) {
         width: padded.width.saturating_sub(1),
         ..padded
     };
-    let lines = build_transcript_lines(app, text_area.width as usize);
-    let copy_lines: Vec<String> = lines.iter().map(|line| line.copy.clone()).collect();
+    let (lines, copy_lines) = cached_transcript_lines(app, text_area.width as usize);
     *app.bridges.ai_transcript_copy_lines.borrow_mut() = copy_lines;
 
     let len = lines.len();
@@ -221,12 +223,12 @@ fn render_transcript(frame: &mut Frame, app: &App, area: Rect) {
         .map(|(vis, line)| {
             let abs = offset + vis;
             if selected.is_some_and(|(start, end)| abs >= start && abs <= end) {
-                Line::from(line.copy.clone()).style(selection_style)
+                Line::from(line.copy.as_str()).style(selection_style)
             } else {
                 Line::from(
                     line.spans
                         .iter()
-                        .map(|(text, style)| Span::styled(text.clone(), *style))
+                        .map(|(text, style)| Span::styled(text.as_str(), *style))
                         .collect::<Vec<Span>>(),
                 )
             }
@@ -260,6 +262,23 @@ struct TranscriptLine {
     spans: Vec<(String, Style)>,
 }
 
+struct TranscriptCache {
+    owner: Arc<()>,
+    revision: u64,
+    width: usize,
+    korean: bool,
+    thinking_text: Option<String>,
+    styles: [Style; 6],
+    #[cfg(test)]
+    fixture_messages: Vec<(AiRole, String)>,
+    lines: Arc<[TranscriptLine]>,
+    copy_lines: Arc<[String]>,
+}
+
+thread_local! {
+    static TRANSCRIPT_CACHE: RefCell<Option<TranscriptCache>> = const { RefCell::new(None) };
+}
+
 impl TranscriptLine {
     fn blank() -> Self {
         Self {
@@ -276,7 +295,17 @@ impl TranscriptLine {
     }
 }
 
+#[cfg(test)]
 fn build_transcript_lines(app: &App, width: usize) -> Vec<TranscriptLine> {
+    let thinking = transcript_thinking_text(app);
+    build_transcript_lines_with_thinking(app, width, thinking.as_deref())
+}
+
+fn build_transcript_lines_with_thinking(
+    app: &App,
+    width: usize,
+    thinking_text: Option<&str>,
+) -> Vec<TranscriptLine> {
     let mut lines = Vec::new();
     let width = width.max(1);
     let accent = app.theme.style(R::Accent);
@@ -299,15 +328,10 @@ fn build_transcript_lines(app: &App, width: usize) -> Vec<TranscriptLine> {
         };
         push_wrapped_styled(&mut lines, prefix, base, &chars, width);
     }
-    if app.ai.thinking {
+    if let Some(text) = thinking_text {
         if !lines.is_empty() {
             lines.push(TranscriptLine::blank());
         }
-        // Animated dots while a request is in flight (the static text when the flag is off).
-        let text = match crate::ui::anim::activity_dots(app) {
-            Some(dots) => format!("{}{dots}", t!("…thinking", "…생각 중")),
-            None => t!("…thinking", "…생각 중").to_owned(),
-        };
         let style = app.theme.style(R::AiThinking);
         let chars: Vec<(char, Style)> = text.chars().map(|c| (c, style)).collect();
         push_wrapped_styled(&mut lines, t!("Gem ", "Gem   "), style, &chars, width);
@@ -323,6 +347,91 @@ fn build_transcript_lines(app: &App, width: usize) -> Vec<TranscriptLine> {
         ));
     }
     lines
+}
+
+fn transcript_thinking_text(app: &App) -> Option<String> {
+    app.ai.thinking.then(|| {
+        // Animated dots while a request is in flight (the static text when the flag is off).
+        match crate::ui::anim::activity_dots(app) {
+            Some(dots) => format!("{}{dots}", t!("…thinking", "…생각 중")),
+            None => t!("…thinking", "…생각 중").to_owned(),
+        }
+    })
+}
+
+fn cached_transcript_lines(app: &App, width: usize) -> (Arc<[TranscriptLine]>, Arc<[String]>) {
+    let thinking_text = transcript_thinking_text(app);
+    let korean = crate::i18n::is_korean();
+    let styles = [
+        R::Accent,
+        R::AiUser,
+        R::AiAssistant,
+        R::AiError,
+        R::AiThinking,
+        R::TextMuted,
+    ]
+    .map(|role| app.theme.style(role));
+    #[cfg(test)]
+    let fixture_messages = app
+        .ai
+        .messages
+        .iter()
+        .map(|message| (message.role, message.text.clone()))
+        .collect::<Vec<_>>();
+
+    TRANSCRIPT_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(cached) = cache.as_ref()
+            && Arc::ptr_eq(&cached.owner, &app.ai.transcript_cache_token)
+            && cached.revision == app.ai.transcript_revision
+            && cached.width == width
+            && cached.korean == korean
+            && cached.thinking_text == thinking_text
+            && cached.styles == styles
+            && fixture_messages_match(cached, app)
+        {
+            return (Arc::clone(&cached.lines), Arc::clone(&cached.copy_lines));
+        }
+
+        let lines = build_transcript_lines_with_thinking(app, width, thinking_text.as_deref());
+        let copy_lines: Arc<[String]> = lines
+            .iter()
+            .map(|line| line.copy.clone())
+            .collect::<Vec<_>>()
+            .into();
+        let lines: Arc<[TranscriptLine]> = lines.into();
+        *cache = Some(TranscriptCache {
+            owner: Arc::clone(&app.ai.transcript_cache_token),
+            revision: app.ai.transcript_revision,
+            width,
+            korean,
+            thinking_text,
+            styles,
+            #[cfg(test)]
+            fixture_messages,
+            lines: Arc::clone(&lines),
+            copy_lines: Arc::clone(&copy_lines),
+        });
+        (lines, copy_lines)
+    })
+}
+
+#[cfg(not(test))]
+fn fixture_messages_match(_cached: &TranscriptCache, _app: &App) -> bool {
+    true
+}
+
+/// UI tests intentionally build fixtures by mutating `messages` directly instead of going through
+/// the private reducer helper. Keep that test seam exact without making production redraws hash or
+/// compare the full transcript; production invalidation is the monotonic revision above.
+#[cfg(test)]
+fn fixture_messages_match(cached: &TranscriptCache, app: &App) -> bool {
+    cached.fixture_messages.len() == app.ai.messages.len()
+        && cached
+            .fixture_messages
+            .iter()
+            .zip(&app.ai.messages)
+            .all(|((role, text), message)| *role == message.role && text == &message.text)
 }
 
 /// Wrap one styled message under its role tag. The tag renders as a reversed-video chip
@@ -735,7 +844,7 @@ mod tests {
     use ratatui::style::Color;
 
     use super::*;
-    use crate::app::AiMessage;
+    use crate::app::{AiMessage, AiMsg, Msg};
 
     #[test]
     fn wraps_on_words_when_possible() {
@@ -775,6 +884,60 @@ mod tests {
             .collect::<String>();
         assert!(text.contains("DJ"));
         assert!(text.contains("GEM"));
+    }
+
+    #[test]
+    fn unchanged_transcript_reuses_wrapped_and_copy_storage() {
+        let mut app = App::new(100);
+        app.ai.messages.push(AiMessage {
+            role: AiRole::Ai,
+            text: "**cached** transcript line with enough words to wrap".to_owned(),
+        });
+
+        let (first_lines, first_copy) = cached_transcript_lines(&app, 18);
+        let (same_lines, same_copy) = cached_transcript_lines(&app, 18);
+        assert!(Arc::ptr_eq(&first_lines, &same_lines));
+        assert!(Arc::ptr_eq(&first_copy, &same_copy));
+
+        app.ai.messages[0].text.push('!');
+        let (changed_lines, changed_copy) = cached_transcript_lines(&app, 18);
+        assert!(!Arc::ptr_eq(&first_lines, &changed_lines));
+        assert!(!Arc::ptr_eq(&first_copy, &changed_copy));
+    }
+
+    #[test]
+    fn reducer_append_advances_revision_and_rebuilds_cached_transcript() {
+        let mut app = App::new(100);
+        let before_revision = app.ai.transcript_revision;
+        let _ = app.update(Msg::Ai(AiMsg::Chat("first reply".to_owned())));
+        assert_eq!(app.ai.transcript_revision, before_revision.wrapping_add(1));
+        let (first_lines, first_copy) = cached_transcript_lines(&app, 18);
+
+        let _ = app.update(Msg::Ai(AiMsg::Chat("second reply".to_owned())));
+        let (changed_lines, changed_copy) = cached_transcript_lines(&app, 18);
+        assert!(!Arc::ptr_eq(&first_lines, &changed_lines));
+        assert!(!Arc::ptr_eq(&first_copy, &changed_copy));
+    }
+
+    #[test]
+    fn transcript_cache_invalidates_for_presentation_and_app_identity() {
+        let mut app = App::new(100);
+        app.ai.messages.push(AiMessage {
+            role: AiRole::Ai,
+            text: "one transcript owned by one app".to_owned(),
+        });
+        let (first_lines, _) = cached_transcript_lines(&app, 18);
+
+        let (different_width, _) = cached_transcript_lines(&app, 19);
+        assert!(!Arc::ptr_eq(&first_lines, &different_width));
+
+        app.ai.thinking = true;
+        let (with_thinking, _) = cached_transcript_lines(&app, 19);
+        assert!(!Arc::ptr_eq(&different_width, &with_thinking));
+
+        let other_app = App::new(100);
+        let (other_owner, _) = cached_transcript_lines(&other_app, 19);
+        assert!(!Arc::ptr_eq(&with_thinking, &other_owner));
     }
 
     fn plain_text(chars: &[(char, Style)]) -> String {

--- a/src/ui/views/library.rs
+++ b/src/ui/views/library.rs
@@ -44,7 +44,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     .split(inner);
 
     let playlists_root = app.playlists_root();
-    let library_rows = app.library_rows();
+    let library_rows_len = app.library_rows_len();
 
     render_tabs(frame, app, rows[0]);
     // The filter prompt rides the spacer row when active, so opening it never reflows the
@@ -53,7 +53,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         let matches = if playlists_root {
             app.filtered_playlists().len()
         } else {
-            library_rows.len()
+            library_rows_len
         };
         render_filter(frame, app, rows[1], matches);
     } else if !app.status.text.is_empty() {
@@ -87,7 +87,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if playlists_root {
         render_playlist_list(frame, app, rows[2]);
     } else {
-        render_list(frame, app, rows[2], &library_rows);
+        render_list(frame, app, rows[2], library_rows_len);
     }
 
     buttons::render_help_button(frame, app, rows[3]);
@@ -189,11 +189,11 @@ fn render_filter(frame: &mut Frame, app: &App, area: Rect, matches: usize) {
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
-fn render_list(frame: &mut Frame, app: &App, area: Rect, rows: &[&crate::api::Song]) {
+fn render_list(frame: &mut Frame, app: &App, area: Rect, len: usize) {
     // Record the viewport height so PageUp/PageDown can move by a screenful (see app::page_step).
     app.bridges.list_viewport_rows.set(area.height);
 
-    if rows.is_empty() {
+    if len == 0 {
         // A filtered-to-nothing list gets a filter-specific message, not the per-tab "empty" hint.
         let msg: String = if !app.library_ui.filter_query.is_empty() {
             if crate::i18n::is_korean() {
@@ -272,7 +272,6 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect, rows: &[&crate::api::So
     // inclusive anchor..=cursor range and each deletable row can carry a trailing ✗ button.
     // The All tab is an aggregate view (a track may live in several tabs at once), so it has
     // no per-row delete — manage tracks from their own Favorites/History/Downloads tab.
-    let len = rows.len();
     let cursor = app.library_ui.selected.min(len - 1);
     let sel_lo = cursor.min(app.library_ui.anchor);
     let sel_hi = cursor.max(app.library_ui.anchor);
@@ -288,13 +287,12 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect, rows: &[&crate::api::So
             .resolve(cursor, area.height, len, crate::ui::scroll::SCROLLOFF);
 
     let body_w = area.width.saturating_sub(del_w) as usize;
-    for (vis, (i, song)) in rows
-        .iter()
-        .enumerate()
-        .skip(start)
-        .take(visible)
-        .enumerate()
-    {
+    let render_rows = app.library_render_window(start, visible);
+    for (vis, song) in render_rows.into_iter().enumerate() {
+        let i = start + vis;
+        let Some(song) = song else {
+            continue;
+        };
         let y = area.y + vis as u16;
         let selected = i >= sel_lo && i <= sel_hi;
         let marker = if i == cursor { "▶ " } else { "  " };

--- a/src/ui/views/library.rs
+++ b/src/ui/views/library.rs
@@ -10,6 +10,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use crate::app::{App, LibraryTab, MouseTarget, ScrollSurface};
+use crate::library::FavoriteLookup;
 use crate::t;
 use crate::theme::ThemeRole as R;
 use crate::ui::buttons;
@@ -87,7 +88,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     if playlists_root {
         render_playlist_list(frame, app, rows[2]);
     } else {
-        render_list(frame, app, rows[2], library_rows_len);
+        let favorite_lookup = app.library.favorite_lookup();
+        render_list(frame, app, rows[2], library_rows_len, &favorite_lookup);
     }
 
     buttons::render_help_button(frame, app, rows[3]);
@@ -189,7 +191,13 @@ fn render_filter(frame: &mut Frame, app: &App, area: Rect, matches: usize) {
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
-fn render_list(frame: &mut Frame, app: &App, area: Rect, len: usize) {
+fn render_list(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    len: usize,
+    favorite_lookup: &FavoriteLookup<'_>,
+) {
     // Record the viewport height so PageUp/PageDown can move by a screenful (see app::page_step).
     app.bridges.list_viewport_rows.set(area.height);
 
@@ -296,7 +304,7 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect, len: usize) {
         let y = area.y + vis as u16;
         let selected = i >= sel_lo && i <= sel_hi;
         let marker = if i == cursor { "▶ " } else { "  " };
-        let heart = if app.library.is_favorite(&song.video_id) {
+        let heart = if favorite_lookup.is_favorite(&song.video_id) {
             "♥ "
         } else {
             "  "

--- a/src/ui/views/local.rs
+++ b/src/ui/views/local.rs
@@ -7,14 +7,19 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use crate::app::{
-    App, LocalImportAcceptAllConfirm, LocalModeConfirm, LocalOrganizeConfirm, LocalSection,
-    MouseTarget, ScrollSurface,
+    App, LocalImportAcceptAllConfirm, LocalModeConfirm, LocalOrganizeConfirm, LocalRowsSnapshot,
+    LocalSection, MouseTarget, ScrollSurface,
 };
 use crate::t;
 use crate::theme::ThemeRole as R;
 use crate::ui::buttons;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+    let local_rows = app.local_rows_snapshot();
+    render_with_snapshot(frame, app, area, &local_rows);
+}
+
+fn render_with_snapshot(frame: &mut Frame, app: &App, area: Rect, local_rows: &LocalRowsSnapshot) {
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(app.theme.style(R::BorderFocused))
@@ -41,15 +46,25 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     ])
     .split(inner);
 
-    render_header(frame, app, rows[0]);
-    render_status(frame, app, rows[1]);
-    render_body(frame, app, rows[2]);
+    render_header(frame, app, local_rows, rows[0]);
+    render_status(frame, app, local_rows, rows[1]);
+    render_body(frame, app, local_rows, rows[2]);
     buttons::render_help_button(frame, app, rows[3]);
 }
 
-fn render_header(frame: &mut Frame, app: &App, area: Rect) {
-    let count = app.local_total_rows_len();
-    let visible_count = app.local_rows_len();
+#[cfg(test)]
+pub(crate) fn render_test_snapshot(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    local_rows: &LocalRowsSnapshot,
+) {
+    render_with_snapshot(frame, app, area, local_rows);
+}
+
+fn render_header(frame: &mut Frame, app: &App, local_rows: &LocalRowsSnapshot, area: Rect) {
+    let count = local_rows.total_len();
+    let visible_count = local_rows.rows().len();
     let count_label = if !app.local_mode.ui.filter_query.is_empty() {
         if crate::i18n::is_korean() {
             format!("{visible_count}/{count}개")
@@ -86,7 +101,7 @@ fn render_header(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(Paragraph::new(line), area);
 }
 
-fn render_status(frame: &mut Frame, app: &App, area: Rect) {
+fn render_status(frame: &mut Frame, app: &App, local_rows: &LocalRowsSnapshot, area: Rect) {
     let text = if app.local_mode.ui.filter_editing || !app.local_mode.ui.filter_query.is_empty() {
         if app.local_mode.ui.filter_editing {
             format!("/{}", app.local_mode.ui.filter_query)
@@ -97,7 +112,7 @@ fn render_status(frame: &mut Frame, app: &App, area: Rect) {
                 app.local_mode.ui.filter_query
             )
         }
-    } else if let Some(hint) = app.local_import_action_hint() {
+    } else if let Some(hint) = app.local_import_action_hint_for_snapshot(local_rows) {
         hint
     } else if app.local_mode.index.loading {
         t!(
@@ -163,7 +178,7 @@ fn render_status(frame: &mut Frame, app: &App, area: Rect) {
     );
 }
 
-fn render_body(frame: &mut Frame, app: &App, area: Rect) {
+fn render_body(frame: &mut Frame, app: &App, local_rows: &LocalRowsSnapshot, area: Rect) {
     if area.height == 0 || area.width < 4 {
         return;
     }
@@ -182,8 +197,8 @@ fn render_body(frame: &mut Frame, app: &App, area: Rect) {
         )
         .split(area);
         render_sidebar(frame, app, panes[0]);
-        render_rows(frame, app, panes[1]);
-        render_details(frame, app, panes[2]);
+        render_rows(frame, app, local_rows, panes[1]);
+        render_details(frame, app, local_rows, panes[2]);
     } else if area.width >= 80 {
         let rows = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(area);
         let panes = Layout::new(
@@ -192,8 +207,8 @@ fn render_body(frame: &mut Frame, app: &App, area: Rect) {
         )
         .split(rows[0]);
         render_sidebar(frame, app, panes[0]);
-        render_rows(frame, app, panes[1]);
-        render_details_strip(frame, app, rows[1]);
+        render_rows(frame, app, local_rows, panes[1]);
+        render_details_strip(frame, app, local_rows, rows[1]);
     } else if area.width >= 72 {
         let panes = Layout::new(
             Direction::Horizontal,
@@ -201,19 +216,19 @@ fn render_body(frame: &mut Frame, app: &App, area: Rect) {
         )
         .split(area);
         render_sidebar(frame, app, panes[0]);
-        render_rows(frame, app, panes[1]);
+        render_rows(frame, app, local_rows, panes[1]);
     } else {
-        render_rows(frame, app, area);
+        render_rows(frame, app, local_rows, area);
     }
 }
 
-fn render_details(frame: &mut Frame, app: &App, area: Rect) {
+fn render_details(frame: &mut Frame, app: &App, local_rows: &LocalRowsSnapshot, area: Rect) {
     if area.height == 0 || area.width == 0 {
         return;
     }
     let width = area.width as usize;
     for (i, line) in app
-        .local_details_lines()
+        .local_details_lines_for_snapshot(local_rows)
         .into_iter()
         .take(area.height as usize)
         .enumerate()
@@ -239,12 +254,12 @@ fn render_details(frame: &mut Frame, app: &App, area: Rect) {
     }
 }
 
-fn render_details_strip(frame: &mut Frame, app: &App, area: Rect) {
+fn render_details_strip(frame: &mut Frame, app: &App, local_rows: &LocalRowsSnapshot, area: Rect) {
     if area.height == 0 || area.width == 0 {
         return;
     }
     let text = crate::ui::text::truncate_owned_to_width(
-        app.local_details_summary(),
+        app.local_details_summary_for_snapshot(local_rows),
         area.width.saturating_sub(1) as usize,
     );
     frame.render_widget(
@@ -330,8 +345,8 @@ fn render_sidebar(frame: &mut Frame, app: &App, area: Rect) {
     }
 }
 
-fn render_rows(frame: &mut Frame, app: &App, area: Rect) {
-    let rows = app.local_visible_rows();
+fn render_rows(frame: &mut Frame, app: &App, local_rows: &LocalRowsSnapshot, area: Rect) {
+    let rows = local_rows.rows();
     if rows.is_empty() {
         if app.local_mode.ui.filter_query.is_empty() {
             render_empty_section(frame, app, area);
@@ -359,21 +374,21 @@ fn render_rows(frame: &mut Frame, app: &App, area: Rect) {
     {
         let y = area.y + vis as u16;
         let selected = i == cursor;
-        let deletable = app.local_import_record_deletable(song);
+        let deletable = app.local_import_record_deletable_at(local_rows, i);
         let delete_width = if deletable { 2 } else { 0 };
         let body_w = row_width.saturating_sub(delete_width) as usize;
         let marker = if selected { "> " } else { "  " };
-        let text = app.local_row_text(song);
+        let text = app.local_row_text_at(local_rows, i);
         let text = if selected {
             crate::ui::anim::selected_marquee(
                 app,
                 ScrollSurface::Library,
                 i,
-                &text,
+                text.as_ref(),
                 body_w.saturating_sub(3),
             )
         } else {
-            text
+            text.to_string()
         };
         let body = crate::ui::text::truncate_owned_to_width(
             format!("{marker}{text}"),

--- a/src/ui/views/search.rs
+++ b/src/ui/views/search.rs
@@ -12,11 +12,13 @@ use ratatui::widgets::{Block, Borders, HighlightSpacing, List, ListItem, ListSta
 use unicode_width::UnicodeWidthStr;
 
 use crate::app::{App, MouseTarget, ScrollSurface, SearchFocus, SearchKind, StatusKind};
+use crate::library::FavoriteLookup;
 use crate::t;
 use crate::theme::ThemeRole as R;
 use crate::ui::buttons;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+    let favorite_lookup = search_favorite_lookup(app);
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(app.theme.style(R::BorderPrimary))
@@ -69,7 +71,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     render_input(frame, app, rows[1]);
-    render_results(frame, app, rows[2]);
+    render_results(frame, app, rows[2], favorite_lookup.as_ref());
 
     buttons::render_help_button(frame, app, rows[3]);
     if app.dropdowns.search_source_open {
@@ -79,8 +81,13 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     // overlays, like the queue window on the player). Its rect is a per-frame output.
     app.search_filter.rect.set(None);
     if app.search_filter.open {
-        render_filter_popup(frame, app, inner);
+        render_filter_popup(frame, app, inner, favorite_lookup.as_ref());
     }
+}
+
+fn search_favorite_lookup(app: &App) -> Option<FavoriteLookup<'_>> {
+    (!app.search.results.is_empty() || app.search_filter.open)
+        .then(|| app.library.favorite_lookup())
 }
 
 fn render_input(frame: &mut Frame, app: &App, area: Rect) {
@@ -255,14 +262,18 @@ fn render_filter_button(frame: &mut Frame, app: &App, area: Rect) {
 /// the fixed-width heart gutter, and the un-marqueed `title — artist (dur)` body — so the
 /// results list and the filter popup format rows identically and never drift. Each caller
 /// applies its own leading marker and marquee/truncation on top.
-fn result_row_cells(app: &App, song: &crate::api::Song) -> (String, &'static str, String) {
+fn result_row_cells(
+    app: &App,
+    song: &crate::api::Song,
+    favorite_lookup: Option<&FavoriteLookup<'_>>,
+) -> (String, &'static str, String) {
     // Fixed-width heart slot (like the library lists) so favoriting a row never shifts its
     // title relative to its neighbors.
-    let heart = if app.library.is_favorite(&song.video_id) {
-        "♥ "
-    } else {
-        "  "
-    };
+    let is_favorite = favorite_lookup.map_or_else(
+        || app.library.is_favorite(&song.video_id),
+        |lookup| lookup.is_favorite(&song.video_id),
+    );
+    let heart = if is_favorite { "♥ " } else { "  " };
     // Playlist rows get their own tag so they read as containers, not tracks. Codes vary in
     // width ([YT] vs [RAD]); pad to a fixed column so titles align across mixed-source results.
     let source = if song.youtube_playlist_id().is_some() {
@@ -281,7 +292,12 @@ fn result_row_cells(app: &App, song: &crate::api::Song) -> (String, &'static str
     (source, heart, text)
 }
 
-fn render_results(frame: &mut Frame, app: &App, area: Rect) {
+fn render_results(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    favorite_lookup: Option<&FavoriteLookup<'_>>,
+) {
     // Record the viewport height so PageUp/PageDown can move by a screenful (see app::page_step).
     app.bridges.list_viewport_rows.set(area.height);
 
@@ -322,7 +338,7 @@ fn render_results(frame: &mut Frame, app: &App, area: Rect) {
         .skip(offset)
         .take(area.height as usize)
         .map(|(i, s)| {
-            let (source, heart, text) = result_row_cells(app, s);
+            let (source, heart, text) = result_row_cells(app, s, favorite_lookup);
             // The focused, visible cursor row marquees when clipped — the source tag and
             // heart gutter stay put while the text crawls (see `anim::selected_marquee`).
             // Suppressed while the filter popup is open: its cursor row marquees instead,
@@ -505,7 +521,12 @@ fn render_dropdown(
 /// live filter input and the narrowed result rows. Typing edits the query, ↑↓/PgUp/PgDn/
 /// Home/End move within the matches, Enter or a double-click plays the highlighted one, a
 /// right-click enqueues it (popup stays open), Esc or a click outside closes.
-fn render_filter_popup(frame: &mut Frame, app: &App, area: Rect) {
+fn render_filter_popup(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    favorite_lookup: Option<&FavoriteLookup<'_>>,
+) {
     let rows_all = app.search_filter_rows();
     let total = app.search.results.len();
 
@@ -602,7 +623,7 @@ fn render_filter_popup(frame: &mut Frame, app: &App, area: Rect) {
             let y = list_area.y + vis as u16;
             let selected = display_idx == cursor;
             let marker = if selected { "▶ " } else { "  " };
-            let (source, heart, text) = result_row_cells(app, song);
+            let (source, heart, text) = result_row_cells(app, song, favorite_lookup);
             // The cursor row marquees when clipped, keyed by the *original* row index so
             // retyping (which shifts display positions) doesn't restart a crawl that is
             // still on the same song. The marker/source/heart gutter (10 cols) stays put.
@@ -670,4 +691,42 @@ fn render_filter_popup(frame: &mut Frame, app: &App, area: Rect) {
     );
     crate::ui::seal_popup_background(frame, app, popup);
     crate::ui::mark_art_rows_for_popup(frame, app, popup);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn favorite_lookup_is_skipped_only_for_an_empty_closed_search() {
+        let mut app = App::new(100);
+        assert!(search_favorite_lookup(&app).is_none());
+
+        app.search_filter.open = true;
+        assert!(search_favorite_lookup(&app).is_some());
+
+        app.search_filter.open = false;
+        app.search
+            .results
+            .push(crate::api::Song::local_file(PathBuf::from("result.mp3")));
+        assert!(search_favorite_lookup(&app).is_some());
+    }
+
+    #[test]
+    fn lazy_favorite_lookup_preserves_result_row_output() {
+        let mut app = App::new(100);
+        let favorite = crate::api::Song::remote("favorite", "Favorite", "Artist", "3:00");
+        let other = crate::api::Song::remote("other", "Other", "Artist", "2:00");
+        app.library.toggle_favorite(&favorite);
+
+        let lookup = app.library.favorite_lookup();
+        for song in [&favorite, &other] {
+            assert_eq!(
+                result_row_cells(&app, song, None),
+                result_row_cells(&app, song, Some(&lookup))
+            );
+        }
+    }
 }

--- a/src/ui/views/search.rs
+++ b/src/ui/views/search.rs
@@ -319,6 +319,8 @@ fn render_results(frame: &mut Frame, app: &App, area: Rect) {
         .results
         .iter()
         .enumerate()
+        .skip(offset)
+        .take(area.height as usize)
         .map(|(i, s)| {
             let (source, heart, text) = result_row_cells(app, s);
             // The focused, visible cursor row marquees when clipped — the source tag and
@@ -369,15 +371,16 @@ fn render_results(frame: &mut Frame, app: &App, area: Rect) {
         // viewport and snaps back when it returns.
         .highlight_spacing(HighlightSpacing::Always);
 
-    // Pre-seed the wheel offset so ratatui honors it; only highlight the selection while
-    // it is actually visible, so the wheel can scroll past it.
-    let mut state = ListState::default().with_offset(offset);
+    // Only the visible window is formatted above, so its local list offset is zero. Keep all
+    // hit targets, selection, animation indices, and scrollbar positions in absolute result
+    // coordinates to preserve the existing interaction semantics.
+    let mut state = ListState::default();
     if let Some(sel) = visible_sel {
-        state.select(Some(sel));
+        state.select(Some(sel - offset));
     }
     frame.render_stateful_widget(list, area, &mut state);
     // Each visible row is a click target: single-click selects, double-click plays.
-    buttons::register_list_rows(app, area, state.offset(), len, Some);
+    buttons::register_list_rows(app, area, offset, len, Some);
     // Scrollbar on the right border, tracking the viewport position; hidden when results fit.
     buttons::render_list_scrollbar(
         frame,
@@ -390,7 +393,7 @@ fn render_results(frame: &mut Frame, app: &App, area: Rect) {
         },
         ScrollSurface::Search,
         len,
-        state.offset(),
+        offset,
         area.height as usize,
     );
 }

--- a/src/util/safe_fs.rs
+++ b/src/util/safe_fs.rs
@@ -17,7 +17,9 @@ use serde_json::{Map, Value};
 #[cfg(unix)]
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 #[cfg(windows)]
-use std::os::windows::fs::MetadataExt;
+use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
 
 #[cfg(unix)]
 const PRIVATE_DIR_MODE: u32 = 0o700;
@@ -99,6 +101,79 @@ fn reject_symlink(path: &Path) -> io::Result<()> {
 
 #[cfg(windows)]
 const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+
+#[cfg(any(windows, test))]
+fn validate_windows_change_time(change_time: i64) -> io::Result<i64> {
+    if change_time > 0 {
+        Ok(change_time)
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "filesystem did not provide a usable change time",
+        ))
+    }
+}
+
+#[cfg(windows)]
+fn windows_change_time(file: &File) -> io::Result<i64> {
+    use std::mem::{MaybeUninit, size_of};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_BASIC_INFO, FileBasicInfo, GetFileInformationByHandleEx,
+    };
+
+    let mut info = MaybeUninit::<FILE_BASIC_INFO>::uninit();
+    // SAFETY: `file` owns a valid handle, `info` points to writable storage of exactly the size
+    // passed, and the buffer is read only after Win32 reports success.
+    let succeeded = unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle(),
+            FileBasicInfo,
+            info.as_mut_ptr().cast(),
+            size_of::<FILE_BASIC_INFO>() as u32,
+        )
+    };
+    if succeeded == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: a nonzero result guarantees Win32 initialized the FILE_BASIC_INFO buffer.
+    let change_time = unsafe { info.assume_init() }.ChangeTime;
+    validate_windows_change_time(change_time)
+}
+
+/// Query the Windows change timestamp for the directory currently bound to `path`. The handle is
+/// deliberately transient: retaining a share-delete handle can keep observing an old directory
+/// after an ancestor of `path` is atomically replaced.
+#[cfg(windows)]
+pub(crate) fn windows_directory_change_time(path: &Path) -> io::Result<i64> {
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE,
+    };
+
+    let file = OpenOptions::new()
+        .access_mode(FILE_READ_ATTRIBUTES)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(path)?;
+    windows_change_time(&file)
+}
+
+/// Query one artifact's Windows change timestamp through a transient handle. The handle is
+/// dropped before this function returns, so fingerprinting never pins imported files open.
+#[cfg(windows)]
+pub(crate) fn windows_file_change_time(path: &Path) -> io::Result<i64> {
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE,
+    };
+
+    let file = OpenOptions::new()
+        .access_mode(FILE_READ_ATTRIBUTES)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    windows_change_time(&file)
+}
 
 #[cfg(windows)]
 fn is_windows_reparse_point(meta: &fs::Metadata) -> bool {
@@ -812,6 +887,33 @@ mod tests {
         getrandom::fill(&mut bytes).unwrap();
         let suffix = bytes.iter().map(|b| format!("{b:02x}")).collect::<String>();
         std::env::temp_dir().join(format!("yututui-{name}-{}-{suffix}", std::process::id()))
+    }
+
+    #[test]
+    fn windows_change_time_requires_a_positive_generation() {
+        assert_eq!(validate_windows_change_time(1).unwrap(), 1);
+        assert_eq!(
+            validate_windows_change_time(0).unwrap_err().kind(),
+            io::ErrorKind::Unsupported
+        );
+        assert_eq!(
+            validate_windows_change_time(-1).unwrap_err().kind(),
+            io::ErrorKind::Unsupported
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_file_change_time_uses_a_transient_handle() {
+        let dir = temp_root("file-change-time");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("artifact.json");
+        fs::write(&path, b"{}").unwrap();
+
+        assert!(windows_file_change_time(&path).unwrap() > 0);
+        // The helper's local handle has already been dropped, so the artifact is not pinned.
+        fs::remove_file(&path).unwrap();
+        fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a reproducible, fail-closed native performance harness with AB/BA pairing, process-tree sampling, playback control, deterministic render digests, provenance/checksum validation, and Unix/PowerShell launchers
- reduce hot-path work in terminal telemetry, observers, remote/media projections, Search/Library/Local/AI rendering, logging, lyrics, album art, and mpv numeric IPC
- preserve existing animation cadence and exact stable UI cells/hit maps; bound Linux/Windows media delivery while keeping latest progress and ordered critical events
- keep mpv cache defaults at 32MiB/8MiB and migration revision dormant because the required three-OS cache evidence was not completed

## User-visible behavior

Normal layout, labels, keybindings, mouse hit targets, animation cadence, artwork quality, paused-player lifetime, and visible one-second progress are unchanged.

Approved edge cases:
- adjacent TimePos/CacheTime updates may skip a fleeting intermediate frame and render the final state once
- if an OS media consumer falls more than 256 ordered updates behind, intermediate states may be coalesced while the latest state is retained

Lyrics cache is bounded to 64 entries / 8 MiB, so an evicted track may use the existing loading/refetch flow.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --quiet`: 1,989 + 8 passed
- performance examples: 30 passed, 1 intentionally ignored
- Python perf-harness self-test, Python compile, Bash syntax, and `git diff --check`
- Windows GNU workspace check + clippy passed
- vendored ratatui-image production-feature clippy + 26 tests passed
- isolated fake-HOME tmux verification at 80x24, 30x30, 100x30, and 160x50
- frozen baseline/candidate captures and 11 render cases have identical buffer/style and mouse hit-map digests

## Performance evidence

macOS `render_and_interaction` passes the seven-pair gate:
- normal80x24 ratio 0.9970, 95% upper 1.0188
- AI long transcript about 87.5% faster
- large/filter Local paths about 84–94% faster
- all exact visual gates pass

Linux render evidence is intentionally reported as inconclusive/failing, not a pass:
- the first run contained transient normal80 slow windows
- a fresh predeclared rerun did not reproduce the regression and every point/upper ratio was below 1.1
- multiple baseline CV values still exceeded the strict 10% limit

## Draft blockers / not claimed

- idle, playback, network, feature, and memory-soak process reports were not completed after scope was stopped
- Windows native PowerShell/ConPTY evidence is unavailable; local MSVC cross-check is blocked by missing `llvm-rc`
- canonical `run-gates` is blocked because `.claude/harness/project-profile.json` is absent
- four cache candidates, hysteresis, and opt-level experiments were not completed across all three OSes
- therefore this PR does not claim the planned 80% idle CPU, 50% playback CPU, 30% playback RSS, or three-OS completion

This remains a draft until the missing native gates are completed or the scope is explicitly revised.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new process-tree kill/cleanup logic on Unix/Windows is safety-critical for perf runs; ratatui-image sharing changes memory/encoding behavior for album art but is covered by tests.
> 
> **Overview**
> Adds a **reproducible TUI performance harness** as two Rust examples: `tui_perf_sampler` launches a single `ytt`, samples CPU/RSS for the owner process tree (with warmup/measure windows, optional silent-mpv proof, and exact PID/executable/IPC-based cleanup), and `tui_perf_control` drives playback through the authenticated remote API while observing mpv IPC for seek/latency and buffering NDJSON.
> 
> **`ratatui-image`** now keeps decoded album art in `Arc<DynamicImage>` via `StatefulProtocol::new_shared` and picker `new_resize_protocol_shared*` helpers so multiple widgets can share full-resolution pixels without multi-megabyte clones; opaque backgrounds still get a composited copy, with unit tests for parity and `Send + Sync`.
> 
> Minor repo tweaks: ignore Python `__pycache__` / `*.py[cod]`, and enable `Win32_Storage_FileSystem` on `windows-sys` for the harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bdb7ec1f069a8ac79ad058b76c08f50b03a44ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->