### PR TITLE
Add configurable album art quality

### DIFF
--- a/src/app/artwork.rs
+++ b/src/app/artwork.rs
@@ -788,6 +788,7 @@ impl App {
             Some(path) => ArtSource::Local(path.clone()),
             None => ArtSource::Remote {
                 video_id: song.youtube_id()?.to_owned(),
+                quality: self.config.album_art_quality,
             },
         })
     }

--- a/src/app/reducer.rs
+++ b/src/app/reducer.rs
@@ -476,10 +476,17 @@ impl App {
                     self.dirty = true;
                 }
             }
-            Msg::ArtworkResult { video_id, image } => {
-                self.art.loading = false;
-                // Drop results for a track we've already skipped past.
-                if self.queue.current().is_some_and(|s| s.video_id == video_id) {
+            Msg::ArtworkResult {
+                video_id,
+                quality,
+                image,
+            } => {
+                // Drop results for a track we've already skipped past, and remote results that
+                // belong to the same track's previous quality selection.
+                let current = self.queue.current().is_some_and(|s| s.video_id == video_id);
+                let current_quality = quality.is_none_or(|q| q == self.config.album_art_quality);
+                if current && current_quality {
+                    self.art.loading = false;
                     self.set_artwork(video_id, image);
                     self.dirty = true;
                 }

--- a/src/app/settings_audio.rs
+++ b/src/app/settings_audio.rs
@@ -441,6 +441,7 @@ fn reset_settings_state(state: &mut SettingsState) {
     draft.search = defaults.effective_search();
     draft.mouse = defaults.effective_mouse();
     draft.album_art = defaults.effective_album_art();
+    draft.album_art_quality = defaults.album_art_quality;
     draft.autoplay_on_start = defaults.effective_autoplay_on_start();
     draft.enqueue_next = defaults.effective_enqueue_next();
     draft.speed = defaults.effective_speed();

--- a/src/app/settings_reducer.rs
+++ b/src/app/settings_reducer.rs
@@ -117,6 +117,7 @@ impl App {
             search: self.config.effective_search(),
             mouse: self.config.effective_mouse(),
             album_art: self.config.effective_album_art(),
+            album_art_quality: self.config.album_art_quality,
             autoplay_on_start: self.config.effective_autoplay_on_start(),
             enqueue_next: self.config.effective_enqueue_next(),
             update_check_enabled: self.config.update_check_enabled,
@@ -680,6 +681,17 @@ impl App {
                 let next = s.draft.video_layout.cycled(dir >= 0);
                 s.draft.video_layout = next;
                 self.status.text = format!("{}: {}", t!("Video window", "영상 창"), next.label());
+                Vec::new()
+            }
+            Field::AlbumArtQuality => {
+                let s = self.settings_mut();
+                let next = s.draft.album_art_quality.cycled(dir >= 0);
+                s.draft.album_art_quality = next;
+                self.status.text = format!(
+                    "{}: {}",
+                    t!("Album art quality", "앨범 아트 화질"),
+                    next.label()
+                );
                 Vec::new()
             }
             Field::PlayerBarPosition => {
@@ -1829,6 +1841,7 @@ impl App {
         let old_key = self.config.gemini_api_key.clone();
         let old_ai_enabled = self.config.effective_ai_enabled();
         let old_romanized_titles = self.config.effective_romanized_titles();
+        let old_album_art_quality = self.config.album_art_quality;
         let old_download_dir = self.config.effective_download_dir();
         let old_local_roots = self.local_scan_roots();
         let normal_theme = if self.radio_dedicated_mode {
@@ -1843,6 +1856,7 @@ impl App {
         };
         let old_zoom = self.zoom.percent();
         d.apply_to(&mut self.config);
+        let album_art_quality_changed = self.config.album_art_quality != old_album_art_quality;
         // Push the resolved DJ Gem reply language to the AI actor. The UI language was set live
         // as the user cycled it; this global isn't, so it's resolved and applied here on save
         // (retro → English, `Auto` → the UI language, else the concrete pick).
@@ -1927,21 +1941,27 @@ impl App {
         cmds.push(Cmd::Scrobble(ScrobbleCmd::Reconfigure(Box::new(
             self.config.scrobble_settings(),
         ))));
-        // React to an album-art toggle. Turning it off drops the held image (frees RAM).
-        // Turning it on fetches the current track's art live: the graphics protocol is probed
-        // unconditionally at startup, so the picker is always present and `artwork_source`
-        // resolves as soon as the flag flips — no relaunch needed.
+        // React to an album-art toggle or quality change. Turning it off drops the held image
+        // (frees RAM). Turning it on or selecting a different quality fetches the current track's
+        // art live: the graphics protocol is probed unconditionally at startup, so the picker is
+        // always present and `artwork_source` resolves without a relaunch.
         if !self.config.effective_album_art() {
             self.clear_artwork();
-        } else if let Some(song) = self.queue.current().cloned()
-            && self.art.video_id.as_deref() != Some(song.video_id.as_str())
-            && let Some(source) = self.artwork_source(&song)
-        {
-            self.art.loading = true;
-            cmds.push(Cmd::FetchArtwork {
-                video_id: song.video_id.clone(),
-                source,
-            });
+        } else if let Some(song) = self.queue.current().cloned() {
+            // Local embedded covers keep the legacy 768px cap, so a remote-quality change must
+            // not re-read and decode the same local file.
+            if album_art_quality_changed && song.local_path.is_none() {
+                self.clear_artwork();
+            }
+            if self.art.video_id.as_deref() != Some(song.video_id.as_str())
+                && let Some(source) = self.artwork_source(&song)
+            {
+                self.art.loading = true;
+                cmds.push(Cmd::FetchArtwork {
+                    video_id: song.video_id.clone(),
+                    source,
+                });
+            }
         }
         cmds
     }

--- a/src/app/tests/lyrics_art_download.rs
+++ b/src/app/tests/lyrics_art_download.rs
@@ -86,12 +86,18 @@ fn album_art_on_fetches_remote_then_builds_protocol() {
     assert!(app.art.loading);
     assert!(cmds.iter().any(|c| matches!(
         c,
-        Cmd::FetchArtwork { video_id, source: ArtSource::Remote { video_id: vid } }
-            if video_id == "id1" && vid == "id1"
+        Cmd::FetchArtwork {
+            video_id,
+            source: ArtSource::Remote {
+                video_id: vid,
+                quality: crate::config::AlbumArtQuality::High,
+            },
+        } if video_id == "id1" && vid == "id1"
     )));
     // The decoded image becomes a render-ready protocol for the current track.
     app.update(Msg::ArtworkResult {
         video_id: "id1".to_owned(),
+        quality: Some(crate::config::AlbumArtQuality::High),
         image: Some(image::DynamicImage::new_rgb8(120, 120)),
     });
     assert!(!app.art.loading);
@@ -157,9 +163,36 @@ fn artwork_result_for_stale_track_is_ignored() {
     app.art.picker = Some(Picker::halfblocks());
     app.update(Msg::ArtworkResult {
         video_id: "stale".to_owned(),
+        quality: Some(crate::config::AlbumArtQuality::High),
         image: Some(image::DynamicImage::new_rgb8(8, 8)),
     });
     assert!(!app.art_active());
+}
+
+#[test]
+fn artwork_result_for_previous_quality_is_ignored_on_the_same_track() {
+    let mut app = app_playing(1, 0);
+    app.config.album_art = Some(true);
+    app.config.album_art_quality = crate::config::AlbumArtQuality::Original;
+    app.art.picker = Some(Picker::halfblocks());
+    app.art.loading = true;
+
+    app.update(Msg::ArtworkResult {
+        video_id: "id0".to_owned(),
+        quality: Some(crate::config::AlbumArtQuality::High),
+        image: None,
+    });
+    assert!(
+        app.art.loading,
+        "the replacement Original request is still in flight"
+    );
+
+    app.update(Msg::ArtworkResult {
+        video_id: "id0".to_owned(),
+        quality: Some(crate::config::AlbumArtQuality::Original),
+        image: None,
+    });
+    assert!(!app.art.loading);
 }
 
 #[test]

--- a/src/app/tests/settings_forms.rs
+++ b/src/app/tests/settings_forms.rs
@@ -2,6 +2,89 @@ use super::*;
 use std::sync::Arc;
 
 #[test]
+fn album_art_quality_cycles_persists_and_refetches_the_current_remote_track() {
+    let mut app = app_playing(1, 0);
+    app.config.album_art = Some(true);
+    app.art.picker = Some(Picker::halfblocks());
+    app.art.video_id = Some("id0".to_owned());
+
+    app.open_settings();
+    focus_settings_field(&mut app, SettingsTab::Playback, Field::AlbumArtQuality);
+    assert!(app.settings_change(1).is_empty()); // High -> Original
+    assert_eq!(
+        app.settings.as_ref().unwrap().draft.album_art_quality,
+        crate::config::AlbumArtQuality::Original
+    );
+
+    let mut cmds = app.update(Msg::Key(key(KeyCode::Esc)));
+    admit_player_transition(&mut app, &mut cmds);
+    assert_eq!(
+        app.config.album_art_quality,
+        crate::config::AlbumArtQuality::Original
+    );
+    assert!(app.art.loading);
+    assert!(cmds.iter().any(|cmd| matches!(
+        cmd,
+        Cmd::FetchArtwork {
+            video_id,
+            source: ArtSource::Remote {
+                quality: crate::config::AlbumArtQuality::Original,
+                ..
+            },
+        } if video_id == "id0"
+    )));
+    assert_eq!(
+        save_config(&cmds)
+            .expect("quality save persists config")
+            .album_art_quality,
+        crate::config::AlbumArtQuality::Original
+    );
+}
+
+#[test]
+fn remote_album_art_quality_change_does_not_refetch_a_loaded_local_cover() {
+    let mut app = App::new(100);
+    let song = Song::local_file(std::path::PathBuf::from("/music/local.m4a"));
+    let video_id = song.video_id.clone();
+    app.queue.set(vec![song], 0);
+    app.config.album_art = Some(true);
+    app.art.picker = Some(Picker::halfblocks());
+    app.art.video_id = Some(video_id.clone());
+
+    app.open_settings();
+    focus_settings_field(&mut app, SettingsTab::Playback, Field::AlbumArtQuality);
+    assert!(app.settings_change(1).is_empty());
+    let mut cmds = app.update(Msg::Key(key(KeyCode::Esc)));
+    admit_player_transition(&mut app, &mut cmds);
+
+    assert_eq!(app.art.video_id.as_deref(), Some(video_id.as_str()));
+    assert!(
+        !cmds
+            .iter()
+            .any(|cmd| matches!(cmd, Cmd::FetchArtwork { .. }))
+    );
+}
+
+#[test]
+fn unchanged_album_art_quality_keeps_the_loaded_remote_cover() {
+    let mut app = app_playing(1, 0);
+    app.config.album_art = Some(true);
+    app.art.picker = Some(Picker::halfblocks());
+    app.art.video_id = Some("id0".to_owned());
+
+    app.open_settings();
+    let mut cmds = app.update(Msg::Key(key(KeyCode::Esc)));
+    admit_player_transition(&mut app, &mut cmds);
+
+    assert_eq!(app.art.video_id.as_deref(), Some("id0"));
+    assert!(
+        !cmds
+            .iter()
+            .any(|cmd| matches!(cmd, Cmd::FetchArtwork { .. }))
+    );
+}
+
+#[test]
 fn settings_search_provider_toggles_normalize_selected_sources() {
     let mut app = App::new(100);
     app.open_settings();

--- a/src/app/tests/settings_ui.rs
+++ b/src/app/tests/settings_ui.rs
@@ -1034,6 +1034,7 @@ fn reset_all_button_confirms_then_restores_defaults() {
         d.speed = 1.8;
         d.seek_seconds = 45.0;
         d.gemini_api_key = "AIzaSecret".to_owned();
+        d.album_art_quality = crate::config::AlbumArtQuality::Original;
     }
     // Enter opens the confirmation modal (does not reset yet).
     app.update(Msg::Key(key(KeyCode::Enter)));
@@ -1049,6 +1050,7 @@ fn reset_all_button_confirms_then_restores_defaults() {
     assert!((d.speed - 1.0).abs() < 1e-9);
     assert!((d.seek_seconds - 10.0).abs() < 1e-9);
     assert!(d.gemini_api_key.is_empty());
+    assert_eq!(d.album_art_quality, crate::config::AlbumArtQuality::High);
 }
 
 #[test]

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -175,6 +175,7 @@ pub enum Msg {
     /// Decoded album art / thumbnail for `video_id` (`None` = none found / fetch failed).
     ArtworkResult {
         video_id: String,
+        quality: Option<crate::config::AlbumArtQuality>,
         image: Option<DynamicImage>,
     },
     /// Album-art protocol resize/encode finished off the UI thread.

--- a/src/artwork.rs
+++ b/src/artwork.rs
@@ -1,11 +1,11 @@
 //! Album art / video thumbnail fetch + decode actor.
 //!
 //! Remote (catalog) tracks: the thumbnail is derived from the `video_id` via
-//! `i.ytimg.com/vi/<id>/…` — `maxresdefault.jpg` (clean native aspect) first, falling
-//! back to `hqdefault.jpg` (always present). Local tracks: the embedded cover art is read
-//! straight out of the file with `lofty`. Either way we decode + downscale off the main
-//! thread and hand the UI a ready [`image::DynamicImage`]; the player view turns it into a
-//! terminal graphics protocol via `ratatui-image`.
+//! `i.ytimg.com/vi/<id>/…`; the Playback setting chooses a bandwidth/detail tier from
+//! `sddefault.jpg` through the untouched `maxresdefault.jpg` source. Local tracks read embedded
+//! cover art with `lofty` and retain the historical 768px cap. Either way we decode + optionally
+//! downscale off the main thread and hand the UI a ready [`image::DynamicImage`]; the player view
+//! turns it into a terminal graphics protocol via `ratatui-image`.
 //!
 //! This is opt-in (config `album_art`): the reducer only emits a fetch when the feature is
 //! on and a graphics protocol was detected at startup, so nothing here runs otherwise.
@@ -15,23 +15,24 @@ use std::path::PathBuf;
 use image::DynamicImage;
 use tokio::sync::watch;
 
+use crate::config::AlbumArtQuality;
 use crate::util::delivery::{DeliveryError, DeliveryReceipt, DeliveryResult};
 use crate::util::http;
 
-/// Cap the decoded image to this many pixels on its longest side. The render protocol now
-/// upscales (`Resize::Scale`) to fill the art area, so the source needs enough detail to
-/// stay sharp when enlarged; this still bounds in-flight RAM and per-track decode/encode
-/// cost. Only the current track's image is held at a time, so peak cost is one image.
-/// (`maxresdefault` is natively 1280×720; 768px is enough for terminal-cell rendering while
-/// keeping protocol resize/encode work smaller.)
-const MAX_DIM: u32 = 768;
+/// The default/high tier and local-cover cap. This is the historical fixed limit, so existing
+/// configs keep identical detail and memory bounds after the quality setting is introduced.
+const HIGH_MAX_DIM: u32 = 768;
+const STANDARD_MAX_DIM: u32 = 640;
 const REMOTE_ART_MAX_BYTES: usize = 5 * 1024 * 1024;
 
 /// Where a track's art comes from.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ArtSource {
     /// A catalog track: fetch `i.ytimg.com/vi/<video_id>/…`.
-    Remote { video_id: String },
+    Remote {
+        video_id: String,
+        quality: AlbumArtQuality,
+    },
     /// A local file: read its embedded cover art.
     Local(PathBuf),
 }
@@ -44,6 +45,8 @@ pub enum ArtworkCmd {
 pub enum ArtworkEvent {
     Result {
         video_id: String,
+        /// `Some` for remote art, so a same-track result from the previous quality can be dropped.
+        quality: Option<AlbumArtQuality>,
         image: Option<DynamicImage>,
     },
 }
@@ -95,27 +98,59 @@ where
             continue;
         };
         let ArtworkCmd::Fetch { video_id, source } = cmd;
-        let bytes = match source {
-            ArtSource::Remote { video_id: id } => match client.as_ref() {
-                Some(client) => fetch_remote(client, &id).await,
-                None => None,
-            },
-            ArtSource::Local(path) => fetch_local(path).await,
+        let (bytes, max_dimension, quality) = match source {
+            ArtSource::Remote {
+                video_id: id,
+                quality,
+            } => (
+                match client.as_ref() {
+                    Some(client) => fetch_remote(client, &id, quality).await,
+                    None => None,
+                },
+                remote_max_dimension(quality),
+                Some(quality),
+            ),
+            ArtSource::Local(path) => (fetch_local(path).await, Some(HIGH_MAX_DIM), None),
         };
         let image = match bytes {
-            Some(b) => decode_scaled(b).await,
+            Some(b) => decode_scaled(b, max_dimension).await,
             None => None,
         };
         tracing::info!(video_id = %video_id, found = image.is_some(), "artwork");
-        emit(ArtworkEvent::Result { video_id, image });
+        emit(ArtworkEvent::Result {
+            video_id,
+            quality,
+            image,
+        });
     }
 }
 
-/// Fetch the YouTube thumbnail for `video_id`: try the clean native-aspect `maxresdefault`
-/// (absent for some tracks), then the always-present 4:3 `hqdefault`.
-async fn fetch_remote(client: &reqwest::Client, video_id: &str) -> Option<Vec<u8>> {
-    for quality in ["maxresdefault", "hqdefault"] {
-        let url = format!("https://i.ytimg.com/vi/{video_id}/{quality}.jpg");
+fn remote_candidates(quality: AlbumArtQuality) -> &'static [&'static str] {
+    match quality {
+        AlbumArtQuality::Standard => &["sddefault", "hqdefault"],
+        AlbumArtQuality::High | AlbumArtQuality::Original => {
+            &["maxresdefault", "sddefault", "hqdefault"]
+        }
+    }
+}
+
+fn remote_max_dimension(quality: AlbumArtQuality) -> Option<u32> {
+    match quality {
+        AlbumArtQuality::Standard => Some(STANDARD_MAX_DIM),
+        AlbumArtQuality::High => Some(HIGH_MAX_DIM),
+        AlbumArtQuality::Original => None,
+    }
+}
+
+/// Fetch the YouTube thumbnail for `video_id` at the selected tier, with progressively more
+/// compatible fallbacks for videos that do not publish the preferred rendition.
+async fn fetch_remote(
+    client: &reqwest::Client,
+    video_id: &str,
+    quality: AlbumArtQuality,
+) -> Option<Vec<u8>> {
+    for candidate in remote_candidates(quality) {
+        let url = format!("https://i.ytimg.com/vi/{video_id}/{candidate}.jpg");
         if let Ok(resp) = client.get(&url).send().await
             && !resp.status().is_redirection()
             && let Ok(resp) = resp.error_for_status()
@@ -141,17 +176,18 @@ fn local_cover_bytes(path: &std::path::Path) -> Option<Vec<u8>> {
     crate::util::art::local_cover_bytes(path)
 }
 
-/// Decode the raw bytes and downscale to [`MAX_DIM`] (off-thread — decode/resize is CPU).
-async fn decode_scaled(bytes: Vec<u8>) -> Option<DynamicImage> {
+/// Decode the raw bytes and optionally cap the longest side (off-thread — decode/resize is CPU).
+async fn decode_scaled(bytes: Vec<u8>, max_dimension: Option<u32>) -> Option<DynamicImage> {
     crate::util::blocking::spawn_cpu(move || {
         // Decode-bomb-guarded decode (shared): a hostile/corrupt image can't spike RAM.
         let img = crate::util::art::decode_untrusted(&bytes)?;
-        Some(if img.width() > MAX_DIM || img.height() > MAX_DIM {
-            // `resize` preserves aspect, fitting within the box; Triangle is a good
-            // quality/speed balance (the protocol re-scales again at render).
-            img.resize(MAX_DIM, MAX_DIM, image::imageops::FilterType::Triangle)
-        } else {
-            img
+        Some(match max_dimension {
+            Some(max) if img.width() > max || img.height() > max => {
+                // `resize` preserves aspect, fitting within the box; Triangle is a good
+                // quality/speed balance (the protocol re-scales again at render).
+                img.resize(max, max, image::imageops::FilterType::Triangle)
+            }
+            _ => img,
         })
     })
     .await
@@ -169,21 +205,34 @@ mod tests {
     async fn watch_channel_coalesces_a_burst_to_the_newest() {
         let (tx, mut rx) = watch::channel(None);
         for i in 0..5 {
+            let quality = if i == 4 {
+                AlbumArtQuality::Original
+            } else {
+                AlbumArtQuality::Standard
+            };
             tx.send(Some(ArtworkCmd::Fetch {
                 video_id: format!("v{i}"),
                 source: ArtSource::Remote {
                     video_id: format!("v{i}"),
+                    quality,
                 },
             }))
             .unwrap();
         }
         rx.changed().await.unwrap();
-        let ArtworkCmd::Fetch { video_id, .. } =
+        let ArtworkCmd::Fetch { video_id, source } =
             rx.borrow_and_update().clone().expect("latest request");
         assert_eq!(
             video_id, "v4",
             "a burst of skips collapses to the current track"
         );
+        assert!(matches!(
+            source,
+            ArtSource::Remote {
+                quality: AlbumArtQuality::Original,
+                ..
+            }
+        ));
         assert!(
             !rx.has_changed().expect("sender is still open"),
             "the backlog is fully coalesced"
@@ -201,21 +250,67 @@ mod tests {
 
     #[tokio::test]
     async fn decode_scaled_rejects_invalid_image_bytes() {
-        assert!(decode_scaled(b"not an image".to_vec()).await.is_none());
+        assert!(
+            decode_scaled(b"not an image".to_vec(), Some(HIGH_MAX_DIM))
+                .await
+                .is_none()
+        );
     }
 
     #[tokio::test]
     async fn decode_scaled_keeps_small_images_at_original_size() {
-        let img = decode_scaled(png_bytes(64, 32)).await.unwrap();
+        let img = decode_scaled(png_bytes(64, 32), Some(HIGH_MAX_DIM))
+            .await
+            .unwrap();
 
         assert_eq!((img.width(), img.height()), (64, 32));
     }
 
     #[tokio::test]
-    async fn decode_scaled_downscales_large_images_to_max_dimension() {
-        let img = decode_scaled(png_bytes(1024, 512)).await.unwrap();
+    async fn decode_scaled_downscales_large_images_to_selected_dimension() {
+        let img = decode_scaled(png_bytes(1024, 512), Some(HIGH_MAX_DIM))
+            .await
+            .unwrap();
 
-        assert_eq!((img.width(), img.height()), (MAX_DIM, MAX_DIM / 2));
+        assert_eq!(
+            (img.width(), img.height()),
+            (HIGH_MAX_DIM, HIGH_MAX_DIM / 2)
+        );
+    }
+
+    #[tokio::test]
+    async fn standard_quality_caps_the_longest_side_at_640px() {
+        let img = decode_scaled(png_bytes(960, 480), Some(STANDARD_MAX_DIM))
+            .await
+            .unwrap();
+
+        assert_eq!((img.width(), img.height()), (640, 320));
+    }
+
+    #[tokio::test]
+    async fn original_quality_preserves_source_dimensions() {
+        let img = decode_scaled(png_bytes(1024, 512), None).await.unwrap();
+
+        assert_eq!((img.width(), img.height()), (1024, 512));
+    }
+
+    #[test]
+    fn remote_quality_tiers_choose_expected_sources_and_caps() {
+        assert_eq!(
+            remote_candidates(AlbumArtQuality::Standard),
+            ["sddefault", "hqdefault"]
+        );
+        assert_eq!(
+            remote_candidates(AlbumArtQuality::High),
+            ["maxresdefault", "sddefault", "hqdefault"]
+        );
+        assert_eq!(
+            remote_candidates(AlbumArtQuality::Original),
+            ["maxresdefault", "sddefault", "hqdefault"]
+        );
+        assert_eq!(remote_max_dimension(AlbumArtQuality::Standard), Some(640));
+        assert_eq!(remote_max_dimension(AlbumArtQuality::High), Some(768));
+        assert_eq!(remote_max_dimension(AlbumArtQuality::Original), None);
     }
 
     #[tokio::test]
@@ -243,8 +338,13 @@ mod tests {
             .expect("actor should emit a result")
             .expect("result channel should stay open until emit");
         match event {
-            ArtworkEvent::Result { video_id, image } => {
+            ArtworkEvent::Result {
+                video_id,
+                quality,
+                image,
+            } => {
                 assert_eq!(video_id, "missing-local");
+                assert_eq!(quality, None);
                 assert!(image.is_none());
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -352,6 +352,41 @@ impl AnimationsConfig {
     }
 }
 
+/// Source/detail level for remote album art shown inside the terminal. `High` preserves the
+/// historical max-resolution preference and 768px cap; `Original` keeps the fetched source
+/// dimensions intact. Persisted in `config.json`.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AlbumArtQuality {
+    Standard,
+    #[default]
+    High,
+    Original,
+}
+
+impl AlbumArtQuality {
+    /// Step through `Standard → High → Original`, wrapping in either direction.
+    pub fn cycled(self, forward: bool) -> Self {
+        match (self, forward) {
+            (Self::Standard, true) => Self::High,
+            (Self::High, true) => Self::Original,
+            (Self::Original, true) => Self::Standard,
+            (Self::Standard, false) => Self::Original,
+            (Self::High, false) => Self::Standard,
+            (Self::Original, false) => Self::High,
+        }
+    }
+
+    /// Short human label for the Playback settings row.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Standard => t!("Standard · up to 640 px", "표준 · 최대 640 px"),
+            Self::High => t!("High · up to 768 px", "고화질 · 최대 768 px"),
+            Self::Original => t!("Original source", "원본 화질"),
+        }
+    }
+}
+
 /// Window layout for the external mpv video overlay launched from the player (`v`), cycled
 /// live with `Shift+V` and chosen as the open default in Settings. `Compact` docks a small
 /// ~30% window top-right; `Large` centers a ~50% window; `Fullscreen` fills the screen.
@@ -615,6 +650,9 @@ pub struct Config {
     /// terminal's graphics protocol is probed unconditionally at startup (the About icon needs
     /// it regardless), so turning this on takes effect live. See [`crate::artwork`].
     pub album_art: Option<bool>,
+    /// Detail level for remote album art rendered inside the terminal. Defaults to `High`, which
+    /// matches the pre-setting 768px cap; local embedded covers retain that existing cap.
+    pub album_art_quality: AlbumArtQuality,
     /// Where the player control block sits (see [`PlayerBarPosition`]). `None` → `Bottom`,
     /// the docked layout; `Top` keeps the legacy layout.
     pub player_bar_position: Option<PlayerBarPosition>,
@@ -881,6 +919,7 @@ impl Default for Config {
             download_concurrency: None,
             mouse: None,
             album_art: None,
+            album_art_quality: AlbumArtQuality::default(),
             player_bar_position: None,
             control_box_collapsed: None,
             eq_preset: EqPreset::default(),

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -114,7 +114,7 @@ fn recording_config_round_trips_and_forward_migrates() {
 }
 
 #[test]
-fn drifted_enum_recovers_instead_of_wiping_the_whole_config() {
+fn drifted_enums_recover_instead_of_wiping_the_whole_config() {
     // A config written by a previous build whose `video_layout` value this build no
     // longer understands. Under the old strict load this reset the ENTIRE file (and
     // overwrote it) — the "settings reset after every install" bug. Now only the drifted
@@ -131,6 +131,7 @@ fn drifted_enum_recovers_instead_of_wiping_the_whole_config() {
 
     let mut value = serde_json::to_value(&original).unwrap();
     value["video_layout"] = serde_json::Value::String("hologram".into());
+    value["album_art_quality"] = serde_json::Value::String("future_ultra".into());
 
     // Strict parse fails outright (the behaviour that caused the reset)...
     assert!(
@@ -152,6 +153,11 @@ fn drifted_enum_recovers_instead_of_wiping_the_whole_config() {
         recovered.video_layout,
         VideoOverlay::default(),
         "only the drifted field falls back to default",
+    );
+    assert_eq!(
+        recovered.album_art_quality,
+        AlbumArtQuality::High,
+        "the new drifted field also falls back without losing siblings",
     );
 }
 
@@ -182,6 +188,7 @@ fn json_round_trips() {
         download_concurrency: Some(2),
         mouse: Some(false),
         album_art: Some(true),
+        album_art_quality: AlbumArtQuality::Original,
         player_bar_position: Some(PlayerBarPosition::Bottom),
         control_box_collapsed: Some(true),
         eq_preset: EqPreset::BassBoost,
@@ -290,6 +297,7 @@ fn json_round_trips() {
     assert_eq!(back.local.import_path_template(), "{artist}/{title}");
     assert_eq!(back.mouse, Some(false));
     assert_eq!(back.album_art, Some(true));
+    assert_eq!(back.album_art_quality, AlbumArtQuality::Original);
     assert_eq!(back.player_bar_position, Some(PlayerBarPosition::Bottom));
     assert_eq!(back.control_box_collapsed, Some(true));
     assert_eq!(back.eq_preset, EqPreset::BassBoost);
@@ -605,6 +613,32 @@ fn album_art_off_by_default_and_overridable() {
         ..Config::default()
     };
     assert!(on.effective_album_art());
+}
+
+#[test]
+fn album_art_quality_defaults_to_legacy_high_and_cycles() {
+    let legacy: Config = serde_json::from_str("{}").unwrap();
+    assert_eq!(legacy.album_art_quality, AlbumArtQuality::High);
+    assert_eq!(
+        AlbumArtQuality::Standard.cycled(true),
+        AlbumArtQuality::High
+    );
+    assert_eq!(
+        AlbumArtQuality::High.cycled(true),
+        AlbumArtQuality::Original
+    );
+    assert_eq!(
+        AlbumArtQuality::Original.cycled(true),
+        AlbumArtQuality::Standard
+    );
+    assert_eq!(
+        AlbumArtQuality::Standard.cycled(false),
+        AlbumArtQuality::Original
+    );
+    assert_eq!(
+        serde_json::to_string(&AlbumArtQuality::Original).unwrap(),
+        "\"original\""
+    );
 }
 
 #[test]

--- a/src/data_export.rs
+++ b/src/data_export.rs
@@ -528,6 +528,7 @@ fn project_settings(config: &Config) -> PortableSettingsV1 {
             "autoplay_on_start": config.autoplay_on_start,
             "auto_continue_videos": config.auto_continue_videos,
             "video_layout": config.video_layout,
+            "album_art_quality": config.album_art_quality,
             "media_controls": config.media_controls,
         }),
         search: project_search(&config.search),

--- a/src/data_export/tests.rs
+++ b/src/data_export/tests.rs
@@ -175,6 +175,7 @@ fn projection_is_fail_closed_for_secrets_paths_urls_and_transfer_fields() {
     assert!(snapshot.privacy.contains_listening_history);
     assert_eq!(snapshot.summary.omitted_signal_tracks, 1);
     assert_eq!(snapshot.summary.omitted_signal_events, 1);
+    assert_eq!(snapshot.settings.playback["album_art_quality"], "high");
 }
 
 #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -416,9 +416,15 @@ impl From<RuntimeEvent> for Msg {
                 // (`daemon_required`), so its api actor never produces this.
                 crate::api::ApiEvent::GuiSearchCompleted { .. } => Msg::Noop,
             },
-            RuntimeEvent::Artwork(crate::artwork::ArtworkEvent::Result { video_id, image }) => {
-                Msg::ArtworkResult { video_id, image }
-            }
+            RuntimeEvent::Artwork(crate::artwork::ArtworkEvent::Result {
+                video_id,
+                quality,
+                image,
+            }) => Msg::ArtworkResult {
+                video_id,
+                quality,
+                image,
+            },
             RuntimeEvent::ArtworkResized(response) => Msg::ArtworkResized(response),
             RuntimeEvent::Download(event) => match event {
                 crate::download::DownloadEvent::Progress { video_id, percent } => {

--- a/src/runtime/tests/policy.rs
+++ b/src/runtime/tests/policy.rs
@@ -215,6 +215,7 @@ fn runtime_event_policy_covers_leaf_event_classes() {
     assert_policy(
         RuntimeEvent::Artwork(crate::artwork::ArtworkEvent::Result {
             video_id: "v".to_owned(),
+            quality: Some(crate::config::AlbumArtQuality::High),
             image: None,
         }),
         EventPolicy::DropIfStale {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,8 +11,8 @@ use std::path::{Path, PathBuf};
 
 use crate::ai::GeminiModel;
 use crate::config::{
-    AnimationsConfig, Config, LocalRootConfig, MPV_CACHE_BACK_DEFAULT, MPV_CACHE_FORWARD_DEFAULT,
-    SpotifyImportMode, default_cookies_file, default_download_dir,
+    AlbumArtQuality, AnimationsConfig, Config, LocalRootConfig, MPV_CACHE_BACK_DEFAULT,
+    MPV_CACHE_FORWARD_DEFAULT, SpotifyImportMode, default_cookies_file, default_download_dir,
 };
 use crate::eq::{self, EqPreset};
 use crate::i18n::Language;
@@ -136,6 +136,7 @@ impl SettingsTab {
                     Field::MediaControls,
                     Field::AutoContinueVideos,
                     Field::VideoLayout,
+                    Field::AlbumArtQuality,
                     // Radio-only entry (the recording popup); filtered out by
                     // `SettingsState::fields` when not in radio mode. Keep it last in the
                     // "Now Playing" section so the static count below stays partition-correct.
@@ -239,10 +240,10 @@ impl SettingsTab {
     pub fn sections(self) -> Vec<(&'static str, usize)> {
         match self {
             SettingsTab::Playback => vec![
-                // 8 = the 7 Now-Playing controls + the radio-only recording entry. When not
-                // in radio mode, `SettingsState::sections` decrements this back to 7 in
+                // 9 = the 8 Now-Playing controls + the radio-only recording entry. When not
+                // in radio mode, `SettingsState::sections` decrements this back to 8 in
                 // lockstep with `SettingsState::fields` hiding `RadioRecording`.
-                (t!("Now Playing", "현재 재생"), 8),
+                (t!("Now Playing", "현재 재생"), 9),
                 (t!("Audio backend", "오디오 백엔드"), 5),
                 (t!("EQ", "EQ"), eq::BANDS + 2),
             ],
@@ -330,6 +331,8 @@ pub enum Field {
     /// Which layout the `v` video overlay opens in by default (Compact / Large / Fullscreen);
     /// a Select field cycled like the others. `Shift+V` still cycles the live window.
     VideoLayout,
+    /// Detail level for remote album art rendered inside the terminal.
+    AlbumArtQuality,
     /// Opens the radio-recording settings popup. Radio-mode only — hidden outside it by
     /// [`SettingsState::fields`]; lives in the "Now Playing" section.
     RadioRecording,
@@ -580,6 +583,7 @@ pub struct SettingsDraft {
     pub search: SearchConfig,
     pub mouse: bool,
     pub album_art: bool,
+    pub album_art_quality: AlbumArtQuality,
     /// Where the player control block sits (previewed live while Settings is open).
     pub player_bar_position: crate::config::PlayerBarPosition,
     pub autoplay_on_start: bool,
@@ -736,6 +740,7 @@ impl SettingsDraft {
             Field::LocalMusicRootRecursive => toggle_str(self.local_music_root_recursive),
             Field::Mouse => toggle_str(self.mouse),
             Field::AlbumArt => toggle_str(self.album_art),
+            Field::AlbumArtQuality => self.album_art_quality.label().to_owned(),
             Field::PlayerBarPosition => self.player_bar_position.label().to_owned(),
             Field::AutoplayOnStart => toggle_str(self.autoplay_on_start),
             Field::EnqueueNext => toggle_str(self.enqueue_next),
@@ -950,6 +955,7 @@ impl SettingsDraft {
         cfg.search = self.search.clone().normalized();
         cfg.mouse = Some(self.mouse);
         cfg.album_art = Some(self.album_art);
+        cfg.album_art_quality = self.album_art_quality;
         cfg.player_bar_position = Some(self.player_bar_position);
         cfg.autoplay_on_start = Some(self.autoplay_on_start);
         cfg.enqueue_next = Some(self.enqueue_next);

--- a/src/settings/field_meta.rs
+++ b/src/settings/field_meta.rs
@@ -104,6 +104,7 @@ impl Field {
             | Field::DjGemLanguage
             | Field::AudioBackend
             | Field::VideoLayout
+            | Field::AlbumArtQuality
             | Field::PlayerBarPosition
             | Field::SpotifyImportMode
             | Field::StreamingMode => FieldKind::Select,
@@ -201,6 +202,7 @@ impl Field {
             }
             Field::Mouse => t!("Mouse (next launch)", "마우스 (재시작 후 적용)").to_owned(),
             Field::AlbumArt => t!("Album art", "앨범 아트").to_owned(),
+            Field::AlbumArtQuality => t!("Album art quality", "앨범 아트 화질").to_owned(),
             Field::PlayerBarPosition => t!("Player bar position", "플레이어 바 위치").to_owned(),
             Field::AutoplayOnStart => t!("Autoplay on launch", "앱 시작 시 자동재생").to_owned(),
             Field::EnqueueNext => t!("Enqueue as next", "큐 추가: 다음 곡").to_owned(),

--- a/src/settings/tests.rs
+++ b/src/settings/tests.rs
@@ -12,6 +12,7 @@ fn base_draft() -> SettingsDraft {
         search: SearchConfig::default(),
         mouse: true,
         album_art: false,
+        album_art_quality: crate::config::AlbumArtQuality::High,
         player_bar_position: crate::config::PlayerBarPosition::Bottom,
         autoplay_on_start: false,
         enqueue_next: false,
@@ -243,10 +244,12 @@ fn background_none_toggle_tracks_transparency() {
 
 #[test]
 fn playback_tab_groups_now_playing_and_eq() {
+    let _guard = crate::i18n::lock_for_test();
+    crate::i18n::set_language(crate::i18n::Language::English);
     let f = SettingsTab::Playback.fields();
     // Speed + SeekInterval + WheelVolume + Gapless + MediaControls + AutoContinueVideos +
-    // VideoLayout + RadioRecording (radio-only), then audio backend, then EQ.
-    assert_eq!(f.len(), 8 + 5 + 1 + eq::BANDS + 1);
+    // VideoLayout + AlbumArtQuality + RadioRecording (radio-only), then audio backend, then EQ.
+    assert_eq!(f.len(), 9 + 5 + 1 + eq::BANDS + 1);
     assert_eq!(f[0], Field::Speed);
     assert_eq!(f[1], Field::SeekInterval);
     assert_eq!(f[2], Field::MouseWheelVolume);
@@ -254,14 +257,20 @@ fn playback_tab_groups_now_playing_and_eq() {
     assert_eq!(f[4], Field::MediaControls);
     assert_eq!(f[5], Field::AutoContinueVideos);
     assert_eq!(f[6], Field::VideoLayout);
-    assert_eq!(f[7], Field::RadioRecording);
-    assert_eq!(f[8], Field::AudioBackend);
-    assert_eq!(f[9], Field::AudioMpvOutput);
-    assert_eq!(f[12], Field::AudioMpvCacheBack);
-    assert_eq!(f[13], Field::EqPreset);
-    assert_eq!(f[13 + eq::BANDS + 1], Field::Normalize);
+    assert_eq!(f[7], Field::AlbumArtQuality);
+    assert_eq!(f[8], Field::RadioRecording);
+    assert_eq!(f[9], Field::AudioBackend);
+    assert_eq!(f[10], Field::AudioMpvOutput);
+    assert_eq!(f[13], Field::AudioMpvCacheBack);
+    assert_eq!(f[14], Field::EqPreset);
+    assert_eq!(f[14 + eq::BANDS + 1], Field::Normalize);
     assert_eq!(Field::MouseWheelVolume.kind(), FieldKind::Toggle);
+    assert_eq!(Field::AlbumArtQuality.kind(), FieldKind::Select);
     assert_eq!(base_draft().value_display(Field::MouseWheelVolume), "[x]");
+    assert_eq!(
+        base_draft().value_display(Field::AlbumArtQuality),
+        "High · up to 768 px"
+    );
     assert_eq!(base_draft().value_display(Field::AudioBackend), "mpv");
     let total: usize = SettingsTab::Playback
         .sections()
@@ -269,6 +278,18 @@ fn playback_tab_groups_now_playing_and_eq() {
         .map(|(_, n)| n)
         .sum();
     assert_eq!(total, f.len());
+}
+
+#[test]
+fn album_art_quality_has_localized_labels() {
+    let _guard = crate::i18n::lock_for_test();
+    crate::i18n::set_language(crate::i18n::Language::Korean);
+    assert_eq!(Field::AlbumArtQuality.label(), "앨범 아트 화질");
+    assert_eq!(
+        base_draft().value_display(Field::AlbumArtQuality),
+        "고화질 · 최대 768 px"
+    );
+    crate::i18n::set_language(crate::i18n::Language::English);
 }
 
 #[test]
@@ -471,6 +492,7 @@ fn apply_to_persists_every_settings_field() {
         },
         mouse: false,
         album_art: true,
+        album_art_quality: crate::config::AlbumArtQuality::Original,
         player_bar_position: crate::config::PlayerBarPosition::Top,
         autoplay_on_start: true,
         enqueue_next: true,
@@ -567,6 +589,10 @@ fn apply_to_persists_every_settings_field() {
     assert_eq!(cfg.search.jamendo_client_id.as_deref(), Some("jam-id"));
     assert_eq!(cfg.mouse, Some(false));
     assert_eq!(cfg.album_art, Some(true));
+    assert_eq!(
+        cfg.album_art_quality,
+        crate::config::AlbumArtQuality::Original
+    );
     assert_eq!(
         cfg.player_bar_position,
         Some(crate::config::PlayerBarPosition::Top)


### PR DESCRIPTION
## Summary

- add Standard, High, and Original Source choices under Settings > Playback
- request tier-appropriate YouTube thumbnails and preserve source dimensions at the Original tier
- refresh the current remote cover after a quality change while rejecting stale results from the previous tier

## Compatibility

- existing configs default to High, preserving the previous max-resolution-first 768 px behavior
- local embedded covers keep their existing 768 px cap
- the separate OS/desktop media artwork cache remains unchanged

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- architecture, file-size, documentation-honesty, ratatui-image patch, and unsafe-inventory checks
- isolated tmux verification: changed High to Original Source, confirmed `album_art_quality: original` on disk, and confirmed it after relaunch without starting playback

The canonical `run-gates` wrapper could not locate the repository-local `.claude/harness/project-profile.json` from the isolated worktree, so its exact component commands were run individually instead.
