### PR TITLE
Refactor persistence state transitions

### DIFF
--- a/src/persist.rs
+++ b/src/persist.rs
@@ -41,6 +41,8 @@ mod panic_ownership;
 mod panic_shadow;
 #[path = "persist/recovery.rs"]
 mod recovery;
+#[path = "persist/snapshot_state.rs"]
+mod snapshot_state;
 #[path = "persist/startup.rs"]
 mod startup;
 #[path = "persist/writer_lease.rs"]
@@ -74,6 +76,12 @@ pub use recovery::{
 #[cfg(test)]
 pub(crate) use recovery::{
     clear_startup_recovery_error_for_test, latch_startup_recovery_error_for_test,
+};
+#[cfg(test)]
+use snapshot_state::SnapshotPublication;
+use snapshot_state::{
+    JournalCompletion, PendingAction, PendingOperation, PendingQueue, ShadowCoveredOperation,
+    SnapshotAdmission, publish_pending_batch, publish_pending_operation,
 };
 pub use startup::{
     StartupStoreSet, load_startup_store_set, load_verified_startup_state,
@@ -147,6 +155,7 @@ pub enum Snapshot {
     },
 }
 
+#[cfg(test)]
 impl Snapshot {
     fn kind(&self) -> StoreKind {
         match self {
@@ -181,140 +190,7 @@ fn debounce(kind: StoreKind) -> Duration {
     }
 }
 
-enum PendingAction {
-    Save(Arc<OwnedSnapshot>),
-    DeleteRomanizedTitles,
-    #[cfg(test)]
-    TestDeleteRomanizedTitles {
-        deleter: Arc<dyn Fn() -> std::io::Result<()> + Send + Sync>,
-    },
-}
-
-#[derive(Clone)]
-struct PendingOperation {
-    order: JournalOrder,
-    kind: StoreKind,
-    ordering_error: Option<Arc<str>>,
-    journaled: bool,
-    action: Arc<PendingAction>,
-}
-
-impl PendingOperation {
-    fn save(snapshot: Snapshot, accepted: AcceptedJournalOrder) -> Self {
-        let snapshot = OwnedSnapshot::from(snapshot);
-        let kind = snapshot.kind();
-        Self {
-            order: accepted.order,
-            kind,
-            ordering_error: accepted.error,
-            journaled: false,
-            action: Arc::new(PendingAction::Save(Arc::new(snapshot))),
-        }
-    }
-
-    fn new(action: PendingAction, accepted: AcceptedJournalOrder) -> Self {
-        Self {
-            order: accepted.order,
-            kind: StoreKind::RomanizedTitles,
-            ordering_error: accepted.error,
-            journaled: false,
-            action: Arc::new(action),
-        }
-    }
-
-    fn kind(&self) -> StoreKind {
-        self.kind
-    }
-
-    fn label(&self) -> &'static str {
-        match self.action.as_ref() {
-            PendingAction::Save(snapshot) => snapshot.label(),
-            PendingAction::DeleteRomanizedTitles => StoreKind::RomanizedTitles.label(),
-            #[cfg(test)]
-            PendingAction::TestDeleteRomanizedTitles { .. } => "romanized title cache delete",
-        }
-    }
-
-    fn storage_path(&self) -> Option<PathBuf> {
-        match self.action.as_ref() {
-            PendingAction::Save(snapshot) => snapshot.storage_path(),
-            PendingAction::DeleteRomanizedTitles => crate::romanize::cache_path(),
-            #[cfg(test)]
-            PendingAction::TestDeleteRomanizedTitles { .. } => None,
-        }
-    }
-
-    fn write(&self) -> std::io::Result<()> {
-        match self.action.as_ref() {
-            PendingAction::Save(snapshot) => snapshot.write(),
-            PendingAction::DeleteRomanizedTitles => crate::romanize::RomanizeCache::delete_saved(),
-            #[cfg(test)]
-            PendingAction::TestDeleteRomanizedTitles { deleter } => deleter(),
-        }
-    }
-
-    fn ensure_ordering(&self) -> std::io::Result<()> {
-        match &self.ordering_error {
-            Some(error) => Err(std::io::Error::other(error.to_string())),
-            None => Ok(()),
-        }
-    }
-
-    fn debounce(&self) -> Duration {
-        match self.action.as_ref() {
-            PendingAction::Save(_) => debounce(self.kind),
-            PendingAction::DeleteRomanizedTitles => Duration::ZERO,
-            #[cfg(test)]
-            PendingAction::TestDeleteRomanizedTitles { .. } => Duration::ZERO,
-        }
-    }
-
-    fn journal_intent(&self) -> Option<JournalIntent> {
-        if self.ordering_error.is_some() {
-            return None;
-        }
-        match self.action.as_ref() {
-            PendingAction::Save(snapshot) => {
-                let path = snapshot.storage_path()?;
-                let bytes = match snapshot.to_json_bytes() {
-                    Ok(bytes) => bytes,
-                    Err(error) => {
-                        tracing::warn!(
-                            store = snapshot.kind().label(),
-                            error = %error,
-                            "failed to encode persistence intent"
-                        );
-                        return None;
-                    }
-                };
-                Some(JournalIntent::Replace {
-                    order: self.order,
-                    kind: snapshot.kind(),
-                    path,
-                    bytes,
-                })
-            }
-            PendingAction::DeleteRomanizedTitles => Some(JournalIntent::Delete {
-                order: self.order,
-                kind: StoreKind::RomanizedTitles,
-                path: crate::romanize::cache_path()?,
-            }),
-            #[cfg(test)]
-            PendingAction::TestDeleteRomanizedTitles { .. } => None,
-        }
-    }
-
-    #[cfg(test)]
-    fn snapshot(&self) -> Option<&OwnedSnapshot> {
-        match self.action.as_ref() {
-            PendingAction::Save(snapshot) => Some(snapshot),
-            PendingAction::DeleteRomanizedTitles
-            | PendingAction::TestDeleteRomanizedTitles { .. } => None,
-        }
-    }
-}
-
-type SharedPending = Arc<Mutex<HashMap<StoreKind, PendingOperation>>>;
+type SharedPending = Arc<Mutex<PendingQueue>>;
 type SharedInflight = Arc<Mutex<HashMap<StoreKind, PanicOperation>>>;
 
 const INTENT_JOURNAL_MAX_BYTES: u64 = 1024 * 1024;
@@ -356,7 +232,6 @@ pub struct PersistHandle {
     dirty: Arc<Notify>,
     events: EventSinkSlot,
     order_source: Arc<JournalOrderSource>,
-    admission_open: Arc<std::sync::atomic::AtomicBool>,
     panic_shadow: Arc<PanicShadow>,
 }
 
@@ -378,7 +253,7 @@ pub fn spawn() -> PersistHandle {
     let (tx, rx) = crate::util::backpressure::bounded_channel(
         crate::util::backpressure::PERSIST_CONTROL_QUEUE,
     );
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
     let inflight: SharedInflight = Arc::new(Mutex::new(HashMap::new()));
     let dirty = Arc::new(Notify::new());
     let events: EventSinkSlot = Arc::new(Mutex::new(None));
@@ -398,7 +273,6 @@ pub fn spawn() -> PersistHandle {
         dirty,
         events,
         order_source,
-        admission_open: Arc::new(std::sync::atomic::AtomicBool::new(true)),
         panic_shadow,
     }
 }
@@ -461,9 +335,7 @@ async fn run_actor(
     }
 }
 
-fn lock(
-    pending: &SharedPending,
-) -> std::sync::MutexGuard<'_, HashMap<StoreKind, PendingOperation>> {
+fn lock(pending: &SharedPending) -> std::sync::MutexGuard<'_, PendingQueue> {
     // A panicking writer can't leave the map half-mutated in a harmful way (it's a
     // plain insert/remove), so recover from poisoning instead of propagating it.
     pending.lock().unwrap_or_else(PoisonError::into_inner)
@@ -522,8 +394,8 @@ async fn journal_pending_operations(pending: &SharedPending) {
         let guard = lock(pending);
         guard
             .values()
-            .filter(|operation| !operation.journaled)
-            .filter_map(PendingOperation::journal_intent)
+            .filter(|operation| operation.publication().needs_journal())
+            .filter_map(|operation| operation.journal_intent())
             .collect()
     };
     if intents.is_empty() {
@@ -534,8 +406,8 @@ async fn journal_pending_operations(pending: &SharedPending) {
         let mut written = Vec::new();
         for intent in intents {
             match write_journal_intent_if_current(&intent, &io_pending) {
-                Ok(JournalAppend::Written(order) | JournalAppend::Superseded(order)) => {
-                    written.push((intent.kind(), order));
+                Ok(JournalAppend::Written(completion) | JournalAppend::Superseded(completion)) => {
+                    written.push(completion);
                 }
                 Ok(JournalAppend::Stale) => {}
                 Err(error) => {
@@ -553,12 +425,8 @@ async fn journal_pending_operations(pending: &SharedPending) {
     match result {
         Ok(written) => {
             let mut guard = lock(pending);
-            for (kind, order) in written {
-                if let Some(operation) = guard.get_mut(&kind)
-                    && operation.order == order
-                {
-                    operation.journaled = true;
-                }
+            for completion in written {
+                guard.resolve_journal(completion);
             }
         }
         Err(error) => tracing::warn!(error = %error, "persistence intent task failed"),
@@ -574,8 +442,8 @@ impl JournalIntent {
 }
 
 enum JournalAppend {
-    Written(JournalOrder),
-    Superseded(JournalOrder),
+    Written(JournalCompletion),
+    Superseded(JournalCompletion),
     Stale,
 }
 
@@ -645,8 +513,14 @@ fn write_journal_intent_if_current(
     }
     let state = replace_journal_with_record_locked(kind, path, &record)?;
     match verify_intent_state(&state, intent.order())? {
-        IntentState::Current => Ok(JournalAppend::Written(intent.order())),
-        IntentState::Superseded => Ok(JournalAppend::Superseded(intent.order())),
+        IntentState::Current => Ok(JournalAppend::Written(JournalCompletion::confirmed(
+            kind,
+            intent.order(),
+        ))),
+        IntentState::Superseded => Ok(JournalAppend::Superseded(JournalCompletion::confirmed(
+            kind,
+            intent.order(),
+        ))),
     }
 }
 
@@ -1250,11 +1124,10 @@ fn write_operation_durable_using(
     let Some(path) = operation.storage_path() else {
         return write();
     };
-    operation.ensure_ordering()?;
+    operation.publication().ensure_ordering()?;
     let kind = operation.kind();
     let _lock = acquire_intent_lock(&path)?;
-    let mut journaled = operation.journaled;
-    if !journaled {
+    if operation.publication().needs_journal() {
         let intent = operation
             .journal_intent()
             .ok_or_else(|| std::io::Error::other("failed to prepare persistence journal intent"))?;
@@ -1263,21 +1136,16 @@ fn write_operation_durable_using(
         if verify_intent_state(&state, operation.order)? == IntentState::Superseded {
             return Ok(());
         }
-        journaled = true;
     }
-    if journaled {
-        let state = read_journal_state(kind, &path)?;
-        if verify_intent_state(&state, operation.order)? == IntentState::Superseded {
-            // A newer accepted operation (possibly from another process) superseded this one.
-            // Treat it as settled without touching the store; its unique sidecar was discarded
-            // by compaction only after the newer record became durable.
-            return Ok(());
-        }
+    let state = read_journal_state(kind, &path)?;
+    if verify_intent_state(&state, operation.order)? == IntentState::Superseded {
+        // A newer accepted operation (possibly from another process) superseded this one.
+        // Treat it as settled without touching the store; its unique sidecar was discarded
+        // by compaction only after the newer record became durable.
+        return Ok(());
     }
     write()?;
-    if journaled {
-        commit_journal_generation_locked(kind, &path, operation.order)?;
-    }
+    commit_journal_generation_locked(kind, &path, operation.order)?;
     Ok(())
 }
 
@@ -1302,7 +1170,7 @@ fn requeue_failed_operation(
     due: &mut HashMap<StoreKind, tokio::time::Instant>,
     retries: &mut RetryMap,
     events: &EventSinkSlot,
-    operation: PendingOperation,
+    operation: ShadowCoveredOperation,
     error: String,
 ) {
     let kind = operation.kind();
@@ -1332,27 +1200,24 @@ fn requeue_failed_operation(
         .unwrap_or(0);
 
     let mut guard = lock(pending);
-    match guard.entry(kind) {
-        std::collections::hash_map::Entry::Occupied(_) => {
-            tracing::warn!(
-                error = %last_error,
-                retry_count,
-                retry_in_ms,
-                failure_age_ms,
-                "failed to save {label}; newer snapshot is already pending"
-            );
-        }
-        std::collections::hash_map::Entry::Vacant(entry) => {
-            entry.insert(operation);
-            due.insert(kind, retry_at);
-            tracing::warn!(
-                error = %last_error,
-                retry_count,
-                retry_in_ms,
-                failure_age_ms,
-                "failed to save {label}; retry scheduled"
-            );
-        }
+    if guard.contains_key(&kind) {
+        tracing::warn!(
+            error = %last_error,
+            retry_count,
+            retry_in_ms,
+            failure_age_ms,
+            "failed to save {label}; newer snapshot is already pending"
+        );
+    } else {
+        guard.insert_owned(operation);
+        due.insert(kind, retry_at);
+        tracing::warn!(
+            error = %last_error,
+            retry_count,
+            retry_in_ms,
+            failure_age_ms,
+            "failed to save {label}; retry scheduled"
+        );
     }
     drop(guard);
 

--- a/src/persist/handle.rs
+++ b/src/persist/handle.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::Ordering;
-
 use super::*;
 
 impl PersistHandle {
@@ -7,20 +5,15 @@ impl PersistHandle {
         if ensure_persistence_writes_allowed().is_err() {
             return Err(crate::util::delivery::DeliveryError::Closed);
         }
-        let kind = snapshot.kind();
         let mut pending = lock(&self.pending);
-        if !self.admission_open.load(Ordering::Acquire) {
+        if pending.admission() == SnapshotAdmission::Sealed {
             return Err(crate::util::delivery::DeliveryError::Closed);
         }
         let accepted = self.order_source.accept();
         let operation = PendingOperation::save(snapshot, accepted);
-        if let Err(PanicShadowSealed) = self
-            .panic_shadow
-            .publish(PanicOwnedOperation::Pending(Arc::new(operation.clone())))
-        {
-            return Err(crate::util::delivery::DeliveryError::Closed);
-        }
-        let replaced_existing = pending.insert(kind, operation).is_some();
+        let operation = publish_pending_operation(&self.panic_shadow, operation)
+            .map_err(|PanicShadowSealed| crate::util::delivery::DeliveryError::Closed)?;
+        let replaced_existing = pending.insert_owned(operation).is_some();
         drop(pending);
         self.dirty.notify_one();
         if replaced_existing {
@@ -45,30 +38,61 @@ impl PersistHandle {
     where
         I: IntoIterator<Item = Snapshot>,
     {
-        if ensure_persistence_writes_allowed().is_err() {
-            self.admission_open.store(false, Ordering::Release);
+        let mutation_allowed = ensure_persistence_writes_allowed();
+        self.seal_with_snapshots_after_check(snapshots, mutation_allowed)
+    }
+
+    pub(super) fn seal_with_snapshots_after_check<I>(
+        &self,
+        snapshots: I,
+        mutation_allowed: std::io::Result<()>,
+    ) -> Result<(), crate::util::delivery::DeliveryError>
+    where
+        I: IntoIterator<Item = Snapshot>,
+    {
+        self.seal_with_snapshots_after_check_and_hook(snapshots, mutation_allowed, || {})
+    }
+
+    fn seal_with_snapshots_after_check_and_hook<I>(
+        &self,
+        snapshots: I,
+        mutation_allowed: std::io::Result<()>,
+        after_seal: impl FnOnce(),
+    ) -> Result<(), crate::util::delivery::DeliveryError>
+    where
+        I: IntoIterator<Item = Snapshot>,
+    {
+        let mut pending = lock(&self.pending);
+        pending.seal();
+        after_seal();
+        if mutation_allowed.is_err() {
             return Err(crate::util::delivery::DeliveryError::Closed);
         }
-        let mut pending = lock(&self.pending);
-        self.admission_open.store(false, Ordering::Release);
         let operations: Vec<_> = snapshots
             .into_iter()
             .map(|snapshot| PendingOperation::save(snapshot, self.order_source.accept()))
             .collect();
-        let shadow_operations = operations
-            .iter()
-            .cloned()
-            .map(|operation| PanicOwnedOperation::Pending(Arc::new(operation)))
-            .collect();
-        if let Err(PanicShadowSealed) = self.panic_shadow.publish_batch(shadow_operations) {
-            return Err(crate::util::delivery::DeliveryError::Closed);
-        }
+        let operations = publish_pending_batch(&self.panic_shadow, operations)
+            .map_err(|PanicShadowSealed| crate::util::delivery::DeliveryError::Closed)?;
         for operation in operations {
-            pending.insert(operation.kind(), operation);
+            pending.insert_owned(operation);
         }
         drop(pending);
         self.dirty.notify_one();
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(super) fn seal_with_snapshots_after_check_and_hook_for_test<I>(
+        &self,
+        snapshots: I,
+        mutation_allowed: std::io::Result<()>,
+        after_seal: impl FnOnce(),
+    ) -> Result<(), crate::util::delivery::DeliveryError>
+    where
+        I: IntoIterator<Item = Snapshot>,
+    {
+        self.seal_with_snapshots_after_check_and_hook(snapshots, mutation_allowed, after_seal)
     }
 
     /// Make deletion the latest pending romanize-cache operation. The shared slot is
@@ -86,20 +110,14 @@ impl PersistHandle {
             return Err(crate::util::delivery::DeliveryError::Closed);
         }
         let mut pending = lock(&self.pending);
-        if !self.admission_open.load(Ordering::Acquire) {
+        if pending.admission() == SnapshotAdmission::Sealed {
             return Err(crate::util::delivery::DeliveryError::Closed);
         }
         let accepted = self.order_source.accept();
         let operation = PendingOperation::new(action, accepted);
-        if let Err(PanicShadowSealed) = self
-            .panic_shadow
-            .publish(PanicOwnedOperation::Pending(Arc::new(operation.clone())))
-        {
-            return Err(crate::util::delivery::DeliveryError::Closed);
-        }
-        let replaced_existing = pending
-            .insert(StoreKind::RomanizedTitles, operation)
-            .is_some();
+        let operation = publish_pending_operation(&self.panic_shadow, operation)
+            .map_err(|PanicShadowSealed| crate::util::delivery::DeliveryError::Closed)?;
+        let replaced_existing = pending.insert_owned(operation).is_some();
         drop(pending);
         self.dirty.notify_one();
         if replaced_existing {

--- a/src/persist/ordered_fallback.rs
+++ b/src/persist/ordered_fallback.rs
@@ -97,15 +97,14 @@ impl PersistHandle {
         let operation = PendingOperation::save(snapshot, self.order_source.accept());
         let kind = operation.kind();
         let order = operation.order;
-        if let Err(PanicShadowSealed) = self
-            .panic_shadow
-            .publish(PanicOwnedOperation::Pending(Arc::new(operation.clone())))
-        {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::WouldBlock,
-                "panic-time persistence frontier is sealed",
-            ));
-        }
+        let operation = publish_pending_operation(&self.panic_shadow, operation).map_err(
+            |PanicShadowSealed| {
+                std::io::Error::new(
+                    std::io::ErrorKind::WouldBlock,
+                    "panic-time persistence frontier is sealed",
+                )
+            },
+        )?;
         let prepared = match operation.panic_operation() {
             Ok(prepared) => prepared,
             Err(error) => {
@@ -135,7 +134,7 @@ impl PersistHandle {
                     "ordered persistence fallback was superseded before admission",
                 ));
             }
-            pending.insert(kind, operation);
+            pending.insert_owned(operation);
         }
 
         if !retain_newest_inflight(&self.inflight, prepared.clone()) {
@@ -182,7 +181,7 @@ impl PersistHandle {
         }
     }
 
-    fn retain_ordered_operation(&self, operation: PendingOperation) {
+    fn retain_ordered_operation(&self, operation: ShadowCoveredOperation) {
         let kind = operation.kind();
         let order = operation.order;
         let mut pending = lock(&self.pending);
@@ -190,7 +189,7 @@ impl PersistHandle {
             .get(&kind)
             .is_none_or(|current| current.order <= order)
         {
-            pending.insert(kind, operation);
+            pending.insert_owned(operation);
         }
         drop(pending);
         self.dirty.notify_one();

--- a/src/persist/panic_ownership.rs
+++ b/src/persist/panic_ownership.rs
@@ -7,8 +7,8 @@ type PanicDeleteRemover = Arc<dyn Fn(&Path) -> std::io::Result<()> + Send + Sync
 
 impl PendingOperation {
     pub(super) fn panic_operation(&self) -> std::io::Result<PanicOperation> {
-        self.ensure_ordering()?;
-        let action = match self.action.as_ref() {
+        self.publication().ensure_ordering()?;
+        let action = match self.action() {
             PendingAction::Save(snapshot) => {
                 #[cfg(test)]
                 if let OwnedSnapshot::Test {
@@ -143,13 +143,6 @@ impl PanicOwnedOperation {
         match self {
             Self::Pending(operation) => write_operation_caught(operation),
             Self::Prepared(operation) => write_panic_operation(operation),
-        }
-    }
-
-    pub(super) fn priority(&self) -> u8 {
-        match self {
-            Self::Pending(_) => 0,
-            Self::Prepared(_) => 1,
         }
     }
 }

--- a/src/persist/panic_shadow.rs
+++ b/src/persist/panic_shadow.rs
@@ -6,8 +6,14 @@ use super::{JournalOrder, PanicOwnedOperation, StoreKind};
 pub(super) struct PanicShadowSealed;
 
 struct PanicShadowState {
-    sealed: bool,
+    phase: PanicShadowPhase,
     slots: [Option<PanicOwnedOperation>; 8],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PanicShadowPhase {
+    Publishing,
+    Sealed,
 }
 
 /// Fixed-size newest-owned persistence frontier read by the panic hook.
@@ -24,7 +30,7 @@ impl PanicShadow {
     pub(super) fn new() -> Self {
         Self {
             state: RwLock::new(PanicShadowState {
-                sealed: false,
+                phase: PanicShadowPhase::Publishing,
                 slots: std::array::from_fn(|_| None),
             }),
         }
@@ -33,26 +39,35 @@ impl PanicShadow {
     /// Publish one operation unless the panic hook has already fixed its one-shot frontier.
     #[must_use = "a sealed panic frontier rejects new persistence ownership"]
     pub(super) fn publish(&self, operation: PanicOwnedOperation) -> Result<(), PanicShadowSealed> {
+        self.publish_with_lock_hook(operation, || {})
+    }
+
+    fn publish_with_lock_hook(
+        &self,
+        operation: PanicOwnedOperation,
+        after_phase_check: impl FnOnce(),
+    ) -> Result<(), PanicShadowSealed> {
         let index = slot(operation.kind());
         let mut state = self.state.write().unwrap_or_else(PoisonError::into_inner);
-        if state.sealed {
+        if state.phase == PanicShadowPhase::Sealed {
             drop(state);
             drop(operation);
             return Err(PanicShadowSealed);
         }
-        let replace = state.slots[index].as_ref().is_none_or(|current| {
-            operation.order() > current.order()
-                || (operation.order() == current.order()
-                    && operation.priority() > current.priority())
-        });
-        let retired = if replace {
-            state.slots[index].replace(operation)
-        } else {
-            Some(operation)
-        };
+        after_phase_check();
+        let retired = replace_slot_if_newer(&mut state.slots[index], operation);
         drop(state);
         drop(retired);
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(super) fn publish_with_lock_hook_for_test(
+        &self,
+        operation: PanicOwnedOperation,
+        after_phase_check: impl FnOnce(),
+    ) -> Result<(), PanicShadowSealed> {
+        self.publish_with_lock_hook(operation, after_phase_check)
     }
 
     /// Atomically publish an owner's complete final batch or reject the whole batch.
@@ -62,7 +77,7 @@ impl PanicShadow {
         operations: Vec<PanicOwnedOperation>,
     ) -> Result<(), PanicShadowSealed> {
         let mut state = self.state.write().unwrap_or_else(PoisonError::into_inner);
-        if state.sealed {
+        if state.phase == PanicShadowPhase::Sealed {
             drop(state);
             drop(operations);
             return Err(PanicShadowSealed);
@@ -70,16 +85,7 @@ impl PanicShadow {
         let mut retired = Vec::with_capacity(operations.len());
         for operation in operations {
             let index = slot(operation.kind());
-            let replace = state.slots[index].as_ref().is_none_or(|current| {
-                operation.order() > current.order()
-                    || (operation.order() == current.order()
-                        && operation.priority() > current.priority())
-            });
-            if replace {
-                if let Some(operation) = state.slots[index].replace(operation) {
-                    retired.push(operation);
-                }
-            } else {
+            if let Some(operation) = replace_slot_if_newer(&mut state.slots[index], operation) {
                 retired.push(operation);
             }
         }
@@ -115,16 +121,40 @@ impl PanicShadow {
         &self,
     ) -> Result<[Option<PanicOwnedOperation>; 8], PanicShadowSealed> {
         let mut state = self.state.write().unwrap_or_else(PoisonError::into_inner);
-        if state.sealed {
+        if state.phase == PanicShadowPhase::Sealed {
             return Err(PanicShadowSealed);
         }
-        state.sealed = true;
+        state.phase = PanicShadowPhase::Sealed;
         Ok(std::array::from_fn(|index| state.slots[index].clone()))
     }
 
     #[cfg(test)]
     pub(super) fn peek_for_test(&self) -> [Option<PanicOwnedOperation>; 8] {
         self.snapshot()
+    }
+}
+
+fn replace_slot_if_newer(
+    slot: &mut Option<PanicOwnedOperation>,
+    incoming: PanicOwnedOperation,
+) -> Option<PanicOwnedOperation> {
+    let replace =
+        slot.as_ref()
+            .is_none_or(|current| match incoming.order().cmp(&current.order()) {
+                std::cmp::Ordering::Greater => true,
+                std::cmp::Ordering::Less => false,
+                std::cmp::Ordering::Equal => matches!(
+                    (&incoming, current),
+                    (
+                        PanicOwnedOperation::Prepared(_),
+                        PanicOwnedOperation::Pending(_)
+                    )
+                ),
+            });
+    if replace {
+        slot.replace(incoming)
+    } else {
+        Some(incoming)
     }
 }
 

--- a/src/persist/snapshot_state.rs
+++ b/src/persist/snapshot_state.rs
@@ -1,0 +1,353 @@
+use std::collections::HashMap;
+use std::ops::Deref;
+#[cfg(test)]
+use std::ops::Index;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::{
+    AcceptedJournalOrder, JournalIntent, JournalOrder, OwnedSnapshot, PanicOwnedOperation,
+    PanicShadow, PanicShadowSealed, Snapshot, StoreKind, debounce,
+};
+
+pub(super) enum PendingAction {
+    Save(Arc<OwnedSnapshot>),
+    DeleteRomanizedTitles,
+    #[cfg(test)]
+    TestDeleteRomanizedTitles {
+        deleter: Arc<dyn Fn() -> std::io::Result<()> + Send + Sync>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum SnapshotPublication {
+    OrderingUnavailable(Arc<str>),
+    NeedsJournal,
+    JournalResolved,
+}
+
+impl SnapshotPublication {
+    fn from_accepted(accepted: &AcceptedJournalOrder) -> Self {
+        match &accepted.error {
+            Some(error) => Self::OrderingUnavailable(Arc::clone(error)),
+            None => Self::NeedsJournal,
+        }
+    }
+
+    pub(super) fn ensure_ordering(&self) -> std::io::Result<()> {
+        match self {
+            Self::OrderingUnavailable(error) => Err(std::io::Error::other(error.to_string())),
+            Self::NeedsJournal | Self::JournalResolved => Ok(()),
+        }
+    }
+
+    pub(super) fn needs_journal(&self) -> bool {
+        matches!(self, Self::NeedsJournal)
+    }
+
+    fn resolve_journal(&mut self) {
+        if matches!(self, Self::NeedsJournal) {
+            *self = Self::JournalResolved;
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct PendingOperation {
+    pub(super) order: JournalOrder,
+    kind: StoreKind,
+    publication: SnapshotPublication,
+    action: Arc<PendingAction>,
+}
+
+impl PendingOperation {
+    pub(super) fn save(snapshot: Snapshot, accepted: AcceptedJournalOrder) -> Self {
+        let publication = SnapshotPublication::from_accepted(&accepted);
+        let snapshot = OwnedSnapshot::from(snapshot);
+        let kind = snapshot.kind();
+        Self {
+            order: accepted.order,
+            kind,
+            publication,
+            action: Arc::new(PendingAction::Save(Arc::new(snapshot))),
+        }
+    }
+
+    pub(super) fn new(action: PendingAction, accepted: AcceptedJournalOrder) -> Self {
+        let publication = SnapshotPublication::from_accepted(&accepted);
+        Self {
+            order: accepted.order,
+            kind: StoreKind::RomanizedTitles,
+            publication,
+            action: Arc::new(action),
+        }
+    }
+
+    pub(super) fn kind(&self) -> StoreKind {
+        self.kind
+    }
+
+    pub(super) fn action(&self) -> &PendingAction {
+        self.action.as_ref()
+    }
+
+    pub(super) fn label(&self) -> &'static str {
+        match self.action.as_ref() {
+            PendingAction::Save(snapshot) => snapshot.label(),
+            PendingAction::DeleteRomanizedTitles => StoreKind::RomanizedTitles.label(),
+            #[cfg(test)]
+            PendingAction::TestDeleteRomanizedTitles { .. } => "romanized title cache delete",
+        }
+    }
+
+    pub(super) fn storage_path(&self) -> Option<PathBuf> {
+        match self.action.as_ref() {
+            PendingAction::Save(snapshot) => snapshot.storage_path(),
+            PendingAction::DeleteRomanizedTitles => crate::romanize::cache_path(),
+            #[cfg(test)]
+            PendingAction::TestDeleteRomanizedTitles { .. } => None,
+        }
+    }
+
+    pub(super) fn write(&self) -> std::io::Result<()> {
+        match self.action.as_ref() {
+            PendingAction::Save(snapshot) => snapshot.write(),
+            PendingAction::DeleteRomanizedTitles => crate::romanize::RomanizeCache::delete_saved(),
+            #[cfg(test)]
+            PendingAction::TestDeleteRomanizedTitles { deleter } => deleter(),
+        }
+    }
+
+    pub(super) fn publication(&self) -> &SnapshotPublication {
+        &self.publication
+    }
+
+    #[cfg(test)]
+    pub(super) fn resolve_journal_for_test(&mut self) {
+        self.publication.resolve_journal();
+    }
+
+    pub(super) fn debounce(&self) -> Duration {
+        match self.action.as_ref() {
+            PendingAction::Save(_) => debounce(self.kind),
+            PendingAction::DeleteRomanizedTitles => Duration::ZERO,
+            #[cfg(test)]
+            PendingAction::TestDeleteRomanizedTitles { .. } => Duration::ZERO,
+        }
+    }
+
+    pub(super) fn journal_intent(&self) -> Option<JournalIntent> {
+        if !self.publication.needs_journal() {
+            return None;
+        }
+        match self.action.as_ref() {
+            PendingAction::Save(snapshot) => {
+                let path = snapshot.storage_path()?;
+                let bytes = match snapshot.to_json_bytes() {
+                    Ok(bytes) => bytes,
+                    Err(error) => {
+                        tracing::warn!(
+                            store = snapshot.kind().label(),
+                            error = %error,
+                            "failed to encode persistence intent"
+                        );
+                        return None;
+                    }
+                };
+                Some(JournalIntent::Replace {
+                    order: self.order,
+                    kind: snapshot.kind(),
+                    path,
+                    bytes,
+                })
+            }
+            PendingAction::DeleteRomanizedTitles => Some(JournalIntent::Delete {
+                order: self.order,
+                kind: StoreKind::RomanizedTitles,
+                path: crate::romanize::cache_path()?,
+            }),
+            #[cfg(test)]
+            PendingAction::TestDeleteRomanizedTitles { .. } => None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn snapshot(&self) -> Option<&OwnedSnapshot> {
+        match self.action.as_ref() {
+            PendingAction::Save(snapshot) => Some(snapshot),
+            PendingAction::DeleteRomanizedTitles
+            | PendingAction::TestDeleteRomanizedTitles { .. } => None,
+        }
+    }
+}
+
+/// A pending-map value covered by an equal or newer panic-time owner.
+///
+/// The constructor is intentionally private to the publication helpers below. Actor code can
+/// move or requeue this value, but cannot create pending work that the panic hook does not own.
+#[derive(Clone)]
+pub(super) struct ShadowCoveredOperation(PendingOperation);
+
+impl ShadowCoveredOperation {
+    #[cfg(test)]
+    pub(super) fn for_test(operation: PendingOperation) -> Self {
+        Self(operation)
+    }
+
+    #[cfg(test)]
+    pub(super) fn pending_clone(&self) -> PendingOperation {
+        self.0.clone()
+    }
+}
+
+impl Deref for ShadowCoveredOperation {
+    type Target = PendingOperation;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub(super) fn publish_pending_operation(
+    shadow: &PanicShadow,
+    operation: PendingOperation,
+) -> Result<ShadowCoveredOperation, PanicShadowSealed> {
+    shadow.publish(PanicOwnedOperation::Pending(Arc::new(operation.clone())))?;
+    Ok(ShadowCoveredOperation(operation))
+}
+
+pub(super) fn publish_pending_batch(
+    shadow: &PanicShadow,
+    operations: Vec<PendingOperation>,
+) -> Result<Vec<ShadowCoveredOperation>, PanicShadowSealed> {
+    let shadow_operations = operations
+        .iter()
+        .cloned()
+        .map(|operation| PanicOwnedOperation::Pending(Arc::new(operation)))
+        .collect();
+    shadow.publish_batch(shadow_operations)?;
+    Ok(operations.into_iter().map(ShadowCoveredOperation).collect())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct JournalCompletion {
+    kind: StoreKind,
+    order: JournalOrder,
+}
+
+impl JournalCompletion {
+    pub(super) fn confirmed(kind: StoreKind, order: JournalOrder) -> Self {
+        Self { kind, order }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum SnapshotAdmission {
+    Open,
+    Sealed,
+}
+
+pub(super) struct PendingQueue {
+    admission: SnapshotAdmission,
+    operations: HashMap<StoreKind, ShadowCoveredOperation>,
+}
+
+impl PendingQueue {
+    pub(super) fn new() -> Self {
+        Self {
+            admission: SnapshotAdmission::Open,
+            operations: HashMap::new(),
+        }
+    }
+
+    pub(super) fn admission(&self) -> SnapshotAdmission {
+        self.admission
+    }
+
+    pub(super) fn seal(&mut self) {
+        self.admission = SnapshotAdmission::Sealed;
+    }
+
+    pub(super) fn insert_owned(
+        &mut self,
+        operation: ShadowCoveredOperation,
+    ) -> Option<ShadowCoveredOperation> {
+        self.operations.insert(operation.kind(), operation)
+    }
+
+    pub(super) fn resolve_journal(&mut self, completion: JournalCompletion) -> bool {
+        let Some(operation) = self.operations.get_mut(&completion.kind) else {
+            return false;
+        };
+        if operation.order != completion.order {
+            return false;
+        }
+        operation.0.publication.resolve_journal();
+        true
+    }
+
+    pub(super) fn get(&self, kind: &StoreKind) -> Option<&ShadowCoveredOperation> {
+        self.operations.get(kind)
+    }
+
+    pub(super) fn values(
+        &self,
+    ) -> std::collections::hash_map::Values<'_, StoreKind, ShadowCoveredOperation> {
+        self.operations.values()
+    }
+
+    pub(super) fn iter(
+        &self,
+    ) -> std::collections::hash_map::Iter<'_, StoreKind, ShadowCoveredOperation> {
+        self.operations.iter()
+    }
+
+    pub(super) fn keys(
+        &self,
+    ) -> std::collections::hash_map::Keys<'_, StoreKind, ShadowCoveredOperation> {
+        self.operations.keys()
+    }
+
+    pub(super) fn contains_key(&self, kind: &StoreKind) -> bool {
+        self.operations.contains_key(kind)
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.operations.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.operations.len()
+    }
+
+    pub(super) fn remove(&mut self, kind: &StoreKind) -> Option<ShadowCoveredOperation> {
+        self.operations.remove(kind)
+    }
+
+    #[cfg(test)]
+    pub(super) fn insert(
+        &mut self,
+        kind: StoreKind,
+        operation: PendingOperation,
+    ) -> Option<ShadowCoveredOperation> {
+        self.operations
+            .insert(kind, ShadowCoveredOperation::for_test(operation))
+    }
+}
+
+impl Default for PendingQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+impl Index<&StoreKind> for PendingQueue {
+    type Output = ShadowCoveredOperation;
+
+    fn index(&self, kind: &StoreKind) -> &Self::Output {
+        &self.operations[kind]
+    }
+}

--- a/src/persist/tests.rs
+++ b/src/persist/tests.rs
@@ -103,7 +103,7 @@ fn debounce_windows_match_store_durability_policy() {
 
 #[test]
 fn pending_lock_recovers_from_poisoned_mutex() {
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
 
     let _ = std::panic::catch_unwind(AssertUnwindSafe({
         let pending = Arc::clone(&pending);
@@ -388,7 +388,7 @@ fn stale_journal_completion_cannot_replace_newer_delete_or_save() {
     let dir = temp_dir("stale-journal-completion");
     std::fs::create_dir_all(&dir).unwrap();
     let path = dir.join("tiny.json");
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
 
     let old_save_order = journal_order(10, 1);
     lock(&pending).insert(
@@ -892,7 +892,7 @@ fn delayed_old_cross_instance_writer_cannot_overtake_newer_frontier() {
             Ok(())
         }),
     );
-    delayed_old.journaled = true;
+    delayed_old.resolve_journal_for_test();
     write_operation_durable(&delayed_old).unwrap();
     assert_eq!(writes.load(Ordering::SeqCst), 0);
 
@@ -1006,7 +1006,7 @@ fn process_epoch_and_acceptance_sequence_exhaustion_fail_explicitly() {
 
 #[tokio::test]
 async fn write_stores_clears_stale_due_entries_when_snapshot_is_missing() {
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
     let mut due = HashMap::from([(StoreKind::Library, tokio::time::Instant::now())]);
     let mut retries = HashMap::new();
     let events = Arc::new(Mutex::new(None));
@@ -1019,7 +1019,7 @@ async fn write_stores_clears_stale_due_entries_when_snapshot_is_missing() {
 
 #[test]
 fn queued_saves_are_latest_wins_without_extending_deadline() {
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
     let mut due = HashMap::new();
     let mut created = crate::playlists::Playlists::default();
     created.create("Focus").expect("playlist created");
@@ -1040,7 +1040,7 @@ fn queued_saves_are_latest_wins_without_extending_deadline() {
     let guard = lock(&pending);
     let Some(OwnedSnapshot::Playlists(playlists)) = guard
         .get(&StoreKind::Playlists)
-        .and_then(PendingOperation::snapshot)
+        .and_then(|operation| operation.snapshot())
     else {
         panic!("expected playlists snapshot");
     };
@@ -1051,7 +1051,7 @@ fn queued_saves_are_latest_wins_without_extending_deadline() {
 
 #[tokio::test]
 async fn write_stores_requeues_failed_snapshot_and_retries_until_success() {
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
     let mut due = HashMap::from([(StoreKind::Config, tokio::time::Instant::now())]);
     let mut retries = HashMap::new();
     let events = Arc::new(Mutex::new(None));
@@ -1090,7 +1090,7 @@ async fn write_stores_requeues_failed_snapshot_and_retries_until_success() {
 
 #[tokio::test]
 async fn panicking_blocking_writer_is_requeued_and_can_succeed_on_retry() {
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
     let mut due = HashMap::from([(StoreKind::Config, tokio::time::Instant::now())]);
     let mut retries = HashMap::new();
     let events = Arc::new(Mutex::new(None));
@@ -1122,7 +1122,7 @@ async fn panicking_blocking_writer_is_requeued_and_can_succeed_on_retry() {
 
 #[tokio::test]
 async fn disk_full_during_write_preserves_a_newer_coalesced_snapshot() {
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
     let captured_events = Arc::new(Mutex::new(Vec::new()));
     let event_log = Arc::clone(&captured_events);
     let events: EventSinkSlot = Arc::new(Mutex::new(Some(Arc::new(move |event| {
@@ -1189,7 +1189,7 @@ async fn disk_full_during_write_preserves_a_newer_coalesced_snapshot() {
         let guard = lock(&pending);
         let Some(OwnedSnapshot::Test { label, .. }) = guard
             .get(&StoreKind::Config)
-            .and_then(PendingOperation::snapshot)
+            .and_then(|operation| operation.snapshot())
         else {
             panic!("expected injected config snapshot");
         };
@@ -1215,7 +1215,7 @@ async fn disk_full_during_write_preserves_a_newer_coalesced_snapshot() {
 
 #[test]
 fn failed_snapshot_does_not_overwrite_newer_pending_snapshot() {
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
     let mut due = HashMap::new();
     let mut retries = HashMap::new();
     let events = Arc::new(Mutex::new(None));
@@ -1234,19 +1234,19 @@ fn failed_snapshot_does_not_overwrite_newer_pending_snapshot() {
         &mut due,
         &mut retries,
         &events,
-        pending_save(Snapshot::Test {
+        ShadowCoveredOperation::for_test(pending_save(Snapshot::Test {
             kind: StoreKind::Config,
             label: "older",
             storage_path: None,
             writer: Arc::new(|| Ok(())),
-        }),
+        })),
         "transient".to_owned(),
     );
 
     let guard = lock(&pending);
     let Some(OwnedSnapshot::Test { label, .. }) = guard
         .get(&StoreKind::Config)
-        .and_then(PendingOperation::snapshot)
+        .and_then(|operation| operation.snapshot())
     else {
         panic!("expected test snapshot");
     };
@@ -1301,7 +1301,7 @@ async fn delete_is_latest_wins_with_save_in_both_orders() {
     let (tx, _rx) = crate::util::backpressure::bounded_channel(
         crate::util::backpressure::PERSIST_CONTROL_QUEUE,
     );
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
     let handle = PersistHandle {
         tx,
         pending: Arc::clone(&pending),
@@ -1309,7 +1309,6 @@ async fn delete_is_latest_wins_with_save_in_both_orders() {
         dirty: Arc::new(Notify::new()),
         events: Arc::new(Mutex::new(None)),
         order_source: test_order_source(),
-        admission_open: Arc::new(AtomicBool::new(true)),
         panic_shadow: Arc::new(PanicShadow::new()),
     };
     let saves = Arc::new(AtomicUsize::new(0));
@@ -1363,7 +1362,7 @@ async fn delete_is_latest_wins_with_save_in_both_orders() {
 
 #[tokio::test]
 async fn delete_queued_during_an_older_save_runs_after_that_save() {
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
     let events = Arc::new(Mutex::new(None));
     let order = Arc::new(Mutex::new(Vec::new()));
     let save_order = Arc::clone(&order);
@@ -1416,7 +1415,6 @@ async fn delete_queued_during_an_older_save_runs_after_that_save() {
         dirty: Arc::new(Notify::new()),
         events: Arc::clone(&events),
         order_source: test_order_source(),
-        admission_open: Arc::new(AtomicBool::new(true)),
         panic_shadow: Arc::new(PanicShadow::new()),
     };
     let delete_order = Arc::clone(&order);
@@ -1475,7 +1473,7 @@ async fn saturated_control_queue_cannot_lose_delete_before_immediate_flush() {
         tx.try_send(PersistMsg::Flush(ack))
             .expect("prefill persist control queue");
     }
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
     let inflight: SharedInflight = Arc::new(Mutex::new(HashMap::new()));
     let dirty = Arc::new(Notify::new());
     let events = Arc::new(Mutex::new(None));
@@ -1486,7 +1484,6 @@ async fn saturated_control_queue_cannot_lose_delete_before_immediate_flush() {
         dirty: Arc::clone(&dirty),
         events: Arc::clone(&events),
         order_source: test_order_source(),
-        admission_open: Arc::new(AtomicBool::new(true)),
         panic_shadow: Arc::new(PanicShadow::new()),
     };
     let deletes = Arc::new(AtomicUsize::new(0));

--- a/src/persist/tests/handle.rs
+++ b/src/persist/tests/handle.rs
@@ -5,7 +5,7 @@ fn save_replaces_pending_without_queueing_payloads() {
     let (tx, mut rx) = crate::util::backpressure::bounded_channel(
         crate::util::backpressure::PERSIST_CONTROL_QUEUE,
     );
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
     let handle = PersistHandle {
         tx,
         pending: Arc::clone(&pending),
@@ -13,7 +13,6 @@ fn save_replaces_pending_without_queueing_payloads() {
         dirty: Arc::new(Notify::new()),
         events: Arc::new(Mutex::new(None)),
         order_source: test_order_source(),
-        admission_open: Arc::new(AtomicBool::new(true)),
         panic_shadow: Arc::new(PanicShadow::new()),
     };
     let mut created = crate::playlists::Playlists::default();
@@ -34,10 +33,391 @@ fn save_replaces_pending_without_queueing_payloads() {
     let guard = lock(&pending);
     let Some(OwnedSnapshot::Playlists(playlists)) = guard
         .get(&StoreKind::Playlists)
-        .and_then(PendingOperation::snapshot)
+        .and_then(|operation| operation.snapshot())
     else {
         panic!("expected playlists snapshot");
     };
     let focus = playlists.find("Focus").expect("focus playlist");
     assert_eq!(focus.songs.len(), 1);
+}
+
+fn injected_snapshot(kind: StoreKind, label: &'static str) -> Snapshot {
+    Snapshot::Test {
+        kind,
+        label,
+        storage_path: None,
+        writer: Arc::new(|| Ok(())),
+    }
+}
+
+fn detached_test_handle() -> PersistHandle {
+    PersistHandle {
+        tx: crate::util::backpressure::bounded_channel(
+            crate::util::backpressure::PERSIST_CONTROL_QUEUE,
+        )
+        .0,
+        pending: Arc::new(Mutex::new(PendingQueue::new())),
+        inflight: Arc::new(Mutex::new(HashMap::new())),
+        dirty: Arc::new(Notify::new()),
+        events: Arc::new(Mutex::new(None)),
+        order_source: test_order_source(),
+        panic_shadow: Arc::new(PanicShadow::new()),
+    }
+}
+
+#[test]
+fn ordering_failure_precedes_intent_lock_acquisition() {
+    let dir = temp_dir("ordering-before-intent-lock");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("config.json");
+    let _held = acquire_intent_lock(&path).unwrap();
+    let reason: Arc<str> = Arc::from("injected ordering allocation failure");
+    let operation = PendingOperation::save(
+        Snapshot::Test {
+            kind: StoreKind::Config,
+            label: "ordering before intent lock",
+            storage_path: Some(path.clone()),
+            writer: Arc::new(|| panic!("an unordered operation must not reach its writer")),
+        },
+        AcceptedJournalOrder {
+            order: journal_order(1, 1),
+            error: Some(Arc::clone(&reason)),
+        },
+    );
+    let (contended_tx, contended_rx) = std::sync::mpsc::channel();
+
+    let error =
+        with_intent_lock_contention_observer(contended_tx, || write_operation_durable(&operation))
+            .unwrap_err();
+
+    assert_eq!(error.kind(), std::io::ErrorKind::Other);
+    assert_eq!(error.to_string(), reason.as_ref());
+    assert!(
+        contended_rx.try_recv().is_err(),
+        "ordering failure must return before attempting the contended intent lock"
+    );
+    drop(_held);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn snapshot_publication_transitions_are_monotonic_and_clone_local() {
+    let order = journal_order_in_epoch(21, 1, 0xa1);
+    let mut operation = PendingOperation::save(
+        injected_snapshot(StoreKind::Config, "publication"),
+        accepted_order(order),
+    );
+    let shadow_clone = operation.clone();
+    assert_eq!(operation.publication(), &SnapshotPublication::NeedsJournal);
+
+    operation.resolve_journal_for_test();
+    operation.resolve_journal_for_test();
+    assert_eq!(
+        operation.publication(),
+        &SnapshotPublication::JournalResolved
+    );
+    assert_eq!(
+        shadow_clone.publication(),
+        &SnapshotPublication::NeedsJournal,
+        "map-local journal completion must not mutate the panic-owned clone"
+    );
+
+    let reason: Arc<str> = Arc::from("ordering allocation failed");
+    let mut unavailable = PendingOperation::save(
+        injected_snapshot(StoreKind::Config, "unavailable"),
+        AcceptedJournalOrder {
+            order,
+            error: Some(Arc::clone(&reason)),
+        },
+    );
+    unavailable.resolve_journal_for_test();
+    assert_eq!(
+        unavailable.publication(),
+        &SnapshotPublication::OrderingUnavailable(Arc::clone(&reason))
+    );
+    assert_eq!(
+        unavailable
+            .publication()
+            .ensure_ordering()
+            .unwrap_err()
+            .to_string(),
+        reason.as_ref()
+    );
+}
+
+#[tokio::test]
+async fn exact_journal_completion_resolves_the_pending_snapshot_once() {
+    let directory = temp_dir("snapshot-publication-state");
+    std::fs::create_dir_all(&directory).unwrap();
+    let path = directory.join("config.json");
+    let order = journal_order_in_epoch(22, 1, 0xa2);
+    let operation = test_operation(
+        StoreKind::Config,
+        order,
+        Some(path.clone()),
+        Arc::new(|| Ok(())),
+    );
+    let shadow = PanicShadow::new();
+    let operation = publish_pending_operation(&shadow, operation).unwrap();
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
+    lock(&pending).insert_owned(operation);
+
+    journal_pending_operations(&pending).await;
+    assert_eq!(
+        lock(&pending)[&StoreKind::Config].publication(),
+        &SnapshotPublication::JournalResolved
+    );
+    let journal_path = intent_journal_path(&path).unwrap();
+    let first_publication = std::fs::read(&journal_path).unwrap();
+
+    journal_pending_operations(&pending).await;
+    assert_eq!(std::fs::read(&journal_path).unwrap(), first_publication);
+    clear_store_journal(&path);
+    let _ = std::fs::remove_dir_all(directory);
+}
+
+#[tokio::test]
+async fn superseded_completion_resolves_exact_operation_but_stale_does_not_resolve_replacement() {
+    let directory = temp_dir("snapshot-publication-superseded");
+    std::fs::create_dir_all(&directory).unwrap();
+    let path = directory.join("config.json");
+    let old_order = journal_order_in_epoch(24, 1, 0xa4);
+    let newer_order = journal_order_in_epoch(24, 2, 0xa5);
+    write_journal_intent(&JournalIntent::Replace {
+        order: newer_order,
+        kind: StoreKind::Config,
+        path: path.clone(),
+        bytes: b"newer".to_vec(),
+    })
+    .unwrap();
+    commit_journal_generation(StoreKind::Config, &path, newer_order).unwrap();
+
+    let shadow = PanicShadow::new();
+    let old = test_operation(
+        StoreKind::Config,
+        old_order,
+        Some(path.clone()),
+        Arc::new(|| Ok(())),
+    );
+    let old = publish_pending_operation(&shadow, old).unwrap();
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
+    lock(&pending).insert_owned(old);
+    journal_pending_operations(&pending).await;
+    assert_eq!(
+        lock(&pending)[&StoreKind::Config].publication(),
+        &SnapshotPublication::JournalResolved,
+        "a confirmed superseded append settles the exact map operation"
+    );
+
+    let stale_intent = JournalIntent::Replace {
+        order: old_order,
+        kind: StoreKind::Config,
+        path: path.clone(),
+        bytes: b"stale".to_vec(),
+    };
+    let replacement = test_operation(
+        StoreKind::Config,
+        newer_order,
+        Some(path.clone()),
+        Arc::new(|| Ok(())),
+    );
+    lock(&pending).insert(StoreKind::Config, replacement);
+    assert!(matches!(
+        write_journal_intent_if_current(&stale_intent, &pending).unwrap(),
+        JournalAppend::Stale
+    ));
+    {
+        let mut pending = lock(&pending);
+        assert!(
+            !pending.resolve_journal(JournalCompletion::confirmed(StoreKind::Config, old_order,)),
+            "an exact-order completion token must not settle a replacement"
+        );
+        assert_eq!(
+            pending[&StoreKind::Config].publication(),
+            &SnapshotPublication::NeedsJournal
+        );
+    }
+
+    clear_store_journal(&path);
+    let _ = std::fs::remove_dir_all(directory);
+}
+
+#[tokio::test]
+async fn ordering_unavailable_stays_pending_without_inflight_transition() {
+    let order = journal_order_in_epoch(23, 1, 0xa3);
+    let reason: Arc<str> = Arc::from("injected ordering allocation failure");
+    let operation = PendingOperation::save(
+        injected_snapshot(StoreKind::Config, "unordered config"),
+        AcceptedJournalOrder {
+            order,
+            error: Some(Arc::clone(&reason)),
+        },
+    );
+    let shadow = PanicShadow::new();
+    let operation = publish_pending_operation(&shadow, operation).unwrap();
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
+    lock(&pending).insert_owned(operation);
+    let inflight: SharedInflight = Arc::new(Mutex::new(HashMap::new()));
+    let mut due = HashMap::new();
+    let mut retries = RetryMap::new();
+    let events: EventSinkSlot = Arc::new(Mutex::new(None));
+
+    assert!(
+        !write_stores_with_inflight(
+            &pending,
+            &inflight,
+            &shadow,
+            &mut due,
+            &mut retries,
+            &events,
+            true,
+        )
+        .await
+    );
+
+    let pending = lock(&pending);
+    let retained = pending
+        .get(&StoreKind::Config)
+        .expect("unordered operation remains pending");
+    assert_eq!(retained.order, order);
+    assert_eq!(
+        retained.publication(),
+        &SnapshotPublication::OrderingUnavailable(Arc::clone(&reason))
+    );
+    drop(pending);
+    assert!(lock_inflight(&inflight).is_empty());
+    assert!(due.contains_key(&StoreKind::Config));
+    assert_eq!(retries[&StoreKind::Config].retry_count, 1);
+
+    let owned = shadow.peek_for_test();
+    let Some(PanicOwnedOperation::Pending(operation)) = owned[3].as_ref() else {
+        panic!("unordered operation must stay in pending panic-shadow form");
+    };
+    assert_eq!(operation.order, order);
+    assert_eq!(
+        operation.publication(),
+        &SnapshotPublication::OrderingUnavailable(reason)
+    );
+}
+
+#[test]
+fn clean_seal_is_monotonic_while_repeated_final_batches_stay_refreshable() {
+    let handle = PersistHandle {
+        tx: crate::util::backpressure::bounded_channel(
+            crate::util::backpressure::PERSIST_CONTROL_QUEUE,
+        )
+        .0,
+        pending: Arc::new(Mutex::new(PendingQueue::new())),
+        inflight: Arc::new(Mutex::new(HashMap::new())),
+        dirty: Arc::new(Notify::new()),
+        events: Arc::new(Mutex::new(None)),
+        order_source: test_order_source(),
+        panic_shadow: Arc::new(PanicShadow::new()),
+    };
+
+    handle
+        .seal_with_snapshots([injected_snapshot(StoreKind::Config, "first final")])
+        .unwrap();
+    assert_eq!(lock(&handle.pending).admission(), SnapshotAdmission::Sealed);
+    assert_eq!(
+        handle.save(injected_snapshot(StoreKind::Library, "late ordinary")),
+        Err(crate::util::delivery::DeliveryError::Closed)
+    );
+
+    handle
+        .seal_with_snapshots([injected_snapshot(StoreKind::Config, "refreshed final")])
+        .unwrap();
+    let (pending_order, pending_label) = {
+        let pending = lock(&handle.pending);
+        let operation = pending
+            .get(&StoreKind::Config)
+            .expect("expected refreshed final operation");
+        let Some(OwnedSnapshot::Test { label, .. }) = operation.snapshot() else {
+            panic!("expected refreshed final snapshot");
+        };
+        (operation.order, *label)
+    };
+    assert_eq!(pending_label, "refreshed final");
+
+    let shadow = handle.panic_shadow.peek_for_test();
+    let Some(PanicOwnedOperation::Pending(shadow_operation)) = shadow[3].as_ref() else {
+        panic!("panic shadow must own the refreshed final in pending form");
+    };
+    assert_eq!(shadow_operation.order, pending_order);
+    assert_eq!(shadow_operation.label(), pending_label);
+}
+
+#[test]
+fn failed_clean_seal_closes_admission_without_publishing_snapshots() {
+    let handle = detached_test_handle();
+    let sequence_before = *handle
+        .order_source
+        .next_sequence
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    assert!(
+        handle
+            .panic_shadow
+            .peek_for_test()
+            .iter()
+            .all(Option::is_none)
+    );
+
+    let worker_handle = handle.clone();
+    let (sealed_tx, sealed_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let worker = std::thread::spawn(move || {
+        worker_handle.seal_with_snapshots_after_check_and_hook_for_test(
+            std::iter::once_with(|| {
+                panic!("failed mutation check must not consume the snapshots iterator")
+            }),
+            Err(std::io::Error::other("mutation gate revoked")),
+            || {
+                sealed_tx.send(()).unwrap();
+                release_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            },
+        )
+    });
+    sealed_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("failed seal reaches the production admission critical section");
+
+    let late_handle = handle.clone();
+    let (save_started_tx, save_started_rx) = std::sync::mpsc::channel();
+    let late_saver = std::thread::spawn(move || {
+        save_started_tx.send(()).unwrap();
+        late_handle.save(injected_snapshot(StoreKind::Config, "late ordinary"))
+    });
+    save_started_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("late saver starts while the failed seal owns admission");
+    release_tx.send(()).unwrap();
+
+    assert_eq!(
+        worker.join().unwrap(),
+        Err(crate::util::delivery::DeliveryError::Closed)
+    );
+    assert_eq!(
+        late_saver.join().unwrap(),
+        Err(crate::util::delivery::DeliveryError::Closed)
+    );
+    assert_eq!(lock(&handle.pending).admission(), SnapshotAdmission::Sealed);
+    assert!(lock(&handle.pending).is_empty());
+    assert_eq!(
+        *handle
+            .order_source
+            .next_sequence
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner),
+        sequence_before,
+        "mutation rejection must not allocate an order"
+    );
+    assert!(
+        handle
+            .panic_shadow
+            .peek_for_test()
+            .iter()
+            .all(Option::is_none),
+        "mutation rejection must not publish a panic batch"
+    );
 }

--- a/src/persist/tests/panic_shadow_seal.rs
+++ b/src/persist/tests/panic_shadow_seal.rs
@@ -6,12 +6,11 @@ fn test_handle() -> PersistHandle {
     );
     PersistHandle {
         tx,
-        pending: Arc::new(Mutex::new(HashMap::new())),
+        pending: Arc::new(Mutex::new(PendingQueue::new())),
         inflight: Arc::new(Mutex::new(HashMap::new())),
         dirty: Arc::new(Notify::new()),
         events: Arc::new(Mutex::new(None)),
         order_source: test_order_source(),
-        admission_open: Arc::new(AtomicBool::new(true)),
         panic_shadow: Arc::new(PanicShadow::new()),
     }
 }
@@ -110,7 +109,7 @@ async fn paused_panic_hook_snapshot_rejects_every_late_admission_without_partial
 
 #[tokio::test]
 async fn actor_prepared_rejection_preserves_the_pending_operation_captured_by_the_hook() {
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
     let inflight: SharedInflight = Arc::new(Mutex::new(HashMap::new()));
     let shadow = PanicShadow::new();
     let writes = Arc::new(AtomicUsize::new(0));
@@ -156,4 +155,124 @@ async fn actor_prepared_rejection_preserves_the_pending_operation_captured_by_th
     assert!(lock_inflight(&inflight).is_empty());
     assert_eq!(captured.order(), order);
     assert!(matches!(captured, PanicOwnedOperation::Pending(_)));
+}
+
+fn pending_owner(order: JournalOrder) -> PanicOwnedOperation {
+    PanicOwnedOperation::Pending(Arc::new(test_operation(
+        StoreKind::Config,
+        order,
+        None,
+        Arc::new(|| Ok(())),
+    )))
+}
+
+fn prepared_owner(order: JournalOrder) -> PanicOwnedOperation {
+    let operation = test_operation(StoreKind::Config, order, None, Arc::new(|| Ok(())));
+    PanicOwnedOperation::Prepared(Arc::new(operation.panic_operation().unwrap()))
+}
+
+#[test]
+fn panic_shadow_slot_transitions_are_monotonic_and_exhaustive() {
+    let shadow = PanicShadow::new();
+    let older = journal_order_in_epoch(31, 1, 0xb1);
+    let current = journal_order_in_epoch(31, 2, 0xb2);
+    let newer = journal_order_in_epoch(31, 3, 0xb3);
+
+    shadow.publish(pending_owner(current)).unwrap();
+    assert!(matches!(
+        shadow.peek_for_test()[3],
+        Some(PanicOwnedOperation::Pending(_))
+    ));
+    shadow.publish(prepared_owner(current)).unwrap();
+    assert!(matches!(
+        shadow.peek_for_test()[3],
+        Some(PanicOwnedOperation::Prepared(_))
+    ));
+
+    shadow.publish(pending_owner(current)).unwrap();
+    shadow.publish(prepared_owner(older)).unwrap();
+    let retained = shadow.peek_for_test()[3].clone().unwrap();
+    assert_eq!(retained.order(), current);
+    assert!(matches!(retained, PanicOwnedOperation::Prepared(_)));
+
+    shadow.publish(pending_owner(newer)).unwrap();
+    let retained = shadow.peek_for_test()[3].clone().unwrap();
+    assert_eq!(retained.order(), newer);
+    assert!(matches!(retained, PanicOwnedOperation::Pending(_)));
+
+    shadow.clear_through(StoreKind::Config, current);
+    assert_eq!(shadow.peek_for_test()[3].as_ref().unwrap().order(), newer);
+    shadow.clear_through(StoreKind::Config, newer);
+    assert!(shadow.peek_for_test()[3].is_none());
+
+    shadow.publish(pending_owner(current)).unwrap();
+    shadow.clear_through(StoreKind::Config, newer);
+    assert!(
+        shadow.peek_for_test()[3].is_none(),
+        "a durable frontier above the retained order must clear stale panic ownership"
+    );
+}
+
+#[test]
+fn open_snapshot_does_not_seal_but_terminal_seal_rejects_every_publisher() {
+    let shadow = PanicShadow::new();
+    let first = journal_order_in_epoch(32, 1, 0xc1);
+    let second = journal_order_in_epoch(32, 2, 0xc2);
+    shadow.publish(pending_owner(first)).unwrap();
+    assert_eq!(shadow.snapshot()[3].as_ref().unwrap().order(), first);
+    shadow.publish(pending_owner(second)).unwrap();
+
+    let sealed = shadow.seal_and_snapshot().unwrap();
+    assert_eq!(sealed[3].as_ref().unwrap().order(), second);
+    assert!(matches!(
+        shadow.publish(prepared_owner(second)),
+        Err(PanicShadowSealed)
+    ));
+    assert!(matches!(
+        shadow.publish_batch(vec![pending_owner(journal_order_in_epoch(32, 3, 0xc3))]),
+        Err(PanicShadowSealed)
+    ));
+    assert!(matches!(shadow.seal_and_snapshot(), Err(PanicShadowSealed)));
+
+    shadow.clear_through(StoreKind::Config, second);
+    assert!(shadow.snapshot()[3].is_none());
+}
+
+#[test]
+fn concurrent_publish_and_seal_have_one_linearized_frontier() {
+    let shadow = Arc::new(PanicShadow::new());
+    let order = journal_order_in_epoch(33, 1, 0xd1);
+    let (publish_locked_tx, publish_locked_rx) = std::sync::mpsc::channel();
+    let (release_publish_tx, release_publish_rx) = std::sync::mpsc::channel();
+
+    let publish_shadow = Arc::clone(&shadow);
+    let publisher = std::thread::spawn(move || {
+        publish_shadow.publish_with_lock_hook_for_test(pending_owner(order), || {
+            publish_locked_tx.send(()).unwrap();
+            release_publish_rx
+                .recv_timeout(Duration::from_secs(5))
+                .unwrap();
+        })
+    });
+    publish_locked_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("publisher reaches the production write-lock critical section");
+
+    let seal_shadow = Arc::clone(&shadow);
+    let (seal_started_tx, seal_started_rx) = std::sync::mpsc::channel();
+    let sealer = std::thread::spawn(move || {
+        seal_started_tx.send(()).unwrap();
+        seal_shadow.seal_and_snapshot().unwrap()
+    });
+    seal_started_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("sealer starts while the publisher owns the write lock");
+    release_publish_tx.send(()).unwrap();
+
+    assert_eq!(publisher.join().unwrap(), Ok(()));
+    let sealed = sealer.join().unwrap();
+    let Some(PanicOwnedOperation::Pending(operation)) = sealed[3].as_ref() else {
+        panic!("publish-first frontier must retain the exact pending form");
+    };
+    assert_eq!(operation.order, order);
 }

--- a/src/persist/tests/races.rs
+++ b/src/persist/tests/races.rs
@@ -51,7 +51,7 @@ fn panic_shadow_is_independent_of_transition_locks_and_keeps_a_monotonic_frontie
         Arc::new(|| Ok(())),
     ));
     let newer_order = newer.order;
-    let pending: SharedPending = Arc::new(Mutex::new(HashMap::new()));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
     let inflight: SharedInflight = Arc::new(Mutex::new(HashMap::new()));
     let _pending_transition = lock(&pending);
     let _inflight_transition = lock_inflight(&inflight);
@@ -239,13 +239,16 @@ async fn panic_flush_owns_unjournaled_write_while_blocking_pool_is_full() {
         }),
     });
     let expected_order = operation.order;
-    let pending: SharedPending =
-        Arc::new(Mutex::new(HashMap::from([(StoreKind::Config, operation)])));
+    let pending: SharedPending = Arc::new(Mutex::new(PendingQueue::new()));
+    lock(&pending).insert(StoreKind::Config, operation);
     let inflight: SharedInflight = Arc::new(Mutex::new(HashMap::new()));
 
     journal_pending_operations(&pending).await;
     assert!(
-        !lock(&pending)[&StoreKind::Config].journaled,
+        matches!(
+            lock(&pending)[&StoreKind::Config].publication(),
+            SnapshotPublication::NeedsJournal
+        ),
         "the missing parent injects a journal failure before pool admission"
     );
     std::fs::remove_file(&late_parent).unwrap();
@@ -287,7 +290,7 @@ async fn panic_flush_owns_unjournaled_write_while_blocking_pool_is_full() {
     let panic_shadow = Arc::new(PanicShadow::new());
     panic_shadow
         .publish(PanicOwnedOperation::Pending(Arc::new(
-            lock(&pending)[&StoreKind::Config].clone(),
+            lock(&pending)[&StoreKind::Config].pending_clone(),
         )))
         .unwrap();
     let write_shadow = Arc::clone(&panic_shadow);

--- a/src/persist/writer_lease.rs
+++ b/src/persist/writer_lease.rs
@@ -38,11 +38,18 @@ struct PersistenceWriterLease {
 }
 
 enum ProcessWriterState {
+    Uninitialized,
     Writable(PersistenceWriterLease),
     ReadOnly(Arc<str>),
 }
 
-impl ProcessWriterState {
+/// A completed acquisition cannot represent the process-only pre-initialization state.
+enum InitializedWriterState {
+    Writable(PersistenceWriterLease),
+    ReadOnly(Arc<str>),
+}
+
+impl InitializedWriterState {
     fn access(&self) -> PersistenceAccess {
         match self {
             Self::Writable(_) => PersistenceAccess::Writable,
@@ -52,8 +59,52 @@ impl ProcessWriterState {
         }
     }
 
+    fn mutation_access(&self) -> Result<(), Arc<str>> {
+        match self {
+            Self::Writable(_) => Ok(()),
+            Self::ReadOnly(reason) => Err(Arc::clone(reason)),
+        }
+    }
+
+    #[cfg(test)]
     fn ensure_writable(&self) -> std::io::Result<()> {
         match self {
+            Self::Writable(lease) => {
+                let _held_root_count = lease._locks.len();
+                Ok(())
+            }
+            Self::ReadOnly(reason) => Err(read_only_error(reason)),
+        }
+    }
+}
+
+impl From<InitializedWriterState> for ProcessWriterState {
+    fn from(state: InitializedWriterState) -> Self {
+        match state {
+            InitializedWriterState::Writable(lease) => Self::Writable(lease),
+            InitializedWriterState::ReadOnly(reason) => Self::ReadOnly(reason),
+        }
+    }
+}
+
+impl ProcessWriterState {
+    fn access(&self) -> PersistenceAccess {
+        match self {
+            Self::Uninitialized => PersistenceAccess::ReadOnly {
+                reason: Arc::from("the process did not initialize its persistence writer lease"),
+            },
+            Self::Writable(_) => PersistenceAccess::Writable,
+            Self::ReadOnly(reason) => PersistenceAccess::ReadOnly {
+                reason: Arc::clone(reason),
+            },
+        }
+    }
+
+    fn ensure_writable(&self) -> std::io::Result<()> {
+        match self {
+            Self::Uninitialized => Err(read_only_error(
+                "the process did not initialize its persistence writer lease",
+            )),
             Self::Writable(lease) => {
                 // Reading the field documents that the RAII guards intentionally live as long as
                 // this state. An environment with no resolvable roots legitimately owns zero.
@@ -66,11 +117,11 @@ impl ProcessWriterState {
 }
 
 #[cfg(not(test))]
-static PROCESS_WRITER: OnceLock<Mutex<Option<ProcessWriterState>>> = OnceLock::new();
+static PROCESS_WRITER: OnceLock<Mutex<ProcessWriterState>> = OnceLock::new();
 
 #[cfg(not(test))]
-fn process_writer() -> &'static Mutex<Option<ProcessWriterState>> {
-    PROCESS_WRITER.get_or_init(|| Mutex::new(None))
+fn process_writer() -> &'static Mutex<ProcessWriterState> {
+    PROCESS_WRITER.get_or_init(|| Mutex::new(ProcessWriterState::Uninitialized))
 }
 
 fn read_only_error(reason: &str) -> std::io::Error {
@@ -177,7 +228,7 @@ fn configured_roots() -> Vec<PathBuf> {
 fn acquire_state_for_roots<I, P>(
     roots: I,
     allow_read_only: bool,
-) -> std::io::Result<ProcessWriterState>
+) -> std::io::Result<InitializedWriterState>
 where
     I: IntoIterator<Item = P>,
     P: AsRef<Path>,
@@ -189,7 +240,7 @@ where
     let roots = match normalized_roots(&configured) {
         Ok(roots) => roots,
         Err(error) if allow_read_only => {
-            return Ok(ProcessWriterState::ReadOnly(Arc::from(format!(
+            return Ok(InitializedWriterState::ReadOnly(Arc::from(format!(
                 "the persistence roots could not be verified ({error}); changes are not saved"
             ))));
         }
@@ -214,13 +265,13 @@ where
                     root.display()
                 ));
                 return if allow_read_only {
-                    Ok(ProcessWriterState::ReadOnly(reason))
+                    Ok(InitializedWriterState::ReadOnly(reason))
                 } else {
                     Err(read_only_error(&reason))
                 };
             }
             Err(error) if allow_read_only => {
-                return Ok(ProcessWriterState::ReadOnly(Arc::from(format!(
+                return Ok(InitializedWriterState::ReadOnly(Arc::from(format!(
                     "the persistence writer lease at {} could not be verified ({error}); changes are not saved",
                     root.display()
                 ))));
@@ -243,7 +294,7 @@ where
     let verified_roots = match normalized_roots(&configured) {
         Ok(roots) => roots,
         Err(error) if allow_read_only => {
-            return Ok(ProcessWriterState::ReadOnly(Arc::from(format!(
+            return Ok(InitializedWriterState::ReadOnly(Arc::from(format!(
                 "persistence roots changed or became unreadable while acquiring the writer lease ({error}); changes are not saved"
             ))));
         }
@@ -255,16 +306,63 @@ where
             "persistence roots changed while acquiring the writer lease",
         );
         return if allow_read_only {
-            Ok(ProcessWriterState::ReadOnly(Arc::from(format!(
+            Ok(InitializedWriterState::ReadOnly(Arc::from(format!(
                 "{error}; changes are not saved"
             ))))
         } else {
             Err(error)
         };
     }
-    Ok(ProcessWriterState::Writable(PersistenceWriterLease {
+    Ok(InitializedWriterState::Writable(PersistenceWriterLease {
         _locks: locks,
     }))
+}
+
+fn initialize_writer_state<I, P>(
+    state: &mut ProcessWriterState,
+    roots: I,
+    allow_read_only: bool,
+    acquire: impl FnOnce(I, bool) -> std::io::Result<InitializedWriterState>,
+    configure: impl FnOnce(Result<(), Arc<str>>) -> std::io::Result<()>,
+) -> std::io::Result<PersistenceAccess>
+where
+    I: IntoIterator<Item = P>,
+    P: AsRef<Path>,
+{
+    match state {
+        ProcessWriterState::Uninitialized => {}
+        existing => {
+            if !allow_read_only {
+                existing.ensure_writable()?;
+            }
+            return Ok(existing.access());
+        }
+    }
+
+    let acquired = acquire(roots, allow_read_only)?;
+    let access = acquired.access();
+    configure(acquired.mutation_access())?;
+    *state = acquired.into();
+    Ok(access)
+}
+
+fn initialize_reader_state(
+    state: &mut ProcessWriterState,
+    reason: Arc<str>,
+    configure: impl FnOnce(Result<(), Arc<str>>) -> std::io::Result<()>,
+) -> std::io::Result<PersistenceAccess> {
+    match state {
+        ProcessWriterState::Uninitialized => {
+            configure(Err(Arc::clone(&reason)))?;
+            *state = ProcessWriterState::ReadOnly(Arc::clone(&reason));
+            Ok(PersistenceAccess::ReadOnly { reason })
+        }
+        ProcessWriterState::ReadOnly(_) => Ok(state.access()),
+        ProcessWriterState::Writable(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            "cannot downgrade an initialized persistence writer to a reader",
+        )),
+    }
 }
 
 /// Establish the process-wide writer lease before `Config::load` or any other mutating loader.
@@ -299,21 +397,13 @@ where
             tracing::error!("recovering poisoned persistence writer-lease state");
             poisoned.into_inner()
         });
-        if let Some(existing) = state.as_ref() {
-            if !allow_read_only {
-                existing.ensure_writable()?;
-            }
-            return Ok(existing.access());
-        }
-        let acquired = acquire_state_for_roots(roots, allow_read_only)?;
-        let access = acquired.access();
-        let mutation_access = match &access {
-            PersistenceAccess::Writable => Ok(()),
-            PersistenceAccess::ReadOnly { reason } => Err(Arc::clone(reason)),
-        };
-        crate::util::safe_fs::configure_process_mutations(mutation_access)?;
-        *state = Some(acquired);
-        Ok(access)
+        initialize_writer_state(
+            &mut state,
+            roots,
+            allow_read_only,
+            acquire_state_for_roots,
+            crate::util::safe_fs::configure_process_mutations,
+        )
     }
 }
 
@@ -331,18 +421,11 @@ pub fn initialize_persistence_reader() -> std::io::Result<PersistenceAccess> {
         let mut state = process_writer()
             .lock()
             .unwrap_or_else(PoisonError::into_inner);
-        if let Some(existing) = state.as_ref() {
-            return match existing {
-                ProcessWriterState::ReadOnly(_) => Ok(existing.access()),
-                ProcessWriterState::Writable(_) => Err(std::io::Error::new(
-                    std::io::ErrorKind::AlreadyExists,
-                    "cannot downgrade an initialized persistence writer to a reader",
-                )),
-            };
-        }
-        crate::util::safe_fs::configure_process_mutations(Err(Arc::clone(&reason)))?;
-        *state = Some(ProcessWriterState::ReadOnly(Arc::clone(&reason)));
-        Ok(PersistenceAccess::ReadOnly { reason })
+        initialize_reader_state(
+            &mut state,
+            reason,
+            crate::util::safe_fs::configure_process_mutations,
+        )
     }
 }
 
@@ -356,11 +439,7 @@ pub(crate) fn persistence_access() -> PersistenceAccess {
         process_writer()
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
-            .as_ref()
-            .map(ProcessWriterState::access)
-            .unwrap_or_else(|| PersistenceAccess::ReadOnly {
-                reason: Arc::from("the process did not initialize its persistence writer lease"),
-            })
+            .access()
     }
 }
 
@@ -377,10 +456,6 @@ pub(crate) fn writer_lease_allows_mutation() -> std::io::Result<()> {
                 tracing::error!("recovering poisoned persistence writer-lease state");
                 poisoned.into_inner()
             })
-            .as_ref()
-            .ok_or_else(|| {
-                read_only_error("the process did not initialize its persistence writer lease")
-            })?
             .ensure_writable()
     }
 }
@@ -404,151 +479,5 @@ where
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn test_dir(label: &str) -> PathBuf {
-        let mut suffix = [0_u8; 8];
-        getrandom::fill(&mut suffix).unwrap();
-        let suffix = suffix
-            .into_iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect::<String>();
-        std::env::temp_dir().join(format!(
-            "yututui-writer-lease-{}-{label}-{suffix}",
-            std::process::id()
-        ))
-    }
-
-    fn assert_read_only(state: &ProcessWriterState) {
-        assert!(matches!(state.access(), PersistenceAccess::ReadOnly { .. }));
-        assert_eq!(
-            state.ensure_writable().unwrap_err().kind(),
-            std::io::ErrorKind::WouldBlock
-        );
-    }
-
-    #[test]
-    fn configured_roots_include_the_local_index_storage_domain() {
-        let roots = configured_roots();
-        let local_index_root = crate::paths::local_index_data_dir().unwrap();
-
-        assert!(roots.contains(&local_index_root));
-        assert_eq!(
-            roots.len(),
-            4,
-            "all four configured storage domains remain leased"
-        );
-    }
-
-    #[test]
-    fn shared_root_is_deduplicated_and_only_one_writer_wins() {
-        let root = test_dir("dedupe");
-        let primary = acquire_state_for_roots([&root, &root, &root], false).unwrap();
-        primary.ensure_writable().unwrap();
-        let secondary = acquire_state_for_roots([&root], true).unwrap();
-        assert_read_only(&secondary);
-        drop(primary);
-        acquire_state_for_roots([&root], false)
-            .unwrap()
-            .ensure_writable()
-            .unwrap();
-        let _ = std::fs::remove_dir_all(root);
-    }
-
-    #[test]
-    fn shared_config_with_split_data_and_cache_blocks_second_writer() {
-        let shared = test_dir("shared-config");
-        let a_data = test_dir("a-data");
-        let a_cache = test_dir("a-cache");
-        let b_data = test_dir("b-data");
-        let b_cache = test_dir("b-cache");
-        let primary = acquire_state_for_roots([&shared, &a_data, &a_cache], false).unwrap();
-        let secondary = acquire_state_for_roots([&shared, &b_data, &b_cache], true).unwrap();
-        assert_read_only(&secondary);
-        drop(primary);
-        for path in [shared, a_data, a_cache, b_data, b_cache] {
-            let _ = std::fs::remove_dir_all(path);
-        }
-    }
-
-    #[test]
-    fn shared_cache_with_split_config_and_data_blocks_second_writer() {
-        let shared = test_dir("shared-cache");
-        let a_config = test_dir("a-config");
-        let a_data = test_dir("a-data");
-        let b_config = test_dir("b-config");
-        let b_data = test_dir("b-data");
-        let primary = acquire_state_for_roots([&a_config, &a_data, &shared], false).unwrap();
-        let secondary = acquire_state_for_roots([&b_config, &b_data, &shared], true).unwrap();
-        assert_read_only(&secondary);
-        drop(primary);
-        for path in [shared, a_config, a_data, b_config, b_data] {
-            let _ = std::fs::remove_dir_all(path);
-        }
-    }
-
-    #[test]
-    fn fully_split_roots_allow_independent_writers() {
-        let a = [
-            test_dir("a-config"),
-            test_dir("a-data"),
-            test_dir("a-cache"),
-        ];
-        let b = [
-            test_dir("b-config"),
-            test_dir("b-data"),
-            test_dir("b-cache"),
-        ];
-        let first = acquire_state_for_roots(&a, false).unwrap();
-        let second = acquire_state_for_roots(&b, false).unwrap();
-        first.ensure_writable().unwrap();
-        second.ensure_writable().unwrap();
-        drop((first, second));
-        for path in a.into_iter().chain(b) {
-            let _ = std::fs::remove_dir_all(path);
-        }
-    }
-
-    #[test]
-    fn partial_acquisition_failure_releases_all_earlier_roots() {
-        let earlier = test_dir("a-earlier");
-        let later = test_dir("z-later");
-        let held_later = crate::util::safe_fs::try_lock_private_file(
-            &normalize_root(&later).unwrap().join(WRITER_LEASE_FILE),
-        )
-        .unwrap()
-        .unwrap();
-
-        let failed = acquire_state_for_roots([&earlier, &later], true).unwrap();
-        assert_read_only(&failed);
-        let earlier_lock = crate::util::safe_fs::try_lock_private_file(
-            &normalize_root(&earlier).unwrap().join(WRITER_LEASE_FILE),
-        )
-        .unwrap();
-        assert!(
-            earlier_lock.is_some(),
-            "partial lease stranded the first root"
-        );
-
-        drop((earlier_lock, held_later));
-        let _ = std::fs::remove_dir_all(earlier);
-        let _ = std::fs::remove_dir_all(later);
-    }
-
-    #[test]
-    fn primary_remains_writable_until_drop_then_successor_acquires_every_root() {
-        let roots = [test_dir("config"), test_dir("data"), test_dir("cache")];
-        let primary = acquire_state_for_roots(&roots, false).unwrap();
-        primary.ensure_writable().unwrap();
-        assert_read_only(&acquire_state_for_roots(&roots, true).unwrap());
-
-        drop(primary);
-        let successor = acquire_state_for_roots(&roots, false).unwrap();
-        successor.ensure_writable().unwrap();
-        drop(successor);
-        for path in roots {
-            let _ = std::fs::remove_dir_all(path);
-        }
-    }
-}
+#[path = "writer_lease/tests.rs"]
+mod tests;

--- a/src/persist/writer_lease/tests.rs
+++ b/src/persist/writer_lease/tests.rs
@@ -1,0 +1,348 @@
+use super::*;
+use std::cell::{Cell, RefCell};
+
+fn test_dir(label: &str) -> PathBuf {
+    let mut suffix = [0_u8; 8];
+    getrandom::fill(&mut suffix).unwrap();
+    let suffix = suffix
+        .into_iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    std::env::temp_dir().join(format!(
+        "yututui-writer-lease-{}-{label}-{suffix}",
+        std::process::id()
+    ))
+}
+
+fn assert_read_only(state: &InitializedWriterState) {
+    assert!(matches!(state.access(), PersistenceAccess::ReadOnly { .. }));
+    assert_eq!(
+        state.ensure_writable().unwrap_err().kind(),
+        std::io::ErrorKind::WouldBlock
+    );
+}
+
+fn empty_writable_state() -> InitializedWriterState {
+    InitializedWriterState::Writable(PersistenceWriterLease { _locks: Vec::new() })
+}
+
+#[test]
+fn uninitialized_writer_state_is_default_deny() {
+    const REASON: &str = "the process did not initialize its persistence writer lease";
+    let state = ProcessWriterState::Uninitialized;
+
+    assert_eq!(
+        state.access(),
+        PersistenceAccess::ReadOnly {
+            reason: Arc::from(REASON)
+        }
+    );
+    let error = state.ensure_writable().unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
+    assert_eq!(
+        error.to_string(),
+        format!("persistence is read-only: {REASON}")
+    );
+}
+
+#[test]
+fn writer_state_transitions_are_terminal_and_configured_once() {
+    let acquisitions = Cell::new(0_u8);
+    let configurations = RefCell::new(Vec::new());
+    let mut state = ProcessWriterState::Uninitialized;
+
+    assert_eq!(
+        initialize_writer_state(
+            &mut state,
+            std::iter::empty::<PathBuf>(),
+            false,
+            |_, allow_read_only| {
+                assert!(!allow_read_only);
+                acquisitions.set(acquisitions.get() + 1);
+                Ok(empty_writable_state())
+            },
+            |access| {
+                configurations.borrow_mut().push(access.is_ok());
+                Ok(())
+            },
+        )
+        .unwrap(),
+        PersistenceAccess::Writable
+    );
+    assert!(matches!(state, ProcessWriterState::Writable(_)));
+    assert_eq!(acquisitions.get(), 1);
+    assert_eq!(&*configurations.borrow(), &[true]);
+
+    assert_eq!(
+        initialize_writer_state(
+            &mut state,
+            std::iter::empty::<PathBuf>(),
+            false,
+            |_, _| panic!("an initialized writer must not reacquire its lease"),
+            |_| panic!("an initialized writer must not reconfigure mutations"),
+        )
+        .unwrap(),
+        PersistenceAccess::Writable
+    );
+    assert_eq!(
+        initialize_reader_state(&mut state, Arc::from("reader"), |_| {
+            panic!("a writer-to-reader request must not reconfigure mutations")
+        })
+        .unwrap_err()
+        .kind(),
+        std::io::ErrorKind::AlreadyExists
+    );
+    assert!(matches!(state, ProcessWriterState::Writable(_)));
+}
+
+#[test]
+fn read_only_state_cannot_upgrade_and_strict_failure_stays_uninitialized() {
+    let reason: Arc<str> = Arc::from("lease contention");
+    let mut state = ProcessWriterState::Uninitialized;
+    let configured_reason = RefCell::new(None::<Arc<str>>);
+    assert!(matches!(
+        initialize_writer_state(
+            &mut state,
+            std::iter::empty::<PathBuf>(),
+            true,
+            |_, allow_read_only| {
+                assert!(allow_read_only);
+                Ok(InitializedWriterState::ReadOnly(Arc::clone(&reason)))
+            },
+            |access| {
+                *configured_reason.borrow_mut() = access.err();
+                Ok(())
+            },
+        )
+        .unwrap(),
+        PersistenceAccess::ReadOnly { .. }
+    ));
+    assert_eq!(
+        configured_reason.borrow().as_deref(),
+        Some("lease contention")
+    );
+
+    assert!(matches!(
+        initialize_writer_state(
+            &mut state,
+            std::iter::empty::<PathBuf>(),
+            true,
+            |_, _| panic!("a read-only process must not attempt an upgrade"),
+            |_| panic!("a read-only process must not reconfigure mutations"),
+        )
+        .unwrap(),
+        PersistenceAccess::ReadOnly { .. }
+    ));
+    assert_eq!(
+        initialize_writer_state(
+            &mut state,
+            std::iter::empty::<PathBuf>(),
+            false,
+            |_, _| panic!("a strict request cannot upgrade a read-only process"),
+            |_| panic!("a strict request cannot reconfigure a read-only process"),
+        )
+        .unwrap_err()
+        .kind(),
+        std::io::ErrorKind::WouldBlock
+    );
+
+    let mut failed = ProcessWriterState::Uninitialized;
+    let error = initialize_writer_state(
+        &mut failed,
+        std::iter::empty::<PathBuf>(),
+        false,
+        |_, _| Err(std::io::Error::other("acquisition failed")),
+        |_| panic!("failed acquisition must not configure mutations"),
+    )
+    .unwrap_err();
+    assert_eq!(error.to_string(), "acquisition failed");
+    assert!(matches!(failed, ProcessWriterState::Uninitialized));
+
+    let mut reader = ProcessWriterState::Uninitialized;
+    let reader_reason: Arc<str> = Arc::from("explicit reader");
+    assert!(matches!(
+        initialize_reader_state(&mut reader, Arc::clone(&reader_reason), |access| {
+            assert_eq!(access.err().as_deref(), Some("explicit reader"));
+            Ok(())
+        })
+        .unwrap(),
+        PersistenceAccess::ReadOnly { .. }
+    ));
+    assert!(matches!(reader, ProcessWriterState::ReadOnly(_)));
+    assert!(matches!(
+        initialize_reader_state(&mut reader, Arc::from("ignored"), |_| {
+            panic!("an initialized reader must not reconfigure mutations")
+        })
+        .unwrap(),
+        PersistenceAccess::ReadOnly { .. }
+    ));
+}
+
+#[test]
+fn failed_state_publication_drops_the_acquired_lease() {
+    let root = test_dir("state-publication-rollback");
+    let mut state = ProcessWriterState::Uninitialized;
+    let error =
+        initialize_writer_state(&mut state, [&root], false, acquire_state_for_roots, |_| {
+            Err(std::io::Error::other("mutation gate rejected state"))
+        })
+        .unwrap_err();
+    assert_eq!(error.to_string(), "mutation gate rejected state");
+    assert!(matches!(state, ProcessWriterState::Uninitialized));
+
+    let successor = acquire_state_for_roots([&root], false).unwrap();
+    successor.ensure_writable().unwrap();
+    drop(successor);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn rejected_read_only_configurations_leave_process_uninitialized() {
+    let mut fallback = ProcessWriterState::Uninitialized;
+    let error = initialize_writer_state(
+        &mut fallback,
+        std::iter::empty::<PathBuf>(),
+        true,
+        |_, _| {
+            Ok(InitializedWriterState::ReadOnly(Arc::from(
+                "injected lease contention",
+            )))
+        },
+        |_| Err(std::io::Error::other("mutation gate rejected fallback")),
+    )
+    .unwrap_err();
+    assert_eq!(error.to_string(), "mutation gate rejected fallback");
+    assert!(matches!(fallback, ProcessWriterState::Uninitialized));
+
+    let mut reader = ProcessWriterState::Uninitialized;
+    let error = initialize_reader_state(&mut reader, Arc::from("explicit reader"), |_| {
+        Err(std::io::Error::other("mutation gate rejected reader"))
+    })
+    .unwrap_err();
+    assert_eq!(error.to_string(), "mutation gate rejected reader");
+    assert!(matches!(reader, ProcessWriterState::Uninitialized));
+}
+
+#[test]
+fn configured_roots_include_the_local_index_storage_domain() {
+    let roots = configured_roots();
+    let local_index_root = crate::paths::local_index_data_dir().unwrap();
+
+    assert!(roots.contains(&local_index_root));
+    assert_eq!(
+        roots.len(),
+        4,
+        "all four configured storage domains remain leased"
+    );
+}
+
+#[test]
+fn shared_root_is_deduplicated_and_only_one_writer_wins() {
+    let root = test_dir("dedupe");
+    let primary = acquire_state_for_roots([&root, &root, &root], false).unwrap();
+    primary.ensure_writable().unwrap();
+    let secondary = acquire_state_for_roots([&root], true).unwrap();
+    assert_read_only(&secondary);
+    drop(primary);
+    acquire_state_for_roots([&root], false)
+        .unwrap()
+        .ensure_writable()
+        .unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn shared_config_with_split_data_and_cache_blocks_second_writer() {
+    let shared = test_dir("shared-config");
+    let a_data = test_dir("a-data");
+    let a_cache = test_dir("a-cache");
+    let b_data = test_dir("b-data");
+    let b_cache = test_dir("b-cache");
+    let primary = acquire_state_for_roots([&shared, &a_data, &a_cache], false).unwrap();
+    let secondary = acquire_state_for_roots([&shared, &b_data, &b_cache], true).unwrap();
+    assert_read_only(&secondary);
+    drop(primary);
+    for path in [shared, a_data, a_cache, b_data, b_cache] {
+        let _ = std::fs::remove_dir_all(path);
+    }
+}
+
+#[test]
+fn shared_cache_with_split_config_and_data_blocks_second_writer() {
+    let shared = test_dir("shared-cache");
+    let a_config = test_dir("a-config");
+    let a_data = test_dir("a-data");
+    let b_config = test_dir("b-config");
+    let b_data = test_dir("b-data");
+    let primary = acquire_state_for_roots([&a_config, &a_data, &shared], false).unwrap();
+    let secondary = acquire_state_for_roots([&b_config, &b_data, &shared], true).unwrap();
+    assert_read_only(&secondary);
+    drop(primary);
+    for path in [shared, a_config, a_data, b_config, b_data] {
+        let _ = std::fs::remove_dir_all(path);
+    }
+}
+
+#[test]
+fn fully_split_roots_allow_independent_writers() {
+    let a = [
+        test_dir("a-config"),
+        test_dir("a-data"),
+        test_dir("a-cache"),
+    ];
+    let b = [
+        test_dir("b-config"),
+        test_dir("b-data"),
+        test_dir("b-cache"),
+    ];
+    let first = acquire_state_for_roots(&a, false).unwrap();
+    let second = acquire_state_for_roots(&b, false).unwrap();
+    first.ensure_writable().unwrap();
+    second.ensure_writable().unwrap();
+    drop((first, second));
+    for path in a.into_iter().chain(b) {
+        let _ = std::fs::remove_dir_all(path);
+    }
+}
+
+#[test]
+fn partial_acquisition_failure_releases_all_earlier_roots() {
+    let earlier = test_dir("a-earlier");
+    let later = test_dir("z-later");
+    let held_later = crate::util::safe_fs::try_lock_private_file(
+        &normalize_root(&later).unwrap().join(WRITER_LEASE_FILE),
+    )
+    .unwrap()
+    .unwrap();
+
+    let failed = acquire_state_for_roots([&earlier, &later], true).unwrap();
+    assert_read_only(&failed);
+    let earlier_lock = crate::util::safe_fs::try_lock_private_file(
+        &normalize_root(&earlier).unwrap().join(WRITER_LEASE_FILE),
+    )
+    .unwrap();
+    assert!(
+        earlier_lock.is_some(),
+        "partial lease stranded the first root"
+    );
+
+    drop((earlier_lock, held_later));
+    let _ = std::fs::remove_dir_all(earlier);
+    let _ = std::fs::remove_dir_all(later);
+}
+
+#[test]
+fn primary_remains_writable_until_drop_then_successor_acquires_every_root() {
+    let roots = [test_dir("config"), test_dir("data"), test_dir("cache")];
+    let primary = acquire_state_for_roots(&roots, false).unwrap();
+    primary.ensure_writable().unwrap();
+    assert_read_only(&acquire_state_for_roots(&roots, true).unwrap());
+
+    drop(primary);
+    let successor = acquire_state_for_roots(&roots, false).unwrap();
+    successor.ensure_writable().unwrap();
+    drop(successor);
+    for path in roots {
+        let _ = std::fs::remove_dir_all(path);
+    }
+}


### PR DESCRIPTION
## Summary

- Model the process writer lifecycle with explicit uninitialized, writable, and read-only states, while making an uninitialized acquisition result impossible.
- Model snapshot admission/publication and panic-shadow publication/sealing as explicit enums.
- Require a shadow-covered operation before pending-map insertion and an exact journal-completion token before resolving a snapshot.
- Linearize clean-shutdown sealing under the pending mutex and preserve immediate ordering failures ahead of intent-lock acquisition.
- Extract snapshot state and writer-lease tests into focused modules, with deterministic transition, race, rollback, supersession, stale-completion, and default-deny coverage.

## Why

Persistence and recovery behavior had accumulated correlated booleans, optional states, and ordering conventions. Making these transitions explicit removes invalid combinations and turns shadow ownership, admission sealing, and journal completion into type-checked invariants.

## Compatibility

- No CLI or UI/UX changes.
- No journal schema or persisted-store format changes.
- No dependency or lockfile changes.

## Validation

- Canonical `run-gates`: passed (fmt, workspace/all-target clippy with warnings denied, workspace tests, architecture checks).
- Native workspace tests: 3,303 library + 21 main + 21 dev + 18 CLI smoke passed.
- Focused persistence tests: 82 passed serially.
- Windows GNU workspace/all-target checks: passed with default and desktop features.
- Correctness, stability, test, and architecture reviews: no blocker/high/medium findings; skill gates 100/100.