### PR TITLE
Publish Jellyfin-ready imports and add bulk Ready review

### DIFF
--- a/src/app/download.rs
+++ b/src/app/download.rs
@@ -3,6 +3,10 @@
 use super::*;
 use std::collections::HashSet;
 
+use crate::transfer::organize_plan::{
+    ImportOrganizeDecision, apply_import_organize_plan, build_import_organize_plan,
+};
+
 /// Ceiling on in-flight (dispatched-but-unfinished) downloads. Held comfortably below the
 /// bounded command channel (`backpressure::DOWNLOAD_QUEUE` = 128) so a bulk batch drains
 /// through `Downloads::pending` instead of overflowing the actor's `try_send`.
@@ -151,6 +155,15 @@ impl App {
             self.downloads
                 .active
                 .insert(tracking_key.clone(), DownloadState::Running(0));
+            if let (Some(session_id), Some(source_order)) =
+                (song.import_session_id.as_ref(), song.import_source_order)
+            {
+                self.downloads
+                    .auto_organize_rows
+                    .entry(session_id.clone())
+                    .or_default()
+                    .insert(source_order);
+            }
             self.downloads.sources.insert(tracking_key, song.clone());
             self.downloads.dispatched += 1;
             cmds.push(Cmd::Download(DownloadCmd::Start(Box::new(song))));
@@ -205,9 +218,20 @@ impl App {
             .insert(tracking_key.clone(), DownloadState::Done);
         self.downloads.dispatched = self.downloads.dispatched.saturating_sub(1);
         let saved = !path.trim().is_empty();
+        let import_session_id = self
+            .downloads
+            .sources
+            .get(&tracking_key)
+            .and_then(|song| song.import_session_id.clone());
+        // Preserve the ordinary empty-path terminal behavior; import ownership must still be
+        // released so it cannot block the session's settled check forever.
+        let source = if saved || import_session_id.is_some() {
+            self.downloads.sources.remove(&tracking_key)
+        } else {
+            None
+        };
         if saved {
             let path_buf = PathBuf::from(&path);
-            let source = self.downloads.sources.remove(&tracking_key);
             let local = source
                 .map(|source| source.with_local_path(path_buf.clone()))
                 .unwrap_or_else(|| Song::local_file(path_buf));
@@ -217,7 +241,14 @@ impl App {
         self.status.text = format!("{}: {path}", t!("Saved", "저장됨"));
         self.dirty = true;
         let mut commands = self.pump_downloads();
-        if saved {
+        if let Some(session_id) = import_session_id {
+            commands.extend(self.auto_organize_settled_import(&session_id));
+        }
+        if saved
+            && !commands
+                .iter()
+                .any(|cmd| matches!(cmd, Cmd::Persist(PersistCmd::Downloads)))
+        {
             commands.push(Cmd::Persist(PersistCmd::Downloads));
         }
         commands
@@ -237,11 +268,163 @@ impl App {
         self.downloads
             .active
             .insert(tracking_key.clone(), DownloadState::Failed);
-        self.downloads.sources.remove(&tracking_key);
+        let import_session_id = self
+            .downloads
+            .sources
+            .remove(&tracking_key)
+            .and_then(|song| song.import_session_id);
         self.downloads.dispatched = self.downloads.dispatched.saturating_sub(1);
         self.status.text = format!("{}: {error}", t!("Download failed", "다운로드 실패"));
         self.dirty = true;
-        self.pump_downloads()
+        let mut commands = self.pump_downloads();
+        if let Some(session_id) = import_session_id {
+            commands.extend(self.auto_organize_settled_import(&session_id));
+        }
+        commands
+    }
+
+    /// Publish only the import rows admitted in this runtime batch once every queued/running
+    /// download from the same session has reached a terminal state. A saved session may contain
+    /// older inbox artifacts, so the full deterministic plan is filtered to the tracked source
+    /// orders before it is applied.
+    fn auto_organize_settled_import(&mut self, session_id: &str) -> Vec<Cmd> {
+        let still_pending = self
+            .downloads
+            .pending
+            .iter()
+            .any(|song| song.import_session_id.as_deref() == Some(session_id));
+        let still_running = self
+            .downloads
+            .sources
+            .values()
+            .any(|song| song.import_session_id.as_deref() == Some(session_id));
+        if still_pending || still_running {
+            return Vec::new();
+        }
+
+        let Some(source_orders) = self.downloads.auto_organize_rows.remove(session_id) else {
+            return Vec::new();
+        };
+        let result: anyhow::Result<
+            Option<crate::transfer::organize_plan::ImportOrganizeApplyReport>,
+        > = (|| {
+            let session = crate::transfer::session::ImportSession::load(session_id)?;
+            let mut plan = build_import_organize_plan(&session, &self.import_organize_options())?;
+            plan.rows
+                .retain(|row| source_orders.contains(&row.source_order));
+            plan.move_count = 0;
+            plan.already_count = 0;
+            plan.skipped_count = 0;
+            for row in &plan.rows {
+                match row.decision {
+                    ImportOrganizeDecision::Move => plan.move_count += 1,
+                    ImportOrganizeDecision::AlreadyAtTarget => plan.already_count += 1,
+                    ImportOrganizeDecision::NotAccepted
+                    | ImportOrganizeDecision::MissingLocalPath => plan.skipped_count += 1,
+                }
+            }
+            if plan.move_count == 0 {
+                return Ok(None);
+            }
+            let report = apply_import_organize_plan(&plan)?;
+            Ok(Some(report))
+        })();
+
+        let paths_changed =
+            self.refresh_organized_import_download_paths(session_id, &source_orders);
+        let mut deferred_refresh = if paths_changed && !matches!(&result, Ok(Some(_))) {
+            self.request_local_scan(false)
+        } else {
+            Vec::new()
+        };
+        let mut commands = match result {
+            Ok(Some(report)) => {
+                let commands = self.request_local_scan(false);
+                self.status.kind = StatusKind::Info;
+                self.status.text = format!(
+                    "{} {session_id}: {} {}, {} {}, {} {}",
+                    t!("Organized import session", "임포트 세션 정리됨"),
+                    report.moved_count,
+                    t!("moved", "이동됨"),
+                    report.already_count,
+                    t!("already", "이미 정리됨"),
+                    report.skipped_count,
+                    t!("failed; retry from Local Deck", "실패; 로컬 덱에서 재시도")
+                );
+                self.dirty = true;
+                commands
+            }
+            Ok(None) => Vec::new(),
+            Err(error) => {
+                self.status.kind = StatusKind::Error;
+                self.status.text = format!(
+                    "{}: {error:#}. {}",
+                    t!(
+                        "Automatic import organize did not finish; artifacts remain recoverable",
+                        "임포트 자동 정리가 완료되지 않음; 파일은 복구 가능한 상태로 유지됨"
+                    ),
+                    t!(
+                        "Select the session in Local Deck and press m to retry",
+                        "로컬 덱에서 세션을 선택하고 m을 눌러 재시도하세요"
+                    )
+                );
+                self.dirty = true;
+                Vec::new()
+            }
+        };
+        deferred_refresh.append(&mut commands);
+        let mut commands = deferred_refresh;
+        if paths_changed {
+            commands.push(Cmd::Persist(PersistCmd::Downloads));
+        }
+        commands
+    }
+
+    fn refresh_organized_import_download_paths(
+        &mut self,
+        session_id: &str,
+        source_orders: &HashSet<u32>,
+    ) -> bool {
+        let Ok(session) = crate::transfer::session::ImportSession::load(session_id) else {
+            return false;
+        };
+        let paths: std::collections::HashMap<_, _> = session
+            .rows
+            .into_iter()
+            .filter(|row| source_orders.contains(&row.source_order))
+            .filter_map(|row| row.local_path.map(|path| (row.source_order, path)))
+            .collect();
+        if paths.is_empty() {
+            return false;
+        }
+
+        let manifest_changed = self
+            .download_store
+            .relocate_import_paths(session_id, &paths);
+        let mut runtime_changed = false;
+        for song in &mut self.library_ui.downloaded {
+            if song.import_session_id.as_deref() != Some(session_id) {
+                continue;
+            }
+            let Some(path) = song
+                .import_source_order
+                .and_then(|source_order| paths.get(&source_order))
+            else {
+                continue;
+            };
+            if song.local_path.as_ref() != Some(path) {
+                *song = song.with_local_path(path.clone());
+                runtime_changed = true;
+            }
+        }
+        if runtime_changed {
+            let mut seen = HashSet::new();
+            self.library_ui
+                .downloaded
+                .retain(|song| seen.insert(song.video_id.clone()));
+            self.library_ui.downloaded_rev = self.library_ui.downloaded_rev.wrapping_add(1);
+        }
+        manifest_changed || runtime_changed
     }
 
     pub(in crate::app) fn add_downloaded_track(&mut self, song: Song) {

--- a/src/app/local.rs
+++ b/src/app/local.rs
@@ -393,6 +393,7 @@ impl App {
                 Vec::new()
             }
             LocalMsg::ScanFinished { index_path, result } => {
+                let pending_rescan = self.local_mode.index.pending_rescan.take();
                 self.local_mode.index.index_path = index_path;
                 self.local_mode.index.index = result.index;
                 self.local_mode.index.loaded = true;
@@ -415,7 +416,7 @@ impl App {
                     t!("tracks", "곡")
                 );
                 self.dirty = true;
-                Vec::new()
+                pending_rescan.map_or_else(Vec::new, |full| self.request_local_scan(full))
             }
             LocalMsg::ScanProgress(progress) => {
                 if self.local_mode.index.scanning {
@@ -427,6 +428,7 @@ impl App {
                 Vec::new()
             }
             LocalMsg::ScanFailed { error } => {
+                let pending_rescan = self.local_mode.index.pending_rescan.take();
                 self.local_mode.index.loading = false;
                 self.local_mode.index.scanning = false;
                 self.local_mode.index.progress = None;
@@ -434,7 +436,7 @@ impl App {
                 self.status.text =
                     format!("{}: {error}", t!("Local scan failed", "로컬 스캔 실패"));
                 self.dirty = true;
-                Vec::new()
+                pending_rescan.map_or_else(Vec::new, |full| self.request_local_scan(full))
             }
             LocalMsg::ImportReviewFinished {
                 op_id,
@@ -481,6 +483,8 @@ impl App {
 
     pub(in crate::app) fn request_local_scan(&mut self, full: bool) -> Vec<Cmd> {
         if self.local_mode.index.scanning {
+            self.local_mode.index.pending_rescan =
+                Some(self.local_mode.index.pending_rescan.unwrap_or_default() || full);
             return Vec::new();
         }
         let roots = self.local_scan_roots();

--- a/src/app/local_format.rs
+++ b/src/app/local_format.rs
@@ -38,6 +38,20 @@ pub(in crate::app) fn local_song_text(app: &App, song: &Song) -> String {
 
 pub(in crate::app) fn local_import_session_text(session_id: &str, track_count: usize) -> String {
     if let Ok(session) = crate::transfer::session::ImportSession::load(session_id) {
+        let ready_plan = crate::transfer::review_action::plan_ready_candidates(session_id).ok();
+        let ready = ready_plan
+            .as_ref()
+            .map(|plan| plan.ready_count.to_string())
+            .unwrap_or_else(|| "?".to_owned());
+        let total = ready_plan
+            .as_ref()
+            .map_or(session.counts.total, |plan| plan.total_count);
+        let review = ready_plan
+            .as_ref()
+            .map_or(session.counts.ambiguous, |plan| plan.review_left);
+        let missing = ready_plan
+            .as_ref()
+            .map_or(session.counts.not_found, |plan| plan.missing_left);
         let local_files = session
             .rows
             .iter()
@@ -48,15 +62,17 @@ pub(in crate::app) fn local_import_session_text(session_id: &str, track_count: u
             .iter()
             .filter(|row| !row.errors.is_empty())
             .count();
-        return format!(
-            "{session_id}  ({} written, {}/{} local, {failed} failed, {} review, {} missing, {} pending)",
-            session.counts.written,
-            local_files,
-            session.counts.total,
-            session.counts.ambiguous,
-            session.counts.not_found,
-            session.counts.pending
-        );
+        return if crate::i18n::is_korean() {
+            format!(
+                "{session_id}  (준비 {ready}/{total} · 로컬 {local_files}/{total} · 실패 {failed} · 검토 {review} · 누락 {missing} · 대기 {})",
+                session.counts.pending
+            )
+        } else {
+            format!(
+                "{session_id}  (Ready {ready}/{total} · Local {local_files}/{total} · {failed} failed · {review} review · {missing} missing · {} pending)",
+                session.counts.pending
+            )
+        };
     }
     format!("{session_id}  ({track_count} {})", t!("tracks", "곡"))
 }
@@ -83,26 +99,32 @@ pub(in crate::app) fn push_import_session_summary_details(
         t!("Rows", "행"),
         format!("{} {}", session.counts.total, t!("rows", "행")),
     );
-    push_detail_line(
-        lines,
-        t!("Written", "작성됨"),
-        session.counts.written.to_string(),
-    );
-    push_detail_line(
-        lines,
-        t!("Local files", "로컬 파일"),
-        format!("{local_files}/{}", session.counts.total),
-    );
+    let ready_plan = crate::transfer::review_action::plan_ready_candidates(session_id).ok();
+    let ready = ready_plan
+        .as_ref()
+        .map(|plan| plan.ready_count.to_string())
+        .unwrap_or_else(|| "?".to_owned());
+    let total = ready_plan
+        .as_ref()
+        .map_or(session.counts.total, |plan| plan.total_count);
+    push_detail_line(lines, t!("Ready", "준비"), format!("{ready}/{total}"));
+    push_detail_line(lines, t!("Local", "로컬"), format!("{local_files}/{total}"));
     push_detail_line(lines, t!("Failed", "실패"), failed.to_string());
     push_detail_line(
         lines,
         t!("Review", "검토"),
-        session.counts.ambiguous.to_string(),
+        ready_plan
+            .as_ref()
+            .map_or(session.counts.ambiguous, |plan| plan.review_left)
+            .to_string(),
     );
     push_detail_line(
         lines,
         t!("Missing", "누락"),
-        session.counts.not_found.to_string(),
+        ready_plan
+            .as_ref()
+            .map_or(session.counts.not_found, |plan| plan.missing_left)
+            .to_string(),
     );
     push_detail_line(
         lines,

--- a/src/app/local_import.rs
+++ b/src/app/local_import.rs
@@ -386,15 +386,11 @@ impl App {
                 if failed > 0 {
                     actions.push(t!("r retry failed", "r 실패 재시도"));
                 }
-                if load_import_session_recovering(&session_id)
+                if crate::transfer::review_action::plan_ready_candidates(&session_id)
                     .ok()
-                    .is_some_and(|session| {
-                        import_session_accept_all_candidate_count(&session)
-                            + import_session_unwritten_ready_count(&session)
-                            > 0
-                    })
+                    .is_some_and(|plan| plan.total_count > 0)
                 {
-                    actions.push(t!("A accept & write", "A 수락 및 작성"));
+                    actions.push(t!("A mark all ready", "A 전체 준비"));
                 }
                 actions.push(t!("d download accepted", "d 수락 곡 다운로드"));
                 actions.push(t!("m commit inbox", "m 인박스 커밋"));
@@ -417,15 +413,11 @@ impl App {
                         t!("x skip", "x 건너뜀"),
                     ]);
                 }
-                if load_import_session_recovering(&session_id)
+                if crate::transfer::review_action::plan_ready_candidates(&session_id)
                     .ok()
-                    .is_some_and(|session| {
-                        import_session_accept_all_candidate_count(&session)
-                            + import_session_unwritten_ready_count(&session)
-                            > 0
-                    })
+                    .is_some_and(|plan| plan.total_count > 0)
                 {
-                    actions.push(t!("A accept & write", "A 수락 및 작성"));
+                    actions.push(t!("A mark all ready", "A 전체 준비"));
                 }
                 if !row.errors.is_empty() {
                     actions.push(t!("r retry failed", "r 실패 재시도"));
@@ -851,29 +843,43 @@ impl App {
             self.dirty = true;
             return Some(Vec::new());
         };
-        let candidate_count = import_session_accept_all_candidate_count(&session);
-        let ready_count = import_session_unwritten_ready_count(&session) + candidate_count;
-        if candidate_count == 0 && ready_count == 0 {
+        let Ok(plan) = crate::transfer::review_action::plan_ready_candidates(&session_id) else {
+            self.status.kind = StatusKind::Error;
+            self.status.text = format!(
+                "{}: {session_id}",
+                t!(
+                    "Import checkpoint not found",
+                    "임포트 체크포인트를 찾을 수 없음"
+                )
+            );
+            self.dirty = true;
+            return Some(Vec::new());
+        };
+        let local_count = session
+            .rows
+            .iter()
+            .filter(|row| row.local_path.is_some())
+            .count() as u32;
+        if plan.candidate_count == 0 {
             self.status.kind = StatusKind::Info;
-            self.status.text = t!(
-                "No import candidates or ready rows to write",
-                "수락할 후보나 작성할 준비 행이 없음"
-            )
-            .to_owned();
+            self.status.text =
+                local_ready_status_text(plan.ready_count, plan.total_count, local_count);
             self.dirty = true;
             return Some(Vec::new());
         }
         self.local_mode.pending_accept_all_confirm = Some(LocalImportAcceptAllConfirm {
             session_id,
-            candidate_count,
-            ready_count,
-            review_left: session.counts.ambiguous.saturating_sub(candidate_count),
-            missing_left: session.counts.not_found,
+            candidate_count: plan.candidate_count,
+            ready_count: plan.resulting_ready_count,
+            total_count: plan.total_count,
+            local_count,
+            review_left: plan.review_left,
+            missing_left: plan.missing_left,
         });
         self.status.kind = StatusKind::Info;
         self.status.text = t!(
-            "Confirm accepting and writing the import",
-            "임포트 수락 및 작성을 확인하세요"
+            "Confirm marking all safe candidates Ready",
+            "안전한 후보 전체 준비 완료를 확인하세요"
         )
         .to_owned();
         self.dirty = true;
@@ -904,29 +910,12 @@ impl App {
             .pending_import_reviews
             .insert(confirm.session_id.clone(), op_id);
         self.status.kind = StatusKind::Info;
-        if confirm.candidate_count == 0 {
-            self.local_mode
-                .pending_import_reviews
-                .remove(&confirm.session_id);
-            self.local_mode
-                .pending_accept_write_summaries
-                .insert(confirm.session_id.clone(), 0);
-            self.transfer_running = true;
-            self.status.text = t!(
-                "Writing accepted import rows to Library playlist...",
-                "수락된 임포트 행을 Library 플레이리스트에 쓰는 중..."
-            )
-            .to_owned();
-            self.dirty = true;
-            return vec![Cmd::Transfer(
-                crate::transfer::actor::TransferCmd::WriteReviewedLocal {
-                    job_id: confirm.session_id,
-                },
-            )];
-        }
         self.status.text = format!(
             "{} {}...",
-            t!("Accepting import candidates", "임포트 후보 수락 중"),
+            t!(
+                "Marking safe candidates Ready",
+                "안전한 후보 준비 완료 표시 중"
+            ),
             confirm.candidate_count
         );
         self.dirty = true;
@@ -990,27 +979,18 @@ impl App {
         match result {
             Ok(summary) => {
                 self.status.kind = StatusKind::Info;
-                self.local_mode
-                    .pending_accept_write_summaries
-                    .insert(session_id.clone(), summary.accepted_count);
-                self.transfer_running = true;
-                self.status.text = if crate::i18n::is_korean() {
-                    format!(
-                        "임포트 후보 {}개 수락 · Library 플레이리스트 작성 중...",
-                        summary.accepted_count
-                    )
-                } else {
-                    format!(
-                        "Accepted {} import candidate{} · writing Library playlist...",
-                        summary.accepted_count,
-                        if summary.accepted_count == 1 { "" } else { "s" }
-                    )
-                };
-                self.clamp_local_after_import_change();
-                self.dirty = true;
-                return vec![Cmd::Transfer(
-                    crate::transfer::actor::TransferCmd::WriteReviewedLocal { job_id: session_id },
-                )];
+                let local_count = load_import_session_recovering(&session_id)
+                    .ok()
+                    .map(|session| {
+                        session
+                            .rows
+                            .iter()
+                            .filter(|row| row.local_path.is_some())
+                            .count() as u32
+                    })
+                    .unwrap_or_default();
+                self.status.text =
+                    local_ready_status_text(summary.ready_count, summary.total_count, local_count);
             }
             Err(error) => {
                 self.status.kind = StatusKind::Error;
@@ -1228,7 +1208,7 @@ impl App {
         }
     }
 
-    fn import_organize_options(&self) -> ImportOrganizeOptions {
+    pub(in crate::app) fn import_organize_options(&self) -> ImportOrganizeOptions {
         ImportOrganizeOptions {
             root: self.import_organize_root(),
             template: self.config.local.import_path_template().to_owned(),
@@ -1457,6 +1437,14 @@ fn import_review_action_progress_label(action: ImportReviewAction) -> &'static s
         }
         ImportReviewAction::Reject => t!("Rejecting import row", "임포트 행 거부 중"),
         ImportReviewAction::Skip => t!("Skipping import row", "임포트 행 건너뛰는 중"),
+    }
+}
+
+fn local_ready_status_text(ready_count: u32, total_count: u32, local_count: u32) -> String {
+    if crate::i18n::is_korean() {
+        format!("준비 {ready_count}/{total_count} · 로컬 {local_count}/{total_count}")
+    } else {
+        format!("Ready {ready_count}/{total_count} · Local {local_count}/{total_count}")
     }
 }
 

--- a/src/app/local_import_helpers.rs
+++ b/src/app/local_import_helpers.rs
@@ -2,7 +2,7 @@
 
 use crate::t;
 use crate::transfer::checkpoint::{ReportCandidate, ReviewDecision};
-use crate::transfer::session::{ImportSession, ImportSessionRow, ImportSessionRowStatus};
+use crate::transfer::session::{ImportSessionRow, ImportSessionRowStatus};
 
 pub(in crate::app) fn import_session_row_status_label(row: &ImportSessionRow) -> &'static str {
     if row.local_path.as_deref().is_some_and(path_is_import_inbox) {
@@ -33,12 +33,12 @@ pub(in crate::app) fn import_session_row_status_detail(
             "매칭 중이거나 이 행 처리 전에 가져오기가 중단됐어요"
         )),
         ImportSessionRowStatus::Matched if !row.written => Some(t!(
-            "ready to write to the Library playlist",
-            "Library 플레이리스트에 쓸 준비가 됐어요"
+            "Ready; downloading is a separate step",
+            "준비 완료; 다운로드는 별도 단계예요"
         )),
         ImportSessionRowStatus::Ambiguous => Some(t!(
-            "review candidate scores; A accept & write, a accept, s search",
-            "후보 점수를 확인하세요; A 수락 및 작성, a 수락, s 검색"
+            "review candidate scores; A mark all ready, a accept, s search",
+            "후보 점수를 확인하세요; A 전체 준비, a 수락, s 검색"
         )),
         ImportSessionRowStatus::NotFound => Some(t!(
             "no usable YouTube Music candidate was found",
@@ -198,40 +198,6 @@ pub(in crate::app) fn import_session_row_accepts_manual_review_action(
                 | ImportSessionRowStatus::SkippedLocal
                 | ImportSessionRowStatus::SkippedCapacity
         )
-}
-
-pub(in crate::app) fn import_session_accept_all_candidate_count(session: &ImportSession) -> u32 {
-    session
-        .rows
-        .iter()
-        .filter(|row| import_session_row_has_acceptable_first_candidate(row))
-        .count() as u32
-}
-
-fn import_session_row_has_acceptable_first_candidate(row: &ImportSessionRow) -> bool {
-    import_session_row_accepts_manual_review_action(row)
-        && row.candidates.first().is_some_and(|candidate| {
-            candidate
-                .score_breakdown
-                .as_ref()
-                .is_none_or(|score| !score.accept_blocked && score.reject_reason.is_none())
-        })
-}
-
-pub(in crate::app) fn import_session_unwritten_ready_count(session: &ImportSession) -> u32 {
-    session
-        .rows
-        .iter()
-        .filter(|row| {
-            !row.written
-                && row.local_path.is_none()
-                && matches!(row.status, ImportSessionRowStatus::Matched)
-                && !matches!(
-                    row.review_decision,
-                    Some(ReviewDecision::Rejected | ReviewDecision::Skipped)
-                )
-        })
-        .count() as u32
 }
 
 pub(in crate::app) fn import_session_row_selected_key(row: &ImportSessionRow) -> Option<&str> {

--- a/src/app/settings_reducer.rs
+++ b/src/app/settings_reducer.rs
@@ -44,30 +44,6 @@ fn transfer_done_status(report: &crate::transfer::checkpoint::TransferReport) ->
     }
 }
 
-fn local_accept_write_done_status(
-    report: &crate::transfer::checkpoint::TransferReport,
-    accepted_count: u32,
-) -> String {
-    let review_left = report.ambiguous.len() as u32;
-    let missing_left = report.not_found.len() as u32;
-    if crate::i18n::is_korean() {
-        format!(
-            "임포트 세션 작성 완료: 후보 {}개 수락 · 준비 행 {}개 작성 · 검토 {}개 남음 · 누락 {}개 남음 · Library > Playlists",
-            accepted_count, report.written, review_left, missing_left
-        )
-    } else {
-        format!(
-            "Import session written: {} candidate{} accepted · {} ready row{} written · {} review left · {} missing left · Library > Playlists",
-            accepted_count,
-            if accepted_count == 1 { "" } else { "s" },
-            report.written,
-            if report.written == 1 { "" } else { "s" },
-            review_left,
-            missing_left
-        )
-    }
-}
-
 impl App {
     // --- Settings screen ----------------------------------------------------
 
@@ -1523,24 +1499,12 @@ impl App {
                 // The store changed under the Playlists tab: drop a drill-down or pending
                 // delete whose playlist vanished and re-clamp the cursor into the new rows.
                 self.reconcile_playlists_reload();
-                if let Some(accepted_count) = self
-                    .local_mode
-                    .pending_accept_write_summaries
-                    .remove(&report.job_id)
-                {
-                    self.status.text = local_accept_write_done_status(&report, accepted_count);
-                } else {
-                    self.status.text = transfer_done_status(&report);
-                }
+                self.status.text = transfer_done_status(&report);
                 self.status.kind = StatusKind::Info;
             }
-            TransferEvent::JobRejected { job_id, error } => {
-                // The actor still owns a different active job. Clear only bookkeeping for the
-                // rejected attempt; its terminal will never arrive, while the active job's guard
-                // must remain set until that job emits JobDone/JobFailed.
-                self.local_mode
-                    .pending_accept_write_summaries
-                    .remove(&job_id);
+            TransferEvent::JobRejected { error, .. } => {
+                // The actor still owns a different active job, so its running guard remains set
+                // until that job emits JobDone/JobFailed.
                 let error = crate::util::sanitize::sanitize_error_text(error);
                 self.status.text = format!(
                     "{}: {error}",
@@ -1554,9 +1518,6 @@ impl App {
                 resumable,
             } => {
                 self.transfer_running = false;
-                self.local_mode
-                    .pending_accept_write_summaries
-                    .remove(&job_id);
                 let error = crate::util::sanitize::sanitize_error_text(error);
                 self.status.text = if resumable && !job_id.is_empty() {
                     format!(

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -350,6 +350,10 @@ pub struct Downloads {
     /// Downloads handed to the actor but not yet done/failed. Gates `pump_downloads` under the
     /// channel bound; decremented as each `DownloadDone`/`DownloadError` arrives.
     pub(in crate::app) dispatched: usize,
+    /// Import rows admitted during the current runtime batch, grouped by session. The terminal
+    /// reducer consumes a group only after that session has no queued or running work, then uses
+    /// it to keep automatic organization from sweeping up unrelated, pre-existing inbox files.
+    pub(in crate::app) auto_organize_rows: HashMap<String, HashSet<u32>>,
 }
 
 /// The Spotify playlist picker overlay (Settings › Accounts › Import from Spotify…):
@@ -857,6 +861,9 @@ pub struct LocalIndexRuntime {
     pub loaded: bool,
     pub loading: bool,
     pub scanning: bool,
+    /// A scan requested while another scan owns the worker. `Some(true)` upgrades the queued
+    /// follow-up to a full rebuild; otherwise one incremental pass runs after settlement.
+    pub(in crate::app) pending_rescan: Option<bool>,
     pub progress: Option<crate::local::LocalScanProgress>,
     pub last_summary: Option<crate::local::LocalScanSummary>,
     pub load_errors: Vec<crate::local::ScanError>,
@@ -905,7 +912,6 @@ pub struct LocalMode {
     pub pending_accept_all_confirm: Option<LocalImportAcceptAllConfirm>,
     /// Import-history artifact selected for confirmed deletion. Imported songs are retained.
     pub pending_import_record_delete: Option<String>,
-    pub(in crate::app) pending_accept_write_summaries: HashMap<String, u32>,
     pub(in crate::app) pending_import_reviews: HashMap<String, u64>,
     pub(in crate::app) next_import_review_op_id: u64,
 }

--- a/src/app/tests/downloads.rs
+++ b/src/app/tests/downloads.rs
@@ -1,4 +1,7 @@
 use super::*;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_AUTO_ORGANIZE_FIXTURE: AtomicU64 = AtomicU64::new(1);
 
 #[test]
 fn missing_download_tools_keep_the_queue_pending_and_open_setup() {
@@ -31,6 +34,107 @@ fn test_import_context(
             source_order,
             video_id,
         ),
+    }
+}
+
+struct AutoOrganizeFixture {
+    root: PathBuf,
+    session_id: String,
+    session: crate::transfer::session::ImportSession,
+}
+
+impl AutoOrganizeFixture {
+    fn new(label: &str, row_count: u32) -> Self {
+        let sequence = NEXT_AUTO_ORGANIZE_FIXTURE.fetch_add(1, Ordering::Relaxed);
+        let session_id = format!("sp2yt-auto-{label}-{}-{sequence}", std::process::id());
+        let root = std::env::temp_dir().join(format!(
+            "yututui-auto-organize-{label}-{}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create organize fixture root");
+        let private_root = root.join(".yututui-inbox");
+        let session_root = private_root.join(&session_id);
+        let complete = session_root.join("complete");
+        for directory in [&private_root, &session_root, &complete] {
+            crate::util::safe_fs::ensure_private_dir(directory)
+                .expect("create private organize fixture directory");
+        }
+
+        let rows = (1..=row_count)
+            .map(|source_order| {
+                let video_id = format!("auto{source_order:07}");
+                let path = complete.join(format!("Track {source_order} [{video_id}].m4a"));
+                std::fs::write(&path, format!("audio-{source_order}").as_bytes())
+                    .expect("write organize fixture audio");
+                crate::transfer::session::ImportSessionRow {
+                    row_id: format!("row-{source_order:05}"),
+                    source_order,
+                    status: crate::transfer::session::ImportSessionRowStatus::Matched,
+                    title: format!("Track {source_order}"),
+                    artists: vec!["Artist".to_owned()],
+                    album: Some("Album".to_owned()),
+                    album_artists: vec!["Album Artist".to_owned()],
+                    selected_key: Some(video_id),
+                    written: true,
+                    local_path: Some(path),
+                    disc_number: Some(1),
+                    track_number: Some(source_order),
+                    ..crate::transfer::session::ImportSessionRow::default()
+                }
+            })
+            .collect();
+        let session = crate::transfer::session::ImportSession {
+            session_id: session_id.clone(),
+            job_id: session_id.clone(),
+            rows,
+            ..crate::transfer::session::ImportSession::default()
+        };
+        session.save().expect("save organize fixture session");
+        Self {
+            root,
+            session_id,
+            session,
+        }
+    }
+
+    fn song(&self, source_order: u32) -> Song {
+        let row = self
+            .session
+            .rows
+            .iter()
+            .find(|row| row.source_order == source_order)
+            .expect("fixture row");
+        Song::remote(
+            row.selected_key.clone().expect("fixture video id"),
+            row.title.clone(),
+            row.artists.join(", "),
+            "3:00",
+        )
+        .with_import_session(Some(self.session_id.clone()), Some(source_order))
+    }
+
+    fn source_path(&self, source_order: u32) -> PathBuf {
+        self.session
+            .rows
+            .iter()
+            .find(|row| row.source_order == source_order)
+            .and_then(|row| row.local_path.clone())
+            .expect("fixture source path")
+    }
+
+    fn configure(&self, app: &mut App) {
+        app.config.local.roots = vec![crate::config::LocalRootConfig {
+            path: self.root.clone(),
+            enabled: Some(true),
+            recursive: Some(true),
+        }];
+        app.config.local.import_path_template =
+            Some("{album_artist}/{album}/{disc_track} - {title} [{youtube_id}]".to_owned());
+    }
+
+    fn cleanup(&self) {
+        let _ = crate::transfer::session::ImportSession::delete_record(&self.session_id);
+        let _ = std::fs::remove_dir_all(&self.root);
     }
 }
 
@@ -565,6 +669,217 @@ fn app_import_error_does_not_rewrite_worker_owned_session_row() {
     assert!(session.rows[0].errors.is_empty());
     assert_eq!(session.counts.written, 0);
     let _ = crate::transfer::session::ImportSession::delete_record(session_id);
+}
+
+#[test]
+fn import_batch_auto_organizes_only_after_the_session_settles() {
+    let _guard = crate::i18n::lock_for_test();
+    let fixture = AutoOrganizeFixture::new("settled", 2);
+    let mut app = App::new(100);
+    fixture.configure(&mut app);
+    app.library_ui.confirm_download = Some(vec![fixture.song(1), fixture.song(2)]);
+    app.confirm_download_apply();
+
+    let first = app.update(Msg::Download(DownloadMsg::ImportDone {
+        context: test_import_context(&fixture.session_id, "row-00001", 1, "auto0000001"),
+        path: fixture.source_path(1).to_string_lossy().into_owned(),
+    }));
+    assert!(
+        !first
+            .iter()
+            .any(|cmd| matches!(cmd, Cmd::Local(LocalCmd::ScanRoots { .. }))),
+        "the first terminal must wait for the other running row"
+    );
+    let waiting = crate::transfer::session::ImportSession::load(&fixture.session_id)
+        .expect("load waiting session");
+    assert_eq!(waiting.rows[0].local_path, Some(fixture.source_path(1)));
+    assert_eq!(waiting.rows[1].local_path, Some(fixture.source_path(2)));
+
+    let last = app.update(Msg::Download(DownloadMsg::ImportDone {
+        context: test_import_context(&fixture.session_id, "row-00002", 2, "auto0000002"),
+        path: fixture.source_path(2).to_string_lossy().into_owned(),
+    }));
+    assert!(
+        last.iter()
+            .any(|cmd| matches!(cmd, Cmd::Local(LocalCmd::ScanRoots { .. }))),
+        "the last terminal refreshes Local Deck after publishing"
+    );
+    let organized = crate::transfer::session::ImportSession::load(&fixture.session_id)
+        .expect("load organized session");
+    for row in &organized.rows {
+        let path = row.local_path.as_ref().expect("organized local path");
+        assert!(path.starts_with(&fixture.root));
+        assert!(!path.to_string_lossy().contains(".yututui-inbox"));
+        assert!(path.is_file());
+        let runtime = app
+            .library_ui
+            .downloaded
+            .iter()
+            .find(|song| song.import_source_order == Some(row.source_order))
+            .expect("organized runtime download row");
+        assert_eq!(runtime.local_path.as_ref(), Some(path));
+        let manifest = app
+            .download_store
+            .tracks()
+            .iter()
+            .find(|song| song.import_source_order == Some(row.source_order))
+            .expect("organized manifest row");
+        assert_eq!(manifest.local_path.as_ref(), Some(path));
+    }
+    assert!(app.status.text.contains("Organized import session"));
+    assert!(app.downloads.auto_organize_rows.is_empty());
+    fixture.cleanup();
+}
+
+#[test]
+fn import_batch_auto_organize_moves_successes_and_leaves_failures_retryable() {
+    let _guard = crate::i18n::lock_for_test();
+    let fixture = AutoOrganizeFixture::new("partial-failure", 2);
+    let mut persisted = fixture.session.clone();
+    persisted.rows[1].written = false;
+    persisted.rows[1].local_path = None;
+    persisted.rows[1].errors = vec!["private video".to_owned()];
+    persisted.save().expect("save partial failure session");
+
+    let mut app = App::new(100);
+    fixture.configure(&mut app);
+    app.library_ui.confirm_download = Some(vec![fixture.song(1), fixture.song(2)]);
+    app.confirm_download_apply();
+    app.update(Msg::Download(DownloadMsg::ImportDone {
+        context: test_import_context(&fixture.session_id, "row-00001", 1, "auto0000001"),
+        path: fixture.source_path(1).to_string_lossy().into_owned(),
+    }));
+    let final_commands = app.update(Msg::Download(DownloadMsg::ImportError {
+        context: test_import_context(&fixture.session_id, "row-00002", 2, "auto0000002"),
+        error: "private video".to_owned(),
+    }));
+
+    let organized = crate::transfer::session::ImportSession::load(&fixture.session_id)
+        .expect("load partial organize session");
+    let success = organized.rows[0]
+        .local_path
+        .as_ref()
+        .expect("successful row published");
+    assert!(!success.to_string_lossy().contains(".yututui-inbox"));
+    assert!(organized.rows[0].written);
+    assert!(!organized.rows[1].written);
+    assert!(organized.rows[1].local_path.is_none());
+    assert_eq!(organized.rows[1].errors, vec!["private video"]);
+    let manifest = app
+        .download_store
+        .tracks()
+        .iter()
+        .find(|song| song.import_source_order == Some(1))
+        .expect("successful manifest row");
+    assert_eq!(manifest.local_path.as_ref(), Some(success));
+    assert!(
+        final_commands
+            .iter()
+            .any(|cmd| matches!(cmd, Cmd::Persist(PersistCmd::Downloads)))
+    );
+    assert!(app.status.text.contains("retry from Local Deck"));
+    fixture.cleanup();
+}
+
+#[test]
+fn import_batch_auto_organize_does_not_sweep_preexisting_inbox_rows() {
+    let _guard = crate::i18n::lock_for_test();
+    let fixture = AutoOrganizeFixture::new("cohort", 2);
+    let old_path = fixture.source_path(1);
+    let mut app = App::new(100);
+    fixture.configure(&mut app);
+
+    app.start_download(fixture.song(2));
+    app.update(Msg::Download(DownloadMsg::ImportDone {
+        context: test_import_context(&fixture.session_id, "row-00002", 2, "auto0000002"),
+        path: fixture.source_path(2).to_string_lossy().into_owned(),
+    }));
+
+    let organized = crate::transfer::session::ImportSession::load(&fixture.session_id)
+        .expect("load cohort organize session");
+    assert_eq!(
+        organized.rows[0].local_path.as_deref(),
+        Some(old_path.as_path())
+    );
+    assert!(old_path.is_file());
+    let current = organized.rows[1]
+        .local_path
+        .as_ref()
+        .expect("current batch row published");
+    assert!(!current.to_string_lossy().contains(".yututui-inbox"));
+    fixture.cleanup();
+}
+
+#[test]
+fn import_batch_auto_organize_failure_keeps_inbox_and_points_to_manual_retry() {
+    let _guard = crate::i18n::lock_for_test();
+    let fixture = AutoOrganizeFixture::new("organize-error", 1);
+    let bad_root = fixture.root.with_extension("not-a-directory");
+    std::fs::write(&bad_root, b"not a directory").expect("write invalid organize root");
+    let source = fixture.source_path(1);
+    let mut app = App::new(100);
+    app.config.local.roots = vec![crate::config::LocalRootConfig {
+        path: bad_root.clone(),
+        enabled: Some(true),
+        recursive: Some(true),
+    }];
+
+    app.start_download(fixture.song(1));
+    app.update(Msg::Download(DownloadMsg::ImportDone {
+        context: test_import_context(&fixture.session_id, "row-00001", 1, "auto0000001"),
+        path: source.to_string_lossy().into_owned(),
+    }));
+
+    assert!(source.is_file(), "the inbox artifact remains available");
+    let saved = crate::transfer::session::ImportSession::load(&fixture.session_id)
+        .expect("load failed organize session");
+    assert_eq!(saved.rows[0].local_path.as_deref(), Some(source.as_path()));
+    assert_eq!(app.status.kind, StatusKind::Error);
+    assert!(app.status.text.contains("artifacts remain recoverable"));
+    assert!(app.status.text.contains("press m to retry"));
+    assert!(app.downloads.auto_organize_rows.is_empty());
+    let _ = std::fs::remove_file(bad_root);
+    fixture.cleanup();
+}
+
+#[test]
+fn import_batch_auto_organize_latches_refresh_behind_an_active_scan() {
+    let _guard = crate::i18n::lock_for_test();
+    let fixture = AutoOrganizeFixture::new("scan-latch", 1);
+    let mut app = App::new(100);
+    fixture.configure(&mut app);
+    app.local_mode.index.loaded = true;
+    app.local_mode.index.scanning = true;
+
+    app.start_download(fixture.song(1));
+    let terminal = app.update(Msg::Download(DownloadMsg::ImportDone {
+        context: test_import_context(&fixture.session_id, "row-00001", 1, "auto0000001"),
+        path: fixture.source_path(1).to_string_lossy().into_owned(),
+    }));
+
+    assert!(
+        !terminal
+            .iter()
+            .any(|cmd| matches!(cmd, Cmd::Local(LocalCmd::ScanRoots { .. })))
+    );
+    assert_eq!(app.local_mode.index.pending_rescan, Some(false));
+
+    let follow_up = app.update(Msg::Local(LocalMsg::ScanFinished {
+        index_path: None,
+        result: crate::local::LocalScanResult {
+            index: crate::local::LocalIndex::default(),
+            summary: crate::local::LocalScanSummary::default(),
+            errors: Vec::new(),
+        },
+    }));
+    assert!(
+        follow_up
+            .iter()
+            .any(|cmd| matches!(cmd, Cmd::Local(LocalCmd::ScanRoots { .. })))
+    );
+    assert!(app.local_mode.index.scanning);
+    assert_eq!(app.local_mode.index.pending_rescan, None);
+    fixture.cleanup();
 }
 
 #[test]

--- a/src/app/tests/local_import.rs
+++ b/src/app/tests/local_import.rs
@@ -579,7 +579,7 @@ fn local_deck_import_sessions_include_saved_session_rows_without_tracks() {
         .unwrap_or_else(|| panic!("missing saved session in labels: {labels:?}"));
     assert_eq!(
         labels[session_index],
-        "sp2yt-local-inbox-session  (0 written, 1/3 local, 1 failed, 1 review, 1 missing, 0 pending)"
+        "sp2yt-local-inbox-session  (Ready ?/3 · Local 1/3 · 1 failed · 1 review · 1 missing · 0 pending)"
     );
 
     app.local_mode.ui.filter_query = session_id.to_owned();
@@ -591,7 +591,7 @@ fn local_deck_import_sessions_include_saved_session_rows_without_tracks() {
     assert_eq!(
         labels,
         vec![
-            "sp2yt-local-inbox-session  (0 written, 1/3 local, 1 failed, 1 review, 1 missing, 0 pending)"
+            "sp2yt-local-inbox-session  (Ready ?/3 · Local 1/3 · 1 failed · 1 review · 1 missing · 0 pending)"
         ]
     );
     let session_index = 0;
@@ -601,8 +601,8 @@ fn local_deck_import_sessions_include_saved_session_rows_without_tracks() {
     for expected in [
         "Import session: sp2yt-local-inbox-session",
         "Rows: 3 rows",
-        "Written: 0",
-        "Local files: 1/3",
+        "Ready: ?/3",
+        "Local: 1/3",
         "Failed: 1",
         "Review: 1",
         "Missing: 1",
@@ -1047,6 +1047,7 @@ fn local_deck_import_row_s_starts_manual_youtube_search() {
     app.local_mode.ui.filter_query.clear();
     let hint = app.local_import_action_hint().expect("review action hint");
     for expected in [
+        "A mark all ready",
         "a accept",
         "r reject",
         "c candidate",
@@ -1241,7 +1242,7 @@ fn local_deck_import_review_keys_choose_next_and_skip_rows() {
 }
 
 #[test]
-fn local_deck_shift_a_confirms_and_accepts_all_session_candidates() {
+fn local_deck_shift_a_marks_all_safe_session_candidates_ready_without_writing() {
     let session_id = "sp2yt-local-review-accept-all";
     save_ambiguous_import_job(session_id);
 
@@ -1261,30 +1262,28 @@ fn local_deck_shift_a_confirms_and_accepts_all_session_candidates() {
             .map(|confirm| (
                 confirm.session_id.clone(),
                 confirm.candidate_count,
-                confirm.ready_count
+                confirm.ready_count,
+                confirm.total_count,
+                confirm.local_count,
             )),
-        Some((session_id.to_owned(), 1, 1))
+        Some((session_id.to_owned(), 1, 1, 1, 0))
     );
 
     let cmd = single_cmd(app.update(Msg::Key(key(KeyCode::Enter))));
-    let write_cmd = single_cmd(finish_import_accept_all_cmd(&mut app, cmd));
+    let follow_up = finish_import_accept_all_cmd(&mut app, cmd);
     let accepted =
         crate::transfer::session::ImportSession::load(session_id).expect("load accepted session");
     assert!(matches!(
         accepted.rows[0].review_decision,
         Some(ReviewDecision::Accepted { ref key, .. }) if key == "dQw4w9WgXcQ"
     ));
-    assert!(matches!(
-        write_cmd,
-        Cmd::Transfer(crate::transfer::actor::TransferCmd::WriteReviewedLocal { ref job_id })
-            if job_id == session_id
-    ));
-    assert!(app.transfer_running);
-    assert!(app.status.text.contains("writing Library playlist"));
+    assert!(follow_up.is_empty(), "Ready must not start a transfer");
+    assert!(!app.transfer_running);
+    assert_eq!(app.status.text, "Ready 1/1 · Local 0/1");
 }
 
 #[test]
-fn local_deck_shift_a_writes_ready_rows_without_review_candidates() {
+fn local_deck_shift_a_reports_already_ready_without_confirmation_or_transfer() {
     let session_id = "sp2yt-local-ready-write";
     save_ready_local_playlist_job(session_id);
 
@@ -1297,26 +1296,41 @@ fn local_deck_shift_a_writes_ready_rows_without_review_candidates() {
 
     let cmds = app.update(Msg::Key(key(KeyCode::Char('A'))));
     assert!(cmds.is_empty());
-    assert_eq!(
-        app.local_mode
-            .pending_accept_all_confirm
-            .as_ref()
-            .map(|confirm| (confirm.candidate_count, confirm.ready_count)),
-        Some((0, 1))
-    );
+    assert!(app.local_mode.pending_accept_all_confirm.is_none());
+    assert!(!app.transfer_running);
+    assert_eq!(app.status.text, "Ready 1/1 · Local 0/1");
+}
 
-    let write_cmd = single_cmd(app.update(Msg::Key(key(KeyCode::Enter))));
-    assert!(matches!(
-        write_cmd,
-        Cmd::Transfer(crate::transfer::actor::TransferCmd::WriteReviewedLocal { ref job_id })
-            if job_id == session_id
-    ));
-    assert!(app.transfer_running);
-    assert!(
-        app.status
-            .text
-            .contains("Writing accepted import rows to Library playlist")
-    );
+#[test]
+fn local_deck_shift_a_keeps_visible_enqueue_fallback_for_ordinary_tracks() {
+    let tracks = vec![
+        local_deck_track(
+            "/tmp/local-a-first.m4a",
+            "First",
+            &["Artist"],
+            Some("Album"),
+            Some("Artist"),
+            &[],
+            1,
+        ),
+        local_deck_track(
+            "/tmp/local-a-second.m4a",
+            "Second",
+            &["Artist"],
+            Some("Album"),
+            Some("Artist"),
+            &[],
+            2,
+        ),
+    ];
+    let mut app = app_with_local_deck_index(tracks);
+
+    let mut cmds = app.update(Msg::Key(key(KeyCode::Char('A'))));
+
+    assert!(!cmds.is_empty());
+    admit_player_transition(&mut app, &mut cmds);
+    assert_eq!(app.queue.len(), 2);
+    assert!(app.local_mode.pending_accept_all_confirm.is_none());
 }
 
 #[test]

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1083,34 +1083,34 @@ impl LocalOrganizeConfirm {
     }
 }
 
-/// Pending confirmation before accepting every reviewable candidate in an import session.
+/// Pending confirmation before marking every safely reviewable candidate Ready.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocalImportAcceptAllConfirm {
     pub session_id: String,
     pub candidate_count: u32,
     pub ready_count: u32,
+    pub total_count: u32,
+    pub local_count: u32,
     pub review_left: u32,
     pub missing_left: u32,
 }
 
 impl LocalImportAcceptAllConfirm {
     pub fn title(&self) -> &'static str {
-        t!(" Accept & write import ", " 임포트 수락 및 작성 ")
+        t!(" Mark all Ready ", " 전체 준비 완료 표시 ")
     }
 
     pub fn prompt(&self) -> String {
         if crate::i18n::is_korean() {
             format!(
-                "후보 {}개를 수락하고 준비된 {}행을 Library 플레이리스트에 쓸까요?",
-                self.candidate_count, self.ready_count
+                "안전한 후보 {}개를 준비 완료로 표시할까요?",
+                self.candidate_count
             )
         } else {
             format!(
-                "Accept {} candidate{} and write {} ready row{} to the Library playlist?",
+                "Mark {} safe candidate{} Ready for this playlist?",
                 self.candidate_count,
                 if self.candidate_count == 1 { "" } else { "s" },
-                self.ready_count,
-                if self.ready_count == 1 { "" } else { "s" }
             )
         }
     }
@@ -1118,13 +1118,23 @@ impl LocalImportAcceptAllConfirm {
     pub fn detail(&self) -> String {
         if crate::i18n::is_korean() {
             format!(
-                "세션: {} · 남을 검토 {} · 누락 {}",
-                self.session_id, self.review_left, self.missing_left
+                "준비 {}/{} · 로컬 {}/{} · 남을 검토 {} · 누락 {}",
+                self.ready_count,
+                self.total_count,
+                self.local_count,
+                self.total_count,
+                self.review_left,
+                self.missing_left
             )
         } else {
             format!(
-                "Session: {} · review left {} · missing {}",
-                self.session_id, self.review_left, self.missing_left
+                "Ready {}/{} · Local {}/{} · review left {} · missing {}",
+                self.ready_count,
+                self.total_count,
+                self.local_count,
+                self.total_count,
+                self.review_left,
+                self.missing_left
             )
         }
     }

--- a/src/download/import_inbox.rs
+++ b/src/download/import_inbox.rs
@@ -55,6 +55,10 @@ pub(super) fn retained_import_inventory(root: &Path) -> Result<RetainedImportInv
             let entry = entry?;
             let path = entry.path();
             let metadata = std::fs::symlink_metadata(&path)?;
+            if depth == 0 && entry.file_name() == ".ignore" {
+                validate_ignore_file(&path, &metadata)?;
+                continue;
+            }
             if metadata.is_dir() && !is_link_or_reparse(&metadata) {
                 if depth >= RETAINED_SCAN_DEPTH_CAP {
                     bail!(
@@ -138,6 +142,7 @@ pub(super) fn prepare_import_inbox_dirs(root: &Path, session_id: &str) -> Result
     let private_base = root.join(".yututui-inbox");
     crate::util::safe_fs::ensure_private_dir_durable(&private_base)
         .with_context(|| format!("create private import root {}", private_base.display()))?;
+    ensure_private_ignore_file(&private_base)?;
     let session_dir = dirs
         .incoming
         .parent()
@@ -150,6 +155,57 @@ pub(super) fn prepare_import_inbox_dirs(root: &Path, session_id: &str) -> Result
     }
     validate_import_inbox_dirs(root, &dirs)?;
     Ok(dirs)
+}
+
+fn ensure_private_ignore_file(private_base: &Path) -> Result<()> {
+    let pinned =
+        crate::util::safe_fs::PinnedDir::open_private_existing(private_base, Path::new(""))
+            .with_context(|| format!("pin private import root {}", private_base.display()))?;
+    let name = std::ffi::OsStr::new(".ignore");
+    match pinned.open_child_readonly(name) {
+        Ok(existing) => {
+            validate_ignore_file(&private_base.join(name), &existing.file()?.metadata()?)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let mut created = match pinned.create_new(name) {
+                Ok(created) => created,
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    let existing = pinned.open_child_readonly(name)?;
+                    validate_ignore_file(&private_base.join(name), &existing.file()?.metadata()?)?;
+                    return Ok(());
+                }
+                Err(error) => return Err(error.into()),
+            };
+            #[cfg(unix)]
+            created.set_mode(0o600)?;
+            created.sync_durable()?;
+            validate_ignore_file(&private_base.join(name), &created.file()?.metadata()?)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn validate_ignore_file(path: &Path, metadata: &std::fs::Metadata) -> Result<()> {
+    if !metadata.is_file() || metadata.len() != 0 {
+        bail!(
+            "private import ignore marker must be an empty regular file: {}",
+            path.display()
+        );
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+
+        if !crate::util::safe_fs::is_owned_by_current_user(metadata)
+            || metadata.mode() & 0o777 != 0o600
+        {
+            bail!(
+                "private import ignore marker must be owned by the current user with mode 0600: {}",
+                path.display()
+            );
+        }
+    }
+    Ok(())
 }
 
 pub(super) fn validate_real_directory_chain(root: &Path, target: &Path) -> Result<()> {
@@ -348,6 +404,35 @@ mod retained_tests {
                 directory.display()
             );
         }
+        let ignore = root.join(".yututui-inbox/.ignore");
+        let metadata = std::fs::metadata(&ignore).unwrap();
+        assert_eq!(metadata.mode() & 0o777, 0o600);
+        assert_eq!(metadata.len(), 0);
+        assert_eq!(retained_import_inventory(&root).unwrap().files, 0);
+
+        prepare_import_inbox_dirs(&root, "session-a").unwrap();
+        assert_eq!(std::fs::metadata(ignore).unwrap().len(), 0);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preparation_rejects_a_foreign_ignore_marker_without_replacing_it() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = temp_root("hostile-ignore");
+        std::fs::create_dir_all(&root).unwrap();
+        let private = root.join(".yututui-inbox");
+        crate::util::safe_fs::ensure_private_dir(&private).unwrap();
+        let ignore = private.join(".ignore");
+        std::fs::write(&ignore, b"foreign policy").unwrap();
+        std::fs::set_permissions(&ignore, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        let error = prepare_import_inbox_dirs(&root, "session-a").unwrap_err();
+
+        assert!(format!("{error:#}").contains("must be an empty regular file"));
+        assert_eq!(std::fs::read(&ignore).unwrap(), b"foreign policy");
+        assert!(!private.join("session-a").exists());
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/src/downloads.rs
+++ b/src/downloads.rs
@@ -238,6 +238,38 @@ impl DownloadStore {
         self.tracks.truncate(STORE_MAX);
     }
 
+    /// Re-key imported download records after their inbox artifacts are organized. The
+    /// destination scan remains authoritative, but the manifest must not persist a path that was
+    /// removed by the same reducer turn.
+    pub(crate) fn relocate_import_paths(
+        &mut self,
+        session_id: &str,
+        paths: &HashMap<u32, PathBuf>,
+    ) -> bool {
+        let mut changed = false;
+        for song in &mut self.tracks {
+            if song.import_session_id.as_deref() != Some(session_id) {
+                continue;
+            }
+            let Some(path) = song
+                .import_source_order
+                .and_then(|source_order| paths.get(&source_order))
+            else {
+                continue;
+            };
+            if song.local_path.as_ref() != Some(path) {
+                *song = song.with_local_path(path.clone());
+                changed = true;
+            }
+        }
+        if changed {
+            let mut seen = HashSet::new();
+            self.tracks
+                .retain(|song| seen.insert(song.video_id.clone()));
+        }
+        changed
+    }
+
     /// Drop records whose on-disk file is among `paths` (after a confirmed delete).
     pub fn remove_paths(&mut self, paths: &[PathBuf]) {
         let doomed: HashSet<&PathBuf> = paths.iter().collect();
@@ -775,6 +807,14 @@ where
         drop(original_file);
 
         rewrite_and_validate(&mut stage_file, &stage)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            stage_file.set_permissions(fs::Permissions::from_mode(
+                initial.permissions().mode() & 0o777,
+            ))?;
+        }
         stage_file.flush()?;
         stage_file.sync_all()?;
 
@@ -1279,6 +1319,11 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         let audio = dir.join("Track.wav");
         fs::write(&audio, wav_bytes()).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            fs::set_permissions(&audio, fs::Permissions::from_mode(0o640)).unwrap();
+        }
         let original = safe_fs::open_regular_no_symlink(&audio).unwrap();
         let original_object = safe_fs::file_object_id(&original).unwrap();
         drop(original);
@@ -1295,6 +1340,11 @@ mod tests {
         assert!(validate_tagged_audio_path(&song, &audio).unwrap());
         assert!(!staged_audio_backup_path(&audio).exists());
         assert_eq!(fs::read_dir(&dir).unwrap().count(), 1);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt as _;
+            assert_eq!(fs::metadata(&audio).unwrap().mode() & 0o777, 0o640);
+        }
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -194,8 +194,8 @@ const ACTION_META: &[(Action, &str, &str, &str)] = &[
     (
         Action::AcceptAllImportReview,
         "accept_all_import_review",
-        "Accept all import candidates",
-        "임포트 후보 전체 수락",
+        "Mark all import tracks Ready",
+        "임포트 곡 전체 준비 완료",
     ),
     (
         Action::ToggleShuffle,

--- a/src/transfer/artifact_move.rs
+++ b/src/transfer/artifact_move.rs
@@ -19,6 +19,8 @@ use crate::util::safe_fs;
 
 mod recovery;
 use recovery::committed_session_path;
+mod permissions;
+use permissions::{artifact_publish_modes, ensure_scoped_directory, validate_publish_mode};
 mod reconcile;
 use reconcile::{
     ReconcileFilePair, ReconcileFilePolicy, ReconcileOptionalFilePair, pin_transaction_scopes,
@@ -135,6 +137,16 @@ struct ArtifactMoveTxn {
     sidecar_stage_name: String,
     audio_stage_object_id: Option<safe_fs::FileObjectId>,
     sidecar_stage_object_id: Option<safe_fs::FileObjectId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    audio_publish_mode: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    sidecar_publish_mode: Option<u32>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    audio_source_private_stage: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    sidecar_source_private_stage: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    verify_legacy_existing_modes: bool,
     audio_object_id: safe_fs::FileObjectId,
     audio_identity: ArtifactIdentity,
     sidecar_object_id: Option<safe_fs::FileObjectId>,
@@ -403,7 +415,9 @@ fn prepare_transaction(request: ArtifactMoveRequest) -> anyhow::Result<ArtifactM
             request.destination_root.display()
         )
     })?;
-    let requested_parent = ensure_scoped_directory(&destination_root, relative_parent)?;
+    let publish_modes = artifact_publish_modes(request.kind, &destination_root)?;
+    let requested_parent =
+        ensure_scoped_directory(&destination_root, relative_parent, publish_modes.directory)?;
     let destination_parent = destination_root.join(relative_parent);
     let (
         destination_root_pin,
@@ -541,6 +555,14 @@ fn prepare_transaction(request: ArtifactMoveRequest) -> anyhow::Result<ArtifactM
             sidecar_from.display()
         );
     }
+    // Linux can publish an anonymous O_TMPFILE created on the destination filesystem, so keep
+    // staging there. Besides avoiding a recoverable public stage, this also lets an inbox and
+    // library live on different mounts. Other Unix platforms need the app-owned source namespace
+    // for their named no-replace staging fallback.
+    let source_private_stage = cfg!(all(unix, not(target_os = "linux")))
+        && matches!(request.kind, ArtifactMoveKind::Organize)
+        && source_private_root.is_some()
+        && destination_private_root.is_none();
     Ok(ArtifactMoveTxn {
         schema_version: TXN_SCHEMA_VERSION,
         kind: request.kind,
@@ -568,6 +590,11 @@ fn prepare_transaction(request: ArtifactMoveRequest) -> anyhow::Result<ArtifactM
         sidecar_stage_name: format!(".ytt-stage-{stage_tag}-sidecar"),
         audio_stage_object_id: None,
         sidecar_stage_object_id: None,
+        audio_publish_mode: publish_modes.audio,
+        sidecar_publish_mode: publish_modes.sidecar,
+        audio_source_private_stage: source_private_stage,
+        sidecar_source_private_stage: source_private_stage,
+        verify_legacy_existing_modes: false,
         audio_object_id: source_audio.identity(),
         audio_identity,
         sidecar_object_id: source_sidecar.as_ref().map(|sidecar| sidecar.identity()),
@@ -582,6 +609,7 @@ fn resume_transaction(
     fault: Option<&dyn Fn(ArtifactMoveFaultPoint) -> std::io::Result<()>>,
 ) -> anyhow::Result<PathBuf> {
     validate_transaction(txn)?;
+    backfill_publication_policy(path, txn)?;
     if let Some(claim) = txn.claim.as_ref() {
         super::session::validate_import_download_claim_unlocked(claim, true)?;
     }
@@ -601,6 +629,13 @@ fn resume_transaction(
         let expected = txn.audio_identity.clone();
         let expected_source = txn.audio_object_id;
         let expected_stage = txn.audio_stage_object_id;
+        let publish_mode = txn.audio_publish_mode;
+        let verify_legacy_existing_mode = txn.verify_legacy_existing_modes;
+        let stage_parent = if txn.audio_source_private_stage {
+            &scopes.source_parent
+        } else {
+            &scopes.destination_parent
+        };
         let mut record_stage = |identity| {
             txn.audio_stage_object_id = Some(identity);
             persist_transaction(path, txn)
@@ -610,6 +645,7 @@ fn resume_transaction(
                 source_parent: &scopes.source_parent,
                 source_name: &source_name,
                 expected_source_object: expected_source,
+                stage_parent,
                 destination_parent: &scopes.destination_parent,
                 destination_stage_name: std::ffi::OsStr::new(&stage_name),
                 expected_stage_object: expected_stage,
@@ -623,6 +659,8 @@ fn resume_transaction(
                 after_publish: ArtifactMoveFaultPoint::AfterAudioPublishBeforeSourceUnlink,
                 retained_source_boundary: ArtifactMoveFaultPoint::BeforeAudioSourceUnlinkValidation,
                 max_bytes: ARTIFACT_AUDIO_MAX_BYTES,
+                publish_mode,
+                verify_legacy_existing_mode,
             },
         )
         .context("reconcile import audio move")?;
@@ -646,6 +684,13 @@ fn resume_transaction(
         let expected = txn.sidecar_identity.clone();
         let expected_source = txn.sidecar_object_id;
         let expected_stage = txn.sidecar_stage_object_id;
+        let publish_mode = txn.sidecar_publish_mode;
+        let verify_legacy_existing_mode = txn.verify_legacy_existing_modes;
+        let stage_parent = if txn.sidecar_source_private_stage {
+            &scopes.source_parent
+        } else {
+            &scopes.destination_parent
+        };
         let mut record_stage = |identity| {
             txn.sidecar_stage_object_id = Some(identity);
             persist_transaction(path, txn)
@@ -655,6 +700,7 @@ fn resume_transaction(
                 source_parent: &scopes.source_parent,
                 source_name: &source_name,
                 expected_source_object: expected_source,
+                stage_parent,
                 destination_parent: &scopes.destination_parent,
                 destination_stage_name: std::ffi::OsStr::new(&stage_name),
                 expected_stage_object: expected_stage,
@@ -663,6 +709,8 @@ fn resume_transaction(
             },
             &mut record_stage,
             fault,
+            publish_mode,
+            verify_legacy_existing_mode,
         )
         .context("reconcile import sidecar move")?;
     }
@@ -724,6 +772,32 @@ fn import_private_root(path: &Path) -> Option<PathBuf> {
                 .is_some_and(|name| name == ".yututui-inbox")
         })
         .map(Path::to_path_buf)
+}
+
+fn backfill_publication_policy(path: &Path, txn: &mut ArtifactMoveTxn) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        if txn.audio_publish_mode.is_none() && txn.sidecar_publish_mode.is_none() {
+            let modes = artifact_publish_modes(txn.kind, &txn.destination_root)?;
+            if modes.audio.is_some() || modes.sidecar.is_some() {
+                txn.audio_publish_mode = modes.audio;
+                txn.sidecar_publish_mode = modes.sidecar;
+                txn.verify_legacy_existing_modes = matches!(txn.kind, ArtifactMoveKind::Organize);
+                if cfg!(all(unix, not(target_os = "linux")))
+                    && matches!(txn.kind, ArtifactMoveKind::Organize)
+                    && txn.source_private_root.is_some()
+                    && txn.destination_private_root.is_none()
+                {
+                    txn.audio_source_private_stage = txn.audio_stage_object_id.is_none();
+                    txn.sidecar_source_private_stage = txn.sidecar_stage_object_id.is_none();
+                }
+                persist_transaction(path, txn)?;
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = (path, txn);
+    Ok(())
 }
 
 fn reclaim_private_sources(
@@ -918,6 +992,8 @@ fn validate_transaction(txn: &ArtifactMoveTxn) -> anyhow::Result<()> {
     if txn.sidecar_identity.is_some() != txn.sidecar_object_id.is_some() {
         bail!("artifact move sidecar content/object identities are inconsistent");
     }
+    validate_publish_mode(txn.audio_publish_mode)?;
+    validate_publish_mode(txn.sidecar_publish_mode)?;
     match (txn.source_private_root.as_ref(), txn.source_private_root_id) {
         (Some(root), Some(_))
             if root
@@ -939,6 +1015,13 @@ fn validate_transaction(txn: &ArtifactMoveTxn) -> anyhow::Result<()> {
                 && txn.destination_parent.starts_with(root) => {}
         (None, None) => {}
         _ => bail!("artifact move private destination root is inconsistent"),
+    }
+    if (txn.audio_source_private_stage || txn.sidecar_source_private_stage)
+        && (!matches!(txn.kind, ArtifactMoveKind::Organize)
+            || txn.source_private_root.is_none()
+            || txn.destination_private_root.is_some())
+    {
+        bail!("artifact move private stage policy is inconsistent");
     }
     reject_parent_components(&txn.audio_from)?;
     reject_parent_components(&txn.audio_to)?;
@@ -1045,36 +1128,8 @@ fn reject_parent_components(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Create only real directory components beneath an already-canonical root. In particular, do
-/// not let `create_dir_all` follow an existing in-root symlink and create directories outside the
-/// selected destination before the later canonical-scope check gets a chance to reject it.
-fn ensure_scoped_directory(root: &Path, relative: &Path) -> std::io::Result<PathBuf> {
-    let mut current = root.to_path_buf();
-    for component in relative.components() {
-        let Component::Normal(component) = component else {
-            if matches!(component, Component::CurDir) {
-                continue;
-            }
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("invalid relative artifact directory {}", relative.display()),
-            ));
-        };
-        current.push(component);
-        match fs::symlink_metadata(&current) {
-            Ok(_) => reject_symlink_or_non_directory(&current)?,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                match fs::create_dir(&current) {
-                    Ok(()) => safe_fs::sync_parent_dir(&current)?,
-                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
-                    Err(error) => return Err(error),
-                }
-                reject_symlink_or_non_directory(&current)?;
-            }
-            Err(error) => return Err(error),
-        }
-    }
-    Ok(current)
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 fn reject_symlink_or_non_directory(path: &Path) -> std::io::Result<()> {

--- a/src/transfer/artifact_move/permission_boundary_tests.rs
+++ b/src/transfer/artifact_move/permission_boundary_tests.rs
@@ -1,0 +1,109 @@
+use super::*;
+
+#[cfg(unix)]
+#[test]
+fn inaccessible_existing_organize_directory_is_rejected_without_chmod() {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let mut fixture = MoveFixture::new("existing-private-dir", ArtifactMoveKind::Organize);
+    let library_root = fixture.request.destination_root.clone();
+    std::fs::set_permissions(&library_root, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let artist = library_root.join("Artist");
+    std::fs::create_dir(&artist).unwrap();
+    std::fs::set_permissions(&artist, std::fs::Permissions::from_mode(0o700)).unwrap();
+    fixture.destination = artist.join("Album/Track [abc123def45].m4a");
+    fixture.request.audio_to = fixture.destination.clone();
+
+    let error = commit(fixture.request.clone())
+        .expect_err("inaccessible existing directory must fail publication");
+
+    assert!(format!("{error:#}").contains("library publication requires at least 0755"));
+    assert_eq!(std::fs::metadata(&artist).unwrap().mode() & 0o777, 0o700);
+    assert!(fixture.source.exists());
+    assert!(!fixture.transaction_path().exists());
+    fixture.cleanup();
+}
+
+#[test]
+fn legacy_transaction_schema_is_refused_without_mutating_artifacts() {
+    let fixture = MoveFixture::new("legacy-schema", ArtifactMoveKind::ImportDownload);
+    // Keep startup reconciliation from observing the transaction as current-schema in the
+    // interval between its creation and the deliberate legacy-schema rewrite below.
+    let record_guard =
+        ImportRecordGuard::try_acquire(&fixture.session_id).expect("own legacy fixture session");
+    let fault = |point| {
+        if point == ArtifactMoveFaultPoint::BeforeAudioPublish {
+            Err(std::io::Error::other("legacy fixture fault injection"))
+        } else {
+            Ok(())
+        }
+    };
+    commit_locked_with_hook(fixture.request.clone(), Some(&fault))
+        .expect_err("fault must retain a prepared transaction");
+    let transaction = fixture.transaction_path();
+    let mut value: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&transaction).unwrap()).unwrap();
+    value["schema_version"] = serde_json::Value::from(TXN_SCHEMA_VERSION - 1);
+    {
+        // Production transaction rewrites hold this lock so inventory cannot mistake their
+        // live atomic-write temp for a stale crash remnant. Mirror that contract here.
+        let _registry = acquire_registry_lock().expect("own transaction registry");
+        safe_fs::write_private_atomic_json(&transaction, &value).unwrap();
+    }
+    drop(record_guard);
+
+    let error = reconcile_row(&fixture.session_id, &fixture.row_id, fixture.source_order)
+        .expect_err("legacy transaction must not infer missing object identities");
+
+    assert!(format!("{error:#}").contains("unsupported artifact move schema"));
+    assert_eq!(std::fs::read(&fixture.source).unwrap(), b"fixture audio");
+    assert!(!fixture.destination.exists());
+    assert!(transaction.exists());
+    fixture.cleanup();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn organize_publishes_across_filesystems_with_destination_anonymous_staging() {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let mut fixture = MoveFixture::new("cross-filesystem", ArtifactMoveKind::Organize);
+    let shared_memory = Path::new("/dev/shm");
+    let Ok(shared_memory_metadata) = std::fs::metadata(shared_memory) else {
+        fixture.cleanup();
+        return;
+    };
+    let source_metadata = std::fs::metadata(fixture.source.parent().unwrap()).unwrap();
+    if source_metadata.dev() == shared_memory_metadata.dev() {
+        fixture.cleanup();
+        return;
+    }
+
+    let destination_root = shared_memory.join(format!(
+        "yututui-cross-filesystem-{}-{}",
+        std::process::id(),
+        NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir(&destination_root).unwrap();
+    std::fs::set_permissions(&destination_root, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let destination = destination_root.join(fixture.destination.file_name().unwrap());
+    fixture.destination = destination.clone();
+    fixture.request.audio_to = destination.clone();
+    fixture.request.destination_root = destination_root.clone();
+
+    commit(fixture.request.clone()).expect("cross-filesystem organize must publish");
+
+    assert_eq!(std::fs::read(&destination).unwrap(), b"fixture audio");
+    assert_eq!(
+        std::fs::metadata(&destination).unwrap().mode() & 0o777,
+        0o644
+    );
+    let sidecar = crate::downloads::sidecar_path(&destination);
+    assert_eq!(std::fs::read(&sidecar).unwrap(), b"fixture sidecar");
+    assert_eq!(std::fs::metadata(&sidecar).unwrap().mode() & 0o777, 0o600);
+    assert!(!fixture.source.exists());
+    assert!(!fixture.transaction_path().exists());
+
+    let _ = std::fs::remove_dir_all(destination_root);
+    fixture.cleanup();
+}

--- a/src/transfer/artifact_move/permissions.rs
+++ b/src/transfer/artifact_move/permissions.rs
@@ -1,0 +1,165 @@
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::bail;
+
+use super::{ArtifactMoveKind, import_private_root, reject_symlink_or_non_directory};
+use crate::util::safe_fs;
+
+/// Create only real directory components beneath an already-canonical root. In particular, do
+/// not let `create_dir_all` follow an existing in-root symlink and create directories outside the
+/// selected destination before the later canonical-scope check gets a chance to reject it.
+pub(super) fn ensure_scoped_directory(
+    root: &Path,
+    relative: &Path,
+    directory_mode: Option<u32>,
+) -> std::io::Result<PathBuf> {
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(component) = component else {
+            if matches!(component, Component::CurDir) {
+                continue;
+            }
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid relative artifact directory {}", relative.display()),
+            ));
+        };
+        current.push(component);
+        match fs::symlink_metadata(&current) {
+            Ok(_) => {
+                reject_symlink_or_non_directory(&current)?;
+                validate_scoped_directory_mode(&current, directory_mode)?;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                match create_scoped_directory(&current, directory_mode) {
+                    Ok(()) => safe_fs::sync_parent_dir(&current)?,
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                    Err(error) => return Err(error),
+                }
+                reject_symlink_or_non_directory(&current)?;
+                validate_scoped_directory_mode(&current, directory_mode)?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(current)
+}
+
+#[derive(Clone, Copy, Default)]
+pub(super) struct ArtifactPublishModes {
+    pub(super) audio: Option<u32>,
+    pub(super) sidecar: Option<u32>,
+    pub(super) directory: Option<u32>,
+}
+
+pub(super) fn artifact_publish_modes(
+    kind: ArtifactMoveKind,
+    destination_root: &Path,
+) -> std::io::Result<ArtifactPublishModes> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+
+        if matches!(kind, ArtifactMoveKind::Organize)
+            && import_private_root(destination_root).is_none()
+        {
+            let root_mode = fs::metadata(destination_root)?.mode() & 0o777;
+            let group_visible = root_mode & 0o050 == 0o050;
+            let other_visible = root_mode & 0o005 == 0o005;
+            let directory = 0o700
+                | if group_visible { 0o050 } else { 0 }
+                | if other_visible { 0o005 } else { 0 };
+            let audio = 0o600
+                | if group_visible { 0o040 } else { 0 }
+                | if other_visible { 0o004 } else { 0 };
+            return Ok(ArtifactPublishModes {
+                audio: Some(audio),
+                sidecar: Some(0o600),
+                directory: Some(directory),
+            });
+        }
+        if matches!(kind, ArtifactMoveKind::ImportDownload)
+            && import_private_root(destination_root).is_some()
+        {
+            return Ok(ArtifactPublishModes {
+                audio: Some(0o600),
+                sidecar: Some(0o600),
+                directory: None,
+            });
+        }
+        Ok(ArtifactPublishModes::default())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (kind, destination_root);
+        Ok(ArtifactPublishModes::default())
+    }
+}
+
+pub(super) fn validate_publish_mode(mode: Option<u32>) -> anyhow::Result<()> {
+    if mode.is_some_and(|mode| !matches!(mode, 0o600 | 0o640 | 0o644)) {
+        bail!("artifact move contains an invalid publication mode");
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn create_scoped_directory(path: &Path, mode: Option<u32>) -> std::io::Result<()> {
+    use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _};
+
+    let Some(mode) = mode else {
+        return fs::create_dir(path);
+    };
+    let mut builder = fs::DirBuilder::new();
+    builder.mode(mode).create(path)?;
+    let observed = fs::symlink_metadata(path)?;
+    if observed.file_type().is_symlink() || !observed.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!("new artifact directory was replaced: {}", path.display()),
+        ));
+    }
+    let observed_mode = observed.mode() & 0o777;
+    if observed_mode & mode != mode {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "new artifact directory {} has mode {observed_mode:04o}; expected {mode:04o} (check the process umask)",
+                path.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_scoped_directory_mode(path: &Path, mode: Option<u32>) -> std::io::Result<()> {
+    use std::os::unix::fs::MetadataExt as _;
+
+    let Some(mode) = mode else {
+        return Ok(());
+    };
+    let observed = fs::symlink_metadata(path)?.mode() & 0o777;
+    if observed & mode == mode {
+        Ok(())
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "artifact directory {} has mode {observed:04o}; library publication requires at least {mode:04o}",
+                path.display()
+            ),
+        ))
+    }
+}
+
+#[cfg(not(unix))]
+fn create_scoped_directory(path: &Path, _mode: Option<u32>) -> std::io::Result<()> {
+    fs::create_dir(path)
+}
+
+#[cfg(not(unix))]
+fn validate_scoped_directory_mode(_path: &Path, _mode: Option<u32>) -> std::io::Result<()> {
+    Ok(())
+}

--- a/src/transfer/artifact_move/reconcile.rs
+++ b/src/transfer/artifact_move/reconcile.rs
@@ -8,6 +8,8 @@ pub(super) struct ReconcileFilePolicy<'a> {
     pub(super) after_publish: ArtifactMoveFaultPoint,
     pub(super) retained_source_boundary: ArtifactMoveFaultPoint,
     pub(super) max_bytes: u64,
+    pub(super) publish_mode: Option<u32>,
+    pub(super) verify_legacy_existing_mode: bool,
 }
 
 pub(super) struct PinnedTransactionScopes {
@@ -19,6 +21,7 @@ pub(super) struct ReconcileFilePair<'a> {
     pub(super) source_parent: &'a safe_fs::PinnedDir,
     pub(super) source_name: &'a std::ffi::OsStr,
     pub(super) expected_source_object: safe_fs::FileObjectId,
+    pub(super) stage_parent: &'a safe_fs::PinnedDir,
     pub(super) destination_parent: &'a safe_fs::PinnedDir,
     pub(super) destination_stage_name: &'a std::ffi::OsStr,
     pub(super) expected_stage_object: Option<safe_fs::FileObjectId>,
@@ -35,6 +38,7 @@ pub(super) fn reconcile_file_pair(
         source_parent,
         source_name,
         expected_source_object,
+        stage_parent,
         destination_parent,
         destination_stage_name,
         expected_stage_object,
@@ -61,7 +65,7 @@ pub(super) fn reconcile_file_pair(
         Err(error) => return Err(error),
     };
 
-    if let Some(destination) = destination.as_ref() {
+    if let Some(mut destination) = destination {
         if destination.identity != *expected {
             return Err(identity_conflict(
                 "destination",
@@ -89,10 +93,16 @@ pub(super) fn reconcile_file_pair(
                 "final destination aliases the retained source object",
             ));
         }
-        if let Some(stage_object) = expected_stage_object {
-            match destination_parent
-                .open_existing_child_readonly(destination_stage_name, stage_object)
-            {
+        let destination_is_owned_stage = expected_stage_object
+            .is_some_and(|stage_object| stage_object == destination.generation.identity());
+        if destination_is_owned_stage {
+            apply_publish_mode(&mut destination.generation, policy.publish_mode)?;
+            destination.generation.sync_durable()?;
+        } else if policy.verify_legacy_existing_mode {
+            verify_publish_mode(&destination.generation, policy.publish_mode)?;
+        }
+        if let Some(stage_object) = expected_stage_object.filter(|_| !destination_is_owned_stage) {
+            match stage_parent.open_existing_child_readonly(destination_stage_name, stage_object) {
                 Ok(_) => {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::AlreadyExists,
@@ -109,11 +119,11 @@ pub(super) fn reconcile_file_pair(
     let stage = match expected_stage_object {
         Some(expected_object) => {
             #[cfg(windows)]
-            let reopened = destination_parent
+            let reopened = stage_parent
                 .open_existing_recoverable_child(destination_stage_name, expected_object);
             #[cfg(not(windows))]
             let reopened =
-                destination_parent.open_existing_child(destination_stage_name, expected_object);
+                stage_parent.open_existing_child(destination_stage_name, expected_object);
             match reopened {
                 Ok(generation) => Some(generation),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
@@ -122,7 +132,7 @@ pub(super) fn reconcile_file_pair(
         }
         None => None,
     };
-    let stage = match (stage, source.as_ref()) {
+    let mut stage = match (stage, source.as_ref()) {
         (Some(generation), source) => {
             let mut stage = bound_artifact(
                 generation,
@@ -160,25 +170,28 @@ pub(super) fn reconcile_file_pair(
             // macOS can clone directly from the exact source handle into the final name. This is
             // independent copy-on-write publication and leaves no destination stage. Filesystems
             // without clone support fall through to the recoverable copy stage below.
-            #[cfg(target_os = "macos")]
-            inject(policy.fault, policy.before_publish)?;
-            if let Some(published) = try_publish_independent_clone(
-                source.as_ref().expect("source matched above"),
-                destination_parent,
-                destination_name,
-            )? {
-                return validate_published_pair(
-                    source.as_ref(),
+            if policy.publish_mode.is_none() {
+                #[cfg(target_os = "macos")]
+                inject(policy.fault, policy.before_publish)?;
+                if let Some(published) = try_publish_independent_clone(
+                    source.as_ref().expect("source matched above"),
                     destination_parent,
                     destination_name,
-                    expected,
-                    policy,
-                    published,
-                );
+                    policy.publish_mode,
+                )? {
+                    return validate_published_pair(
+                        source.as_ref(),
+                        destination_parent,
+                        destination_name,
+                        expected,
+                        policy,
+                        published,
+                    );
+                }
             }
             create_destination_stage(
                 source.as_ref().expect("source matched above"),
-                destination_parent,
+                stage_parent,
                 destination_stage_name,
                 expected,
                 policy.max_bytes,
@@ -196,6 +209,8 @@ pub(super) fn reconcile_file_pair(
         }
     };
 
+    apply_publish_mode(&mut stage.generation, policy.publish_mode)?;
+    stage.generation.sync_durable()?;
     inject(policy.fault, policy.before_publish)?;
     let stage_retained_on_error = stage.generation.retains_name_on_drop();
     let published = match stage
@@ -279,12 +294,17 @@ fn try_publish_independent_clone(
     source: &BoundArtifact,
     destination_parent: &safe_fs::PinnedDir,
     destination_name: &std::ffi::OsStr,
+    publish_mode: Option<u32>,
 ) -> std::io::Result<Option<safe_fs::OwnedGeneration>> {
     match source
         .generation
         .publish_noreplace(destination_parent, destination_name)
     {
-        Ok(published) => Ok(Some(published)),
+        Ok(mut published) => {
+            apply_publish_mode(&mut published, publish_mode)?;
+            published.sync_durable()?;
+            Ok(Some(published))
+        }
         Err(error)
             if matches!(
                 error.raw_os_error(),
@@ -302,6 +322,7 @@ fn try_publish_independent_clone(
     _source: &BoundArtifact,
     _destination_parent: &safe_fs::PinnedDir,
     _destination_name: &std::ffi::OsStr,
+    _publish_mode: Option<u32>,
 ) -> std::io::Result<Option<safe_fs::OwnedGeneration>> {
     Ok(None)
 }
@@ -310,6 +331,7 @@ pub(super) struct ReconcileOptionalFilePair<'a> {
     pub(super) source_parent: &'a safe_fs::PinnedDir,
     pub(super) source_name: &'a std::ffi::OsStr,
     pub(super) expected_source_object: Option<safe_fs::FileObjectId>,
+    pub(super) stage_parent: &'a safe_fs::PinnedDir,
     pub(super) destination_parent: &'a safe_fs::PinnedDir,
     pub(super) destination_stage_name: &'a std::ffi::OsStr,
     pub(super) expected_stage_object: Option<safe_fs::FileObjectId>,
@@ -321,11 +343,14 @@ pub(super) fn reconcile_optional_file_pair(
     pair: ReconcileOptionalFilePair<'_>,
     record_stage_object: &mut dyn FnMut(safe_fs::FileObjectId) -> std::io::Result<()>,
     fault: Option<&dyn Fn(ArtifactMoveFaultPoint) -> std::io::Result<()>>,
+    publish_mode: Option<u32>,
+    verify_legacy_existing_mode: bool,
 ) -> std::io::Result<()> {
     let ReconcileOptionalFilePair {
         source_parent,
         source_name,
         expected_source_object,
+        stage_parent,
         destination_parent,
         destination_stage_name,
         expected_stage_object,
@@ -338,6 +363,7 @@ pub(super) fn reconcile_optional_file_pair(
                 source_parent,
                 source_name,
                 expected_source_object: object,
+                stage_parent,
                 destination_parent,
                 destination_stage_name,
                 expected_stage_object,
@@ -352,6 +378,8 @@ pub(super) fn reconcile_optional_file_pair(
                 retained_source_boundary:
                     ArtifactMoveFaultPoint::BeforeSidecarSourceUnlinkValidation,
                 max_bytes: ARTIFACT_SIDECAR_MAX_BYTES,
+                publish_mode,
+                verify_legacy_existing_mode,
             },
         ),
         (None, None) => {
@@ -365,7 +393,7 @@ pub(super) fn reconcile_optional_file_pair(
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
                 Err(error) => return Err(error),
             };
-            let stage = match destination_parent.open_child(destination_stage_name) {
+            let stage = match stage_parent.open_child(destination_stage_name) {
                 Ok(_) => true,
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
                 Err(error) => return Err(error),
@@ -384,6 +412,42 @@ pub(super) fn reconcile_optional_file_pair(
             "sidecar content and object identities are inconsistent",
         )),
     }
+}
+
+fn apply_publish_mode(
+    generation: &mut safe_fs::OwnedGeneration,
+    mode: Option<u32>,
+) -> std::io::Result<()> {
+    #[cfg(unix)]
+    if let Some(mode) = mode {
+        generation.set_mode(mode)?;
+    }
+    #[cfg(not(unix))]
+    let _ = (generation, mode);
+    Ok(())
+}
+
+fn verify_publish_mode(
+    generation: &safe_fs::OwnedGeneration,
+    mode: Option<u32>,
+) -> std::io::Result<()> {
+    #[cfg(unix)]
+    if let Some(mode) = mode {
+        use std::os::unix::fs::MetadataExt as _;
+
+        let observed = generation.file()?.metadata()?.mode() & 0o777;
+        if observed != mode {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!(
+                    "legacy artifact destination has mode {observed:04o}; expected {mode:04o} and lacks transaction-owned chmod proof"
+                ),
+            ));
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = (generation, mode);
+    Ok(())
 }
 
 struct BoundArtifact {

--- a/src/transfer/artifact_move/tests.rs
+++ b/src/transfer/artifact_move/tests.rs
@@ -7,7 +7,11 @@ use crate::transfer::session::{ImportSessionRow, ImportSessionRowStatus};
 
 static NEXT_FIXTURE: AtomicU64 = AtomicU64::new(1);
 
+#[path = "permission_boundary_tests.rs"]
+mod permission_boundary_tests;
+
 struct MoveFixture {
+    kind: ArtifactMoveKind,
     root: PathBuf,
     session_id: String,
     row_id: String,
@@ -31,17 +35,29 @@ impl MoveFixture {
                 .expect("clock after epoch")
                 .as_nanos()
         ));
-        let source_dir = root.join("incoming");
+        let organize = matches!(kind, ArtifactMoveKind::Organize);
         let destination_root = root.join("complete");
-        std::fs::create_dir_all(&source_dir).expect("create source directory");
         std::fs::create_dir_all(&destination_root).expect("create destination directory");
+        let source_dir = if organize {
+            let private_root = root.join(".yututui-inbox");
+            let session = private_root.join(&session_id);
+            let complete = session.join("complete");
+            for directory in [&private_root, &session, &complete] {
+                crate::util::safe_fs::ensure_private_dir(directory)
+                    .expect("create private organize source directory");
+            }
+            complete
+        } else {
+            let incoming = root.join("incoming");
+            std::fs::create_dir_all(&incoming).expect("create source directory");
+            incoming
+        };
         let source = source_dir.join("Track [abc123def45].m4a");
         let destination = destination_root.join("Track [abc123def45].m4a");
         std::fs::write(&source, b"fixture audio").expect("write source audio");
         std::fs::write(crate::downloads::sidecar_path(&source), b"fixture sidecar")
             .expect("write source sidecar");
 
-        let organize = matches!(kind, ArtifactMoveKind::Organize);
         let claim = crate::transfer::artifact_identity::test_import_claim(
             &session_id,
             &row_id,
@@ -87,6 +103,7 @@ impl MoveFixture {
             ),
         };
         Self {
+            kind,
             root,
             session_id,
             row_id,
@@ -127,7 +144,12 @@ impl MoveFixture {
     }
 
     fn assert_committed_once(&self) {
-        assert!(self.source.is_file(), "retained source audio is missing");
+        let source_is_private = matches!(self.kind, ArtifactMoveKind::Organize);
+        assert_eq!(
+            self.source.is_file(),
+            !source_is_private,
+            "source audio retention did not match its namespace"
+        );
         assert!(self.destination.is_file(), "destination audio is missing");
         assert_eq!(
             std::fs::read(&self.destination).expect("read committed audio"),
@@ -135,24 +157,30 @@ impl MoveFixture {
         );
         let source_sidecar = crate::downloads::sidecar_path(&self.source);
         let destination_sidecar = crate::downloads::sidecar_path(&self.destination);
-        assert!(
+        assert_eq!(
             source_sidecar.is_file(),
-            "retained source sidecar is missing"
+            !source_is_private,
+            "source sidecar retention did not match its namespace"
         );
         assert!(destination_sidecar.is_file(), "destination sidecar missing");
         assert_eq!(
             std::fs::read(destination_sidecar).expect("read committed sidecar"),
             b"fixture sidecar"
         );
-        assert_eq!(regular_file_count(self.source.parent().unwrap()), 2);
-        assert_eq!(regular_file_count(self.destination.parent().unwrap()), 2);
-        let source_file = safe_fs::open_regular_no_symlink(&self.source).unwrap();
-        let destination_file = safe_fs::open_regular_no_symlink(&self.destination).unwrap();
-        assert_ne!(
-            safe_fs::file_object_id(&source_file).unwrap(),
-            safe_fs::file_object_id(&destination_file).unwrap(),
-            "destination must not alias the mutable retained source"
+        assert_eq!(
+            regular_file_count(self.source.parent().unwrap()),
+            if source_is_private { 0 } else { 2 }
         );
+        assert_eq!(regular_file_count(self.destination.parent().unwrap()), 2);
+        let destination_file = safe_fs::open_regular_no_symlink(&self.destination).unwrap();
+        if !source_is_private {
+            let source_file = safe_fs::open_regular_no_symlink(&self.source).unwrap();
+            assert_ne!(
+                safe_fs::file_object_id(&source_file).unwrap(),
+                safe_fs::file_object_id(&destination_file).unwrap(),
+                "destination must not alias the mutable retained source"
+            );
+        }
 
         let saved = ImportSession::load(&self.session_id).expect("load committed session");
         let row = &saved.rows[0];
@@ -290,40 +318,323 @@ fn every_durable_phase_rolls_forward_to_exactly_one_pair_and_row() {
     }
 }
 
+#[cfg(unix)]
 #[test]
-fn legacy_transaction_schema_is_refused_without_mutating_artifacts() {
-    let fixture = MoveFixture::new("legacy-schema", ArtifactMoveKind::ImportDownload);
-    // Keep startup reconciliation from observing the transaction as current-schema in the
-    // interval between its creation and the deliberate legacy-schema rewrite below.
-    let record_guard =
-        ImportRecordGuard::try_acquire(&fixture.session_id).expect("own legacy fixture session");
-    let fault = |point| {
-        if point == ArtifactMoveFaultPoint::BeforeAudioPublish {
-            Err(std::io::Error::other("legacy fixture fault injection"))
-        } else {
-            Ok(())
+fn organize_publication_derives_library_modes_from_the_root() {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    for (root_mode, directory_mode, audio_mode) in [
+        (0o755, 0o755, 0o644),
+        (0o750, 0o750, 0o640),
+        (0o700, 0o700, 0o600),
+    ] {
+        let mut fixture = MoveFixture::new("public-modes", ArtifactMoveKind::Organize);
+        let library_root = fixture.request.destination_root.clone();
+        std::fs::set_permissions(&library_root, std::fs::Permissions::from_mode(root_mode))
+            .unwrap();
+        fixture.destination = library_root
+            .join("Artist")
+            .join("Album")
+            .join("Track [abc123def45].m4a");
+        fixture.request.audio_to = fixture.destination.clone();
+
+        commit(fixture.request.clone()).expect("publish organized library artifact");
+
+        assert_eq!(
+            std::fs::metadata(&library_root).unwrap().mode() & 0o777,
+            root_mode
+        );
+        for directory in [
+            library_root.join("Artist"),
+            library_root.join("Artist/Album"),
+        ] {
+            assert_eq!(
+                std::fs::metadata(directory).unwrap().mode() & 0o777,
+                directory_mode
+            );
         }
-    };
-    commit_locked_with_hook(fixture.request.clone(), Some(&fault))
-        .expect_err("fault must retain a prepared transaction");
-    let transaction = fixture.transaction_path();
-    let mut value: serde_json::Value =
-        serde_json::from_slice(&std::fs::read(&transaction).unwrap()).unwrap();
-    value["schema_version"] = serde_json::Value::from(TXN_SCHEMA_VERSION - 1);
-    {
-        // Production transaction rewrites hold this lock so inventory cannot mistake their
-        // live atomic-write temp for a stale crash remnant. Mirror that contract here.
-        let _registry = acquire_registry_lock().expect("own transaction registry");
-        safe_fs::write_private_atomic_json(&transaction, &value).unwrap();
+        assert_eq!(
+            std::fs::metadata(&fixture.destination).unwrap().mode() & 0o777,
+            audio_mode
+        );
+        assert_eq!(
+            std::fs::metadata(crate::downloads::sidecar_path(&fixture.destination))
+                .unwrap()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        fixture.cleanup();
     }
-    drop(record_guard);
+}
+
+#[cfg(unix)]
+#[test]
+fn organized_mode_is_durable_before_recovery_boundary() {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let fixture = MoveFixture::new("mode-recovery", ArtifactMoveKind::Organize);
+    std::fs::set_permissions(
+        &fixture.request.destination_root,
+        std::fs::Permissions::from_mode(0o755),
+    )
+    .unwrap();
+
+    commit_with_fault(
+        fixture.request.clone(),
+        ArtifactMoveFaultPoint::AfterAudioPublishBeforeSourceUnlink,
+    )
+    .expect_err("fault must retain the public-mode transaction");
+
+    assert_eq!(
+        std::fs::metadata(&fixture.destination).unwrap().mode() & 0o777,
+        0o644
+    );
+    assert!(fixture.source.exists());
+    assert!(fixture.transaction_path().exists());
+
+    reconcile_row(&fixture.session_id, &fixture.row_id, fixture.source_order)
+        .expect("recover organized publication")
+        .expect("recovered row is committed");
+    assert_eq!(
+        std::fs::metadata(&fixture.destination).unwrap().mode() & 0o777,
+        0o644
+    );
+    assert_eq!(
+        std::fs::metadata(crate::downloads::sidecar_path(&fixture.destination))
+            .unwrap()
+            .mode()
+            & 0o777,
+        0o600
+    );
+    fixture.cleanup();
+}
+
+#[cfg(unix)]
+#[test]
+fn matching_existing_organized_files_and_directories_are_never_chmodded() {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let mut fixture = MoveFixture::new("existing-modes", ArtifactMoveKind::Organize);
+    let library_root = fixture.request.destination_root.clone();
+    std::fs::set_permissions(&library_root, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let album = library_root.join("Artist/Album");
+    std::fs::create_dir_all(&album).unwrap();
+    std::fs::set_permissions(
+        library_root.join("Artist"),
+        std::fs::Permissions::from_mode(0o755),
+    )
+    .unwrap();
+    std::fs::set_permissions(&album, std::fs::Permissions::from_mode(0o755)).unwrap();
+    fixture.destination = album.join("Track [abc123def45].m4a");
+    fixture.request.audio_to = fixture.destination.clone();
+    std::fs::copy(&fixture.source, &fixture.destination).unwrap();
+    std::fs::copy(
+        crate::downloads::sidecar_path(&fixture.source),
+        crate::downloads::sidecar_path(&fixture.destination),
+    )
+    .unwrap();
+    std::fs::set_permissions(&fixture.destination, std::fs::Permissions::from_mode(0o600)).unwrap();
+    let destination_sidecar = crate::downloads::sidecar_path(&fixture.destination);
+    std::fs::set_permissions(&destination_sidecar, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+    commit(fixture.request.clone()).expect("accept matching organized destination");
+
+    assert_eq!(std::fs::metadata(&album).unwrap().mode() & 0o777, 0o755);
+    assert_eq!(
+        std::fs::metadata(&fixture.destination).unwrap().mode() & 0o777,
+        0o600
+    );
+    assert_eq!(
+        std::fs::metadata(destination_sidecar).unwrap().mode() & 0o777,
+        0o640
+    );
+    fixture.cleanup();
+}
+
+#[cfg(unix)]
+#[test]
+fn organize_publish_race_does_not_chmod_the_foreign_destination() {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let fixture = MoveFixture::new("mode-publish-race", ArtifactMoveKind::Organize);
+    std::fs::set_permissions(
+        &fixture.request.destination_root,
+        std::fs::Permissions::from_mode(0o755),
+    )
+    .unwrap();
+    let destination = fixture.destination.clone();
+    let hook = |point| {
+        if point == ArtifactMoveFaultPoint::BeforeAudioPublish {
+            std::fs::write(&destination, b"foreign destination")?;
+            std::fs::set_permissions(&destination, std::fs::Permissions::from_mode(0o620))?;
+        }
+        Ok(())
+    };
+    let _guard = ImportRecordGuard::try_acquire(&fixture.session_id).unwrap();
+
+    commit_locked_with_hook(fixture.request.clone(), Some(&hook))
+        .expect_err("foreign destination must win no-replace publication");
+
+    assert_eq!(
+        std::fs::metadata(&fixture.destination).unwrap().mode() & 0o777,
+        0o620
+    );
+    assert_eq!(
+        std::fs::read(&fixture.destination).unwrap(),
+        b"foreign destination"
+    );
+    assert!(fixture.source.exists());
+    drop(_guard);
+    fixture.cleanup();
+}
+
+#[cfg(unix)]
+#[test]
+fn legacy_v3_prepared_transaction_backfills_private_stage_and_public_modes() {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let fixture = MoveFixture::new("legacy-stage-location", ArtifactMoveKind::Organize);
+    std::fs::set_permissions(
+        &fixture.request.destination_root,
+        std::fs::Permissions::from_mode(0o755),
+    )
+    .unwrap();
+    commit_with_fault(
+        fixture.request.clone(),
+        ArtifactMoveFaultPoint::BeforeAudioPublish,
+    )
+    .expect_err("fault must retain a staged transaction");
+    let transaction = fixture.transaction_path();
+    let mut txn = load_transaction(&transaction).unwrap();
+    let source_stage = fixture.source.parent().unwrap().join(&txn.audio_stage_name);
+    let _ = std::fs::remove_file(source_stage);
+    txn.audio_stage_object_id = None;
+    txn.sidecar_stage_object_id = None;
+    txn.audio_publish_mode = None;
+    txn.sidecar_publish_mode = None;
+    txn.audio_source_private_stage = false;
+    txn.sidecar_source_private_stage = false;
+    txn.verify_legacy_existing_modes = false;
+    persist_transaction(&transaction, &txn).unwrap();
+
+    reconcile_row(&fixture.session_id, &fixture.row_id, fixture.source_order)
+        .expect("recover legacy prepared transaction")
+        .expect("legacy row is committed");
+
+    assert_eq!(
+        std::fs::metadata(&fixture.destination).unwrap().mode() & 0o777,
+        0o644
+    );
+    assert_eq!(
+        std::fs::metadata(crate::downloads::sidecar_path(&fixture.destination))
+            .unwrap()
+            .mode()
+            & 0o777,
+        0o600
+    );
+    fixture.cleanup();
+}
+
+#[cfg(unix)]
+#[test]
+fn legacy_v3_mixed_audio_and_sidecar_stages_recover_independently() {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let fixture = MoveFixture::new("legacy-mixed-stages", ArtifactMoveKind::Organize);
+    std::fs::set_permissions(
+        &fixture.request.destination_root,
+        std::fs::Permissions::from_mode(0o755),
+    )
+    .unwrap();
+    commit_with_fault(
+        fixture.request.clone(),
+        ArtifactMoveFaultPoint::BeforeSidecarPublish,
+    )
+    .expect_err("fault must leave audio published and sidecar staged");
+    let transaction = fixture.transaction_path();
+    let mut txn = load_transaction(&transaction).unwrap();
+    assert!(txn.audio_stage_object_id.is_some());
+    assert!(txn.sidecar_stage_object_id.is_some());
+    assert!(fixture.destination.exists());
+    let _ = std::fs::remove_file(
+        fixture
+            .source
+            .parent()
+            .unwrap()
+            .join(&txn.sidecar_stage_name),
+    );
+    txn.sidecar_stage_object_id = None;
+    txn.audio_publish_mode = None;
+    txn.sidecar_publish_mode = None;
+    txn.audio_source_private_stage = false;
+    txn.sidecar_source_private_stage = false;
+    txn.verify_legacy_existing_modes = false;
+    persist_transaction(&transaction, &txn).unwrap();
+    std::fs::set_permissions(&fixture.destination, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+    reconcile_row(&fixture.session_id, &fixture.row_id, fixture.source_order)
+        .expect("recover mixed legacy publication stages")
+        .expect("mixed legacy row is committed");
+
+    assert_eq!(
+        std::fs::metadata(&fixture.destination).unwrap().mode() & 0o777,
+        0o644
+    );
+    assert_eq!(
+        std::fs::metadata(crate::downloads::sidecar_path(&fixture.destination))
+            .unwrap()
+            .mode()
+            & 0o777,
+        0o600
+    );
+    assert!(!fixture.source.exists());
+    assert!(!transaction.exists());
+    fixture.cleanup();
+}
+
+#[cfg(unix)]
+#[test]
+fn legacy_v3_final_without_owned_mode_proof_fails_without_chmod() {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let fixture = MoveFixture::new("legacy-final-mode", ArtifactMoveKind::Organize);
+    std::fs::set_permissions(
+        &fixture.request.destination_root,
+        std::fs::Permissions::from_mode(0o755),
+    )
+    .unwrap();
+    commit_with_fault(
+        fixture.request.clone(),
+        ArtifactMoveFaultPoint::BeforeAudioPublish,
+    )
+    .expect_err("fault must retain a prepared transaction");
+    let transaction = fixture.transaction_path();
+    let mut txn = load_transaction(&transaction).unwrap();
+    let _ = std::fs::remove_file(fixture.source.parent().unwrap().join(&txn.audio_stage_name));
+    txn.audio_stage_object_id = None;
+    txn.sidecar_stage_object_id = None;
+    txn.audio_publish_mode = None;
+    txn.sidecar_publish_mode = None;
+    txn.audio_source_private_stage = false;
+    txn.sidecar_source_private_stage = false;
+    txn.verify_legacy_existing_modes = false;
+    persist_transaction(&transaction, &txn).unwrap();
+    std::fs::copy(&fixture.source, &fixture.destination).unwrap();
+    std::fs::set_permissions(&fixture.destination, std::fs::Permissions::from_mode(0o600)).unwrap();
 
     let error = reconcile_row(&fixture.session_id, &fixture.row_id, fixture.source_order)
-        .expect_err("legacy transaction must not infer missing object identities");
+        .expect_err("unowned legacy final must not be chmodded");
 
-    assert!(format!("{error:#}").contains("unsupported artifact move schema"));
-    assert_eq!(std::fs::read(&fixture.source).unwrap(), b"fixture audio");
-    assert!(!fixture.destination.exists());
+    assert!(
+        format!("{error:#}").contains("lacks transaction-owned chmod proof"),
+        "unexpected recovery error: {error:#}"
+    );
+    assert_eq!(
+        std::fs::metadata(&fixture.destination).unwrap().mode() & 0o777,
+        0o600
+    );
+    assert!(fixture.source.exists());
     assert!(transaction.exists());
     fixture.cleanup();
 }
@@ -474,6 +785,7 @@ fn matching_final_with_a_journal_owned_named_stage_is_not_forgotten() {
             source_parent: &source_parent,
             source_name: std::ffi::OsStr::new("source.audio"),
             expected_source_object: source.identity(),
+            stage_parent: &destination_parent,
             destination_parent: &destination_parent,
             destination_stage_name: std::ffi::OsStr::new("owned.stage"),
             expected_stage_object: Some(stage.identity()),
@@ -487,6 +799,8 @@ fn matching_final_with_a_journal_owned_named_stage_is_not_forgotten() {
             after_publish: ArtifactMoveFaultPoint::AfterAudioPublishBeforeSourceUnlink,
             retained_source_boundary: ArtifactMoveFaultPoint::BeforeAudioSourceUnlinkValidation,
             max_bytes: ARTIFACT_AUDIO_MAX_BYTES,
+            publish_mode: None,
+            verify_legacy_existing_mode: false,
         },
     )
     .expect_err("a retained named stage requires explicit recovery");
@@ -531,6 +845,7 @@ fn journal_owned_partial_stage_is_repaired_and_promoted() {
             source_parent: &source_parent,
             source_name: std::ffi::OsStr::new("source.audio"),
             expected_source_object: source.identity(),
+            stage_parent: &destination_parent,
             destination_parent: &destination_parent,
             destination_stage_name: std::ffi::OsStr::new("owned.stage"),
             expected_stage_object: Some(stage.identity()),
@@ -544,6 +859,8 @@ fn journal_owned_partial_stage_is_repaired_and_promoted() {
             after_publish: ArtifactMoveFaultPoint::AfterAudioPublishBeforeSourceUnlink,
             retained_source_boundary: ArtifactMoveFaultPoint::BeforeAudioSourceUnlinkValidation,
             max_bytes: ARTIFACT_AUDIO_MAX_BYTES,
+            publish_mode: None,
+            verify_legacy_existing_mode: false,
         },
     )
     .expect("repair and promote journal-owned stage");
@@ -615,6 +932,22 @@ fn successful_private_inbox_commit_reclaims_sources_and_leaves_no_stage() {
         std::fs::read(&fixture.destination).unwrap(),
         b"fixture audio"
     );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+
+        assert_eq!(
+            std::fs::metadata(&fixture.destination).unwrap().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(
+            std::fs::metadata(crate::downloads::sidecar_path(&fixture.destination))
+                .unwrap()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
     assert!(!fixture.transaction_path().exists());
     fixture.cleanup();
 }

--- a/src/transfer/download_plan.rs
+++ b/src/transfer/download_plan.rs
@@ -126,7 +126,10 @@ fn plan_row(
     existing: &ImportDownloadDedupeIndex,
     seen: &mut HashMap<String, u32>,
 ) -> ImportDownloadDecision {
-    if row.written || row.local_path.is_some() {
+    // `written` can come from a legacy LocalPlaylist write with no downloaded artifact. Local
+    // readiness is represented by `local_path`/the durable receipt, so those playlist-only rows
+    // must remain downloadable after bulk Ready selection.
+    if super::session::row_has_artifact_ownership(row) {
         return ImportDownloadDecision::AlreadyWritten {
             path: row.local_path.clone(),
         };

--- a/src/transfer/review_action.rs
+++ b/src/transfer/review_action.rs
@@ -4,7 +4,10 @@ use anyhow::{Context as _, anyhow, bail};
 
 use super::checkpoint::{Checkpoint, ReviewDecision};
 use super::matching::{MatchOutcome, MatchScoreBreakdown};
-use super::session::{ImportRecordGuard, ImportSession, ensure_review_row_mutable_unlocked};
+use super::session::{
+    ImportRecordGuard, ImportSession, ensure_ready_row_mutable_unlocked,
+    ensure_review_row_mutable_unlocked,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReviewActionSummary {
@@ -19,7 +22,22 @@ pub struct ReviewActionSummary {
 pub struct ReviewBatchSummary {
     pub session_id: String,
     pub accepted_count: u32,
+    pub ready_count: u32,
+    pub total_count: u32,
+    pub review_left: u32,
+    pub missing_left: u32,
     pub rows: Vec<ReviewActionSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReviewReadyPlan {
+    pub session_id: String,
+    pub candidate_count: u32,
+    pub ready_count: u32,
+    pub resulting_ready_count: u32,
+    pub total_count: u32,
+    pub review_left: u32,
+    pub missing_left: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -84,19 +102,20 @@ pub fn skip_row(job_id: &str, source_order: u32) -> anyhow::Result<ReviewActionS
 pub fn accept_all_candidates(job_id: &str) -> anyhow::Result<ReviewBatchSummary> {
     let _guard = ImportRecordGuard::try_acquire(job_id)?;
     let mut cp = Checkpoint::load(job_id)?;
+    let selections: Vec<_> = cp
+        .tracks
+        .iter()
+        .enumerate()
+        .filter(|(_, entry)| !review_decision_is_terminal(entry.review_decision.as_ref()))
+        .filter_map(|(index, entry)| {
+            best_safe_ambiguous_candidate(&cp.spec, &entry.outcome)
+                .map(|candidate| (index, candidate))
+        })
+        .collect();
     let mut rows = Vec::new();
-    for index in 0..cp.tracks.len() {
-        if cp.tracks[index].written {
-            continue;
-        }
+    for (index, selected) in selections {
         let source_order = u32::try_from(index + 1).unwrap_or(u32::MAX);
-        let Some(selected) = first_ambiguous_candidate(&cp.tracks[index].outcome) else {
-            continue;
-        };
-        ensure_review_row_mutable_unlocked(job_id, source_order)?;
-        if ensure_review_candidate_allowed(&cp.spec, selected.score_breakdown.as_ref()).is_err() {
-            continue;
-        }
+        ensure_ready_row_mutable_unlocked(job_id, source_order)?;
         apply_accepted_candidate(&mut cp, index, selected.clone());
         rows.push(ReviewActionSummary {
             source_order,
@@ -109,11 +128,57 @@ pub fn accept_all_candidates(job_id: &str) -> anyhow::Result<ReviewBatchSummary>
     if !rows.is_empty() {
         save_checkpoint_and_session(&mut cp)?;
     }
+    let plan = ready_plan(&cp);
     Ok(ReviewBatchSummary {
         session_id: job_id.to_owned(),
         accepted_count: rows.len() as u32,
+        ready_count: plan.ready_count,
+        total_count: plan.total_count,
+        review_left: plan.review_left,
+        missing_left: plan.missing_left,
         rows,
     })
+}
+
+pub fn plan_ready_candidates(job_id: &str) -> anyhow::Result<ReviewReadyPlan> {
+    let cp = Checkpoint::load(job_id)?;
+    Ok(ready_plan(&cp))
+}
+
+fn ready_plan(cp: &Checkpoint) -> ReviewReadyPlan {
+    let mut ready_count = 0_u32;
+    let mut candidate_count = 0_u32;
+    let mut ambiguous_count = 0_u32;
+    let mut missing_left = 0_u32;
+    for entry in &cp.tracks {
+        if review_decision_is_terminal(entry.review_decision.as_ref()) {
+            continue;
+        }
+        match &entry.outcome {
+            Some(MatchOutcome::Matched { .. }) => {
+                ready_count = ready_count.saturating_add(1);
+            }
+            Some(MatchOutcome::Ambiguous { .. }) => {
+                ambiguous_count = ambiguous_count.saturating_add(1);
+                if best_safe_ambiguous_candidate(&cp.spec, &entry.outcome).is_some() {
+                    candidate_count = candidate_count.saturating_add(1);
+                }
+            }
+            Some(MatchOutcome::NotFound) => {
+                missing_left = missing_left.saturating_add(1);
+            }
+            _ => {}
+        }
+    }
+    ReviewReadyPlan {
+        session_id: cp.job_id.clone(),
+        candidate_count,
+        ready_count,
+        resulting_ready_count: ready_count.saturating_add(candidate_count),
+        total_count: cp.tracks.len() as u32,
+        review_left: ambiguous_count.saturating_sub(candidate_count),
+        missing_left,
+    }
 }
 
 fn accept_candidate(
@@ -248,24 +313,45 @@ fn candidates_from_outcome(outcome: &Option<MatchOutcome>) -> Vec<SelectedCandid
     }
 }
 
-fn first_ambiguous_candidate(outcome: &Option<MatchOutcome>) -> Option<SelectedCandidate> {
+fn best_safe_ambiguous_candidate(
+    spec: &super::JobSpec,
+    outcome: &Option<MatchOutcome>,
+) -> Option<SelectedCandidate> {
     let Some(MatchOutcome::Ambiguous { candidates }) = outcome else {
         return None;
     };
-    candidates
-        .first()
-        .filter(|candidate| {
-            candidate
+    let mut best = None::<SelectedCandidate>;
+    for candidate in candidates {
+        if !candidate.score.is_finite()
+            || candidate
                 .score_breakdown
                 .as_ref()
-                .is_none_or(|score| !score.accept_blocked && score.reject_reason.is_none())
-        })
-        .map(|candidate| SelectedCandidate {
+                .is_some_and(|score| score.accept_blocked || score.reject_reason.is_some())
+            || ensure_review_candidate_allowed(spec, candidate.score_breakdown.as_ref()).is_err()
+        {
+            continue;
+        }
+        if best
+            .as_ref()
+            .is_some_and(|selected| candidate.score <= selected.score)
+        {
+            continue;
+        }
+        best = Some(SelectedCandidate {
             key: candidate.key.clone(),
             score: candidate.score,
             display: candidate.display.clone(),
             score_breakdown: candidate.score_breakdown.clone(),
-        })
+        });
+    }
+    best
+}
+
+fn review_decision_is_terminal(decision: Option<&ReviewDecision>) -> bool {
+    matches!(
+        decision,
+        Some(ReviewDecision::Rejected | ReviewDecision::Skipped)
+    )
 }
 
 fn selected_key(entry: &super::checkpoint::TrackEntry) -> Option<&str> {
@@ -351,6 +437,234 @@ mod tests {
             source_key: format!("spotify:track:{title}"),
             known_video_id: None,
         }
+    }
+
+    fn ambiguous_candidate(key: &str, score: f32, accept_blocked: bool) -> AmbiguousCandidate {
+        AmbiguousCandidate {
+            key: key.to_owned(),
+            score,
+            display: key.to_owned(),
+            score_breakdown: Some(MatchScoreBreakdown {
+                total: score,
+                accept_blocked,
+                ..MatchScoreBreakdown::default()
+            }),
+        }
+    }
+
+    #[test]
+    fn bulk_ready_uses_checkpoint_state_and_picks_highest_safe_candidate() {
+        let job_id = "sp2yt-review-action-ready-all";
+        let mut cp = Checkpoint::new(
+            job_id.to_owned(),
+            spec(ImportMediaKind::Track),
+            vec![
+                TrackEntry {
+                    input: input("Already Ready"),
+                    outcome: Some(MatchOutcome::Matched {
+                        key: "ready".to_owned(),
+                        score: 0.95,
+                        display: "Ready".to_owned(),
+                        title: None,
+                        artist: None,
+                        album: None,
+                        duration_secs: None,
+                        score_breakdown: None,
+                    }),
+                    review_decision: None,
+                    written: true,
+                },
+                TrackEntry {
+                    input: input("Choose Safe"),
+                    outcome: Some(MatchOutcome::Ambiguous {
+                        candidates: vec![
+                            ambiguous_candidate("blocked-first", 0.99, true),
+                            ambiguous_candidate("safe-low", 0.75, false),
+                            ambiguous_candidate("safe-high", 0.88, false),
+                        ],
+                    }),
+                    review_decision: None,
+                    written: false,
+                },
+                TrackEntry {
+                    input: input("Missing"),
+                    outcome: Some(MatchOutcome::NotFound),
+                    review_decision: None,
+                    written: false,
+                },
+                TrackEntry {
+                    input: input("Pending"),
+                    outcome: None,
+                    review_decision: None,
+                    written: false,
+                },
+                TrackEntry {
+                    input: input("Rejected"),
+                    outcome: Some(MatchOutcome::Ambiguous {
+                        candidates: vec![ambiguous_candidate("rejected-safe", 0.91, false)],
+                    }),
+                    review_decision: Some(ReviewDecision::Rejected),
+                    written: false,
+                },
+                TrackEntry {
+                    input: input("Capacity"),
+                    outcome: Some(MatchOutcome::SkippedCapacity),
+                    review_decision: None,
+                    written: false,
+                },
+                TrackEntry {
+                    input: input("Unsafe"),
+                    outcome: Some(MatchOutcome::Ambiguous {
+                        candidates: vec![ambiguous_candidate("unsafe-only", 0.97, true)],
+                    }),
+                    review_decision: None,
+                    written: false,
+                },
+            ],
+        );
+        cp.save().unwrap();
+        ImportSession::from_checkpoint(&cp).save().unwrap();
+
+        assert_eq!(
+            plan_ready_candidates(job_id).unwrap(),
+            ReviewReadyPlan {
+                session_id: job_id.to_owned(),
+                candidate_count: 1,
+                ready_count: 1,
+                resulting_ready_count: 2,
+                total_count: 7,
+                review_left: 1,
+                missing_left: 1,
+            }
+        );
+
+        let summary = accept_all_candidates(job_id).unwrap();
+        assert_eq!(summary.accepted_count, 1);
+        assert_eq!(summary.ready_count, 2);
+        assert_eq!(summary.total_count, 7);
+        assert_eq!(summary.review_left, 1);
+        assert_eq!(summary.missing_left, 1);
+        let saved = Checkpoint::load(job_id).unwrap();
+        assert!(matches!(
+            saved.tracks[1].review_decision,
+            Some(ReviewDecision::Accepted { ref key, .. }) if key == "safe-high"
+        ));
+        assert_eq!(
+            saved.tracks[4].review_decision,
+            Some(ReviewDecision::Rejected)
+        );
+        assert!(matches!(
+            saved.tracks[6].outcome,
+            Some(MatchOutcome::Ambiguous { .. })
+        ));
+        ImportSession::delete_record(job_id).unwrap();
+    }
+
+    #[test]
+    fn bulk_ready_applies_music_video_eligibility_to_every_candidate() {
+        let outcome = Some(MatchOutcome::Ambiguous {
+            candidates: vec![
+                AmbiguousCandidate {
+                    key: "no-evidence".to_owned(),
+                    score: 0.99,
+                    display: "No evidence".to_owned(),
+                    score_breakdown: None,
+                },
+                ambiguous_candidate("eligible", 0.80, false),
+            ],
+        });
+
+        let selected = best_safe_ambiguous_candidate(&spec(ImportMediaKind::MusicVideo), &outcome)
+            .expect("eligible candidate");
+        assert_eq!(selected.key, "eligible");
+    }
+
+    #[test]
+    fn bulk_ready_projects_legacy_playlist_write_and_keeps_it_downloadable() {
+        let job_id = "sp2yt-review-action-ready-legacy-written";
+        let mut cp = Checkpoint::new(
+            job_id.to_owned(),
+            spec(ImportMediaKind::Track),
+            vec![TrackEntry {
+                input: input("Legacy playlist row"),
+                outcome: Some(MatchOutcome::Ambiguous {
+                    candidates: vec![ambiguous_candidate("safe-download", 0.91, false)],
+                }),
+                review_decision: None,
+                written: true,
+            }],
+        );
+        cp.save().unwrap();
+        ImportSession::from_checkpoint(&cp).save().unwrap();
+
+        let summary = accept_all_candidates(job_id).unwrap();
+        assert_eq!(summary.ready_count, 1);
+        let saved_cp = Checkpoint::load(job_id).unwrap();
+        assert!(
+            saved_cp.tracks[0].written,
+            "playlist idempotency is retained"
+        );
+        assert!(matches!(
+            saved_cp.tracks[0].outcome,
+            Some(MatchOutcome::Matched { ref key, .. }) if key == "safe-download"
+        ));
+
+        let session = ImportSession::load(job_id).unwrap();
+        assert!(matches!(
+            session.rows[0].status,
+            super::super::session::ImportSessionRowStatus::Matched
+        ));
+        assert_eq!(session.rows[0].revision, 2);
+        assert_eq!(
+            session.rows[0].selected_key.as_deref(),
+            Some("safe-download")
+        );
+        let plan = super::super::download_plan::build_import_download_plan(
+            &session,
+            &super::super::download_plan::ImportDownloadDedupeIndex::default(),
+        );
+        assert!(matches!(
+            plan.rows[0].decision,
+            super::super::download_plan::ImportDownloadDecision::Enqueue
+        ));
+
+        let claim = super::super::session::claim_import_download(job_id, 1, "safe-download")
+            .expect("playlist-only write can enter the artifact lifecycle");
+        assert!(!ImportSession::load(job_id).unwrap().rows[0].written);
+        assert!(
+            super::super::session::record_import_download_error(&claim, "test cleanup").unwrap()
+        );
+        ImportSession::delete_record(job_id).unwrap();
+    }
+
+    #[test]
+    fn bulk_ready_refuses_to_retarget_an_owned_local_artifact() {
+        let job_id = "sp2yt-review-action-ready-owned-artifact";
+        let mut cp = Checkpoint::new(
+            job_id.to_owned(),
+            spec(ImportMediaKind::Track),
+            vec![TrackEntry {
+                input: input("Owned artifact"),
+                outcome: Some(MatchOutcome::Ambiguous {
+                    candidates: vec![ambiguous_candidate("replacement", 0.93, false)],
+                }),
+                review_decision: None,
+                written: false,
+            }],
+        );
+        cp.save().unwrap();
+        let mut session = ImportSession::from_checkpoint(&cp);
+        session.rows[0].written = true;
+        session.rows[0].local_path = Some(std::path::PathBuf::from("/tmp/owned-artifact.m4a"));
+        session.save().unwrap();
+
+        let error = accept_all_candidates(job_id).unwrap_err();
+        assert!(format!("{error:#}").contains("already owns a local artifact"));
+        assert!(matches!(
+            Checkpoint::load(job_id).unwrap().tracks[0].outcome,
+            Some(MatchOutcome::Ambiguous { .. })
+        ));
+        ImportSession::delete_record(job_id).unwrap();
     }
 
     #[test]

--- a/src/transfer/session.rs
+++ b/src/transfer/session.rs
@@ -29,8 +29,8 @@ pub(crate) use artifact_receipt::{
     record_import_download_interruption,
 };
 pub(crate) use claim::{
-    claim_import_download, ensure_review_row_mutable_unlocked,
-    validate_import_download_claim_unlocked,
+    claim_import_download, ensure_ready_row_mutable_unlocked, ensure_review_row_mutable_unlocked,
+    row_has_artifact_ownership, validate_import_download_claim_unlocked,
 };
 
 const IMPORT_SESSION_SCHEMA_VERSION: u32 = 1;

--- a/src/transfer/session/claim.rs
+++ b/src/transfer/session/claim.rs
@@ -30,7 +30,7 @@ where
     }
     let session_instance_id = session.session_instance_id.clone();
     let row = row_by_source_order_mut(&mut session, source_order)?;
-    if row.written || row.artifact_receipt.is_some() {
+    if row_has_artifact_ownership(row) {
         bail!("import row {source_order} is already written");
     }
     if !matches!(row.status, ImportSessionRowStatus::Matched)
@@ -67,6 +67,10 @@ where
         claim_id: new_durable_id(),
         expected_key: expected_key.to_owned(),
     };
+    // Legacy LocalPlaylist jobs may have set checkpoint/session `written` after adding the
+    // remote selection to the Library playlist. That is not a local audio artifact: admission
+    // establishes the session row's artifact lifecycle without changing checkpoint idempotency.
+    row.written = false;
     row.download_claim = Some(claim.clone());
     match save(session) {
         Ok(()) => Ok(claim),
@@ -147,6 +151,34 @@ pub(crate) fn ensure_review_row_mutable_unlocked(
         bail!("row {source_order} has an active download; review cannot change it");
     }
     Ok(())
+}
+
+/// Bulk Ready changes are checkpoint-owned and independent of playlist-write/download state.
+/// They still must not retarget a row while an admitted download owns that selection.
+pub(crate) fn ensure_ready_row_mutable_unlocked(
+    session_id: &str,
+    source_order: u32,
+) -> anyhow::Result<()> {
+    if !session_path(session_id).is_some_and(|path| path.exists()) {
+        return Ok(());
+    }
+    let session = ImportSession::load(session_id)?;
+    let row = session
+        .rows
+        .iter()
+        .find(|row| row.source_order == source_order)
+        .ok_or_else(|| anyhow::anyhow!("import row {source_order} is missing"))?;
+    if row.download_claim.is_some() {
+        bail!("row {source_order} has an active download; Ready selection cannot change it");
+    }
+    if row_has_artifact_ownership(row) {
+        bail!("row {source_order} already owns a local artifact; Ready selection cannot change it");
+    }
+    Ok(())
+}
+
+pub(crate) fn row_has_artifact_ownership(row: &ImportSessionRow) -> bool {
+    row.local_path.is_some() || row.artifact_receipt.is_some()
 }
 
 pub(super) fn new_durable_id() -> String {

--- a/src/transfer/session/projection.rs
+++ b/src/transfer/session/projection.rs
@@ -35,11 +35,12 @@ impl ImportSession {
                     continue;
                 };
                 let target_changed = row_download_target(row) != row_download_target(previous);
+                let has_local_artifact = super::claim::row_has_artifact_ownership(previous);
                 row.revision = previous.revision.max(1);
-                if target_changed && !previous.written && previous.download_claim.is_none() {
+                if target_changed && !has_local_artifact && previous.download_claim.is_none() {
                     row.revision = row.revision.saturating_add(1);
                 }
-                if previous.written || previous.download_claim.is_some() {
+                if has_local_artifact || previous.download_claim.is_some() {
                     preserve_review_identity(row, previous);
                 }
                 row.written = previous.written;

--- a/src/ui/views/help.rs
+++ b/src/ui/views/help.rs
@@ -849,7 +849,7 @@ mod tests {
             .into_iter()
             .find_map(|(title, rows)| (title == "Local Deck").then_some(rows))
             .expect("local deck group");
-        assert!(local_deck.contains(&("A".to_owned(), "Accept all import candidates".to_owned())));
+        assert!(local_deck.contains(&("A".to_owned(), "Mark all import tracks Ready".to_owned())));
     }
 
     #[test]

--- a/src/ui/views/local.rs
+++ b/src/ui/views/local.rs
@@ -683,7 +683,7 @@ pub fn render_local_accept_all_confirm(
     let segs = [
         buttons::Seg::button(
             MouseTarget::ConfirmLocalAcceptAll,
-            t!(" Accept & write (Enter) ", " 수락 및 작성 (Enter) "),
+            t!(" Mark Ready (Enter) ", " 준비 완료 (Enter) "),
         ),
         buttons::Seg::label("    "),
         buttons::Seg::button(

--- a/src/util/safe_fs/pinned.rs
+++ b/src/util/safe_fs/pinned.rs
@@ -347,6 +347,18 @@ impl OwnedGeneration {
         self.identity
     }
 
+    /// Set Unix permission bits on this exact owned generation, without resolving its name.
+    #[cfg(unix)]
+    pub(crate) fn set_mode(&mut self, mode: u32) -> io::Result<()> {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        ensure_process_mutation_allowed()?;
+        self.verify()?;
+        self.file
+            .set_permissions(std::fs::Permissions::from_mode(mode & 0o777))?;
+        self.verify()
+    }
+
     /// Whether dropping this handle before promotion leaves a named recovery generation.
     pub(crate) fn retains_name_on_drop(&self) -> bool {
         match self.residence {


### PR DESCRIPTION
## Summary

- Make `A` in Local Deck import review mark every policy-safe candidate Ready without writing a Library playlist, and show Ready and Local counts separately.
- Automatically organize only the completed import cohort into the configured `Album Artist/Year - Album/Track - Title` layout, relocate manifest/runtime paths, and queue a follow-up local scan.
- Keep `.yututui-inbox` private and ignored while publishing organized audio with library-root-derived Unix permissions, crash recovery, and Linux cross-filesystem staging.
- Preserve manual `m` organize as the recovery path without sweeping older inbox artifacts.

## Why

Local Deck already reads embedded artist and album metadata, but admitted downloads remained in the private inbox until a separate organize step. Media servers such as Jellyfin could therefore miss or be unable to read those artifacts. The review flow also lacked a session-wide way to make every safe track Ready without coupling that action to playlist writing.

## User impact

Completed imports are published automatically in a media-server-friendly layout with readable library permissions, while failures remain recoverable. During review, one confirmed uppercase `A` action prepares all safe candidates for download and leaves unsafe or unresolved rows untouched.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --quiet` (2,942 library tests plus binary and CLI suites)
- Project architecture, file-size, documentation-honesty, ratatui patch, and unsafe-inventory checks
- Isolated TUI verification through the project `verify` skill
- Linux cross-filesystem publication regression is target-gated and uses `/dev/shm` when it is a distinct filesystem

## Environment note

An optional macOS-hosted Linux cross-target compile could not locate a cross OpenSSL/pkg-config sysroot; native workspace gates and the target-gated regression suite passed on the available host.
