### PR TITLE
Gate Konsole images and simplify relaunch notice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,12 +84,9 @@ ratatui = "0.30.2"
 # `image` directly with just the formats we need). The Kitty/Sixel/iTerm2/halfblocks
 # protocol encoders are pure Rust and compiled unconditionally — no feature gates them —
 # so `crossterm` alone is enough. Opt-in feature; nothing renders unless the user enables it.
-# Patched to a local fork (see `[patch.crates-io]` below + `crates/ratatui-image`): (1) its Kitty
-# renderer emits explicit per-cell coordinates so a popup drawn over the album art (the
-# `eq:`/`radio:` dropdowns) can't blank the image to the right of it; (2) its Sixel + iTerm2
-# renderers stamp a per-encode tag into the image's anchor cell so a rebuilt protocol
-# (`App::refresh_art` on a popup toggle) re-transmits once and the art doesn't ghost on Windows
-# Terminal — see `crate::protocol::next_redraw_tag`. Same 11.0.6 otherwise.
+# Patched to a local fork (see `[patch.crates-io]` below +
+# `crates/ratatui-image/PATCHES.md`) for popup-safe Kitty rendering, reliable Sixel/iTerm2
+# retransmission, and conservative Konsole protocol detection. Same public crate version.
 ratatui-image = { version = "11", default-features = false, features = ["crossterm", "tokio"] }
 # Synced-lyrics fetch (lrclib) + raw browse. `native-tls` uses the OS TLS stack —
 # Security.framework on macOS, SChannel on Windows — so there's no bundled C crypto
@@ -213,10 +210,10 @@ wry = { version = "0.55.1", default-features = false, features = ["transparent"]
 [target.'cfg(target_os = "linux")'.dependencies]
 mpris-server = { version = "0.10", features = ["tokio"] }
 
-# Local fork of ratatui-image 11.0.6 with the Kitty explicit-coordinate + Sixel/iTerm2 anchor
-# redraw-tag patches (see the dep note above). A vendored path patch — not a git/crates.io fork —
-# so the source travels with the repo and `cargo install --path .` / the CI build need nothing
-# extra. Re-apply the patches on any bump (grep the fork for `yututui patch`).
+# Local fork of ratatui-image 11.0.6 with the rendering and terminal-detection patches documented
+# in `crates/ratatui-image/PATCHES.md`. A vendored path patch — not a git/crates.io fork — so the
+# source travels with the repo and `cargo install --path .` / the CI build need nothing extra.
+# Re-apply the patches on any bump (grep the fork for `yututui patch`).
 [patch.crates-io]
 ratatui-image = { path = "crates/ratatui-image" }
 

--- a/crates/ratatui-image/PATCHES.md
+++ b/crates/ratatui-image/PATCHES.md
@@ -18,6 +18,8 @@ The fork is intentionally narrow and should stay easy to rebase onto a future up
 - Kitty rows damaged by overlay redraws can be marked for retransmission.
 - Sixel and iTerm2 encodes stamp the anchor cell with a monotonic redraw tag so freshly rebuilt
   protocols are not skipped by ratatui's diffing.
+- Konsole versions before 26.08 keep Kitty and Sixel capability queries disabled; 26.08 and newer
+  may select Sixel only after DA1 advertises it and the cell-size query returns usable dimensions.
 
 All local code changes should include a nearby `yututui patch` comment. CI runs
 `scripts/check-ratatui-image-patch.sh` to catch accidental removal of the path patch, base-version
@@ -26,7 +28,7 @@ drift, or missing patch markers.
 ## Upgrade Checklist
 
 1. Replace this directory with the desired upstream `ratatui-image` release.
-2. Reapply the four local patch groups above.
+2. Reapply the five local patch groups above.
 3. Keep `yututui patch` comments next to each local behavior change.
 4. Update the upstream base version in this file and in `scripts/check-ratatui-image-patch.sh`.
 5. Run:

--- a/crates/ratatui-image/src/picker.rs
+++ b/crates/ratatui-image/src/picker.rs
@@ -45,6 +45,9 @@ pub enum Capability {
 
 const STDIN_READ_TIMEOUT_MILLIS: u64 = 2000;
 
+// yututui patch: Konsole's 26.08 line includes the Sixel placement cleanup needed for TUI redraws.
+const KONSOLE_SIXEL_TUI_MIN_VERSION: u32 = 260_800;
+
 #[derive(Clone, Debug)]
 pub struct Picker {
     font_size: FontSize,
@@ -120,20 +123,36 @@ impl Picker {
         };
 
         let mut options_with_blacklist = options;
-        let is_wezterm = env::var("WEZTERM_EXECUTABLE").is_ok_and(|s| !s.is_empty());
-        let is_konsole = env::var("KONSOLE_VERSION").is_ok_and(|s| !s.is_empty());
-        if is_wezterm || is_konsole {
-            // WezTerm could use Sixel, but iTerm2 (detected later is better).
-            // Konsole's Sixel implementation is buggy: https://github.com/ratatui/ratatui-image?tab=readme-ov-file#compatibility-matrix
-            // Neither implement the placeholder part of kitty correctly.
-            options_with_blacklist.blacklist_protocols =
-                vec![ProtocolType::Kitty, ProtocolType::Sixel];
+        let wezterm_executable = env::var("WEZTERM_EXECUTABLE").ok();
+        let konsole_version = env::var("KONSOLE_VERSION").ok();
+        let term = env::var("TERM").ok();
+        let require_reported_cell_size_for_konsole_sixel = konsole_supports_sixel_tui_redraws(
+            wezterm_executable.as_deref(),
+            konsole_version.as_deref(),
+            term.as_deref(),
+        );
+        for protocol in terminal_protocol_blacklist(
+            wezterm_executable.as_deref(),
+            konsole_version.as_deref(),
+            term.as_deref(),
+        ) {
+            if !options_with_blacklist
+                .blacklist_protocols
+                .contains(&protocol)
+            {
+                options_with_blacklist.blacklist_protocols.push(protocol);
+            }
         }
 
         // Write and read to stdin to query protocol capabilities and font-size.
         match query_with_timeout(is_tmux, options_with_blacklist) {
             Ok((capability_proto, font_size, caps)) => {
                 let iterm2_proto = iterm2_from_env();
+                let capability_proto = require_reported_cell_size_for_sixel(
+                    capability_proto,
+                    &caps,
+                    require_reported_cell_size_for_konsole_sixel,
+                );
 
                 // IO-based detection is authoritative; env-based hints are fallbacks
                 // (env vars like KITTY_WINDOW_ID can be stale in tmux sessions).
@@ -318,6 +337,67 @@ impl Picker {
             }),
         };
         StatefulProtocol::new_shared(image, self.font_size, self.background_color, protocol_type)
+    }
+}
+
+// yututui patch: keep older/unknown Konsole versions conservative, and capability-gate 26.08+.
+fn terminal_protocol_blacklist(
+    wezterm_executable: Option<&str>,
+    konsole_version: Option<&str>,
+    term: Option<&str>,
+) -> Vec<ProtocolType> {
+    let is_wezterm = wezterm_executable.is_some_and(|value| !value.is_empty());
+    if is_wezterm {
+        // WezTerm could use Sixel, but iTerm2 (detected later) is better. It also does not
+        // implement the placeholder part of Kitty correctly.
+        return vec![ProtocolType::Kitty, ProtocolType::Sixel];
+    }
+
+    let is_konsole = konsole_version.is_some_and(|value| !value.is_empty())
+        || term.is_some_and(|value| value.to_ascii_lowercase().contains("konsole"));
+    if !is_konsole {
+        return Vec::new();
+    }
+
+    if konsole_supports_sixel_tui_redraws(wezterm_executable, konsole_version, term) {
+        // Konsole's Kitty implementation still lacks Unicode placeholders. Sixel remains subject
+        // to the normal DA1 capability and cell-size response checks below.
+        vec![ProtocolType::Kitty]
+    } else {
+        vec![ProtocolType::Kitty, ProtocolType::Sixel]
+    }
+}
+
+fn konsole_supports_sixel_tui_redraws(
+    wezterm_executable: Option<&str>,
+    konsole_version: Option<&str>,
+    term: Option<&str>,
+) -> bool {
+    let is_wezterm = wezterm_executable.is_some_and(|value| !value.is_empty());
+    let is_konsole = konsole_version.is_some_and(|value| !value.is_empty())
+        || term.is_some_and(|value| value.to_ascii_lowercase().contains("konsole"));
+
+    !is_wezterm
+        && is_konsole
+        && konsole_version
+            .and_then(|version| version.trim().parse::<u32>().ok())
+            .is_some_and(|version| version >= KONSOLE_SIXEL_TUI_MIN_VERSION)
+}
+
+fn require_reported_cell_size_for_sixel(
+    protocol_type: Option<ProtocolType>,
+    capabilities: &[Capability],
+    required: bool,
+) -> Option<ProtocolType> {
+    if required
+        && protocol_type == Some(ProtocolType::Sixel)
+        && !capabilities
+            .iter()
+            .any(|capability| matches!(capability, Capability::CellSize(Some(_))))
+    {
+        None
+    } else {
+        protocol_type
     }
 }
 
@@ -666,7 +746,11 @@ mod tests {
 
     use crate::picker::{Capability, Picker, ProtocolType};
 
-    use super::{cap_parser::Response, interpret_parser_responses};
+    use super::{
+        cap_parser::{Parser, QueryStdioOptions, Response},
+        interpret_parser_responses, require_reported_cell_size_for_sixel,
+        terminal_protocol_blacklist,
+    };
 
     #[test]
     fn test_cycle_protocol() {
@@ -684,6 +768,176 @@ mod tests {
     #[test]
     fn test_from_query_stdio_no_hang() {
         let _ = Picker::from_query_stdio();
+    }
+
+    #[test]
+    fn test_terminal_protocol_blacklist() {
+        struct Case {
+            name: &'static str,
+            wezterm_executable: Option<&'static str>,
+            konsole_version: Option<&'static str>,
+            term: Option<&'static str>,
+            expected: Vec<ProtocolType>,
+        }
+
+        let cases = [
+            Case {
+                name: "unrelated terminal",
+                wezterm_executable: None,
+                konsole_version: None,
+                term: Some("xterm-256color"),
+                expected: vec![],
+            },
+            Case {
+                name: "WezTerm keeps Kitty and Sixel blacklisted",
+                wezterm_executable: Some("/Applications/WezTerm.app/Contents/MacOS/wezterm-gui"),
+                konsole_version: None,
+                term: Some("xterm-256color"),
+                expected: vec![ProtocolType::Kitty, ProtocolType::Sixel],
+            },
+            Case {
+                name: "Konsole detected from TERM without a version",
+                wezterm_executable: None,
+                konsole_version: None,
+                term: Some("konsole-256color"),
+                expected: vec![ProtocolType::Kitty, ProtocolType::Sixel],
+            },
+            Case {
+                name: "empty Konsole version is not a hint",
+                wezterm_executable: None,
+                konsole_version: Some(""),
+                term: Some("xterm-256color"),
+                expected: vec![],
+            },
+            Case {
+                name: "invalid Konsole version stays conservative",
+                wezterm_executable: None,
+                konsole_version: Some("26.08"),
+                term: Some("xterm-256color"),
+                expected: vec![ProtocolType::Kitty, ProtocolType::Sixel],
+            },
+            Case {
+                name: "Konsole before 26.08 stays conservative",
+                wezterm_executable: None,
+                konsole_version: Some("260799"),
+                term: Some("xterm-256color"),
+                expected: vec![ProtocolType::Kitty, ProtocolType::Sixel],
+            },
+            Case {
+                name: "Konsole 26.08 allows Sixel capability queries",
+                wezterm_executable: None,
+                konsole_version: Some("260800"),
+                term: Some("xterm-256color"),
+                expected: vec![ProtocolType::Kitty],
+            },
+            Case {
+                name: "newer Konsole allows Sixel capability queries",
+                wezterm_executable: None,
+                konsole_version: Some("260801"),
+                term: Some("xterm-256color"),
+                expected: vec![ProtocolType::Kitty],
+            },
+            Case {
+                name: "WezTerm policy wins over a new Konsole hint",
+                wezterm_executable: Some("wezterm-gui"),
+                konsole_version: Some("260800"),
+                term: Some("konsole-256color"),
+                expected: vec![ProtocolType::Kitty, ProtocolType::Sixel],
+            },
+        ];
+
+        for case in cases {
+            assert_eq!(
+                terminal_protocol_blacklist(
+                    case.wezterm_executable,
+                    case.konsole_version,
+                    case.term,
+                ),
+                case.expected,
+                "{}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_konsole_sixel_query_is_version_gated() {
+        let query_for = |konsole_version| {
+            let options = QueryStdioOptions {
+                blacklist_protocols: terminal_protocol_blacklist(
+                    None,
+                    Some(konsole_version),
+                    Some("konsole-256color"),
+                ),
+                ..QueryStdioOptions::default()
+            };
+            Parser::query(false, options)
+        };
+
+        let old_konsole_query = query_for("260799");
+        assert!(!old_konsole_query.contains("_Gi="));
+        assert!(!old_konsole_query.contains("\x1b[c"));
+
+        let new_konsole_query = query_for("260800");
+        assert!(!new_konsole_query.contains("_Gi="));
+        assert!(new_konsole_query.contains("\x1b[c"));
+    }
+
+    #[test]
+    fn test_terminal_blacklist_preserves_caller_entries() {
+        let mut blacklist = vec![ProtocolType::Iterm2];
+        for protocol in terminal_protocol_blacklist(None, Some("260799"), None) {
+            if !blacklist.contains(&protocol) {
+                blacklist.push(protocol);
+            }
+        }
+
+        assert_eq!(
+            blacklist,
+            vec![
+                ProtocolType::Iterm2,
+                ProtocolType::Kitty,
+                ProtocolType::Sixel
+            ]
+        );
+    }
+
+    #[test]
+    fn test_konsole_sixel_requires_reported_cell_size() {
+        let (sixel_without_cell_size, _, capabilities) =
+            interpret_parser_responses(vec![Response::Sixel]).unwrap();
+
+        assert_eq!(
+            require_reported_cell_size_for_sixel(sixel_without_cell_size, &capabilities, true),
+            None
+        );
+
+        let (sixel_without_valid_cell_size, _, capabilities) =
+            interpret_parser_responses(vec![Response::Sixel, Response::CellSize(None)]).unwrap();
+        assert_eq!(
+            require_reported_cell_size_for_sixel(
+                sixel_without_valid_cell_size,
+                &capabilities,
+                true
+            ),
+            None
+        );
+
+        let (sixel_with_cell_size, _, capabilities) =
+            interpret_parser_responses(vec![Response::Sixel, Response::CellSize(Some((10, 20)))])
+                .unwrap();
+        assert_eq!(
+            require_reported_cell_size_for_sixel(sixel_with_cell_size, &capabilities, true),
+            Some(ProtocolType::Sixel)
+        );
+        assert_eq!(
+            require_reported_cell_size_for_sixel(sixel_without_cell_size, &[], false),
+            Some(ProtocolType::Sixel)
+        );
+        assert_eq!(
+            require_reported_cell_size_for_sixel(Some(ProtocolType::Kitty), &[], true),
+            Some(ProtocolType::Kitty)
+        );
     }
 
     #[test]

--- a/crates/ratatui-image/src/picker/cap_parser.rs
+++ b/crates/ratatui-image/src/picker/cap_parser.rs
@@ -41,9 +41,9 @@ pub struct QueryStdioOptions {
     ///
     /// This can be useful for sixels which have binary transparency instead of an alpha channel.
     pub terminal_background_color_osc: bool,
-    /// Blacklist protocols from the detection query. Currently only kitty can be detected, so that
-    /// is the only ProtocolType that can have any effect here.
-    /// [`crate::picker::Picker`] currently sets ProtocolType::Kitty for WezTerm and Konsole.
+    /// Blacklist graphics protocols from the detection query. Kitty suppresses the graphics query;
+    /// Sixel suppresses the Device Attributes query.
+    /// [`crate::picker::Picker`] applies terminal-specific defaults for WezTerm and Konsole.
     pub blacklist_protocols: Vec<ProtocolType>,
 }
 

--- a/docs/terminal-compatibility.md
+++ b/docs/terminal-compatibility.md
@@ -1,6 +1,6 @@
 # Terminal Compatibility
 
-Status: initial public-beta matrix, updated 2026-07-07. Entries marked
+Status: initial public-beta matrix, updated 2026-07-13. Entries marked
 `Expected` still need a dated ytm-tui smoke run before they are marketed as
 fully verified.
 
@@ -31,7 +31,7 @@ ytm-tui configuration.
 | Legacy conhost / bare cmd.exe | Unknown / Versioned | Expected partial | Version-dependent | Yes | Expected only in a desktop session with mpv | Unknown | Do not promise without a Windows build and terminal version. |
 | Ghostty | Expected via Kitty graphics | Expected | Expected; grapheme clustering is documented | Yes | Expected on macOS/Linux with mpv | Unknown unless OSC 66 lands or DECDHL probe passes | Windows support must be verified separately. |
 | foot | Expected via Sixel | Expected | Expected; package descriptions document IME through text-input-v3 | Yes | Expected on Linux GUI with mpv | Unknown | Wayland-only in normal use; verify on the target compositor. |
-| Konsole | Expected via Kitty or Sixel | Expected | Expected | Yes | Expected on Linux GUI with mpv | Unknown | Probe longer, but use an override until smoke evidence records the best protocol. |
+| Konsole / Yakuake | Versioned: < 26.08 defaults to halfblocks; >= 26.08 is Expected via capability-gated Sixel | Expected | Expected | Yes | Expected on Linux GUI with mpv | Unknown | Yakuake inherits Konsole's terminal behavior. Sixel is selected only when DA1 advertises it and a real cell size is obtained; Kitty is not recommended. |
 | mintty | Expected via Sixel | Expected | Expected | Yes | Expected on Windows desktop with mpv | Unknown | Probe longer, but Sixel is the first override to try. |
 | mlterm | Expected via Sixel | Expected | Expected | Yes | Expected on GUI OS with mpv | Unknown | Probe longer, but Sixel is the first override to try. |
 | VS Code integrated terminal | Fallback: halfblocks | Expected | Expected | Yes | Expected only through the host desktop session | Unknown | Keep conservative fallback unless a specific VS Code build is verified. |
@@ -44,6 +44,12 @@ ytm-tui configuration.
 - Album art uses `ratatui-image`, which can query Kitty, Sixel, iTerm2, and
   halfblock fallback protocols. If stdout is not a TTY, ytm-tui skips image
   probing and uses halfblocks.
+- Detected Konsole and Yakuake versions older than 26.08, or detected sessions
+  without a valid `KONSOLE_VERSION`, stay on halfblocks by default. Starting with 26.08,
+  ytm-tui permits a Sixel probe and selects Sixel only when DA1 advertises the
+  capability and the terminal returns a real cell size. A missing response or
+  either failed check still falls back to halfblocks. Kitty is not part of the
+  normal Konsole/Yakuake path.
 - Text zoom uses OSC 66 when the probe succeeds, `WT_SESSION` / DECDHL where
   applicable, and otherwise stays at 100%.
 - Keyboard enhancement intentionally omits `REPORT_ALL_KEYS_AS_ESCAPE_CODES` so
@@ -76,8 +82,13 @@ Recommended first override by terminal:
 | WezTerm | `YTM_TUI_IMAGE_PROTOCOL=iterm2` | `kitty`, `sixel` |
 | Windows Terminal | `YTM_TUI_IMAGE_PROTOCOL=sixel` | None |
 | foot / mintty / mlterm | `YTM_TUI_IMAGE_PROTOCOL=sixel` | None |
-| Konsole | `YTM_TUI_IMAGE_PROTOCOL=kitty` | `sixel` |
+| Konsole / Yakuake | `YTM_TUI_IMAGE_PROTOCOL=sixel` | None |
 | Unknown native hint | `YTM_TUI_IMAGE_PROTOCOL=kitty` | `iterm2`, `sixel` |
+
+On Konsole/Yakuake versions older than 26.08, manually forcing Sixel is an
+experimental escape hatch: it bypasses the conservative default and may leave
+stale or broken image fragments. Do not use Kitty as the normal Konsole or
+Yakuake override.
 
 ## Smoke Runbook
 

--- a/scripts/check-ratatui-image-patch.sh
+++ b/scripts/check-ratatui-image-patch.sh
@@ -26,6 +26,12 @@ grep -Rqs 'mark_rows_for_redraw' crates/ratatui-image/src/protocol/kitty.rs crat
 grep -Rqs 'new_with_z_index' crates/ratatui-image/src/protocol/kitty.rs crates/ratatui-image/src/picker.rs \
   || fail "Kitty z-index patch marker is missing"
 
+grep -Fq 'KONSOLE_SIXEL_TUI_MIN_VERSION' crates/ratatui-image/src/picker.rs \
+  || fail "Konsole Sixel version-gate patch marker is missing"
+
+grep -Fq 'require_reported_cell_size_for_sixel' crates/ratatui-image/src/picker.rs \
+  || fail "Konsole Sixel cell-size guard is missing"
+
 test -f crates/ratatui-image/PATCHES.md \
   || fail "crates/ratatui-image/PATCHES.md is missing"
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -17,6 +17,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+const KONSOLE_SIXEL_TUI_MIN_VERSION: u32 = 260_800;
+
 #[path = "doctor/directory_probe.rs"]
 mod directory_probe;
 #[cfg(test)]
@@ -119,13 +121,18 @@ fn run_terminal_json() -> i32 {
     // No config load, cookie read, playback init, mpv spawn, terminal raw mode, or writes.
     let term = std::env::var("TERM").ok();
     let term_program = std::env::var("TERM_PROGRAM").ok();
+    let konsole_version = std::env::var("KONSOLE_VERSION").ok();
     let wt_session = std::env::var_os("WT_SESSION").is_some();
     let image_protocol_override = std::env::var("YTM_TUI_IMAGE_PROTOCOL").ok();
     let image_protocol_override_supported = image_protocol_override
         .as_deref()
         .map(image_protocol_override_supported);
-    let image_protocol =
-        terminal_image_protocol(term.as_deref(), term_program.as_deref(), wt_session);
+    let image_protocol = terminal_image_protocol(
+        term.as_deref(),
+        term_program.as_deref(),
+        wt_session,
+        konsole_version.as_deref(),
+    );
     let native_image_hint =
         terminal_native_image_hint(term.as_deref(), term_program.as_deref(), wt_session);
     let image_protocol_override_suggestions =
@@ -591,10 +598,7 @@ fn terminal_image_override_suggestions(
         ];
     }
     if env_nonempty("KONSOLE_VERSION") || term.contains("konsole") {
-        return vec![
-            "YTM_TUI_IMAGE_PROTOCOL=kitty",
-            "YTM_TUI_IMAGE_PROTOCOL=sixel",
-        ];
+        return vec!["YTM_TUI_IMAGE_PROTOCOL=sixel"];
     }
     if wt_session || term.contains("foot") || term.contains("mintty") || term.contains("mlterm") {
         return vec!["YTM_TUI_IMAGE_PROTOCOL=sixel"];
@@ -613,6 +617,7 @@ fn terminal_image_protocol(
     term: Option<&str>,
     term_program: Option<&str>,
     wt_session: bool,
+    konsole_version: Option<&str>,
 ) -> &'static str {
     let term = term.unwrap_or_default().to_ascii_lowercase();
     let term_program = term_program.unwrap_or_default().to_ascii_lowercase();
@@ -626,8 +631,16 @@ fn terminal_image_protocol(
         "sixel_versioned"
     } else if term.contains("foot") || term.contains("mintty") || term.contains("mlterm") {
         "sixel"
-    } else if term.contains("konsole") {
-        "kitty_or_sixel"
+    } else if term.contains("konsole") || konsole_version.is_some_and(|version| !version.is_empty())
+    {
+        if konsole_version
+            .and_then(|version| version.trim().parse::<u32>().ok())
+            .is_some_and(|version| version >= KONSOLE_SIXEL_TUI_MIN_VERSION)
+        {
+            "sixel_versioned"
+        } else {
+            "halfblocks"
+        }
     } else if term_program.contains("ghostty") || term.contains("ghostty") {
         "kitty"
     } else if term.contains("linux") {
@@ -1250,19 +1263,19 @@ mod tests {
     fn terminal_doctor_detects_common_protocol_hints_without_probing() {
         with_var("YTM_TUI_TEXT_SIZING", None, || {
             assert_eq!(
-                terminal_image_protocol(Some("xterm-kitty"), None, false),
+                terminal_image_protocol(Some("xterm-kitty"), None, false, None),
                 "kitty"
             );
             assert_eq!(
-                terminal_image_protocol(Some("xterm-256color"), Some("WezTerm"), false),
+                terminal_image_protocol(Some("xterm-256color"), Some("WezTerm"), false, None),
                 "iterm2_or_kitty_or_sixel"
             );
             assert_eq!(
-                terminal_image_protocol(Some("xterm-256color"), Some("iTerm.app"), false),
+                terminal_image_protocol(Some("xterm-256color"), Some("iTerm.app"), false, None),
                 "iterm2"
             );
             assert_eq!(
-                terminal_image_protocol(Some("xterm-256color"), None, true),
+                terminal_image_protocol(Some("xterm-256color"), None, true, None),
                 "sixel_versioned"
             );
             assert_eq!(
@@ -1279,25 +1292,40 @@ mod tests {
     #[test]
     fn terminal_doctor_covers_protocol_keyboard_and_zoom_edges() {
         with_var("YTM_TUI_TEXT_SIZING", None, || {
-            assert_eq!(terminal_image_protocol(Some("foot"), None, false), "sixel");
             assert_eq!(
-                terminal_image_protocol(Some("mintty"), None, false),
+                terminal_image_protocol(Some("foot"), None, false, None),
                 "sixel"
             );
             assert_eq!(
-                terminal_image_protocol(Some("konsole"), None, false),
-                "kitty_or_sixel"
+                terminal_image_protocol(Some("mintty"), None, false, None),
+                "sixel"
             );
             assert_eq!(
-                terminal_image_protocol(Some("ghostty"), Some("ignored"), false),
+                terminal_image_protocol(Some("konsole"), None, false, None),
+                "halfblocks"
+            );
+            assert_eq!(
+                terminal_image_protocol(Some("xterm-256color"), None, false, Some("invalid")),
+                "halfblocks"
+            );
+            assert_eq!(
+                terminal_image_protocol(Some("xterm-256color"), None, false, Some("260799")),
+                "halfblocks"
+            );
+            assert_eq!(
+                terminal_image_protocol(Some("xterm-256color"), None, false, Some("260800")),
+                "sixel_versioned"
+            );
+            assert_eq!(
+                terminal_image_protocol(Some("ghostty"), Some("ignored"), false, None),
                 "kitty"
             );
             assert_eq!(
-                terminal_image_protocol(Some("linux"), None, false),
+                terminal_image_protocol(Some("linux"), None, false, None),
                 "halfblocks_or_retro"
             );
             assert_eq!(
-                terminal_image_protocol(Some("dumb"), None, false),
+                terminal_image_protocol(Some("dumb"), None, false, None),
                 "unknown"
             );
             assert_eq!(
@@ -1367,6 +1395,14 @@ mod tests {
             assert_eq!(
                 terminal_image_override_suggestions(Some("ghostty"), None, false),
                 vec!["YTM_TUI_IMAGE_PROTOCOL=kitty"]
+            );
+        });
+
+        with_terminal_env(&[("KONSOLE_VERSION", Some("260800"))], || {
+            assert!(terminal_native_image_hint(None, None, false));
+            assert_eq!(
+                terminal_image_override_suggestions(None, None, false),
+                vec!["YTM_TUI_IMAGE_PROTOCOL=sixel"]
             );
         });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,9 @@ use std::time::Duration;
 /// grace only prevents a timed-out `spawn_blocking` closure from making `Runtime::drop` wait
 /// without a bound; normal shutdown should have no work left by the time it starts.
 const RUNTIME_SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
+const ALREADY_RUNNING_NOTICE: &str = "ytt is already running.\n  \
+                                      Control it:  ytt -r <command>   (e.g. `ytt -r pp`, `ytt -r next`)\n  \
+                                      Stop it:     ytt -r quit";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CliPersistence {
@@ -423,12 +426,7 @@ async fn async_main(new_instance: bool, mut startup: StartupTrace) -> Result<()>
     // socket; a bind failure degrades to running without remote control rather than refusing.
     let remote = match remote::bind_or_detect(new_instance).await {
         remote::BindOutcome::AlreadyRunning => {
-            eprintln!(
-                "ytt is already running.\n  \
-                 Control it:  ytt -r <command>   (e.g. `ytt -r pp`, `ytt -r next`)\n  \
-                 Stop it:     ytt -r quit\n  \
-                 New player:  ytt --new-instance"
-            );
+            eprintln!("{ALREADY_RUNNING_NOTICE}");
             return Ok(());
         }
         remote::BindOutcome::Bound(server) => Some(*server),
@@ -501,6 +499,15 @@ mod tests {
     #[test]
     fn ordinary_interactive_owner_requests_the_writer_capability() {
         assert_eq!(interactive_persistence_mode(false), CliPersistence::Writer);
+    }
+
+    #[test]
+    fn already_running_notice_keeps_controls_without_advertising_new_instance() {
+        assert!(ALREADY_RUNNING_NOTICE.contains("Control it:"));
+        assert!(ALREADY_RUNNING_NOTICE.contains("ytt -r <command>"));
+        assert!(ALREADY_RUNNING_NOTICE.contains("Stop it:"));
+        assert!(ALREADY_RUNNING_NOTICE.contains("ytt -r quit"));
+        assert!(!ALREADY_RUNNING_NOTICE.contains("--new-instance"));
     }
 
     #[test]

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -229,6 +229,7 @@ fn top_level_help_and_version_exit_before_tui_startup() {
     let help_out = stdout(&help);
     assert!(help_out.contains("Usage: ytt [OPTIONS]"));
     assert!(help_out.contains("ytt doctor terminal --json"));
+    assert!(help_out.contains("--new-instance"));
 
     let version = run(&["--version"]);
     assert!(version.status.success(), "stderr: {}", stderr(&version));
@@ -644,6 +645,30 @@ fn doctor_terminal_json_reports_capabilities_without_config_or_runtime_startup()
             .and_then(|v| v.as_bool()),
         Some(true)
     );
+
+    let run_konsole_doctor = |version: &str| {
+        Command::new(env!("CARGO_BIN_EXE_ytt"))
+            .args(["doctor", "terminal", "--json"])
+            .env("TERM", "xterm-256color")
+            .env("KONSOLE_VERSION", version)
+            .env_remove("TERM_PROGRAM")
+            .env_remove("WEZTERM_EXECUTABLE")
+            .env_remove("KITTY_WINDOW_ID")
+            .env_remove("WT_SESSION")
+            .output()
+            .expect("Konsole doctor terminal JSON")
+    };
+    for (version, expected) in [("260799", "halfblocks"), ("260800", "sixel_versioned")] {
+        let output = run_konsole_doctor(version);
+        assert!(output.status.success(), "stderr: {}", stderr(&output));
+        let json: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("Konsole doctor terminal JSON");
+        assert_eq!(
+            json.get("image_protocol").and_then(|value| value.as_str()),
+            Some(expected),
+            "KONSOLE_VERSION={version}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- Keep Konsole/Yakuake versions before 26.08, missing versions, and invalid versions on the conservative Halfblocks path.
- For `KONSOLE_VERSION >= 260800`, continue blocking Kitty but permit the Sixel DA1 probe.
- Select Sixel on that modern-Konsole path only when DA1 advertises Sixel and the terminal returns usable cell dimensions.
- Preserve WezTerm behavior, caller-supplied protocol blacklists, and explicit `YTM_TUI_IMAGE_PROTOCOL` overrides.
- Align `ytt doctor terminal --json` and terminal compatibility guidance with the versioned policy.
- Remove only the `New player: ytt --new-instance` line from the already-running notice; the option, behavior, and top-level help remain available.

## Why

The vendored ratatui-image picker treated every non-empty `KONSOLE_VERSION` as a permanent Kitty+Sixel blacklist. That is still the safe policy for released Konsole versions through 26.04, but Konsole's 26.08 line contains the non-Kitty placement cleanup needed for TUI redraws. A version gate plus live DA1 and cell-size checks enables the fixed path without adding a user setting or guessing terminal capabilities.

Research references:

- https://github.com/ratatui/ratatui-image/issues/88
- https://github.com/ratatui/ratatui-image/issues/148
- https://github.com/KDE/konsole/commit/a05e38fc6aa28ccb0e7875c82bd4d7a0b4e26cf5

## User impact

Older or unidentifiable Konsole sessions retain the artifact-safe fallback. Konsole 26.08+ can discover Sixel automatically with zero new configuration, while any missing capability or size response still falls back. Kitty remains unsupported for the normal Konsole path.

## Checks

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (final exact rerun passed)
- Vendored ratatui-image tests, doc tests, targeted rustfmt, and clippy with `-D warnings`.
- Architecture, file-size, doc-honesty, ratatui-image patch, and unsafe-inventory checks.
- Isolated tmux verification: TUI rendered; a second `ytt` showed Control/Stop, omitted `--new-instance`, and exited 0.

One earlier full-suite run hit three unrelated timing-sensitive download test timeouts; all three passed immediately in isolation and the exact full suite passed on rerun.

## Verification gap

No Konsole/Yakuake 26.08 runtime was available locally. Documentation intentionally keeps that path at **Expected** until a dated real-terminal smoke run confirms image placement and cleanup.
