### PR TITLE
Improve interactive player layout and canvas composition

### DIFF
--- a/examples/tui_render_perf.rs
+++ b/examples/tui_render_perf.rs
@@ -3,6 +3,22 @@
 //! This is intentionally an `example`, not a criterion benchmark: the exact same source can
 //! be copied onto the frozen baseline tree, it needs no new dependency, and it emits one stable
 //! JSON schema that `scripts/tui-perf.py compare` can pair across revisions.
+//!
+//! ## Interactive Player performance TODO
+//!
+//! `TODO(interactive-player-canvas-perf)`: recover the full-field Player canvas cost without
+//! lowering configured FPS, density, animation phase, or visual cadence. Against frozen
+//! `origin/main` `435e362c8c0bea05df8f2688a6b748609d841a83`, seven alternating release-mode
+//! AB/BA pairs recorded median candidate/baseline draw-p95 ratios of 1.234 (art 100x30), 1.310
+//! (art 160x50), 1.366 (art + lyrics 100x30), and 1.547 (art + lyrics 160x50). The acceptance
+//! ceiling is 1.10; baseline mean-draw CV remained between 0.40% and 1.93%.
+//!
+//! The lyrics cases compare intentionally different work: the frozen baseline suppresses canvas
+//! rendering while lyrics are visible, whereas the interactive layout requires one full-Player
+//! canvas behind lyrics. Keep the four `canvas_art*` cases below until the debt is resolved, and
+//! report them separately from the pre-existing general `render_and_interaction` gate. Resolution
+//! requires a fresh seven-pair AB/BA run with baseline CV at most 10%, at least six passing pairs,
+//! draw p95 at most 1.10, and the original one-sided ytt/process-tree CPU bounds at most 1.05.
 
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::collections::hash_map::DefaultHasher;
@@ -10,18 +26,26 @@ use std::fs::File;
 use std::hash::{Hash, Hasher};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+use image::DynamicImage;
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
+use ratatui_image::picker::Picker;
+use ratatui_image::thread::ThreadProtocol;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use yututui::api::Song;
-use yututui::app::{AiMessage, AiRole, App, LibraryTab, LocalSection, Mode, Msg, SearchFocus};
+use yututui::app::{
+    AiMessage, AiRole, App, LibraryTab, LocalSection, Mode, Msg, SearchFocus, TrackLyrics,
+};
+use yututui::config::PlayerBarPosition;
 use yututui::i18n::Language;
 use yututui::local::{LocalIndex, LocalTrack};
+use yututui::lyrics::LyricLine;
 
 const SCHEMA: &str = "ytt.tui-perf.render.v1";
 const LOCAL_SCROLL_TRACKS: usize = 180;
@@ -167,7 +191,9 @@ fn positive_usize(name: &str, raw: &str) -> Result<usize, String> {
 fn usage() -> &'static str {
     "Usage: tui_render_perf [--output FILE] [--case NAME] [--warmup N] [--batches N] [--draws N]\n\
      Cases: player, search50, library999, ai_long, reducer_input, retro160x50, normal80x24, \
-     local_empty60x16, local_scroll72x18, local_max120x30, local_filter_ko90x24"
+     local_empty60x16, local_scroll72x18, local_max120x30, local_filter_ko90x24, \
+     canvas_art100x30, canvas_art160x50, canvas_art_lyrics100x30, \
+     canvas_art_lyrics160x50"
 }
 
 #[derive(Serialize)]
@@ -413,6 +439,42 @@ fn case_specs() -> Vec<CaseSpec> {
             update: mutate_for_interaction,
         },
         CaseSpec {
+            name: "canvas_art100x30",
+            update_path: "direct_fixture_state",
+            width: 100,
+            height: 30,
+            language: Language::English,
+            build: canvas_art_app,
+            update: canvas_interaction,
+        },
+        CaseSpec {
+            name: "canvas_art160x50",
+            update_path: "direct_fixture_state",
+            width: 160,
+            height: 50,
+            language: Language::English,
+            build: canvas_art_app,
+            update: canvas_interaction,
+        },
+        CaseSpec {
+            name: "canvas_art_lyrics100x30",
+            update_path: "direct_fixture_state",
+            width: 100,
+            height: 30,
+            language: Language::English,
+            build: canvas_art_lyrics_app,
+            update: canvas_interaction,
+        },
+        CaseSpec {
+            name: "canvas_art_lyrics160x50",
+            update_path: "direct_fixture_state",
+            width: 160,
+            height: 50,
+            language: Language::English,
+            build: canvas_art_lyrics_app,
+            update: canvas_interaction,
+        },
+        CaseSpec {
             name: "local_empty60x16",
             update_path: "direct_fixture_state",
             width: 60,
@@ -610,6 +672,39 @@ fn player_app() -> App {
     app.playback.duration = Some(245.0);
     app.playback.time_pos = Some(73.0);
     app.playback.volume = 67;
+    app
+}
+
+fn canvas_art_app() -> App {
+    let mut app = player_app();
+    app.config.player_bar_position = Some(PlayerBarPosition::Bottom);
+    app.config.album_art = Some(true);
+    app.config.animations.master = true;
+    app.config.animations.plasma = true;
+    app.playback.paused = false;
+
+    let picker = Picker::halfblocks();
+    let image = Arc::new(DynamicImage::new_rgba8(32, 32));
+    let protocol = picker.new_resize_protocol_shared(image);
+    let (tx, _rx) = tokio::sync::mpsc::channel(8);
+    app.art.dims = (32, 32);
+    app.art.picker = Some(picker);
+    *app.art.protocol.borrow_mut() = Some(ThreadProtocol::new(tx, Some(protocol)));
+    app
+}
+
+fn canvas_art_lyrics_app() -> App {
+    let mut app = canvas_art_app();
+    let video_id = app.queue.current().expect("fixture track").video_id.clone();
+    app.lyrics.visible = true;
+    app.lyrics.track = Some(TrackLyrics {
+        video_id,
+        lines: vec![LyricLine {
+            time: 0.0,
+            text: "Deterministic performance fixture lyric".to_owned(),
+        }]
+        .into(),
+    });
     app
 }
 
@@ -812,13 +907,18 @@ fn mutate_for_interaction(app: &mut App, step: usize) {
     }
 }
 
+fn canvas_interaction(app: &mut App, step: usize) {
+    app.update(Msg::AnimTick);
+    app.playback.time_pos = Some((step % 244) as f64);
+}
+
 #[cfg(test)]
 mod tests {
     use std::cell::Cell;
     use std::time::{Duration, Instant};
 
     use super::{
-        LOCAL_FILTER_STRIDE, LOCAL_LARGE_TRACKS, LOCAL_SCROLL_TRACKS, local_empty_app,
+        LOCAL_FILTER_STRIDE, LOCAL_LARGE_TRACKS, LOCAL_SCROLL_TRACKS, case_specs, local_empty_app,
         local_filter_korean_app, local_max_app, local_scroll_app,
         measure_update_to_draw_with_clock, percentile, reducer_input, search_app,
     };
@@ -907,5 +1007,22 @@ mod tests {
         );
         assert_eq!(filtered.local_mode.ui.filter_query, "한글 바늘");
         assert!(filtered.local_mode.ui.filter_editing);
+    }
+
+    #[test]
+    fn interactive_player_performance_todo_cases_remain_in_the_harness() {
+        let cases = case_specs();
+        for (name, width, height) in [
+            ("canvas_art100x30", 100, 30),
+            ("canvas_art160x50", 160, 50),
+            ("canvas_art_lyrics100x30", 100, 30),
+            ("canvas_art_lyrics160x50", 160, 50),
+        ] {
+            let case = cases
+                .iter()
+                .find(|case| case.name == name)
+                .unwrap_or_else(|| panic!("missing tracked performance TODO case {name}"));
+            assert_eq!((case.width, case.height), (width, height));
+        }
     }
 }

--- a/src/app/artwork.rs
+++ b/src/app/artwork.rs
@@ -154,7 +154,7 @@ impl App {
                 || a.time_glow
                 || a.progress_sparkle
                 || a.border_chase
-                || (!self.lyrics.visible && a.any_canvas()))
+                || self.bridges.canvas_active.get())
     }
 
     /// Whether an enabled one-shot feedback effect is still inside its window. While true the clock
@@ -275,7 +275,7 @@ impl App {
         let player_running = matches!(self.mode, Mode::Player)
             && !self.playback.paused
             && self.queue.current().is_some();
-        if player_running && a.master && !self.lyrics.visible && a.any_canvas_heavy() {
+        if player_running && a.master && self.bridges.canvas_heavy_active.get() {
             return fps.min(20);
         }
         if player_running
@@ -522,8 +522,8 @@ impl App {
     /// status redraws avoid the extra escape traffic; album art and canvas animation keep the
     /// atomic swap that prevents tearing/ghosting on terminals that support it.
     pub fn synchronized_draw_active(&self) -> bool {
-        let a = self.animations();
-        self.art_active() || (matches!(self.mode, Mode::Player) && a.master && a.any_canvas_heavy())
+        self.art_active()
+            || (matches!(self.mode, Mode::Player) && self.bridges.canvas_heavy_active.get())
     }
 
     /// Whether the "Gemini-tan" mascot on the DJ Gem start screen should be dancing right now. True

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -75,6 +75,12 @@ pub struct RenderBridges {
     pub marquee_origin: Cell<u64>,
     pub marquee_ran: Cell<bool>,
     pub marquee_cache: RefCell<crate::ui::marquee::MarqueeCache>,
+    /// Whether the last render actually placed at least one canvas effect. Unlike raw config,
+    /// this excludes effects hidden by the responsive layout or focal safe-area constraints.
+    pub canvas_active: Cell<bool>,
+    /// Whether any actually placed canvas effect uses the heavy redraw cadence. This keeps the
+    /// 20 fps cap and synchronized terminal updates active even when lyrics are in the foreground.
+    pub canvas_heavy_active: Cell<bool>,
 }
 
 impl RenderBridges {

--- a/src/app/tests/animations.rs
+++ b/src/app/tests/animations.rs
@@ -7,6 +7,8 @@ fn losing_terminal_focus_parks_animations_then_regaining_resumes() {
     // Master + one effect on → animations are logically running.
     app.config.animations.master = true;
     app.config.animations.rain = true;
+    app.bridges.canvas_active.set(true);
+    app.bridges.canvas_heavy_active.set(true);
     assert!(
         app.config.animations.pause_unfocused,
         "pause_unfocused defaults on"
@@ -36,6 +38,8 @@ fn overlays_do_not_park_animations_but_focus_still_does() {
     app.playback.paused = false;
     app.config.animations.master = true;
     app.config.animations.rain = true;
+    app.bridges.canvas_active.set(true);
+    app.bridges.canvas_heavy_active.set(true);
 
     assert!(app.animation_active());
 
@@ -590,6 +594,8 @@ fn canvas_animation_advances_phase_every_tick_but_caps_redraws() {
     app.config.animations.master = true;
     app.config.animations.rain = true;
     app.config.animations.fps = 30;
+    app.bridges.canvas_active.set(true);
+    app.bridges.canvas_heavy_active.set(true);
 
     assert_eq!(app.animation_tick_fps(), 30);
     assert_eq!(app.animation_draw_fps(), 20);
@@ -719,6 +725,8 @@ async fn delayed_interval_skip_matches_one_tick_oracle_for_canvas_marquee_and_fx
         app.config.animations.master = true;
         app.config.animations.rain = true;
         app.config.animations.fps = 30;
+        app.bridges.canvas_active.set(true);
+        app.bridges.canvas_heavy_active.set(true);
         assert_eq!(app.animation_draw_fps(), 20);
         app
     }

--- a/src/app/tests/art_overlay.rs
+++ b/src/app/tests/art_overlay.rs
@@ -468,16 +468,14 @@ fn popup_art_marker_leaves_current_player_anchor_unchanged() {
 }
 
 #[test]
-fn player_about_popup_keeps_full_kitty_art_rows_at_the_edges() {
+fn player_popup_marker_keeps_full_kitty_art_rows_at_the_edges() {
     use image::imageops::FilterType;
     use ratatui_image::picker::ProtocolType;
     use ratatui_image::{Resize, ResizeEncodeRender};
 
     let area = Rect::new(0, 0, 120, 50);
-    let popup = centered_fixed(area, 60, 25);
     let image = image::DynamicImage::new_rgba8(160, 90);
     let mut app = app_playing(1, 0);
-    app.overlays.about_visible = true;
     configure_test_art_picker(&mut app, ProtocolType::Kitty);
     let video_id = app.queue.current().unwrap().video_id.clone();
     app.set_artwork(video_id, Some(image.clone()));
@@ -491,6 +489,12 @@ fn player_about_popup_keeps_full_kitty_art_rows_at_the_edges() {
         .rect
         .get()
         .expect("player render should publish art rect");
+    let popup = Rect::new(
+        art.left() + art.width / 4,
+        art.top() + art.height / 4,
+        art.width / 2,
+        (art.height / 2).max(1),
+    );
     assert!(
         art.left() < popup.left(),
         "test geometry must expose a left art edge"
@@ -513,7 +517,15 @@ fn player_about_popup_keeps_full_kitty_art_rows_at_the_edges() {
     let (tx, _rx) = tokio::sync::mpsc::channel(8);
     *app.art.protocol.borrow_mut() = Some(ThreadProtocol::new(tx, Some(protocol)));
 
-    let buf = render_app_buffer(&app, area.width, area.height);
+    let backend = TestBackend::new(area.width, area.height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            crate::ui::render(frame, &app);
+            crate::ui::mark_art_rows_for_popup(frame, &app, popup);
+        })
+        .unwrap();
+    let buf = terminal.backend().buffer();
     let overlap = art.intersection(popup);
     for y in overlap.top()..overlap.bottom() {
         let symbol = buf

--- a/src/app/tests/docked_bar.rs
+++ b/src/app/tests/docked_bar.rs
@@ -388,12 +388,20 @@ fn art_geometry_moves_request_a_native_clear() {
         app.take_clear_before_draw(),
         "lyrics toggle moves the art band"
     );
+    assert!(
+        !app.take_clear_before_draw(),
+        "lyrics reflow should request exactly one native clear"
+    );
     // Moving the bar between Top and Bottom relocates the whole filler.
     app.config.player_bar_position = Some(PlayerBarPosition::Top);
     app.sync_art_geometry();
     assert!(
         app.take_clear_before_draw(),
         "bar-position change moves the art band"
+    );
+    assert!(
+        !app.take_clear_before_draw(),
+        "bar relocation should request exactly one native clear"
     );
 }
 

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -35,6 +35,7 @@ mod nav_mouse;
 mod now_playing_overlay;
 mod playback_auto_advance;
 mod playback_settings;
+mod player_composition;
 mod player_controls;
 mod player_intent_preflight;
 mod playlist_search;

--- a/src/app/tests/player_composition.rs
+++ b/src/app/tests/player_composition.rs
@@ -1,0 +1,300 @@
+use super::*;
+
+use crate::config::PlayerBarPosition;
+use crate::ui::layout::UiTier;
+use ratatui::layout::Rect;
+use ratatui_image::picker::ProtocolType;
+use unicode_width::UnicodeWidthStr;
+
+const LYRIC_MARKER: &str = "SIDE LYRICS";
+
+fn bottom_player_with_art_and_lyrics() -> App {
+    let mut app = app_playing(2, 0);
+    app.config.player_bar_position = Some(PlayerBarPosition::Bottom);
+    make_test_art_active(&mut app, ProtocolType::Halfblocks);
+    app.playback.time_pos = Some(0.0);
+    app.playback.time_pos_at = None;
+    app.lyrics.visible = true;
+    app.lyrics.track = Some(TrackLyrics {
+        video_id: app.queue.current().expect("current track").video_id.clone(),
+        lines: vec![crate::lyrics::LyricLine {
+            time: 0.0,
+            text: LYRIC_MARKER.to_owned(),
+        }]
+        .into(),
+    });
+    app
+}
+
+fn text_position(buffer: &ratatui::buffer::Buffer, needle: &str) -> Option<(u16, u16)> {
+    (0..buffer.area.height).find_map(|y| {
+        let row = buffer_row(buffer, y);
+        row.find(needle).map(|byte| {
+            let x = UnicodeWidthStr::width(&row[..byte]) as u16;
+            (x, y)
+        })
+    })
+}
+
+fn disjoint(a: Rect, b: Rect) -> bool {
+    a.intersection(b).is_empty()
+}
+
+#[test]
+fn bottom_final_art_rects_follow_requested_frame_geometry_and_yield_tiny_space() {
+    let _guard = crate::i18n::lock_for_test();
+    let app = bottom_player_with_art_and_lyrics();
+    let cases = [
+        ((160, 50), Some(Rect::new(44, 15, 30, 15))),
+        ((100, 30), Some(Rect::new(14, 5, 30, 15))),
+        ((80, 24), Some(Rect::new(4, 2, 30, 15))),
+        ((60, 18), Some(Rect::new(1, 2, 18, 9))),
+        ((32, 14), None),
+    ];
+
+    for ((width, height), expected_art) in cases {
+        let buffer = render_app_buffer(&app, width, height);
+        assert_eq!(
+            app.art.rect.get(),
+            expected_art,
+            "unexpected final art rect at {width}x{height}"
+        );
+        assert!(
+            buffer_contains(&buffer, LYRIC_MARKER),
+            "lyrics should retain the filler at {width}x{height}"
+        );
+
+        if let Some(art) = expected_art {
+            let (lyrics_x, lyrics_y) =
+                text_position(&buffer, LYRIC_MARKER).expect("unique lyric marker rendered");
+            assert!(
+                lyrics_x >= art.right().saturating_add(2),
+                "{width}x{height}: lyrics at x={lyrics_x} must sit beyond art {art:?} and its two-cell gap"
+            );
+            assert!(
+                lyrics_y >= 2 && lyrics_y < height.saturating_sub(7),
+                "{width}x{height}: lyrics row {lyrics_y} escaped the filler"
+            );
+        }
+    }
+}
+
+#[test]
+fn bottom_art_never_overlaps_controls_or_footer() {
+    let _guard = crate::i18n::lock_for_test();
+    let app = bottom_player_with_art_and_lyrics();
+
+    for (width, height) in [(160, 50), (100, 30), (80, 24), (60, 18)] {
+        let _ = render_app_buffer(&app, width, height);
+        let art = app.art.rect.get().expect("art fits this full-tier frame");
+        for target in [
+            MouseTarget::Player(Action::TogglePause),
+            MouseTarget::VolumeArea,
+            MouseTarget::Global(Action::ToggleHelp),
+            MouseTarget::MouseHelp,
+        ] {
+            let foreground = app
+                .hits
+                .rect_of_target(target.clone())
+                .unwrap_or_else(|| panic!("{target:?} registered at {width}x{height}"));
+            assert!(
+                disjoint(art, foreground),
+                "{width}x{height}: art {art:?} overlaps {target:?} at {foreground:?}"
+            );
+        }
+        let seekbar = app.hits.seekbar_rect().expect("seekbar registered");
+        assert!(
+            disjoint(art, seekbar),
+            "{width}x{height}: art {art:?} overlaps seekbar {seekbar:?}"
+        );
+    }
+}
+
+#[test]
+fn bottom_art_suppresses_only_the_rendered_donut() {
+    let mut app = app_playing(1, 0);
+    app.playback.paused = false;
+    app.config.animations.master = true;
+    app.config.animations.donut = true;
+    app.config.player_bar_position = Some(PlayerBarPosition::Bottom);
+    make_test_art_active(&mut app, ProtocolType::Halfblocks);
+
+    let _ = render_app_buffer(&app, 100, 30);
+    assert!(app.config.animations.donut, "raw config must be retained");
+    assert!(
+        app.art.rect.get().is_some(),
+        "Bottom art is actually visible"
+    );
+    assert!(
+        !app.bridges.canvas_active.get() && !app.bridges.canvas_heavy_active.get(),
+        "the only configured canvas effect is contextually suppressed"
+    );
+
+    app.config.player_bar_position = Some(PlayerBarPosition::Top);
+    let _ = render_app_buffer(&app, 100, 30);
+    assert!(
+        app.config.animations.donut,
+        "layout changes do not edit config"
+    );
+    assert!(
+        app.bridges.canvas_active.get() && app.bridges.canvas_heavy_active.get(),
+        "Top restores the configured donut"
+    );
+
+    app.config.player_bar_position = Some(PlayerBarPosition::Bottom);
+    app.config.album_art = Some(false);
+    let _ = render_app_buffer(&app, 100, 30);
+    assert!(app.art.rect.get().is_none(), "art-off publishes no mask");
+    assert!(
+        app.bridges.canvas_active.get() && app.bridges.canvas_heavy_active.get(),
+        "Bottom restores donut as soon as no final art rect exists"
+    );
+
+    app.config.album_art = Some(true);
+    app.art.loading = true;
+    app.art.protocol.borrow_mut().take();
+    let _ = render_app_buffer(&app, 100, 30);
+    assert!(
+        app.art.rect.get().is_none(),
+        "loading art publishes no mask"
+    );
+    assert!(
+        app.bridges.canvas_active.get(),
+        "a loading image must not contextually suppress donut"
+    );
+
+    let video_id = app.queue.current().expect("current track").video_id.clone();
+    app.set_artwork(video_id, Some(image::DynamicImage::new_rgba8(32, 32)));
+    app.art
+        .picker
+        .as_mut()
+        .expect("test picker")
+        .set_protocol_type(ProtocolType::Kitty);
+    app.zoom.set_mode(crate::zoom::ZoomMode::Osc66);
+    app.zoom.set(125);
+    let _ = render_app_buffer(&app, 100, 30);
+    assert!(
+        app.art.rect.get().is_none(),
+        "zoom-hidden native art publishes no mask"
+    );
+    assert!(
+        app.bridges.canvas_active.get(),
+        "zoom-hidden native art must restore donut"
+    );
+}
+
+#[test]
+fn visible_canvas_bridge_caps_heavy_redraws_even_with_lyrics() {
+    let mut app = bottom_player_with_art_and_lyrics();
+    app.playback.paused = false;
+    app.config.animations.master = true;
+    app.config.animations.fps = 30;
+    app.config.animations.plasma = true;
+
+    let _ = render_app_buffer(&app, 80, 24);
+    assert!(app.bridges.canvas_active.get());
+    assert!(app.bridges.canvas_heavy_active.get());
+    assert_eq!(
+        app.animation_draw_fps(),
+        20,
+        "visible heavy canvas keeps its redraw cap while lyrics are visible"
+    );
+    assert!(
+        app.synchronized_draw_active(),
+        "a rendered heavy canvas requests synchronized drawing"
+    );
+}
+
+#[test]
+fn mini_frame_clears_canvas_bridges_and_art_geometry() {
+    let mut app = bottom_player_with_art_and_lyrics();
+    app.config.animations.master = true;
+    app.config.animations.plasma = true;
+
+    let _ = render_app_buffer(&app, 80, 24);
+    assert!(app.bridges.canvas_active.get());
+    assert!(app.bridges.canvas_heavy_active.get());
+    assert!(app.art.rect.get().is_some());
+
+    let _ = render_app_buffer(&app, 28, 8);
+    assert_eq!(app.bridges.ui_tier.get(), UiTier::Mini);
+    assert!(!app.bridges.canvas_active.get());
+    assert!(!app.bridges.canvas_heavy_active.get());
+    assert!(app.art.rect.get().is_none());
+}
+
+#[test]
+fn tiny_bottom_lyrics_hide_focal_only_canvas_without_waking_redraws() {
+    let mut app = bottom_player_with_art_and_lyrics();
+    app.config.album_art = Some(false);
+    app.config.animations.master = true;
+    app.config.animations.cube = true;
+    app.config.animations.donut = true;
+
+    let buffer = render_app_buffer(&app, 32, 14);
+    assert!(buffer_contains(&buffer, LYRIC_MARKER));
+    assert!(app.art.rect.get().is_none());
+    assert!(!app.bridges.canvas_active.get());
+    assert!(!app.bridges.canvas_heavy_active.get());
+}
+
+#[test]
+fn animations_off_frames_are_stable_across_animation_phase_changes() {
+    let _guard = crate::i18n::lock_for_test();
+    for position in [PlayerBarPosition::Top, PlayerBarPosition::Bottom] {
+        let mut app = app_playing(1, 0);
+        app.config.player_bar_position = Some(position);
+        app.config.animations.master = false;
+        app.playback.paused = true;
+        app.playback.time_pos = Some(15.0);
+        app.playback.time_pos_at = None;
+        app.playback.duration = Some(120.0);
+
+        app.anim.anim_frame = 0;
+        let first = render_app_buffer(&app, 100, 30);
+        app.anim.anim_frame = 1_337;
+        let later = render_app_buffer(&app, 100, 30);
+
+        assert_eq!(
+            later, first,
+            "animations-off {position:?} output changed with animation phase"
+        );
+        assert!(!app.bridges.canvas_active.get());
+        assert!(!app.bridges.canvas_heavy_active.get());
+    }
+}
+
+#[test]
+fn art_protocols_retro_and_popup_stack_render_without_geometry_regressions() {
+    let _guard = crate::i18n::lock_for_test();
+    for protocol in [
+        ProtocolType::Halfblocks,
+        ProtocolType::Kitty,
+        ProtocolType::Sixel,
+        ProtocolType::Iterm2,
+    ] {
+        let mut app = app_playing(2, 0);
+        app.config.player_bar_position = Some(PlayerBarPosition::Bottom);
+        app.config.animations.master = true;
+        app.config.animations.plasma = true;
+        app.queue_popup.open = true;
+        make_test_art_active(&mut app, protocol);
+
+        let _ = render_app_buffer(&app, 100, 30);
+        assert!(app.art.rect.get().is_some(), "{protocol:?}: final art rect");
+        assert!(
+            app.queue_popup.rect.get().is_some(),
+            "{protocol:?}: queue popup stays in the foreground"
+        );
+        assert!(app.bridges.canvas_active.get(), "{protocol:?}: canvas ran");
+    }
+
+    let mut retro = app_playing(2, 0);
+    retro.config.player_bar_position = Some(PlayerBarPosition::Bottom);
+    retro.config.retro_mode = true;
+    retro.queue_popup.open = true;
+    make_test_art_active(&mut retro, ProtocolType::Kitty);
+    let _ = render_app_buffer(&retro, 100, 30);
+    assert!(retro.art.rect.get().is_some());
+    assert!(retro.queue_popup.rect.get().is_some());
+}

--- a/src/app/tests/radio_mode.rs
+++ b/src/app/tests/radio_mode.rs
@@ -577,7 +577,7 @@ fn radio_art_hidden_when_album_art_disabled() {
 }
 
 #[test]
-fn radio_mode_keeps_gap_and_animates_canvas_below_separator() {
+fn radio_mode_field_canvas_spans_player_behind_the_set_piece() {
     let mut app = App::new(100);
     app.config.album_art = Some(true);
     apply_radio_mode_and_admit(&mut app, RadioModeConfirm::Enter);
@@ -592,24 +592,23 @@ fn radio_mode_keeps_gap_and_animates_canvas_below_separator() {
         .find(|&y| buffer_row(&first, y).contains("ılılı"))
         .expect("one-line art row");
 
-    // Two luxury rows sit between the set piece's bottom edge and the one-line art
-    // (the art's own blank-braille pad row is ⠀ glyphs, not spaces, so a collapsed gap
-    // would show up here).
-    for dy in 1..=2u16 {
-        let interior: String = buffer_row(&first, sep_y - dy)
-            .chars()
-            .skip(1)
-            .take(97)
-            .collect();
-        assert!(
-            interior.trim().is_empty(),
-            "row {dy} above the one-line art should be blank, got: {interior:?}"
-        );
-    }
+    // Rain is a Player-interior field effect now. It occupies the structural gap behind the
+    // foreground set piece instead of being dispatched into a second below-art canvas.
+    let gap_before = buffer_row(&first, sep_y - 1);
+    assert!(
+        !gap_before.trim().is_empty(),
+        "the full-player field should be visible in the radio-art gap"
+    );
+    assert!(app.bridges.canvas_active.get());
+    assert!(app.bridges.canvas_heavy_active.get());
 
-    // The music-mode canvas (rain) animates in the blank band below the one-line art.
     app.anim.anim_frame = 40;
     let later = render_app_buffer(&app, 100, 36);
+    assert_ne!(
+        gap_before,
+        buffer_row(&later, sep_y - 1),
+        "the field behind the radio set piece should animate"
+    );
     let below = |buf: &ratatui::buffer::Buffer| -> String {
         (sep_y + 1..34).map(|y| buffer_row(buf, y)).collect()
     };

--- a/src/ui/anim.rs
+++ b/src/ui/anim.rs
@@ -15,10 +15,9 @@
 //!   popup fade-in). Each reads its start frame from [`App::fx`](crate::app::FxState) and its
 //!   window from [`fx_window`]; the window is defined in wall-clock ms and converted through
 //!   [`App::anim_ms_frames`], so a one-shot feels the same length at 5 fps and at 60 fps.
-//! * **Canvas** — drawn straight into the back buffer in the blank filler zone only (never over
-//!   album art or lyrics), dispatched by [`render_canvas`] across the `canvas` (matrix rain,
-//!   donut, visualizer, starfield, bounce), `canvas_ext` (comets, snow, fireflies, cube,
-//!   aquarium, waves) and `canvas_sim` (fireworks, Life, pipes, plasma) submodules.
+//! * **Canvas** — drawn straight into the back buffer through [`render_canvas_composite`]. Field
+//!   effects share the Player interior, scenes use the filler stage, focal effects receive safe
+//!   regions, and every write hard-masks album art.
 //! * **Overlay** — the About card's sparkles and brand gradient.
 //!
 //! All phase comes from [`App::anim_frame`] (a frame counter frozen while paused, except while a
@@ -44,7 +43,7 @@ mod canvas_ext;
 mod canvas_sim;
 mod element_ext;
 
-pub use canvas::render_canvas;
+pub use canvas::render_canvas_composite;
 pub use element_ext::{
     border_chase_overlay, pause_flash_overlay, progress_sparkle_overlay, time_glow_gauge_style,
     time_glow_label,
@@ -1231,7 +1230,7 @@ mod tests {
         );
 
         let canvas = render_with(&app, 48, 16, |f, app, area| {
-            render_canvas(f, app, area);
+            render_canvas_composite(f, app, area, area, None, None, false);
         });
         assert!(
             (0..canvas.area.height)

--- a/src/ui/anim/canvas.rs
+++ b/src/ui/anim/canvas.rs
@@ -1,12 +1,11 @@
-//! First-wave filler-canvas effects — matrix rain, the starfield, the faux visualizer, the
-//! spinning donut and the bouncing logo — plus [`render_canvas`], the single dispatcher every
-//! blank filler zone is painted through (back-to-front across this module, `canvas_ext` and
-//! `canvas_sim`). Split out of the parent module verbatim when the second wave landed.
+//! Canvas composition and first-wave effects. [`render_canvas_composite`] paints each enabled
+//! effect once in its assigned coordinate space and hard-masks album art for every write.
 
 use std::cell::RefCell;
 use std::sync::OnceLock;
 
 use ratatui::Frame;
+use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 
@@ -14,62 +13,457 @@ use super::{bar_blocks, canvas_ext, canvas_sim, hash32, lerp_color, put_char, wa
 use crate::app::App;
 use crate::theme::ThemeRole as R;
 
-/// Draw all enabled canvas effects into a blank `zone`, back to front: full-field washes
-/// first (plasma, Life, pipes), then weather and sky (waves, rain, snow, starfield,
-/// fireflies, comets), then the scene pieces (aquarium, visualizer, fireworks, cube, donut)
-/// and finally the bouncing logo on top. Called only for the blank filler region, so it never
-/// overdraws album art or lyrics.
-pub fn render_canvas(frame: &mut Frame, app: &App, zone: Rect) {
-    let a = app.animations();
-    if !a.master || zone.width < 4 || zone.height < 2 {
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CanvasActivity {
+    pub active: bool,
+    pub heavy: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct CellSpan {
+    pub start: u16,
+    pub end: u16,
+}
+
+/// Direct writer for canvas effects. Album art is a hard exclusion even though the image widget
+/// renders later: Kitty album art intentionally sits below terminal text, so merely relying on
+/// widget order would still let an animation glyph shine through the image.
+pub(super) struct CanvasWriter<'a> {
+    buffer: &'a mut Buffer,
+    art_mask: Option<Rect>,
+}
+
+impl<'a> CanvasWriter<'a> {
+    pub(super) fn new(buffer: &'a mut Buffer, art_mask: Option<Rect>) -> Self {
+        Self { buffer, art_mask }
+    }
+
+    pub(super) fn put(&mut self, x: u16, y: u16, ch: char, style: Style) {
+        if self.masked(x, y) {
+            return;
+        }
+        put_char(self.buffer, x, y, ch, style);
+    }
+
+    /// Write a cell already proven visible by [`Self::visible_spans`]. Callers must keep the
+    /// coordinates inside both the returned span and the source zone. This skips the duplicate
+    /// album-art and coordinate tests on the hottest full-field loops. These effects only patch
+    /// foreground colour, so assigning it directly also avoids rebuilding a one-field `Style`.
+    pub(super) fn put_visible_fg(&mut self, x: u16, y: u16, ch: char, fg: Color) {
+        let area = self.buffer.area;
+        let index = usize::from(y - area.y) * usize::from(area.width) + usize::from(x - area.x);
+        let cell = &mut self.buffer.content[index];
+        cell.set_char(ch);
+        cell.fg = fg;
+    }
+
+    fn masked(&self, x: u16, y: u16) -> bool {
+        self.art_mask.is_some_and(|mask| {
+            x >= mask.left() && x < mask.right() && y >= mask.top() && y < mask.bottom()
+        })
+    }
+
+    /// Horizontal spans in `zone` that remain visible after subtracting album art. The fixed
+    /// two-span result lets full-field effects skip masked cells without allocating a temporary
+    /// buffer or paying a mask branch for every cell.
+    pub(super) fn visible_spans(&self, zone: Rect, y: u16) -> ([CellSpan; 2], usize) {
+        let full = CellSpan {
+            start: zone.left(),
+            end: zone.right(),
+        };
+        let Some(mask) = self.art_mask else {
+            return (
+                [full, CellSpan::default()],
+                usize::from(full.start < full.end),
+            );
+        };
+        if y < mask.top() || y >= mask.bottom() {
+            return (
+                [full, CellSpan::default()],
+                usize::from(full.start < full.end),
+            );
+        }
+        let cut_left = mask.left().clamp(zone.left(), zone.right());
+        let cut_right = mask.right().clamp(zone.left(), zone.right());
+        if cut_left >= cut_right {
+            return (
+                [full, CellSpan::default()],
+                usize::from(full.start < full.end),
+            );
+        }
+        let spans = [
+            CellSpan {
+                start: zone.left(),
+                end: cut_left,
+            },
+            CellSpan {
+                start: cut_right,
+                end: zone.right(),
+            },
+        ];
+        match (spans[0].start < spans[0].end, spans[1].start < spans[1].end) {
+            (true, true) => (spans, 2),
+            (true, false) => ([spans[0], CellSpan::default()], 1),
+            (false, true) => ([spans[1], CellSpan::default()], 1),
+            (false, false) => ([CellSpan::default(); 2], 0),
+        }
+    }
+}
+
+const MAX_FREE_RECTS: usize = 16;
+const MAX_FOCAL_OPTIONS: usize = 64;
+
+#[derive(Clone, Copy)]
+struct RectList<const N: usize> {
+    rects: [Rect; N],
+    len: usize,
+}
+
+impl<const N: usize> RectList<N> {
+    fn new() -> Self {
+        Self {
+            rects: [Rect::ZERO; N],
+            len: 0,
+        }
+    }
+
+    fn push(&mut self, rect: Rect) {
+        if !rect.is_empty() && self.len < N {
+            self.rects[self.len] = rect;
+            self.len += 1;
+        }
+    }
+
+    fn as_slice(&self) -> &[Rect] {
+        &self.rects[..self.len]
+    }
+}
+
+fn subtract_rect(source: Rect, exclusion: Rect, out: &mut RectList<MAX_FREE_RECTS>) {
+    let cut = source.intersection(exclusion);
+    if cut.is_empty() {
+        out.push(source);
         return;
     }
+    out.push(Rect::new(
+        source.left(),
+        source.top(),
+        source.width,
+        cut.top().saturating_sub(source.top()),
+    ));
+    out.push(Rect::new(
+        source.left(),
+        cut.bottom(),
+        source.width,
+        source.bottom().saturating_sub(cut.bottom()),
+    ));
+    out.push(Rect::new(
+        source.left(),
+        cut.top(),
+        cut.left().saturating_sub(source.left()),
+        cut.height,
+    ));
+    out.push(Rect::new(
+        cut.right(),
+        cut.top(),
+        source.right().saturating_sub(cut.right()),
+        cut.height,
+    ));
+}
+
+fn subtract_all(
+    free: RectList<MAX_FREE_RECTS>,
+    exclusion: Option<Rect>,
+) -> RectList<MAX_FREE_RECTS> {
+    let Some(exclusion) = exclusion.filter(|rect| !rect.is_empty()) else {
+        return free;
+    };
+    let mut next = RectList::new();
+    for rect in free.as_slice() {
+        subtract_rect(*rect, exclusion, &mut next);
+    }
+    next
+}
+
+fn art_halo(art: Rect, bounds: Rect) -> Rect {
+    let left = art.left().saturating_sub(1).max(bounds.left());
+    let top = art.top().saturating_sub(1).max(bounds.top());
+    let right = art.right().saturating_add(1).min(bounds.right());
+    let bottom = art.bottom().saturating_add(1).min(bounds.bottom());
+    Rect::new(
+        left,
+        top,
+        right.saturating_sub(left),
+        bottom.saturating_sub(top),
+    )
+}
+
+fn fit_two_to_one(area: Rect, min_width: u16, min_height: u16) -> Option<Rect> {
+    let height = area.height.min(area.width / 2);
+    let width = height.saturating_mul(2);
+    if width < min_width || height < min_height {
+        return None;
+    }
+    Some(Rect::new(
+        area.x + area.width.saturating_sub(width) / 2,
+        area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    ))
+}
+
+fn focal_options(
+    free: &RectList<MAX_FREE_RECTS>,
+    min_width: u16,
+    min_height: u16,
+) -> RectList<MAX_FOCAL_OPTIONS> {
+    let mut options = RectList::new();
+    for area in free.as_slice() {
+        if let Some(rect) = fit_two_to_one(*area, min_width, min_height) {
+            options.push(rect);
+        }
+
+        let left_width = area.width / 2;
+        let right_width = area.width.saturating_sub(left_width);
+        let top_height = area.height / 2;
+        let bottom_height = area.height.saturating_sub(top_height);
+        for part in [
+            Rect::new(area.x, area.y, left_width, area.height),
+            Rect::new(
+                area.x.saturating_add(left_width),
+                area.y,
+                right_width,
+                area.height,
+            ),
+            Rect::new(area.x, area.y, area.width, top_height),
+            Rect::new(
+                area.x,
+                area.y.saturating_add(top_height),
+                area.width,
+                bottom_height,
+            ),
+        ] {
+            if let Some(rect) = fit_two_to_one(part, min_width, min_height) {
+                options.push(rect);
+            }
+        }
+
+        // Equal halves alone miss valid asymmetric pairings (for example, a 12x6 cube beside a
+        // 10x5 donut in a 22x6 strip). Edge-anchored minimum slices make every minimum-sized
+        // horizontal or vertical pairing available to the fixed-array pair search.
+        if area.width >= min_width {
+            for part in [
+                Rect::new(area.x, area.y, min_width, area.height),
+                Rect::new(
+                    area.right().saturating_sub(min_width),
+                    area.y,
+                    min_width,
+                    area.height,
+                ),
+            ] {
+                if let Some(rect) = fit_two_to_one(part, min_width, min_height) {
+                    options.push(rect);
+                }
+            }
+        }
+        if area.height >= min_height {
+            for part in [
+                Rect::new(area.x, area.y, area.width, min_height),
+                Rect::new(
+                    area.x,
+                    area.bottom().saturating_sub(min_height),
+                    area.width,
+                    min_height,
+                ),
+            ] {
+                if let Some(rect) = fit_two_to_one(part, min_width, min_height) {
+                    options.push(rect);
+                }
+            }
+        }
+    }
+    options
+}
+
+fn rect_score(rect: Rect) -> u32 {
+    u32::from(rect.width) * u32::from(rect.height)
+}
+
+fn best_single(options: &RectList<MAX_FOCAL_OPTIONS>) -> Option<Rect> {
+    options
+        .as_slice()
+        .iter()
+        .copied()
+        .max_by_key(|rect| rect_score(*rect))
+}
+
+fn focal_placements(
+    player_rect: Rect,
+    art_mask: Option<Rect>,
+    lyrics_rect: Option<Rect>,
+    cube_on: bool,
+    donut_on: bool,
+) -> (Option<Rect>, Option<Rect>) {
+    if !cube_on && !donut_on {
+        return (None, None);
+    }
+
+    let mut free = RectList::new();
+    free.push(player_rect);
+    free = subtract_all(free, art_mask.map(|art| art_halo(art, player_rect)));
+    free = subtract_all(
+        free,
+        lyrics_rect.map(|lyrics| lyrics.intersection(player_rect)),
+    );
+
+    if cube_on && donut_on {
+        let cube = focal_options(&free, 12, 6);
+        let donut = focal_options(&free, 10, 5);
+        let mut pair = None;
+        let mut pair_score = 0u32;
+        for cube_rect in cube.as_slice() {
+            for donut_rect in donut.as_slice() {
+                if !cube_rect.intersection(*donut_rect).is_empty() {
+                    continue;
+                }
+                let score = rect_score(*cube_rect).saturating_add(rect_score(*donut_rect));
+                if pair.is_none() || score > pair_score {
+                    pair = Some((*cube_rect, *donut_rect));
+                    pair_score = score;
+                }
+            }
+        }
+        if let Some((cube, donut)) = pair {
+            return (Some(cube), Some(donut));
+        }
+        let cube = best_single(&cube);
+        let donut = best_single(&donut);
+        return match (cube, donut) {
+            (Some(cube), Some(donut)) if rect_score(donut) > rect_score(cube) => {
+                (None, Some(donut))
+            }
+            (cube, _) if cube.is_some() => (cube, None),
+            (_, donut) => (None, donut),
+        };
+    }
+    if cube_on {
+        let cube = focal_options(&free, 12, 6);
+        return (best_single(&cube), None);
+    }
+    let donut = focal_options(&free, 10, 5);
+    (None, best_single(&donut))
+}
+
+fn supports(zone: Rect, min_width: u16, min_height: u16) -> bool {
+    zone.width >= min_width && zone.height >= min_height
+}
+
+/// Composite every enabled canvas effect exactly once in a stable coordinate system. Field
+/// effects use the full Player interior; scene effects use the filler stage; focal effects are
+/// assigned to allocation-free 2:1 safe regions outside album art (plus a one-cell halo) and
+/// lyrics. Album art remains a hard write mask for every family.
+pub fn render_canvas_composite(
+    frame: &mut Frame,
+    app: &App,
+    player_rect: Rect,
+    stage_rect: Rect,
+    art_mask: Option<Rect>,
+    lyrics_rect: Option<Rect>,
+    suppress_donut: bool,
+) -> CanvasActivity {
+    let a = app.animations();
+    let mut activity = CanvasActivity::default();
+    if !a.master {
+        app.bridges.canvas_active.set(false);
+        app.bridges.canvas_heavy_active.set(false);
+        return activity;
+    }
     let f = app.anim_frame();
-    if a.plasma {
-        canvas_sim::plasma(frame, app, zone, f);
+    let (cube_rect, donut_rect) = focal_placements(
+        stage_rect,
+        art_mask,
+        lyrics_rect,
+        a.cube,
+        a.donut && !suppress_donut,
+    );
+    let mut canvas = CanvasWriter::new(frame.buffer_mut(), art_mask);
+    if a.plasma && supports(player_rect, 4, 2) {
+        canvas_sim::plasma(&mut canvas, app, player_rect, f);
+        activity.active = true;
+        activity.heavy = true;
     }
-    if a.life {
-        canvas_sim::life(frame, app, zone, f);
+    if a.life && supports(player_rect, 8, 6) {
+        canvas_sim::life(&mut canvas, app, player_rect, f);
+        activity.active = true;
+        activity.heavy = true;
     }
-    if a.pipes {
-        canvas_sim::pipes(frame, app, zone, f);
+    if a.pipes && supports(player_rect, 10, 5) {
+        canvas_sim::pipes(&mut canvas, app, player_rect, f);
+        activity.active = true;
+        activity.heavy = true;
     }
-    if a.waves {
-        canvas_ext::waves(frame, app, zone, f);
+    if a.rain && supports(player_rect, 4, 2) {
+        rain(&mut canvas, app, player_rect, f);
+        activity.active = true;
+        activity.heavy = true;
     }
-    if a.rain {
-        rain(frame, app, zone, f);
+    if a.snow && supports(player_rect, 4, 2) {
+        canvas_ext::snow(&mut canvas, app, player_rect, f);
+        activity.active = true;
+        activity.heavy = true;
     }
-    if a.snow {
-        canvas_ext::snow(frame, app, zone, f);
+    if a.starfield && supports(player_rect, 4, 2) {
+        starfield(&mut canvas, app, player_rect, f);
+        activity.active = true;
+        activity.heavy = true;
     }
-    if a.starfield {
-        starfield(frame, app, zone, f);
+    if a.fireflies && supports(player_rect, 8, 3) {
+        canvas_ext::fireflies(&mut canvas, app, player_rect, f);
+        activity.active = true;
+        activity.heavy = true;
     }
-    if a.fireflies {
-        canvas_ext::fireflies(frame, app, zone, f);
+    if a.comets && supports(player_rect, 10, 4) {
+        canvas_ext::comets(&mut canvas, app, player_rect, f);
+        activity.active = true;
+        activity.heavy = true;
     }
-    if a.comets {
-        canvas_ext::comets(frame, app, zone, f);
+    if a.waves && supports(stage_rect, 8, 3) {
+        canvas_ext::waves(&mut canvas, app, stage_rect, f);
+        activity.active = true;
+        activity.heavy = true;
     }
-    if a.aquarium {
-        canvas_ext::aquarium(frame, app, zone, f);
+    if a.visualizer && supports(stage_rect, 4, 2) {
+        visualizer(&mut canvas, app, stage_rect, f);
+        activity.active = true;
+        activity.heavy = true;
     }
-    if a.visualizer {
-        visualizer(frame, app, zone, f);
+    if a.fireworks && supports(stage_rect, 16, 6) {
+        canvas_sim::fireworks(&mut canvas, app, stage_rect, f);
+        activity.active = true;
+        activity.heavy = true;
     }
-    if a.fireworks {
-        canvas_sim::fireworks(frame, app, zone, f);
+    if a.aquarium && supports(stage_rect, 14, 3) {
+        canvas_ext::aquarium(&mut canvas, app, stage_rect, f);
+        activity.active = true;
+        activity.heavy = true;
     }
-    if a.cube {
-        canvas_ext::cube(frame, app, zone, f);
+    if a.bounce && supports(stage_rect, 10, 2) {
+        bounce(&mut canvas, app, stage_rect, f);
+        activity.active = true;
     }
-    if a.donut {
-        donut(frame, app, zone, f);
+    if let Some(zone) = cube_rect {
+        canvas_ext::cube(&mut canvas, app, zone, f);
+        activity.active = true;
+        activity.heavy = true;
     }
-    if a.bounce {
-        bounce(frame, app, zone, f);
+    if let Some(zone) = donut_rect {
+        donut(&mut canvas, app, zone, f);
+        activity.active = true;
+        activity.heavy = true;
     }
+    app.bridges.canvas_active.set(activity.active);
+    app.bridges.canvas_heavy_active.set(activity.heavy);
+    activity
 }
 
 const RAIN_GLYPHS: [char; 22] = [
@@ -100,7 +494,7 @@ thread_local! {
 /// Classic matrix digital rain: each column is an independently-falling head with a fading green
 /// trail. Speed / length / phase are hashed from the column index so columns desync but stay
 /// stable frame to frame.
-fn rain(frame: &mut Frame, _app: &App, zone: Rect, f: u64) {
+fn rain(canvas: &mut CanvasWriter<'_>, _app: &App, zone: Rect, f: u64) {
     let h = u64::from(zone.height);
     RAIN_SCRATCH.with(|scratch| {
         let mut scratch = scratch.borrow_mut();
@@ -125,7 +519,6 @@ fn rain(frame: &mut Frame, _app: &App, zone: Rect, f: u64) {
             }
         }
 
-        let buf = frame.buffer_mut();
         for (i, column) in scratch.columns.iter().enumerate() {
             let x = zone.left() + i as u16;
             let head = (f / column.speed + column.offset) % column.period;
@@ -152,7 +545,7 @@ fn rain(frame: &mut Frame, _app: &App, zone: Rect, f: u64) {
                     let b = 1.0 - k as f64 / column.len as f64;
                     Color::Rgb((30.0 * b) as u8, (60.0 + 180.0 * b) as u8, (40.0 * b) as u8)
                 };
-                put_char(buf, x, y, g, Style::default().fg(color));
+                canvas.put(x, y, g, Style::default().fg(color));
             }
         }
     });
@@ -181,7 +574,7 @@ thread_local! {
 
 /// Drifting stars / musical sparkles rising slowly up the zone, each twinkling between a subtle and
 /// an accent colour. Density scales with the zone area.
-fn starfield(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+fn starfield(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let w = u32::from(zone.width);
     let h = u64::from(zone.height);
     let count = ((w * u32::from(zone.height)) / 40).clamp(6, 60);
@@ -204,7 +597,6 @@ fn starfield(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
             }
         }
 
-        let buf = frame.buffer_mut();
         for (i, star) in scratch.stars.iter().enumerate() {
             let i = i as u64;
             let yv = (f / star.speed + star.seed) % (h + 4);
@@ -214,14 +606,14 @@ fn starfield(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
             let y = zone.top() + (h - 1 - yv) as u16;
             let g = STAR_GLYPHS[(hash32(i * 7 + f / 20) as usize) % STAR_GLYPHS.len()];
             let color = lerp_color(dim, bright, wave24[((f + i * 5) % 24) as usize]);
-            put_char(buf, zone.left() + star.x, y, g, Style::default().fg(color));
+            canvas.put(zone.left() + star.x, y, g, Style::default().fg(color));
         }
     });
 }
 
 /// A decorative (non-audio-reactive) spectrum: bars rising from the bottom strip of the zone, each
 /// mixing two waves, coloured from the gauge colour up to the accent.
-fn visualizer(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+fn visualizer(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let blocks = bar_blocks(app);
     let strip = (zone.height / 3).clamp(2, 8);
     let baseline = i32::from(zone.bottom());
@@ -242,7 +634,6 @@ fn visualizer(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
             Style::default()
         }
     });
-    let buf = frame.buffer_mut();
     for bx in 0..zone.width {
         let x = zone.left() + bx;
         let phase = u64::from(bx) * 3;
@@ -259,10 +650,10 @@ fn visualizer(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
             let y = yy as u16;
             let style = row_styles[row as usize];
             if row < full {
-                put_char(buf, x, y, '█', style);
+                canvas.put(x, y, '█', style);
             } else if row == full && frac > 0.05 {
                 let idx = (frac * (blocks.len() - 1) as f64).round() as usize;
-                put_char(buf, x, y, blocks[idx.min(blocks.len() - 1)], style);
+                canvas.put(x, y, blocks[idx.min(blocks.len() - 1)], style);
             }
         }
     }
@@ -296,7 +687,7 @@ fn donut_trig_steps() -> &'static [(f64, f64)] {
 /// The classic spinning ASCII torus (Andy Sloane's donut), z-buffered into the centre of the zone.
 /// Two rotation angles advance with the frame counter. Luminance picks a glyph and a colour ramp
 /// from accent to alt-accent.
-fn donut(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+fn donut(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let w = i32::from(zone.width);
     let h = i32::from(zone.height);
     if w < 8 || h < 5 {
@@ -348,7 +739,6 @@ fn donut(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
             }
         }
 
-        let buf = frame.buffer_mut();
         for yy in 0..h {
             for xx in 0..w {
                 let v = scratch.out[(xx + yy * w) as usize];
@@ -356,8 +746,7 @@ fn donut(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
                     continue;
                 }
                 let ci = (v as usize - 1).min(DONUT_LUM.len() - 1);
-                put_char(
-                    buf,
+                canvas.put(
                     zone.left() + xx as u16,
                     zone.top() + yy as u16,
                     DONUT_LUM[ci] as char,
@@ -370,7 +759,7 @@ fn donut(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
 
 /// DVD-style bouncing logo: an ASCII tag ricochets around the zone on a triangle-wave path, its
 /// colour cycling each time it crosses a wall.
-fn bounce(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+fn bounce(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     const LABEL: &str = "<yututui>";
     let tw = LABEL.chars().count() as i64;
     let w = i64::from(zone.width);
@@ -393,14 +782,12 @@ fn bounce(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
     const PALETTE: [R; 5] = [R::Accent, R::AccentAlt, R::Success, R::Warning, R::Error];
     let color = app.theme.color(PALETTE[cyc % PALETTE.len()]);
     let right = i64::from(zone.right());
-    let buf = frame.buffer_mut();
     for (i, ch) in LABEL.chars().enumerate() {
         let cx = x + i as i64;
         if cx < i64::from(zone.left()) || cx >= right {
             continue;
         }
-        put_char(
-            buf,
+        canvas.put(
             cx as u16,
             y as u16,
             ch,
@@ -425,16 +812,35 @@ mod tests {
         app
     }
 
-    fn render_zone(app: &App, zone: Rect) -> Buffer {
+    fn render_zone_with_mask(app: &App, zone: Rect, art_mask: Option<Rect>) -> Buffer {
         let backend = TestBackend::new(50, 20);
         let mut terminal = Terminal::new(backend).unwrap();
-        terminal.draw(|f| render_canvas(f, app, zone)).unwrap();
+        terminal
+            .draw(|f| {
+                render_canvas_composite(f, app, zone, zone, art_mask, None, false);
+            })
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn render_zone(app: &App, zone: Rect) -> Buffer {
+        render_zone_with_mask(app, zone, None)
+    }
+
+    fn render_regions(app: &App, player: Rect, stage: Rect) -> Buffer {
+        let backend = TestBackend::new(50, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_canvas_composite(frame, app, player, stage, None, None, false);
+            })
+            .unwrap();
         terminal.backend().buffer().clone()
     }
 
     /// Every canvas effect must (a) never write a cell outside the zone it was given, and
     /// (b) actually paint something inside it within a few hundred frames. One sweep covers
-    /// all 15 flags, so a new effect added to `render_canvas` is tested by construction.
+    /// all 15 flags, so a new effect added to the compositor is tested by construction.
     #[test]
     fn every_canvas_effect_paints_inside_the_zone_only() {
         let _guard = crate::i18n::lock_for_test();
@@ -513,5 +919,153 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn every_canvas_family_obeys_the_art_hard_mask() {
+        let _guard = crate::i18n::lock_for_test();
+        let zone = Rect::new(2, 1, 46, 18);
+        let mask = Rect::new(15, 5, 18, 9);
+        let mut app = app_with(|a| {
+            a.rain = true;
+            a.donut = true;
+            a.visualizer = true;
+            a.starfield = true;
+            a.bounce = true;
+            a.comets = true;
+            a.snow = true;
+            a.fireflies = true;
+            a.cube = true;
+            a.aquarium = true;
+            a.waves = true;
+            a.fireworks = true;
+            a.life = true;
+            a.pipes = true;
+            a.plasma = true;
+        });
+        for _ in 0..80 {
+            app.update(Msg::AnimTick);
+            let buffer = render_zone_with_mask(&app, zone, Some(mask));
+            for y in mask.top()..mask.bottom() {
+                for x in mask.left()..mask.right() {
+                    assert_eq!(buffer[(x, y)].symbol(), " ", "masked write at ({x},{y})");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn every_stage_effect_stays_inside_the_filler_stage() {
+        let _guard = crate::i18n::lock_for_test();
+        type SetFlag = fn(&mut crate::config::AnimationsConfig);
+        let flags: [(&str, SetFlag); 5] = [
+            ("waves", |a| a.waves = true),
+            ("visualizer", |a| a.visualizer = true),
+            ("fireworks", |a| a.fireworks = true),
+            ("aquarium", |a| a.aquarium = true),
+            ("bounce", |a| a.bounce = true),
+        ];
+        let player = Rect::new(2, 1, 46, 18);
+        let stage = Rect::new(10, 9, 30, 9);
+        for (name, set) in flags {
+            let mut app = app_with(set);
+            let mut painted = false;
+            for _ in 0..200 {
+                app.update(Msg::AnimTick);
+                let buffer = render_regions(&app, player, stage);
+                for y in 0..buffer.area.height {
+                    for x in 0..buffer.area.width {
+                        if buffer[(x, y)].symbol() == " " {
+                            continue;
+                        }
+                        assert!(
+                            x >= stage.left()
+                                && x < stage.right()
+                                && y >= stage.top()
+                                && y < stage.bottom(),
+                            "{name} wrote outside the filler stage at ({x},{y})"
+                        );
+                        painted = true;
+                    }
+                }
+            }
+            assert!(painted, "{name} never painted inside the filler stage");
+        }
+    }
+
+    #[test]
+    fn focal_effects_share_safe_space_and_exclude_art_halo_and_lyrics() {
+        let player = Rect::new(0, 0, 100, 30);
+        let art = Rect::new(4, 6, 30, 12);
+        let lyrics = Rect::new(58, 5, 36, 18);
+        let (cube, donut) = focal_placements(player, Some(art), Some(lyrics), true, true);
+        let cube = cube.expect("cube should receive a safe region");
+        let donut = donut.expect("donut should receive a separate safe region");
+        let halo = art_halo(art, player);
+        assert!(cube.intersection(donut).is_empty());
+        for focal in [cube, donut] {
+            assert!(focal.intersection(halo).is_empty());
+            assert!(focal.intersection(lyrics).is_empty());
+            assert_eq!(focal.width, focal.height * 2);
+        }
+    }
+
+    #[test]
+    fn focal_effects_keep_both_minimum_regions_in_an_asymmetric_strip() {
+        let strip = Rect::new(3, 4, 22, 6);
+        let (cube, donut) = focal_placements(strip, None, None, true, true);
+        let cube = cube.expect("12x6 cube should fit");
+        let donut = donut.expect("10x5 donut should fit beside the cube");
+        assert!(cube.intersection(donut).is_empty());
+        assert_eq!(cube.as_size(), ratatui::layout::Size::new(12, 6));
+        assert_eq!(donut.as_size(), ratatui::layout::Size::new(10, 5));
+    }
+
+    #[test]
+    fn focal_only_activity_stays_off_when_lyrics_consume_the_stage() {
+        let _guard = crate::i18n::lock_for_test();
+        let app = app_with(|a| {
+            a.cube = true;
+            a.donut = true;
+        });
+        let player = Rect::new(1, 1, 30, 12);
+        let stage = Rect::new(1, 2, 30, 5);
+        let backend = TestBackend::new(32, 14);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let activity =
+                    render_canvas_composite(frame, &app, player, stage, None, Some(stage), false);
+                assert_eq!(activity, CanvasActivity::default());
+            })
+            .unwrap();
+        assert!(!app.bridges.canvas_active.get());
+        assert!(!app.bridges.canvas_heavy_active.get());
+    }
+
+    #[test]
+    fn suppressed_or_unplaceable_donut_preserves_raw_config_but_stays_inactive() {
+        let _guard = crate::i18n::lock_for_test();
+        let app = app_with(|a| a.donut = true);
+        let zone = Rect::new(0, 0, 40, 12);
+        let backend = TestBackend::new(40, 12);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let activity = render_canvas_composite(
+                    frame,
+                    &app,
+                    zone,
+                    zone,
+                    Some(Rect::new(4, 2, 30, 8)),
+                    None,
+                    true,
+                );
+                assert_eq!(activity, CanvasActivity::default());
+            })
+            .unwrap();
+        assert!(app.config.animations.donut);
+        assert!(!app.bridges.canvas_active.get());
+        assert!(!app.bridges.canvas_heavy_active.get());
     }
 }

--- a/src/ui/anim/canvas_ext.rs
+++ b/src/ui/anim/canvas_ext.rs
@@ -7,11 +7,11 @@
 //! and each effect degrades in retro mode either at the source (forked glyph sets) or through
 //! the CP437 scrubber. Nothing here allocates per frame beyond tiny fixed buffers.
 
-use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 
-use super::{hash32, lerp_color, put_char, wave};
+use super::canvas::CanvasWriter;
+use super::{hash32, lerp_color, wave};
 use crate::app::App;
 use crate::theme::ThemeRole as R;
 
@@ -19,7 +19,7 @@ use crate::theme::ThemeRole as R;
 
 /// Occasional shooting stars: up to two diagonal streaks with fading tails, each on its own
 /// hashed launch cycle so the sky stays mostly calm with a rare bright crossing.
-pub(super) fn comets(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+pub(super) fn comets(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let w = i64::from(zone.width);
     let h = i64::from(zone.height);
     if w < 10 || h < 4 {
@@ -33,7 +33,6 @@ pub(super) fn comets(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
     } else {
         ('✦', ['✧', '·', '·'])
     };
-    let buf = frame.buffer_mut();
     for slot in 0..2u64 {
         // Each slot fires once per cycle; most of the cycle is empty sky.
         let period = 140 + u64::from(hash32(slot * 13 + 5) % 160);
@@ -70,8 +69,7 @@ pub(super) fn comets(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
                     lerp_color(tail_base, dim, fade),
                 )
             };
-            put_char(
-                buf,
+            canvas.put(
                 (i64::from(zone.left()) + x) as u16,
                 (i64::from(zone.top()) + y) as u16,
                 glyph,
@@ -88,7 +86,7 @@ const SNOW_GLYPHS_RETRO: [char; 4] = ['*', '*', '.', '.'];
 
 /// Sparse snowfall: flakes drift down at hashed speeds with a gentle sinusoidal wobble,
 /// heavier flakes reading brighter and faster than the fine ones behind them.
-pub(super) fn snow(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+pub(super) fn snow(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let w = u32::from(zone.width);
     let h = u64::from(zone.height);
     if w < 4 || h < 2 {
@@ -102,7 +100,6 @@ pub(super) fn snow(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
     };
     let bright = Color::Rgb(235, 240, 250);
     let dim = app.theme.color(R::TextSubtle);
-    let buf = frame.buffer_mut();
     for i in 0..u64::from(count) {
         // Size class picks glyph, speed and brightness together (big flakes fall faster).
         let class = (hash32(i * 3 + 7) % 4) as usize;
@@ -119,8 +116,7 @@ pub(super) fn snow(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
             continue;
         }
         let color = lerp_color(dim, bright, class as f64 / 3.0);
-        put_char(
-            buf,
+        canvas.put(
             zone.left() + x as u16,
             zone.top() + yv as u16,
             glyphs[3 - class],
@@ -133,7 +129,7 @@ pub(super) fn snow(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
 
 /// Fireflies wandering on smooth per-fly Lissajous paths, each breathing between the subtle
 /// text colour and a warm glow on its own phase — the calm counterpart to the starfield.
-pub(super) fn fireflies(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+pub(super) fn fireflies(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let w = f64::from(zone.width);
     let h = f64::from(zone.height);
     if zone.width < 8 || zone.height < 3 {
@@ -147,7 +143,6 @@ pub(super) fn fireflies(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
     } else {
         ('●', '·')
     };
-    let buf = frame.buffer_mut();
     for i in 0..u64::from(count) {
         // Two incommensurate angular speeds per axis make the path wander without looping
         // visibly; amplitudes keep every fly comfortably inside the zone.
@@ -166,8 +161,7 @@ pub(super) fn fireflies(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
             continue;
         }
         let glyph = if b > 0.62 { bright_glyph } else { dim_glyph };
-        put_char(
-            buf,
+        canvas.put(
             zone.left() + xi,
             zone.top() + yi,
             glyph,
@@ -209,7 +203,7 @@ const CUBE_EDGES: [(usize, usize); 12] = [
 /// A rotating 3-D wireframe cube, perspective-projected into the middle of the zone — the
 /// donut's angular little sibling at a fraction of its cost (12 edge rasters instead of a
 /// full solid-of-revolution sweep). Edge brightness follows depth so the near face pops.
-pub(super) fn cube(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+pub(super) fn cube(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let w = f64::from(zone.width);
     let h = f64::from(zone.height);
     if zone.width < 12 || zone.height < 6 {
@@ -238,7 +232,6 @@ pub(super) fn cube(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
         proj[i] = (px, py, zc);
     }
 
-    let buf = frame.buffer_mut();
     let mut plot = |x: f64, y: f64, depth: f64, glyph: char, bold: bool| {
         if x < 0.0 || y < 0.0 || x >= w || y >= h {
             return;
@@ -249,13 +242,7 @@ pub(super) fn cube(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
         if bold {
             style = style.add_modifier(Modifier::BOLD);
         }
-        put_char(
-            buf,
-            zone.left() + x as u16,
-            zone.top() + y as u16,
-            glyph,
-            style,
-        );
+        canvas.put(zone.left() + x as u16, zone.top() + y as u16, glyph, style);
     };
 
     for &(a, b) in &CUBE_EDGES {
@@ -290,14 +277,13 @@ const BUBBLE_GLYPHS_RETRO: [char; 3] = ['o', 'o', '.'];
 
 /// A little ASCII aquarium: fish cruise across on their own lanes (both directions, hashed
 /// species/speed/colour), while bubbles wobble up from the depths.
-pub(super) fn aquarium(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+pub(super) fn aquarium(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let w = i64::from(zone.width);
     let h = u64::from(zone.height);
     if w < 14 || h < 3 {
         return;
     }
     let retro = app.retro_mode();
-    let buf = frame.buffer_mut();
 
     // Fish: one per ~3 rows, capped so a huge zone doesn't become a trawler's net.
     let fish_count = (h / 3).clamp(2, 5);
@@ -330,8 +316,7 @@ pub(super) fn aquarium(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
             if x < 0 || x >= w {
                 continue;
             }
-            put_char(
-                buf,
+            canvas.put(
                 zone.left() + x as u16,
                 zone.top() + lane + bob,
                 ch,
@@ -364,8 +349,7 @@ pub(super) fn aquarium(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
         }
         // Bubbles grow as they rise: dot → ring near the surface.
         let stage = ((yv * 3) / h.max(1)).min(2) as usize;
-        put_char(
-            buf,
+        canvas.put(
             zone.left() + x as u16,
             zone.top() + y,
             glyphs[2 - stage],
@@ -378,7 +362,7 @@ pub(super) fn aquarium(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
 
 /// Layered ocean swell along the bottom of the zone: two-to-four out-of-phase sine crests,
 /// deeper layers darker and slower, with sparse foam flecks on the top crest.
-pub(super) fn waves(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+pub(super) fn waves(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let w = zone.width;
     if w < 8 || zone.height < 3 {
         return;
@@ -394,7 +378,6 @@ pub(super) fn waves(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
     };
     let bottom = zone.bottom() - 1;
     let top = zone.top();
-    let buf = frame.buffer_mut();
     for layer in 0..layers {
         // Front layers ride higher amplitude and faster phase; each gets its own base row.
         let li = f64::from(layer);
@@ -410,14 +393,13 @@ pub(super) fn waves(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
             if y < i32::from(top) || y > i32::from(bottom) {
                 continue;
             }
-            put_char(buf, zone.left() + x, y as u16, crest_glyph, style);
+            canvas.put(zone.left() + x, y as u16, crest_glyph, style);
             // Foam: rare bright flecks dancing on the front crest only.
             if layer == 0
                 && hash32(u64::from(x) * 37 + f / 8).is_multiple_of(23)
                 && y > i32::from(top)
             {
-                put_char(
-                    buf,
+                canvas.put(
                     zone.left() + x,
                     (y - 1) as u16,
                     foam_glyph,

--- a/src/ui/anim/canvas_sim.rs
+++ b/src/ui/anim/canvas_sim.rs
@@ -9,43 +9,13 @@
 
 use std::cell::RefCell;
 
-use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 
-use super::{ease_out_cubic, hash32, lerp_color, put_char};
+use super::canvas::CanvasWriter;
+use super::{ease_out_cubic, hash32, lerp_color};
 use crate::app::App;
 use crate::theme::ThemeRole as R;
-
-/// Player album art can split the filler canvas into an upper and lower zone. Keep one
-/// simulation per full rectangle so those zones evolve independently without allowing an
-/// unbounded cache if the terminal is repeatedly resized.
-const STATEFUL_ZONE_CAPACITY: usize = 2;
-
-struct ZoneSlots<T> {
-    slots: Vec<(Rect, T)>,
-}
-
-impl<T> Default for ZoneSlots<T> {
-    fn default() -> Self {
-        Self { slots: Vec::new() }
-    }
-}
-
-impl<T: Default> ZoneSlots<T> {
-    fn get_mut(&mut self, zone: Rect) -> &mut T {
-        if let Some(index) = self.slots.iter().position(|(key, _)| *key == zone) {
-            let entry = self.slots.remove(index);
-            self.slots.push(entry);
-        } else {
-            if self.slots.len() == STATEFUL_ZONE_CAPACITY {
-                self.slots.remove(0);
-            }
-            self.slots.push((zone, T::default()));
-        }
-        &mut self.slots.last_mut().expect("zone slot was inserted").1
-    }
-}
 
 // ── fireworks ───────────────────────────────────────────────────────────────
 
@@ -54,14 +24,13 @@ const FIREWORK_PALETTE: [R; 5] = [R::Accent, R::AccentAlt, R::Success, R::Warnin
 /// One launcher's state within its cycle, all derived from `f`: a rocket climbs from the
 /// bottom, then a radial burst blooms at the apex, droops under gravity and fades out.
 /// Two launchers run half a cycle out of phase so the sky is never empty for long.
-pub(super) fn fireworks(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+pub(super) fn fireworks(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let w = i64::from(zone.width);
     let h = i64::from(zone.height);
     if w < 16 || h < 6 {
         return;
     }
     let retro = app.retro_mode();
-    let buf = frame.buffer_mut();
     let period = 130u64;
     for launcher in 0..2u64 {
         let lf = f + launcher * (period / 2); // half-cycle offset between the two
@@ -95,8 +64,7 @@ pub(super) fn fireworks(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
                     1 => ('|', color),
                     _ => ('.', app.theme.color(R::TextSubtle)),
                 };
-                put_char(
-                    buf,
+                canvas.put(
                     (i64::from(zone.left()) + x) as u16,
                     (i64::from(zone.top()) + yy) as u16,
                     g,
@@ -138,8 +106,7 @@ pub(super) fn fireworks(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
                 color,
                 bright * (1.0 - bt * 0.5),
             );
-            put_char(
-                buf,
+            canvas.put(
                 (i64::from(zone.left()) + x as i64) as u16,
                 (i64::from(zone.top()) + y as i64) as u16,
                 glyph,
@@ -165,7 +132,7 @@ struct LifeScratch {
 }
 
 thread_local! {
-    static LIFE_SCRATCH: RefCell<ZoneSlots<LifeScratch>> = RefCell::new(ZoneSlots::default());
+    static LIFE_SCRATCH: RefCell<LifeScratch> = RefCell::new(LifeScratch::default());
 }
 
 /// Frames between generations (~7 steps/sec at the default 30 fps — fast enough to read as
@@ -175,7 +142,7 @@ const LIFE_STEP_FRAMES: u64 = 4;
 /// Conway's Game of Life on the filler zone: a hashed soup seeds the board, generations tick
 /// every few frames, and cells colour by age (newborn accent → elder ember). When the colony
 /// dies down or stabilises into stasis it quietly reseeds.
-pub(super) fn life(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+pub(super) fn life(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let w = usize::from(zone.width);
     let h = usize::from(zone.height);
     if w < 8 || h < 6 {
@@ -183,6 +150,7 @@ pub(super) fn life(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
     }
     let young = app.theme.color(R::Accent);
     let old = app.theme.color(R::GaugeFilled);
+    let age_colors = [young, lerp_color(young, old, 0.5), old];
     let glyphs: [char; 3] = if app.retro_mode() {
         ['#', 'x', '.']
     } else {
@@ -190,15 +158,17 @@ pub(super) fn life(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
     };
 
     LIFE_SCRATCH.with(|scratch| {
-        let mut slots = scratch.borrow_mut();
-        let s = slots.get_mut(zone);
+        let mut scratch = scratch.borrow_mut();
+        let s = &mut *scratch;
         let cells = w * h;
         if s.width != zone.width || s.height != zone.height || f < s.last_step {
             // Resize — or a frame-counter context change (f went backwards) — restarts the show.
             s.width = zone.width;
             s.height = zone.height;
-            s.age = vec![0; cells];
-            s.next = vec![0; cells];
+            s.age.resize(cells, 0);
+            s.age.fill(0);
+            s.next.resize(cells, 0);
+            s.next.fill(0);
             s.epoch = s.epoch.wrapping_add(1);
             s.last_step = f;
             let epoch = s.epoch;
@@ -216,20 +186,23 @@ pub(super) fn life(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
             let LifeScratch { age, next, .. } = &mut *s;
             let mut alive = 0usize;
             for y in 0..h {
+                let prev_y = if y == 0 { h - 1 } else { y - 1 } * w;
+                let row_y = y * w;
+                let next_y = if y + 1 == h { 0 } else { y + 1 } * w;
                 for x in 0..w {
-                    let mut n = 0u8;
-                    for dy in [h - 1, 0, 1] {
-                        for dx in [w - 1, 0, 1] {
-                            if dx == 0 && dy == 0 {
-                                continue;
-                            }
-                            // Toroidal wrap keeps gliders flying forever.
-                            let nx = (x + dx) % w;
-                            let ny = (y + dy) % h;
-                            n += u8::from(age[ny * w + nx] > 0);
-                        }
-                    }
-                    let idx = y * w + x;
+                    // Toroidal wrap keeps gliders flying forever. Resolve the four edge cases
+                    // once instead of executing eight modulo operations for every cell.
+                    let prev_x = if x == 0 { w - 1 } else { x - 1 };
+                    let next_x = if x + 1 == w { 0 } else { x + 1 };
+                    let n = u8::from(age[prev_y + prev_x] > 0)
+                        + u8::from(age[prev_y + x] > 0)
+                        + u8::from(age[prev_y + next_x] > 0)
+                        + u8::from(age[row_y + prev_x] > 0)
+                        + u8::from(age[row_y + next_x] > 0)
+                        + u8::from(age[next_y + prev_x] > 0)
+                        + u8::from(age[next_y + x] > 0)
+                        + u8::from(age[next_y + next_x] > 0);
+                    let idx = row_y + x;
                     let was = age[idx] > 0;
                     let lives = matches!((was, n), (true, 2) | (true, 3) | (false, 3));
                     next[idx] = if lives {
@@ -250,26 +223,24 @@ pub(super) fn life(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
             }
         }
 
-        let buf = frame.buffer_mut();
         for y in 0..h {
-            for x in 0..w {
-                let a = s.age[y * w + x];
-                if a == 0 {
-                    continue;
+            let abs_y = zone.top() + y as u16;
+            let (spans, span_count) = canvas.visible_spans(zone, abs_y);
+            for span in &spans[..span_count] {
+                for abs_x in span.start..span.end {
+                    let x = usize::from(abs_x - zone.left());
+                    let a = s.age[y * w + x];
+                    if a == 0 {
+                        continue;
+                    }
+                    // Age buckets: newborn / settled / ancient.
+                    let (g, color) = match a {
+                        1..=2 => (glyphs[0], age_colors[0]),
+                        3..=8 => (glyphs[1], age_colors[1]),
+                        _ => (glyphs[2], age_colors[2]),
+                    };
+                    canvas.put_visible_fg(abs_x, abs_y, g, color);
                 }
-                // Age buckets: newborn / settled / ancient.
-                let (g, t) = match a {
-                    1..=2 => (glyphs[0], 0.0),
-                    3..=8 => (glyphs[1], 0.5),
-                    _ => (glyphs[2], 1.0),
-                };
-                put_char(
-                    buf,
-                    zone.left() + x as u16,
-                    zone.top() + y as u16,
-                    g,
-                    Style::default().fg(lerp_color(young, old, t)),
-                );
             }
         }
     });
@@ -311,7 +282,7 @@ struct PipesScratch {
 }
 
 thread_local! {
-    static PIPES_SCRATCH: RefCell<ZoneSlots<PipesScratch>> = RefCell::new(ZoneSlots::default());
+    static PIPES_SCRATCH: RefCell<PipesScratch> = RefCell::new(PipesScratch::default());
 }
 
 /// glyph_index → glyph, [straight-vertical, straight-horizontal, and the four elbows].
@@ -323,7 +294,7 @@ const PIPE_PALETTE: [R; 5] = [R::Accent, R::AccentAlt, R::Success, R::Warning, R
 /// frame, elbowing at hashed corners; when the board is ~clogged everything clears and a new
 /// epoch starts. The laid pipe is repainted from scratch each frame (the back buffer holds
 /// nothing between frames), which is what earns pipes its "showpiece" price tag.
-pub(super) fn pipes(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+pub(super) fn pipes(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let w = usize::from(zone.width);
     let h = usize::from(zone.height);
     if w < 10 || h < 5 {
@@ -335,30 +306,32 @@ pub(super) fn pipes(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
     } else {
         &PIPE_GLYPHS
     };
+    let colors = PIPE_PALETTE.map(|role| app.theme.color(role));
 
     PIPES_SCRATCH.with(|scratch| {
-        let mut slots = scratch.borrow_mut();
-        let s = slots.get_mut(zone);
+        let mut scratch = scratch.borrow_mut();
+        let s = &mut *scratch;
         let cells = w * h;
         let clogged = s.filled * 10 >= cells * 6;
         if s.width != zone.width || s.height != zone.height || f < s.last_f || clogged {
             s.width = zone.width;
             s.height = zone.height;
-            s.cells = vec![0; cells];
+            s.cells.resize(cells, 0);
+            s.cells.fill(0);
             s.filled = 0;
             s.epoch = s.epoch.wrapping_add(1);
             let epoch = s.epoch;
             let pipe_count = (w / 24 + 2).min(5);
-            s.heads = (0..pipe_count)
-                .map(|i| {
-                    let seed = hash32(epoch.wrapping_mul(31) + i as u64);
-                    (
-                        (seed as usize % w) as u16,
-                        (hash32(u64::from(seed) + 7) as usize % h) as u16,
-                        (seed % 4) as u8,
-                    )
-                })
-                .collect();
+            s.heads.clear();
+            s.heads.reserve(pipe_count);
+            for i in 0..pipe_count {
+                let seed = hash32(epoch.wrapping_mul(31) + i as u64);
+                s.heads.push((
+                    (seed as usize % w) as u16,
+                    (hash32(u64::from(seed) + 7) as usize % h) as u16,
+                    (seed % 4) as u8,
+                ));
+            }
         }
 
         // One cell of progress per pipe per frame (bounded even after a long park).
@@ -417,24 +390,20 @@ pub(super) fn pipes(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
             }
         }
 
-        let buf = frame.buffer_mut();
         for y in 0..h {
-            for x in 0..w {
-                let v = s.cells[y * w + x];
-                if v == 0 {
-                    continue;
+            let abs_y = zone.top() + y as u16;
+            let (spans, span_count) = canvas.visible_spans(zone, abs_y);
+            for span in &spans[..span_count] {
+                for abs_x in span.start..span.end {
+                    let x = usize::from(abs_x - zone.left());
+                    let v = s.cells[y * w + x];
+                    if v == 0 {
+                        continue;
+                    }
+                    let color = colors[usize::from(v >> 4) % colors.len()];
+                    let g = glyphs[usize::from((v & 0x0F) - 1).min(glyphs.len() - 1)];
+                    canvas.put_visible_fg(abs_x, abs_y, g, color);
                 }
-                let color = app
-                    .theme
-                    .color(PIPE_PALETTE[usize::from(v >> 4) % PIPE_PALETTE.len()]);
-                let g = glyphs[usize::from((v & 0x0F) - 1).min(glyphs.len() - 1)];
-                put_char(
-                    buf,
-                    zone.left() + x as u16,
-                    zone.top() + y as u16,
-                    g,
-                    Style::default().fg(color),
-                );
             }
         }
     });
@@ -444,63 +413,81 @@ pub(super) fn pipes(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
 
 const PLASMA_GLYPHS: [char; 4] = [' ', '░', '▒', '▓'];
 
+#[derive(Default)]
+struct PlasmaScratch {
+    col_wave: Vec<f64>,
+    row_wave: Vec<f64>,
+    diag_wave: Vec<f64>,
+}
+
+thread_local! {
+    static PLASMA_SCRATCH: RefCell<PlasmaScratch> = RefCell::new(PlasmaScratch::default());
+}
+
 /// A demoscene plasma field washing over the whole zone: three phase-shifted sine bands
 /// (one per axis plus a diagonal) sum into a scalar that picks both a density glyph and a
 /// colour along a Background→Accent→AccentAlt ramp. Every cell is touched every frame —
 /// deliberately the most expensive effect in the app, and last in the resource ordering.
 /// The three bands are 1-D, so each frame precomputes `w + h + (w+h)` sines instead of
 /// `3·w·h` (the per-cell work is two adds and two table lookups).
-pub(super) fn plasma(frame: &mut Frame, app: &App, zone: Rect, f: u64) {
+pub(super) fn plasma(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let w = usize::from(zone.width);
     let h = usize::from(zone.height);
     if w < 4 || h < 2 {
         return;
     }
-    let t = f as f64;
-    let col_wave: Vec<f64> = (0..w)
-        .map(|x| (x as f64 * 0.30 + t * 0.055).sin())
-        .collect();
-    let row_wave: Vec<f64> = (0..h)
-        .map(|y| (y as f64 * 0.55 - t * 0.038).sin())
-        .collect();
-    let diag_wave: Vec<f64> = (0..w + h)
-        .map(|d| (d as f64 * 0.21 + t * 0.024).sin())
-        .collect();
-
     let bg = app.theme.color(R::Background);
     let mid = app.theme.color(R::Accent);
     let hot = app.theme.color(R::AccentAlt);
     // Quantized style ramp (16 steps) so cells share Style values instead of allocating a
     // fresh blend per cell.
-    let ramp: [Style; 16] = std::array::from_fn(|i| {
+    let ramp: [Color; 16] = std::array::from_fn(|i| {
         let v = i as f64 / 15.0;
-        let c = if v < 0.5 {
+        if v < 0.5 {
             lerp_color(bg, mid, v * 2.0)
         } else {
             lerp_color(mid, hot, (v - 0.5) * 2.0)
-        };
-        Style::default().fg(c)
+        }
     });
 
-    let buf = frame.buffer_mut();
-    for y in 0..h {
-        for x in 0..w {
-            // v ∈ [-3, 3] → normalized [0, 1].
-            let v = (col_wave[x] + row_wave[y] + diag_wave[x + y] + 3.0) / 6.0;
-            let bucket = (v * 3.999) as usize; // 0..=3 density glyph
-            if bucket == 0 {
-                continue; // the trough stays blank — cheaper, and lets the theme breathe
-            }
-            let ci = (v * 15.999) as usize;
-            put_char(
-                buf,
-                zone.left() + x as u16,
-                zone.top() + y as u16,
-                PLASMA_GLYPHS[bucket],
-                ramp[ci.min(15)],
-            );
+    PLASMA_SCRATCH.with(|scratch| {
+        let mut scratch = scratch.borrow_mut();
+        scratch.col_wave.resize(w, 0.0);
+        scratch.row_wave.resize(h, 0.0);
+        scratch.diag_wave.resize(w + h, 0.0);
+        let t = f as f64;
+        for (x, value) in scratch.col_wave.iter_mut().enumerate() {
+            *value = (x as f64 * 0.30 + t * 0.055).sin();
         }
-    }
+        for (y, value) in scratch.row_wave.iter_mut().enumerate() {
+            *value = (y as f64 * 0.55 - t * 0.038).sin();
+        }
+        for (d, value) in scratch.diag_wave.iter_mut().enumerate() {
+            *value = (d as f64 * 0.21 + t * 0.024).sin();
+        }
+
+        for y in 0..h {
+            let abs_y = zone.top() + y as u16;
+            let (spans, span_count) = canvas.visible_spans(zone, abs_y);
+            for span in &spans[..span_count] {
+                for abs_x in span.start..span.end {
+                    let x = usize::from(abs_x - zone.left());
+                    // v ∈ [-3, 3] → normalized [0, 1].
+                    let v = (scratch.col_wave[x]
+                        + scratch.row_wave[y]
+                        + scratch.diag_wave[x + y]
+                        + 3.0)
+                        / 6.0;
+                    let bucket = (v * 3.999) as usize; // 0..=3 density glyph
+                    if bucket == 0 {
+                        continue; // the trough stays blank — cheaper, and lets the theme breathe
+                    }
+                    let ci = (v * 15.999) as usize;
+                    canvas.put_visible_fg(abs_x, abs_y, PLASMA_GLYPHS[bucket], ramp[ci.min(15)]);
+                }
+            }
+        }
+    });
 }
 
 #[cfg(test)]
@@ -510,23 +497,19 @@ mod tests {
     use ratatui::backend::TestBackend;
     use ratatui::buffer::Buffer;
 
-    fn dual_zones() -> [Rect; 2] {
-        [Rect::new(4, 1, 40, 6), Rect::new(4, 10, 40, 7)]
-    }
-
-    fn render_dual(
+    fn render_effect(
         app: &App,
-        zones: [Rect; 2],
+        zone: Rect,
+        art_mask: Option<Rect>,
         f: u64,
-        effect: fn(&mut Frame, &App, Rect, u64),
+        effect: impl Fn(&mut CanvasWriter<'_>, &App, Rect, u64),
     ) -> Buffer {
         let backend = TestBackend::new(50, 20);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| {
-                for zone in zones {
-                    effect(frame, app, zone, f);
-                }
+                let mut canvas = CanvasWriter::new(frame.buffer_mut(), art_mask);
+                effect(&mut canvas, app, zone, f);
             })
             .unwrap();
         terminal.backend().buffer().clone()
@@ -543,102 +526,90 @@ mod tests {
     }
 
     #[test]
-    fn zone_slots_use_full_rect_keys_and_evict_lru_at_capacity() {
-        let first = Rect::new(0, 0, 20, 6);
-        let second = Rect::new(0, 8, 20, 6);
-        let third = Rect::new(22, 0, 20, 6);
-        let mut slots = ZoneSlots::<u8>::default();
-
-        *slots.get_mut(first) = 1;
-        *slots.get_mut(second) = 2;
-        assert_eq!(slots.slots.len(), STATEFUL_ZONE_CAPACITY);
-        assert_eq!(*slots.get_mut(first), 1);
-
-        *slots.get_mut(third) = 3;
-        assert_eq!(slots.slots.len(), STATEFUL_ZONE_CAPACITY);
-        assert!(slots.slots.iter().all(|(zone, _)| *zone != second));
-        assert_eq!(slots.slots.iter().map(|(_, value)| *value).sum::<u8>(), 4);
-    }
-
-    #[test]
-    fn life_keeps_both_player_zones_evolving_independently() {
-        LIFE_SCRATCH.with(|scratch| scratch.borrow_mut().slots.clear());
+    fn life_mask_changes_do_not_reset_the_scene() {
+        LIFE_SCRATCH.with(|scratch| *scratch.borrow_mut() = LifeScratch::default());
         let app = App::new(100);
-        let zones = dual_zones();
+        let zone = Rect::new(4, 2, 40, 14);
+        let first_mask = Rect::new(10, 5, 10, 5);
+        let second_mask = Rect::new(24, 7, 8, 4);
 
-        render_dual(&app, zones, 0, life);
+        render_effect(&app, zone, Some(first_mask), 0, life);
         let before = LIFE_SCRATCH.with(|scratch| {
             let scratch = scratch.borrow();
-            zones.map(|zone| {
-                let state = &scratch
-                    .slots
-                    .iter()
-                    .find(|(key, _)| *key == zone)
-                    .expect("life state for both zones")
-                    .1;
-                (state.epoch, state.age.clone())
-            })
+            (scratch.epoch, scratch.age.clone())
         });
 
-        let buffer = render_dual(&app, zones, LIFE_STEP_FRAMES, life);
+        render_effect(&app, zone, Some(second_mask), 0, life);
         LIFE_SCRATCH.with(|scratch| {
             let scratch = scratch.borrow();
-            assert_eq!(scratch.slots.len(), STATEFUL_ZONE_CAPACITY);
-            for (index, zone) in zones.into_iter().enumerate() {
-                let state = &scratch
-                    .slots
-                    .iter()
-                    .find(|(key, _)| *key == zone)
-                    .expect("life state for both zones")
-                    .1;
-                assert_eq!(state.epoch, before[index].0, "zone {index} was reseeded");
-                assert_eq!(state.last_step, LIFE_STEP_FRAMES);
-                assert_ne!(state.age, before[index].1, "zone {index} did not evolve");
-                assert!(painted_cells(&buffer, zone) > 0);
-            }
+            assert_eq!(scratch.epoch, before.0);
+            assert_eq!(scratch.age, before.1);
         });
+
+        let buffer = render_effect(&app, zone, Some(second_mask), LIFE_STEP_FRAMES, life);
+        LIFE_SCRATCH.with(|scratch| {
+            let scratch = scratch.borrow();
+            assert_eq!(scratch.last_step, LIFE_STEP_FRAMES);
+            assert_ne!(scratch.age, before.1);
+        });
+        assert!(painted_cells(&buffer, zone) > 0);
+        assert_eq!(painted_cells(&buffer, second_mask), 0);
     }
 
     #[test]
-    fn pipes_paint_and_advance_in_both_player_zones() {
-        PIPES_SCRATCH.with(|scratch| scratch.borrow_mut().slots.clear());
+    fn pipes_mask_changes_do_not_reset_the_scene() {
+        PIPES_SCRATCH.with(|scratch| *scratch.borrow_mut() = PipesScratch::default());
         let app = App::new(100);
-        let zones = dual_zones();
+        let zone = Rect::new(4, 2, 40, 14);
+        let first_mask = Rect::new(10, 5, 10, 5);
+        let second_mask = Rect::new(24, 7, 8, 4);
 
-        let first = render_dual(&app, zones, 1, pipes);
-        for zone in zones {
-            assert!(painted_cells(&first, zone) > 0);
-        }
+        let first = render_effect(&app, zone, Some(first_mask), 1, pipes);
+        assert!(painted_cells(&first, zone) > 0);
         let before = PIPES_SCRATCH.with(|scratch| {
             let scratch = scratch.borrow();
-            assert_eq!(scratch.slots.len(), STATEFUL_ZONE_CAPACITY);
-            zones.map(|zone| {
-                let state = &scratch
-                    .slots
-                    .iter()
-                    .find(|(key, _)| *key == zone)
-                    .expect("pipes state for both zones")
-                    .1;
-                (state.epoch, state.cells.clone())
-            })
+            (scratch.epoch, scratch.cells.clone())
         });
 
-        let second = render_dual(&app, zones, 2, pipes);
+        let second = render_effect(&app, zone, Some(second_mask), 2, pipes);
         PIPES_SCRATCH.with(|scratch| {
             let scratch = scratch.borrow();
-            assert_eq!(scratch.slots.len(), STATEFUL_ZONE_CAPACITY);
-            for (index, zone) in zones.into_iter().enumerate() {
-                let state = &scratch
-                    .slots
-                    .iter()
-                    .find(|(key, _)| *key == zone)
-                    .expect("pipes state for both zones")
-                    .1;
-                assert_eq!(state.epoch, before[index].0, "zone {index} was reset");
-                assert_eq!(state.last_f, 2);
-                assert_ne!(state.cells, before[index].1, "zone {index} did not advance");
-                assert!(painted_cells(&second, zone) > 0);
-            }
+            assert_eq!(scratch.epoch, before.0);
+            assert_eq!(scratch.last_f, 2);
+            assert_ne!(scratch.cells, before.1);
         });
+        assert!(painted_cells(&second, zone) > 0);
+        assert_eq!(painted_cells(&second, second_mask), 0);
+    }
+
+    #[test]
+    fn plasma_reuses_scratch_capacity_and_skips_the_art_mask() {
+        PLASMA_SCRATCH.with(|scratch| *scratch.borrow_mut() = PlasmaScratch::default());
+        let app = App::new(100);
+        let zone = Rect::new(4, 2, 40, 14);
+        let mask = Rect::new(14, 6, 16, 7);
+
+        render_effect(&app, zone, Some(mask), 1, plasma);
+        let capacities = PLASMA_SCRATCH.with(|scratch| {
+            let scratch = scratch.borrow();
+            (
+                scratch.col_wave.capacity(),
+                scratch.row_wave.capacity(),
+                scratch.diag_wave.capacity(),
+            )
+        });
+        let buffer = render_effect(&app, zone, Some(mask), 2, plasma);
+        PLASMA_SCRATCH.with(|scratch| {
+            let scratch = scratch.borrow();
+            assert_eq!(
+                (
+                    scratch.col_wave.capacity(),
+                    scratch.row_wave.capacity(),
+                    scratch.diag_wave.capacity(),
+                ),
+                capacities
+            );
+        });
+        assert_eq!(painted_cells(&buffer, mask), 0);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -40,6 +40,10 @@ pub fn render(frame: &mut Frame, app: &App) {
     // The selected-row marquee flag is a per-frame output too: a list view sets it while it
     // renders a scrolling cursor row; `animation_active` reads the latest frame's verdict.
     app.bridges.marquee_ran.set(false);
+    // Canvas activity is geometry-dependent (art/lyrics masks and focal safe regions can hide
+    // configured effects), so stale Player state must never keep Mini or another view awake.
+    app.bridges.canvas_active.set(false);
+    app.bridges.canvas_heavy_active.set(false);
     // The responsive tier is decided from the real cell grid each frame and bridged back
     // to the reducer (text zoom rescales the grid without a resize event, so only the
     // render pass knows it). Below the mini thresholds the whole UI is the miniplayer;

--- a/src/ui/views/mod.rs
+++ b/src/ui/views/mod.rs
@@ -11,6 +11,7 @@ pub mod mini;
 pub mod now_playing;
 pub mod onboarding;
 pub mod player;
+mod player_layout;
 pub mod search;
 pub mod settings;
 pub mod why_ai;

--- a/src/ui/views/player.rs
+++ b/src/ui/views/player.rs
@@ -16,6 +16,8 @@ use crate::t;
 use crate::theme::ThemeRole as R;
 use crate::ui::buttons;
 
+use super::player_layout::calculate_player_filler_layout;
+
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
@@ -53,7 +55,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             Constraint::Length(1), // help
         ])
         .split(inner);
-        render_filler(frame, app, rows[1]);
+        render_filler(frame, app, inner, rows[1]);
         crate::ui::control_box::render_docked(frame, app, rows[2]);
         buttons::render_help_button(frame, app, rows[3]);
     } else {
@@ -73,11 +75,11 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
         // Title / seekbar / transport strip / status line — the shared control block
         // (see `ui::control_box`); the rects are this view's legacy rows, so bytes are unchanged.
+        // The canvas composes before every foreground player surface. With animations off this
+        // reordering is cell-identical; with a field effect on, the control widgets cover it in
+        // one deterministic foreground pass.
+        render_filler(frame, app, inner, rows[8]);
         crate::ui::control_box::render_at(frame, app, rows[1], rows[3], rows[5], rows[7]);
-
-        // Central filler: album art (top) and/or the lyrics panel (below). With album art off
-        // this is exactly the old behaviour — lyrics fill the whole area, nothing else draws.
-        render_filler(frame, app, rows[8]);
 
         // The full key list lives in the `?` cheat-sheet now; the footer just points to it
         // (chord pulled live from the keymap, so a remap of "toggle help" updates it).
@@ -255,126 +257,43 @@ const RADIO_ART_SEP_GAP: u16 = 2;
 /// Smallest lyrics window (rows) we keep below the art when both are shown.
 const MIN_LYRICS_ROWS: u16 = 3;
 
-/// The central area below the transport strip. Album art (when enabled and ready) sits at
-/// the top, just under the status line; the lyrics panel (when toggled) starts right below
-/// the art's real bottom edge. When album art is off the layout is unchanged — lyrics get
-/// the whole area, and an empty area draws nothing.
-fn render_filler(frame: &mut Frame, app: &App, area: Rect) {
+/// Compose the central Player stage once, then draw its artwork and lyrics foreground. The
+/// responsive geometry helper preserves the classic Top stack and prefers a side-by-side Bottom
+/// layout; when artwork is unavailable, lyrics receive the whole filler.
+fn render_filler(frame: &mut Frame, app: &App, player_area: Rect, area: Rect) {
     app.art.rect.set(None);
     // The radio set piece rides the album-art toggle: with it off, radio mode falls
     // through to the plain music-mode arms below (`art_active()` is hard-false in radio
     // mode, so those resolve to the no-art layout — lyrics, or the bare animation canvas).
     if app.radio_dedicated_mode && app.config.effective_album_art() {
+        crate::ui::anim::render_canvas_composite(
+            frame,
+            app,
+            player_area,
+            area,
+            None,
+            app.lyrics.visible.then_some(area),
+            false,
+        );
         render_radio_filler(frame, app, area);
         return;
     }
-    let centered = app.player_bar_position() == crate::config::PlayerBarPosition::Bottom;
-    match (app.art_active(), app.lyrics.visible) {
-        // Art with lyrics right under it. The art is capped so a readable lyrics window
-        // always remains, then lyrics start one row below the art's actual bottom (not at a
-        // fixed split), so there's no dead gap between them. Top mode anchors the pair to
-        // the top of the filler; Bottom mode centers the [art, gap, lyrics] group.
-        (true, true) => {
-            let after_gap = area.height.saturating_sub(ART_TOP_GAP);
-            // ~50% of the filler, but never so tall that lyrics drop below MIN_LYRICS_ROWS.
-            let cap = (after_gap / 2).min(after_gap.saturating_sub(MIN_LYRICS_ROWS));
-            let (band, centered_lyrics_h) = if centered {
-                // Probe the art's real height first (`art_fit_rect` is a pure query), so
-                // the group's total height is known before anything is drawn. The lyrics
-                // window is capped at 12 rows (~5 lines of context either side of the
-                // current one) so the centered group stays compact and the centering reads.
-                let art_h = app.art_fit_rect(art_band(area, 0, cap)).height;
-                let lyrics_h = area
-                    .height
-                    .saturating_sub(art_h + ART_LYRICS_GAP)
-                    .clamp(MIN_LYRICS_ROWS, 12);
-                let group_h = art_h + ART_LYRICS_GAP + lyrics_h;
-                (
-                    Rect {
-                        x: area.x,
-                        y: area.y + area.height.saturating_sub(group_h) / 2,
-                        width: area.width,
-                        height: art_h.min(area.height),
-                    },
-                    lyrics_h,
-                )
-            } else {
-                (art_band(area, ART_TOP_GAP, cap), 0)
-            };
-            match draw_art(frame, app, band) {
-                Some(art) => {
-                    let lyrics_y = art.bottom().saturating_add(ART_LYRICS_GAP);
-                    let lyrics_bottom = if centered {
-                        // Keep the group's computed window so the centering holds; the
-                        // canvas gets the residual bands.
-                        area.bottom()
-                            .min(lyrics_y.saturating_add(centered_lyrics_h))
-                    } else {
-                        area.bottom()
-                    };
-                    let lyrics_area = Rect {
-                        x: area.x,
-                        y: lyrics_y,
-                        width: area.width,
-                        height: lyrics_bottom.saturating_sub(lyrics_y),
-                    };
-                    render_lyrics(frame, app, lyrics_area);
-                }
-                None => render_lyrics(frame, app, area),
-            }
-        }
-        // Art only: medium size, capped to ~55% of the filler height. Top mode anchors it
-        // under the status line; Bottom mode centers it in the filler. Canvas animations
-        // fill the blank region around the art's real edges (never over the art).
-        (true, false) => {
-            let cap = (u32::from(area.height) * 11 / 20) as u16;
-            let band = if centered {
-                // Probe the art's real height (`art_fit_rect` is a pure query) so the band
-                // is sized to it exactly — `draw_art`'s top re-anchor then lands centered.
-                let art_h = app.art_fit_rect(art_band(area, 0, cap)).height;
-                Rect {
-                    x: area.x,
-                    y: area.y + area.height.saturating_sub(art_h) / 2,
-                    width: area.width,
-                    height: art_h.min(area.height),
-                }
-            } else {
-                art_band(area, ART_TOP_GAP, cap)
-            };
-            let art = draw_art(frame, app, band);
-            if centered && let Some(art) = art {
-                // Band above the centered art.
-                let above_h = art.y.saturating_sub(area.y).saturating_sub(ART_LYRICS_GAP);
-                if above_h > 0 {
-                    crate::ui::anim::render_canvas(
-                        frame,
-                        app,
-                        Rect {
-                            x: area.x,
-                            y: area.y,
-                            width: area.width,
-                            height: above_h,
-                        },
-                    );
-                }
-            }
-            let below = art
-                .map_or(area.y, |r| r.bottom())
-                .saturating_add(ART_LYRICS_GAP);
-            if below < area.bottom() {
-                let zone = Rect {
-                    x: area.x,
-                    y: below,
-                    width: area.width,
-                    height: area.bottom() - below,
-                };
-                crate::ui::anim::render_canvas(frame, app, zone);
-            }
-        }
-        (false, true) => render_lyrics(frame, app, area),
-        // No art, no lyrics: the whole filler is blank — the maximum canvas. With every animation
-        // off this stays empty (drawing nothing), exactly as before.
-        (false, false) => crate::ui::anim::render_canvas(frame, app, area),
+    let layout = calculate_player_filler_layout(app, area, app.art_active(), app.lyrics.visible);
+    crate::ui::anim::render_canvas_composite(
+        frame,
+        app,
+        player_area,
+        area,
+        layout.art,
+        layout.lyrics,
+        app.player_bar_position() == crate::config::PlayerBarPosition::Bottom
+            && layout.art.is_some(),
+    );
+    if let Some(art) = layout.art {
+        draw_art(frame, app, art);
+    }
+    if let Some(lyrics) = layout.lyrics {
+        render_lyrics(frame, app, lyrics);
     }
 }
 
@@ -477,22 +396,6 @@ fn render_radio_filler(frame: &mut Frame, app: &App, area: Rect) {
                 );
             }
             if !app.lyrics.visible {
-                // Music-mode filler animations run in radio mode too: the canvas gets
-                // the blank band below the one-line art, mirroring the album-art arm
-                // of `render_filler`.
-                let below = separator_y.saturating_add(ART_LYRICS_GAP);
-                if below < area.bottom() {
-                    crate::ui::anim::render_canvas(
-                        frame,
-                        app,
-                        Rect {
-                            x: area.x,
-                            y: below,
-                            width: area.width,
-                            height: area.bottom() - below,
-                        },
-                    );
-                }
                 return;
             }
             let lyrics_y = separator_y.saturating_add(ART_LYRICS_GAP);
@@ -505,9 +408,7 @@ fn render_radio_filler(frame: &mut Frame, app: &App, area: Rect) {
             render_lyrics(frame, app, lyrics_area);
         }
         None if app.lyrics.visible => render_lyrics(frame, app, area),
-        // Too small for the set piece and no lyrics: the whole filler is canvas, like
-        // the music-mode no-art arm.
-        None => crate::ui::anim::render_canvas(frame, app, area),
+        None => {}
     }
 }
 
@@ -675,21 +576,10 @@ fn art_band(area: Rect, gap: u16, max_h: u16) -> Rect {
     }
 }
 
-/// Draw the current track's album art / thumbnail top-anchored within `band` and centered
-/// horizontally by its true aspect ratio (square covers stay square, 16:9 thumbnails stay
-/// wide — the picker knows the terminal's font cell size). Returns the rect the art
-/// actually occupies so the caller can start the lyrics right below it, or `None` when the
-/// band is too small to render anything legible. Only called when `app.art_active()`, so
-/// the protocol is present; with no graphics protocol this renders as unicode half-blocks.
-/// `Resize::Scale` lets a small source thumbnail grow to fill the rect (the default `Fit`
-/// never upscales).
-fn draw_art(frame: &mut Frame, app: &App, band: Rect) -> Option<Rect> {
-    // Below a few cells there's nothing but mush; skip so a tiny terminal stays clean.
-    if band.width < 6 || band.height < 3 {
-        return None;
-    }
-    let mut rect = app.art_fit_rect(band);
-    rect.y = band.y; // art_fit_rect centers vertically; re-anchor to the top of the band.
+/// Draw the current track's album art into the already aspect-fitted final rectangle. The layout
+/// and the canvas hard mask share this exact value, so native protocols never expose animation
+/// glyphs through placeholder cells.
+fn draw_art(frame: &mut Frame, app: &App, rect: Rect) {
     app.art.rect.set(Some(rect));
     // Retro mode draws the cover itself as luminance-ramp ASCII art: a basic console has no
     // graphics protocol, and the half-block fallback needs truecolor cells the scrubber
@@ -704,7 +594,7 @@ fn draw_art(frame: &mut Frame, app: &App, band: Rect) -> Option<Rect> {
                 rect,
             );
         }
-        return Some(rect);
+        return;
     }
     if let Some(proto) = app.art.protocol.borrow_mut().as_mut() {
         frame.render_stateful_widget(
@@ -713,7 +603,6 @@ fn draw_art(frame: &mut Frame, app: &App, band: Rect) -> Option<Rect> {
             proto,
         );
     }
-    Some(rect)
 }
 
 /// The synced-lyrics panel: a window of lines centered on the current one, which is

--- a/src/ui/views/player_layout.rs
+++ b/src/ui/views/player_layout.rs
@@ -1,0 +1,478 @@
+//! Pure geometry for the ordinary music Player filler.
+//!
+//! Rendering stays in `player`: this module only decides the final album-art and lyrics
+//! rectangles. Keeping that decision separate lets the canvas use the same rectangles as hard
+//! masks before either foreground surface is drawn.
+
+use ratatui::layout::{Rect, Size};
+
+use crate::app::App;
+use crate::config::PlayerBarPosition;
+
+pub(super) const ART_MIN_WIDTH: u16 = 6;
+pub(super) const ART_MIN_HEIGHT: u16 = 3;
+pub(super) const ART_PREFERRED_WIDTH: u16 = 48;
+pub(super) const ART_PREFERRED_HEIGHT: u16 = 15;
+pub(super) const LYRICS_MIN_WIDTH: u16 = 24;
+pub(super) const LYRICS_MIN_HEIGHT: u16 = 3;
+pub(super) const LYRICS_PREFERRED_WIDTH: u16 = 40;
+pub(super) const LYRICS_PREFERRED_HEIGHT: u16 = 12;
+
+const TOP_ART_GAP: u16 = 1;
+const SIDE_GAP: u16 = 2;
+const STACK_GAP: u16 = 1;
+
+/// How the ordinary music filler placed its visible foreground surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PlayerFillerArrangement {
+    Empty,
+    ArtOnly,
+    LyricsOnly,
+    SideBySide,
+    Stacked,
+}
+
+/// Final, non-overlapping foreground rectangles inside the Player filler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct PlayerFillerLayout {
+    pub(super) art: Option<Rect>,
+    pub(super) lyrics: Option<Rect>,
+    pub(super) arrangement: PlayerFillerArrangement,
+}
+
+impl PlayerFillerLayout {
+    const fn empty() -> Self {
+        Self {
+            art: None,
+            lyrics: None,
+            arrangement: PlayerFillerArrangement::Empty,
+        }
+    }
+
+    const fn lyrics_only(area: Rect) -> Self {
+        Self {
+            art: None,
+            lyrics: Some(area),
+            arrangement: PlayerFillerArrangement::LyricsOnly,
+        }
+    }
+}
+
+/// Calculate the ordinary music-mode filler geometry.
+///
+/// `art_visible` is deliberately supplied by the caller. In production it is
+/// `App::art_active()`, but taking the resolved value keeps loading, zoom suppression, and the
+/// album-art toggle out of this pure layout policy. Dedicated Radio mode has its own renderer and
+/// must not call this helper.
+pub(super) fn calculate_player_filler_layout(
+    app: &App,
+    area: Rect,
+    art_visible: bool,
+    lyrics_visible: bool,
+) -> PlayerFillerLayout {
+    if area.is_empty() {
+        return PlayerFillerLayout::empty();
+    }
+
+    match app.player_bar_position() {
+        PlayerBarPosition::Top => top_layout(app, area, art_visible, lyrics_visible),
+        PlayerBarPosition::Bottom => bottom_layout(app, area, art_visible, lyrics_visible),
+    }
+}
+
+/// The classic Top geometry is intentionally a direct transcription of the old render-time
+/// calculation. In particular, its art is top-anchored after `App::art_fit_rect` and its lyrics
+/// consume the full width below the real art bottom.
+fn top_layout(
+    app: &App,
+    area: Rect,
+    art_visible: bool,
+    lyrics_visible: bool,
+) -> PlayerFillerLayout {
+    match (art_visible, lyrics_visible) {
+        (true, true) => {
+            let after_gap = area.height.saturating_sub(TOP_ART_GAP);
+            let cap = (after_gap / 2).min(after_gap.saturating_sub(LYRICS_MIN_HEIGHT));
+            let band = top_art_band(area, TOP_ART_GAP, cap);
+            let Some(art) = top_art_rect(app, band) else {
+                return PlayerFillerLayout::lyrics_only(area);
+            };
+            let lyrics_y = art.bottom().saturating_add(STACK_GAP);
+            let lyrics = Rect {
+                x: area.x,
+                y: lyrics_y,
+                width: area.width,
+                height: area.bottom().saturating_sub(lyrics_y),
+            };
+            PlayerFillerLayout {
+                art: Some(art),
+                lyrics: Some(lyrics),
+                arrangement: PlayerFillerArrangement::Stacked,
+            }
+        }
+        (true, false) => {
+            let cap = (u32::from(area.height) * 11 / 20) as u16;
+            let art = top_art_rect(app, top_art_band(area, TOP_ART_GAP, cap));
+            PlayerFillerLayout {
+                art,
+                lyrics: None,
+                arrangement: if art.is_some() {
+                    PlayerFillerArrangement::ArtOnly
+                } else {
+                    PlayerFillerArrangement::Empty
+                },
+            }
+        }
+        (false, true) => PlayerFillerLayout::lyrics_only(area),
+        (false, false) => PlayerFillerLayout::empty(),
+    }
+}
+
+fn bottom_layout(
+    app: &App,
+    area: Rect,
+    art_visible: bool,
+    lyrics_visible: bool,
+) -> PlayerFillerLayout {
+    match (art_visible, lyrics_visible) {
+        (true, true) => bottom_art_and_lyrics(app, area),
+        (true, false) => {
+            let art = fitted_bottom_art(app, area.width, area.height)
+                .map(|size| centered_rect(area, size));
+            PlayerFillerLayout {
+                art,
+                lyrics: None,
+                arrangement: if art.is_some() {
+                    PlayerFillerArrangement::ArtOnly
+                } else {
+                    PlayerFillerArrangement::Empty
+                },
+            }
+        }
+        (false, true) => PlayerFillerLayout::lyrics_only(area),
+        (false, false) => PlayerFillerLayout::empty(),
+    }
+}
+
+fn bottom_art_and_lyrics(app: &App, area: Rect) -> PlayerFillerLayout {
+    if let Some(layout) = side_by_side_layout(app, area) {
+        return layout;
+    }
+    stacked_layout(app, area).unwrap_or_else(|| PlayerFillerLayout::lyrics_only(area))
+}
+
+/// Prefer the fully fitted art and spend width on lyrics down toward their minimum. Only after
+/// that minimum is reached may the art shrink. Height constraints aspect-fit the art immediately;
+/// there is no useful vertical padding left once the preferred 15-row box no longer fits.
+fn side_by_side_layout(app: &App, area: Rect) -> Option<PlayerFillerLayout> {
+    if area.width < ART_MIN_WIDTH + SIDE_GAP + LYRICS_MIN_WIDTH
+        || area.height < ART_MIN_HEIGHT.max(LYRICS_MIN_HEIGHT)
+    {
+        return None;
+    }
+
+    let mut art = fitted_bottom_art(app, area.width, area.height)?;
+    if art.width + SIDE_GAP + LYRICS_MIN_WIDTH > area.width {
+        let art_budget = area.width.saturating_sub(SIDE_GAP + LYRICS_MIN_WIDTH);
+        art = fitted_bottom_art(app, art_budget, area.height)?;
+    }
+
+    let lyrics_width = area
+        .width
+        .saturating_sub(art.width + SIDE_GAP)
+        .min(LYRICS_PREFERRED_WIDTH);
+    if lyrics_width < LYRICS_MIN_WIDTH {
+        return None;
+    }
+    let lyrics_height = area.height.min(LYRICS_PREFERRED_HEIGHT);
+    if lyrics_height < LYRICS_MIN_HEIGHT {
+        return None;
+    }
+
+    let group = Size::new(
+        art.width + SIDE_GAP + lyrics_width,
+        art.height.max(lyrics_height),
+    );
+    let group_rect = centered_rect(area, group);
+    let art_rect = Rect::new(
+        group_rect.x,
+        group_rect.y + group.height.saturating_sub(art.height) / 2,
+        art.width,
+        art.height,
+    );
+    let lyrics_rect = Rect::new(
+        art_rect.right() + SIDE_GAP,
+        group_rect.y + group.height.saturating_sub(lyrics_height) / 2,
+        lyrics_width,
+        lyrics_height,
+    );
+    Some(PlayerFillerLayout {
+        art: Some(art_rect),
+        lyrics: Some(lyrics_rect),
+        arrangement: PlayerFillerArrangement::SideBySide,
+    })
+}
+
+fn stacked_layout(app: &App, area: Rect) -> Option<PlayerFillerLayout> {
+    if area.width < LYRICS_MIN_WIDTH || area.height < ART_MIN_HEIGHT + STACK_GAP + LYRICS_MIN_HEIGHT
+    {
+        return None;
+    }
+
+    // Reserve the minimum readable lyrics window first. The art retains its preferred size while
+    // it fits in the remaining space, then aspect-fits monotonically as rows/columns disappear.
+    let art_budget_height = area.height.saturating_sub(STACK_GAP + LYRICS_MIN_HEIGHT);
+    let art = fitted_bottom_art(app, area.width, art_budget_height)?;
+    let lyrics_height = area
+        .height
+        .saturating_sub(art.height + STACK_GAP)
+        .min(LYRICS_PREFERRED_HEIGHT);
+    if lyrics_height < LYRICS_MIN_HEIGHT {
+        return None;
+    }
+    let lyrics_width = area.width.min(LYRICS_PREFERRED_WIDTH);
+    if lyrics_width < LYRICS_MIN_WIDTH {
+        return None;
+    }
+
+    let group_height = art.height + STACK_GAP + lyrics_height;
+    let group_y = area.y + area.height.saturating_sub(group_height) / 2;
+    let art_rect = Rect::new(
+        area.x + area.width.saturating_sub(art.width) / 2,
+        group_y,
+        art.width,
+        art.height,
+    );
+    let lyrics_rect = Rect::new(
+        area.x + area.width.saturating_sub(lyrics_width) / 2,
+        art_rect.bottom() + STACK_GAP,
+        lyrics_width,
+        lyrics_height,
+    );
+    Some(PlayerFillerLayout {
+        art: Some(art_rect),
+        lyrics: Some(lyrics_rect),
+        arrangement: PlayerFillerArrangement::Stacked,
+    })
+}
+
+/// Fit the source aspect into the preferred 48x15-cell box, clipped by the available size.
+/// Reject the result (not merely its bounding box) when aspect fitting makes it smaller than the
+/// legibility floor.
+fn fitted_bottom_art(app: &App, available_width: u16, available_height: u16) -> Option<Size> {
+    let bounds = Rect::new(
+        0,
+        0,
+        available_width.min(ART_PREFERRED_WIDTH),
+        available_height.min(ART_PREFERRED_HEIGHT),
+    );
+    if bounds.width == 0 || bounds.height == 0 {
+        return None;
+    }
+    let fitted = app.art_fit_rect(bounds);
+    (fitted.width >= ART_MIN_WIDTH && fitted.height >= ART_MIN_HEIGHT)
+        .then_some(Size::new(fitted.width, fitted.height))
+}
+
+fn top_art_band(area: Rect, gap: u16, max_height: u16) -> Rect {
+    let available = area.height.saturating_sub(gap);
+    Rect {
+        x: area.x,
+        y: area.y + gap,
+        width: area.width,
+        height: max_height.min(available),
+    }
+}
+
+fn top_art_rect(app: &App, band: Rect) -> Option<Rect> {
+    // This check is on the band, not the aspect-fitted result, matching the classic renderer.
+    if band.width < ART_MIN_WIDTH || band.height < ART_MIN_HEIGHT {
+        return None;
+    }
+    let mut rect = app.art_fit_rect(band);
+    rect.y = band.y;
+    Some(rect)
+}
+
+fn centered_rect(area: Rect, size: Size) -> Rect {
+    Rect::new(
+        area.x + area.width.saturating_sub(size.width) / 2,
+        area.y + area.height.saturating_sub(size.height) / 2,
+        size.width.min(area.width),
+        size.height.min(area.height),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui_image::picker::Picker;
+
+    fn app_with_art(position: PlayerBarPosition, dimensions: (u32, u32)) -> App {
+        let mut app = App::new(100);
+        app.config.player_bar_position = Some(position);
+        app.art.picker = Some(Picker::halfblocks()); // 10x20-pixel cells
+        app.art.dims = dimensions;
+        app
+    }
+
+    fn layout(
+        app: &App,
+        area: Rect,
+        art_visible: bool,
+        lyrics_visible: bool,
+    ) -> PlayerFillerLayout {
+        calculate_player_filler_layout(app, area, art_visible, lyrics_visible)
+    }
+
+    fn contains_rect(outer: Rect, inner: Rect) -> bool {
+        inner.left() >= outer.left()
+            && inner.top() >= outer.top()
+            && inner.right() <= outer.right()
+            && inner.bottom() <= outer.bottom()
+    }
+
+    #[test]
+    fn bottom_art_only_keeps_preferred_size_while_padding_collapses() {
+        let app = app_with_art(PlayerBarPosition::Bottom, (100, 100));
+        let large = layout(&app, Rect::new(0, 0, 98, 21), true, false);
+        let less_padding = layout(&app, Rect::new(0, 0, 40, 15), true, false);
+        let no_padding = layout(&app, Rect::new(0, 0, 30, 15), true, false);
+
+        assert_eq!(large.art.unwrap().as_size(), Size::new(30, 15));
+        assert_eq!(less_padding.art.unwrap().as_size(), Size::new(30, 15));
+        assert_eq!(no_padding.art.unwrap().as_size(), Size::new(30, 15));
+        assert_eq!(large.art.unwrap(), Rect::new(34, 3, 30, 15));
+        assert_eq!(less_padding.art.unwrap(), Rect::new(5, 0, 30, 15));
+    }
+
+    #[test]
+    fn bottom_art_only_shrinks_monotonically_with_source_aspect() {
+        let app = app_with_art(PlayerBarPosition::Bottom, (160, 90));
+        let mut previous = Size::new(u16::MAX, u16::MAX);
+        for area in [
+            Rect::new(0, 0, 58, 20),
+            Rect::new(0, 0, 48, 15),
+            Rect::new(0, 0, 40, 12),
+            Rect::new(0, 0, 32, 9),
+        ] {
+            let art = layout(&app, area, true, false).art.unwrap();
+            assert!(art.width <= previous.width && art.height <= previous.height);
+            // 16:9 pixels in 1:2 cells is approximately a 32:9 cell ratio. Allow one cell
+            // for independent integer rounding of width and height.
+            assert!((i32::from(art.width) * 9 - i32::from(art.height) * 32).abs() <= 16);
+            previous = art.as_size();
+        }
+    }
+
+    #[test]
+    fn bottom_requested_filler_sizes_choose_side_by_side_then_yield_tiny_filler() {
+        let square = app_with_art(PlayerBarPosition::Bottom, (100, 100));
+        for area in [
+            Rect::new(1, 2, 158, 41), // 160x50 frame
+            Rect::new(1, 2, 98, 21),  // 100x30 frame
+            Rect::new(1, 2, 78, 15),  // 80x24 frame
+            Rect::new(1, 2, 58, 9),   // 60x18 frame
+        ] {
+            let result = layout(&square, area, true, true);
+            assert_eq!(result.arrangement, PlayerFillerArrangement::SideBySide);
+            assert!(contains_rect(area, result.art.unwrap()));
+            assert!(contains_rect(area, result.lyrics.unwrap()));
+            assert_eq!(
+                result.art.unwrap().right() + SIDE_GAP,
+                result.lyrics.unwrap().x
+            );
+        }
+
+        let tiny = Rect::new(1, 2, 30, 5); // 32x14 Full-frame filler
+        let result = layout(&square, tiny, true, true);
+        assert_eq!(result, PlayerFillerLayout::lyrics_only(tiny));
+    }
+
+    #[test]
+    fn wide_art_spends_lyrics_width_before_shrinking() {
+        let app = app_with_art(PlayerBarPosition::Bottom, (160, 90));
+        let preferred = layout(&app, Rect::new(0, 0, 90, 15), true, true);
+        assert_eq!(preferred.art.unwrap().as_size(), Size::new(48, 14));
+        assert_eq!(preferred.lyrics.unwrap().as_size(), Size::new(40, 12));
+
+        let narrower = layout(&app, Rect::new(0, 0, 78, 15), true, true);
+        assert_eq!(narrower.art.unwrap().as_size(), Size::new(48, 14));
+        assert_eq!(narrower.lyrics.unwrap().width, 28);
+
+        let short = layout(&app, Rect::new(0, 0, 58, 9), true, true);
+        assert_eq!(short.art.unwrap().as_size(), Size::new(32, 9));
+        assert_eq!(short.lyrics.unwrap().as_size(), Size::new(24, 9));
+    }
+
+    #[test]
+    fn horizontal_minimum_failure_falls_back_to_centered_stack() {
+        let app = app_with_art(PlayerBarPosition::Bottom, (100, 100));
+        let area = Rect::new(10, 4, 30, 20);
+        let result = layout(&app, area, true, true);
+        assert_eq!(result.arrangement, PlayerFillerArrangement::Stacked);
+        assert_eq!(result.art.unwrap(), Rect::new(10, 4, 30, 15));
+        assert_eq!(result.lyrics.unwrap(), Rect::new(10, 20, 30, 4));
+        assert_eq!(
+            result.art.unwrap().bottom() + STACK_GAP,
+            result.lyrics.unwrap().y
+        );
+    }
+
+    #[test]
+    fn art_that_cannot_reach_its_final_minimum_is_hidden() {
+        let app = app_with_art(PlayerBarPosition::Bottom, (160, 90));
+        let area = Rect::new(3, 7, 30, 6);
+        let result = layout(&app, area, true, true);
+        assert_eq!(result, PlayerFillerLayout::lyrics_only(area));
+
+        let art_only = layout(&app, Rect::new(0, 0, 8, 3), true, false);
+        assert_eq!(art_only, PlayerFillerLayout::empty());
+    }
+
+    #[test]
+    fn art_off_or_loading_gives_lyrics_the_entire_filler() {
+        let app = app_with_art(PlayerBarPosition::Bottom, (100, 100));
+        let area = Rect::new(1, 2, 78, 15);
+        assert_eq!(
+            layout(&app, area, false, true),
+            PlayerFillerLayout::lyrics_only(area)
+        );
+        assert_eq!(
+            layout(&app, area, false, false),
+            PlayerFillerLayout::empty()
+        );
+    }
+
+    #[test]
+    fn top_art_only_geometry_matches_the_classic_formula() {
+        let app = app_with_art(PlayerBarPosition::Top, (100, 100));
+        let area = Rect::new(1, 9, 78, 13);
+        let result = layout(&app, area, true, false);
+        // cap=floor(13*11/20)=7; a square is 14x7 cells and is re-anchored at y+1.
+        assert_eq!(result.art, Some(Rect::new(33, 10, 14, 7)));
+        assert_eq!(result.lyrics, None);
+    }
+
+    #[test]
+    fn top_art_and_lyrics_geometry_matches_the_classic_formula() {
+        let app = app_with_art(PlayerBarPosition::Top, (100, 100));
+        let area = Rect::new(1, 9, 78, 13);
+        let result = layout(&app, area, true, true);
+        // after_gap=12, cap=min(6, 9)=6; square art=12x6, then the old one-row gap.
+        assert_eq!(result.art, Some(Rect::new(34, 10, 12, 6)));
+        assert_eq!(result.lyrics, Some(Rect::new(1, 17, 78, 5)));
+        assert_eq!(result.arrangement, PlayerFillerArrangement::Stacked);
+    }
+
+    #[test]
+    fn top_tiny_band_preserves_old_art_rejection_and_lyrics_fallback() {
+        let app = app_with_art(PlayerBarPosition::Top, (100, 100));
+        let area = Rect::new(0, 0, 30, 5);
+        assert_eq!(
+            layout(&app, area, true, true),
+            PlayerFillerLayout::lyrics_only(area)
+        );
+        assert_eq!(layout(&app, area, true, false), PlayerFillerLayout::empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Add a responsive Bottom player filler layout: album art keeps its preferred 48×15-cell box while padding collapses, lyrics stay beside art when space permits, and narrow views fall back to a stacked layout.
- Preserve the existing Top geometry and Mini behavior while moving canvas effects into a one-pass compositor with a hard album-art mask.
- Allocate cube and donut effects from art/lyrics-safe focal regions, contextually suppress Bottom donut rendering only when a real art rectangle exists, and retain raw configuration state.
- Record actual visible canvas/heavy activity for frame pacing, reuse hot-path buffers, and keep Life/Pipes scene state stable across art and lyrics changes.
- Add deterministic layout/composition regressions plus four interactive-player performance benchmark cases.

## Why

The previous Bottom layout reduced album art before consuming available padding and always stacked lyrics below it. Canvas rendering was also split around album art, could invoke effects more than once, and was suppressed while lyrics were visible. That made the new interactive layout less space-efficient and prevented a single coherent background scene.

This change computes layout before rendering and composes every enabled canvas effect once into its intended region, with foreground content layered afterward.

## Verification

- `~/.fable-harness/bin/run-gates .` — PASS
  - `cargo fmt --all --check`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo test --workspace`
  - project harness architecture and inventory checks
- `cargo test --example tui_render_perf` — 6 passed
- Isolated TUI verification through the project `verify` workflow with fake HOME, isolated tmux, and silent mpv at 160×50, 100×30, 60×18, 32×14, and the Mini boundary.

## Known performance debt

This is intentionally a draft because the required draw-p95 performance gate is not yet met. Seven alternating release AB/BA measurements produced candidate/baseline p95 median ratios of:

- 1.234 — art, 100×30
- 1.310 — art, 160×50
- 1.366 — art + lyrics, 100×30
- 1.547 — art + lyrics, 160×50

The acceptance ceiling is 1.10; baseline CV was 0.40–1.93%. The lyrics comparison is also behaviorally asymmetric: the baseline suppresses canvas rendering when lyrics are visible, while the candidate intentionally renders the required full-player canvas behind lyrics.

The remaining work and exact acceptance criteria are tracked as `TODO(interactive-player-canvas-perf)` in `examples/tui_render_perf.rs`. It must be resolved without lowering FPS, density, animation phase, or cadence, followed by a fresh seven-pair AB/BA run. This PR should remain draft until that debt is resolved or explicitly accepted.
