### PR TITLE
Add custom theme and TUI color picker

### DIFF
--- a/gui/src/lib/dev/democore.ts
+++ b/gui/src/lib/dev/democore.ts
@@ -135,7 +135,7 @@ interface ThemeSeed {
   selBg: string;
 }
 
-// The 13 TUI presets (ThemePreset, src/theme.rs) — compact seeds, faithful hues.
+// Built-in TUI presets (ThemePreset, src/theme.rs) — compact seeds, faithful hues.
 const THEME_SEEDS: Record<string, ThemeSeed> = {
   // prettier-ignore
   Default: { bg: '#12141a', surface: '#2a2e3a', text: '#e6e8ee', textMuted: '#a0a6b4', textSubtle: '#6b7180', textInverse: '#0b0d12', borderPrimary: '#3a3f4d', borderFocused: '#5b8cff', accent: '#5b8cff', accentAlt: '#8f6bff', success: '#4ec98a', warning: '#e0b341', error: '#e5556b', selFg: '#ffffff', selBg: '#2f3646' },
@@ -165,11 +165,15 @@ const THEME_SEEDS: Record<string, ThemeSeed> = {
   'Rosé Pine': { bg: '#191724', surface: '#26233a', text: '#e0def4', textMuted: '#908caa', textSubtle: '#6e6a86', textInverse: '#191724', borderPrimary: '#302d41', borderFocused: '#ebbcba', accent: '#ebbcba', accentAlt: '#c4a7e7', success: '#9ccfd8', warning: '#f6c177', error: '#eb6f92', selFg: '#191724', selBg: '#403d52' },
 };
 
-const PRESET_NAMES = Object.keys(THEME_SEEDS);
+const CUSTOM_PRESET = 'Custom';
+const PRESET_NAMES = [...Object.keys(THEME_SEEDS), CUSTOM_PRESET];
 
 /** Derive the full 34-role palette from a preset seed (mirrors roles.ts ids exactly). */
 function presetPalette(name: string): Record<string, string> {
-  const s = THEME_SEEDS[name] ?? THEME_SEEDS.Default;
+  // Custom has no intrinsic palette: like the Rust core, it starts from Default and layers
+  // its separately persisted overrides on top.
+  const s =
+    name === CUSTOM_PRESET ? THEME_SEEDS.Default : (THEME_SEEDS[name] ?? THEME_SEEDS.Default);
   return {
     background: s.bg,
     'text-primary': s.text,
@@ -365,6 +369,8 @@ export class DemoCoreTransport implements Transport {
   #radioMode = false;
   // The `settings` topic read model (docs/gui/07 §6–§10), mutated by `apply`.
   #settings: SettingsModelV8 = defaultSettings();
+  // Custom owns a second override map that stays alive while a built-in theme is active.
+  #customThemeOverrides: Record<string, string> = {};
   // Fake romanization cache size, drained by clear_romanization_cache.
   #romanizationCache = 12;
   // Local playlists (the `playlists` topic) — summaries + their track lists by id.
@@ -670,6 +676,7 @@ export class DemoCoreTransport implements Transport {
         return;
       case 'reset_all_settings':
         this.#settings = defaultSettings();
+        this.#customThemeOverrides = {};
         this.#settings.rev++;
         this.#pushSettings();
         return;
@@ -1072,6 +1079,8 @@ export class DemoCoreTransport implements Transport {
   #applySetting(group: SettingGroup, field: string, value: unknown, push = true): boolean {
     const block = (this.#settings as unknown as Record<string, Record<string, unknown>>)[group];
     if (!block || typeof block !== 'object' || !field) return false;
+    const previousThemePreset =
+      group === 'theme' && field === 'preset' ? this.#settings.theme.preset : null;
     block[field] = value;
     // EQ preset and manual band edits keep each other honest, like the real af chain.
     if (group === 'eq' && field === 'preset') {
@@ -1079,10 +1088,17 @@ export class DemoCoreTransport implements Transport {
     } else if (group === 'eq' && field === 'bands') {
       this.#settings.eq.preset = 'custom';
     } else if (group === 'theme' && field === 'preset') {
-      // Re-resolve the 34 roles for the new preset, keeping the user's overrides on top —
-      // the demo stand-in for ThemeConfig::effective_hex(preset, overrides).
+      const requested = String(value);
+      const next = PRESET_NAMES.includes(requested) ? requested : 'Default';
+      block[field] = next;
+      if (next !== previousThemePreset) {
+        // A built-in edit is only restart-persistent. A real transition discards it, while
+        // Custom restores its own durable map after any number of round trips.
+        this.#settings.theme.overrides =
+          next === CUSTOM_PRESET ? { ...this.#customThemeOverrides } : {};
+      }
       this.#settings.theme.roles = {
-        ...presetPalette(String(value)),
+        ...presetPalette(next),
         ...this.#settings.theme.overrides,
       };
     }
@@ -1095,6 +1111,9 @@ export class DemoCoreTransport implements Transport {
   #themeSetOverride(role: string, hex: string): void {
     if (!role) return;
     this.#settings.theme.overrides[role] = hex;
+    if (this.#settings.theme.preset === CUSTOM_PRESET) {
+      this.#customThemeOverrides[role] = hex;
+    }
     this.#settings.theme.roles[role] = hex;
     this.#settings.rev++;
     this.#pushSettings();
@@ -1104,6 +1123,9 @@ export class DemoCoreTransport implements Transport {
   #themeClearOverride(role: string): void {
     if (!(role in this.#settings.theme.overrides)) return;
     delete this.#settings.theme.overrides[role];
+    if (this.#settings.theme.preset === CUSTOM_PRESET) {
+      delete this.#customThemeOverrides[role];
+    }
     this.#settings.theme.roles[role] = presetPalette(this.#settings.theme.preset)[role];
     this.#settings.rev++;
     this.#pushSettings();

--- a/gui/tests/theme.test.ts
+++ b/gui/tests/theme.test.ts
@@ -112,14 +112,15 @@ describe('ThemeStore push → paint', () => {
 });
 
 describe('ThemeStore against the demo core', () => {
-  it('seeds all 13 presets and 34 roles, and switches preset live', async () => {
+  it('seeds all 14 presets and 34 roles, and switches preset live', async () => {
     const client = new Client(new DemoCoreTransport());
     const store = new ThemeStore(client);
     client.sub(['settings']);
     await settle();
 
     expect(store.model?.preset).toBe('Default');
-    expect(store.model?.presets.length).toBe(13);
+    expect(store.model?.presets.length).toBe(14);
+    expect(store.model?.presets.at(-1)?.name).toBe('Custom');
     expect(Object.keys(store.model?.roles ?? {}).length).toBe(34);
 
     store.setPreset('Nord', client);
@@ -127,6 +128,60 @@ describe('ThemeStore against the demo core', () => {
     expect(store.model?.preset).toBe('Nord');
     expect(store.model?.roles.accent).toBe('#88c0d0');
     expect(cssVar('--role-accent')).toBe('#88c0d0');
+  });
+
+  it('keeps a built-in edit only until a real preset transition', async () => {
+    const client = new Client(new DemoCoreTransport());
+    const store = new ThemeStore(client);
+    client.sub(['settings']);
+    await settle();
+
+    store.setOverride('accent', '#123456', client);
+    await settle();
+    store.setPreset('Default', client);
+    await settle();
+    expect(store.model?.overrides.accent).toBe('#123456');
+
+    store.setPreset('not-a-theme', client);
+    await settle();
+    expect(store.model?.preset).toBe('Default');
+    expect(store.model?.overrides.accent).toBe('#123456');
+
+    store.setPreset('Nord', client);
+    await settle();
+    expect(store.model?.overrides).toEqual({});
+    expect(store.model?.roles.accent).toBe('#88c0d0');
+
+    store.setPreset('Default', client);
+    await settle();
+    expect(store.model?.roles.accent).toBe('#5b8cff');
+    expect(store.model?.overrides).toEqual({});
+  });
+
+  it('starts Custom from Default and restores its edits after a preset round trip', async () => {
+    const client = new Client(new DemoCoreTransport());
+    const store = new ThemeStore(client);
+    client.sub(['settings']);
+    await settle();
+
+    store.setOverride('accent', '#112233', client);
+    await settle();
+    store.setPreset('Custom', client);
+    await settle();
+    expect(store.model?.roles.accent).toBe('#5b8cff');
+    expect(store.model?.overrides).toEqual({});
+
+    store.setOverride('accent', '#abcdef', client);
+    await settle();
+    store.setPreset('Nord', client);
+    await settle();
+    expect(store.model?.roles.accent).toBe('#88c0d0');
+    expect(store.model?.overrides).toEqual({});
+
+    store.setPreset('Custom', client);
+    await settle();
+    expect(store.model?.roles.accent).toBe('#abcdef');
+    expect(store.model?.overrides.accent).toBe('#abcdef');
   });
 
   it('applies an override after acknowledgement and reconciles it on the push', async () => {

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -17,6 +17,12 @@ impl App {
             return self.on_key_tool_setup(k);
         }
 
+        // The Settings color picker is a mode-owned modal (also rendered in Mini). Capture every
+        // key before global shortcuts or the hidden Settings form can act on it.
+        if self.settings_color_picker_is_open() {
+            return self.settings_color_picker_key(k);
+        }
+
         // A keybinding-conflict warning is modal: the next keypress just dismisses it (the
         // rejected rebind already left the binding untouched), so it never leaks through to
         // the screen underneath.
@@ -473,10 +479,9 @@ impl App {
         match self.mode {
             Mode::Settings => {
                 self.overlays.spotify_picker.is_some()
-                    || self
-                        .settings
-                        .as_ref()
-                        .is_some_and(|s| s.spotify_import_mode_dropdown.is_some())
+                    || self.settings.as_ref().is_some_and(|s| {
+                        s.spotify_import_mode_dropdown.is_some() || s.color_picker.is_some()
+                    })
             }
             Mode::Library => !self.local_dedicated_mode && self.library_ui.create_input.is_some(),
             _ => false,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -110,6 +110,7 @@ mod romanize;
 mod scrobble_reducer;
 mod search;
 mod settings_audio;
+mod settings_color_picker;
 mod settings_mouse;
 mod settings_reducer;
 mod spotify_import_reducer;

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -116,6 +116,7 @@ impl App {
         self.interaction.recording_drag = None;
         self.interaction.context_menu_press = false;
         self.interaction.context_menu_click = None;
+        self.interaction.color_picker_click = None;
         self.interaction.pending_double_click_selection = None;
         // The context menu is a small modal: a row click executes it, while every outside
         // click closes and is consumed so it can never activate the covered surface.
@@ -440,6 +441,9 @@ impl App {
             if let MouseTarget::Scrollbar(surface) = region.target {
                 return self.on_scrollbar_press(surface, region.rect, row);
             }
+            if matches!(region.target, MouseTarget::SettingsColorSwatch(_)) {
+                self.interaction.color_picker_click = Some((col, row));
+            }
             // Ctrl/Cmd+click on a list row toggles it in/out of the multi-selection.
             if multi && let MouseTarget::ListRow(i) = region.target {
                 match self.mode {
@@ -690,6 +694,10 @@ impl App {
                 self.settings_activate()
             }
             MouseTarget::SettingsActivate(_) => Vec::new(),
+            MouseTarget::SettingsColorSwatch(row) => self.settings_color_swatch_click(row),
+            MouseTarget::SettingsColorPickerSurface
+            | MouseTarget::SettingsColorPickerCurrent
+            | MouseTarget::SettingsColorPickerChoice(_) => Vec::new(),
             MouseTarget::SettingsSpotifyImportModeMenu if self.mode == Mode::Settings => {
                 if self
                     .settings

--- a/src/app/reducer.rs
+++ b/src/app/reducer.rs
@@ -89,6 +89,33 @@ impl App {
         {
             return Vec::new();
         }
+        // A picker-opening/applying press owns its paired double-click. Check this before the
+        // open-modal route: the second press of a swatch double-click arrives after the first has
+        // opened the picker and must not be reinterpreted against the newly rendered popup.
+        if let Msg::MouseDoubleClick { col, row } = &msg
+            && self.interaction.color_picker_click.take() == Some((*col, *row))
+        {
+            self.dirty = true;
+            return Vec::new();
+        }
+        // The Settings-owned picker captures every pointer event at the dispatcher boundary so
+        // none of the many screen-specific mouse routes can see through the modal.
+        if self.settings_color_picker_is_open() {
+            match &msg {
+                Msg::MouseClick { col, row, .. } | Msg::MouseDoubleClick { col, row } => {
+                    return self.settings_color_picker_mouse_click(*col, *row);
+                }
+                Msg::MouseScroll { up, .. } => {
+                    self.settings_color_picker_scroll(*up, MOUSE_SCROLL_LINES);
+                    return Vec::new();
+                }
+                Msg::MouseRightClick { .. }
+                | Msg::MouseRightDoubleClick { .. }
+                | Msg::MouseDrag { .. }
+                | Msg::MouseLeftUp => return Vec::new(),
+                _ => {}
+            }
+        }
         match msg {
             Msg::Noop => return Vec::new(),
             Msg::Key(k) => return self.on_key(k),

--- a/src/app/settings_color_picker.rs
+++ b/src/app/settings_color_picker.rs
@@ -1,0 +1,134 @@
+//! Settings-owned color-picker reducer. Keeping modal behavior here avoids growing the already
+//! size-tight Settings view and reducer while giving every input path one capture point.
+
+use super::*;
+use crate::settings::ColorPickerState;
+
+impl App {
+    pub(in crate::app) fn settings_color_picker_is_open(&self) -> bool {
+        self.mode == Mode::Settings
+            && self
+                .settings
+                .as_ref()
+                .is_some_and(|state| state.color_picker.is_some())
+    }
+
+    pub(in crate::app) fn settings_open_color_picker(&mut self) {
+        let Some(Field::ThemeColor(role)) = self.settings.as_ref().and_then(|s| s.current_field())
+        else {
+            return;
+        };
+        let Some(state) = self.settings.as_mut() else {
+            return;
+        };
+        let current = state.draft.theme.effective_hex(role);
+        state.editing_text = false;
+        state.spotify_import_mode_dropdown = None;
+        state.color_picker = Some(ColorPickerState::new(role, current));
+        self.dirty = true;
+    }
+
+    pub(in crate::app) fn settings_color_swatch_click(&mut self, row: usize) -> Vec<Cmd> {
+        if self.mode != Mode::Settings || self.settings_close_spotify_import_mode_dropdown() {
+            return Vec::new();
+        }
+        self.settings_focus_row(row);
+        self.settings_open_color_picker();
+        Vec::new()
+    }
+
+    pub(in crate::app) fn settings_cancel_color_picker(&mut self) {
+        if let Some(state) = self.settings.as_mut()
+            && state.color_picker.take().is_some()
+        {
+            self.dirty = true;
+        }
+    }
+
+    pub(in crate::app) fn settings_color_picker_key(&mut self, key: KeyEvent) -> Vec<Cmd> {
+        match key.code {
+            KeyCode::Esc => self.settings_cancel_color_picker(),
+            KeyCode::Enter => return self.settings_commit_color_picker(),
+            KeyCode::Left => self.settings_move_color_picker(|picker| picker.move_left()),
+            KeyCode::Right => self.settings_move_color_picker(|picker| picker.move_right()),
+            KeyCode::Up => self.settings_move_color_picker(|picker| picker.move_up()),
+            KeyCode::Down => self.settings_move_color_picker(|picker| picker.move_down()),
+            _ => {}
+        }
+        Vec::new()
+    }
+
+    pub(in crate::app) fn settings_color_picker_scroll(&mut self, up: bool, rows: usize) {
+        self.settings_move_color_picker(|picker| picker.wheel(up, rows));
+    }
+
+    fn settings_move_color_picker(&mut self, move_picker: impl FnOnce(&mut ColorPickerState)) {
+        let Some(picker) = self
+            .settings
+            .as_mut()
+            .and_then(|state| state.color_picker.as_mut())
+        else {
+            return;
+        };
+        move_picker(picker);
+        self.dirty = true;
+    }
+
+    pub(in crate::app) fn settings_color_picker_mouse_click(
+        &mut self,
+        col: u16,
+        row: u16,
+    ) -> Vec<Cmd> {
+        // Retain ownership of the complete click gesture even when this press closes the modal;
+        // a translator-emitted double-click must not hit the Settings form underneath.
+        self.interaction.color_picker_click = Some((col, row));
+        match self.mouse_target_at(col, row) {
+            Some(MouseTarget::SettingsColorPickerCurrent) => {
+                self.settings_move_color_picker(ColorPickerState::select_current);
+                self.settings_commit_color_picker()
+            }
+            Some(MouseTarget::SettingsColorPickerChoice(index)) => {
+                self.settings_move_color_picker(|picker| picker.select_choice(index));
+                self.settings_commit_color_picker()
+            }
+            Some(MouseTarget::SettingsColorPickerSurface) => Vec::new(),
+            _ => {
+                self.settings_cancel_color_picker();
+                Vec::new()
+            }
+        }
+    }
+
+    fn settings_commit_color_picker(&mut self) -> Vec<Cmd> {
+        let Some((role, value)) = self.settings.as_ref().and_then(|state| {
+            state
+                .color_picker
+                .as_ref()
+                .map(|picker| (picker.role, picker.selected_value()))
+        }) else {
+            return Vec::new();
+        };
+        let Some(state) = self.settings.as_mut() else {
+            return Vec::new();
+        };
+        match state.draft.theme.set_override(role, &value) {
+            Ok(()) => {
+                state.color_picker = None;
+                self.theme = state.draft.theme.normalized();
+                let hex = state.draft.theme.effective_hex(role);
+                self.status.kind = StatusKind::Info;
+                self.status.text = if crate::i18n::is_korean() {
+                    format!("{} 을(를) {hex} 로 설정함", role.label())
+                } else {
+                    format!("Set {} to {hex}", role.label())
+                };
+            }
+            Err(message) => {
+                self.status.kind = StatusKind::Error;
+                self.status.text = message;
+            }
+        }
+        self.dirty = true;
+        Vec::new()
+    }
+}

--- a/src/app/settings_reducer.rs
+++ b/src/app/settings_reducer.rs
@@ -208,6 +208,7 @@ impl App {
             row: 0,
             draft,
             editing_text: false,
+            color_picker: None,
             secret_restore: None,
             keymap: self.keymap.clone(),
             mousemap: self.mousemap.clone(),
@@ -261,6 +262,10 @@ impl App {
             .settings
             .as_ref()
             .is_some_and(|s| matches!(s.current_field(), Some(Field::ThemeColor(_))));
+        if on_color_field && k.code == KeyCode::Char(' ') && k.modifiers == KeyModifiers::NONE {
+            self.settings_open_color_picker();
+            return Vec::new();
+        }
         // The editor must stay operable no matter how keys are remapped, so the literal
         // arrows / Enter / Esc / Backspace are always honored here, on top of the configured
         // ones. Tab switching deliberately comes only from the keymap's FocusNext/FocusPrev

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -771,6 +771,10 @@ pub struct Interaction {
     /// paired `MouseDoubleClick` can be swallowed instead of leaking into a modal opened by the
     /// first press; the next ordinary single click resets it.
     pub(in crate::app) context_menu_click: Option<(u16, u16)>,
+    /// Coordinates of a picker-opening or picker-owned press, retained until a paired
+    /// double-click arrives so the second press cannot be reinterpreted by a newly opened popup
+    /// or click through after the first press closes it.
+    pub(in crate::app) color_picker_click: Option<(u16, u16)>,
     /// Multi-selection hidden by the latest plain Search/Library row press while the input
     /// translator waits to learn whether that press is the first half of a double-click.
     pub(in crate::app) pending_double_click_selection: Option<PendingDoubleClickSelection>,

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -53,6 +53,7 @@ mod search_results;
 mod selection_navigation;
 #[cfg(test)]
 mod settings_cache_policy;
+mod settings_color_picker;
 mod settings_forms;
 mod settings_ui;
 mod startup_playback;

--- a/src/app/tests/render_hit_targets.rs
+++ b/src/app/tests/render_hit_targets.rs
@@ -161,6 +161,10 @@ fn rendering_settings_registers_clickable_controls() {
         "background toggle"
     );
     assert!(
+        has(&g, MouseTarget::SettingsColorSwatch(3)),
+        "color swatch opens picker"
+    );
+    assert!(
         has(&g, MouseTarget::SettingsActivate(3)),
         "color row enters hex editor"
     );

--- a/src/app/tests/settings_color_picker.rs
+++ b/src/app/tests/settings_color_picker.rs
@@ -1,0 +1,302 @@
+use super::*;
+use crate::settings::{
+    COLOR_PICKER_CHOICE_COUNT, ColorPickerSelection, SettingsTab, color_picker_choice,
+};
+use crate::theme::ThemeRole;
+
+fn color_row(role: ThemeRole) -> usize {
+    SettingsTab::Graphics
+        .fields()
+        .iter()
+        .position(|field| *field == Field::ThemeColor(role))
+        .unwrap()
+}
+
+fn color_settings(role: ThemeRole, value: &str) -> App {
+    let mut app = app_playing(1, 0);
+    app.update(Msg::Key(key(KeyCode::Char('o'))));
+    let row = color_row(role);
+    let state = app.settings.as_mut().unwrap();
+    state.tab = SettingsTab::Graphics;
+    state.row = row;
+    state.draft.theme.set_override(role, value).unwrap();
+    app.theme = state.draft.theme.normalized();
+    app
+}
+
+fn render(app: &App, width: u16, height: u16) {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| crate::ui::render(frame, app))
+        .unwrap();
+}
+
+fn target_rect(app: &App, target: MouseTarget) -> ratatui::layout::Rect {
+    app.hits
+        .regions()
+        .iter()
+        .find(|region| region.target == target)
+        .unwrap_or_else(|| panic!("missing target {target:?}"))
+        .rect
+}
+
+#[test]
+fn swatch_and_hex_are_separate_buttons_with_distinct_actions() {
+    let role = ThemeRole::Accent;
+    let row = color_row(role);
+    let mut swatch_app = color_settings(role, "#123456");
+    render(&swatch_app, 80, 40);
+    let swatch = target_rect(&swatch_app, MouseTarget::SettingsColorSwatch(row));
+    let hex = target_rect(&swatch_app, MouseTarget::SettingsActivate(row));
+    assert_eq!(swatch.width, 2);
+    assert_eq!(hex.width, 9);
+    assert_eq!(swatch.y, hex.y);
+    assert_eq!(hex.x, swatch.right() + 2);
+
+    swatch_app.update(Msg::MouseClick {
+        col: swatch.x,
+        row: swatch.y,
+        multi: false,
+    });
+    assert!(swatch_app.settings.as_ref().unwrap().color_picker.is_some());
+    assert!(!swatch_app.settings.as_ref().unwrap().editing_text);
+
+    let mut hex_app = color_settings(role, "#123456");
+    render(&hex_app, 80, 40);
+    let hex = target_rect(&hex_app, MouseTarget::SettingsActivate(row));
+    hex_app.update(Msg::MouseClick {
+        col: hex.x,
+        row: hex.y,
+        multi: false,
+    });
+    assert!(hex_app.settings.as_ref().unwrap().editing_text);
+    assert!(hex_app.settings.as_ref().unwrap().color_picker.is_none());
+}
+
+#[test]
+fn paired_swatch_double_click_cannot_act_on_the_newly_opened_picker() {
+    let role = ThemeRole::Accent;
+    let mut app = color_settings(role, "#123456");
+    render(&app, 80, 24);
+    let row = color_row(role);
+    let swatch = target_rect(&app, MouseTarget::SettingsColorSwatch(row));
+
+    app.update(Msg::MouseClick {
+        col: swatch.x,
+        row: swatch.y,
+        multi: false,
+    });
+    assert!(app.settings.as_ref().unwrap().color_picker.is_some());
+    assert_eq!(
+        app.interaction.color_picker_click,
+        Some((swatch.x, swatch.y))
+    );
+
+    render(&app, 80, 24);
+    app.update(Msg::MouseDoubleClick {
+        col: swatch.x,
+        row: swatch.y,
+    });
+    assert!(app.settings.as_ref().unwrap().color_picker.is_some());
+    assert_eq!(app.theme.effective_hex(role), "#123456");
+    assert!(app.interaction.color_picker_click.is_none());
+}
+
+#[test]
+fn space_opens_picker_enter_is_lossless_and_enter_still_edits_hex() {
+    let role = ThemeRole::Accent;
+    let mut app = color_settings(role, "#123456");
+
+    app.update(Msg::Key(key(KeyCode::Char(' '))));
+    let picker = app
+        .settings
+        .as_ref()
+        .unwrap()
+        .color_picker
+        .as_ref()
+        .unwrap();
+    assert_eq!(picker.selection(), ColorPickerSelection::Current);
+    assert_eq!(picker.current(), "#123456");
+    app.update(Msg::Key(key(KeyCode::Enter)));
+    assert_eq!(app.theme.effective_hex(role), "#123456");
+    assert!(app.settings.as_ref().unwrap().color_picker.is_none());
+
+    app.update(Msg::Key(key(KeyCode::Enter)));
+    assert!(app.settings.as_ref().unwrap().editing_text);
+    for _ in 0..7 {
+        app.update(Msg::Key(key(KeyCode::Backspace)));
+    }
+    for ch in "#A1B2C3".chars() {
+        app.update(Msg::Key(key(KeyCode::Char(ch))));
+    }
+    app.update(Msg::Key(key(KeyCode::Enter)));
+    assert_eq!(app.theme.effective_hex(role), "#A1B2C3");
+    assert!(!app.settings.as_ref().unwrap().editing_text);
+}
+
+#[test]
+fn keyboard_navigation_applies_or_cancels_without_leaking() {
+    let role = ThemeRole::Accent;
+    let mut app = color_settings(role, "#123456");
+    app.update(Msg::Key(key(KeyCode::Char(' '))));
+    app.update(Msg::Key(key(KeyCode::Down)));
+    assert_eq!(
+        app.settings
+            .as_ref()
+            .unwrap()
+            .color_picker
+            .as_ref()
+            .unwrap()
+            .selection(),
+        ColorPickerSelection::Choice(0)
+    );
+    app.update(Msg::Key(key(KeyCode::Esc)));
+    assert_eq!(app.theme.effective_hex(role), "#123456");
+
+    app.update(Msg::Key(key(KeyCode::Char(' '))));
+    app.update(Msg::Key(key(KeyCode::Down)));
+    app.update(Msg::Key(key(KeyCode::Enter)));
+    assert_eq!(app.theme.effective_hex(role), "none");
+    assert!(app.settings.as_ref().unwrap().color_picker.is_none());
+}
+
+#[test]
+fn full_popup_registers_surface_current_and_all_palette_buttons() {
+    let mut app = color_settings(ThemeRole::Accent, "#123456");
+    app.update(Msg::Key(key(KeyCode::Char(' '))));
+    render(&app, 80, 24);
+
+    let regions = app.hits.regions();
+    assert!(
+        regions
+            .iter()
+            .any(|region| { region.target == MouseTarget::SettingsColorPickerSurface })
+    );
+    assert!(
+        regions
+            .iter()
+            .any(|region| { region.target == MouseTarget::SettingsColorPickerCurrent })
+    );
+    assert_eq!(
+        regions
+            .iter()
+            .filter(|region| matches!(region.target, MouseTarget::SettingsColorPickerChoice(_)))
+            .count(),
+        COLOR_PICKER_CHOICE_COUNT
+    );
+}
+
+#[test]
+fn mini_narrow_popup_stays_visible_and_scrolls_to_the_selection() {
+    let mut app = color_settings(ThemeRole::Accent, "#123456");
+    let row = app.settings.as_ref().unwrap().row;
+    app.update(Msg::Key(key(KeyCode::Char(' '))));
+    render(&app, 30, 10);
+    assert_eq!(app.bridges.ui_tier.get(), crate::ui::layout::UiTier::Mini);
+    assert!(
+        app.hits
+            .regions()
+            .iter()
+            .any(|region| region.target == MouseTarget::SettingsColorPickerSurface)
+    );
+    assert_eq!(
+        app.settings
+            .as_ref()
+            .unwrap()
+            .color_picker
+            .as_ref()
+            .unwrap()
+            .columns(),
+        8
+    );
+
+    for _ in 0..10 {
+        app.update(Msg::Key(key(KeyCode::Down)));
+    }
+    // A typeable global must be swallowed while the mode-owned Mini modal is open.
+    app.update(Msg::Key(key(KeyCode::Char('s'))));
+    assert_eq!(app.mode, Mode::Settings);
+    assert_eq!(app.settings.as_ref().unwrap().row, row);
+    render(&app, 30, 10);
+    let selection = app
+        .settings
+        .as_ref()
+        .unwrap()
+        .color_picker
+        .as_ref()
+        .unwrap()
+        .selection();
+    let ColorPickerSelection::Choice(index) = selection else {
+        panic!("navigation should enter the grid");
+    };
+    assert!(
+        app.hits
+            .regions()
+            .iter()
+            .any(|region| { region.target == MouseTarget::SettingsColorPickerChoice(index) })
+    );
+}
+
+#[test]
+fn mouse_apply_outside_cancel_and_modal_inputs_never_reach_settings() {
+    let role = ThemeRole::Accent;
+    let mut app = color_settings(role, "#123456");
+    let settings_row = app.settings.as_ref().unwrap().row;
+    app.update(Msg::Key(key(KeyCode::Char(' '))));
+    render(&app, 80, 24);
+
+    app.update(Msg::MouseScroll {
+        up: false,
+        col: 0,
+        row: 0,
+        ctrl: true,
+    });
+    assert!(matches!(
+        app.settings
+            .as_ref()
+            .unwrap()
+            .color_picker
+            .as_ref()
+            .unwrap()
+            .selection(),
+        ColorPickerSelection::Choice(_)
+    ));
+    app.update(Msg::MouseDrag { col: 0, row: 0 });
+    app.update(Msg::MouseRightClick { col: 0, row: 0 });
+    assert!(app.overlays.context_menu.is_none());
+    assert_eq!(app.settings.as_ref().unwrap().row, settings_row);
+
+    app.update(Msg::MouseClick {
+        col: 0,
+        row: 0,
+        multi: false,
+    });
+    assert!(app.settings.as_ref().unwrap().color_picker.is_none());
+    assert_eq!(app.theme.effective_hex(role), "#123456");
+    app.update(Msg::MouseDoubleClick { col: 0, row: 0 });
+    assert_eq!(app.mode, Mode::Settings, "paired double click is consumed");
+    assert_eq!(app.settings.as_ref().unwrap().row, settings_row);
+
+    app.update(Msg::Key(key(KeyCode::Char(' '))));
+    render(&app, 80, 24);
+    let choice = 2;
+    let rect = target_rect(&app, MouseTarget::SettingsColorPickerChoice(choice));
+    app.update(Msg::MouseClick {
+        col: rect.x,
+        row: rect.y,
+        multi: false,
+    });
+    assert!(app.settings.as_ref().unwrap().color_picker.is_none());
+    assert_eq!(
+        app.theme.effective_hex(role),
+        color_picker_choice(choice).unwrap().value()
+    );
+    assert_eq!(app.interaction.color_picker_click, Some((rect.x, rect.y)));
+    app.update(Msg::MouseDoubleClick {
+        col: rect.x,
+        row: rect.y,
+    });
+    assert_eq!(app.mode, Mode::Settings, "paired double click is consumed");
+    assert!(app.interaction.color_picker_click.is_none());
+}

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -588,6 +588,14 @@ pub enum MouseTarget {
     /// A clickable Settings button or text value, by field-row index — enters edit mode (text)
     /// or fires the action (button); the mouse equivalent of Enter on that row.
     SettingsActivate(usize),
+    /// The two-cell color swatch on a Settings theme row — opens the full color picker.
+    SettingsColorSwatch(usize),
+    /// Modal picker backdrop/chrome. It captures clicks inside the popup that are not choices.
+    SettingsColorPickerSurface,
+    /// The lossless current-value row in the modal color picker.
+    SettingsColorPickerCurrent,
+    /// A picker-grid choice: transparent at zero, then the 240 xterm colors.
+    SettingsColorPickerChoice(usize),
     /// Open/close the Settings Spotify import-mode dropdown.
     SettingsSpotifyImportModeMenu,
     /// Pick a Settings Spotify import-mode dropdown option.

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -362,6 +362,35 @@ fn json_round_trips() {
 }
 
 #[test]
+fn custom_theme_palettes_round_trip_independently() {
+    let mut config = Config::default();
+    config.theme.set_preset(crate::theme::ThemePreset::Custom);
+    config
+        .theme
+        .set_override(crate::theme::ThemeRole::Accent, "#123456")
+        .unwrap();
+
+    let mut radio_theme = ThemeConfig::radio();
+    radio_theme.set_preset(crate::theme::ThemePreset::Custom);
+    radio_theme
+        .set_override(crate::theme::ThemeRole::Accent, "#654321")
+        .unwrap();
+    config.radio_theme = Some(radio_theme);
+
+    let back: Config = serde_json::from_str(&serde_json::to_string(&config).unwrap()).unwrap();
+    assert_eq!(
+        back.theme.effective_hex(crate::theme::ThemeRole::Accent),
+        "#123456"
+    );
+    assert_eq!(
+        back.effective_radio_theme()
+            .unwrap()
+            .effective_hex(crate::theme::ThemeRole::Accent),
+        "#654321"
+    );
+}
+
+#[test]
 fn search_onboarding_is_fresh_only_for_new_profiles() {
     assert!(!Config::default().search_onboarding_seen);
     let legacy: Config = serde_json::from_str("{\"volume\": 42}").unwrap();

--- a/src/daemon/engine.rs
+++ b/src/daemon/engine.rs
@@ -1030,11 +1030,12 @@ impl DaemonEngine {
             },
             ("theme", "preset") => match as_str() {
                 Some(name) => {
-                    // Clone-then-normalize: a fresh ThemeConfig cache (Clone resets it)
-                    // so the direct preset write can't leave a stale resolved palette.
-                    let mut theme = self.config.theme.clone();
-                    theme.preset = name;
-                    self.config.theme = theme.normalized();
+                    // Preserve the existing wire behavior for unknown names (fall back to
+                    // Default), but route recognized presets through the shared transition
+                    // path so built-in overrides are discarded and Custom stays durable.
+                    let preset = crate::theme::ThemePreset::from_id(&name)
+                        .unwrap_or(crate::theme::ThemePreset::Default);
+                    self.config.theme.set_preset(preset);
                     self.save_config("daemon theme preset");
                     ok(self)
                 }

--- a/src/daemon/engine/keymap_theme.rs
+++ b/src/daemon/engine/keymap_theme.rs
@@ -88,7 +88,7 @@ impl DaemonEngine {
         else {
             return RemoteResponse::err("unknown_setting");
         };
-        self.config.theme.overrides.remove(role.id());
+        self.config.theme.reset_role(role);
         self.save_config("daemon theme clear override");
         RemoteResponse::ok("theme override cleared".to_owned())
     }
@@ -177,9 +177,43 @@ mod tests {
 
         let (set, _) = engine.gui_theme_set_override("accent".to_owned(), "#aabbcc".to_owned());
         assert!(set.ok, "{set:?}");
-        assert!(engine.config.theme.overrides.contains_key("accent"));
+        assert!(
+            engine
+                .config
+                .theme
+                .active_overrides()
+                .contains_key("accent")
+        );
         assert!(engine.gui_theme_clear_override("accent").ok);
-        assert!(!engine.config.theme.overrides.contains_key("accent"));
+        assert!(
+            !engine
+                .config
+                .theme
+                .active_overrides()
+                .contains_key("accent")
+        );
+
+        engine
+            .config
+            .theme
+            .set_preset(crate::theme::ThemePreset::Custom);
+        let (set, _) = engine.gui_theme_set_override("accent".to_owned(), "#ccbbaa".to_owned());
+        assert!(set.ok, "{set:?}");
+        assert!(
+            engine
+                .config
+                .theme
+                .active_overrides()
+                .contains_key("accent")
+        );
+        assert!(engine.gui_theme_clear_override("accent").ok);
+        assert!(
+            !engine
+                .config
+                .theme
+                .active_overrides()
+                .contains_key("accent")
+        );
         assert!(!engine.gui_theme_clear_override("nonsense").ok);
     }
 }

--- a/src/daemon/engine/tests.rs
+++ b/src/daemon/engine/tests.rs
@@ -378,6 +378,55 @@ fn gui_apply_routes_settings_to_live_daemon_state() {
 }
 
 #[test]
+fn gui_theme_preset_switching_discards_built_in_overrides_but_retains_custom() {
+    use crate::theme::{ThemePreset, ThemeRole};
+
+    let mut engine = engine_with_queue(&["seed"]);
+
+    apply_gui_ok(&mut engine, "theme", "accent", json!("#123456"));
+    apply_gui_ok(&mut engine, "theme", "preset", json!("default"));
+    assert_eq!(
+        engine.config.theme.effective_hex(ThemeRole::Accent),
+        "#123456",
+        "reselecting the active preset must preserve its restart-persistent edit"
+    );
+
+    apply_gui_ok(&mut engine, "theme", "preset", json!("midnight"));
+    assert!(engine.config.theme.active_overrides().is_empty());
+    assert_eq!(
+        engine.config.theme.effective_hex(ThemeRole::Accent),
+        ThemeRole::Accent.default_hex(ThemePreset::Midnight)
+    );
+    apply_gui_ok(&mut engine, "theme", "preset", json!("default"));
+    assert_eq!(
+        engine.config.theme.effective_hex(ThemeRole::Accent),
+        ThemeRole::Accent.default_hex(ThemePreset::Default),
+        "returning to a built-in preset must restore its original palette"
+    );
+
+    apply_gui_ok(&mut engine, "theme", "preset", json!("custom"));
+    assert_eq!(
+        engine.config.theme.effective_hex(ThemeRole::Accent),
+        ThemeRole::Accent.default_hex(ThemePreset::Default),
+        "Custom starts from Default"
+    );
+    apply_gui_ok(&mut engine, "theme", "accent", json!("#abcdef"));
+    apply_gui_ok(&mut engine, "theme", "preset", json!("nord"));
+    assert!(engine.config.theme.active_overrides().is_empty());
+    apply_gui_ok(&mut engine, "theme", "preset", json!("custom"));
+    assert_eq!(
+        engine.config.theme.effective_hex(ThemeRole::Accent),
+        "#ABCDEF",
+        "Custom edits must survive a preset round trip"
+    );
+
+    // This lane historically accepted unknown strings by normalizing them to Default.
+    apply_gui_ok(&mut engine, "theme", "preset", json!("not-a-theme"));
+    assert_eq!(engine.config.theme.preset_enum(), ThemePreset::Default);
+    assert_eq!(engine.config.theme.preset, "default");
+}
+
+#[test]
 fn gui_apply_rejects_bad_values_and_unknown_fields() {
     let mut engine = engine_with_queue(&["seed"]);
 

--- a/src/data_export.rs
+++ b/src/data_export.rs
@@ -543,10 +543,12 @@ fn project_settings(config: &Config) -> PortableSettingsV1 {
             "theme": {
                 "preset": theme.preset,
                 "overrides": theme.overrides,
+                "custom_overrides": theme.custom_overrides,
             },
             "radio_theme": radio_theme.map(|theme| json!({
                 "preset": theme.preset,
                 "overrides": theme.overrides,
+                "custom_overrides": theme.custom_overrides,
             })),
         }),
         bindings: json!({

--- a/src/remote/publish.rs
+++ b/src/remote/publish.rs
@@ -845,7 +845,7 @@ pub(crate) fn settings_model(view: &CoreView<'_>, rev: u64) -> super::proto::Set
                 .into_iter()
                 .map(|role| (role.id().to_string(), c.theme.effective_hex(role)))
                 .collect(),
-            overrides: c.theme.overrides.clone(),
+            overrides: c.theme.active_overrides().clone(),
             background_none: c.theme.is_role_transparent(ThemeRole::Background),
             retro: c.retro_mode,
             presets: ThemePreset::ALL

--- a/src/remote/publish/tests.rs
+++ b/src/remote/publish/tests.rs
@@ -64,6 +64,46 @@ fn settings_revs(lines: &[SessionLine]) -> Vec<u64> {
 }
 
 #[test]
+fn settings_theme_projects_active_overrides_and_lists_custom() {
+    use crate::theme::{ThemePreset, ThemeRole};
+
+    let queue = Queue::default();
+    let mut config = crate::config::Config::default();
+    config.theme.set_preset(ThemePreset::Custom);
+    config
+        .theme
+        .set_override(ThemeRole::Accent, "#123456")
+        .unwrap();
+
+    config.theme.set_preset(ThemePreset::Nord);
+    let mut core = test_view(&queue);
+    core.config = &config;
+    let built_in = settings_model(&core, 1);
+    assert!(built_in.theme.overrides.is_empty());
+    assert!(
+        built_in
+            .theme
+            .presets
+            .iter()
+            .any(|preset| preset.name == "custom" && preset.label == "Custom")
+    );
+
+    config.theme.set_preset(ThemePreset::Custom);
+    let mut core = test_view(&queue);
+    core.config = &config;
+    let custom = settings_model(&core, 2);
+    assert_eq!(custom.theme.preset, "custom");
+    assert_eq!(
+        custom.theme.overrides.get("accent").map(String::as_str),
+        Some("#123456")
+    );
+    assert_eq!(
+        custom.theme.roles.get("accent").map(String::as_str),
+        Some("#123456")
+    );
+}
+
+#[test]
 fn subscribe_emits_snapshots_before_reply_and_only_for_new_topics() {
     let (hub, session, mut rx) = test_register(SessionTuning::default());
     let mut publisher = Publisher::new(hub);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -24,8 +24,13 @@ use crate::t;
 use crate::theme::{ThemeConfig, ThemeRole};
 
 mod actions;
+mod color_picker;
 mod field_meta;
 pub use actions::{FieldKind, PersonalDataExportStatus};
+pub use color_picker::{
+    COLOR_PICKER_CHOICE_COUNT, ColorPickerChoice, ColorPickerSelection, ColorPickerState,
+    color_picker_choice,
+};
 
 #[cfg(test)]
 mod spotify_tests;
@@ -935,7 +940,11 @@ impl SettingsDraft {
             Field::ListenBrainzToken => Some(&self.listenbrainz_token),
             Field::SpotifyClientId => Some(&self.spotify_client_id),
             Field::SpotifyRedirectPort => Some(&self.spotify_redirect_port),
-            Field::ThemeColor(role) => self.theme.overrides.get(role.id()).map(String::as_str),
+            Field::ThemeColor(role) => self
+                .theme
+                .active_overrides()
+                .get(role.id())
+                .map(String::as_str),
             _ => None,
         }
     }
@@ -1054,6 +1063,9 @@ pub struct SettingsState {
     pub draft: SettingsDraft,
     /// Whether the focused text field is in character-entry mode.
     pub editing_text: bool,
+    /// Open color picker for the focused theme role. Owned here (rather than the global overlay
+    /// mask) so closing Settings always drops it and does not consume an album-art mask bit.
+    pub color_picker: Option<ColorPickerState>,
     /// The masked secret's value captured when its editor opened. The buffer is cleared
     /// on edit-start (blind-paste of a whole new key), so this lets a commit that typed
     /// nothing restore the prior key instead of wiping it. `None` outside a secret edit.

--- a/src/settings/color_picker.rs
+++ b/src/settings/color_picker.rs
@@ -1,0 +1,251 @@
+//! Settings color-picker state and the terminal-safe xterm palette.
+
+use std::cell::Cell;
+
+use crate::theme::ThemeRole;
+
+/// Number of real colors in the picker: the 216-color RGB cube plus 24 grays.
+pub const COLOR_PICKER_COLOR_COUNT: usize = 240;
+/// A transparent choice precedes the 240 real colors in the navigable grid.
+pub const COLOR_PICKER_CHOICE_COUNT: usize = COLOR_PICKER_COLOR_COUNT + 1;
+
+/// A selectable value in the picker grid. The current value is a separate header choice so an
+/// arbitrary 24-bit color (or `none`) can be accepted without being coerced into the palette.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorPickerChoice {
+    Transparent,
+    Rgb(u8, u8, u8),
+}
+
+impl ColorPickerChoice {
+    pub fn value(self) -> String {
+        match self {
+            Self::Transparent => "none".to_owned(),
+            Self::Rgb(r, g, b) => format!("#{r:02X}{g:02X}{b:02X}"),
+        }
+    }
+}
+
+/// Return one grid choice: transparent first, then the xterm RGB cube and gray ramp.
+pub fn color_picker_choice(index: usize) -> Option<ColorPickerChoice> {
+    if index == 0 {
+        return Some(ColorPickerChoice::Transparent);
+    }
+    let color = index - 1;
+    if color < 216 {
+        const LEVELS: [u8; 6] = [0, 95, 135, 175, 215, 255];
+        let r = LEVELS[color / 36];
+        let g = LEVELS[(color / 6) % 6];
+        let b = LEVELS[color % 6];
+        Some(ColorPickerChoice::Rgb(r, g, b))
+    } else if color < COLOR_PICKER_COLOR_COUNT {
+        let gray = 8 + 10 * (color - 216) as u8;
+        Some(ColorPickerChoice::Rgb(gray, gray, gray))
+    } else {
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorPickerSelection {
+    Current,
+    Choice(usize),
+}
+
+/// Modal picker state owned by the Settings session. Layout facts are bridged from render with
+/// `Cell`s because only the render pass knows the terminal's current virtual cell grid.
+#[derive(Debug, Clone)]
+pub struct ColorPickerState {
+    pub role: ThemeRole,
+    current: String,
+    selection: ColorPickerSelection,
+    columns: Cell<usize>,
+    visible_rows: Cell<usize>,
+    row_offset: Cell<usize>,
+}
+
+impl ColorPickerState {
+    pub fn new(role: ThemeRole, current: String) -> Self {
+        Self {
+            role,
+            current,
+            selection: ColorPickerSelection::Current,
+            columns: Cell::new(1),
+            visible_rows: Cell::new(1),
+            row_offset: Cell::new(0),
+        }
+    }
+
+    pub fn current(&self) -> &str {
+        &self.current
+    }
+
+    pub fn selection(&self) -> ColorPickerSelection {
+        self.selection
+    }
+
+    pub fn selected_value(&self) -> String {
+        match self.selection {
+            ColorPickerSelection::Current => self.current.clone(),
+            ColorPickerSelection::Choice(index) => color_picker_choice(index)
+                .expect("picker selection is always in range")
+                .value(),
+        }
+    }
+
+    pub fn select_current(&mut self) {
+        self.selection = ColorPickerSelection::Current;
+        self.ensure_visible();
+    }
+
+    pub fn select_choice(&mut self, index: usize) {
+        self.selection = ColorPickerSelection::Choice(index.min(COLOR_PICKER_CHOICE_COUNT - 1));
+        self.ensure_visible();
+    }
+
+    pub fn set_layout(&self, columns: usize, visible_rows: usize) {
+        self.columns.set(columns.max(1));
+        self.visible_rows.set(visible_rows.max(1));
+        self.ensure_visible();
+    }
+
+    pub fn columns(&self) -> usize {
+        self.columns.get().max(1)
+    }
+
+    pub fn visible_rows(&self) -> usize {
+        self.visible_rows.get().max(1)
+    }
+
+    pub fn row_offset(&self) -> usize {
+        self.row_offset.get()
+    }
+
+    pub fn choice_rows(&self) -> usize {
+        COLOR_PICKER_CHOICE_COUNT.div_ceil(self.columns())
+    }
+
+    pub fn move_left(&mut self) {
+        match self.selection {
+            ColorPickerSelection::Current => self.select_choice(COLOR_PICKER_CHOICE_COUNT - 1),
+            ColorPickerSelection::Choice(0) => self.select_current(),
+            ColorPickerSelection::Choice(index) => self.select_choice(index - 1),
+        }
+    }
+
+    pub fn move_right(&mut self) {
+        match self.selection {
+            ColorPickerSelection::Current => self.select_choice(0),
+            ColorPickerSelection::Choice(index) => {
+                self.select_choice((index + 1).min(COLOR_PICKER_CHOICE_COUNT - 1));
+            }
+        }
+    }
+
+    pub fn move_up(&mut self) {
+        match self.selection {
+            ColorPickerSelection::Current => self.select_choice(COLOR_PICKER_CHOICE_COUNT - 1),
+            ColorPickerSelection::Choice(index) if index < self.columns() => {
+                self.select_current();
+            }
+            ColorPickerSelection::Choice(index) => self.select_choice(index - self.columns()),
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        match self.selection {
+            ColorPickerSelection::Current => self.select_choice(0),
+            ColorPickerSelection::Choice(index) => {
+                self.select_choice((index + self.columns()).min(COLOR_PICKER_CHOICE_COUNT - 1))
+            }
+        }
+    }
+
+    pub fn wheel(&mut self, up: bool, rows: usize) {
+        for _ in 0..rows.max(1) {
+            if up {
+                self.move_up();
+            } else {
+                self.move_down();
+            }
+        }
+    }
+
+    fn ensure_visible(&self) {
+        let max_offset = self.choice_rows().saturating_sub(self.visible_rows());
+        let next = match self.selection {
+            ColorPickerSelection::Current => 0,
+            ColorPickerSelection::Choice(index) => {
+                let selected_row = index / self.columns();
+                let current = self.row_offset.get().min(max_offset);
+                if selected_row < current {
+                    selected_row
+                } else if selected_row >= current + self.visible_rows() {
+                    selected_row + 1 - self.visible_rows()
+                } else {
+                    current
+                }
+            }
+        };
+        self.row_offset.set(next.min(max_offset));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn palette_is_exact_xterm_cube_then_gray_ramp() {
+        assert_eq!(COLOR_PICKER_COLOR_COUNT, 216 + 24);
+        assert_eq!(color_picker_choice(0), Some(ColorPickerChoice::Transparent));
+        assert_eq!(
+            color_picker_choice(1),
+            Some(ColorPickerChoice::Rgb(0, 0, 0))
+        );
+        assert_eq!(
+            color_picker_choice(216),
+            Some(ColorPickerChoice::Rgb(255, 255, 255))
+        );
+        assert_eq!(
+            color_picker_choice(217),
+            Some(ColorPickerChoice::Rgb(8, 8, 8))
+        );
+        assert_eq!(
+            color_picker_choice(240),
+            Some(ColorPickerChoice::Rgb(238, 238, 238))
+        );
+        assert_eq!(color_picker_choice(241), None);
+    }
+
+    #[test]
+    fn current_value_is_lossless_until_navigation_changes_the_selection() {
+        let mut picker = ColorPickerState::new(ThemeRole::Accent, "#123456".to_owned());
+        picker.set_layout(18, 14);
+        assert_eq!(picker.selected_value(), "#123456");
+        picker.move_down();
+        assert_eq!(picker.selected_value(), "none");
+
+        let transparent = ColorPickerState::new(ThemeRole::Background, "none".to_owned());
+        assert_eq!(transparent.selected_value(), "none");
+        assert_eq!(transparent.selection(), ColorPickerSelection::Current);
+    }
+
+    #[test]
+    fn navigation_tracks_selection_in_a_narrow_viewport() {
+        let mut picker = ColorPickerState::new(ThemeRole::Accent, "#ABCDEF".to_owned());
+        picker.set_layout(4, 3);
+        for _ in 0..5 {
+            picker.move_down();
+        }
+        assert_eq!(picker.selection(), ColorPickerSelection::Choice(16));
+        assert_eq!(picker.row_offset(), 2);
+        picker.move_up();
+        picker.move_up();
+        picker.move_up();
+        picker.move_up();
+        picker.move_up();
+        assert_eq!(picker.selection(), ColorPickerSelection::Current);
+        assert_eq!(picker.row_offset(), 0);
+    }
+}

--- a/src/settings/tests.rs
+++ b/src/settings/tests.rs
@@ -76,6 +76,7 @@ fn state_on(tab: SettingsTab, radio_mode: bool, retro: bool) -> SettingsState {
         row: 0,
         draft,
         editing_text: false,
+        color_picker: None,
         secret_restore: None,
         keymap: KeyMap::default(),
         mousemap: MouseMap::default(),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -29,6 +29,10 @@ pub struct ThemeConfig {
     pub preset: String,
     /// Same caveat as `preset`: go through `set_override`/`reset_role`/`override_value_mut`.
     pub overrides: BTreeMap<String, String>,
+    /// Persistent overrides for the Custom preset. Unlike built-in preset overrides, these
+    /// survive switching to another preset and back.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub custom_overrides: BTreeMap<String, String>,
     /// Lazily resolved palette; every mutating method resets it.
     #[serde(skip)]
     palette: OnceLock<Box<ResolvedPalette>>,
@@ -40,6 +44,7 @@ impl Clone for ThemeConfig {
         Self {
             preset: self.preset.clone(),
             overrides: self.overrides.clone(),
+            custom_overrides: self.custom_overrides.clone(),
             palette: OnceLock::new(),
         }
     }
@@ -47,7 +52,9 @@ impl Clone for ThemeConfig {
 
 impl PartialEq for ThemeConfig {
     fn eq(&self, other: &Self) -> bool {
-        self.preset == other.preset && self.overrides == other.overrides
+        self.preset == other.preset
+            && self.overrides == other.overrides
+            && self.custom_overrides == other.custom_overrides
     }
 }
 
@@ -58,6 +65,7 @@ impl Default for ThemeConfig {
         Self {
             preset: ThemePreset::Default.id().to_owned(),
             overrides: BTreeMap::new(),
+            custom_overrides: BTreeMap::new(),
             palette: OnceLock::new(),
         }
     }
@@ -68,6 +76,7 @@ impl ThemeConfig {
         Self {
             preset: ThemePreset::Radio.id().to_owned(),
             overrides: BTreeMap::new(),
+            custom_overrides: BTreeMap::new(),
             palette: OnceLock::new(),
         }
     }
@@ -77,12 +86,36 @@ impl ThemeConfig {
     }
 
     pub fn set_preset(&mut self, preset: ThemePreset) {
+        if self.preset == preset.id() {
+            return;
+        }
+        let changes_effective_preset = self.preset_enum() != preset;
         self.palette = OnceLock::new();
+        if changes_effective_preset {
+            self.overrides.clear();
+        }
         self.preset = preset.id().to_owned();
     }
 
+    /// Overrides that apply to the currently selected preset.
+    pub fn active_overrides(&self) -> &BTreeMap<String, String> {
+        if self.preset_enum() == ThemePreset::Custom {
+            &self.custom_overrides
+        } else {
+            &self.overrides
+        }
+    }
+
+    fn active_overrides_mut(&mut self) -> &mut BTreeMap<String, String> {
+        if self.preset_enum() == ThemePreset::Custom {
+            &mut self.custom_overrides
+        } else {
+            &mut self.overrides
+        }
+    }
+
     pub fn effective_hex(&self, role: ThemeRole) -> String {
-        self.overrides
+        self.active_overrides()
             .get(role.id())
             .and_then(|s| normalize_value(s))
             .unwrap_or_else(|| role.default_hex(self.preset_enum()).to_owned())
@@ -109,7 +142,9 @@ impl ThemeConfig {
 
     /// The old per-call `color()` body, now only run when (re)building the palette.
     fn resolve_color(&self, role: ThemeRole) -> Color {
-        if self.preset_enum() == ThemePreset::Retro && !self.overrides.contains_key(role.id()) {
+        if self.preset_enum() == ThemePreset::Retro
+            && !self.active_overrides().contains_key(role.id())
+        {
             return role.retro_color();
         }
         let value = self.effective_hex(role);
@@ -142,51 +177,68 @@ impl ThemeConfig {
                 format!("Invalid color for {}: use #RRGGBB or none", role.label())
             });
         };
-        if canonical.eq_ignore_ascii_case(role.default_hex(self.preset_enum())) {
-            self.overrides.remove(role.id());
+        let preset = self.preset_enum();
+        if canonical.eq_ignore_ascii_case(role.default_hex(preset)) {
+            self.active_overrides_mut().remove(role.id());
         } else {
-            self.overrides.insert(role.id().to_owned(), canonical);
+            self.active_overrides_mut()
+                .insert(role.id().to_owned(), canonical);
         }
         Ok(())
     }
 
     pub fn reset_role(&mut self, role: ThemeRole) {
         self.palette = OnceLock::new();
-        self.overrides.remove(role.id());
+        self.active_overrides_mut().remove(role.id());
     }
 
     pub fn ensure_override_for_edit(&mut self, role: ThemeRole) {
         self.palette = OnceLock::new();
         let value = self.effective_hex(role);
-        self.overrides.entry(role.id().to_owned()).or_insert(value);
+        self.active_overrides_mut()
+            .entry(role.id().to_owned())
+            .or_insert(value);
     }
 
     /// Mutable access to an existing override's raw value (live hex editing in Settings).
     /// Routed through a method so handing out the `&mut` invalidates the palette first.
     pub fn override_value_mut(&mut self, role: ThemeRole) -> Option<&mut String> {
         self.palette = OnceLock::new();
-        self.overrides.get_mut(role.id())
+        self.active_overrides_mut().get_mut(role.id())
     }
 
     pub fn normalized(&self) -> Self {
         let preset = self.preset_enum();
-        let mut overrides = BTreeMap::new();
-        for role in ThemeRole::ALL {
-            if let Some(value) = self
-                .overrides
-                .get(role.id())
-                .and_then(|value| normalize_value(value))
-                && !value.eq_ignore_ascii_case(role.default_hex(preset))
-            {
-                overrides.insert(role.id().to_owned(), value);
-            }
-        }
+        let overrides = if preset == ThemePreset::Custom {
+            BTreeMap::new()
+        } else {
+            normalized_overrides(&self.overrides, preset)
+        };
+        let custom_overrides = normalized_overrides(&self.custom_overrides, ThemePreset::Custom);
         Self {
             preset: preset.id().to_owned(),
             overrides,
+            custom_overrides,
             palette: OnceLock::new(),
         }
     }
+}
+
+fn normalized_overrides(
+    source: &BTreeMap<String, String>,
+    preset: ThemePreset,
+) -> BTreeMap<String, String> {
+    let mut normalized = BTreeMap::new();
+    for role in ThemeRole::ALL {
+        if let Some(value) = source
+            .get(role.id())
+            .and_then(|value| normalize_value(value))
+            && !value.eq_ignore_ascii_case(role.default_hex(preset))
+        {
+            normalized.insert(role.id().to_owned(), value);
+        }
+    }
+    normalized
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -205,10 +257,11 @@ pub enum ThemePreset {
     TokyoNight,
     Solarized,
     RosePine,
+    Custom,
 }
 
 impl ThemePreset {
-    pub const ALL: [ThemePreset; 14] = [
+    pub const ALL: [ThemePreset; 15] = [
         ThemePreset::Default,
         ThemePreset::Midnight,
         ThemePreset::LocalLaunch,
@@ -223,6 +276,7 @@ impl ThemePreset {
         ThemePreset::RosePine,
         ThemePreset::Radio,
         ThemePreset::Retro,
+        ThemePreset::Custom,
     ];
 
     pub fn id(self) -> &'static str {
@@ -241,6 +295,7 @@ impl ThemePreset {
             ThemePreset::TokyoNight => "tokyo_night",
             ThemePreset::Solarized => "solarized_dark",
             ThemePreset::RosePine => "rose_pine",
+            ThemePreset::Custom => "custom",
         }
     }
 
@@ -260,6 +315,7 @@ impl ThemePreset {
             ThemePreset::TokyoNight => "Tokyo Night",
             ThemePreset::Solarized => "Solarized Dark",
             ThemePreset::RosePine => "Rosé Pine",
+            ThemePreset::Custom => "Custom",
         }
     }
 
@@ -533,6 +589,7 @@ impl ThemeRole {
             ThemePreset::TokyoNight => self.tokyo_night(),
             ThemePreset::Solarized => self.solarized(),
             ThemePreset::RosePine => self.rose_pine(),
+            ThemePreset::Custom => self.default_dark(),
         }
     }
 
@@ -1093,6 +1150,88 @@ mod tests {
     }
 
     #[test]
+    fn built_in_overrides_survive_restart_until_the_preset_changes() {
+        let mut cfg = ThemeConfig::default();
+        cfg.set_override(ThemeRole::Accent, "#123456").unwrap();
+
+        let json = serde_json::to_string(&cfg).unwrap();
+        let mut restored: ThemeConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.effective_hex(ThemeRole::Accent), "#123456");
+
+        restored.set_preset(ThemePreset::Default);
+        assert_eq!(restored.effective_hex(ThemeRole::Accent), "#123456");
+        restored.set_preset(ThemePreset::Midnight);
+        assert!(restored.overrides.is_empty());
+        assert_eq!(
+            restored.effective_hex(ThemeRole::Accent),
+            ThemeRole::Accent.default_hex(ThemePreset::Midnight)
+        );
+        restored.set_preset(ThemePreset::Default);
+        assert_eq!(
+            restored.effective_hex(ThemeRole::Accent),
+            ThemeRole::Accent.default_hex(ThemePreset::Default)
+        );
+    }
+
+    #[test]
+    fn custom_overrides_survive_restart_and_preset_round_trips() {
+        assert_eq!(ThemePreset::ALL.last(), Some(&ThemePreset::Custom));
+        assert_eq!(ThemePreset::from_id("custom"), Some(ThemePreset::Custom));
+        assert_eq!(ThemePreset::Custom.label(), "Custom");
+
+        let mut cfg = ThemeConfig::default();
+        cfg.set_preset(ThemePreset::Custom);
+        assert_eq!(
+            cfg.effective_hex(ThemeRole::Accent),
+            ThemeRole::Accent.default_hex(ThemePreset::Default)
+        );
+        cfg.set_override(ThemeRole::Accent, "#123456").unwrap();
+        assert!(cfg.overrides.is_empty());
+        assert_eq!(
+            cfg.active_overrides().get("accent").map(String::as_str),
+            Some("#123456")
+        );
+
+        let json = serde_json::to_string(&cfg).unwrap();
+        let mut restored: ThemeConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, cfg);
+        assert_eq!(restored.effective_hex(ThemeRole::Accent), "#123456");
+
+        restored.set_preset(ThemePreset::Midnight);
+        assert!(restored.active_overrides().is_empty());
+        assert_eq!(
+            restored.custom_overrides.get("accent").map(String::as_str),
+            Some("#123456")
+        );
+        restored.set_preset(ThemePreset::Custom);
+        assert_eq!(restored.effective_hex(ThemeRole::Accent), "#123456");
+        restored.reset_role(ThemeRole::Accent);
+        assert!(restored.custom_overrides.is_empty());
+    }
+
+    #[test]
+    fn legacy_theme_json_loads_without_custom_overrides() {
+        let cfg: ThemeConfig =
+            serde_json::from_str(r##"{"preset":"midnight","overrides":{"accent":"#123456"}}"##)
+                .unwrap();
+        assert!(cfg.custom_overrides.is_empty());
+        assert_eq!(cfg.effective_hex(ThemeRole::Accent), "#123456");
+    }
+
+    #[test]
+    fn selecting_the_effective_preset_canonicalizes_a_malformed_id_without_losing_edits() {
+        let mut cfg: ThemeConfig =
+            serde_json::from_str(r##"{"preset":"bogus","overrides":{"accent":"#123456"}}"##)
+                .unwrap();
+        assert_eq!(cfg.preset_enum(), ThemePreset::Default);
+
+        cfg.set_preset(ThemePreset::Default);
+
+        assert_eq!(cfg.preset, "default");
+        assert_eq!(cfg.effective_hex(ThemeRole::Accent), "#123456");
+    }
+
+    #[test]
     fn every_preset_role_has_a_valid_value() {
         for preset in ThemePreset::ALL {
             for role in ThemeRole::ALL {
@@ -1227,11 +1366,23 @@ mod tests {
             .insert("border_primary".to_owned(), "not-a-color".to_owned());
         cfg.overrides
             .insert("text_primary".to_owned(), "#eeeeee".to_owned());
+        cfg.custom_overrides
+            .insert("accent".to_owned(), "not-a-color".to_owned());
+        cfg.custom_overrides
+            .insert("text_primary".to_owned(), "#123456".to_owned());
         let normalized = cfg.normalized();
         assert_eq!(normalized.overrides.get("border_primary"), None);
         assert_eq!(
             normalized.overrides.get("text_primary").map(String::as_str),
             Some("#EEEEEE")
+        );
+        assert_eq!(normalized.custom_overrides.get("accent"), None);
+        assert_eq!(
+            normalized
+                .custom_overrides
+                .get("text_primary")
+                .map(String::as_str),
+            Some("#123456")
         );
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -117,6 +117,15 @@ pub fn render(frame: &mut Frame, app: &App) {
     if let Some(confirm) = app.overlays.pending_settings_confirm {
         views::settings::render_confirm(frame, app, area, confirm);
     }
+    // The Settings-owned color picker is rendered at the top level so it stays visible and
+    // operable when the responsive layout has replaced Settings with the miniplayer.
+    if app
+        .settings
+        .as_ref()
+        .is_some_and(|state| state.color_picker.is_some())
+    {
+        views::color_picker::render(frame, app, area);
+    }
     // The Spotify playlist picker (Import from Spotify…) is modal over Settings.
     if app.overlays.spotify_picker.is_some() {
         views::settings::render_spotify_picker(frame, app, area);

--- a/src/ui/views/color_picker.rs
+++ b/src/ui/views/color_picker.rs
@@ -1,0 +1,264 @@
+//! Responsive Settings color-picker modal.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+use crate::app::{App, MouseTarget};
+use crate::settings::{
+    COLOR_PICKER_CHOICE_COUNT, ColorPickerChoice, ColorPickerSelection, ColorPickerState,
+    color_picker_choice,
+};
+use crate::t;
+use crate::theme::ThemeRole as R;
+
+const DESIRED_WIDTH: u16 = 58;
+const DESIRED_HEIGHT: u16 = 20;
+const CELL_PITCH: u16 = 3;
+const PREFERRED_COLUMNS: usize = 18;
+
+pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+    let Some(picker) = app
+        .settings
+        .as_ref()
+        .and_then(|state| state.color_picker.as_ref())
+    else {
+        return;
+    };
+    let popup = centered_picker_rect(area);
+    if popup.width == 0 || popup.height == 0 {
+        return;
+    }
+
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(
+            " {} · {} ",
+            t!("Color", "색상"),
+            picker.role.label()
+        ))
+        .border_style(crate::ui::popup_style(app, R::BorderFocused))
+        .style(crate::ui::popup_style(app, R::TextPrimary));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+    app.register_mouse_button(popup, MouseTarget::SettingsColorPickerSurface);
+
+    if inner.height == 0 || inner.width == 0 {
+        crate::ui::seal_popup_background(frame, app, popup);
+        return;
+    }
+    let current = Rect { height: 1, ..inner };
+    let help_height = u16::from(inner.height >= 2);
+    let grid = Rect {
+        x: inner.x,
+        y: inner.y.saturating_add(1),
+        width: inner.width,
+        height: inner.height.saturating_sub(1 + help_height),
+    };
+    let help = Rect {
+        x: inner.x,
+        y: inner.bottom().saturating_sub(help_height),
+        width: inner.width,
+        height: help_height,
+    };
+    let columns = usize::from((grid.width / CELL_PITCH).max(1)).min(PREFERRED_COLUMNS);
+    picker.set_layout(columns, usize::from(grid.height.max(1)));
+
+    render_current(frame, app, picker, current);
+    render_grid(frame, app, picker, grid);
+    if help.height > 0 {
+        let hint = if help.width < 40 {
+            t!("arrows · Enter apply · Esc", "방향키 · Enter 적용 · Esc")
+        } else {
+            t!(
+                "arrows/wheel · Enter/click apply · Esc/outside cancel",
+                "방향키/휠 · Enter/클릭 적용 · Esc/바깥 취소"
+            )
+        };
+        frame.render_widget(
+            Paragraph::new(hint)
+                .centered()
+                .style(crate::ui::popup_style(app, R::TextMuted)),
+            help,
+        );
+    }
+    crate::ui::seal_popup_background(frame, app, popup);
+    crate::ui::mark_art_rows_for_popup(frame, app, popup);
+}
+
+fn render_current(frame: &mut Frame, app: &App, picker: &ColorPickerState, area: Rect) {
+    let selected = picker.selection() == ColorPickerSelection::Current;
+    let label_style = crate::ui::popup_style(
+        app,
+        if selected {
+            R::SettingsValueFocused
+        } else {
+            R::SettingsLabel
+        },
+    )
+    .add_modifier(if selected {
+        Modifier::BOLD
+    } else {
+        Modifier::empty()
+    });
+    let swatch = swatch_span(app, picker.current(), selected);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(if selected { "> " } else { "  " }, label_style),
+            Span::styled(t!("Current ", "현재 "), label_style),
+            swatch,
+            Span::raw(" "),
+            Span::styled(picker.current().to_owned(), label_style),
+        ])),
+        area,
+    );
+    app.register_mouse_button(area, MouseTarget::SettingsColorPickerCurrent);
+}
+
+fn render_grid(frame: &mut Frame, app: &App, picker: &ColorPickerState, area: Rect) {
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+    let columns = picker.columns();
+    let first_row = picker.row_offset();
+    let last_row = first_row + picker.visible_rows();
+    let start = first_row.saturating_mul(columns);
+    let end = last_row
+        .saturating_mul(columns)
+        .min(COLOR_PICKER_CHOICE_COUNT);
+    for index in start..end {
+        let row = index / columns;
+        let column = index % columns;
+        let x = area
+            .x
+            .saturating_add((column as u16).saturating_mul(CELL_PITCH));
+        let y = area.y.saturating_add((row - first_row) as u16);
+        if x >= area.right() || y >= area.bottom() {
+            continue;
+        }
+        let cell = Rect {
+            x,
+            y,
+            width: 2.min(area.right() - x),
+            height: 1,
+        };
+        let selected = picker.selection() == ColorPickerSelection::Choice(index);
+        let choice = color_picker_choice(index).expect("rendered picker choice is in range");
+        let (text, style) = choice_cell(app, choice, selected);
+        frame.render_widget(Paragraph::new(text).style(style), cell);
+        app.register_mouse_button(cell, MouseTarget::SettingsColorPickerChoice(index));
+    }
+}
+
+fn choice_cell(app: &App, choice: ColorPickerChoice, selected: bool) -> (&'static str, Style) {
+    match choice {
+        ColorPickerChoice::Transparent => (
+            if selected { "[]" } else { "▒▒" },
+            crate::ui::popup_style(app, if selected { R::Accent } else { R::TextMuted })
+                .add_modifier(if selected {
+                    Modifier::BOLD
+                } else {
+                    Modifier::empty()
+                }),
+        ),
+        ColorPickerChoice::Rgb(r, g, b) => {
+            let fg = contrast_color(r, g, b);
+            (
+                if selected { "[]" } else { "  " },
+                Style::default()
+                    .fg(fg)
+                    .bg(Color::Rgb(r, g, b))
+                    .add_modifier(if selected {
+                        Modifier::BOLD
+                    } else {
+                        Modifier::empty()
+                    }),
+            )
+        }
+    }
+}
+
+fn swatch_span(app: &App, value: &str, selected: bool) -> Span<'static> {
+    let Some((r, g, b)) = parse_hex(value) else {
+        return Span::styled(
+            if selected { "[]" } else { "▒▒" },
+            crate::ui::popup_style(app, if selected { R::Accent } else { R::TextMuted }),
+        );
+    };
+    Span::styled(
+        if selected { "[]" } else { "  " },
+        Style::default()
+            .fg(contrast_color(r, g, b))
+            .bg(Color::Rgb(r, g, b)),
+    )
+}
+
+fn parse_hex(value: &str) -> Option<(u8, u8, u8)> {
+    let hex = value.strip_prefix('#')?;
+    if hex.len() != 6 {
+        return None;
+    }
+    Some((
+        u8::from_str_radix(&hex[0..2], 16).ok()?,
+        u8::from_str_radix(&hex[2..4], 16).ok()?,
+        u8::from_str_radix(&hex[4..6], 16).ok()?,
+    ))
+}
+
+fn contrast_color(r: u8, g: u8, b: u8) -> Color {
+    let luma = u32::from(r) * 299 + u32::from(g) * 587 + u32::from(b) * 114;
+    if luma >= 128_000 {
+        Color::Black
+    } else {
+        Color::White
+    }
+}
+
+fn centered_picker_rect(area: Rect) -> Rect {
+    let available_width = if area.width > 2 {
+        area.width - 2
+    } else {
+        area.width
+    };
+    let available_height = if area.height > 2 {
+        area.height - 2
+    } else {
+        area.height
+    };
+    let width = DESIRED_WIDTH.min(available_width);
+    let height = DESIRED_HEIGHT.min(available_height);
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eighty_by_twenty_four_has_room_for_the_full_palette() {
+        let popup = centered_picker_rect(Rect::new(0, 0, 80, 24));
+        let inner_width = popup.width - 2;
+        let inner_height = popup.height - 2;
+        let columns = usize::from(inner_width / CELL_PITCH).min(PREFERRED_COLUMNS);
+        let grid_rows = usize::from(inner_height - 2);
+        assert_eq!(columns, 18);
+        assert!(grid_rows >= COLOR_PICKER_CHOICE_COUNT.div_ceil(columns));
+    }
+
+    #[test]
+    fn narrow_picker_reduces_columns_without_overflowing() {
+        let popup = centered_picker_rect(Rect::new(0, 0, 30, 30));
+        assert_eq!(popup.width, 28);
+        assert_eq!((popup.width - 2) / CELL_PITCH, 8);
+        assert!(popup.right() <= 30);
+        assert!(popup.bottom() <= 30);
+    }
+}

--- a/src/ui/views/mod.rs
+++ b/src/ui/views/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod about;
 pub mod ai;
+pub mod color_picker;
 pub mod context_menu;
 pub mod help;
 pub mod library;

--- a/src/ui/views/settings.rs
+++ b/src/ui/views/settings.rs
@@ -751,9 +751,10 @@ fn register_field_controls(
         let focused = i == focused_field;
 
         if let Field::ThemeColor(_) = field {
-            // The swatch + hex value opens the inline hex editor.
+            // The swatch opens the palette; the hex value retains the inline editor.
             let vx = area.x + gutter + color_lw + 1; // gutter + label + leading space
-            put(vx, 2 + 2 + 9, y, MouseTarget::SettingsActivate(i)); // swatch + gap + hex
+            put(vx, 2, y, MouseTarget::SettingsColorSwatch(i));
+            put(vx + 4, 9, y, MouseTarget::SettingsActivate(i));
             continue;
         }
 


### PR DESCRIPTION
## What

- make built-in theme edits persist across restarts, then reset to the preset palette after an effective preset transition
- add a durable Custom theme palette that survives preset round trips
- add clickable TUI color swatches with a responsive 240-color picker while retaining hex editing
- keep daemon, remote settings, DemoCore, and data export behavior aligned

## Why

Theme overrides previously followed users across every preset, so returning to a built-in preset did not restore its original palette. Color editing also required manual hex input.

## Impact

Existing config remains backward-compatible. Built-in edits are discarded only when the effective preset changes; Custom edits persist independently for normal and radio themes.

## Checks

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- architecture, file-size, documentation, ratatui patch, and unsafe-inventory gates
- GUI lint, type check, 214 tests, build, and generated-type check
- isolated TUI verification at 80x24 and 30x30, including restart and preset round trips

The canonical gate wrapper could not find its local-only profile inside the isolated worktree, so its exact four profile commands were run manually and passed.