### PR TITLE
Harden MPRIS controls and enable KDE 26.04+ Sixel

### DIFF
--- a/crates/ratatui-image/PATCHES.md
+++ b/crates/ratatui-image/PATCHES.md
@@ -18,8 +18,10 @@ The fork is intentionally narrow and should stay easy to rebase onto a future up
 - Kitty rows damaged by overlay redraws can be marked for retransmission.
 - Sixel and iTerm2 encodes stamp the anchor cell with a monotonic redraw tag so freshly rebuilt
   protocols are not skipped by ratatui's diffing.
-- Konsole versions before 26.08 keep Kitty and Sixel capability queries disabled; 26.08 and newer
-  may select Sixel only after DA1 advertises it and the cell-size query returns usable dimensions.
+- KonsolePart versions before 26.04 keep Kitty and Sixel capability queries disabled. Konsole and
+  Yakuake on 26.04 and newer may select Sixel only after DA1 advertises it and the cell-size query
+  returns usable dimensions. This is best-effort on 26.04-26.07 because the upstream placement
+  cleanup landed for 26.08; users can force `YTM_TUI_IMAGE_PROTOCOL=halfblocks` if fragments linger.
 
 All local code changes should include a nearby `yututui patch` comment. CI runs
 `scripts/check-ratatui-image-patch.sh` to catch accidental removal of the path patch, base-version

--- a/crates/ratatui-image/src/picker.rs
+++ b/crates/ratatui-image/src/picker.rs
@@ -45,8 +45,8 @@ pub enum Capability {
 
 const STDIN_READ_TIMEOUT_MILLIS: u64 = 2000;
 
-// yututui patch: Konsole's 26.08 line includes the Sixel placement cleanup needed for TUI redraws.
-const KONSOLE_SIXEL_TUI_MIN_VERSION: u32 = 260_800;
+// yututui patch: allow a conservative, capability-gated Sixel probe on KDE 26.04+.
+const KONSOLE_SIXEL_TUI_MIN_VERSION: u32 = 260_400;
 
 #[derive(Clone, Debug)]
 pub struct Picker {
@@ -126,7 +126,7 @@ impl Picker {
         let wezterm_executable = env::var("WEZTERM_EXECUTABLE").ok();
         let konsole_version = env::var("KONSOLE_VERSION").ok();
         let term = env::var("TERM").ok();
-        let require_reported_cell_size_for_konsole_sixel = konsole_supports_sixel_tui_redraws(
+        let require_reported_cell_size_for_konsole_sixel = konsole_allows_capability_gated_sixel(
             wezterm_executable.as_deref(),
             konsole_version.as_deref(),
             term.as_deref(),
@@ -340,7 +340,7 @@ impl Picker {
     }
 }
 
-// yututui patch: keep older/unknown Konsole versions conservative, and capability-gate 26.08+.
+// yututui patch: keep older/unknown Konsole versions conservative, and capability-gate 26.04+.
 fn terminal_protocol_blacklist(
     wezterm_executable: Option<&str>,
     konsole_version: Option<&str>,
@@ -359,7 +359,7 @@ fn terminal_protocol_blacklist(
         return Vec::new();
     }
 
-    if konsole_supports_sixel_tui_redraws(wezterm_executable, konsole_version, term) {
+    if konsole_allows_capability_gated_sixel(wezterm_executable, konsole_version, term) {
         // Konsole's Kitty implementation still lacks Unicode placeholders. Sixel remains subject
         // to the normal DA1 capability and cell-size response checks below.
         vec![ProtocolType::Kitty]
@@ -368,7 +368,7 @@ fn terminal_protocol_blacklist(
     }
 }
 
-fn konsole_supports_sixel_tui_redraws(
+fn konsole_allows_capability_gated_sixel(
     wezterm_executable: Option<&str>,
     konsole_version: Option<&str>,
     term: Option<&str>,
@@ -812,35 +812,35 @@ mod tests {
             Case {
                 name: "invalid Konsole version stays conservative",
                 wezterm_executable: None,
-                konsole_version: Some("26.08"),
+                konsole_version: Some("26.04"),
                 term: Some("xterm-256color"),
                 expected: vec![ProtocolType::Kitty, ProtocolType::Sixel],
             },
             Case {
-                name: "Konsole before 26.08 stays conservative",
+                name: "Konsole before 26.04 stays conservative",
                 wezterm_executable: None,
-                konsole_version: Some("260799"),
+                konsole_version: Some("260399"),
                 term: Some("xterm-256color"),
                 expected: vec![ProtocolType::Kitty, ProtocolType::Sixel],
             },
             Case {
-                name: "Konsole 26.08 allows Sixel capability queries",
+                name: "Konsole 26.04 allows Sixel capability queries",
                 wezterm_executable: None,
-                konsole_version: Some("260800"),
-                term: Some("xterm-256color"),
+                konsole_version: Some("260400"),
+                term: Some("konsole-256color"),
                 expected: vec![ProtocolType::Kitty],
             },
             Case {
-                name: "newer Konsole allows Sixel capability queries",
+                name: "Yakuake KonsolePart hint works with a generic TERM",
                 wezterm_executable: None,
-                konsole_version: Some("260801"),
+                konsole_version: Some("260401"),
                 term: Some("xterm-256color"),
                 expected: vec![ProtocolType::Kitty],
             },
             Case {
                 name: "WezTerm policy wins over a new Konsole hint",
                 wezterm_executable: Some("wezterm-gui"),
-                konsole_version: Some("260800"),
+                konsole_version: Some("260400"),
                 term: Some("konsole-256color"),
                 expected: vec![ProtocolType::Kitty, ProtocolType::Sixel],
             },
@@ -874,11 +874,11 @@ mod tests {
             Parser::query(false, options)
         };
 
-        let old_konsole_query = query_for("260799");
+        let old_konsole_query = query_for("260399");
         assert!(!old_konsole_query.contains("_Gi="));
         assert!(!old_konsole_query.contains("\x1b[c"));
 
-        let new_konsole_query = query_for("260800");
+        let new_konsole_query = query_for("260400");
         assert!(!new_konsole_query.contains("_Gi="));
         assert!(new_konsole_query.contains("\x1b[c"));
     }
@@ -886,7 +886,7 @@ mod tests {
     #[test]
     fn test_terminal_blacklist_preserves_caller_entries() {
         let mut blacklist = vec![ProtocolType::Iterm2];
-        for protocol in terminal_protocol_blacklist(None, Some("260799"), None) {
+        for protocol in terminal_protocol_blacklist(None, Some("260399"), None) {
             if !blacklist.contains(&protocol) {
                 blacklist.push(protocol);
             }

--- a/docs/terminal-compatibility.md
+++ b/docs/terminal-compatibility.md
@@ -1,6 +1,6 @@
 # Terminal Compatibility
 
-Status: initial public-beta matrix, updated 2026-07-13. Entries marked
+Status: initial public-beta matrix, updated 2026-07-15. Entries marked
 `Expected` still need a dated ytm-tui smoke run before they are marketed as
 fully verified.
 
@@ -31,7 +31,7 @@ ytm-tui configuration.
 | Legacy conhost / bare cmd.exe | Unknown / Versioned | Expected partial | Version-dependent | Yes | Expected only in a desktop session with mpv | Unknown | Do not promise without a Windows build and terminal version. |
 | Ghostty | Expected via Kitty graphics | Expected | Expected; grapheme clustering is documented | Yes | Expected on macOS/Linux with mpv | Unknown unless OSC 66 lands or DECDHL probe passes | Windows support must be verified separately. |
 | foot | Expected via Sixel | Expected | Expected; package descriptions document IME through text-input-v3 | Yes | Expected on Linux GUI with mpv | Unknown | Wayland-only in normal use; verify on the target compositor. |
-| Konsole / Yakuake | Versioned: < 26.08 defaults to halfblocks; >= 26.08 is Expected via capability-gated Sixel | Expected | Expected | Yes | Expected on Linux GUI with mpv | Unknown | Yakuake inherits Konsole's terminal behavior. Sixel is selected only when DA1 advertises it and a real cell size is obtained; Kitty is not recommended. |
+| Konsole / Yakuake | Versioned: < 26.04 defaults to halfblocks; >= 26.04 is best-effort via capability-gated Sixel | Expected | Expected | Yes | Expected on Linux GUI with mpv | Unknown | Yakuake inherits KonsolePart's terminal behavior. Sixel is selected only when DA1 advertises it and a real cell size is obtained; Kitty is not recommended. |
 | mintty | Expected via Sixel | Expected | Expected | Yes | Expected on Windows desktop with mpv | Unknown | Probe longer, but Sixel is the first override to try. |
 | mlterm | Expected via Sixel | Expected | Expected | Yes | Expected on GUI OS with mpv | Unknown | Probe longer, but Sixel is the first override to try. |
 | VS Code integrated terminal | Fallback: halfblocks | Expected | Expected | Yes | Expected only through the host desktop session | Unknown | Keep conservative fallback unless a specific VS Code build is verified. |
@@ -44,12 +44,18 @@ ytm-tui configuration.
 - Album art uses `ratatui-image`, which can query Kitty, Sixel, iTerm2, and
   halfblock fallback protocols. If stdout is not a TTY, ytm-tui skips image
   probing and uses halfblocks.
-- Detected Konsole and Yakuake versions older than 26.08, or detected sessions
-  without a valid `KONSOLE_VERSION`, stay on halfblocks by default. Starting with 26.08,
+- Detected KonsolePart versions older than 26.04, or detected sessions without a
+  valid `KONSOLE_VERSION`, stay on halfblocks by default. Starting with 26.04,
   ytm-tui permits a Sixel probe and selects Sixel only when DA1 advertises the
-  capability and the terminal returns a real cell size. A missing response or
-  either failed check still falls back to halfblocks. Kitty is not part of the
-  normal Konsole/Yakuake path.
+  capability and the terminal returns a real cell size. Yakuake exports the
+  embedded KonsolePart version through the same variable, so this also works
+  when its `TERM` is a generic `xterm-256color`. A missing response or either
+  failed check still falls back to halfblocks. Kitty is not part of the normal
+  Konsole/Yakuake path.
+- Sixel on KonsolePart 26.04-26.07 is best-effort: the upstream fix that clears
+  lingering non-Kitty image placements during TUI redraws landed for
+  [Konsole 26.08](https://github.com/KDE/konsole/commit/a05e38fc6aa28ccb0e7875c82bd4d7a0b4e26cf5).
+  Set `YTM_TUI_IMAGE_PROTOCOL=halfblocks` if an older build leaves fragments.
 - Text zoom uses OSC 66 when the probe succeeds, `WT_SESSION` / DECDHL where
   applicable, and otherwise stays at 100%.
 - Keyboard enhancement intentionally omits `REPORT_ALL_KEYS_AS_ESCAPE_CODES` so
@@ -85,10 +91,11 @@ Recommended first override by terminal:
 | Konsole / Yakuake | `YTM_TUI_IMAGE_PROTOCOL=sixel` | None |
 | Unknown native hint | `YTM_TUI_IMAGE_PROTOCOL=kitty` | `iterm2`, `sixel` |
 
-On Konsole/Yakuake versions older than 26.08, manually forcing Sixel is an
+On KonsolePart versions older than 26.04, manually forcing Sixel is an
 experimental escape hatch: it bypasses the conservative default and may leave
 stale or broken image fragments. Do not use Kitty as the normal Konsole or
-Yakuake override.
+Yakuake override. On 26.04 and newer, force
+`YTM_TUI_IMAGE_PROTOCOL=halfblocks` to opt out if Sixel still misbehaves.
 
 ## Smoke Runbook
 

--- a/src/app/media_reducer.rs
+++ b/src/app/media_reducer.rs
@@ -190,10 +190,14 @@ impl App {
                 // Same radio guard as SetShuffle — and never remote-trigger a re-sync. Also
                 // enforce the music-mode invariant: an OS widget can't enable repeat while
                 // autoplay streaming is on.
-                if self.current_is_radio_stream()
-                    || self.queue.repeat == mode
-                    || mode.set_blocked_by_streaming(self.autoplay_streaming)
-                {
+                if self.current_is_radio_stream() {
+                    return Vec::new();
+                }
+                if mode.set_blocked_by_streaming(self.autoplay_streaming) {
+                    self.show_repeat_streaming_conflict();
+                    return Vec::new();
+                }
+                if self.queue.repeat == mode {
                     return Vec::new();
                 }
                 self.queue.repeat = mode;
@@ -805,6 +809,56 @@ mod tests {
         assert!(cmds.iter().any(
             |c| matches!(c, Cmd::Persist(PersistCmd::Config(cfg)) if cfg.repeat == Repeat::One)
         ));
+        assert!(
+            app.update(Msg::Media(MediaCommand::SetRepeat(Repeat::One)))
+                .is_empty(),
+            "same repeat value must not churn persisted config"
+        );
+    }
+
+    #[test]
+    fn repeat_from_media_session_rejects_streaming_conflict_with_toast() {
+        let mut app = app_with_queue(3);
+        app.autoplay_streaming = true;
+        app.config.autoplay_streaming = Some(true);
+        app.status.text = "before".to_owned();
+        app.dirty = false;
+
+        let cmds = app.update(Msg::Media(MediaCommand::SetRepeat(Repeat::All)));
+
+        assert!(
+            cmds.is_empty(),
+            "a rejection must not persist or emit effects"
+        );
+        assert_eq!(app.queue.repeat, Repeat::Off);
+        assert_eq!(app.config.repeat, Repeat::Off);
+        assert!(app.autoplay_streaming);
+        assert_eq!(app.config.autoplay_streaming, Some(true));
+        assert!(matches!(
+            app.status.text.as_str(),
+            "Can't use repeat while autoplay is on" | "자동재생 중에는 반복을 켤 수 없어요"
+        ));
+        assert!(app.dirty, "the localized rejection notice must redraw");
+
+        // A legacy/inconsistent state may already contain both modes. Even an
+        // idempotent MPRIS write must explain why repeat is incompatible instead of
+        // silently disappearing behind the same-value no-op.
+        app.queue.repeat = Repeat::All;
+        app.config.repeat = Repeat::All;
+        app.status.text = "before same-value conflict".to_owned();
+        app.dirty = false;
+
+        let cmds = app.update(Msg::Media(MediaCommand::SetRepeat(Repeat::All)));
+
+        assert!(cmds.is_empty());
+        assert_eq!(app.queue.repeat, Repeat::All);
+        assert_eq!(app.config.repeat, Repeat::All);
+        assert!(app.autoplay_streaming);
+        assert!(matches!(
+            app.status.text.as_str(),
+            "Can't use repeat while autoplay is on" | "자동재생 중에는 반복을 켤 수 없어요"
+        ));
+        assert!(app.dirty, "same-value conflict notice must redraw");
     }
 
     #[test]

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -96,6 +96,17 @@ pub(in crate::app) struct YidMemo {
 }
 
 impl App {
+    /// Show the shared music-mode rejection used when a local or media-session
+    /// control tries to enable repeat while autoplay streaming is active.
+    pub(in crate::app) fn show_repeat_streaming_conflict(&mut self) {
+        self.status.text = t!(
+            "Can't use repeat while autoplay is on",
+            "자동재생 중에는 반복을 켤 수 없어요"
+        )
+        .to_owned();
+        self.dirty = true;
+    }
+
     /// Handle an mpv playback error: self-heal a stale-yt-dlp extraction failure
     /// once, otherwise skip the bad track (with a circuit breaker after too many in a
     /// row). Extracted verbatim from the `PlayerMsg::Error` dispatch arm; the
@@ -710,12 +721,7 @@ impl App {
                     .repeat
                     .cycle_blocked_by_streaming(self.autoplay_streaming)
                 {
-                    self.status.text = t!(
-                        "Can't use repeat while autoplay is on",
-                        "자동재생 중에는 반복을 켤 수 없어요"
-                    )
-                    .to_owned();
-                    self.dirty = true;
+                    self.show_repeat_streaming_conflict();
                     return Vec::new();
                 }
                 self.queue.cycle_repeat();

--- a/src/daemon/parity_tests.rs
+++ b/src/daemon/parity_tests.rs
@@ -25,6 +25,7 @@ use crate::api::Song;
 use crate::app::{App, Cmd, Msg, PlayerControl, PlayerMsg};
 use crate::config::Config;
 use crate::library::Library;
+use crate::media::MediaCommand;
 use crate::queue::{Queue, QueueSnapshot, Repeat};
 use crate::remote::proto::{
     GuiSettingChange, InstanceMode, PlayerModel, QueueModel, RateChange, RemoteCommand,
@@ -751,6 +752,105 @@ async fn daemon_conflict_disables_remain_allowed() {
         assert!(effects.is_empty());
         assert!(status.streaming);
         assert_eq!(status.repeat, Repeat::Off);
+    }
+}
+
+#[tokio::test]
+async fn media_option_commands_keep_both_owners_in_lockstep() {
+    let (mut app, mut engine) = hermetic_pair();
+    for (step, command) in [
+        ("media shuffle on", MediaCommand::SetShuffle(true)),
+        ("media shuffle same-value", MediaCommand::SetShuffle(true)),
+        ("media shuffle off", MediaCommand::SetShuffle(false)),
+        ("media repeat all", MediaCommand::SetRepeat(Repeat::All)),
+        ("media repeat one", MediaCommand::SetRepeat(Repeat::One)),
+        ("media repeat off", MediaCommand::SetRepeat(Repeat::Off)),
+        ("media volume fractional", MediaCommand::SetVolume(0.37)),
+        ("media volume upper clamp", MediaCommand::SetVolume(9.0)),
+        ("media volume lower clamp", MediaCommand::SetVolume(-3.0)),
+        ("media volume NaN", MediaCommand::SetVolume(f64::NAN)),
+        (
+            "media volume infinity",
+            MediaCommand::SetVolume(f64::INFINITY),
+        ),
+    ] {
+        let app_commands = app.update(Msg::Media(command.clone()));
+        admit_app_player_intents(&mut app, app_commands);
+        let (shutdown, effects) = engine.handle_media(command).await;
+        assert!(!shutdown, "{step} requested shutdown");
+        assert!(effects.is_empty(), "{step} emitted daemon effects");
+        assert_parity(step, &app, &engine);
+    }
+}
+
+#[tokio::test]
+async fn media_repeat_streaming_conflict_rejects_in_lockstep() {
+    let (mut app, mut engine) = hermetic_pair();
+    app.autoplay_streaming = true;
+    app.config.autoplay_streaming = Some(true);
+    app.status.text = "before".to_owned();
+    app.dirty = false;
+    let (response, shutdown, _) = engine
+        .handle_remote(RemoteCommand::Streaming {
+            state: ToggleState::On,
+        })
+        .await;
+    assert!(response.ok && !shutdown, "test setup must enable streaming");
+    assert_parity("media repeat streaming setup", &app, &engine);
+
+    let app_commands = app.update(Msg::Media(MediaCommand::SetRepeat(Repeat::All)));
+    let (shutdown, effects) = engine
+        .handle_media(MediaCommand::SetRepeat(Repeat::All))
+        .await;
+
+    assert!(app_commands.is_empty(), "App rejection emitted effects");
+    assert!(!shutdown);
+    assert!(effects.is_empty(), "daemon rejection emitted effects");
+    assert!(matches!(
+        app.status.text.as_str(),
+        "Can't use repeat while autoplay is on" | "자동재생 중에는 반복을 켤 수 없어요"
+    ));
+    assert!(app.dirty, "the App rejection toast must redraw");
+    assert_parity("media repeat streaming rejection", &app, &engine);
+
+    // Legacy sessions may restore both modes enabled; turning repeat off must recover
+    // the invariant in both owners without disabling streaming.
+    let (mut app, _) = hermetic_pair();
+    app.autoplay_streaming = true;
+    app.config.autoplay_streaming = Some(true);
+    app.queue.repeat = Repeat::One;
+    let mut engine = engine_with_modes(Repeat::One, true).await;
+    let _ = app.update(Msg::Media(MediaCommand::SetRepeat(Repeat::Off)));
+    let (shutdown, effects) = engine
+        .handle_media(MediaCommand::SetRepeat(Repeat::Off))
+        .await;
+    assert!(!shutdown && effects.is_empty());
+    assert!(app.autoplay_streaming && app.queue.repeat == Repeat::Off);
+    assert_parity("media repeat legacy disable", &app, &engine);
+}
+
+#[tokio::test]
+async fn media_shuffle_and_repeat_are_radio_noops_in_lockstep() {
+    let (mut app, mut engine) = hermetic_pair();
+    let mut station = Song::remote("radio", "Radio", "", "");
+    station.playable = Some(crate::api::PlayableRef::RadioStream {
+        url: "https://radio.example/stream".to_owned(),
+    });
+    let mut queue = Queue::default();
+    queue.set(vec![station], 0);
+    let snapshot = queue.snapshot();
+    app.queue.restore_snapshot(snapshot.clone());
+    engine.restore_queue_snapshot(snapshot, RNG_SEED);
+
+    for (step, command) in [
+        ("radio media shuffle", MediaCommand::SetShuffle(true)),
+        ("radio media repeat", MediaCommand::SetRepeat(Repeat::All)),
+    ] {
+        assert!(app.update(Msg::Media(command.clone())).is_empty());
+        let (shutdown, effects) = engine.handle_media(command).await;
+        assert!(!shutdown);
+        assert!(effects.is_empty());
+        assert_parity(step, &app, &engine);
     }
 }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const KONSOLE_SIXEL_TUI_MIN_VERSION: u32 = 260_800;
+const KONSOLE_SIXEL_TUI_MIN_VERSION: u32 = 260_400;
 
 #[path = "doctor/directory_probe.rs"]
 mod directory_probe;
@@ -1312,11 +1312,15 @@ mod tests {
                 "halfblocks"
             );
             assert_eq!(
-                terminal_image_protocol(Some("xterm-256color"), None, false, Some("260799")),
+                terminal_image_protocol(Some("xterm-256color"), None, false, Some("260399")),
                 "halfblocks"
             );
             assert_eq!(
-                terminal_image_protocol(Some("xterm-256color"), None, false, Some("260800")),
+                terminal_image_protocol(Some("konsole-256color"), None, false, Some("260400")),
+                "sixel_versioned"
+            );
+            assert_eq!(
+                terminal_image_protocol(Some("xterm-256color"), None, false, Some("260401")),
                 "sixel_versioned"
             );
             assert_eq!(
@@ -1401,7 +1405,7 @@ mod tests {
             );
         });
 
-        with_terminal_env(&[("KONSOLE_VERSION", Some("260800"))], || {
+        with_terminal_env(&[("KONSOLE_VERSION", Some("260400"))], || {
             assert!(terminal_native_image_hint(None, None, false));
             assert_eq!(
                 terminal_image_override_suggestions(None, None, false),

--- a/src/media/mpris.rs
+++ b/src/media/mpris.rs
@@ -531,6 +531,7 @@ impl mpris_server::PlayerInterface for Player {
 mod tests {
     use super::*;
     use crate::media::{MediaCaps, MediaTrack};
+    use crate::util::delivery::DeliveryReceipt;
 
     #[test]
     fn track_id_escapes_per_spec() {
@@ -572,6 +573,110 @@ mod tests {
             player.send_zbus(MediaCommand::Pause),
             Err(zbus::Error::Failure(message)) if message.contains("busy")
         ));
+    }
+
+    #[tokio::test]
+    async fn writable_playback_options_read_and_forward_exact_values() {
+        let mut snapshot = MediaSnapshot::idle();
+        snapshot.shuffle = true;
+        snapshot.repeat = Repeat::All;
+        snapshot.volume = 0.37;
+
+        let commands = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&commands);
+        let player = Player {
+            sink: Arc::new(move |command| {
+                captured.lock().unwrap().push(command);
+                Ok(DeliveryReceipt::Enqueued)
+            }),
+            state: Arc::new(Mutex::new(snapshot)),
+        };
+
+        assert!(
+            mpris_server::PlayerInterface::shuffle(&player)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            mpris_server::PlayerInterface::loop_status(&player)
+                .await
+                .unwrap(),
+            LoopStatus::Playlist
+        );
+        assert_eq!(
+            mpris_server::PlayerInterface::volume(&player)
+                .await
+                .unwrap(),
+            0.37
+        );
+
+        for (repeat, expected) in [
+            (Repeat::Off, LoopStatus::None),
+            (Repeat::One, LoopStatus::Track),
+            (Repeat::All, LoopStatus::Playlist),
+        ] {
+            player.state.lock().unwrap().repeat = repeat;
+            assert_eq!(
+                mpris_server::PlayerInterface::loop_status(&player)
+                    .await
+                    .unwrap(),
+                expected
+            );
+        }
+
+        mpris_server::PlayerInterface::set_shuffle(&player, false)
+            .await
+            .unwrap();
+        for loop_status in [LoopStatus::None, LoopStatus::Track, LoopStatus::Playlist] {
+            mpris_server::PlayerInterface::set_loop_status(&player, loop_status)
+                .await
+                .unwrap();
+        }
+        for volume in [-0.5, 0.0, 0.37, 1.0, 1.5] {
+            mpris_server::PlayerInterface::set_volume(&player, volume)
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(
+            *commands.lock().unwrap(),
+            vec![
+                MediaCommand::SetShuffle(false),
+                MediaCommand::SetRepeat(Repeat::Off),
+                MediaCommand::SetRepeat(Repeat::One),
+                MediaCommand::SetRepeat(Repeat::All),
+                MediaCommand::SetVolume(-0.5),
+                MediaCommand::SetVolume(0.0),
+                MediaCommand::SetVolume(0.37),
+                MediaCommand::SetVolume(1.0),
+                MediaCommand::SetVolume(1.5),
+            ]
+        );
+    }
+
+    #[test]
+    fn option_changes_emit_exact_mpris_properties() {
+        let mut snapshot = MediaSnapshot::idle();
+        snapshot.rate = 1.25;
+        snapshot.volume = 0.75;
+        snapshot.shuffle = true;
+        snapshot.repeat = Repeat::One;
+
+        assert_eq!(
+            changed_properties(
+                &snapshot,
+                MediaChanges {
+                    options: true,
+                    ..MediaChanges::default()
+                }
+            ),
+            vec![
+                Property::Rate(1.25),
+                Property::Volume(0.75),
+                Property::Shuffle(true),
+                Property::LoopStatus(LoopStatus::Track),
+            ]
+        );
     }
 
     #[test]

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -658,7 +658,11 @@ fn doctor_terminal_json_reports_capabilities_without_config_or_runtime_startup()
             .output()
             .expect("Konsole doctor terminal JSON")
     };
-    for (version, expected) in [("260799", "halfblocks"), ("260800", "sixel_versioned")] {
+    for (version, expected) in [
+        ("260399", "halfblocks"),
+        ("260400", "sixel_versioned"),
+        ("260401", "sixel_versioned"),
+    ] {
         let output = run_konsole_doctor(version);
         assert!(output.status.success(), "stderr: {}", stderr(&output));
         let json: serde_json::Value =


### PR DESCRIPTION
## What changed

- Reuse the localized repeat/autoplay conflict toast when an OS media session requests repeat while autoplay streaming is active.
- Add App/daemon lockstep coverage for MPRIS shuffle, repeat, and volume behavior, plus Linux adapter getter/setter and changed-property tests.
- Allow capability-gated Sixel probing for KonsolePart 26.04+ (`KONSOLE_VERSION >= 260400`), covering Konsole and Yakuake while preserving DA1, cell-size, WezTerm, and explicit override guards.
- Document the 26.04 best-effort limitation and the `YTM_TUI_IMAGE_PROTOCOL=halfblocks` opt-out.

## Why

Shuffle and volume were already wired correctly, and ordinary repeat mapping worked. The remaining behavioral gap was a repeat-on request rejected during autoplay without any TUI feedback. The existing Konsole gate was also fixed at 26.08 even though this app can offer an explicitly best-effort, capability-checked path for the 26.04 line.

## User impact

Blocked MPRIS repeat requests now explain the autoplay conflict without mutating or persisting incompatible state. Konsole/Yakuake 26.04+ can select Sixel only when the terminal advertises Sixel and returns a valid cell size. KonsolePart 26.04 lacks the upstream lingering-placement cleanup, so that line remains documented as best-effort and can be forced back to halfblocks.

## Validation

- `~/.fable-harness/bin/run-gates .` — PASS (fmt, clippy with warnings denied, workspace tests, architecture, file-size, doc honesty, ratatui-image patch, unsafe inventory)
- App media reducer tests: 26/26
- App/daemon media parity tests: 3/3
- Vendored picker tests: 8/8
- Doctor terminal tests: 5/5
- CLI doctor smoke: 1/1
- Isolated tmux verification: autoplay conflict toast rendered and repeat remained off; no audio or real user config
- Linux-only MPRIS adapter tests are included and will run on Linux CI; the local macOS host cannot compile that target because the cross OpenSSL sysroot is unavailable
