### PR TITLE
feat: add Beginner Mode onboarding

### DIFF
--- a/src/app/artwork.rs
+++ b/src/app/artwork.rs
@@ -22,6 +22,9 @@ pub(in crate::app) const ART_OVERLAY_PLAYLIST_PICKER_BIT: u32 = 1 << 14;
 pub(in crate::app) const ART_OVERLAY_SEARCH_FILTER_BIT: u32 = 1 << 15;
 pub(in crate::app) const ART_OVERLAY_CONTEXT_MENU_BIT: u32 = 1 << 16;
 pub(in crate::app) const ART_OVERLAY_TOOL_SETUP_BIT: u32 = 1 << 17;
+// Bit 18 belongs to the search-source popup in `fx_popup_mask`; keep it free here so the two
+// masks can be ORed without making an onboarding transition indistinguishable from that popup.
+pub(in crate::app) const ART_OVERLAY_BEGINNER_BIT: u32 = 1 << 19;
 
 // INVARIANT(ART-MASK-001): every art-covering surface owns a unique u32 bit; check the risk
 // map before replacing, sharing, or widening any allocation.
@@ -45,6 +48,7 @@ pub(in crate::app) const ART_OVERLAY_BITS: &[(&str, u32)] = &[
     ("search_filter", ART_OVERLAY_SEARCH_FILTER_BIT),
     ("context_menu", ART_OVERLAY_CONTEXT_MENU_BIT),
     ("tool_setup", ART_OVERLAY_TOOL_SETUP_BIT),
+    ("beginner", ART_OVERLAY_BEGINNER_BIT),
 ];
 
 const fn flag(on: bool, bit: u32) -> u32 {
@@ -649,6 +653,7 @@ impl App {
                 ART_OVERLAY_CONTEXT_MENU_BIT,
             )
             | flag(self.tool_setup.is_some(), ART_OVERLAY_TOOL_SETUP_BIT)
+            | flag(self.onboarding.visible(), ART_OVERLAY_BEGINNER_BIT)
     }
 
     /// Track overlay/screen transitions that can cover native terminal graphics. Ratatui's normal

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -196,6 +196,21 @@ impl App {
         )
     }
 
+    /// Live Beginner Mode flag. Settings previews the explanatory labels immediately, while the
+    /// persisted value controls whether a walkthrough is eligible on the next writable launch.
+    pub fn beginner_mode(&self) -> bool {
+        self.settings
+            .as_ref()
+            .map_or(self.config.beginner_mode, |settings| {
+                settings.draft.beginner_mode
+            })
+    }
+
+    /// Whether expanded, explanatory control labels should render on the current frame.
+    pub fn beginner_labels_enabled(&self) -> bool {
+        self.beginner_mode()
+    }
+
     /// Live player-bar position. Same draft-first rule as [`Self::retro_mode`]: while
     /// Settings is open the user is looking at the draft, so cycling the row previews the
     /// layout immediately, before it's committed on close.

--- a/src/app/feedback.rs
+++ b/src/app/feedback.rs
@@ -8,7 +8,7 @@ impl App {
     /// Whether a transient status is currently covering the title (drives the main loop's
     /// expiry tick - see [`Msg::StatusTick`]).
     pub fn status_visible(&self) -> bool {
-        self.status.set_at.is_some() || self.onboarding.visible()
+        self.status.set_at.is_some()
     }
 
     pub(crate) fn set_status_info(&mut self, text: impl Into<String>) {

--- a/src/app/hardening_tests.rs
+++ b/src/app/hardening_tests.rs
@@ -193,6 +193,11 @@ fn status_facades_set_kind_text_and_clear() {
 fn art_overlay_mask_bits_are_unique_and_fit_u32() {
     use super::artwork::ART_OVERLAY_BITS;
 
+    assert_eq!(
+        super::artwork::ART_OVERLAY_BEGINNER_BIT,
+        1 << 19,
+        "Beginner Mode owns the reserved bit 19"
+    );
     let mut seen = 0u32;
     for (name, bit) in ART_OVERLAY_BITS {
         assert_ne!(*bit, 0, "{name} bit must be non-zero");
@@ -205,10 +210,13 @@ fn art_overlay_mask_bits_are_unique_and_fit_u32() {
     }
     assert_eq!(
         ART_OVERLAY_BITS.len(),
-        18,
+        19,
         "all assigned u32 overlay bits are inventoried"
     );
-    assert!(seen & (1 << 17) != 0, "highest allocated bit is tracked");
+    assert!(
+        seen & super::artwork::ART_OVERLAY_BEGINNER_BIT != 0,
+        "highest allocated bit is tracked"
+    );
     assert_eq!(seen.count_ones(), ART_OVERLAY_BITS.len() as u32);
 }
 

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -16,6 +16,13 @@ impl App {
         if self.tool_setup.is_some() {
             return self.on_key_tool_setup(k);
         }
+        // Beginner Mode's F6 focus bridge runs before ordinary surface routing, while every
+        // established overlay keeps precedence. Unowned keys continue through unchanged.
+        if !self.beginner_higher_overlay_open()
+            && let Some(cmds) = self.on_key_beginner(k)
+        {
+            return cmds;
+        }
 
         // A keybinding-conflict warning is modal: the next keypress just dismisses it (the
         // rejected rebind already left the binding untouched), so it never leaks through to

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -57,7 +57,7 @@ pub(in crate::app) use helpers::{
 mod mode_switch;
 mod navigation;
 mod onboarding;
-pub use onboarding::OnboardingState;
+pub use onboarding::{BeginnerStep, OnboardingState};
 mod reducer;
 mod session_restore;
 

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -97,16 +97,24 @@ impl App {
         self.hits.region_at(col, row)
     }
 
-    /// A left-click at `(col, row)`: buttons fire their mapped action; the player's
-    /// seekbar seeks to the matching fraction of the track. Hit rects are published by
-    /// views each render. `multi` (Ctrl/Cmd held) only changes what a Library/Search
-    /// list-row hit does — toggle the row in/out of the selection — and is ignored by
-    /// every other surface, so a modifier click still presses buttons and closes modals.
+    fn beginner_coach_hit(&self, col: u16, row: u16) -> bool {
+        matches!(
+            self.mouse_target_at(col, row),
+            Some(MouseTarget::Onboarding(_))
+        )
+    }
+
+    /// Dispatch a hit-tested left click; `multi` only modifies Search/Library list rows.
     pub(in crate::app) fn on_mouse_click(&mut self, col: u16, row: u16, multi: bool) -> Vec<Cmd> {
         if self.tool_setup.is_some() {
             return self
                 .mouse_target_at(col, row)
                 .map_or_else(Vec::new, |target| self.activate_tool_setup(target));
+        }
+        if !self.beginner_higher_overlay_open()
+            && let Some(MouseTarget::Onboarding(action)) = self.mouse_target_at(col, row)
+        {
+            return self.activate_onboarding(action);
         }
         // Every fresh press re-establishes drag context, so a prior seekbar scrub / recording
         // slider drag can't survive a dropped terminal `Up` and hijack the next gesture. Re-armed
@@ -512,6 +520,7 @@ impl App {
             | MouseTarget::ToolSetupGuide
             | MouseTarget::ToolSetupRetry
             | MouseTarget::ToolSetupLater) => self.activate_tool_setup(target),
+            MouseTarget::Onboarding(action) => self.activate_onboarding(action),
             MouseTarget::Global(Action::ToggleHelp) => {
                 self.overlays.help_visible = true;
                 self.overlays.mouse_help_visible = false;
@@ -929,10 +938,10 @@ impl App {
         }
     }
 
-    /// A left double-click: play a song/queue row (vs. single-click, which selects). Falls
-    /// back to single-click behavior anywhere else so buttons, tabs, and the seekbar still
-    /// respond to the first press of a double-click.
     pub(in crate::app) fn on_mouse_double_click(&mut self, col: u16, row: u16) -> Vec<Cmd> {
+        if self.beginner_coach_hit(col, row) {
+            return Vec::new();
+        }
         // The first press may have activated a menu command that opened a confirmation/picker.
         // Consume its paired double-click press before that new modal can see and act on it.
         if self.interaction.context_menu_click.take() == Some((col, row)) {
@@ -1015,9 +1024,11 @@ impl App {
         }
     }
 
-    /// A left-drag: extend a multi-select range to the row under the pointer (the anchor end
-    /// stays fixed). Works in the queue window and, identically, in the Library list.
+    /// Extend the active pointer gesture while preserving its original surface.
     pub(in crate::app) fn on_mouse_drag(&mut self, col: u16, row: u16) -> Vec<Cmd> {
+        if self.beginner_coach_hit(col, row) {
+            return Vec::new();
+        }
         if self.interaction.context_menu_press {
             return Vec::new();
         }
@@ -1231,12 +1242,7 @@ impl App {
         }
     }
 
-    /// Wheel scroll nudges volume when the pointer is over the player's volume cluster.
-    /// Everywhere else it moves the *viewport* of whichever list is on top by
-    /// [`MOUSE_SCROLL_LINES`] rows — decoupled from the selection, which stays put (it may
-    /// scroll out of view; the render pass keeps it visible only for keyboard nav). An open
-    /// overlay (the queue window) wins over the active screen. Ctrl+wheel bypasses all of
-    /// that and steps the text zoom, browser-style, wherever the pointer is.
+    /// Scroll the topmost pointer surface; Ctrl+wheel retains its text-zoom override.
     pub(in crate::app) fn on_mouse_scroll(
         &mut self,
         up: bool,
@@ -1246,6 +1252,9 @@ impl App {
     ) -> Vec<Cmd> {
         if self.overlays.context_menu.is_some() {
             self.move_context_menu_selection(up);
+            return Vec::new();
+        }
+        if self.beginner_coach_hit(col, row) {
             return Vec::new();
         }
         // While the wheel-zoom lock is on, Ctrl+wheel degrades to a plain wheel scroll

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -112,15 +112,9 @@ impl App {
     /// reachable from any screen. Leaving Settings commits the draft via the normal close
     /// path so edits aren't lost; transient overlays are cleared.
     pub(in crate::app) fn navigate_to(&mut self, mode: Mode) -> Vec<Cmd> {
-        let mut onboarding_cmds = if mode == Mode::Search {
-            self.complete_search_onboarding()
-        } else {
-            Vec::new()
-        };
         if self.mode == Mode::Settings && mode != Mode::Settings {
             self.finish_settings_text_edit();
-            onboarding_cmds.extend(self.close_settings_for_navigation(mode));
-            return onboarding_cmds;
+            return self.close_settings_for_navigation(mode);
         }
         self.overlays.help_visible = false;
         self.overlays.mouse_help_visible = false;
@@ -144,7 +138,7 @@ impl App {
         self.ai.select_all = false;
         if self.mode == mode {
             self.dirty = true;
-            return onboarding_cmds;
+            return Vec::new();
         }
         match mode {
             Mode::Player => self.mode = Mode::Player,
@@ -171,7 +165,7 @@ impl App {
             Mode::Ai => self.enter_ai(),
         }
         self.dirty = true;
-        onboarding_cmds
+        Vec::new()
     }
 
     /// Select a Settings tab by index into [`SettingsTab::ALL`] (from a tab click).

--- a/src/app/onboarding.rs
+++ b/src/app/onboarding.rs
@@ -1,108 +1,637 @@
-use std::cell::Cell;
-use std::time::{Duration, Instant};
+use std::cmp::Ordering;
 
 use super::*;
+use crate::config::{BEGINNER_TUTORIAL_VERSION, BeginnerTutorialProgress};
 
-const SEARCH_ONBOARDING_TTL: Duration = Duration::from_secs(10);
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum BeginnerStep {
+    #[default]
+    Welcome,
+    NavigationHelp,
+    Search,
+    Player,
+    Library,
+    DjGem,
+    Settings,
+    Finish,
+}
+
+impl BeginnerStep {
+    pub const COUNT: usize = 8;
+
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::Welcome => "welcome",
+            Self::NavigationHelp => "navigation_help",
+            Self::Search => "search",
+            Self::Player => "player",
+            Self::Library => "library",
+            Self::DjGem => "dj_gem",
+            Self::Settings => "settings",
+            Self::Finish => "finish",
+        }
+    }
+
+    pub fn from_id(id: &str) -> Option<Self> {
+        Some(match id {
+            "welcome" => Self::Welcome,
+            "navigation_help" => Self::NavigationHelp,
+            "search" => Self::Search,
+            "player" => Self::Player,
+            "library" => Self::Library,
+            "dj_gem" => Self::DjGem,
+            "settings" => Self::Settings,
+            "finish" => Self::Finish,
+            _ => return None,
+        })
+    }
+
+    pub fn number(self) -> usize {
+        match self {
+            Self::Welcome => 1,
+            Self::NavigationHelp => 2,
+            Self::Search => 3,
+            Self::Player => 4,
+            Self::Library => 5,
+            Self::DjGem => 6,
+            Self::Settings => 7,
+            Self::Finish => 8,
+        }
+    }
+
+    fn next(self) -> Option<Self> {
+        Some(match self {
+            Self::Welcome => Self::NavigationHelp,
+            Self::NavigationHelp => Self::Search,
+            Self::Search => Self::Player,
+            Self::Player => Self::Library,
+            Self::Library => Self::DjGem,
+            Self::DjGem => Self::Settings,
+            Self::Settings => Self::Finish,
+            Self::Finish => return None,
+        })
+    }
+
+    fn previous(self) -> Option<Self> {
+        Some(match self {
+            Self::Welcome => return None,
+            Self::NavigationHelp => Self::Welcome,
+            Self::Search => Self::NavigationHelp,
+            Self::Player => Self::Search,
+            Self::Library => Self::Player,
+            Self::DjGem => Self::Library,
+            Self::Settings => Self::DjGem,
+            Self::Finish => Self::Settings,
+        })
+    }
+}
 
 #[derive(Default)]
 pub struct OnboardingState {
     pending: bool,
     armed: bool,
-    visible_elapsed: Cell<Duration>,
-    visible_since: Cell<Option<Instant>>,
+    step: BeginnerStep,
+    target_reached: bool,
+    guide_focused: bool,
+    mini_guide_focused: bool,
+    selected: usize,
+    skip_confirmation: bool,
+    guide_focused_before_skip: bool,
+    mini_guide_focused_before_skip: bool,
+    settings_tab_visited: bool,
+    startup_persist_pending: bool,
 }
 
 impl OnboardingState {
-    /// Whether the one-shot hint is armed. The render pass separately records whether the
-    /// current frame can actually show it so hidden time never consumes the TTL.
     pub fn visible(&self) -> bool {
         self.pending && self.armed
     }
 
-    fn record_render_eligibility(&self, eligible: bool, now: Instant) {
-        if self.visible() && eligible {
-            if self.visible_since.get().is_none() {
-                self.visible_since.set(Some(now));
-            }
-            return;
-        }
+    pub fn active(&self) -> bool {
+        self.visible()
+    }
 
-        if let Some(started) = self.visible_since.take() {
-            let elapsed = now.checked_duration_since(started).unwrap_or_default();
-            self.visible_elapsed
-                .set(self.visible_elapsed.get().saturating_add(elapsed));
+    pub fn step(&self) -> BeginnerStep {
+        self.step
+    }
+
+    pub fn target_reached(&self) -> bool {
+        self.target_reached
+    }
+
+    pub fn guide_focused(&self) -> bool {
+        self.guide_focused
+    }
+
+    pub fn guide_focused_for(&self, mini: bool) -> bool {
+        if mini {
+            self.mini_guide_focused
+        } else {
+            self.guide_focused
         }
     }
 
-    fn tick_expired(&self, now: Instant) -> bool {
-        if !self.visible() {
-            return false;
+    pub fn skip_confirmation(&self) -> bool {
+        self.skip_confirmation
+    }
+
+    pub fn settings_tab_visited(&self) -> bool {
+        self.settings_tab_visited
+    }
+
+    pub fn selected_action(&self) -> OnboardingAction {
+        if self.skip_confirmation {
+            return if self.selected == 0 {
+                OnboardingAction::CancelSkip
+            } else {
+                OnboardingAction::ConfirmSkip
+            };
         }
-        let current = self
-            .visible_since
-            .get()
-            .and_then(|started| now.checked_duration_since(started))
-            .unwrap_or_default();
-        self.visible_elapsed.get().saturating_add(current) >= SEARCH_ONBOARDING_TTL
+        match self.selected {
+            0 => OnboardingAction::Back,
+            1 => OnboardingAction::Primary,
+            _ => OnboardingAction::Skip,
+        }
+    }
+
+    fn primary_index(&self) -> usize {
+        1
+    }
+
+    fn action_count(&self) -> usize {
+        if self.skip_confirmation { 2 } else { 3 }
+    }
+
+    fn select_primary(&mut self) {
+        self.selected = self.primary_index();
+    }
+
+    fn select_skip(&mut self) {
+        self.selected = self.action_count().saturating_sub(1);
+    }
+
+    fn move_selection(&mut self, forward: bool) {
+        let count = self.action_count().max(1);
+        self.selected = if forward {
+            (self.selected + 1) % count
+        } else {
+            (self.selected + count - 1) % count
+        };
     }
 }
 
+#[derive(Clone, Copy)]
+pub(in crate::app) struct BeginnerObservation {
+    help_visible: bool,
+    volume: i64,
+}
+
 impl App {
-    /// Arm the hint only for a writable, genuinely fresh profile. A tool-setup card takes
-    /// precedence; dismissing it starts the ten-second clock.
-    pub fn prepare_search_onboarding(&mut self, writable: bool) {
-        self.onboarding.pending = writable && !self.config.search_onboarding_seen;
-        self.arm_search_onboarding();
+    /// Prepare an event-driven tutorial only for a writable profile whose persisted setting is
+    /// explicitly on. Tool setup remains the higher-priority startup surface and arms the coach
+    /// when it is dismissed.
+    pub fn prepare_beginner_onboarding(&mut self, writable: bool) {
+        self.onboarding = OnboardingState::default();
+        if !writable || !self.config.beginner_mode {
+            return;
+        }
+
+        let progress = &self.config.beginner_tutorial;
+        match progress.content_version.cmp(&BEGINNER_TUTORIAL_VERSION) {
+            Ordering::Greater => return,
+            Ordering::Less => {
+                self.config.beginner_tutorial = BeginnerTutorialProgress::welcome();
+                self.onboarding.startup_persist_pending = true;
+            }
+            Ordering::Equal => {
+                if BeginnerStep::from_id(&progress.next_step).is_none() {
+                    self.config.beginner_tutorial = BeginnerTutorialProgress::welcome();
+                    self.onboarding.startup_persist_pending = true;
+                }
+            }
+        }
+
+        let step = BeginnerStep::from_id(&self.config.beginner_tutorial.next_step)
+            .unwrap_or(BeginnerStep::Welcome);
+        self.onboarding.pending = true;
+        self.onboarding.step = step;
+        self.onboarding.target_reached = self.beginner_step_target_reached(step);
+        self.onboarding.guide_focused = step == BeginnerStep::Welcome;
+        self.onboarding.select_primary();
+        self.arm_beginner_onboarding();
     }
 
-    pub(in crate::app) fn arm_search_onboarding(&mut self) {
+    pub(crate) fn take_beginner_startup_persist(&mut self) -> Option<Cmd> {
+        if !std::mem::take(&mut self.onboarding.startup_persist_pending) {
+            return None;
+        }
+        Some(self.persist_beginner_config())
+    }
+
+    pub(in crate::app) fn arm_beginner_onboarding(&mut self) {
         if self.onboarding.pending && !self.onboarding.armed && self.tool_setup.is_none() {
             self.onboarding.armed = true;
             self.dirty = true;
         }
     }
 
-    /// Record whether this frame can show the hint and return the same render verdict. The
-    /// renderer owns the exact cell grid; App owns screen/modal state, so this is their single
-    /// shared eligibility boundary.
-    pub(crate) fn search_onboarding_render_eligible(&self, layout_sufficient: bool) -> bool {
-        self.search_onboarding_render_eligible_at(layout_sufficient, Instant::now())
+    pub fn beginner_coach_visible(&self) -> bool {
+        self.onboarding.visible() && !self.beginner_higher_overlay_open()
     }
 
-    fn search_onboarding_render_eligible_at(&self, layout_sufficient: bool, now: Instant) -> bool {
-        let covering_surface = self.art_overlay_mask() != 0
-            || self.local_mode.pending_confirm.is_some()
+    pub(in crate::app) fn beginner_higher_overlay_open(&self) -> bool {
+        self.tool_setup.is_some()
+            || self.queue_popup.open
+            || self.search_filter.open
+            || self.dropdowns.eq_open
+            || self.dropdowns.streaming_open
+            || self.dropdowns.search_source_open
+            || self.overlays.help_visible
+            || self.overlays.mouse_help_visible
+            || self.overlays.about_visible
+            || self.overlays.why_ai_visible
+            || self.overlays.now_playing_overlay.is_some()
+            || self.overlays.key_conflict.is_some()
+            || self.overlays.pending_settings_confirm.is_some()
             || self.overlays.spotify_picker.is_some()
             || self.overlays.recording_settings.is_some()
             || self.overlays.recordings_browser.is_some()
-            || self.overlays.now_playing_overlay.is_some();
-        let eligible = self.onboarding.visible()
-            && self.mode == Mode::Player
-            && layout_sufficient
-            && !covering_surface;
-        self.onboarding.record_render_eligibility(eligible, now);
-        eligible
+            || self.overlays.context_menu.is_some()
+            || self.radio_mode.pending_radio_mode_confirm.is_some()
+            || self.local_mode.pending_confirm.is_some()
+            || self.local_mode.pending_organize_confirm.is_some()
+            || self.local_mode.pending_accept_all_confirm.is_some()
+            || self.local_mode.pending_import_record_delete.is_some()
+            || self.library_ui.create_input.is_some()
+            || self.library_ui.confirm_playlist_delete.is_some()
+            || self.library_ui.confirm_delete.is_some()
+            || self.library_ui.confirm_download.is_some()
+            || self.playlist_picker.is_some()
+            || self
+                .settings
+                .as_ref()
+                .is_some_and(|state| state.spotify_import_mode_dropdown.is_some())
     }
 
-    pub(in crate::app) fn complete_search_onboarding(&mut self) -> Vec<Cmd> {
-        if !self.onboarding.pending {
+    pub(in crate::app) fn onboarding_observation(&self) -> BeginnerObservation {
+        BeginnerObservation {
+            help_visible: self.overlays.help_visible,
+            volume: self.playback.volume,
+        }
+    }
+
+    pub(in crate::app) fn observe_beginner_tutorial(
+        &mut self,
+        before: BeginnerObservation,
+    ) -> Vec<Cmd> {
+        if !self.onboarding.visible()
+            || self.bridges.ui_tier.get() == crate::ui::layout::UiTier::Mini
+        {
             return Vec::new();
         }
-        self.onboarding = OnboardingState::default();
-        self.config.search_onboarding_seen = true;
-        self.dirty = true;
-        vec![Cmd::Persist(PersistCmd::Config(Box::new(
-            self.config.clone(),
-        )))]
+
+        if self.onboarding.step == BeginnerStep::NavigationHelp
+            && !before.help_visible
+            && self.overlays.help_visible
+        {
+            return self.advance_beginner_step();
+        }
+
+        if self.onboarding.step == BeginnerStep::Player && before.volume != self.playback.volume {
+            self.onboarding_geometry_changed();
+        }
+
+        let reached = self.beginner_step_target_reached(self.onboarding.step);
+        if reached && !self.onboarding.target_reached {
+            self.onboarding.target_reached = true;
+            self.onboarding_geometry_changed();
+        }
+        if self.onboarding.step == BeginnerStep::Settings
+            && self
+                .settings
+                .as_ref()
+                .is_some_and(|state| state.tab != SettingsTab::General)
+            && !self.onboarding.settings_tab_visited
+        {
+            self.onboarding.settings_tab_visited = true;
+            self.onboarding_geometry_changed();
+        }
+        Vec::new()
     }
 
-    pub(in crate::app) fn tick_search_onboarding(&mut self, now: Instant) -> Vec<Cmd> {
-        if self.onboarding.tick_expired(now) {
-            self.complete_search_onboarding()
-        } else {
-            Vec::new()
+    pub(in crate::app) fn on_key_beginner(&mut self, key: KeyEvent) -> Option<Vec<Cmd>> {
+        if !self.beginner_coach_visible() {
+            return None;
         }
+        let chord = Chord::from(key);
+        if matches!(self.keymap.global_action(chord), Some(Action::Quit)) {
+            return Some(self.quit_app());
+        }
+        let mini = self.bridges.ui_tier.get() == crate::ui::layout::UiTier::Mini;
+        if self.onboarding.skip_confirmation {
+            return Some(match key.code {
+                KeyCode::Esc => self.activate_onboarding(OnboardingAction::CancelSkip),
+                KeyCode::Left | KeyCode::Up => {
+                    self.onboarding.move_selection(false);
+                    self.dirty = true;
+                    Vec::new()
+                }
+                KeyCode::Right | KeyCode::Down => {
+                    self.onboarding.move_selection(true);
+                    self.dirty = true;
+                    Vec::new()
+                }
+                KeyCode::Enter => {
+                    let action = self.onboarding.selected_action();
+                    self.activate_onboarding(action)
+                }
+                _ => Vec::new(),
+            });
+        }
+        if mini {
+            if key.code == KeyCode::F(6) {
+                self.onboarding.guide_focused = true;
+                self.onboarding.mini_guide_focused = true;
+                self.onboarding.select_skip();
+                self.dirty = true;
+                return Some(Vec::new());
+            }
+            if self.onboarding.mini_guide_focused {
+                return Some(match key.code {
+                    KeyCode::Enter => self.activate_onboarding(OnboardingAction::Skip),
+                    KeyCode::Esc => {
+                        self.onboarding.guide_focused = false;
+                        self.onboarding.mini_guide_focused = false;
+                        self.dirty = true;
+                        Vec::new()
+                    }
+                    _ => Vec::new(),
+                });
+            }
+            return None;
+        }
+
+        if !self.onboarding.guide_focused {
+            if key.code == KeyCode::F(6) {
+                self.onboarding.guide_focused = true;
+                self.onboarding.mini_guide_focused = false;
+                self.onboarding.select_primary();
+                self.dirty = true;
+                return Some(Vec::new());
+            }
+            return None;
+        }
+
+        Some(match key.code {
+            KeyCode::F(6) => {
+                self.onboarding.guide_focused = false;
+                self.onboarding.mini_guide_focused = false;
+                self.dirty = true;
+                Vec::new()
+            }
+            KeyCode::Esc if self.onboarding.skip_confirmation => {
+                self.activate_onboarding(OnboardingAction::CancelSkip)
+            }
+            KeyCode::Esc => {
+                self.onboarding.guide_focused = false;
+                self.onboarding.mini_guide_focused = false;
+                self.dirty = true;
+                Vec::new()
+            }
+            KeyCode::Left | KeyCode::Up => {
+                self.onboarding.move_selection(false);
+                self.dirty = true;
+                Vec::new()
+            }
+            KeyCode::Right | KeyCode::Down => {
+                self.onboarding.move_selection(true);
+                self.dirty = true;
+                Vec::new()
+            }
+            KeyCode::Enter => self.activate_onboarding(self.onboarding.selected_action()),
+            _ => Vec::new(),
+        })
+    }
+
+    pub(in crate::app) fn activate_onboarding(&mut self, action: OnboardingAction) -> Vec<Cmd> {
+        if !self.onboarding.visible() {
+            return Vec::new();
+        }
+        match action {
+            OnboardingAction::Noop => Vec::new(),
+            OnboardingAction::Primary => self.activate_beginner_primary(),
+            OnboardingAction::Back => self.back_beginner_step(),
+            OnboardingAction::Skip => {
+                self.onboarding.guide_focused_before_skip = self.onboarding.guide_focused;
+                self.onboarding.mini_guide_focused_before_skip = self.onboarding.mini_guide_focused;
+                self.onboarding.skip_confirmation = true;
+                self.onboarding.guide_focused = true;
+                self.onboarding.mini_guide_focused = true;
+                self.onboarding.selected = 0;
+                self.onboarding_geometry_changed();
+                Vec::new()
+            }
+            OnboardingAction::CancelSkip => {
+                self.onboarding.skip_confirmation = false;
+                self.onboarding.guide_focused = self.onboarding.guide_focused_before_skip;
+                self.onboarding.mini_guide_focused = self.onboarding.mini_guide_focused_before_skip;
+                self.onboarding.select_primary();
+                self.onboarding_geometry_changed();
+                Vec::new()
+            }
+            OnboardingAction::ConfirmSkip => self.skip_beginner_tutorial(),
+        }
+    }
+
+    fn activate_beginner_primary(&mut self) -> Vec<Cmd> {
+        match self.onboarding.step {
+            BeginnerStep::Welcome => self.advance_beginner_step(),
+            BeginnerStep::NavigationHelp => {
+                self.overlays.help_visible = true;
+                self.bridges.help_scroll.reset();
+                self.dirty = true;
+                Vec::new()
+            }
+            BeginnerStep::Search if self.onboarding.target_reached => self.advance_beginner_step(),
+            BeginnerStep::Search => self.navigate_to(Mode::Search),
+            BeginnerStep::Player if self.onboarding.target_reached => self.advance_beginner_step(),
+            BeginnerStep::Player => self.navigate_to(Mode::Player),
+            BeginnerStep::Library if self.onboarding.target_reached => self.advance_beginner_step(),
+            BeginnerStep::Library => self.navigate_to(Mode::Library),
+            BeginnerStep::DjGem if self.onboarding.target_reached => self.advance_beginner_step(),
+            BeginnerStep::DjGem => self.navigate_to(Mode::Ai),
+            BeginnerStep::Settings => self.activate_beginner_settings_primary(),
+            BeginnerStep::Finish => self.activate_beginner_finish_primary(),
+        }
+    }
+
+    fn activate_beginner_settings_primary(&mut self) -> Vec<Cmd> {
+        if self.mode != Mode::Settings {
+            return self.navigate_to(Mode::Settings);
+        }
+        let Some(tab) = self.settings.as_ref().map(|state| state.tab) else {
+            return Vec::new();
+        };
+        if !self.onboarding.settings_tab_visited {
+            self.settings_select_tab(SettingsTab::Playback.index());
+            return Vec::new();
+        }
+        if tab != SettingsTab::General {
+            self.settings_select_tab(SettingsTab::General.index());
+            return Vec::new();
+        }
+        let cmds = self.advance_beginner_step();
+        self.focus_beginner_mode_setting();
+        cmds
+    }
+
+    fn activate_beginner_finish_primary(&mut self) -> Vec<Cmd> {
+        if self.mode != Mode::Settings {
+            return self.navigate_to(Mode::Settings);
+        }
+        let ready = self.settings.as_ref().is_some_and(|state| {
+            state.tab == SettingsTab::General && state.current_field() == Some(Field::BeginnerMode)
+        });
+        if !ready {
+            self.focus_beginner_mode_setting();
+            return Vec::new();
+        }
+        if self
+            .settings
+            .as_ref()
+            .is_some_and(|state| !state.draft.beginner_mode)
+        {
+            return self.close_settings();
+        }
+        self.settings_change(1)
+    }
+
+    fn focus_beginner_mode_setting(&mut self) {
+        let Some(state) = self.settings.as_mut() else {
+            return;
+        };
+        state.tab = SettingsTab::General;
+        state.row = SettingsTab::General
+            .fields()
+            .iter()
+            .position(|field| *field == Field::BeginnerMode)
+            .unwrap_or(0);
+        state.editing_text = false;
+        state.capturing = None;
+        self.bridges.reset_settings_scroll();
+        self.onboarding.target_reached = true;
+        self.onboarding_geometry_changed();
+    }
+
+    fn advance_beginner_step(&mut self) -> Vec<Cmd> {
+        let Some(next) = self.onboarding.step.next() else {
+            return Vec::new();
+        };
+        self.set_beginner_step(next);
+        vec![self.persist_beginner_config()]
+    }
+
+    fn back_beginner_step(&mut self) -> Vec<Cmd> {
+        let Some(previous) = self.onboarding.step.previous() else {
+            self.onboarding.select_primary();
+            self.set_status_info(t!("This is the first step", "첫 번째 단계입니다"));
+            return Vec::new();
+        };
+        if self.onboarding.step == BeginnerStep::Finish
+            && let Some(settings) = self.settings.as_mut()
+        {
+            settings.draft.beginner_mode = true;
+            settings.draft.restart_beginner_tutorial = false;
+        }
+        self.set_beginner_step(previous);
+        vec![self.persist_beginner_config()]
+    }
+
+    fn set_beginner_step(&mut self, step: BeginnerStep) {
+        self.config.beginner_tutorial.content_version = BEGINNER_TUTORIAL_VERSION;
+        self.config.beginner_tutorial.next_step = step.id().to_owned();
+        self.onboarding.step = step;
+        self.onboarding.target_reached = self.beginner_step_target_reached(step);
+        self.onboarding.settings_tab_visited = false;
+        self.onboarding.skip_confirmation = false;
+        self.onboarding.guide_focused = step == BeginnerStep::Welcome;
+        self.onboarding.mini_guide_focused = false;
+        self.onboarding.guide_focused_before_skip = false;
+        self.onboarding.mini_guide_focused_before_skip = false;
+        self.onboarding.select_primary();
+        self.onboarding_geometry_changed();
+    }
+
+    fn beginner_step_target_reached(&self, step: BeginnerStep) -> bool {
+        match step {
+            BeginnerStep::Welcome => true,
+            BeginnerStep::NavigationHelp => false,
+            BeginnerStep::Search => self.mode == Mode::Search,
+            BeginnerStep::Player => self.mode == Mode::Player,
+            BeginnerStep::Library => self.mode == Mode::Library,
+            BeginnerStep::DjGem => self.mode == Mode::Ai,
+            BeginnerStep::Settings | BeginnerStep::Finish => self.mode == Mode::Settings,
+        }
+    }
+
+    fn skip_beginner_tutorial(&mut self) -> Vec<Cmd> {
+        self.config.beginner_mode = false;
+        self.config.beginner_tutorial = BeginnerTutorialProgress::welcome();
+        if let Some(settings) = self.settings.as_mut() {
+            settings.draft.beginner_mode = false;
+            settings.draft.restart_beginner_tutorial = false;
+        }
+        self.onboarding = OnboardingState::default();
+        self.set_status_info(t!(
+            "Beginner Mode is off · turn it on in Settings to see the tour again",
+            "비기너 모드를 껐어요 · 설정에서 다시 켜면 튜토리얼을 볼 수 있어요"
+        ));
+        self.request_native_image_clear();
+        vec![self.persist_beginner_config()]
+    }
+
+    pub(in crate::app) fn apply_beginner_mode_settings_transition(
+        &mut self,
+        old_enabled: bool,
+        restart_requested: bool,
+    ) {
+        let tutorial_was_active = self.onboarding.active();
+        if !self.config.beginner_mode {
+            if old_enabled || tutorial_was_active {
+                // A newer build's suppressed cursor is opaque to this binary. Turning the
+                // display mode off must not downgrade that progress; only a tour this build
+                // actually ran owns the Welcome reset.
+                if tutorial_was_active
+                    || self.config.beginner_tutorial.content_version <= BEGINNER_TUTORIAL_VERSION
+                {
+                    self.config.beginner_tutorial = BeginnerTutorialProgress::welcome();
+                }
+                self.onboarding = OnboardingState::default();
+                self.set_status_info(t!(
+                    "Beginner Mode is off · onboarding complete",
+                    "비기너 모드를 껐어요 · 온보딩을 마쳤습니다"
+                ));
+                self.request_native_image_clear();
+            }
+        } else if !old_enabled || restart_requested {
+            self.config.beginner_tutorial = BeginnerTutorialProgress::welcome();
+            self.onboarding = OnboardingState::default();
+            self.set_status_info(t!(
+                "Beginner Mode is on · the tour starts next launch",
+                "비기너 모드를 켰어요 · 다음 실행 때 튜토리얼이 시작됩니다"
+            ));
+        }
+    }
+
+    fn persist_beginner_config(&self) -> Cmd {
+        Cmd::Persist(PersistCmd::Config(Box::new(self.config.clone())))
+    }
+
+    fn onboarding_geometry_changed(&mut self) {
+        if self.native_art_active() {
+            self.request_native_image_clear();
+        }
+        self.dirty = true;
     }
 }
 
@@ -110,26 +639,67 @@ impl App {
 mod tests {
     use super::*;
 
-    #[test]
-    fn search_entry_completes_and_persists_onboarding() {
+    fn beginner_app(step: BeginnerStep) -> App {
         let mut app = App::new(50);
-        app.prepare_search_onboarding(true);
-        assert!(app.onboarding.visible());
-        let cmds = app.complete_search_onboarding();
-        assert!(app.config.search_onboarding_seen);
+        app.config.beginner_mode = true;
+        app.config.beginner_tutorial.next_step = step.id().to_owned();
+        app.prepare_beginner_onboarding(true);
+        app
+    }
+
+    #[test]
+    fn fresh_enabled_profile_starts_and_legacy_safe_default_does_not() {
+        let mut disabled = App::new(50);
+        disabled.prepare_beginner_onboarding(true);
+        assert!(!disabled.onboarding.visible());
+
+        let enabled = beginner_app(BeginnerStep::Welcome);
+        assert!(enabled.onboarding.visible());
+        assert_eq!(enabled.onboarding.step(), BeginnerStep::Welcome);
+        assert!(enabled.onboarding.guide_focused());
+    }
+
+    #[test]
+    fn steps_persist_once_and_resume_the_last_incomplete_step() {
+        let mut app = beginner_app(BeginnerStep::Welcome);
+        let cmds = app.activate_onboarding(OnboardingAction::Primary);
+        assert_eq!(app.config.beginner_tutorial.next_step, "navigation_help");
         assert!(matches!(
             cmds.as_slice(),
             [Cmd::Persist(PersistCmd::Config(_))]
         ));
+
+        let mut resumed = App::new(50);
+        resumed.config = app.config.clone();
+        resumed.prepare_beginner_onboarding(true);
+        assert_eq!(resumed.onboarding.step(), BeginnerStep::NavigationHelp);
     }
 
     #[test]
-    fn search_onboarding_expires_after_ten_visible_seconds() {
-        let mut app = App::new(50);
-        app.prepare_search_onboarding(true);
-        let started = Instant::now();
-        assert!(app.search_onboarding_render_eligible_at(true, started));
-        let cmds = app.tick_search_onboarding(started + Duration::from_secs(10));
+    fn help_open_advances_navigation_step_only_once() {
+        let mut app = beginner_app(BeginnerStep::NavigationHelp);
+        let before = app.onboarding_observation();
+        app.overlays.help_visible = true;
+        let cmds = app.observe_beginner_tutorial(before);
+        assert_eq!(app.onboarding.step(), BeginnerStep::Search);
+        assert_eq!(cmds.len(), 1);
+        assert!(
+            app.observe_beginner_tutorial(app.onboarding_observation())
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn skip_disables_mode_resets_progress_and_mirrors_settings() {
+        let mut app = beginner_app(BeginnerStep::Player);
+        app.open_settings();
+        let cmds = app.activate_onboarding(OnboardingAction::ConfirmSkip);
+        assert!(!app.config.beginner_mode);
+        assert_eq!(
+            app.config.beginner_tutorial,
+            BeginnerTutorialProgress::welcome()
+        );
+        assert!(!app.settings.as_ref().unwrap().draft.beginner_mode);
         assert!(!app.onboarding.visible());
         assert!(matches!(
             cmds.as_slice(),
@@ -138,26 +708,79 @@ mod tests {
     }
 
     #[test]
-    fn hidden_intervals_do_not_consume_the_onboarding_ttl() {
+    fn old_progress_normalizes_but_future_progress_is_preserved_and_suppressed() {
+        let mut old = App::new(50);
+        old.config.beginner_mode = true;
+        old.config.beginner_tutorial.content_version = 0;
+        old.config.beginner_tutorial.next_step = "old_step".to_owned();
+        old.prepare_beginner_onboarding(true);
+        assert!(old.onboarding.visible());
+        assert_eq!(
+            old.config.beginner_tutorial,
+            BeginnerTutorialProgress::welcome()
+        );
+        assert!(old.take_beginner_startup_persist().is_some());
+
+        let mut future = App::new(50);
+        future.config.beginner_mode = true;
+        future.config.beginner_tutorial.content_version = BEGINNER_TUTORIAL_VERSION + 1;
+        future.config.beginner_tutorial.next_step = "future_step".to_owned();
+        future.prepare_beginner_onboarding(true);
+        assert!(!future.onboarding.visible());
+        assert_eq!(future.config.beginner_tutorial.next_step, "future_step");
+        assert!(future.take_beginner_startup_persist().is_none());
+    }
+
+    #[test]
+    fn readonly_instance_never_arms_or_normalizes() {
         let mut app = App::new(50);
-        app.prepare_search_onboarding(true);
-        let started = Instant::now();
-        assert!(app.search_onboarding_render_eligible_at(true, started));
+        app.config.beginner_mode = true;
+        app.config.beginner_tutorial.content_version = 0;
+        app.prepare_beginner_onboarding(false);
+        assert!(!app.onboarding.visible());
+        assert_eq!(app.config.beginner_tutorial.content_version, 0);
+    }
 
-        app.mode = Mode::Library;
-        assert!(!app.search_onboarding_render_eligible_at(true, started + Duration::from_secs(4)));
-        assert!(
-            app.tick_search_onboarding(started + Duration::from_secs(30))
-                .is_empty()
-        );
+    #[test]
+    fn tool_setup_defers_the_tour_until_the_setup_card_closes() {
+        let mut app = App::new(50);
+        app.config.beginner_mode = true;
+        app.show_tool_setup(ToolSetupContext::Startup, vec!["mpv"]);
+        app.prepare_beginner_onboarding(true);
+        assert!(!app.onboarding.visible());
 
-        app.mode = Mode::Player;
-        assert!(app.search_onboarding_render_eligible_at(true, started + Duration::from_secs(30)));
-        assert!(
-            app.tick_search_onboarding(started + Duration::from_secs(35))
-                .is_empty()
-        );
-        let cmds = app.tick_search_onboarding(started + Duration::from_secs(36));
+        app.activate_tool_setup(MouseTarget::ToolSetupLater);
+        assert!(app.onboarding.visible());
+    }
+
+    #[test]
+    fn mini_tier_pauses_observation_without_losing_the_step() {
+        let mut app = beginner_app(BeginnerStep::Search);
+        app.bridges.ui_tier.set(crate::ui::layout::UiTier::Mini);
+        app.mode = Mode::Search;
+        let before = app.onboarding_observation();
+        assert!(app.observe_beginner_tutorial(before).is_empty());
+        assert_eq!(app.onboarding.step(), BeginnerStep::Search);
+        assert!(!app.onboarding.target_reached());
+
+        app.bridges.ui_tier.set(crate::ui::layout::UiTier::Full);
+        app.observe_beginner_tutorial(before);
+        assert!(app.onboarding.target_reached());
+    }
+
+    #[test]
+    fn skip_confirmation_keeps_keyboard_focus_until_cancel_or_confirm() {
+        let mut app = beginner_app(BeginnerStep::Welcome);
+        app.activate_onboarding(OnboardingAction::Skip);
+        assert!(app.onboarding.skip_confirmation());
+
+        app.on_key_beginner(KeyEvent::new(KeyCode::F(6), KeyModifiers::NONE));
+        assert!(app.onboarding.guide_focused());
+        app.on_key_beginner(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        let cmds = app
+            .on_key_beginner(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .unwrap();
+        assert!(!app.config.beginner_mode);
         assert!(matches!(
             cmds.as_slice(),
             [Cmd::Persist(PersistCmd::Config(_))]
@@ -165,32 +788,48 @@ mod tests {
     }
 
     #[test]
-    fn small_layouts_and_covering_modals_pause_the_onboarding_ttl() {
-        let mut app = App::new(50);
-        app.prepare_search_onboarding(true);
-        let started = Instant::now();
-        assert!(app.search_onboarding_render_eligible_at(true, started));
+    fn mini_welcome_keeps_app_keys_live_until_f6_explicitly_focuses_skip() {
+        let mut app = beginner_app(BeginnerStep::Welcome);
+        app.bridges.ui_tier.set(crate::ui::layout::UiTier::Mini);
+        let ordinary = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE);
+        assert!(app.on_key_beginner(ordinary).is_none());
 
-        assert!(!app.search_onboarding_render_eligible_at(false, started + Duration::from_secs(3)));
         assert!(
-            app.tick_search_onboarding(started + Duration::from_secs(20))
+            app.on_key_beginner(KeyEvent::new(KeyCode::F(6), KeyModifiers::NONE))
+                .is_some()
+        );
+        assert!(app.onboarding.guide_focused_for(true));
+        assert!(app.on_key_beginner(ordinary).is_some());
+        app.on_key_beginner(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(!app.onboarding.guide_focused_for(true));
+        assert!(app.on_key_beginner(ordinary).is_none());
+    }
+
+    #[test]
+    fn cancelling_mouse_skip_restores_the_previous_surface_focus() {
+        let mut app = beginner_app(BeginnerStep::Search);
+        assert!(!app.onboarding.guide_focused());
+        app.activate_onboarding(OnboardingAction::Skip);
+        app.activate_onboarding(OnboardingAction::CancelSkip);
+        assert!(!app.onboarding.guide_focused());
+
+        app.onboarding.guide_focused = true;
+        app.activate_onboarding(OnboardingAction::Skip);
+        app.activate_onboarding(OnboardingAction::CancelSkip);
+        assert!(app.onboarding.guide_focused());
+    }
+
+    #[test]
+    fn finish_primary_can_toggle_the_setting_before_saving() {
+        let mut app = beginner_app(BeginnerStep::Finish);
+        app.open_settings();
+        app.focus_beginner_mode_setting();
+        assert!(app.settings.as_ref().unwrap().draft.beginner_mode);
+        assert!(
+            app.activate_onboarding(OnboardingAction::Primary)
                 .is_empty()
         );
-
-        assert!(app.search_onboarding_render_eligible_at(true, started + Duration::from_secs(20)));
-        app.show_tool_setup(ToolSetupContext::Startup, vec!["mpv"]);
-        assert!(!app.search_onboarding_render_eligible_at(true, started + Duration::from_secs(22)));
-        assert!(
-            app.tick_search_onboarding(started + Duration::from_secs(40))
-                .is_empty()
-        );
-
-        app.tool_setup = None;
-        assert!(app.search_onboarding_render_eligible_at(true, started + Duration::from_secs(40)));
-        let cmds = app.tick_search_onboarding(started + Duration::from_secs(45));
-        assert!(matches!(
-            cmds.as_slice(),
-            [Cmd::Persist(PersistCmd::Config(_))]
-        ));
+        assert!(!app.settings.as_ref().unwrap().draft.beginner_mode);
+        assert!(app.onboarding.active());
     }
 }

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -696,7 +696,6 @@ impl App {
                 Vec::new()
             }
             Action::OpenSearch => {
-                let cmds = self.complete_search_onboarding();
                 self.mode = Mode::Search;
                 self.search.focus = SearchFocus::Input;
                 let search = self.search_config_for_mode();
@@ -705,7 +704,7 @@ impl App {
                 self.dropdowns.streaming_open = false;
                 self.dropdowns.search_source_open = false;
                 self.dirty = true;
-                cmds
+                Vec::new()
             }
             // `P` opens the add-to-playlist picker for the track that's playing.
             Action::AddToPlaylist => {

--- a/src/app/reducer.rs
+++ b/src/app/reducer.rs
@@ -16,6 +16,7 @@ impl App {
         // without a terminal resize). Apply the bridged tier before routing this event so a
         // hidden Search/DJ input cannot consume the first global key after entering Mini.
         self.sync_ui_tier();
+        let beginner_before = self.onboarding_observation();
         let admitted_seek = matches!(
             &msg,
             Msg::Player(PlayerMsg::IntentAdmitted(commit)) if commit.is_seek()
@@ -31,7 +32,8 @@ impl App {
         // an error set by one of the ~40 plain `self.status.text = …` sites can never inherit a
         // leftover `Info` color from a previous green toast.
         self.status.kind = StatusKind::Error;
-        let cmds = self.dispatch(msg);
+        let mut cmds = self.dispatch(msg);
+        cmds.extend(self.observe_beginner_tutorial(beginner_before));
         if self.status.text.is_empty()
             && let Some(warning) = self.recorder.health_warning.as_ref()
         {
@@ -176,7 +178,7 @@ impl App {
                         self.dirty = true;
                     }
                 }
-                return self.tick_search_onboarding(Instant::now());
+                return Vec::new();
             }
             Msg::AnimTick => {
                 // Advance the logical animation phase on every configured tick, but only request

--- a/src/app/settings_audio.rs
+++ b/src/app/settings_audio.rs
@@ -58,6 +58,7 @@ enum SettingsAudioPreviewApply {
 #[derive(Clone, PartialEq)]
 struct SettingsResetGuard {
     projected: Vec<u8>,
+    restart_beginner_tutorial: bool,
     tab: SettingsTab,
     row: usize,
     editing_text: bool,
@@ -71,6 +72,7 @@ impl SettingsResetGuard {
     fn capture(config: &Config, state: &SettingsState) -> Self {
         Self {
             projected: settings_projection(config, state),
+            restart_beginner_tutorial: state.draft.restart_beginner_tutorial,
             tab: state.tab,
             row: state.row,
             editing_text: state.editing_text,
@@ -83,6 +85,7 @@ impl SettingsResetGuard {
 
     fn matches(&self, config: &Config, state: &SettingsState) -> bool {
         self.projected == settings_projection(config, state)
+            && self.restart_beginner_tutorial == state.draft.restart_beginner_tutorial
             && self.tab == state.tab
             && self.row == state.row
             && self.editing_text == state.editing_text
@@ -362,6 +365,8 @@ impl App {
                 SettingsAudioSnapshot::from_draft(&current.draft) == plan.expected_draft
                     && SettingsAudioSnapshot::from_live(self) == plan.expected_live
                     && settings_projection(&self.config, current) == plan.expected_settings
+                    && current.draft.restart_beginner_tutorial
+                        == plan.settings.draft.restart_beginner_tutorial
             })
     }
 
@@ -436,6 +441,10 @@ fn settings_projection(config: &Config, state: &SettingsState) -> Vec<u8> {
 fn reset_settings_state(state: &mut SettingsState) {
     let defaults = Config::default();
     let draft = &mut state.draft;
+    // Reset All is a user-facing factory reset, unlike `Config::default()`'s conservative
+    // legacy/recovery baseline: it opts into Beginner Mode and schedules a Welcome restart.
+    draft.beginner_mode = true;
+    draft.restart_beginner_tutorial = true;
     draft.cookies_file = String::new();
     draft.download_dir = String::new();
     draft.search = defaults.effective_search();
@@ -647,6 +656,8 @@ mod tests {
             assert_eq!(draft.speed, 1.8);
             assert_eq!(draft.eq_bands[0], 6.0);
             assert_eq!(draft.gemini_api_key, "keep-me");
+            assert!(!draft.beginner_mode);
+            assert!(!draft.restart_beginner_tutorial);
             assert_eq!(app.playback.speed, 1.0);
         }
 
@@ -666,6 +677,8 @@ mod tests {
         let draft = &app.settings.as_deref().unwrap().draft;
         assert_eq!(draft.speed, 1.0);
         assert!(draft.gemini_api_key.is_empty());
+        assert!(draft.beginner_mode);
+        assert!(draft.restart_beginner_tutorial);
         assert_eq!(app.playback.speed, 1.0);
         assert_eq!(app.config.speed, None);
     }

--- a/src/app/settings_reducer.rs
+++ b/src/app/settings_reducer.rs
@@ -105,6 +105,8 @@ impl App {
             &cfg_spotify_client_id,
         );
         let draft = SettingsDraft {
+            beginner_mode: self.config.beginner_mode,
+            restart_beginner_tutorial: false,
             cookies_file: path_str(&self.config.cookies_file),
             download_dir: path_str(&self.config.download_dir),
             local_include_download_dir: self.config.local.include_download_dir(),
@@ -505,6 +507,15 @@ impl App {
         };
         self.dirty = true;
         match field {
+            Field::BeginnerMode => {
+                let s = self.settings_mut();
+                let was_enabled = s.draft.beginner_mode;
+                s.draft.beginner_mode = !was_enabled;
+                if !was_enabled {
+                    s.draft.restart_beginner_tutorial = true;
+                }
+                Vec::new()
+            }
             Field::Mouse => {
                 let s = self.settings_mut();
                 s.draft.mouse = !s.draft.mouse;
@@ -1827,6 +1838,7 @@ impl App {
         let model_changed = self.ai.model != d.gemini_model;
         self.ai.model = d.gemini_model;
         let old_key = self.config.gemini_api_key.clone();
+        let old_beginner_mode = self.config.beginner_mode;
         let old_ai_enabled = self.config.effective_ai_enabled();
         let old_romanized_titles = self.config.effective_romanized_titles();
         let old_download_dir = self.config.effective_download_dir();
@@ -1890,6 +1902,12 @@ impl App {
             )
             .to_owned();
         }
+        // The transition owns tutorial completion/restart and its user-facing toast. Keep it
+        // after the generic save message but before cloning the one persisted Config snapshot.
+        self.apply_beginner_mode_settings_transition(
+            old_beginner_mode,
+            d.restart_beginner_tutorial,
+        );
         let mut cmds = vec![Cmd::Persist(PersistCmd::Config(Box::new(
             self.config.clone(),
         )))];

--- a/src/app/tests/art_overlay.rs
+++ b/src/app/tests/art_overlay.rs
@@ -53,6 +53,42 @@ fn named_overlay_transitions_request_one_full_clear_when_native_art_is_active() 
 }
 
 #[test]
+fn beginner_overlay_open_and_close_clear_native_art() {
+    use super::artwork::ART_OVERLAY_BEGINNER_BIT;
+
+    let mut app = app_playing(1, 0);
+    make_test_art_active(&mut app, ratatui_image::picker::ProtocolType::Sixel);
+    app.config.beginner_mode = true;
+
+    app.prepare_beginner_onboarding(true);
+    app.sync_art_overlay_state();
+    assert_eq!(app.art.overlay_mask, ART_OVERLAY_BEGINNER_BIT);
+    assert!(app.take_clear_before_draw());
+    assert!(!app.take_clear_before_draw());
+
+    app.onboarding = OnboardingState::default();
+    app.sync_art_overlay_state();
+    assert_eq!(app.art.overlay_mask, 0);
+    assert!(app.take_clear_before_draw());
+    assert!(!app.take_clear_before_draw());
+}
+
+#[test]
+fn beginner_player_anchor_volume_change_requests_native_art_clear() {
+    let mut app = app_playing(1, 0);
+    make_test_art_active(&mut app, ratatui_image::picker::ProtocolType::Sixel);
+    app.config.beginner_mode = true;
+    app.config.beginner_tutorial.next_step = "player".to_owned();
+    app.prepare_beginner_onboarding(true);
+    let before = app.onboarding_observation();
+    app.playback.volume = 90;
+
+    assert!(app.observe_beginner_tutorial(before).is_empty());
+    assert!(app.take_clear_before_draw());
+    assert!(!app.take_clear_before_draw());
+}
+
+#[test]
 fn art_overlay_transition_does_not_clear_without_art() {
     let mut app = app_playing(1, 0);
 

--- a/src/app/tests/beginner_settings.rs
+++ b/src/app/tests/beginner_settings.rs
@@ -1,0 +1,155 @@
+use super::*;
+
+fn close_settings_and_admit(app: &mut App) -> Vec<Cmd> {
+    let mut cmds = app.update(Msg::Key(key(KeyCode::Char('q'))));
+    admit_player_transition(app, &mut cmds);
+    cmds
+}
+
+#[test]
+fn beginner_mode_toggle_previews_live_and_reenable_requests_restart() {
+    let mut app = app_playing(1, 0);
+    app.config.beginner_mode = false;
+    app.update(Msg::Key(key(KeyCode::Char('o'))));
+    assert_eq!(
+        app.settings.as_ref().unwrap().current_field(),
+        Some(Field::BeginnerMode)
+    );
+    assert!(!app.beginner_mode());
+
+    app.update(Msg::Key(key(KeyCode::Right)));
+    assert!(
+        app.beginner_mode(),
+        "the Settings draft previews immediately"
+    );
+    assert!(
+        app.settings
+            .as_ref()
+            .unwrap()
+            .draft
+            .restart_beginner_tutorial
+    );
+}
+
+#[test]
+fn saving_while_beginner_mode_is_already_off_preserves_future_progress() {
+    let mut app = app_playing(1, 0);
+    app.config.beginner_mode = false;
+    app.config.beginner_tutorial = crate::config::BeginnerTutorialProgress {
+        content_version: crate::config::BEGINNER_TUTORIAL_VERSION + 1,
+        next_step: "future_spatial_mixer".to_owned(),
+    };
+
+    app.update(Msg::Key(key(KeyCode::Char('o'))));
+    let cmds = close_settings_and_admit(&mut app);
+    let saved = save_config(&cmds).expect("a SaveConfig cmd");
+    assert!(!saved.beginner_mode);
+    assert_eq!(saved.beginner_tutorial, app.config.beginner_tutorial);
+    assert_eq!(saved.beginner_tutorial.next_step, "future_spatial_mixer");
+}
+
+#[test]
+fn disabling_suppressed_future_beginner_mode_preserves_its_opaque_cursor() {
+    let mut app = app_playing(1, 0);
+    app.config.beginner_mode = true;
+    app.config.beginner_tutorial = crate::config::BeginnerTutorialProgress {
+        content_version: crate::config::BEGINNER_TUTORIAL_VERSION + 1,
+        next_step: "future_spatial_mixer".to_owned(),
+    };
+    app.prepare_beginner_onboarding(true);
+    assert!(!app.onboarding.active());
+
+    app.update(Msg::Key(key(KeyCode::Char('o'))));
+    app.update(Msg::Key(key(KeyCode::Right)));
+    let cmds = close_settings_and_admit(&mut app);
+    let saved = save_config(&cmds).expect("a SaveConfig cmd");
+    assert!(!saved.beginner_mode);
+    assert_eq!(
+        saved.beginner_tutorial.content_version,
+        crate::config::BEGINNER_TUTORIAL_VERSION + 1
+    );
+    assert_eq!(saved.beginner_tutorial.next_step, "future_spatial_mixer");
+}
+
+#[test]
+fn saving_reenabled_beginner_mode_schedules_welcome_for_next_launch_only() {
+    let mut app = app_playing(1, 0);
+    app.config.beginner_mode = false;
+    app.config.beginner_tutorial.next_step = "library".to_owned();
+    app.update(Msg::Key(key(KeyCode::Char('o'))));
+    app.update(Msg::Key(key(KeyCode::Right)));
+
+    let cmds = close_settings_and_admit(&mut app);
+    let saved = save_config(&cmds).expect("a SaveConfig cmd");
+    assert!(saved.beginner_mode);
+    assert_eq!(
+        saved.beginner_tutorial,
+        crate::config::BeginnerTutorialProgress::welcome()
+    );
+    assert!(
+        !app.onboarding.active(),
+        "re-enabling must not launch the tour in the current session"
+    );
+}
+
+#[test]
+fn active_tour_finishes_only_after_beginner_mode_save_is_admitted() {
+    let mut app = app_playing(1, 0);
+    app.config.beginner_mode = true;
+    app.config.beginner_tutorial.next_step = "finish".to_owned();
+    app.prepare_beginner_onboarding(true);
+    assert!(app.onboarding.active());
+
+    app.open_settings();
+    focus_settings_field(&mut app, SettingsTab::General, Field::BeginnerMode);
+    app.update(Msg::Key(key(KeyCode::Right)));
+    assert!(!app.settings.as_ref().unwrap().draft.beginner_mode);
+
+    let mut cmds = app.update(Msg::Key(key(KeyCode::Char('q'))));
+    assert!(
+        app.config.beginner_mode,
+        "the rejected-or-pending save must leave persisted state untouched"
+    );
+    assert!(app.onboarding.active());
+    assert!(save_config(&cmds).is_none());
+
+    admit_player_transition(&mut app, &mut cmds);
+    assert!(!app.config.beginner_mode);
+    assert_eq!(
+        app.config.beginner_tutorial,
+        crate::config::BeginnerTutorialProgress::welcome()
+    );
+    assert!(!app.onboarding.active());
+    assert_eq!(
+        cmds.iter()
+            .filter(|cmd| matches!(cmd, Cmd::Persist(PersistCmd::Config(_))))
+            .count(),
+        1,
+        "an admitted completion persists one final Config snapshot"
+    );
+}
+
+#[test]
+fn rejected_beginner_completion_keeps_the_tour_and_settings_draft_open() {
+    let mut app = app_playing(1, 0);
+    app.config.beginner_mode = true;
+    app.config.beginner_tutorial.next_step = "finish".to_owned();
+    app.prepare_beginner_onboarding(true);
+    app.open_settings();
+    focus_settings_field(&mut app, SettingsTab::General, Field::BeginnerMode);
+    app.update(Msg::Key(key(KeyCode::Right)));
+
+    let cmds = app.update(Msg::Key(key(KeyCode::Char('q'))));
+    assert!(
+        reject_player_transition(&mut app, cmds, crate::util::delivery::DeliveryError::Busy,)
+            .is_empty()
+    );
+    assert!(app.config.beginner_mode);
+    assert_eq!(app.config.beginner_tutorial.next_step, "finish");
+    assert!(app.onboarding.active());
+    assert!(
+        app.settings
+            .as_ref()
+            .is_some_and(|settings| { !settings.draft.beginner_mode })
+    );
+}

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -12,6 +12,7 @@ use support::*;
 mod ai;
 mod animations;
 mod art_overlay;
+mod beginner_settings;
 mod context_menu;
 mod docked_bar;
 mod downloads;

--- a/src/app/tests/render_hit_targets.rs
+++ b/src/app/tests/render_hit_targets.rs
@@ -122,6 +122,172 @@ fn volume_flash_geometry_is_stable_and_off_mode_keeps_legacy_layout() {
 }
 
 #[test]
+fn beginner_control_row_tracks_volume_rebinds_and_responsive_fallbacks() {
+    let _guard = crate::i18n::lock_for_test();
+    crate::i18n::set_language(crate::i18n::Language::English);
+    let mut app = app_playing(2, 0);
+    app.config.beginner_mode = true;
+    app.config.player_bar_position = Some(crate::config::PlayerBarPosition::Top);
+    let buf = render_app_buffer(&app, 80, 20);
+    let row = (0..80).map(|x| buf[(x, 6)].symbol()).collect::<String>();
+    assert!(row.contains("Volume  [↓] - 100% + [↑]"), "got {row:?}");
+    assert!(
+        app.hits
+            .rect_of_target(MouseTarget::VolumeArea)
+            .is_some_and(|rect| rect.width > 0)
+    );
+
+    // The Player block contributes two border cells, leaving a 35-cell control area.
+    let narrow = render_app_buffer(&app, 37, 20);
+    let narrow_row = (0..37).map(|x| narrow[(x, 6)].symbol()).collect::<String>();
+    assert!(
+        narrow_row.contains("vol  [↓] - 100% + [↑]"),
+        "got {narrow_row:?}"
+    );
+
+    app.keymap
+        .rebind(
+            KeyContext::Player,
+            Action::VolDown,
+            crate::keymap::parse_chord("f8").unwrap(),
+        )
+        .unwrap();
+    app.keymap
+        .rebind(
+            KeyContext::Player,
+            Action::VolUp,
+            crate::keymap::parse_chord("f9").unwrap(),
+        )
+        .unwrap();
+    let rebound = render_app_buffer(&app, 80, 20);
+    let rebound_row = (0..80)
+        .map(|x| rebound[(x, 6)].symbol())
+        .collect::<String>();
+    assert!(
+        rebound_row.contains("Volume  [F8] - 100% + [F9]"),
+        "got {rebound_row:?}"
+    );
+
+    let mini = render_app_buffer(&app, 28, 8);
+    let mini_row = (0..28).map(|x| mini[(x, 2)].symbol()).collect::<String>();
+    assert!(mini_row.contains("vol  - 100% +"), "got {mini_row:?}");
+    assert!(!mini_row.contains("[F"), "got {mini_row:?}");
+
+    app.keymap.unbind(KeyContext::Player, Action::VolDown);
+    let unbound = render_app_buffer(&app, 80, 20);
+    let unbound_row = (0..80)
+        .map(|x| unbound[(x, 6)].symbol())
+        .collect::<String>();
+    assert!(
+        unbound_row.contains("Volume  - 100% + [F9]"),
+        "got {unbound_row:?}"
+    );
+    assert!(!unbound_row.contains("[F8]"), "got {unbound_row:?}");
+}
+
+#[test]
+fn beginner_status_buttons_use_accent_bold_without_changing_off_mode() {
+    let _guard = crate::i18n::lock_for_test();
+    let mut app = app_playing(2, 0);
+    app.config.beginner_mode = true;
+    app.config.player_bar_position = Some(crate::config::PlayerBarPosition::Top);
+    let beginner = render_app_buffer(&app, 100, 20);
+    let rect = app
+        .hits
+        .rect_of_target(MouseTarget::Player(Action::ToggleShuffle))
+        .expect("beginner Shuffle hit target");
+    let cell = beginner
+        .cell((rect.x, rect.y))
+        .expect("Shuffle starts inside the buffer");
+    assert_eq!(cell.fg, app.theme.color(crate::theme::ThemeRole::Accent));
+    assert!(cell.modifier.contains(ratatui::style::Modifier::BOLD));
+
+    app.config.beginner_mode = false;
+    let legacy = render_app_buffer(&app, 100, 20);
+    let rect = app
+        .hits
+        .rect_of_target(MouseTarget::Player(Action::ToggleShuffle))
+        .expect("legacy shuffle hit target");
+    let cell = legacy
+        .cell((rect.x, rect.y))
+        .expect("shuffle starts inside the buffer");
+    assert_eq!(
+        cell.fg,
+        app.theme.color(crate::theme::ThemeRole::PlayerLabel)
+    );
+    assert!(!cell.modifier.contains(ratatui::style::Modifier::BOLD));
+}
+
+#[test]
+fn beginner_coach_actions_fit_the_full_minimum_and_mini_only_offers_skip() {
+    let _guard = crate::i18n::lock_for_test();
+    let mut app = app_playing(1, 0);
+    app.config.beginner_mode = true;
+    app.prepare_beginner_onboarding(true);
+
+    let _ = render_app_buffer(&app, 32, 14);
+    let full_regions = app
+        .hits
+        .regions()
+        .iter()
+        .filter(|region| matches!(region.target, MouseTarget::Onboarding(_)))
+        .cloned()
+        .collect::<Vec<_>>();
+    for action in [
+        OnboardingAction::Noop,
+        OnboardingAction::Back,
+        OnboardingAction::Primary,
+        OnboardingAction::Skip,
+    ] {
+        assert!(
+            full_regions
+                .iter()
+                .any(|region| region.target == MouseTarget::Onboarding(action)),
+            "minimum full layout omitted {action:?}: {full_regions:?}"
+        );
+    }
+    assert!(full_regions.iter().all(|region| {
+        let rect = region.rect;
+        rect.width > 0 && rect.height > 0 && rect.right() <= 32 && rect.bottom() <= 14
+    }));
+
+    let _ = render_app_buffer(&app, 31, 14);
+    let mini_actions = app
+        .hits
+        .regions()
+        .iter()
+        .filter_map(|region| match region.target {
+            MouseTarget::Onboarding(OnboardingAction::Noop) => None,
+            MouseTarget::Onboarding(action) => Some(action),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(mini_actions, vec![OnboardingAction::Skip]);
+}
+
+#[test]
+fn minimum_full_finish_primary_turns_beginner_mode_off_for_mouse_users() {
+    let mut app = app_playing(1, 0);
+    app.config.beginner_mode = true;
+    app.config.beginner_tutorial.next_step = "finish".to_owned();
+    app.prepare_beginner_onboarding(true);
+    app.open_settings();
+    focus_settings_field(&mut app, SettingsTab::General, Field::BeginnerMode);
+    let _ = render_app_buffer(&app, 32, 14);
+    let button = app
+        .hits
+        .regions()
+        .iter()
+        .find(|region| region.target == MouseTarget::Onboarding(OnboardingAction::Primary))
+        .cloned()
+        .expect("Finish primary button");
+
+    app.on_mouse_click(button.rect.x, button.rect.y, false);
+    assert!(!app.settings.as_ref().unwrap().draft.beginner_mode);
+    assert!(app.onboarding.active(), "saving is still required");
+}
+
+#[test]
 fn rendering_settings_registers_clickable_controls() {
     // Each control kind must publish its own hit target *on top of* the row-select rect, so a
     // click changes/activates the value rather than only moving the cursor onto it.
@@ -485,6 +651,11 @@ fn art_overlay_mask_tracks_each_popup_independently() {
     app.show_tool_setup(ToolSetupContext::Startup, vec!["mpv"]);
     assert_eq!(app.art_overlay_mask(), ART_OVERLAY_TOOL_SETUP_BIT);
     app.tool_setup = None;
+    app.config.beginner_mode = true;
+    app.prepare_beginner_onboarding(true);
+    assert!(app.onboarding.visible());
+    assert_eq!(app.art_overlay_mask(), ART_OVERLAY_BEGINNER_BIT);
+    app.onboarding = OnboardingState::default();
     app.overlays.key_conflict = Some(Conflict {
         ctx: KeyContext::Player,
         existing: Action::TogglePause,

--- a/src/app/tests/settings_ui.rs
+++ b/src/app/tests/settings_ui.rs
@@ -613,9 +613,7 @@ fn streaming_source_cycles_on_general_tab_and_persists() {
     let mut app = app_playing(1, 0);
     app.update(Msg::Key(key(KeyCode::Char('o')))); // open settings (General)
     assert_eq!(app.settings.as_ref().unwrap().tab, SettingsTab::General);
-    // Fields: Language(0), SearchSource(1), StreamingSource(2).
-    app.update(Msg::Key(key(KeyCode::Down)));
-    app.update(Msg::Key(key(KeyCode::Down)));
+    focus_current_settings_field(&mut app, Field::StreamingSource);
     app.update(Msg::Key(key(KeyCode::Right))); // YouTube -> SoundCloud
     assert_eq!(
         app.settings.as_ref().unwrap().draft.search.streaming_source,
@@ -1049,6 +1047,8 @@ fn reset_all_button_confirms_then_restores_defaults() {
     assert!((d.speed - 1.0).abs() < 1e-9);
     assert!((d.seek_seconds - 10.0).abs() < 1e-9);
     assert!(d.gemini_api_key.is_empty());
+    assert!(d.beginner_mode);
+    assert!(d.restart_beginner_tutorial);
 }
 
 #[test]
@@ -1233,7 +1233,7 @@ fn settings_preset_selector_snaps_from_custom_to_flat() {
 #[test]
 fn settings_text_field_edits_path_buffer() {
     let mut app = app_playing(1, 0);
-    app.update(Msg::Key(key(KeyCode::Char('o')))); // open (General); row 0 = language
+    app.update(Msg::Key(key(KeyCode::Char('o')))); // open (General)
     let cookies_row = SettingsTab::General
         .fields()
         .iter()

--- a/src/app/tool_setup.rs
+++ b/src/app/tool_setup.rs
@@ -97,7 +97,7 @@ impl App {
                         "Playback tools are ready",
                         "재생 도구가 준비되었습니다"
                     ));
-                    self.arm_search_onboarding();
+                    self.arm_beginner_onboarding();
                     if prompt.context == ToolSetupContext::Downloads {
                         return self.pump_downloads();
                     }
@@ -122,7 +122,7 @@ impl App {
                     self.downloads.pending.clear();
                 }
                 self.tool_setup = None;
-                self.arm_search_onboarding();
+                self.arm_beginner_onboarding();
                 self.dirty = true;
             }
             _ => return Vec::new(),

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -528,6 +528,17 @@ pub enum ImportReviewAction {
     Skip,
 }
 
+/// A button or blocker on the interactive Beginner Mode coach card.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnboardingAction {
+    Noop,
+    Primary,
+    Back,
+    Skip,
+    ConfirmSkip,
+    CancelSkip,
+}
+
 /// A clickable terminal region's semantic target.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MouseTarget {
@@ -537,6 +548,9 @@ pub enum MouseTarget {
     ToolSetupGuide,
     ToolSetupRetry,
     ToolSetupLater,
+    /// A control on the Beginner Mode coach card. `Noop` seals the card body against
+    /// click-through; the remaining actions are rendered as explicit buttons on top.
+    Onboarding(OnboardingAction),
     Global(Action),
     Player(Action),
     /// Open/close the EQ preset dropdown on the player status line (clicking the `eq:` label).

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,36 @@ pub use spotify::SpotifyImportMode;
 pub const SPEED_MIN: f64 = 0.5;
 pub const SPEED_MAX: f64 = 2.0;
 
+/// Version of the interactive Beginner Mode walkthrough shipped by this build. Bump this only
+/// when the ordered steps or their completion contracts change; copy-only edits must not make a
+/// user repeat the tour.
+pub const BEGINNER_TUTORIAL_VERSION: u16 = 1;
+
+/// Persisted Beginner Mode walkthrough cursor. The step stays a string deliberately: a newer
+/// build may write a step this build does not know, and retaining that value lets the app decline
+/// to run an incompatible future tour without destroying its progress on the next settings save.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BeginnerTutorialProgress {
+    pub content_version: u16,
+    pub next_step: String,
+}
+
+impl BeginnerTutorialProgress {
+    pub fn welcome() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for BeginnerTutorialProgress {
+    fn default() -> Self {
+        Self {
+            content_version: BEGINNER_TUTORIAL_VERSION,
+            next_step: "welcome".to_owned(),
+        }
+    }
+}
+
 /// Upper bound on `config.json` when loading. The config holds a handful of settings and EQ
 /// bands — nothing legitimate approaches this — so a larger file (corrupt or hostile) is
 /// treated like an unreadable one and rebuilt rather than read wholesale into memory.
@@ -591,10 +621,12 @@ impl ToolsConfig {
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
-    /// Whether the one-shot Search onboarding hint has been completed. Missing values belong to
-    /// pre-onboarding config files and deserialize as `true`; a genuinely fresh default is false.
-    #[serde(default = "legacy_search_onboarding_seen")]
-    pub search_onboarding_seen: bool,
+    /// Show explanatory control labels and, on a writable launch, the interactive beginner tour.
+    /// The ordinary/default value is false so pre-feature, recovered, and programmatic configs do
+    /// not unexpectedly enter onboarding. [`Self::fresh_install`] is the sole opt-in constructor.
+    pub beginner_mode: bool,
+    /// Versioned cursor for the last incomplete beginner-tour step.
+    pub beginner_tutorial: BeginnerTutorialProgress,
     /// Raw `Cookie:` header for music.youtube.com (takes precedence over the file).
     pub cookie: Option<String>,
     /// Path to a Netscape `cookies.txt` exported from the browser.
@@ -872,7 +904,8 @@ pub struct AiRuntimeConfig {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            search_onboarding_seen: false,
+            beginner_mode: false,
+            beginner_tutorial: BeginnerTutorialProgress::default(),
             cookie: None,
             cookies_file: None,
             volume: 100,
@@ -924,11 +957,18 @@ impl Default for Config {
     }
 }
 
-fn legacy_search_onboarding_seen() -> bool {
-    true
-}
-
 impl Config {
+    /// Defaults written only for a genuinely new profile. Keep this separate from [`Default`]:
+    /// serde recovery, legacy configs, tests, and non-TUI reset paths all rely on conservative
+    /// defaults that do not opt an existing user into a walkthrough.
+    pub(crate) fn fresh_install() -> Self {
+        Self {
+            beginner_mode: true,
+            beginner_tutorial: BeginnerTutorialProgress::welcome(),
+            ..Self::default()
+        }
+    }
+
     pub(crate) fn preflight_persistence_recovery()
     -> Result<(), crate::persist::StartupRecoveryError> {
         let Some(path) = config_path() else {
@@ -946,8 +986,9 @@ impl Config {
     pub fn load() -> Self {
         let Some(path) = config_path() else {
             // No config dir on this platform: migrate from the old app but don't persist.
-            let mut cfg = Config::default();
-            if let Some(old) = old_config_path() {
+            let old = old_config_path();
+            let mut cfg = config_for_missing_profile(old.as_deref());
+            if let Some(old) = old {
                 import_old_from(&old, &mut cfg);
             }
             return cfg;
@@ -1535,6 +1576,22 @@ fn old_config_path() -> Option<PathBuf> {
         return None;
     }
     directories::BaseDirs::new().map(|d| d.home_dir().join(".youtube-music-cli/config.json"))
+}
+
+/// Pick the base for a missing current config. A legacy path that cannot be inspected counts as
+/// present: surprising an existing user with onboarding is worse than conservatively leaving it
+/// off, and the import itself will still use the hardened bounded/no-symlink reader below.
+fn config_for_missing_profile(old: Option<&Path>) -> Config {
+    let legacy_present = old.is_some_and(|path| match fs::symlink_metadata(path) {
+        Ok(_) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => true,
+    });
+    if legacy_present {
+        Config::default()
+    } else {
+        Config::fresh_install()
+    }
 }
 
 /// Pull whatever we can reuse out of the old TypeScript app's config. Favorites,

--- a/src/config/recovery.rs
+++ b/src/config/recovery.rs
@@ -1,26 +1,39 @@
 use super::*;
 
 pub(super) fn load_from_path(path: &std::path::Path) -> Config {
-    let can_persist_default = match safe_fs::read_no_symlink_limited(path, MAX_CONFIG_BYTES) {
-        Ok(bytes) => match String::from_utf8(bytes) {
-            Ok(text) => {
-                if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
-                    return recover_value(path, value, false, true);
-                }
-                safe_fs::backup_aside_secret(path).is_ok()
-            }
-            Err(_) => safe_fs::backup_aside_secret(path).is_ok(),
-        },
-        Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
-            safe_fs::backup_too_large_secret(path).is_ok()
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
-        Err(_) => safe_fs::backup_unreadable_secret(path).is_ok(),
-    };
+    let old = old_config_path();
+    load_from_path_with_legacy(path, old.as_deref())
+}
 
-    let mut cfg = Config::default();
-    if let Some(old) = old_config_path() {
-        import_old_from(&old, &mut cfg);
+pub(super) fn load_from_path_with_legacy(
+    path: &std::path::Path,
+    legacy_path: Option<&std::path::Path>,
+) -> Config {
+    let (can_persist_default, source_was_missing) =
+        match safe_fs::read_no_symlink_limited(path, MAX_CONFIG_BYTES) {
+            Ok(bytes) => match String::from_utf8(bytes) {
+                Ok(text) => {
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
+                        return recover_value(path, value, false, true);
+                    }
+                    (safe_fs::backup_aside_secret(path).is_ok(), false)
+                }
+                Err(_) => (safe_fs::backup_aside_secret(path).is_ok(), false),
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                (safe_fs::backup_too_large_secret(path).is_ok(), false)
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => (true, true),
+            Err(_) => (safe_fs::backup_unreadable_secret(path).is_ok(), false),
+        };
+
+    let mut cfg = if source_was_missing {
+        config_for_missing_profile(legacy_path)
+    } else {
+        Config::default()
+    };
+    if let Some(old) = legacy_path {
+        import_old_from(old, &mut cfg);
     }
     let value = match serde_json::to_value(&cfg) {
         Ok(value) => value,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -22,7 +22,11 @@ fn load_from_preserves_unloadable_config_before_defaulting() {
         "x".repeat(1024 * 1024)
     );
     std::fs::write(&path, &big).unwrap();
-    let _ = Config::load_from(&path);
+    let recovered = Config::load_from(&path);
+    assert!(
+        !recovered.beginner_mode,
+        "recovering an existing oversized config must not look like a fresh install"
+    );
     let too_large = path.with_extension("too-large.bak");
     assert!(
         too_large.exists(),
@@ -39,7 +43,11 @@ fn load_from_preserves_unloadable_config_before_defaulting() {
 
     // (2) Invalid UTF-8 → moved to *.corrupt.bak, original bytes preserved.
     std::fs::write(&path, [0xff, 0xfe, 0xfd, 0xfc]).unwrap();
-    let _ = Config::load_from(&path);
+    let recovered = Config::load_from(&path);
+    assert!(
+        !recovered.beginner_mode,
+        "recovering an existing corrupt config must not opt into onboarding"
+    );
     let corrupt = path.with_extension("corrupt.bak");
     assert!(corrupt.exists(), "invalid-UTF-8 config must be preserved");
     assert_eq!(
@@ -50,8 +58,13 @@ fn load_from_preserves_unloadable_config_before_defaulting() {
 
     // (3) First run (missing) → defaults written, no backup created.
     std::fs::remove_file(&path).unwrap();
-    let _ = Config::load_from(&path);
+    let fresh = recovery::load_from_path_with_legacy(&path, None);
+    assert!(fresh.beginner_mode);
+    assert_eq!(fresh.beginner_tutorial, BeginnerTutorialProgress::welcome());
     assert!(path.exists());
+    let installed: Config = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    assert!(installed.beginner_mode);
+    assert_eq!(installed.beginner_tutorial, fresh.beginner_tutorial);
     assert!(!path.with_extension("too-large.bak").exists());
     assert!(!path.with_extension("corrupt.bak").exists());
 
@@ -165,7 +178,11 @@ fn json_round_trips() {
     let mut radio_theme = ThemeConfig::default();
     radio_theme.set_preset(crate::theme::ThemePreset::RosePine);
     let c = Config {
-        search_onboarding_seen: true,
+        beginner_mode: true,
+        beginner_tutorial: BeginnerTutorialProgress {
+            content_version: BEGINNER_TUTORIAL_VERSION,
+            next_step: "settings".to_owned(),
+        },
         cookie: Some("SID=abc".to_owned()),
         cookies_file: Some(PathBuf::from("/tmp/cookies.txt")),
         volume: 70,
@@ -271,6 +288,8 @@ fn json_round_trips() {
     };
     let s = serde_json::to_string(&c).unwrap();
     let back: Config = serde_json::from_str(&s).unwrap();
+    assert!(back.beginner_mode);
+    assert_eq!(back.beginner_tutorial.next_step, "settings");
     assert!(!back.update_check_enabled);
     assert_eq!(back.recording.mode, crate::recorder::RecordingMode::Decide);
     assert_eq!(back.recording.min_duration_secs, 20);
@@ -362,10 +381,69 @@ fn json_round_trips() {
 }
 
 #[test]
-fn search_onboarding_is_fresh_only_for_new_profiles() {
-    assert!(!Config::default().search_onboarding_seen);
-    let legacy: Config = serde_json::from_str("{\"volume\": 42}").unwrap();
-    assert!(legacy.search_onboarding_seen);
+fn beginner_mode_is_opt_in_only_for_genuinely_fresh_profiles() {
+    let defaults = Config::default();
+    assert!(!defaults.beginner_mode);
+    assert_eq!(
+        defaults.beginner_tutorial,
+        BeginnerTutorialProgress::welcome()
+    );
+
+    for marker in [None, Some(true), Some(false)] {
+        let mut value = serde_json::json!({"volume": 42});
+        if let Some(seen) = marker {
+            value["search_onboarding_seen"] = serde_json::json!(seen);
+        }
+        let legacy: Config = serde_json::from_value(value).unwrap();
+        assert!(
+            !legacy.beginner_mode,
+            "an existing config must stay off for legacy marker {marker:?}"
+        );
+        let rewritten = serde_json::to_value(&legacy).unwrap();
+        assert!(rewritten.get("search_onboarding_seen").is_none());
+    }
+
+    assert!(config_for_missing_profile(None).beginner_mode);
+
+    let dir = std::env::temp_dir().join(format!(
+        "ytm-existing-legacy-beginner-{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    let legacy_path = dir.join("config.json");
+    fs::write(&legacy_path, "{}").unwrap();
+    assert!(
+        !config_for_missing_profile(Some(&legacy_path)).beginner_mode,
+        "a present legacy profile keeps onboarding off"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn beginner_progress_round_trips_unknown_future_step_without_resetting_it() {
+    let original = Config {
+        beginner_mode: true,
+        beginner_tutorial: BeginnerTutorialProgress {
+            content_version: BEGINNER_TUTORIAL_VERSION + 1,
+            next_step: "future_spatial_mixer".to_owned(),
+        },
+        ..Config::default()
+    };
+    let json = serde_json::to_string(&original).unwrap();
+    let decoded: Config = serde_json::from_str(&json).unwrap();
+    assert!(decoded.beginner_mode);
+    assert_eq!(decoded.beginner_tutorial, original.beginner_tutorial);
+
+    let partial: Config = serde_json::from_str(
+        r#"{"beginner_mode":true,"beginner_tutorial":{"next_step":"library"}}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        partial.beginner_tutorial.content_version,
+        BEGINNER_TUTORIAL_VERSION
+    );
+    assert_eq!(partial.beginner_tutorial.next_step, "library");
 }
 
 #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,8 +11,8 @@ use std::path::{Path, PathBuf};
 
 use crate::ai::GeminiModel;
 use crate::config::{
-    AnimationsConfig, Config, LocalRootConfig, MPV_CACHE_BACK_DEFAULT, MPV_CACHE_FORWARD_DEFAULT,
-    SpotifyImportMode, default_cookies_file, default_download_dir,
+    AnimationsConfig, BeginnerTutorialProgress, Config, LocalRootConfig, MPV_CACHE_BACK_DEFAULT,
+    MPV_CACHE_FORWARD_DEFAULT, SpotifyImportMode, default_cookies_file, default_download_dir,
 };
 use crate::eq::{self, EqPreset};
 use crate::i18n::Language;
@@ -99,6 +99,7 @@ impl SettingsTab {
     pub fn fields(self) -> Vec<Field> {
         match self {
             SettingsTab::General => vec![
+                Field::BeginnerMode,
                 Field::Language,
                 Field::SearchSource,
                 Field::StreamingSource,
@@ -279,6 +280,8 @@ impl SettingsTab {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Field {
     // General
+    /// Explanatory labels plus the interactive walkthrough on the next writable launch.
+    BeginnerMode,
     /// The UI language (English / 한국어), cycled like any other Select field.
     Language,
     /// Default source selected in the search box.
@@ -572,6 +575,10 @@ pub fn freq_label(i: usize) -> String {
 // No `Debug`: holds the plaintext `gemini_api_key`, so it must not be `{:?}`-printable (see `Config`).
 #[derive(Clone)]
 pub struct SettingsDraft {
+    pub beginner_mode: bool,
+    /// Internal save intent: re-enabling Beginner Mode and Reset All restart the walkthrough at
+    /// Welcome on the next launch. This is projected into `Config`, but is not itself persisted.
+    pub restart_beginner_tutorial: bool,
     pub cookies_file: String,
     pub download_dir: String,
     pub local_include_download_dir: bool,
@@ -679,6 +686,7 @@ impl SettingsDraft {
     /// Render the current value of `field` for display.
     pub fn value_display(&self, field: Field) -> String {
         match field {
+            Field::BeginnerMode => toggle_str(self.beginner_mode),
             Field::RadioRecording => self.recording_mode.label(),
             // Each language names itself, so this value is the same regardless of the active
             // UI language (English / 한국어).
@@ -943,6 +951,10 @@ impl SettingsDraft {
     /// Merge the draft's persisted fields into `cfg` (called on save). Live audio fields
     /// are also written so they survive a restart.
     pub fn apply_to(&self, cfg: &mut Config) {
+        cfg.beginner_mode = self.beginner_mode;
+        if self.beginner_mode && self.restart_beginner_tutorial {
+            cfg.beginner_tutorial = BeginnerTutorialProgress::welcome();
+        }
         cfg.cookies_file = blank_to_none(&self.cookies_file).map(PathBuf::from);
         cfg.download_dir = blank_to_none(&self.download_dir).map(PathBuf::from);
         cfg.local.include_download_dir = Some(self.local_include_download_dir);

--- a/src/settings/field_meta.rs
+++ b/src/settings/field_meta.rs
@@ -24,7 +24,8 @@ impl Field {
             | Field::SpotifyClientId
             | Field::SpotifyRedirectPort
             | Field::ThemeColor(_) => FieldKind::Text,
-            Field::Mouse
+            Field::BeginnerMode
+            | Field::Mouse
             | Field::AlbumArt
             | Field::LocalIncludeDownloadDir
             | Field::LocalMusicRootRecursive
@@ -175,6 +176,7 @@ impl Field {
 
     pub fn label(self) -> String {
         match self {
+            Field::BeginnerMode => t!("Beginner Mode", "비기너 모드").to_owned(),
             Field::Language => t!("Language", "언어").to_owned(),
             Field::SearchSource => t!("Search source", "검색 소스").to_owned(),
             Field::StreamingSource => t!("Streaming source", "추천 소스").to_owned(),

--- a/src/settings/tests.rs
+++ b/src/settings/tests.rs
@@ -4,6 +4,8 @@ use crate::search_source::SearchSource;
 /// A neutral draft the value/apply tests can tweak one field at a time.
 fn base_draft() -> SettingsDraft {
     SettingsDraft {
+        beginner_mode: false,
+        restart_beginner_tutorial: false,
         cookies_file: String::new(),
         download_dir: String::new(),
         local_include_download_dir: true,
@@ -278,6 +280,7 @@ fn general_tab_has_search_options_and_autoplay_toggle() {
     assert_eq!(
         f,
         vec![
+            Field::BeginnerMode,
             Field::Language,
             Field::SearchSource,
             Field::StreamingSource,
@@ -308,6 +311,7 @@ fn general_tab_has_search_options_and_autoplay_toggle() {
     );
     assert_eq!(Field::ResetKeybindings.kind(), FieldKind::Button);
     assert_eq!(Field::ResetAll.kind(), FieldKind::Button);
+    assert_eq!(Field::BeginnerMode.kind(), FieldKind::Toggle);
     assert_eq!(Field::SearchSource.kind(), FieldKind::Select);
     assert_eq!(Field::StreamingSource.kind(), FieldKind::Select);
     assert_eq!(Field::SearchSoundCloud.kind(), FieldKind::Toggle);
@@ -320,6 +324,7 @@ fn general_tab_has_search_options_and_autoplay_toggle() {
     assert_eq!(Field::AlbumArt.kind(), FieldKind::Toggle);
     // Off by default, and the toggle renders as an empty checkbox.
     let draft = base_draft();
+    assert_eq!(draft.value_display(Field::BeginnerMode), "[ ]");
     assert_eq!(
         draft.value_display(Field::ResetKeybindings),
         "↵ press Enter"
@@ -335,6 +340,27 @@ fn general_tab_has_search_options_and_autoplay_toggle() {
     assert_eq!(draft.value_display(Field::AutoplayOnStart), "[ ]");
     assert!(!draft.enqueue_next);
     assert_eq!(draft.value_display(Field::EnqueueNext), "[ ]");
+}
+
+#[test]
+fn beginner_mode_projection_restarts_only_when_requested() {
+    let mut cfg = Config {
+        beginner_mode: true,
+        beginner_tutorial: BeginnerTutorialProgress {
+            content_version: crate::config::BEGINNER_TUTORIAL_VERSION,
+            next_step: "finish".to_owned(),
+        },
+        ..Config::default()
+    };
+
+    let mut draft = base_draft();
+    draft.beginner_mode = true;
+    draft.apply_to(&mut cfg);
+    assert_eq!(cfg.beginner_tutorial.next_step, "finish");
+
+    draft.restart_beginner_tutorial = true;
+    draft.apply_to(&mut cfg);
+    assert_eq!(cfg.beginner_tutorial, BeginnerTutorialProgress::welcome());
 }
 
 #[test]
@@ -458,6 +484,8 @@ fn apply_to_persists_every_settings_field() {
         .unwrap();
 
     let draft = SettingsDraft {
+        beginner_mode: true,
+        restart_beginner_tutorial: true,
         cookies_file: "/tmp/cookies.txt".to_owned(),
         download_dir: "/tmp/downloads".to_owned(),
         local_include_download_dir: false,
@@ -532,7 +560,10 @@ fn apply_to_persists_every_settings_field() {
     };
 
     let mut cfg = Config::default();
+    cfg.beginner_tutorial.next_step = "finish".to_owned();
     draft.apply_to(&mut cfg);
+    assert!(cfg.beginner_mode);
+    assert_eq!(cfg.beginner_tutorial, BeginnerTutorialProgress::welcome());
     assert_eq!(cfg.recording.mode, crate::recorder::RecordingMode::Decide);
     assert_eq!(cfg.recording.min_duration_secs, 20);
     assert_eq!(cfg.recording.max_duration_secs, 1200);

--- a/src/terminal_runtime/runner.rs
+++ b/src/terminal_runtime/runner.rs
@@ -56,6 +56,15 @@ fn owner_exit_requested(app: &App, shutdown: &player::lifetime::ShutdownLatch) -
     app.should_quit || shutdown.is_triggered()
 }
 
+/// The walkthrough changes persisted config on every transition, so a writer lease alone is not
+/// sufficient: platforms without a resolvable config destination must keep it dormant too.
+fn beginner_profile_persistable(
+    persistence_read_only: bool,
+    config_destination_available: bool,
+) -> bool {
+    !persistence_read_only && config_destination_available
+}
+
 type PlayerReadyResult = Result<(PlayerHandle, player::Mpv), String>;
 const PLAYER_START_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -823,7 +832,10 @@ pub async fn run(
     if !missing.is_empty() {
         app.show_tool_setup(app::ToolSetupContext::Startup, missing);
     }
-    app.prepare_search_onboarding(!persistence_read_only);
+    app.prepare_beginner_onboarding(beginner_profile_persistable(
+        persistence_read_only,
+        config::config_path().is_some(),
+    ));
     startup.mark("deps_checked");
 
     // Worker -> UI channel. Actors hold clones; the original stays alive so the
@@ -973,6 +985,10 @@ pub async fn run(
         scrobble_handle,
         persist.clone(),
     );
+
+    if let Some(cmd) = app.take_beginner_startup_persist() {
+        handles.dispatch(&mut app, cmd);
+    }
 
     // An explicit Save is journaled in the stable recorder cache before its copy worker is
     // admitted. Recover those intents off the owner task and wait for the tracked job before

--- a/src/terminal_runtime/runner/tests.rs
+++ b/src/terminal_runtime/runner/tests.rs
@@ -36,6 +36,18 @@ fn normal_quit_requests_owner_exit_without_an_external_signal() {
     assert!(owner_exit_requested(&app, &shutdown));
 }
 
+#[test]
+fn beginner_tour_requires_both_a_writer_lease_and_a_config_destination() {
+    assert!(beginner_profile_persistable(false, true));
+    assert!(!beginner_profile_persistable(true, true));
+    assert!(!beginner_profile_persistable(false, false));
+
+    let mut app = App::new(50);
+    app.config.beginner_mode = true;
+    app.prepare_beginner_onboarding(beginner_profile_persistable(false, false));
+    assert!(!app.onboarding.active());
+}
+
 #[tokio::test]
 async fn quit_during_player_startup_aborts_and_reaps_the_producer() {
     struct DropFlag(Arc<AtomicBool>);

--- a/src/ui/buttons.rs
+++ b/src/ui/buttons.rs
@@ -350,8 +350,6 @@ pub fn render_nav(frame: &mut Frame, app: &App, area: Rect) -> u16 {
         let style = if app.mode == *mode {
             // A brief accent wash on the tab just switched to (identity when off).
             crate::ui::anim::active_tab_style(app, crate::ui::anim::TabPop::Nav, active)
-        } else if *mode == Mode::Search && app.onboarding.visible() {
-            app.theme.style(R::Accent).add_modifier(Modifier::BOLD)
         } else {
             muted
         };
@@ -456,8 +454,6 @@ fn render_nav_paged(
         );
         let style = if app.mode == *mode {
             crate::ui::anim::active_tab_style(app, crate::ui::anim::TabPop::Nav, active)
-        } else if *mode == Mode::Search && app.onboarding.visible() {
-            app.theme.style(R::Accent).add_modifier(Modifier::BOLD)
         } else {
             muted
         };

--- a/src/ui/control_box.rs
+++ b/src/ui/control_box.rs
@@ -21,6 +21,9 @@ use crate::theme::ThemeRole as R;
 use crate::ui::buttons::{self, Seg};
 use crate::util::format;
 
+mod beginner;
+use beginner::{StatusLabelTier, control_label as beginner_control_label, pad_display_state};
+
 /// Render the control block into four caller-provided single-height rows — the Player
 /// view's legacy top layout passes its own `rows[1]/[3]/[5]/[7]`, so the output is
 /// byte-identical to the pre-extraction rendering.
@@ -334,25 +337,7 @@ pub(in crate::ui) fn render_status_line(frame: &mut Frame, app: &App, area: Rect
     // Roomy separators normally; progressively tighter when the line wouldn't fit (narrow
     // terminals, or text zoom shrinking the virtual grid). Content always wins over air —
     // the `eq:` / `R:` toggles at the tail must stay visible and clickable.
-    let fits = |parts: &Vec<(Option<MouseTarget>, Cow<'static, str>)>| {
-        parts
-            .iter()
-            .map(|(_, text)| buttons::text_width(text))
-            .sum::<u16>()
-            <= area.width
-    };
-    // The last tier also sheds the non-clickable decorations (state word, speed, VU,
-    // download tag), keeping every *control* reachable on even the tiniest grid.
-    let (gap_w, parts) = [("    ", false), ("  ", false), (" ", false), (" ", true)]
-        .iter()
-        .map(|(gap, minimal)| {
-            (
-                buttons::text_width(gap),
-                status_line_parts(app, gap, *minimal, animated),
-            )
-        })
-        .find(|(_, parts)| fits(parts))
-        .unwrap_or_else(|| (1, status_line_parts(app, " ", true, animated)));
+    let (gap_w, parts) = fitted_status_line_parts(app, area.width, animated);
     // The identify chip (`ID?` / `지듣노`) is the smallest control on the line, and its
     // trailing `?` sits right on its rect's edge — fold up to two cells of the flanking
     // gaps into its hit rect (never more than the gap itself, so it can't annex a
@@ -368,9 +353,68 @@ pub(in crate::ui) fn render_status_line(frame: &mut Frame, app: &App, area: Rect
             None => Seg::label(text.as_ref()),
         })
         .collect();
-    // Same style for buttons and labels so the clickable parts are visually indistinguishable.
-    let style = app.theme.style(R::PlayerLabel);
-    buttons::render_segments(frame, app, area, &segments, style, style, Alignment::Center);
+    let label_style = app.theme.style(R::PlayerLabel);
+    let button_style = if app.beginner_labels_enabled() {
+        app.theme.style(R::Accent).add_modifier(Modifier::BOLD)
+    } else {
+        // Beginner mode off preserves the legacy status-line styling exactly.
+        label_style
+    };
+    buttons::render_segments(
+        frame,
+        app,
+        area,
+        &segments,
+        button_style,
+        label_style,
+        Alignment::Center,
+    );
+}
+
+type StatusLinePart = (Option<MouseTarget>, Cow<'static, str>);
+type StatusLineParts = Vec<StatusLinePart>;
+
+fn fitted_status_line_parts(app: &App, width: u16, animated: bool) -> (u16, StatusLineParts) {
+    let fits = |parts: &[StatusLinePart]| {
+        parts
+            .iter()
+            .map(|(_, text)| buttons::text_width(text))
+            .sum::<u16>()
+            <= width
+    };
+    if app.beginner_labels_enabled() {
+        // Shed keycaps and decoration before names, then use compact labels only when necessary.
+        [
+            ("    ", false, StatusLabelTier::BeginnerKeys),
+            ("  ", false, StatusLabelTier::BeginnerKeys),
+            (" ", false, StatusLabelTier::BeginnerKeys),
+            (" ", true, StatusLabelTier::BeginnerKeys),
+            ("  ", false, StatusLabelTier::BeginnerNames),
+            (" ", false, StatusLabelTier::BeginnerNames),
+            (" ", true, StatusLabelTier::BeginnerNames),
+            (" ", true, StatusLabelTier::Compact),
+        ]
+        .into_iter()
+        .map(|(gap, minimal, labels)| {
+            (
+                buttons::text_width(gap),
+                status_line_parts_with_labels(app, gap, minimal, animated, labels),
+            )
+        })
+        .find(|(_, parts)| fits(parts))
+        .unwrap_or_else(|| (1, status_line_parts(app, " ", true, animated)))
+    } else {
+        [("    ", false), ("  ", false), (" ", false), (" ", true)]
+            .into_iter()
+            .map(|(gap, minimal)| {
+                (
+                    buttons::text_width(gap),
+                    status_line_parts(app, gap, minimal, animated),
+                )
+            })
+            .find(|(_, parts)| fits(parts))
+            .unwrap_or_else(|| (1, status_line_parts(app, " ", true, animated)))
+    }
 }
 
 /// Build the transport status-line as `(target, text)` segments from app state — split out
@@ -388,33 +432,64 @@ fn status_line_parts(
     gap: &'static str,
     minimal: bool,
     animated: bool,
-) -> Vec<(Option<MouseTarget>, Cow<'static, str>)> {
+) -> StatusLineParts {
+    status_line_parts_with_labels(app, gap, minimal, animated, StatusLabelTier::Compact)
+}
+
+fn status_line_parts_with_labels(
+    app: &App,
+    gap: &'static str,
+    minimal: bool,
+    animated: bool,
+    labels: StatusLabelTier,
+) -> StatusLineParts {
     let retro = app.retro_mode();
-    let mut parts: Vec<(Option<MouseTarget>, Cow<'static, str>)> = Vec::with_capacity(16);
+    let mut parts = StatusLineParts::with_capacity(16);
     // A braille throbber leads the line when the spinner animation is on (no-op otherwise). It's a
     // plain label, so `render_segments` keeps every later hit rect aligned to its rendered text.
-    if animated && let Some(spin) = crate::ui::anim::spinner_prefix(app) {
+    if (!minimal || !labels.beginner())
+        && animated
+        && let Some(spin) = crate::ui::anim::spinner_prefix(app)
+    {
         parts.push((None, Cow::Owned(format!("{spin} "))));
     }
     // EAW-neutral glyphs (one cell everywhere) — the ⏸/▶ media emoji widen to two
     // cells on some terminals (Windows), which drifts every later segment's hit rect
     // off its rendered text and makes `R:`/`eq:` unclickable. See `render_controls`.
-    let state = match (minimal, app.playback.paused) {
-        (true, true) => "‖",
-        (true, false) => "▸",
-        (false, true) => t!("‖ paused", "‖ 일시정지"),
-        (false, false) => t!("▸ playing", "▸ 재생 중"),
-    };
-    parts.push((None, Cow::Borrowed(state)));
+    if !(minimal && labels.beginner()) {
+        let state = match (minimal, app.playback.paused, labels.beginner() && retro) {
+            (true, true, _) => "‖",
+            (true, false, _) => "▸",
+            (false, true, true) => "‖ paused",
+            (false, false, true) => "▸ playing",
+            (false, true, false) => t!("‖ paused", "‖ 일시정지"),
+            (false, false, false) => t!("▸ playing", "▸ 재생 중"),
+        };
+        parts.push((None, Cow::Borrowed(state)));
+    }
     if !app.queue.is_empty() {
         let (pos, _) = app.queue.position();
         // Clickable (opens the queue window) but styled exactly like the labels around it,
         // so the line looks unchanged — same as the `S:`/`R:` toggles next to it.
         parts.push((None, Cow::Borrowed(gap)));
-        parts.push((
-            Some(MouseTarget::QueuePos),
-            Cow::Owned(format!("{pos}/{}", app.queue.len())),
-        ));
+        let value = format!("{pos}/{}", app.queue.len());
+        let text = if labels.beginner() {
+            beginner_control_label(
+                app,
+                labels,
+                KeyContext::Player,
+                Action::OpenQueue,
+                if retro {
+                    "Queue"
+                } else {
+                    t!("Queue", "대기열")
+                },
+                Some(value),
+            )
+        } else {
+            value
+        };
+        parts.push((Some(MouseTarget::QueuePos), Cow::Owned(text)));
     }
     // The current track's rating: one tri-state glyph (🤔/👍/👎) that replaces the old separate
     // ♥ favorite + ✗ dislike columns. Same `PlayerLabel` style and 4-space gap as `S:`/`R:` next
@@ -423,9 +498,52 @@ fn status_line_parts(
         let liked = app.library.is_favorite(&cur.video_id);
         let disliked = app.signals.is_disliked(&cur.video_id);
         parts.push((None, Cow::Borrowed(gap)));
+        let text = if labels.beginner() {
+            let (state, states) = if retro {
+                (
+                    if liked {
+                        "Like"
+                    } else if disliked {
+                        "Dislike"
+                    } else {
+                        "None"
+                    },
+                    ["Like", "Dislike", "None"],
+                )
+            } else {
+                (
+                    if liked {
+                        t!("Like", "좋아요")
+                    } else if disliked {
+                        t!("Dislike", "싫어요")
+                    } else {
+                        t!("None", "없음")
+                    },
+                    [
+                        t!("Like", "좋아요"),
+                        t!("Dislike", "싫어요"),
+                        t!("None", "없음"),
+                    ],
+                )
+            };
+            beginner_control_label(
+                app,
+                labels,
+                KeyContext::Player,
+                Action::CycleRating,
+                if retro {
+                    "Rating"
+                } else {
+                    t!("Rating", "평가")
+                },
+                Some(pad_display_state(state, &states)),
+            )
+        } else {
+            rating_glyph(liked, disliked, retro).to_owned()
+        };
         parts.push((
             Some(MouseTarget::Player(Action::CycleRating)),
-            Cow::Borrowed(rating_glyph(liked, disliked, retro)),
+            Cow::Owned(text),
         ));
     }
     // Shuffle and repeat are both always shown as click toggles, and every state of each keeps
@@ -436,56 +554,220 @@ fn status_line_parts(
     // read as the live transport instead: `LIVE:` sync verdict, `SYNC:` re-sync.
     if app.current_is_radio_stream() {
         parts.push((None, Cow::Borrowed(gap)));
+        let live = if labels.beginner() {
+            let synced = app.radio_live_synced();
+            let (state, states) = if retro {
+                (
+                    match synced {
+                        Some(true) => "Synced",
+                        Some(false) => "Behind",
+                        None => "Unknown",
+                    },
+                    ["Synced", "Behind", "Unknown"],
+                )
+            } else {
+                (
+                    match synced {
+                        Some(true) => t!("Synced", "동기화"),
+                        Some(false) => t!("Behind", "뒤처짐"),
+                        None => t!("Unknown", "알 수 없음"),
+                    },
+                    [
+                        t!("Synced", "동기화"),
+                        t!("Behind", "뒤처짐"),
+                        t!("Unknown", "알 수 없음"),
+                    ],
+                )
+            };
+            beginner_control_label(
+                app,
+                labels,
+                KeyContext::Player,
+                Action::ToggleShuffle,
+                if retro {
+                    "Live"
+                } else {
+                    t!("Live", "라이브")
+                },
+                Some(pad_display_state(state, &states)),
+            )
+        } else {
+            format!("LIVE:{}", live_sync_glyph(app.radio_live_synced(), retro))
+        };
         parts.push((
             Some(MouseTarget::Player(Action::ToggleShuffle)),
-            Cow::Owned(format!(
-                "LIVE:{}",
-                live_sync_glyph(app.radio_live_synced(), retro)
-            )),
+            Cow::Owned(live),
         ));
         parts.push((None, Cow::Borrowed(gap)));
+        let resync = if labels.beginner() {
+            beginner_control_label(
+                app,
+                labels,
+                KeyContext::Player,
+                Action::CycleRepeat,
+                if retro {
+                    "Resync"
+                } else {
+                    t!("Resync", "다시 동기화")
+                },
+                None,
+            )
+        } else {
+            format!("SYNC:{}", resync_glyph(retro))
+        };
         parts.push((
             Some(MouseTarget::Player(Action::CycleRepeat)),
-            Cow::Owned(format!("SYNC:{}", resync_glyph(retro))),
+            Cow::Owned(resync),
         ));
         // The "what's playing" card — now ICY-metadata-backed, so always offered on a live
         // radio stream, DJ Gem or not. A text label, not a glyph: EAW-ambiguous symbols
         // (♪ …) render wide on some CJK terminals and would drift every later hit rect.
         parts.push((None, Cow::Borrowed(gap)));
+        let identify = if labels.beginner() {
+            beginner_control_label(
+                app,
+                labels,
+                KeyContext::Player,
+                Action::IdentifyNowPlaying,
+                if retro {
+                    "Identify"
+                } else {
+                    t!("Identify", "곡 찾기")
+                },
+                None,
+            )
+        } else {
+            t!("ID?", "지듣노").to_owned()
+        };
         parts.push((
             Some(MouseTarget::Player(Action::IdentifyNowPlaying)),
-            Cow::Borrowed(t!("ID?", "지듣노")),
+            Cow::Owned(identify),
         ));
         // While the radio recorder is writing a track, a click-to-open `REC` chip. A plain
         // text label (not a glyph) for the same EAW-neutral reason as `ID?` above — an
         // ambiguous-width mark would drift later hit rects on some CJK terminals.
         if app.recorder.is_recording() {
             parts.push((None, Cow::Borrowed(gap)));
+            let recordings = if labels.beginner() {
+                beginner_control_label(
+                    app,
+                    labels,
+                    KeyContext::Player,
+                    Action::ToggleRecordings,
+                    if retro {
+                        "Recordings"
+                    } else {
+                        t!("Recordings", "녹음 목록")
+                    },
+                    None,
+                )
+            } else {
+                t!("REC", "녹음").to_owned()
+            };
             parts.push((
                 Some(MouseTarget::Player(Action::ToggleRecordings)),
-                Cow::Borrowed(t!("REC", "녹음")),
+                Cow::Owned(recordings),
             ));
         }
     } else {
         parts.push((None, Cow::Borrowed(gap)));
+        let shuffle = if labels.beginner() {
+            let (state, states) = if retro {
+                (if app.queue.shuffle { "On" } else { "Off" }, ["On", "Off"])
+            } else {
+                (
+                    if app.queue.shuffle {
+                        t!("On", "켬")
+                    } else {
+                        t!("Off", "끔")
+                    },
+                    [t!("On", "켬"), t!("Off", "끔")],
+                )
+            };
+            beginner_control_label(
+                app,
+                labels,
+                KeyContext::Player,
+                Action::ToggleShuffle,
+                if retro {
+                    "Shuffle"
+                } else {
+                    t!("Shuffle", "셔플")
+                },
+                Some(pad_display_state(state, &states)),
+            )
+        } else {
+            format!("S:{}", shuffle_glyph(app.queue.shuffle, retro))
+        };
         parts.push((
             Some(MouseTarget::Player(Action::ToggleShuffle)),
-            Cow::Owned(format!("S:{}", shuffle_glyph(app.queue.shuffle, retro))),
+            Cow::Owned(shuffle),
         ));
         parts.push((None, Cow::Borrowed(gap)));
+        let repeat = if labels.beginner() {
+            let (state, states) = if retro {
+                (
+                    match app.queue.repeat {
+                        Repeat::Off => "Off",
+                        Repeat::All => "All",
+                        Repeat::One => "One",
+                    },
+                    ["Off", "All", "One"],
+                )
+            } else {
+                (
+                    match app.queue.repeat {
+                        Repeat::Off => t!("Off", "끔"),
+                        Repeat::All => t!("All", "전체"),
+                        Repeat::One => t!("One", "한 곡"),
+                    },
+                    [t!("Off", "끔"), t!("All", "전체"), t!("One", "한 곡")],
+                )
+            };
+            beginner_control_label(
+                app,
+                labels,
+                KeyContext::Player,
+                Action::CycleRepeat,
+                if retro {
+                    "Repeat"
+                } else {
+                    t!("Repeat", "반복")
+                },
+                Some(pad_display_state(state, &states)),
+            )
+        } else {
+            format!("R:{}", repeat_glyph(app.queue.repeat, retro))
+        };
         parts.push((
             Some(MouseTarget::Player(Action::CycleRepeat)),
-            Cow::Owned(format!("R:{}", repeat_glyph(app.queue.repeat, retro))),
+            Cow::Owned(repeat),
         ));
     }
     if !minimal && (app.playback.speed - 1.0).abs() > f64::EPSILON {
         parts.push((None, Cow::Owned(format!("{gap}{:.1}x", app.playback.speed))));
     }
     parts.push((None, Cow::Borrowed(gap)));
-    parts.push((
-        Some(MouseTarget::EqMenu),
-        Cow::Owned(format!("eq:{}", app.audio.preset.label())),
-    ));
+    let eq = if labels.beginner() {
+        beginner_control_label(
+            app,
+            labels,
+            KeyContext::Player,
+            Action::CycleEq,
+            if retro {
+                "Equalizer"
+            } else {
+                t!("Equalizer", "이퀄라이저")
+            },
+            Some(pad_display_state(
+                app.audio.preset.label(),
+                &["Flat", "Bass", "Treble", "Vocal", "Rock", "Jazz", "Custom"],
+            )),
+        )
+    } else {
+        format!("eq:{}", app.audio.preset.label())
+    };
+    parts.push((Some(MouseTarget::EqMenu), Cow::Owned(eq)));
     // Faux VU bars trail the EQ label when the EQ-bars animation is on (no-op otherwise).
     if !minimal
         && animated
@@ -497,13 +779,44 @@ fn status_line_parts(
         // Show the station's mode (Focused/Balanced/Discovery) as a click target that opens the
         // mode dropdown — same affordance as the `eq:` label next to it.
         parts.push((None, Cow::Borrowed(gap)));
-        parts.push((
-            Some(MouseTarget::StreamingMenu),
-            Cow::Owned(format!(
+        let streaming = if labels.beginner() {
+            let states = if retro {
+                ["Focused", "Balanced", "Discovery"]
+            } else {
+                crate::streaming::StreamingMode::CYCLE.map(|mode| mode.label())
+            };
+            let mode = if retro {
+                match app.config.streaming.mode {
+                    crate::streaming::StreamingMode::Focused => "Focused",
+                    crate::streaming::StreamingMode::Balanced => "Balanced",
+                    crate::streaming::StreamingMode::Discovery => "Discovery",
+                }
+            } else {
+                app.config.streaming.mode.label()
+            };
+            beginner_control_label(
+                app,
+                labels,
+                KeyContext::Global,
+                Action::ToggleStreaming,
+                if retro {
+                    "Streaming autoplay"
+                } else {
+                    t!("Streaming autoplay", "스트리밍 자동재생")
+                },
+                Some(format!(
+                    "{} · {}",
+                    if retro { "On" } else { t!("On", "켬") },
+                    pad_display_state(mode, &states)
+                )),
+            )
+        } else {
+            format!(
                 "streaming:{}",
                 app.config.streaming.mode.label().to_lowercase()
-            )),
-        ));
+            )
+        };
+        parts.push((Some(MouseTarget::StreamingMenu), Cow::Owned(streaming)));
     }
     // Download indicator for the current track, if one is in flight or finished. While one is
     // actually running and the activity animation is on, a spinner stands in for the `⬇` so
@@ -552,16 +865,47 @@ pub(in crate::ui) fn render_controls(frame: &mut Frame, app: &App, area: Rect, a
         format!("{}%", app.playback.volume)
     };
     // Roomy gaps normally; tighter ones when the strip wouldn't fit (a narrow terminal or
-    // text zoom shrinking the virtual grid). Buttons keep their one-cell inner padding, so
-    // hit targets stay comfortable — only the dead space between them compresses.
-    let full: u16 = 3 * 3
-        + 3
-        + 3
-        + 6
-        + buttons::text_width(t!("vol ", "볼륨 "))
-        + 3
-        + 3
-        + buttons::text_width(&vol);
+    // text zoom shrinking the virtual grid). Beginner mode first shortens Volume to `vol`,
+    // then sheds its keycaps, while the legacy path retains exactly the old segment bytes.
+    let compact_volume_label = t!("vol ", "볼륨 ");
+    let beginner_volume_label = if app.retro_mode() {
+        "Volume "
+    } else {
+        t!("Volume ", "볼륨 ")
+    };
+    let plain_down = " - ";
+    let plain_up = " + ";
+    let (beginner_down, beginner_up) = beginner::volume_buttons(app);
+    let tight_transport_width = 13u16;
+    let cluster_width = |label: &str, down: &str, up: &str| {
+        buttons::text_width(label)
+            .saturating_add(buttons::text_width(down))
+            .saturating_add(buttons::text_width(&vol))
+            .saturating_add(buttons::text_width(up))
+    };
+    let fits_tight = |label: &str, down: &str, up: &str| {
+        tight_transport_width.saturating_add(cluster_width(label, down, up)) <= area.width
+    };
+    let (volume_label, volume_down, volume_up) = if app.beginner_labels_enabled()
+        && fits_tight(beginner_volume_label, &beginner_down, &beginner_up)
+    {
+        (
+            beginner_volume_label,
+            beginner_down.as_str(),
+            beginner_up.as_str(),
+        )
+    } else if app.beginner_labels_enabled()
+        && fits_tight(compact_volume_label, &beginner_down, &beginner_up)
+    {
+        (
+            compact_volume_label,
+            beginner_down.as_str(),
+            beginner_up.as_str(),
+        )
+    } else {
+        (compact_volume_label, plain_down, plain_up)
+    };
+    let full = 21u16.saturating_add(cluster_width(volume_label, volume_down, volume_up));
     let (gap, vol_gap) = if full <= area.width {
         ("   ", "      ")
     } else {
@@ -574,10 +918,10 @@ pub(in crate::ui) fn render_controls(frame: &mut Frame, app: &App, area: Rect, a
         Seg::label(gap),
         Seg::button(MouseTarget::Player(Action::NextTrack), " ⇥ "),
         Seg::label(vol_gap),
-        Seg::label(t!("vol ", "볼륨 ")),
-        Seg::button(MouseTarget::Player(Action::VolDown), " - "),
+        Seg::label(volume_label),
+        Seg::button(MouseTarget::Player(Action::VolDown), volume_down),
         Seg::label(&vol),
-        Seg::button(MouseTarget::Player(Action::VolUp), " + "),
+        Seg::button(MouseTarget::Player(Action::VolUp), volume_up),
     ];
     let widths: Vec<u16> = segments
         .iter()
@@ -903,6 +1247,7 @@ mod tests {
 
     #[test]
     fn radio_stream_swaps_shuffle_repeat_for_live_transport_controls() {
+        let _guard = crate::i18n::lock_for_test();
         let mut app = App::new(100);
         app.queue.set(vec![radio_song()], 0);
         let parts = status_line_parts(&app, "    ", false, true);
@@ -933,6 +1278,20 @@ mod tests {
             t,
             MouseTarget::Player(Action::CycleRepeat)
         )));
+
+        let beginner =
+            status_line_parts_with_labels(&app, " ", true, false, StatusLabelTier::BeginnerNames);
+        assert!(
+            text_for(&beginner, &MouseTarget::Player(Action::ToggleShuffle)).starts_with("Live: ")
+        );
+        assert_eq!(
+            text_for(&beginner, &MouseTarget::Player(Action::CycleRepeat)),
+            "Resync"
+        );
+        assert_eq!(
+            text_for(&beginner, &MouseTarget::Player(Action::IdentifyNowPlaying)),
+            "Identify"
+        );
     }
 
     #[test]
@@ -1050,5 +1409,94 @@ mod tests {
             t,
             MouseTarget::Player(Action::CycleRating)
         )));
+    }
+
+    fn text_for<'a>(parts: &'a [StatusLinePart], target: &MouseTarget) -> &'a str {
+        parts
+            .iter()
+            .find(|(candidate, _)| candidate.as_ref() == Some(target))
+            .map(|(_, text)| text.as_ref())
+            .unwrap_or_else(|| panic!("missing {target:?}"))
+    }
+
+    #[test]
+    fn beginner_status_labels_expand_then_fall_back_by_width() {
+        let _guard = crate::i18n::lock_for_test();
+        let mut app = App::new(100);
+        app.config.beginner_mode = true;
+        app.queue.set(vec![Song::remote("a", "A", "x", "1:00")], 0);
+
+        let (_, roomy) = fitted_status_line_parts(&app, 100, false);
+        assert_eq!(
+            text_for(&roomy, &MouseTarget::Player(Action::ToggleShuffle)).trim_end(),
+            "[S] Shuffle: Off"
+        );
+        assert_eq!(
+            text_for(&roomy, &MouseTarget::Player(Action::CycleRepeat)).trim_end(),
+            "[r] Repeat: Off"
+        );
+        assert_eq!(
+            text_for(&roomy, &MouseTarget::EqMenu).trim_end(),
+            "[e] Equalizer: Flat"
+        );
+
+        let (_, standard) = fitted_status_line_parts(&app, 80, false);
+        let shuffle = text_for(&standard, &MouseTarget::Player(Action::ToggleShuffle));
+        assert!(shuffle.starts_with("Shuffle: "), "got {shuffle:?}");
+        assert!(!shuffle.contains('['), "keycaps should shed before names");
+
+        let (_, narrow) = fitted_status_line_parts(&app, 32, false);
+        assert!(text_for(&narrow, &MouseTarget::Player(Action::ToggleShuffle)).starts_with("S:"));
+        assert!(text_for(&narrow, &MouseTarget::EqMenu).starts_with("eq:"));
+    }
+
+    #[test]
+    fn beginner_off_keeps_legacy_status_segment_bytes() {
+        let _guard = crate::i18n::lock_for_test();
+        let mut app = App::new(100);
+        app.queue.set(vec![Song::remote("a", "A", "x", "1:00")], 0);
+        let parts = status_line_parts(&app, "    ", false, false);
+
+        assert_eq!(text_for(&parts, &MouseTarget::QueuePos), "1/1");
+        assert_eq!(
+            text_for(&parts, &MouseTarget::Player(Action::CycleRating)),
+            "🤔"
+        );
+        assert_eq!(
+            text_for(&parts, &MouseTarget::Player(Action::ToggleShuffle)),
+            "S:✗ "
+        );
+        assert_eq!(
+            text_for(&parts, &MouseTarget::Player(Action::CycleRepeat)),
+            "R:✗ "
+        );
+        assert_eq!(text_for(&parts, &MouseTarget::EqMenu), "eq:Flat");
+    }
+
+    #[test]
+    fn beginner_toggle_states_keep_the_status_line_width_stable() {
+        let _guard = crate::i18n::lock_for_test();
+        let mut app = App::new(100);
+        app.queue.set(vec![Song::remote("a", "A", "x", "1:00")], 0);
+        let mut widths = Vec::new();
+        for shuffle in [false, true] {
+            for repeat in [Repeat::Off, Repeat::All, Repeat::One] {
+                app.queue.shuffle = shuffle;
+                app.queue.repeat = repeat;
+                widths.push(
+                    status_line_parts_with_labels(
+                        &app,
+                        " ",
+                        true,
+                        false,
+                        StatusLabelTier::BeginnerNames,
+                    )
+                    .iter()
+                    .map(|(_, text)| UnicodeWidthStr::width(text.as_ref()))
+                    .sum::<usize>(),
+                );
+            }
+        }
+        assert!(widths.windows(2).all(|pair| pair[0] == pair[1]));
     }
 }

--- a/src/ui/control_box/beginner.rs
+++ b/src/ui/control_box/beginner.rs
@@ -1,0 +1,159 @@
+use crate::app::{App, Mode};
+use crate::keymap::{Action, KeyContext, format_chord_for_display};
+use crate::ui::buttons;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum StatusLabelTier {
+    Compact,
+    BeginnerNames,
+    BeginnerKeys,
+}
+
+impl StatusLabelTier {
+    pub(super) fn beginner(self) -> bool {
+        self != Self::Compact
+    }
+
+    pub(super) fn keycaps(self) -> bool {
+        self == Self::BeginnerKeys
+    }
+}
+
+/// Expand a compact player control into its beginner-facing name and optional state.
+/// Player-context keycaps are only honest on the Player screen: docked bars on other
+/// screens still expose the mouse target, but those keys route through that screen's context.
+pub(super) fn control_label(
+    app: &App,
+    labels: StatusLabelTier,
+    context: KeyContext,
+    action: Action,
+    name: &str,
+    state: Option<String>,
+) -> String {
+    let show_keycap =
+        labels.keycaps() && (context != KeyContext::Player || app.mode == Mode::Player);
+    let keycap = if show_keycap {
+        app.keymap
+            .chord(context, action)
+            .map(|chord| format!("[{}] ", format_chord_for_display(chord, app.retro_mode())))
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+    match state {
+        Some(state) => format!("{keycap}{name}: {state}"),
+        None => format!("{keycap}{name}"),
+    }
+}
+
+pub(super) fn pad_display_state(value: &str, states: &[&str]) -> String {
+    let width = states
+        .iter()
+        .map(|state| buttons::text_width(state))
+        .max()
+        .unwrap_or_default();
+    let mut value = value.to_owned();
+    value.push_str(&" ".repeat(usize::from(
+        width.saturating_sub(buttons::text_width(&value)),
+    )));
+    value
+}
+
+/// Beginner volume buttons include their live Player bindings when those bindings are
+/// active. An unbound action, or a docked bar outside Player mode, keeps the plain +/- button.
+pub(super) fn volume_buttons(app: &App) -> (String, String) {
+    if app.mode != Mode::Player {
+        return (" - ".to_owned(), " + ".to_owned());
+    }
+    let keycap = |action| {
+        app.keymap
+            .chord(KeyContext::Player, action)
+            .map(|chord| format_chord_for_display(chord, app.retro_mode()))
+    };
+    let down = keycap(Action::VolDown)
+        .map(|key| format!(" [{key}] - "))
+        .unwrap_or_else(|| " - ".to_owned());
+    let up = keycap(Action::VolUp)
+        .map(|key| format!(" + [{key}] "))
+        .unwrap_or_else(|| " + ".to_owned());
+    (down, up)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{StatusLinePart, fitted_status_line_parts};
+    use crate::app::{App, Mode, MouseTarget};
+    use crate::keymap::{Action, KeyContext};
+
+    fn text_for<'a>(parts: &'a [StatusLinePart], target: &MouseTarget) -> &'a str {
+        parts
+            .iter()
+            .find(|(candidate, _)| candidate.as_ref() == Some(target))
+            .map(|(_, text)| text.as_ref())
+            .unwrap_or_else(|| panic!("missing {target:?}"))
+    }
+
+    #[test]
+    fn keycaps_follow_rebinds_and_omit_unbound_actions() {
+        let _guard = crate::i18n::lock_for_test();
+        let mut app = App::new(100);
+        app.config.beginner_mode = true;
+        app.keymap
+            .rebind(
+                KeyContext::Player,
+                Action::ToggleShuffle,
+                crate::keymap::parse_chord("f8").unwrap(),
+            )
+            .unwrap();
+        app.keymap.unbind(KeyContext::Player, Action::CycleRepeat);
+
+        let (_, parts) = fitted_status_line_parts(&app, 200, false);
+        assert!(text_for(&parts, &MouseTarget::Player(Action::ToggleShuffle)).starts_with("[F8] "));
+        assert!(
+            text_for(&parts, &MouseTarget::Player(Action::CycleRepeat)).starts_with("Repeat: ")
+        );
+    }
+
+    #[test]
+    fn docked_labels_omit_inactive_player_keycaps() {
+        let _guard = crate::i18n::lock_for_test();
+        let mut app = App::new(100);
+        app.config.beginner_mode = true;
+        app.mode = Mode::Settings;
+
+        let (_, parts) = fitted_status_line_parts(&app, 200, false);
+        for (target, name) in [
+            (MouseTarget::Player(Action::ToggleShuffle), "Shuffle: "),
+            (MouseTarget::Player(Action::CycleRepeat), "Repeat: "),
+            (MouseTarget::EqMenu, "Equalizer: "),
+        ] {
+            let text = text_for(&parts, &target);
+            assert!(text.starts_with(name), "got {text:?}");
+            assert!(!text.contains('['), "inactive keycap leaked into {text:?}");
+        }
+    }
+
+    #[test]
+    fn streaming_label_combines_toggle_state_and_mode() {
+        let _guard = crate::i18n::lock_for_test();
+        let mut app = App::new(100);
+        app.config.beginner_mode = true;
+        app.autoplay_streaming = true;
+        app.config.streaming.mode = crate::streaming::StreamingMode::Balanced;
+
+        let (_, player_parts) = fitted_status_line_parts(&app, 240, false);
+        assert_eq!(
+            text_for(&player_parts, &MouseTarget::StreamingMenu).trim_end(),
+            "[^r] Streaming autoplay: On · Balanced"
+        );
+
+        // The streaming toggle is global, so unlike Player actions its keycap remains honest
+        // in a docked bar on another screen.
+        app.mode = Mode::Settings;
+        let (_, docked_parts) = fitted_status_line_parts(&app, 240, false);
+        assert_eq!(
+            text_for(&docked_parts, &MouseTarget::StreamingMenu).trim_end(),
+            "[^r] Streaming autoplay: On · Balanced"
+        );
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -70,7 +70,9 @@ pub fn render(frame: &mut Frame, app: &App) {
             }
         }
     }
-    views::onboarding::render_search_hint(frame, app, area);
+    // The Beginner coach floats over the live surface. Its visibility gate yields to every
+    // established popup below, so those existing modal layers keep their input and z-order.
+    views::onboarding::render_beginner_coach(frame, app, area);
     // The `?` cheat-sheet draws on top of whatever screen is active.
     if app.overlays.help_visible {
         views::help::render(frame, app, area);

--- a/src/ui/views/onboarding.rs
+++ b/src/ui/views/onboarding.rs
@@ -4,49 +4,654 @@ use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
-use crate::app::{App, MouseTarget, ToolSetupContext};
+use crate::app::{
+    App, BeginnerStep, LibraryTab, Mode, MouseTarget, OnboardingAction, ToolSetupContext,
+};
 use crate::keymap::{Action, KeyContext};
+use crate::settings::{Field, SettingsTab};
 use crate::t;
 use crate::theme::ThemeRole as R;
 use crate::ui::buttons::{self, Seg};
 
-pub fn render_search_hint(frame: &mut Frame, app: &App, area: Rect) {
-    let mini = crate::ui::layout::tier(area) == crate::ui::layout::UiTier::Mini;
-    let layout_sufficient = search_hint_layout_sufficient(area, mini);
-    if !app.search_onboarding_render_eligible(layout_sufficient) {
+struct CoachCopy {
+    heading: String,
+    body: String,
+    primary: String,
+}
+
+pub fn render_beginner_coach(frame: &mut Frame, app: &App, area: Rect) {
+    if !app.beginner_coach_visible() || area.is_empty() {
         return;
     }
-    let key =
-        app.keymap
-            .label_for_display(KeyContext::Player, Action::OpenSearch, app.retro_mode());
-    let text = if mini {
-        format!("{}: {key}", t!("Search", "검색"))
+    let mini = crate::ui::layout::tier(area) == crate::ui::layout::UiTier::Mini;
+    let confirming = app.onboarding.skip_confirmation();
+    if area.width < 8 || area.height < 4 {
+        app.register_mouse_button(area, MouseTarget::Onboarding(OnboardingAction::Noop));
+        frame.render_widget(
+            Paragraph::new(t!(
+                "Beginner Mode · resize",
+                "비기너 모드 · 창을 키워 주세요"
+            ))
+            .style(app.theme.style(R::Accent).add_modifier(Modifier::BOLD)),
+            area,
+        );
+        return;
+    }
+
+    let copy = coach_copy(app, mini, confirming);
+    let max_width = area.width.saturating_sub(2).clamp(6, 68);
+    let body_width = max_width.saturating_sub(4).max(1) as usize;
+    let mut body = crate::ui::text::wrap_to_width(&copy.body, body_width);
+    let max_height = area.height.saturating_sub(2).max(3);
+    let height = u16::try_from(body.len())
+        .unwrap_or(u16::MAX)
+        .saturating_add(7)
+        .min(max_height);
+    let body_rows = usize::from(height.saturating_sub(7));
+    let body_truncated = body.len() > body_rows.max(1);
+    body.truncate(body_rows.max(1));
+    if body_truncated && let Some(last) = body.last_mut() {
+        *last = with_ellipsis(last, body_width);
+    }
+    let anchor = (!mini && !confirming)
+        .then(|| coach_anchor(app))
+        .flatten()
+        .and_then(|target| app.hits.rect_of_target(target));
+    let popup = place_coach(area, anchor, max_width, height);
+
+    // Skip confirmation is the one modal coach state: seal the whole frame. Otherwise only the
+    // card body blocks clicks and the instructed surface remains interactive around it.
+    app.register_mouse_button(
+        if confirming { area } else { popup },
+        MouseTarget::Onboarding(OnboardingAction::Noop),
+    );
+    crate::ui::render_popup_background(frame, app, popup);
+    let title = if confirming {
+        t!(" Skip Beginner Mode? ", " 비기너 모드를 건너뛸까요? ").to_owned()
     } else {
         format!(
-            "→ {} · {} `{key}` {}",
-            t!("Search starts here", "검색은 여기를 누르세요"),
-            t!("press", "키보드는"),
-            t!("or click Search", "또는 검색을 클릭하세요")
+            " {} · {} {}/{} ",
+            t!("Beginner Mode", "비기너 모드"),
+            t!("Step", "단계"),
+            app.onboarding.step().number(),
+            BeginnerStep::COUNT
         )
     };
-    let row = Rect {
-        x: area.x.saturating_add(1),
-        y: if mini {
-            area.bottom().saturating_sub(1)
-        } else {
-            area.y.saturating_add(1)
-        },
-        width: area.width.saturating_sub(2),
-        height: 1,
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(crate::ui::confirm_border_style(app))
+        .style(crate::ui::popup_style(app, R::TextPrimary));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+    if inner.is_empty() {
+        return;
+    }
+
+    let heading = Rect {
+        height: 1.min(inner.height),
+        ..inner
     };
     frame.render_widget(
-        Paragraph::new(text).style(app.theme.style(R::Accent).add_modifier(Modifier::BOLD)),
+        Paragraph::new(copy.heading).style(app.theme.style(R::Accent).add_modifier(Modifier::BOLD)),
+        heading,
+    );
+    let body_area = Rect {
+        y: inner.y.saturating_add(2),
+        height: u16::try_from(body.len())
+            .unwrap_or(u16::MAX)
+            .min(inner.height.saturating_sub(4)),
+        ..inner
+    };
+    let lines: Vec<Line<'_>> = body.into_iter().map(Line::from).collect();
+    frame.render_widget(Paragraph::new(lines), body_area);
+
+    let focused = app.onboarding.guide_focused_for(mini);
+    let hint = if confirming {
+        t!("Esc cancel · ←/→ · Enter", "Esc 취소 · ←/→ · Enter")
+    } else if mini && focused {
+        t!("Esc: app · Enter: Skip", "Esc: 앱 · Enter: 건너뛰기")
+    } else if mini {
+        t!(
+            "F6: Skip · resize to resume",
+            "F6: 건너뛰기 · 창을 키우면 계속"
+        )
+    } else if focused {
+        t!(
+            "F6/Esc: app · ←/→ choose · Enter",
+            "F6/Esc: 앱 · ←/→ 선택 · Enter"
+        )
+    } else {
+        t!(
+            "Use the app normally · F6 guide controls",
+            "앱을 직접 사용해 보세요 · F6 안내 버튼"
+        )
+    };
+    let hint_area = Rect {
+        y: inner.bottom().saturating_sub(2),
+        height: 1.min(inner.height),
+        ..inner
+    };
+    frame.render_widget(
+        Paragraph::new(with_ellipsis(hint, hint_area.width as usize))
+            .alignment(Alignment::Center)
+            .style(app.theme.style(R::TextMuted)),
+        hint_area,
+    );
+    render_coach_buttons(frame, app, inner, &copy.primary, mini, confirming);
+    crate::ui::seal_popup_background(frame, app, popup);
+    crate::ui::mark_art_rows_for_popup(frame, app, popup);
+}
+
+fn coach_copy(app: &App, mini: bool, confirming: bool) -> CoachCopy {
+    if confirming {
+        return CoachCopy {
+            heading: t!(
+                "You can restart it from Settings.",
+                "설정에서 언제든 다시 시작할 수 있어요."
+            )
+            .to_owned(),
+            body: t!(
+                "Skipping turns Beginner Mode off and resets this tour to Welcome.",
+                "건너뛰면 비기너 모드가 꺼지고 이 투어는 처음 단계로 초기화돼요."
+            )
+            .to_owned(),
+            primary: String::new(),
+        };
+    }
+    if mini {
+        return CoachCopy {
+            heading: t!(
+                "Make the terminal a little bigger",
+                "터미널 창을 조금 더 키워 주세요"
+            )
+            .to_owned(),
+            body: format!(
+                "{} · {} 32×14 · {} {}/{}",
+                t!("The tour is paused", "튜토리얼이 잠시 멈췄어요"),
+                t!("minimum", "최소 크기"),
+                t!("Step", "단계"),
+                app.onboarding.step().number(),
+                BeginnerStep::COUNT
+            ),
+            primary: String::new(),
+        };
+    }
+
+    let key = |context, action| {
+        app.keymap
+            .label_for_display(context, action, app.retro_mode())
+    };
+    let reached = app.onboarding.target_reached();
+    match app.onboarding.step() {
+        BeginnerStep::Welcome => CoachCopy {
+            heading: t!("Welcome to YuTuTui!", "YuTuTui!에 오신 걸 환영해요").to_owned(),
+            body: t!(
+                "Take a short, safe tour of every screen. Your place is saved, and the tour never requires playback, downloads, sign-in, or a network search.",
+                "모든 화면을 짧고 안전하게 둘러봐요. 진행 위치는 저장되며 재생, 다운로드, 로그인, 실제 검색은 요구하지 않아요."
+            )
+            .to_owned(),
+            primary: t!("Start tour", "투어 시작").to_owned(),
+        },
+        BeginnerStep::NavigationHelp => CoachCopy {
+            heading: t!("Navigation and Help", "화면 이동과 도움말").to_owned(),
+            body: format!(
+                "{} {}. {}",
+                t!(
+                    "The top row switches between Player, Search, Library, Settings, and DJ Gem. Open the complete live key guide with",
+                    "위쪽 메뉴에서 플레이어, 검색, 라이브러리, 설정, DJ Gem으로 이동할 수 있어요. 현재 단축키 도움말은"
+                ),
+                key(KeyContext::Global, Action::ToggleHelp),
+                t!("Mouse controls work too.", "키로 열 수 있고 마우스도 사용할 수 있어요.")
+            ),
+            primary: t!("Open Help", "도움말 열기").to_owned(),
+        },
+        BeginnerStep::Search => CoachCopy {
+            heading: t!("Find music safely", "안전하게 음악 찾기").to_owned(),
+            body: if reached {
+                t!(
+                    "Choose a source, type in the query box, and inspect results or filters. Enter submits; double-click plays; right-click opens safe row actions. You do not need to search now.",
+                    "검색 소스를 고르고 입력 칸과 결과 필터를 살펴보세요. Enter는 검색, 더블클릭은 재생, 우클릭은 안전한 행 메뉴예요. 지금 실제 검색할 필요는 없어요."
+                )
+                .to_owned()
+            } else {
+                format!(
+                    "{} {} {}",
+                    t!("Open Search with", "검색 화면은"),
+                    key(KeyContext::Player, Action::OpenSearch),
+                    t!("or the top navigation.", "키 또는 위쪽 메뉴로 열 수 있어요.")
+                )
+            },
+            primary: if reached {
+                t!("Continue", "계속").to_owned()
+            } else {
+                t!("Open Search", "검색 열기").to_owned()
+            },
+        },
+        BeginnerStep::Player => CoachCopy {
+            heading: t!("Player controls", "플레이어 조작").to_owned(),
+            body: if reached {
+                t!(
+                    "Transport, seek, Volume, Queue, Rating, Shuffle, Repeat, and Equalizer live here. Beginner Mode spells each control and state out. Autoplay and Repeat cannot be enabled together.",
+                    "재생, 탐색, 볼륨, 대기열, 평가, 셔플, 반복, 이퀄라이저를 여기서 조작해요. 비기너 모드는 이름과 상태를 풀어서 보여 줘요. 자동재생과 반복은 함께 켤 수 없어요."
+                )
+                .to_owned()
+            } else {
+                format!(
+                    "{} {}.",
+                    t!("Return to Player/Home with", "플레이어 홈으로 돌아가는 키는"),
+                    key(KeyContext::Global, Action::Home)
+                )
+            },
+            primary: if reached {
+                t!("Continue", "계속").to_owned()
+            } else {
+                t!("Open Player", "플레이어 열기").to_owned()
+            },
+        },
+        BeginnerStep::Library => CoachCopy {
+            heading: t!("Your Library", "내 라이브러리").to_owned(),
+            body: if reached {
+                t!(
+                    "Browse All, Favorites, History, Downloads, and Playlists. Single-click selects; double-click activates; right-click opens the row menu. Nothing needs to be downloaded now.",
+                    "전체, 즐겨찾기, 기록, 다운로드, 플레이리스트를 둘러보세요. 한 번 클릭은 선택, 더블클릭은 실행, 우클릭은 행 메뉴예요. 지금 다운로드할 필요는 없어요."
+                )
+                .to_owned()
+            } else {
+                format!(
+                    "{} {} {}",
+                    t!("Open Library with", "라이브러리는"),
+                    key(KeyContext::Player, Action::OpenLibrary),
+                    t!("or the top navigation.", "키 또는 위쪽 메뉴로 열 수 있어요.")
+                )
+            },
+            primary: if reached {
+                t!("Continue", "계속").to_owned()
+            } else {
+                t!("Open Library", "라이브러리 열기").to_owned()
+            },
+        },
+        BeginnerStep::DjGem => CoachCopy {
+            heading: t!("Meet DJ Gem", "DJ Gem 만나기").to_owned(),
+            body: if reached {
+                t!(
+                    "DJ Gem can chat about music and help curate autoplay when an API key is configured. It is optional; Radio and Local Deck are optional advanced modes too.",
+                    "DJ Gem은 API 키가 있을 때 음악 대화와 자동재생 큐레이팅을 도와줘요. 선택 기능이며 라디오와 Local Deck도 선택형 고급 모드예요."
+                )
+                .to_owned()
+            } else {
+                let context = match app.mode {
+                    Mode::Player => Some(KeyContext::Player),
+                    Mode::Library
+                        if app.effective_library_tab() == LibraryTab::Playlists =>
+                    {
+                        Some(KeyContext::Playlists)
+                    }
+                    Mode::Library => Some(KeyContext::Library),
+                    _ => None,
+                };
+                context.map_or_else(
+                    || {
+                        t!(
+                            "Use the top navigation or the guide action below.",
+                            "위쪽 메뉴나 아래 안내 버튼을 사용하세요."
+                        )
+                        .to_owned()
+                    },
+                    |context| {
+                        format!(
+                            "{} {} {}",
+                            t!("Open DJ Gem with", "DJ Gem은"),
+                            key(context, Action::OpenAi),
+                            t!(
+                                "or the top navigation.",
+                                "키 또는 위쪽 메뉴로 열 수 있어요."
+                            )
+                        )
+                    },
+                )
+            },
+            primary: if reached {
+                t!("Continue", "계속").to_owned()
+            } else {
+                t!("Open DJ Gem", "DJ Gem 열기").to_owned()
+            },
+        },
+        BeginnerStep::Settings => settings_copy(app, &key),
+        BeginnerStep::Finish => finish_copy(app, &key),
+    }
+}
+
+fn settings_copy(app: &App, key: &impl Fn(KeyContext, Action) -> String) -> CoachCopy {
+    let tab = app.settings.as_ref().map(|settings| settings.tab);
+    let visited = app.onboarding.settings_tab_visited();
+    let (body, primary) = match tab {
+        None => (
+            t!(
+                "Choose Settings in the top navigation, or use the guide action below.",
+                "위쪽 메뉴에서 설정을 선택하거나 아래 안내 버튼을 사용하세요."
+            )
+            .to_owned(),
+            t!("Open Settings", "설정 열기").to_owned(),
+        ),
+        Some(SettingsTab::General) if !visited => (
+            format!(
+                "{} {}.",
+                t!(
+                    "Explore General, Playback, Hotkeys, Graphics, DJ Gem, and Accounts. Switch to any other tab with",
+                    "일반, 재생, 핫키, 그래픽, DJ Gem, 계정 탭을 둘러봐요. 다른 탭으로 이동하는 키는"
+                ),
+                key(KeyContext::Settings, Action::FocusNext)
+            ),
+            t!("Try another tab", "다른 탭 보기").to_owned(),
+        ),
+        Some(SettingsTab::General) => (
+            format!(
+                "{} {}.",
+                t!(
+                    "Great. Arrows change values and Enter activates. Save and close Settings with",
+                    "좋아요. 화살표로 값을 바꾸고 Enter로 실행해요. 설정을 저장하고 닫는 키는"
+                ),
+                key(KeyContext::Settings, Action::SettingsCancel)
+            ),
+            t!("Continue", "계속").to_owned(),
+        ),
+        Some(_) if visited => (
+            t!(
+                "Each tab groups related options. Return to General to finish the tour.",
+                "각 탭에는 관련 설정이 모여 있어요. 투어를 마치려면 일반 탭으로 돌아가세요."
+            )
+            .to_owned(),
+            t!("Back to General", "일반으로 돌아가기").to_owned(),
+        ),
+        Some(_) => (
+            t!(
+                "You switched a settings tab. Return to General when you are ready.",
+                "설정 탭을 직접 바꿨어요. 준비되면 일반 탭으로 돌아가세요."
+            )
+            .to_owned(),
+            t!("Back to General", "일반으로 돌아가기").to_owned(),
+        ),
+    };
+    CoachCopy {
+        heading: t!("Settings tour", "설정 둘러보기").to_owned(),
+        body,
+        primary,
+    }
+}
+
+fn finish_copy(app: &App, key: &impl Fn(KeyContext, Action) -> String) -> CoachCopy {
+    let in_settings = app.mode == Mode::Settings;
+    let enabled = app.beginner_mode();
+    let (body, primary) = if !in_settings {
+        (
+            t!(
+                "Open Settings one last time. The Beginner Mode row is at the top of General.",
+                "마지막으로 설정을 열어 주세요. 비기너 모드는 일반 탭 맨 위에 있어요."
+            )
+            .to_owned(),
+            t!("Open Beginner Mode", "비기너 모드 열기").to_owned(),
+        )
+    } else if enabled {
+        (
+            t!(
+                "Turn Beginner Mode Off yourself. This keeps completion intentional; you can enable it again whenever you want.",
+                "비기너 모드를 직접 꺼 주세요. 그래야 온보딩 완료가 분명해지며, 원하면 언제든 다시 켤 수 있어요."
+            )
+            .to_owned(),
+            t!("Turn off Beginner Mode", "비기너 모드 끄기").to_owned(),
+        )
+    } else {
+        (
+            format!(
+                "{} {}.",
+                t!(
+                    "All set. Save and close Settings with",
+                    "모두 끝났어요. 설정을 저장하고 닫는 키는"
+                ),
+                key(KeyContext::Settings, Action::SettingsCancel)
+            ),
+            t!("Save and finish", "저장하고 완료").to_owned(),
+        )
+    };
+    CoachCopy {
+        heading: t!("Finish Beginner Mode", "비기너 모드 마치기").to_owned(),
+        body,
+        primary,
+    }
+}
+
+fn coach_anchor(app: &App) -> Option<MouseTarget> {
+    let reached = app.onboarding.target_reached();
+    match app.onboarding.step() {
+        BeginnerStep::Welcome => None,
+        BeginnerStep::NavigationHelp => Some(MouseTarget::Global(Action::ToggleHelp)),
+        BeginnerStep::Search => Some(if reached {
+            MouseTarget::SearchInput
+        } else {
+            MouseTarget::Nav(Mode::Search)
+        }),
+        BeginnerStep::Player => Some(if reached {
+            MouseTarget::VolumeArea
+        } else {
+            MouseTarget::Nav(Mode::Player)
+        }),
+        BeginnerStep::Library => Some(if reached {
+            MouseTarget::LibraryTab(app.effective_library_tab())
+        } else {
+            MouseTarget::Nav(Mode::Library)
+        }),
+        BeginnerStep::DjGem => Some(if reached {
+            MouseTarget::AiInput
+        } else {
+            MouseTarget::Nav(Mode::Ai)
+        }),
+        BeginnerStep::Settings => match app.settings.as_ref().map(|settings| settings.tab) {
+            None => Some(MouseTarget::Nav(Mode::Settings)),
+            Some(SettingsTab::General) if !app.onboarding.settings_tab_visited() => {
+                Some(MouseTarget::SettingsTab(SettingsTab::Playback.index()))
+            }
+            _ => Some(MouseTarget::SettingsTab(SettingsTab::General.index())),
+        },
+        BeginnerStep::Finish => {
+            let row = app.settings.as_ref().and_then(|settings| {
+                settings
+                    .fields()
+                    .iter()
+                    .position(|field| *field == Field::BeginnerMode)
+            });
+            row.map_or(Some(MouseTarget::Nav(Mode::Settings)), |row| {
+                Some(MouseTarget::SettingsChange { row, delta: 1 })
+            })
+        }
+    }
+}
+
+fn render_coach_buttons(
+    frame: &mut Frame,
+    app: &App,
+    inner: Rect,
+    primary: &str,
+    mini: bool,
+    confirming: bool,
+) {
+    let selected = app.onboarding.selected_action();
+    let focused = app.onboarding.guide_focused_for(mini);
+    let mut owned: Vec<(OnboardingAction, String)> = if confirming {
+        vec![
+            (
+                OnboardingAction::CancelSkip,
+                t!("Cancel", "취소").to_owned(),
+            ),
+            (
+                OnboardingAction::ConfirmSkip,
+                t!("Skip tour", "투어 건너뛰기").to_owned(),
+            ),
+        ]
+    } else if mini {
+        vec![(OnboardingAction::Skip, t!("Skip", "건너뛰기").to_owned())]
+    } else {
+        vec![
+            (OnboardingAction::Back, t!("Back", "이전").to_owned()),
+            (OnboardingAction::Primary, primary.to_owned()),
+            (OnboardingAction::Skip, t!("Skip", "건너뛰기").to_owned()),
+        ]
+    };
+    let compact = inner.width < 44;
+    if compact
+        && let Some((_, label)) = owned
+            .iter_mut()
+            .find(|(action, _)| *action == OnboardingAction::Primary)
+    {
+        *label = compact_primary_label(app).to_owned();
+    }
+    for (action, label) in &mut owned {
+        let marker = if app.retro_mode() {
+            ('>', '<')
+        } else {
+            ('›', '‹')
+        };
+        let action_selected = focused && (selected == *action || (mini && !confirming));
+        if action_selected {
+            *label = if compact {
+                format!("{}{label}{}", marker.0, marker.1)
+            } else {
+                format!("{} {label} {}", marker.0, marker.1)
+            };
+        } else if !compact {
+            *label = format!("  {label}  ");
+        }
+    }
+    let mut segments = Vec::with_capacity(owned.len().saturating_mul(2));
+    for (index, (action, label)) in owned.iter().enumerate() {
+        if index > 0 {
+            segments.push(Seg::label(" "));
+        }
+        segments.push(Seg::button(MouseTarget::Onboarding(*action), label));
+    }
+    let row = Rect {
+        y: inner.bottom().saturating_sub(1),
+        height: 1.min(inner.height),
+        ..inner
+    };
+    buttons::render_segments(
+        frame,
+        app,
         row,
+        &segments,
+        crate::ui::confirm_button_style(app),
+        crate::ui::confirm_gap_style(app),
+        Alignment::Center,
     );
 }
 
-fn search_hint_layout_sufficient(area: Rect, mini: bool) -> bool {
-    area.width > 2 && area.height >= if mini { 4 } else { 3 }
+fn compact_primary_label(app: &App) -> &'static str {
+    let next = t!("Next", "다음");
+    match app.onboarding.step() {
+        BeginnerStep::Welcome => t!("Start", "시작"),
+        BeginnerStep::NavigationHelp => t!("Help", "도움말"),
+        BeginnerStep::Search => {
+            if app.onboarding.target_reached() {
+                next
+            } else {
+                t!("Search", "검색")
+            }
+        }
+        BeginnerStep::Player => {
+            if app.onboarding.target_reached() {
+                next
+            } else {
+                t!("Player", "플레이어")
+            }
+        }
+        BeginnerStep::Library => {
+            if app.onboarding.target_reached() {
+                next
+            } else {
+                t!("Library", "라이브러리")
+            }
+        }
+        BeginnerStep::DjGem => {
+            if app.onboarding.target_reached() {
+                next
+            } else {
+                "DJ Gem"
+            }
+        }
+        BeginnerStep::Settings => {
+            let tab = app.settings.as_ref().map(|settings| settings.tab);
+            if app.mode != Mode::Settings {
+                t!("Settings", "설정")
+            } else if !app.onboarding.settings_tab_visited() {
+                t!("Try tab", "탭 보기")
+            } else if tab != Some(SettingsTab::General) {
+                t!("General", "일반")
+            } else {
+                next
+            }
+        }
+        BeginnerStep::Finish => {
+            if app.mode != Mode::Settings {
+                t!("Settings", "설정")
+            } else if app.beginner_mode() {
+                t!("Turn off", "끄기")
+            } else {
+                t!("Save", "저장")
+            }
+        }
+    }
+}
+
+fn with_ellipsis(text: &str, width: usize) -> String {
+    if buttons::text_width(text) <= u16::try_from(width).unwrap_or(u16::MAX) {
+        return text.to_owned();
+    }
+    let mut truncated = crate::ui::text::truncate_to_width(text, width.saturating_sub(1));
+    truncated.push('…');
+    truncated
+}
+
+fn place_coach(area: Rect, anchor: Option<Rect>, width: u16, height: u16) -> Rect {
+    let width = width.min(area.width);
+    let height = height.min(area.height);
+    let max_x = area.right().saturating_sub(width);
+    let max_y = area.bottom().saturating_sub(height);
+    let clamp_x = |x: u16| x.clamp(area.x, max_x.max(area.x));
+    let clamp_y = |y: u16| y.clamp(area.y, max_y.max(area.y));
+    if let Some(anchor) = anchor {
+        let centered_x = clamp_x(
+            anchor
+                .x
+                .saturating_add(anchor.width / 2)
+                .saturating_sub(width / 2),
+        );
+        let centered_y = clamp_y(
+            anchor
+                .y
+                .saturating_add(anchor.height / 2)
+                .saturating_sub(height / 2),
+        );
+        let below = anchor.bottom().saturating_add(1);
+        if below.saturating_add(height) <= area.bottom() {
+            return Rect::new(centered_x, below, width, height);
+        }
+        if anchor.y >= area.y.saturating_add(height).saturating_add(1) {
+            return Rect::new(centered_x, anchor.y - height - 1, width, height);
+        }
+        let right = anchor.right().saturating_add(1);
+        if right.saturating_add(width) <= area.right() {
+            return Rect::new(right, centered_y, width, height);
+        }
+        if anchor.x >= area.x.saturating_add(width).saturating_add(1) {
+            return Rect::new(anchor.x - width - 1, centered_y, width, height);
+        }
+    }
+    Rect::new(
+        clamp_x(area.x + area.width.saturating_sub(width) / 2),
+        clamp_y(area.bottom().saturating_sub(height).saturating_sub(1)),
+        width,
+        height,
+    )
 }
 
 pub fn render_tool_setup(frame: &mut Frame, app: &App, area: Rect) {
@@ -176,10 +781,86 @@ mod tests {
     use super::*;
 
     #[test]
-    fn search_hint_requires_a_nonzero_content_row() {
-        assert!(!search_hint_layout_sufficient(Rect::new(0, 0, 2, 4), true));
-        assert!(search_hint_layout_sufficient(Rect::new(0, 0, 3, 4), true));
-        assert!(!search_hint_layout_sufficient(Rect::new(0, 0, 3, 2), false));
-        assert!(search_hint_layout_sufficient(Rect::new(0, 0, 3, 3), false));
+    fn coach_prefers_below_its_anchor() {
+        let area = Rect::new(4, 2, 100, 40);
+        let anchor = Rect::new(40, 5, 12, 1);
+        assert_eq!(
+            place_coach(area, Some(anchor), 30, 10),
+            Rect::new(31, 7, 30, 10)
+        );
+    }
+
+    #[test]
+    fn coach_uses_space_above_a_low_anchor() {
+        let area = Rect::new(0, 0, 80, 30);
+        let anchor = Rect::new(35, 26, 10, 1);
+        assert_eq!(
+            place_coach(area, Some(anchor), 30, 10),
+            Rect::new(25, 15, 30, 10)
+        );
+    }
+
+    #[test]
+    fn coach_fallback_is_clamped_inside_offset_area() {
+        let area = Rect::new(7, 11, 20, 8);
+        let popup = place_coach(area, None, 60, 30);
+        assert_eq!(popup, Rect::new(7, 11, 20, 8));
+        assert!(popup.left() >= area.left() && popup.right() <= area.right());
+        assert!(popup.top() >= area.top() && popup.bottom() <= area.bottom());
+    }
+
+    #[test]
+    fn coach_copy_uses_the_live_remapped_key_label() {
+        let _guard = crate::i18n::lock_for_test();
+        crate::i18n::set_language(crate::i18n::Language::English);
+        let mut app = App::new(50);
+        app.config.beginner_mode = true;
+        app.config.beginner_tutorial.next_step = BeginnerStep::Search.id().to_owned();
+        app.keymap
+            .rebind(
+                KeyContext::Player,
+                Action::OpenSearch,
+                crate::keymap::parse_chord("f8").unwrap(),
+            )
+            .unwrap();
+        app.prepare_beginner_onboarding(true);
+
+        let copy = coach_copy(&app, false, false);
+        assert!(copy.body.contains("F8"), "got {:?}", copy.body);
+    }
+
+    #[test]
+    fn resumed_dj_step_uses_the_current_player_binding() {
+        let _guard = crate::i18n::lock_for_test();
+        crate::i18n::set_language(crate::i18n::Language::English);
+        let mut app = App::new(50);
+        app.config.beginner_mode = true;
+        app.config.beginner_tutorial.next_step = BeginnerStep::DjGem.id().to_owned();
+        app.keymap
+            .rebind(
+                KeyContext::Player,
+                Action::OpenAi,
+                crate::keymap::parse_chord("f8").unwrap(),
+            )
+            .unwrap();
+        app.keymap
+            .rebind(
+                KeyContext::Library,
+                Action::OpenAi,
+                crate::keymap::parse_chord("f9").unwrap(),
+            )
+            .unwrap();
+        app.prepare_beginner_onboarding(true);
+
+        let copy = coach_copy(&app, false, false);
+        assert!(copy.body.contains("F8"), "got {:?}", copy.body);
+        assert!(!copy.body.contains("F9"), "got {:?}", copy.body);
+    }
+
+    #[test]
+    fn clipped_coach_copy_marks_the_omission() {
+        let clipped = with_ellipsis("resize the terminal to continue", 12);
+        assert!(clipped.ends_with('…'));
+        assert!(buttons::text_width(&clipped) <= 12);
     }
 }


### PR DESCRIPTION
## Summary

- add fresh-install-only Beginner Mode persistence with safe legacy, recovery, read-only, and future-version behavior
- replace the timed Search hint with an eight-step interactive, resumable coach covering Help, Search, Player, Library, DJ Gem, Settings, Skip, and intentional completion
- expand live control names and key bindings in Beginner Mode while preserving compact OFF-mode rendering
- add responsive mini-mode, mouse targets, overlay/art clearing, English/Korean copy, and comprehensive regression coverage

## Verification

- `~/.fable-harness/bin/run-gates .`
- targeted Beginner Mode, onboarding, config compatibility, recovery, controls, render, mouse, and overlay tests
- isolated real-TUI verification with a fake HOME and private tmux/runtime socket: fresh Welcome, 31x14 pause card, resume after restart, Skip persistence, re-enable-on-next-launch, and the complete 8-step finish flow
- no playback, network search submission, download, authentication, or real user config access during verification

## Notes

- branched from current `origin/main`
- no daemon, GUI/desktop, workflow, packaging, lockfile, migration, or release changes