### PR TITLE
release: v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "yututui"
-version = "1.6.28"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui"
-version = "1.6.28"
+version = "1.7.0"
 edition = "2024"
 description = "A fast terminal UI for YouTube Music — search, radio, synced lyrics, album art, and downloads, driven by mpv and yt-dlp."
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           lib = pkgs.lib;
           yututui = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui";
-            version = "1.6.28"; # keep in sync with Cargo.toml
+            version = "1.7.0"; # keep in sync with Cargo.toml
 
             # Drop build artifacts and flake results from the copied source so the store path
             # stays small and rebuilds aren't invalidated by a local `target/`.
@@ -84,7 +84,7 @@
           };
           yututui-desktop = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui-desktop";
-            version = "1.6.28"; # keep the yututray binary version in sync with Cargo.toml
+            version = "1.7.0"; # keep the yututray binary version in sync with Cargo.toml
             src = desktopSrc;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = [ pkgs.makeWrapper pkgs.pkg-config ];


### PR DESCRIPTION
## Release preparation
- bump Cargo package version to 1.7.0
- sync Cargo.lock and flake.nix package versions
- leave release workflow and packaging templates unchanged

## Verification
- `~/.fable-harness/bin/run-gates .` passed

After human merge, the exact sanctioned `v1.7.0` tag will trigger the full five-platform artifact and publishing pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no runtime, security, or packaging logic edits in the diff.
> 
> **Overview**
> **Release version bump to 1.7.0** with no application or workflow changes in this diff.
> 
> `Cargo.toml` and the lockfile entry for `yututui` move **1.6.28 → 1.7.0**. `flake.nix` keeps the same “in sync with Cargo.toml” rule for both **`yututui`** and **`yututui-desktop`** (`yututray`); the private GUI npm package version in the flake stays at **1.6.1**.
> 
> Merging and tagging **`v1.7.0`** is what triggers the existing multi-platform publish pipeline described in the PR notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb7155245df24f1651a212dbbc6af5c4a28ed04. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->