### PR TITLE
Make config recovery transactional

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1054,7 +1054,7 @@ impl Config {
     }
 
     fn save_to(&self, path: &std::path::Path) -> std::io::Result<()> {
-        crate::persist::write_store_json(path, self)
+        crate::persist::write_config_json(path, self)
     }
 
     pub fn player_runtime(&self, cookies_file: Option<PathBuf>) -> PlayerRuntimeConfig {

--- a/src/config/recovery.rs
+++ b/src/config/recovery.rs
@@ -9,23 +9,44 @@ pub(super) fn load_from_path_with_legacy(
     path: &std::path::Path,
     legacy_path: Option<&std::path::Path>,
 ) -> Config {
-    let (can_persist_default, source_was_missing) =
-        match safe_fs::read_no_symlink_limited(path, MAX_CONFIG_BYTES) {
-            Ok(bytes) => match String::from_utf8(bytes) {
-                Ok(text) => {
-                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
-                        return recover_value(path, value, false, true);
-                    }
-                    (safe_fs::backup_aside_secret(path).is_ok(), false)
+    let recovery = crate::persist::begin_config_recovery(path);
+    let base = recovery.read_base(MAX_CONFIG_BYTES);
+    load_from_path_with_legacy_after_read(recovery, path, legacy_path, base)
+}
+
+#[cfg(test)]
+fn load_from_path_with_legacy_using(
+    path: &std::path::Path,
+    legacy_path: Option<&std::path::Path>,
+    read: impl FnOnce(&std::path::Path, u64) -> std::io::Result<Vec<u8>>,
+) -> Config {
+    let recovery = crate::persist::begin_config_recovery(path);
+    let base = recovery.read_base_with(MAX_CONFIG_BYTES, read);
+    load_from_path_with_legacy_after_read(recovery, path, legacy_path, base)
+}
+
+fn load_from_path_with_legacy_after_read(
+    recovery: crate::persist::ConfigRecoveryGuard,
+    path: &std::path::Path,
+    legacy_path: Option<&std::path::Path>,
+    base: std::io::Result<Vec<u8>>,
+) -> Config {
+    let (can_persist_default, source_was_missing) = match base {
+        Ok(bytes) => match String::from_utf8(bytes) {
+            Ok(text) => {
+                if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
+                    return recover_value(recovery, value, InstallPolicy::IfChanged);
                 }
-                Err(_) => (safe_fs::backup_aside_secret(path).is_ok(), false),
-            },
-            Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
-                (safe_fs::backup_too_large_secret(path).is_ok(), false)
+                (safe_fs::backup_aside_secret(path).is_ok(), false)
             }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => (true, true),
-            Err(_) => (safe_fs::backup_unreadable_secret(path).is_ok(), false),
-        };
+            Err(_) => (safe_fs::backup_aside_secret(path).is_ok(), false),
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+            (safe_fs::backup_too_large_secret(path).is_ok(), false)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => (true, true),
+        Err(_) => (safe_fs::backup_unreadable_secret(path).is_ok(), false),
+    };
 
     let mut cfg = if source_was_missing {
         config_for_missing_profile(legacy_path)
@@ -46,9 +67,9 @@ pub(super) fn load_from_path_with_legacy(
         }
     };
     if can_persist_default {
-        cfg = recover_value(path, value, true, true);
+        cfg = recover_value(recovery, value, InstallPolicy::Always);
     } else {
-        cfg = recover_value(path, value, false, false);
+        cfg = recover_value(recovery, value, InstallPolicy::Forbidden);
         tracing::error!(
             path = %path.display(),
             "refusing to overwrite unreadable/corrupt config because recovery backup failed"
@@ -60,72 +81,117 @@ pub(super) fn load_from_path_with_legacy(
 /// Replay as raw JSON, then migrate before typed recovery. This preserves unknown keys in both the
 /// primary config and a pending sidecar. A replay is cleared only after its effective raw object is
 /// atomically installed; any failed write leaves the old marker/journal available for retry.
-fn recover_value(
-    path: &std::path::Path,
-    value: serde_json::Value,
-    install_base: bool,
-    allow_persist: bool,
-) -> Config {
-    recover_value_with_writer(
-        path,
-        value,
-        install_base,
-        allow_persist,
-        safe_fs::write_private_atomic_json,
-    )
+#[derive(Clone, Copy)]
+enum InstallPolicy {
+    Always,
+    IfChanged,
+    Forbidden,
 }
 
-fn recover_value_with_writer(
-    path: &std::path::Path,
+struct PreparedConfigRecovery {
+    transaction: crate::persist::ConfigRecoveryTransaction,
+    should_install: bool,
+}
+
+impl PreparedConfigRecovery {
+    fn complete(self) -> serde_json::Value {
+        if self.should_install {
+            finish_install(self.transaction.install_and_settle())
+        } else {
+            self.transaction.into_value()
+        }
+    }
+
+    #[cfg(test)]
+    fn complete_with(
+        self,
+        write: impl FnOnce(&std::path::Path, &serde_json::Value) -> std::io::Result<()>,
+    ) -> serde_json::Value {
+        if self.should_install {
+            finish_install(self.transaction.install_and_settle_with(write))
+        } else {
+            self.transaction.into_value()
+        }
+    }
+}
+
+fn finish_install((value, result): (serde_json::Value, std::io::Result<()>)) -> serde_json::Value {
+    if let Err(error) = result {
+        tracing::warn!(
+            error = %error,
+            "failed to install recovered config snapshot; will retry"
+        );
+    }
+    value
+}
+
+fn prepare_recovery(
+    recovery: crate::persist::ConfigRecoveryGuard,
     base_value: serde_json::Value,
-    install_base: bool,
-    allow_persist: bool,
-    write: impl Fn(&std::path::Path, &serde_json::Value) -> std::io::Result<()>,
+    policy: InstallPolicy,
+    migrate: impl FnOnce(&mut serde_json::Value) -> bool,
+) -> PreparedConfigRecovery {
+    let mut recovery = recovery.replay(base_value, MAX_CONFIG_BYTES);
+    // The persistence layer validates that a replay is an object before returning it, retaining
+    // a rejected scalar/array intent for a future compatible reader.
+    let replayed = recovery.has_replayed_candidate();
+    let migrated = migrate(recovery.value_mut());
+    let should_install = match policy {
+        InstallPolicy::Always => true,
+        InstallPolicy::IfChanged => replayed || migrated,
+        InstallPolicy::Forbidden => false,
+    };
+    PreparedConfigRecovery {
+        transaction: recovery,
+        should_install,
+    }
+}
+
+fn recover_value(
+    recovery: crate::persist::ConfigRecoveryGuard,
+    value: serde_json::Value,
+    policy: InstallPolicy,
+) -> Config {
+    let value = prepare_recovery(
+        recovery,
+        value,
+        policy,
+        super::audio::migrate_cache_defaults_json,
+    )
+    .complete();
+
+    decode_config(value)
+}
+
+#[cfg(test)]
+fn recover_value_with_writer(
+    recovery: crate::persist::ConfigRecoveryGuard,
+    base_value: serde_json::Value,
+    policy: InstallPolicy,
+    write: impl FnOnce(&std::path::Path, &serde_json::Value) -> std::io::Result<()>,
 ) -> Config {
     recover_value_with_migration_and_writer(
-        path,
+        recovery,
         base_value,
-        install_base,
-        allow_persist,
+        policy,
         super::audio::migrate_cache_defaults_json,
         write,
     )
 }
 
+#[cfg(test)]
 fn recover_value_with_migration_and_writer(
-    path: &std::path::Path,
+    recovery: crate::persist::ConfigRecoveryGuard,
     base_value: serde_json::Value,
-    install_base: bool,
-    allow_persist: bool,
-    migrate: impl Fn(&mut serde_json::Value) -> bool,
-    write: impl Fn(&std::path::Path, &serde_json::Value) -> std::io::Result<()>,
+    policy: InstallPolicy,
+    migrate: impl FnOnce(&mut serde_json::Value) -> bool,
+    write: impl FnOnce(&std::path::Path, &serde_json::Value) -> std::io::Result<()>,
 ) -> Config {
-    let (replayed_value, replayed) = crate::persist::replay_config_journaled_value_with_status(
-        path,
-        base_value,
-        MAX_CONFIG_BYTES,
-    );
-    // The persistence layer validates that a replay is an object before returning it, retaining
-    // a rejected scalar/array intent for a future compatible reader.
-    let mut value = replayed_value;
-    let migrated = migrate(&mut value);
+    let value = prepare_recovery(recovery, base_value, policy, migrate).complete_with(write);
+    decode_config(value)
+}
 
-    if allow_persist && (replayed || install_base || migrated) {
-        match write(path, &value) {
-            Ok(()) => {
-                if replayed {
-                    crate::persist::clear_journaled_snapshot(path);
-                }
-            }
-            Err(error) => {
-                tracing::warn!(
-                    error = %error,
-                    "failed to install recovered config snapshot; will retry"
-                );
-            }
-        }
-    }
-
+fn decode_config(value: serde_json::Value) -> Config {
     // Fast path when the schema is current; otherwise keep every field that still fits instead of
     // resetting the whole config. The typed fallback mirrors the raw rule defensively for a value
     // whose marker shape could not be interpreted above.
@@ -137,7 +203,15 @@ fn recover_value_with_migration_and_writer(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, mpsc};
+    use std::time::Duration;
+
+    use sha2::{Digest, Sha256};
+
     use super::*;
+
+    const TEST_SYNC_TIMEOUT: Duration = Duration::from_secs(10);
 
     fn temp_path(name: &str) -> std::path::PathBuf {
         let mut random = [0u8; 8];
@@ -161,13 +235,67 @@ mod tests {
         .unwrap();
     }
 
+    fn sibling(path: &std::path::Path, suffix: &str) -> std::path::PathBuf {
+        let name = path.file_name().unwrap().to_str().unwrap();
+        path.with_file_name(format!("{name}{suffix}"))
+    }
+
+    fn journal_path(path: &std::path::Path) -> std::path::PathBuf {
+        sibling(path, ".intent.jsonl")
+    }
+
+    fn journal_records(path: &std::path::Path) -> Vec<serde_json::Value> {
+        let Ok(text) = std::fs::read_to_string(journal_path(path)) else {
+            return Vec::new();
+        };
+        text.lines()
+            .enumerate()
+            .filter(|(_, line)| !line.trim().is_empty())
+            .map(|(index, line)| {
+                serde_json::from_str(line).unwrap_or_else(|error| {
+                    panic!("invalid journal record at line {}: {error}", index + 1)
+                })
+            })
+            .collect()
+    }
+
+    fn record_order(record: &serde_json::Value) -> (String, String, String) {
+        (
+            record["generation"].as_str().unwrap().to_owned(),
+            record["process_epoch"].as_str().unwrap().to_owned(),
+            record["sequence"].as_str().unwrap().to_owned(),
+        )
+    }
+
+    fn record_sidecar(path: &std::path::Path, record: &serde_json::Value) -> std::path::PathBuf {
+        path.parent()
+            .unwrap()
+            .join(record["sidecar"].as_str().unwrap())
+    }
+
+    fn intent_lock_is_held(path: &std::path::Path) -> bool {
+        match safe_fs::try_lock_private_file(&sibling(path, ".intent.lock")).unwrap() {
+            Some(lock) => {
+                drop(lock);
+                false
+            }
+            None => true,
+        }
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        Sha256::digest(bytes)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+
     fn migrate_selected_cache(value: &mut serde_json::Value) -> bool {
         super::super::audio::migrate_cache_defaults_json_to_for_test(value, "16MiB", "4MiB", 1)
     }
 
-    #[test]
-    fn failed_replay_install_retains_intent_then_retries_and_clears() {
-        let path = temp_path("write-failure");
+    fn assert_failed_replay_install_is_retryable(name: &str, visible_before_error: bool) {
+        let path = temp_path(name);
         let mut base = serde_json::to_value(Config::default()).unwrap();
         base["volume"] = serde_json::json!(17);
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -177,17 +305,52 @@ mod tests {
         pending["volume"] = serde_json::json!(73);
         pending["unknown_pending"] = serde_json::json!({"keep": true});
         write_pending(&path, &pending);
+        let original_journal = std::fs::read(journal_path(&path)).unwrap();
+        let original_records = journal_records(&path);
+        assert_eq!(original_records.len(), 1);
+        assert_eq!(original_records[0]["op"], "replace");
+        let original_order = record_order(&original_records[0]);
+        let original_sidecar = record_sidecar(&path, &original_records[0]);
+        let original_sidecar_bytes = std::fs::read(&original_sidecar).unwrap();
 
-        let recovered = recover_value_with_writer(&path, base.clone(), false, true, |_, _| {
-            Err(std::io::Error::other("injected install failure"))
-        });
+        let recovered = recover_value_with_writer(
+            crate::persist::begin_config_recovery(&path),
+            base.clone(),
+            InstallPolicy::IfChanged,
+            |path, value| {
+                if visible_before_error {
+                    safe_fs::write_private_atomic_json(path, value)?;
+                }
+                Err(std::io::Error::other("injected install failure"))
+            },
+        );
         assert_eq!(recovered.volume, 73, "valid pending state remains usable");
         assert!(crate::persist::test_journal_exists(&path));
+        assert_eq!(
+            std::fs::read(journal_path(&path)).unwrap(),
+            original_journal
+        );
+        assert_eq!(
+            std::fs::read(&original_sidecar).unwrap(),
+            original_sidecar_bytes
+        );
+        assert!(
+            !intent_lock_is_held(&path),
+            "failed installation must release coherent ownership"
+        );
         let disk: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(disk["volume"], 17, "failed install cannot replace the base");
+        assert_eq!(
+            disk["volume"],
+            if visible_before_error { 73 } else { 17 },
+            "the journal must remain retryable whether the failed write became visible or not"
+        );
 
-        let recovered = recover_value(&path, disk, false, true);
+        let recovered = recover_value(
+            crate::persist::begin_config_recovery(&path),
+            disk,
+            InstallPolicy::IfChanged,
+        );
         assert_eq!(recovered.volume, 73);
         assert!(!crate::persist::test_journal_exists(&path));
         let installed: serde_json::Value =
@@ -197,6 +360,285 @@ mod tests {
             installed["unknown_pending"],
             serde_json::json!({"keep": true})
         );
+        let settled_records = journal_records(&path);
+        assert_eq!(settled_records.len(), 1);
+        assert_eq!(settled_records[0]["op"], "commit");
+        assert_eq!(record_order(&settled_records[0]), original_order);
+        assert!(!original_sidecar.exists());
+
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn failed_pre_visible_replay_install_retains_exact_intent_for_retry() {
+        assert_failed_replay_install_is_retryable("pre-visible-write-failure", false);
+    }
+
+    #[test]
+    fn failed_post_visible_replay_install_retains_exact_intent_for_retry() {
+        assert_failed_replay_install_is_retryable("post-visible-write-failure", true);
+    }
+
+    #[test]
+    fn changed_candidate_receipt_is_not_settled_after_install() {
+        let path = temp_path("receipt-changed-before-settle");
+        let mut base = serde_json::to_value(Config::default()).unwrap();
+        base["volume"] = serde_json::json!(17);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        safe_fs::write_private_atomic_json(&path, &base).unwrap();
+
+        let mut pending = base.clone();
+        pending["volume"] = serde_json::json!(73);
+        pending["unknown_pending"] = serde_json::json!({"keep": true});
+        write_pending(&path, &pending);
+        let original_record = journal_records(&path).pop().unwrap();
+        let original_order = record_order(&original_record);
+        let sidecar = record_sidecar(&path, &original_record);
+        let mut changed_record = original_record;
+        changed_record["unexpected_interference"] = serde_json::json!(true);
+        let changed_journal = format!("{changed_record}\n").into_bytes();
+        let journal = journal_path(&path);
+
+        let recovered = recover_value_with_writer(
+            crate::persist::begin_config_recovery(&path),
+            base,
+            InstallPolicy::IfChanged,
+            move |path, value| {
+                safe_fs::write_private_atomic_json(path, value)?;
+                safe_fs::write_private_atomic(&journal, &changed_journal)
+            },
+        );
+        assert_eq!(recovered.volume, 73);
+        assert!(crate::persist::test_journal_exists(&path));
+        let records = journal_records(&path);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0]["op"], "replace");
+        assert_eq!(records[0]["unexpected_interference"], true);
+        assert!(sidecar.exists());
+
+        let disk: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        let recovered = recover_value(
+            crate::persist::begin_config_recovery(&path),
+            disk,
+            InstallPolicy::IfChanged,
+        );
+        assert_eq!(recovered.volume, 73);
+        let records = journal_records(&path);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0]["op"], "commit");
+        assert_eq!(record_order(&records[0]), original_order);
+        assert!(!sidecar.exists());
+
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn config_base_is_read_while_coherent_recovery_lock_is_held() {
+        crate::persist::clear_startup_recovery_error_for_test();
+        let path = temp_path("base-read-lock");
+        let mut base = serde_json::to_value(Config::default()).unwrap();
+        base["volume"] = serde_json::json!(31);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        safe_fs::write_private_atomic_json(&path, &base).unwrap();
+
+        let observed_lock = Arc::new(AtomicBool::new(false));
+        let observed_in_reader = Arc::clone(&observed_lock);
+        let loaded = load_from_path_with_legacy_using(&path, None, move |path, max_bytes| {
+            observed_in_reader.store(intent_lock_is_held(path), Ordering::SeqCst);
+            safe_fs::read_no_symlink_limited(path, max_bytes)
+        });
+
+        assert!(
+            observed_lock.load(Ordering::SeqCst),
+            "the base must not be exposed before coherent ownership is acquired"
+        );
+        assert_eq!(loaded.volume, 31);
+        assert!(!intent_lock_is_held(&path));
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn direct_config_save_after_missing_base_read_wins_after_recovery_install() {
+        crate::persist::clear_startup_recovery_error_for_test();
+        let path = temp_path("direct-save-after-read");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let newer = Config {
+            volume: 88,
+            ..Config::default()
+        };
+        let (start_tx, start_rx) = mpsc::channel();
+        let (contended_tx, contended_rx) = mpsc::channel();
+        let writer_path = path.clone();
+        let observed_lock = Arc::new(AtomicBool::new(false));
+        let read_observation = Arc::clone(&observed_lock);
+        let loaded = std::thread::scope(|scope| {
+            let writer = scope.spawn(move || {
+                start_rx.recv().unwrap();
+                crate::persist::with_intent_lock_contention_observer(contended_tx, || {
+                    newer.save_to(&writer_path).unwrap();
+                });
+            });
+            let loaded = load_from_path_with_legacy_using(&path, None, move |_, _| {
+                start_tx.send(()).unwrap();
+                contended_rx.recv_timeout(TEST_SYNC_TIMEOUT).unwrap();
+                read_observation.store(true, Ordering::SeqCst);
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "injected missing-base cutoff",
+                ))
+            });
+            writer.join().unwrap();
+            loaded
+        });
+
+        assert!(observed_lock.load(Ordering::SeqCst));
+        assert_eq!(loaded.volume, Config::fresh_install().volume);
+        let installed: Config = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(installed.volume, 88, "the later direct save must win");
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn newer_config_intent_waits_for_replayed_candidate_to_settle() {
+        crate::persist::clear_startup_recovery_error_for_test();
+        let path = temp_path("newer-intent-waits");
+        let mut base = serde_json::to_value(Config::default()).unwrap();
+        base["volume"] = serde_json::json!(17);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        safe_fs::write_private_atomic_json(&path, &base).unwrap();
+
+        let mut replayed = base.clone();
+        replayed["volume"] = serde_json::json!(73);
+        replayed["unknown_replayed"] = serde_json::json!({"keep": "x"});
+        write_pending(&path, &replayed);
+        let original_record = journal_records(&path).pop().unwrap();
+        let replayed_order = record_order(&original_record);
+        let replayed_sidecar = record_sidecar(&path, &original_record);
+
+        let mut newer = base.clone();
+        newer["volume"] = serde_json::json!(91);
+        newer["unknown_newer"] = serde_json::json!({"keep": "y"});
+        let newer_bytes = serde_json::to_vec_pretty(&newer).unwrap();
+
+        let (start_tx, start_rx) = mpsc::channel();
+        let (contended_tx, contended_rx) = mpsc::channel();
+        let writer_path = path.clone();
+        let writer_value = newer.clone();
+        let lock_seen_during_migration = Arc::new(AtomicBool::new(false));
+        let migration_observation = Arc::clone(&lock_seen_during_migration);
+        let lock_seen_during_install = Arc::new(AtomicBool::new(false));
+        let install_observation = Arc::clone(&lock_seen_during_install);
+        let recovered = std::thread::scope(|scope| {
+            let newer_writer = scope.spawn(move || {
+                start_rx.recv().unwrap();
+                crate::persist::with_intent_lock_contention_observer(contended_tx, || {
+                    write_pending(&writer_path, &writer_value);
+                });
+            });
+            let recovered = recover_value_with_migration_and_writer(
+                crate::persist::begin_config_recovery(&path),
+                base,
+                InstallPolicy::IfChanged,
+                move |_| {
+                    start_tx.send(()).unwrap();
+                    contended_rx.recv_timeout(TEST_SYNC_TIMEOUT).unwrap();
+                    migration_observation.store(true, Ordering::SeqCst);
+                    false
+                },
+                move |path, value| {
+                    install_observation.store(intent_lock_is_held(path), Ordering::SeqCst);
+                    safe_fs::write_private_atomic_json(path, value)
+                },
+            );
+            newer_writer.join().unwrap();
+            recovered
+        });
+
+        assert!(lock_seen_during_migration.load(Ordering::SeqCst));
+        assert!(lock_seen_during_install.load(Ordering::SeqCst));
+        assert_eq!(recovered.volume, 73);
+        let disk: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(disk, replayed);
+
+        let records = journal_records(&path);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0]["op"], "commit");
+        assert_eq!(record_order(&records[0]), replayed_order);
+        assert_eq!(records[1]["op"], "replace");
+        let newer_order = record_order(&records[1]);
+        assert_ne!(newer_order, replayed_order);
+        let newer_sidecar = record_sidecar(&path, &records[1]);
+        assert!(!replayed_sidecar.exists());
+        assert_eq!(std::fs::read(&newer_sidecar).unwrap(), newer_bytes);
+        assert!(crate::persist::test_journal_exists(&path));
+
+        let recovered = recover_value(
+            crate::persist::begin_config_recovery(&path),
+            disk,
+            InstallPolicy::IfChanged,
+        );
+        assert_eq!(recovered.volume, 91);
+        let installed: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(installed, newer);
+        let records = journal_records(&path);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0]["op"], "commit");
+        assert_eq!(record_order(&records[0]), newer_order);
+        assert!(!newer_sidecar.exists());
+        assert!(!crate::persist::test_journal_exists(&path));
+
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn failed_legacy_replay_keeps_exact_record_until_successful_install() {
+        let path = temp_path("legacy-retry");
+        let mut base = serde_json::to_value(Config::default()).unwrap();
+        base["volume"] = serde_json::json!(11);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        safe_fs::write_private_atomic_json(&path, &base).unwrap();
+
+        let mut pending = base.clone();
+        pending["volume"] = serde_json::json!(67);
+        pending["unknown_legacy"] = serde_json::json!({"keep": true});
+        let pending_bytes = serde_json::to_vec_pretty(&pending).unwrap();
+        let sidecar = sibling(&path, ".intent.latest.json");
+        safe_fs::write_private_atomic(&sidecar, &pending_bytes).unwrap();
+        let record = serde_json::json!({
+            "v": 1,
+            "op": "replace",
+            "kind": "config",
+            "sidecar": sidecar.file_name().unwrap().to_str().unwrap(),
+            "sha256": sha256_hex(&pending_bytes),
+        });
+        let journal = format!("{record}\n").into_bytes();
+        safe_fs::write_private_atomic(&journal_path(&path), &journal).unwrap();
+
+        let recovered = recover_value_with_writer(
+            crate::persist::begin_config_recovery(&path),
+            base.clone(),
+            InstallPolicy::IfChanged,
+            |_, _| Err(std::io::Error::other("injected legacy install failure")),
+        );
+        assert_eq!(recovered.volume, 67);
+        assert_eq!(std::fs::read(journal_path(&path)).unwrap(), journal);
+        assert_eq!(std::fs::read(&sidecar).unwrap(), pending_bytes);
+
+        let recovered = recover_value(
+            crate::persist::begin_config_recovery(&path),
+            base,
+            InstallPolicy::IfChanged,
+        );
+        assert_eq!(recovered.volume, 67);
+        let installed: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(installed, pending);
+        assert!(!journal_path(&path).exists());
+        assert!(!sidecar.exists());
 
         std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
     }
@@ -214,10 +656,9 @@ mod tests {
         safe_fs::write_private_atomic_json(&path, &base).unwrap();
 
         let recovered = recover_value_with_migration_and_writer(
-            &path,
+            crate::persist::begin_config_recovery(&path),
             base.clone(),
-            false,
-            true,
+            InstallPolicy::IfChanged,
             migrate_selected_cache,
             |_, _| Err(std::io::Error::other("injected migration failure")),
         );
@@ -236,10 +677,9 @@ mod tests {
         assert_eq!(disk["audio"]["mpv"]["cache_back"], "8MiB");
 
         let recovered = recover_value_with_migration_and_writer(
-            &path,
+            crate::persist::begin_config_recovery(&path),
             disk,
-            false,
-            true,
+            InstallPolicy::IfChanged,
             migrate_selected_cache,
             safe_fs::write_private_atomic_json,
         );
@@ -268,7 +708,11 @@ mod tests {
         safe_fs::write_private_atomic_json(&path, &base).unwrap();
         write_pending(&path, &serde_json::json!(["not", "a", "config"]));
 
-        let recovered = recover_value(&path, base.clone(), false, true);
+        let recovered = recover_value(
+            crate::persist::begin_config_recovery(&path),
+            base.clone(),
+            InstallPolicy::IfChanged,
+        );
 
         assert_eq!(recovered.volume, 29);
         assert!(crate::persist::test_journal_exists(&path));

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -48,6 +48,8 @@ mod writer_lease;
 #[cfg(test)]
 use durable::allocate_process_epoch_at;
 use durable::{AcceptedJournalOrder, JournalGeneration, JournalOrder, JournalOrderSource};
+#[cfg(test)]
+pub(crate) use locking::with_intent_lock_contention_observer;
 use locking::{acquire_intent_lock, acquire_intent_lock_with_budget, acquire_private_lock};
 pub use ordered_fallback::PersistenceFallbackError;
 use owned_snapshot::OwnedSnapshot;
@@ -61,16 +63,17 @@ use panic_shadow::{PanicShadow, PanicShadowSealed};
 use recovery::load_with_journal_recovery_then;
 #[cfg(test)]
 use recovery::replay_journaled_snapshot;
+pub(crate) use recovery::{
+    ConfigRecoveryGuard, ConfigRecoveryTransaction, begin_config_recovery,
+    ensure_persistence_writes_allowed, load_with_journal_recovery, preflight_journal_recovery,
+    remove_store_file, write_config_json, write_store_json,
+};
 pub use recovery::{
     StartupRecoveryError, StartupRecoveryFailure, ensure_startup_recovery_coherent,
 };
 #[cfg(test)]
 pub(crate) use recovery::{
     clear_startup_recovery_error_for_test, latch_startup_recovery_error_for_test,
-};
-pub(crate) use recovery::{
-    ensure_persistence_writes_allowed, load_with_journal_recovery, preflight_journal_recovery,
-    remove_store_file, replay_config_journaled_value_with_status, write_store_json,
 };
 pub use startup::{
     StartupStoreSet, load_startup_store_set, load_verified_startup_state,
@@ -844,11 +847,15 @@ where
 
     let write_result = writer(&journal_path, desired.as_bytes());
     let observed = read_journal_state(kind, path);
-    if let Ok(state) = &observed {
-        // On a pre-rename failure this removes the just-prepared unreferenced sidecar. If rename
-        // became visible but parent sync failed, it preserves the single referenced generation;
-        // retry reuses the same immutable path and cannot grow artifacts.
-        cleanup_journal_sidecars_locked(path, state);
+    if let Ok(observed_state) = &observed {
+        if write_result.is_ok() {
+            cleanup_journal_sidecars_locked(path, observed_state);
+        } else {
+            // A failed atomic write may be pre-rename, or the rename may be visible while its
+            // directory sync remains uncertain. Preserve the payloads referenced by both the old
+            // durable possibility and the newly observed state until a later confirmed write.
+            cleanup_journal_sidecars_after_ambiguous_write_locked(path, &current, observed_state);
+        }
     }
     write_result?;
     observed
@@ -868,14 +875,34 @@ fn compacted_journal_text(kind: StoreKind, state: &JournalState) -> String {
 }
 
 fn cleanup_journal_sidecars_locked(path: &Path, state: &JournalState) {
-    let retained = state.candidate.as_ref().and_then(|candidate| {
+    let retained = candidate_sidecar(state);
+    cleanup_orphan_sidecars_locked(path, retained);
+}
+
+fn cleanup_journal_sidecars_after_ambiguous_write_locked(
+    path: &Path,
+    previous: &JournalState,
+    observed: &JournalState,
+) {
+    match (candidate_sidecar(previous), candidate_sidecar(observed)) {
+        (Some(previous), Some(observed)) if previous != observed => {
+            cleanup_orphan_sidecars_locked_retaining(path, &[previous, observed]);
+        }
+        (Some(retained), _) | (_, Some(retained)) => {
+            cleanup_orphan_sidecars_locked(path, Some(retained));
+        }
+        (None, None) => cleanup_orphan_sidecars_locked(path, None),
+    }
+}
+
+fn candidate_sidecar(state: &JournalState) -> Option<&str> {
+    state.candidate.as_ref().and_then(|candidate| {
         if let JournalOperation::Replace { sidecar, .. } = &candidate.operation {
             Some(sidecar.as_str())
         } else {
             None
         }
-    });
-    cleanup_orphan_sidecars_locked(path, retained);
+    })
 }
 
 #[cfg(test)]
@@ -928,40 +955,12 @@ fn clear_store_journal(path: &Path) {
     clear_store_journal_locked(path);
 }
 
+#[cfg(test)]
 fn clear_store_journal_locked(path: &Path) {
     if let Some(journal_path) = intent_journal_path(path) {
         remove_file_if_exists(&journal_path, "failed to remove persistence intent");
     }
     cleanup_orphan_sidecars_locked(path, None);
-}
-
-/// Mark an installed config replay complete without discarding PR40's durable ordering frontier.
-/// Ordered candidates advance to a commit record; a legacy generation-less candidate is removed
-/// only while the same advisory lock is held.
-pub(crate) fn clear_journaled_snapshot(path: &Path) {
-    if let Err(error) = ensure_persistence_writes_allowed() {
-        tracing::warn!(%error, "could not settle installed config recovery intent");
-        return;
-    }
-    let Ok(_lock) = acquire_intent_lock(path) else {
-        tracing::warn!("could not lock installed config recovery intent");
-        return;
-    };
-    let state = match read_journal_state(StoreKind::Config, path) {
-        Ok(state) => state,
-        Err(error) => {
-            tracing::warn!(%error, "could not read installed config recovery intent");
-            return;
-        }
-    };
-    match state.candidate.and_then(|candidate| candidate.order) {
-        Some(order) => {
-            if let Err(error) = commit_journal_generation_locked(StoreKind::Config, path, order) {
-                tracing::warn!(%error, "could not commit installed config recovery intent");
-            }
-        }
-        None => clear_store_journal_locked(path),
-    }
 }
 
 #[cfg(test)]
@@ -1182,6 +1181,13 @@ fn read_journal_state(kind: StoreKind, path: &Path) -> std::io::Result<JournalSt
 }
 
 fn cleanup_orphan_sidecars_locked(path: &Path, retained: Option<&str>) {
+    match retained {
+        Some(retained) => cleanup_orphan_sidecars_locked_retaining(path, &[retained]),
+        None => cleanup_orphan_sidecars_locked_retaining(path, &[]),
+    }
+}
+
+fn cleanup_orphan_sidecars_locked_retaining(path: &Path, retained: &[&str]) {
     let (Some(parent), Some(name)) = (
         path.parent(),
         path.file_name().and_then(|value| value.to_str()),
@@ -1205,7 +1211,7 @@ fn cleanup_orphan_sidecars_locked(path: &Path, retained: Option<&str>) {
         if inspected > INTENT_ORPHAN_SCAN_LIMIT {
             break;
         }
-        if retained == Some(file_name) {
+        if retained.contains(&file_name) {
             continue;
         }
         remove_file_if_exists(

--- a/src/persist/locking.rs
+++ b/src/persist/locking.rs
@@ -1,5 +1,55 @@
 use super::*;
 
+#[cfg(test)]
+thread_local! {
+    static INTENT_LOCK_CONTENTION_OBSERVER:
+        std::cell::RefCell<Option<std::sync::mpsc::Sender<()>>> = const {
+            std::cell::RefCell::new(None)
+        };
+}
+
+/// Run one ordinary persistence action while observing its first real contended intent-lock
+/// attempt. Keeping the hook thread-local prevents unrelated parallel tests from consuming it.
+#[cfg(test)]
+pub(crate) fn with_intent_lock_contention_observer<T>(
+    observer: std::sync::mpsc::Sender<()>,
+    action: impl FnOnce() -> T,
+) -> T {
+    struct ResetObserver;
+
+    impl Drop for ResetObserver {
+        fn drop(&mut self) {
+            INTENT_LOCK_CONTENTION_OBSERVER.with(|slot| {
+                slot.borrow_mut().take();
+            });
+        }
+    }
+
+    INTENT_LOCK_CONTENTION_OBSERVER.with(|slot| {
+        assert!(
+            slot.borrow_mut().replace(observer).is_none(),
+            "intent-lock contention observer already installed on this test thread"
+        );
+    });
+    let reset = ResetObserver;
+    let result = action();
+    drop(reset);
+    result
+}
+
+fn observe_intent_lock_contention(observe: bool) {
+    #[cfg(test)]
+    if observe {
+        INTENT_LOCK_CONTENTION_OBSERVER.with(|slot| {
+            if let Some(observer) = slot.borrow_mut().take() {
+                let _ = observer.send(());
+            }
+        });
+    }
+    #[cfg(not(test))]
+    let _ = observe;
+}
+
 pub(super) fn acquire_intent_lock(
     path: &Path,
 ) -> std::io::Result<crate::util::safe_fs::AdvisoryFileLock> {
@@ -12,30 +62,33 @@ pub(super) fn acquire_intent_lock_with_budget(
 ) -> std::io::Result<crate::util::safe_fs::AdvisoryFileLock> {
     let lock_path = intent_lock_path(path)
         .ok_or_else(|| std::io::Error::other("invalid persistence intent lock path"))?;
-    acquire_private_lock_with_budget(&lock_path, "persistence journal", budget)
+    acquire_private_lock_with_budget(&lock_path, "persistence journal", budget, true)
 }
 
 pub(super) fn acquire_private_lock(
     lock_path: &Path,
     purpose: &'static str,
 ) -> std::io::Result<crate::util::safe_fs::AdvisoryFileLock> {
-    acquire_private_lock_with_budget(lock_path, purpose, Duration::from_secs(5))
+    acquire_private_lock_with_budget(lock_path, purpose, Duration::from_secs(5), false)
 }
 
 fn acquire_private_lock_with_budget(
     lock_path: &Path,
     purpose: &'static str,
     budget: Duration,
+    observe_intent_contention: bool,
 ) -> std::io::Result<crate::util::safe_fs::AdvisoryFileLock> {
     let deadline = Instant::now() + budget;
     loop {
         match crate::util::safe_fs::try_lock_private_file(lock_path)? {
             Some(lock) => return Ok(lock),
             None if Instant::now() < deadline => {
+                observe_intent_lock_contention(observe_intent_contention);
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 std::thread::sleep(remaining.min(Duration::from_millis(5)));
             }
             None => {
+                observe_intent_lock_contention(observe_intent_contention);
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::WouldBlock,
                     format!("timed out waiting for the {purpose} lock"),

--- a/src/persist/owned_snapshot.rs
+++ b/src/persist/owned_snapshot.rs
@@ -73,7 +73,10 @@ impl OwnedSnapshot {
             Self::Library(value) => value.save(),
             Self::Signals(value) => value.save(),
             Self::Downloads(value) => value.save(),
-            Self::Config(value) => value.save(),
+            Self::Config(value) => match crate::config::config_path() {
+                Some(path) => crate::persist::write_store_json(&path, value.as_ref()),
+                None => Ok(()),
+            },
             Self::Playlists(value) => value.save(),
             Self::Station(value) => value.save(),
             Self::RomanizedTitles(value) => value.save(),

--- a/src/persist/recovery.rs
+++ b/src/persist/recovery.rs
@@ -1,15 +1,62 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::{
-    INTENT_SNAPSHOT_MAX_BYTES, JournalOperation, StoreKind, acquire_intent_lock_with_budget,
-    read_journal_state, sha256_hex, sibling_path_from_record,
+    INTENT_SNAPSHOT_MAX_BYTES, JournalCandidate, JournalOperation, JournalOrder, StoreKind,
+    acquire_intent_lock_with_budget, read_journal_state, sha256_hex, sibling_path_from_record,
 };
 
 const COHERENT_LOAD_LOCK_TOTAL_BUDGET: Duration = Duration::from_secs(15);
 const COHERENT_LOAD_LOCK_ATTEMPT_BUDGET: Duration = Duration::from_secs(5);
+
+/// Coherent ownership for one config load, acquired before the base file is inspected.
+///
+/// Config recovery can back up an invalid base, import a legacy file, migrate raw JSON, and write
+/// the resulting snapshot. Keeping this guard alive across that entire sequence prevents a base
+/// value read before a concurrent writer's commit from being installed after that newer commit.
+pub(crate) struct ConfigRecoveryGuard {
+    state: ConfigRecoveryGuardState,
+}
+
+enum ConfigRecoveryGuardState {
+    Coherent {
+        path: PathBuf,
+        lock: crate::util::safe_fs::AdvisoryFileLock,
+    },
+    ReadOnly {
+        path: PathBuf,
+    },
+}
+
+enum ConfigRecoveryReceipt {
+    Ordered {
+        order: JournalOrder,
+        raw_line: String,
+    },
+    Legacy {
+        raw_line: String,
+    },
+}
+
+/// Raw config plus the exact journal candidate that produced it, while coherent ownership is
+/// still held. Installation consumes the transaction so settlement cannot be performed twice.
+pub(crate) struct ConfigRecoveryTransaction {
+    state: ConfigRecoveryTransactionState,
+}
+
+enum ConfigRecoveryTransactionState {
+    Coherent {
+        path: PathBuf,
+        lock: crate::util::safe_fs::AdvisoryFileLock,
+        value: serde_json::Value,
+        receipt: Option<ConfigRecoveryReceipt>,
+    },
+    ReadOnly {
+        value: serde_json::Value,
+    },
+}
 
 #[derive(Debug)]
 enum RecoveryLockError {
@@ -216,6 +263,15 @@ pub(crate) fn ensure_persistence_writes_allowed() -> std::io::Result<()> {
 pub(crate) fn write_store_json<T: Serialize>(path: &Path, value: &T) -> std::io::Result<()> {
     ensure_persistence_writes_allowed()?;
     crate::util::safe_fs::write_private_atomic_json(path, value)
+}
+
+/// Serialize a direct config save with the same intent lock used by journaled actor writes and
+/// config recovery. Actor-owned snapshots call [`write_store_json`] only after their outer
+/// journal transaction has already acquired this lock.
+pub(crate) fn write_config_json<T: Serialize>(path: &Path, value: &T) -> std::io::Result<()> {
+    ensure_persistence_writes_allowed()?;
+    let _lock = super::acquire_intent_lock(path)?;
+    write_store_json(path, value)
 }
 
 pub(crate) fn remove_store_file(path: &Path) -> std::io::Result<bool> {
@@ -470,6 +526,7 @@ where
 /// Replay a pending snapshot while holding the same coherent advisory lock used by PR40's
 /// startup loaders. `serde_json::Value` callers retain unknown config keys and can migrate the
 /// raw object before typed recovery; the status remains false on any lock/artifact failure.
+#[cfg(test)]
 pub(crate) fn replay_journaled_snapshot_with_status<T>(
     kind: StoreKind,
     path: &Path,
@@ -502,24 +559,289 @@ where
     }
 }
 
-/// Config-specific raw replay. Invalid scalar/array roots are left pending for a future reader and
-/// never replace a valid base object. The returned `replayed` flag may be used to settle the
-/// ordered intent with [`super::clear_journaled_snapshot`] only after an atomic migrated install
-/// succeeds.
-pub(crate) fn replay_config_journaled_value_with_status(
-    path: &Path,
-    current: serde_json::Value,
-    max_bytes: u64,
-) -> (serde_json::Value, bool) {
-    let base = current.clone();
-    let (candidate, replayed) =
-        replay_journaled_snapshot_with_status(StoreKind::Config, path, current, max_bytes);
-    if replayed && !candidate.is_object() {
-        tracing::warn!("refusing non-object pending config snapshot");
-        (base, false)
-    } else {
-        (candidate, replayed)
+/// Begin a config load before inspecting its base file.
+///
+/// Reader processes and processes that already lost coherent recovery ownership retain the
+/// existing strict read-only behavior and therefore carry no lock. A fresh lock failure is
+/// latched before the caller can run a mutating backup or migration path.
+pub(crate) fn begin_config_recovery(path: &Path) -> ConfigRecoveryGuard {
+    if super::persistence_access().is_read_only() || ensure_startup_recovery_coherent().is_err() {
+        return ConfigRecoveryGuard {
+            state: ConfigRecoveryGuardState::ReadOnly {
+                path: path.to_owned(),
+            },
+        };
     }
+    match acquire_coherent_load_lock(StoreKind::Config, path) {
+        Ok(lock) => ConfigRecoveryGuard {
+            state: ConfigRecoveryGuardState::Coherent {
+                path: path.to_owned(),
+                lock,
+            },
+        },
+        Err(error) => {
+            latch_startup_recovery_error(error.startup_error());
+            ConfigRecoveryGuard {
+                state: ConfigRecoveryGuardState::ReadOnly {
+                    path: path.to_owned(),
+                },
+            }
+        }
+    }
+}
+
+impl ConfigRecoveryGuard {
+    fn path(&self) -> &Path {
+        match &self.state {
+            ConfigRecoveryGuardState::Coherent { path, .. }
+            | ConfigRecoveryGuardState::ReadOnly { path } => path,
+        }
+    }
+
+    /// Read the config base through the guard so production callers cannot inspect a stale base
+    /// before coherent ownership has been resolved.
+    pub(crate) fn read_base(&self, max_bytes: u64) -> std::io::Result<Vec<u8>> {
+        crate::util::safe_fs::read_no_symlink_limited(self.path(), max_bytes)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn read_base_with(
+        &self,
+        max_bytes: u64,
+        read: impl FnOnce(&Path, u64) -> std::io::Result<Vec<u8>>,
+    ) -> std::io::Result<Vec<u8>> {
+        read(self.path(), max_bytes)
+    }
+
+    /// Replay a pending raw config object without releasing coherent ownership. Invalid
+    /// scalar/array roots remain pending for a future compatible reader and never replace the
+    /// valid base object supplied by the caller.
+    pub(crate) fn replay(
+        self,
+        current: serde_json::Value,
+        max_bytes: u64,
+    ) -> ConfigRecoveryTransaction {
+        match self.state {
+            ConfigRecoveryGuardState::ReadOnly { .. } => ConfigRecoveryTransaction {
+                state: ConfigRecoveryTransactionState::ReadOnly { value: current },
+            },
+            ConfigRecoveryGuardState::Coherent { path, lock } => {
+                let base = current.clone();
+                match replay_config_locked(&path, max_bytes) {
+                    Ok(Some((candidate, _receipt))) if !candidate.is_object() => {
+                        tracing::warn!("refusing non-object pending config snapshot");
+                        ConfigRecoveryTransaction {
+                            state: ConfigRecoveryTransactionState::Coherent {
+                                path,
+                                lock,
+                                value: base,
+                                receipt: None,
+                            },
+                        }
+                    }
+                    Ok(Some((value, receipt))) => ConfigRecoveryTransaction {
+                        state: ConfigRecoveryTransactionState::Coherent {
+                            path,
+                            lock,
+                            value,
+                            receipt: Some(receipt),
+                        },
+                    },
+                    Ok(None) => ConfigRecoveryTransaction {
+                        state: ConfigRecoveryTransactionState::Coherent {
+                            path,
+                            lock,
+                            value: current,
+                            receipt: None,
+                        },
+                    },
+                    Err(error) => {
+                        latch_startup_recovery_error(StartupRecoveryError::artifact(
+                            StoreKind::Config,
+                            error,
+                        ));
+                        drop(lock);
+                        ConfigRecoveryTransaction {
+                            state: ConfigRecoveryTransactionState::ReadOnly { value: current },
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl ConfigRecoveryTransaction {
+    pub(crate) fn value_mut(&mut self) -> &mut serde_json::Value {
+        match &mut self.state {
+            ConfigRecoveryTransactionState::Coherent { value, .. }
+            | ConfigRecoveryTransactionState::ReadOnly { value } => value,
+        }
+    }
+
+    pub(crate) fn has_replayed_candidate(&self) -> bool {
+        matches!(
+            &self.state,
+            ConfigRecoveryTransactionState::Coherent {
+                receipt: Some(_),
+                ..
+            }
+        )
+    }
+
+    pub(crate) fn into_value(self) -> serde_json::Value {
+        match self.state {
+            ConfigRecoveryTransactionState::Coherent { lock, value, .. } => {
+                drop(lock);
+                value
+            }
+            ConfigRecoveryTransactionState::ReadOnly { value } => value,
+        }
+    }
+
+    /// Atomically install the raw config and settle only the exact candidate that was replayed.
+    /// Any write or settlement error drops coherent ownership without advancing the journal, so
+    /// a later load can retry from the same durable receipt.
+    pub(crate) fn install_and_settle(self) -> (serde_json::Value, std::io::Result<()>) {
+        self.install_and_settle_using(|path, value| {
+            crate::util::safe_fs::write_private_atomic_json(path, value)
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_and_settle_with(
+        self,
+        write: impl FnOnce(&Path, &serde_json::Value) -> std::io::Result<()>,
+    ) -> (serde_json::Value, std::io::Result<()>) {
+        self.install_and_settle_using(write)
+    }
+
+    fn install_and_settle_using(
+        self,
+        write: impl FnOnce(&Path, &serde_json::Value) -> std::io::Result<()>,
+    ) -> (serde_json::Value, std::io::Result<()>) {
+        match self.state {
+            ConfigRecoveryTransactionState::Coherent {
+                path,
+                lock,
+                value,
+                receipt,
+            } => {
+                let result = ensure_persistence_writes_allowed()
+                    .and_then(|()| write(&path, &value))
+                    .and_then(|()| match receipt {
+                        Some(receipt) => settle_config_recovery_locked(&path, &receipt),
+                        None => Ok(()),
+                    });
+                drop(lock);
+                (value, result)
+            }
+            ConfigRecoveryTransactionState::ReadOnly { value } => {
+                let result = ensure_persistence_writes_allowed().and_then(|()| {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::WouldBlock,
+                        "config recovery has no coherent writer ownership",
+                    ))
+                });
+                (value, result)
+            }
+        }
+    }
+}
+
+fn replay_config_locked(
+    path: &Path,
+    max_bytes: u64,
+) -> std::io::Result<Option<(serde_json::Value, ConfigRecoveryReceipt)>> {
+    let state = read_journal_state(StoreKind::Config, path).map_err(|error| {
+        std::io::Error::new(
+            error.kind(),
+            format!("could not read config recovery journal: {error}"),
+        )
+    })?;
+    let Some(candidate) = state.candidate.as_ref() else {
+        return Ok(None);
+    };
+    let receipt = match candidate.order {
+        Some(order) => ConfigRecoveryReceipt::Ordered {
+            order,
+            raw_line: candidate.raw_line.clone(),
+        },
+        None => ConfigRecoveryReceipt::Legacy {
+            raw_line: candidate.raw_line.clone(),
+        },
+    };
+    replay_candidate(StoreKind::Config, path, max_bytes, Some(candidate))
+        .map(|value| value.map(|value| (value, receipt)))
+}
+
+fn settle_config_recovery_locked(
+    path: &Path,
+    receipt: &ConfigRecoveryReceipt,
+) -> std::io::Result<()> {
+    settle_config_recovery_locked_using(
+        path,
+        receipt,
+        |path, order| super::commit_journal_generation_locked(StoreKind::Config, path, order),
+        clear_legacy_config_recovery_locked,
+    )
+}
+
+fn settle_config_recovery_locked_using(
+    path: &Path,
+    receipt: &ConfigRecoveryReceipt,
+    commit_ordered: impl FnOnce(&Path, JournalOrder) -> std::io::Result<()>,
+    clear_legacy: impl FnOnce(&Path) -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    ensure_persistence_writes_allowed()?;
+    let state = read_journal_state(StoreKind::Config, path)?;
+    let Some(candidate) = state.candidate.as_ref() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "installed config recovery candidate is no longer current",
+        ));
+    };
+    match receipt {
+        ConfigRecoveryReceipt::Ordered { order, raw_line }
+            if candidate.order == Some(*order) && candidate.raw_line == *raw_line =>
+        {
+            commit_ordered(path, *order)
+        }
+        ConfigRecoveryReceipt::Legacy { raw_line }
+            if candidate.order.is_none() && candidate.raw_line == *raw_line =>
+        {
+            clear_legacy(path)
+        }
+        ConfigRecoveryReceipt::Ordered { .. } | ConfigRecoveryReceipt::Legacy { .. } => {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "installed config recovery receipt no longer matches the journal candidate",
+            ))
+        }
+    }
+}
+
+fn clear_legacy_config_recovery_locked(path: &Path) -> std::io::Result<()> {
+    clear_legacy_config_recovery_locked_with(path, |journal_path| {
+        crate::util::safe_fs::remove_private_file_durable(journal_path)
+    })
+}
+
+fn clear_legacy_config_recovery_locked_with(
+    path: &Path,
+    remove_journal: impl FnOnce(&Path) -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    let journal_path = super::intent_journal_path(path)
+        .ok_or_else(|| std::io::Error::other("invalid config recovery journal path"))?;
+    // The sidecar is the only replay payload for a generation-less record. Remove and sync the
+    // journal name first; on any unlink/sync failure the sidecar must remain available for retry.
+    remove_journal(&journal_path)?;
+    // Unix establishes a durable name-removal boundary with the parent-directory sync above.
+    // Windows has no documented directory-fsync API for an unlink, so retain the one bounded
+    // legacy sidecar there; the next confirmed ordered journal write will reclaim it safely.
+    #[cfg(unix)]
+    super::cleanup_orphan_sidecars_locked(path, None);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -545,16 +867,28 @@ where
             format!("could not read {} recovery journal: {error}", kind.label()),
         )
     })?;
-    let Some(candidate) = state.candidate else {
+    replay_candidate(kind, path, max_bytes, state.candidate.as_ref())
+}
+
+fn replay_candidate<T>(
+    kind: StoreKind,
+    path: &Path,
+    max_bytes: u64,
+    candidate: Option<&JournalCandidate>,
+) -> std::io::Result<Option<T>>
+where
+    T: DeserializeOwned + Serialize + Default,
+{
+    let Some(candidate) = candidate else {
         return Ok(None);
     };
-    match candidate.operation {
+    match &candidate.operation {
         JournalOperation::Delete if kind == StoreKind::RomanizedTitles => {
             tracing::info!(store = kind.label(), "replayed pending deletion intent");
             Ok(Some(T::default()))
         }
         JournalOperation::Replace { sidecar, sha256 } => {
-            let sidecar_path = sibling_path_from_record(path, &sidecar).ok_or_else(|| {
+            let sidecar_path = sibling_path_from_record(path, sidecar).ok_or_else(|| {
                 std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
                     format!("{} recovery journal names an invalid sidecar", kind.label()),
@@ -572,7 +906,7 @@ where
                         ),
                     )
                 })?;
-            if sha256_hex(&snapshot_bytes) != sha256 {
+            if sha256_hex(&snapshot_bytes) != *sha256 {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
                     format!("{} recovery sidecar checksum mismatch", kind.label()),
@@ -874,6 +1208,45 @@ mod tests {
         directory
     }
 
+    #[test]
+    fn failed_legacy_journal_removal_keeps_the_only_replay_sidecar() {
+        let directory = artifact_test_dir("legacy-clear-failure");
+        let path = directory.join("config.json");
+        let journal = intent_journal_path(&path).unwrap();
+        let sidecar = path.with_file_name("config.json.intent.latest.json");
+        crate::util::safe_fs::write_private_atomic(&journal, b"legacy record\n").unwrap();
+        crate::util::safe_fs::write_private_atomic(&sidecar, b"replay payload").unwrap();
+
+        let error = clear_legacy_config_recovery_locked_with(&path, |_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "injected journal unlink failure",
+            ))
+        })
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert_eq!(std::fs::read(&journal).unwrap(), b"legacy record\n");
+        assert_eq!(std::fs::read(&sidecar).unwrap(), b"replay payload");
+
+        let error = clear_legacy_config_recovery_locked_with(&path, |journal| {
+            crate::util::safe_fs::remove_private_file_durable(journal)?;
+            Err(std::io::Error::other(
+                "injected failure after durable journal unlink",
+            ))
+        })
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert!(!journal.exists());
+        assert_eq!(std::fs::read(&sidecar).unwrap(), b"replay payload");
+
+        clear_legacy_config_recovery_locked(&path).unwrap();
+        #[cfg(unix)]
+        assert!(!sidecar.exists());
+        #[cfg(not(unix))]
+        assert_eq!(std::fs::read(&sidecar).unwrap(), b"replay payload");
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
     fn seed_artifact_intent(
         path: &Path,
         bytes: Vec<u8>,
@@ -889,6 +1262,78 @@ mod tests {
         .unwrap();
         let sidecar = unique_intent_sidecar_path(path, accepted.order).unwrap();
         (accepted.order, sidecar)
+    }
+
+    fn seed_ordered_config_receipt(
+        label: &str,
+        epoch: u64,
+    ) -> (
+        std::path::PathBuf,
+        std::path::PathBuf,
+        JournalOrder,
+        std::path::PathBuf,
+        ConfigRecoveryReceipt,
+    ) {
+        let directory = artifact_test_dir(label);
+        let path = directory.join("config.json");
+        let bytes = serde_json::to_vec(&ArtifactState {
+            preserved: 7,
+            drifted: 9,
+        })
+        .unwrap();
+        let (order, sidecar) = seed_artifact_intent(&path, bytes, epoch);
+        let (_, receipt) = replay_config_locked(&path, 1024).unwrap().unwrap();
+        (directory, path, order, sidecar, receipt)
+    }
+
+    #[test]
+    fn ordered_settlement_faults_preserve_retry_or_recognize_commit() {
+        clear_startup_recovery_error_for_test();
+        let (directory, path, order, sidecar, receipt) =
+            seed_ordered_config_receipt("ordered-commit-pre-visible", 81);
+        let journal = intent_journal_path(&path).unwrap();
+        let original_journal = std::fs::read(&journal).unwrap();
+        let original_sidecar = std::fs::read(&sidecar).unwrap();
+
+        let error = settle_config_recovery_locked_using(
+            &path,
+            &receipt,
+            |_, _| Err(std::io::Error::other("injected pre-visible commit failure")),
+            |_| unreachable!("ordered receipt must not take the legacy settlement path"),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(std::fs::read(&journal).unwrap(), original_journal);
+        assert_eq!(std::fs::read(&sidecar).unwrap(), original_sidecar);
+
+        settle_config_recovery_locked(&path, &receipt).unwrap();
+        let state = read_journal_state(StoreKind::Config, &path).unwrap();
+        assert_eq!(state.committed_through, Some(order));
+        assert!(state.candidate.is_none());
+        assert!(!sidecar.exists());
+        std::fs::remove_dir_all(directory).unwrap();
+
+        let (directory, path, order, sidecar, receipt) =
+            seed_ordered_config_receipt("ordered-commit-post-visible", 82);
+        let error = settle_config_recovery_locked_using(
+            &path,
+            &receipt,
+            |path, order| {
+                super::super::commit_journal_generation_locked(StoreKind::Config, path, order)?;
+                Err(std::io::Error::other(
+                    "injected failure after visible commit",
+                ))
+            },
+            |_| unreachable!("ordered receipt must not take the legacy settlement path"),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        let state = read_journal_state(StoreKind::Config, &path).unwrap();
+        assert_eq!(state.committed_through, Some(order));
+        assert!(state.candidate.is_none());
+        assert!(!sidecar.exists());
+        assert!(replay_config_locked(&path, 1024).unwrap().is_none());
+        std::fs::remove_dir_all(directory).unwrap();
     }
 
     fn assert_unverifiable_artifact_latches_without_supersession<F>(

--- a/src/persist/tests.rs
+++ b/src/persist/tests.rs
@@ -777,7 +777,7 @@ fn sidecar_artifact_limit_is_a_hard_creation_bound() {
 }
 
 #[test]
-fn rename_visible_journal_failure_keeps_only_the_referenced_sidecar() {
+fn rename_visible_journal_failure_keeps_both_durable_possibilities() {
     #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
     struct Tiny {
         value: u8,
@@ -786,13 +786,17 @@ fn rename_visible_journal_failure_keeps_only_the_referenced_sidecar() {
     let dir = temp_dir("visible-failure-cleanup");
     std::fs::create_dir_all(&dir).unwrap();
     let path = dir.join("tiny.json");
+    let old_order = journal_order(1, 1);
     write_journal_intent(&JournalIntent::Replace {
-        order: journal_order(1, 1),
+        order: old_order,
         kind: StoreKind::Config,
         path: path.clone(),
         bytes: serde_json::to_vec_pretty(&Tiny { value: 1 }).unwrap(),
     })
     .unwrap();
+    let journal_path = intent_journal_path(&path).unwrap();
+    let old_journal = std::fs::read(&journal_path).unwrap();
+    let old_sidecar = unique_intent_sidecar_path(&path, old_order).unwrap();
     let new_order = journal_order(2, 2);
     let new_intent = JournalIntent::Replace {
         order: new_order,
@@ -801,7 +805,7 @@ fn rename_visible_journal_failure_keeps_only_the_referenced_sidecar() {
         bytes: serde_json::to_vec_pretty(&Tiny { value: 2 }).unwrap(),
     };
 
-    for _ in 0..3 {
+    {
         let _lock = acquire_intent_lock(&path).unwrap();
         let record = prepare_journal_record(&new_intent).unwrap();
         let error = replace_journal_with_record_locked_by(
@@ -818,15 +822,31 @@ fn rename_visible_journal_failure_keeps_only_the_referenced_sidecar() {
         .err()
         .expect("the visible rename failure is returned");
         assert!(error.to_string().contains("parent sync"));
-        assert_eq!(intent_sidecar_count(&dir, "tiny.json"), 1);
+        assert_eq!(intent_sidecar_count(&dir, "tiny.json"), 2);
+        assert!(old_sidecar.exists());
         assert!(
             unique_intent_sidecar_path(&path, new_order)
                 .unwrap()
                 .exists()
         );
-        let journal = std::fs::read_to_string(intent_journal_path(&path).unwrap()).unwrap();
+        let journal = std::fs::read_to_string(&journal_path).unwrap();
         assert!(journal.lines().count() <= 2);
     }
+    assert_eq!(
+        replay_journaled_snapshot(StoreKind::Config, &path, Tiny::default(), 1024),
+        Tiny { value: 2 }
+    );
+
+    crate::util::safe_fs::write_private_atomic(&journal_path, &old_journal).unwrap();
+    assert_eq!(
+        replay_journaled_snapshot(StoreKind::Config, &path, Tiny::default(), 1024),
+        Tiny { value: 1 },
+        "a crash rollback to the previous journal must retain its payload"
+    );
+
+    write_journal_intent(&new_intent).unwrap();
+    assert_eq!(intent_sidecar_count(&dir, "tiny.json"), 1);
+    assert!(!old_sidecar.exists());
     assert_eq!(
         replay_journaled_snapshot(StoreKind::Config, &path, Tiny::default(), 1024),
         Tiny { value: 2 }


### PR DESCRIPTION
## What changed

- Acquire the config intent lock before reading the base file and retain coherent ownership through replay, raw migration, atomic installation, and settlement.
- Represent coherent/read-only recovery and install policy as explicit states, and settle only the exact ordered or legacy journal receipt that was replayed.
- Serialize direct `Config` saves with recovery while keeping the actor's already-locked snapshot path non-recursive.
- Preserve both possible sidecar generations after an ambiguous journal rename failure; retain the bounded legacy sidecar on platforms without a durable unlink boundary.
- Add deterministic concurrency, exact-receipt, pre/post-visible fault, legacy unlink, retry, and non-object recovery tests.

## Why

Recovery previously read the base before acquiring the intent lock, then released and reacquired ownership around installation and journal clearing. A newer writer could commit in those gaps and be overwritten or have the wrong recovery intent settled. Ambiguous commit/unlink failures could also discard the only payload needed after a crash rollback.

## Impact

Config recovery and all direct config writers now share one serialization boundary. Recovery remains retryable across write and settlement failures. Persisted JSON and journal record formats, CLI behavior, and UI/UX are unchanged.

## Validation

- Official Fable profile run against this isolated worktree: fmt, clippy (`-D warnings`), workspace tests, and architecture gates all pass.
- 3,283 library tests plus CLI/desktop/doc test targets pass.
- `cargo check --workspace --all-targets --target x86_64-pc-windows-gnu` passes.
- Both deterministic contention tests passed 100 repeated runs.
- Independent architecture, correctness, stability, and test-quality reviews report no unresolved blocker/high/medium findings.
