### PR TITLE
fix: unblock 1.6.28 Windows preflight

### DIFF
--- a/src/util/safe_fs/recovery_backups.rs
+++ b/src/util/safe_fs/recovery_backups.rs
@@ -6,9 +6,11 @@ use std::time::UNIX_EPOCH;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
+#[cfg(unix)]
+use super::private_file_mode;
 use super::{
     create_private_file, ensure_process_mutation_allowed, mark_do_not_clobber, open_no_symlink,
-    private_file_mode, reject_symlink, sync_parent_dir,
+    reject_symlink, sync_parent_dir,
 };
 
 /// Recovery backups for secret-bearing files are useful, but old credentials should not


### PR DESCRIPTION
## Summary
- gate the Unix-only private file mode import on Unix
- keep Windows recovery backup compilation valid

## Verification
- `~/.fable-harness/bin/run-gates .`
- 2,848 library tests passed in the full parallel workspace run

Release tag and publishing workflows are intentionally unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional-import change with no runtime logic changes; Unix permission behavior is unchanged.
> 
> **Overview**
> **Windows build fix** for `recovery_backups`: `private_file_mode` is only defined on Unix in `safe_fs`, but the module was importing it unconditionally.
> 
> The import is moved out of the shared `super::{...}` list and wrapped in `#[cfg(unix)]`, matching the existing Unix-only call site in `backup_by_copy`. No behavior change on Unix; Windows can compile this module again for release preflight (e.g. 1.6.28).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bca5c271884d4e0f0836d402151d8baae870814a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->