### PR TITLE
Type and fuzz CLI persistence capability classification

### DIFF
--- a/src/cli_capability.rs
+++ b/src/cli_capability.rs
@@ -1,0 +1,206 @@
+//! Typed persistence-capability classification for non-interactive CLI entrypoints.
+//!
+//! Classification deliberately runs before the command parser so help and provable usage errors
+//! can exit without contending for the writer lease. Ambiguous forms fail closed as writers; only
+//! syntactically provable observational forms are downgraded to read-only access.
+
+use std::ffi::OsString;
+
+#[must_use]
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CliPersistenceCapability {
+    NotRequired,
+    ReadOnly,
+    Writer,
+}
+
+impl CliPersistenceCapability {
+    pub const fn requires_persistence(self) -> bool {
+        match self {
+            Self::NotRequired => false,
+            Self::ReadOnly | Self::Writer => true,
+        }
+    }
+
+    pub const fn allows_writes(self) -> bool {
+        match self {
+            Self::NotRequired | Self::ReadOnly => false,
+            Self::Writer => true,
+        }
+    }
+}
+
+#[must_use]
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OneShotCommand {
+    Auth,
+    Transfer,
+    Doctor,
+    Tools,
+    Update,
+}
+
+impl OneShotCommand {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Auth => "auth",
+            Self::Transfer => "transfer",
+            Self::Doctor => "doctor",
+            Self::Tools => "tools",
+            Self::Update => "update",
+        }
+    }
+
+    pub fn persistence_capability(self, args: &[String]) -> CliPersistenceCapability {
+        match self {
+            Self::Auth => auth_persistence(args),
+            Self::Transfer => transfer_persistence(args),
+            Self::Doctor => doctor_persistence(args),
+            Self::Tools => tools_persistence(args),
+            Self::Update => CliPersistenceCapability::ReadOnly,
+        }
+    }
+}
+
+pub const fn interactive_persistence_capability(new_instance: bool) -> CliPersistenceCapability {
+    if new_instance {
+        CliPersistenceCapability::ReadOnly
+    } else {
+        CliPersistenceCapability::Writer
+    }
+}
+
+/// Preserve the CLI's existing lossy `OsString` boundary without exposing non-Unicode arguments
+/// to parsers that have always accepted owned UTF-8 strings.
+pub fn collect_lossy_cli_args(args: impl IntoIterator<Item = OsString>) -> Vec<String> {
+    args.into_iter()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect()
+}
+
+fn auth_persistence(args: &[String]) -> CliPersistenceCapability {
+    match args.first().map(String::as_str) {
+        Some("lastfm" | "listenbrainz") => CliPersistenceCapability::Writer,
+        Some("spotify") => spotify_auth_persistence(&args[1..]),
+        _ => CliPersistenceCapability::NotRequired,
+    }
+}
+
+fn spotify_auth_persistence(args: &[String]) -> CliPersistenceCapability {
+    let mut it = args.iter().map(String::as_str);
+    while let Some(arg) = it.next() {
+        match arg {
+            // The command parser consumes the next token even when it looks like a flag.
+            "--client-id" if it.next().is_some() => {}
+            "--client-id" => return CliPersistenceCapability::NotRequired,
+            "--status" | "--logout" => {}
+            "--help" | "-h" => return CliPersistenceCapability::NotRequired,
+            // Unknown flags are rejected before Config/token access.
+            _ => return CliPersistenceCapability::NotRequired,
+        }
+    }
+    // Status can refresh credentials, logout removes them, and the default connect path may save
+    // both config and token state. Those valid or otherwise ambiguous forms require the writer.
+    CliPersistenceCapability::Writer
+}
+
+fn transfer_persistence(args: &[String]) -> CliPersistenceCapability {
+    match args.first().map(String::as_str) {
+        Some("list" | "jobs" | "sessions" | "session" | "report") => {
+            CliPersistenceCapability::ReadOnly
+        }
+        Some("review") => review_persistence(&args[1..]),
+        // This surface only builds and prints a plan; the parser requires `--dry-run` and has no
+        // apply path. Keeping even malformed invocations observational also preserves usage exits
+        // when another process owns the writer lease.
+        Some("download") => CliPersistenceCapability::ReadOnly,
+        Some("organize") => organize_persistence(&args[1..]),
+        Some("import" | "export" | "backup" | "resume") => CliPersistenceCapability::Writer,
+        None | Some("--help" | "-h" | "help") => CliPersistenceCapability::NotRequired,
+        Some(_) => CliPersistenceCapability::NotRequired,
+    }
+}
+
+fn review_persistence(args: &[String]) -> CliPersistenceCapability {
+    let Some(_) = args.first() else {
+        return CliPersistenceCapability::NotRequired;
+    };
+    match args.get(1).map(String::as_str) {
+        None
+        | Some("--all" | "--review" | "--accepted" | "--rejected" | "--skipped" | "--undecided") => {
+            CliPersistenceCapability::ReadOnly
+        }
+        // Known actions mutate, and an unrecognized second token enters the action parser. Keep
+        // that ambiguous path fail-closed under the writer lease rather than guessing from flags.
+        Some(_) => CliPersistenceCapability::Writer,
+    }
+}
+
+fn organize_persistence(args: &[String]) -> CliPersistenceCapability {
+    let mut dry_run = false;
+    let mut apply = false;
+    let mut has_session_id = false;
+    let mut has_root = false;
+    let mut invalid = false;
+    let mut it = args.iter().map(String::as_str);
+    while let Some(arg) = it.next() {
+        match arg {
+            "--dry-run" => dry_run = true,
+            "--apply" => apply = true,
+            "--yes" => {}
+            "--root" => {
+                if it.next().is_some() {
+                    has_root = true;
+                } else {
+                    invalid = true;
+                }
+            }
+            "--template" => {
+                if it.next().is_none() {
+                    invalid = true;
+                }
+            }
+            "--help" | "-h" => invalid = true,
+            other if other.starts_with('-') => invalid = true,
+            _ if has_session_id => invalid = true,
+            _ => has_session_id = true,
+        }
+    }
+
+    if !invalid && has_session_id && has_root && dry_run && !apply {
+        CliPersistenceCapability::ReadOnly
+    } else {
+        // `--apply` is mutating. Malformed or otherwise ambiguous forms retain the conservative
+        // writer classification instead of duplicating the command parser's full validation here.
+        CliPersistenceCapability::Writer
+    }
+}
+
+fn tools_persistence(args: &[String]) -> CliPersistenceCapability {
+    match args.first().map(String::as_str) {
+        None | Some("status") => CliPersistenceCapability::ReadOnly,
+        // These two parsers reject the missing-argument form before loading or saving state. Do
+        // not let writer-lease contention turn their stable usage exit (2) into an I/O exit (1).
+        Some("use" | "reset") if args.len() == 1 => CliPersistenceCapability::NotRequired,
+        Some("use" | "unpin" | "update" | "reset" | "diagnose") => CliPersistenceCapability::Writer,
+        Some(_) => CliPersistenceCapability::NotRequired,
+    }
+}
+
+fn doctor_persistence(args: &[String]) -> CliPersistenceCapability {
+    if matches!(args, [command, flag] if command == "privacy" && flag == "--cleanup") {
+        CliPersistenceCapability::Writer
+    } else if matches!(
+        args.first().map(String::as_str),
+        Some("--help" | "-h" | "help")
+    ) {
+        CliPersistenceCapability::NotRequired
+    } else {
+        CliPersistenceCapability::ReadOnly
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/cli_capability/tests.rs
+++ b/src/cli_capability/tests.rs
@@ -1,0 +1,645 @@
+use super::*;
+
+fn args(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_owned()).collect()
+}
+
+#[test]
+fn interactive_instances_have_explicit_capabilities() {
+    assert_eq!(
+        interactive_persistence_capability(true),
+        CliPersistenceCapability::ReadOnly
+    );
+    assert_eq!(
+        interactive_persistence_capability(false),
+        CliPersistenceCapability::Writer
+    );
+}
+
+#[test]
+fn capability_policy_truth_table_is_explicit_and_write_implies_persistence() {
+    let cases = [
+        (CliPersistenceCapability::NotRequired, false, false),
+        (CliPersistenceCapability::ReadOnly, true, false),
+        (CliPersistenceCapability::Writer, true, true),
+    ];
+    for (capability, requires_persistence, allows_writes) in cases {
+        assert_eq!(
+            capability.requires_persistence(),
+            requires_persistence,
+            "{capability:?} persistence policy"
+        );
+        assert_eq!(
+            capability.allows_writes(),
+            allows_writes,
+            "{capability:?} write policy"
+        );
+        assert!(!capability.allows_writes() || capability.requires_persistence());
+    }
+}
+
+#[test]
+fn transfer_download_and_review_views_are_observational() {
+    let classify = |values: &[&str]| OneShotCommand::Transfer.persistence_capability(&args(values));
+    assert_eq!(
+        classify(&["download", "sp2yt-1", "--accepted", "--dry-run"]),
+        CliPersistenceCapability::ReadOnly
+    );
+    assert_eq!(
+        classify(&["review", "sp2yt-1"]),
+        CliPersistenceCapability::ReadOnly
+    );
+    assert_eq!(
+        classify(&["review", "sp2yt-1", "--accepted"]),
+        CliPersistenceCapability::ReadOnly
+    );
+    assert_eq!(
+        classify(&["review", "sp2yt-1", "accept", "1"]),
+        CliPersistenceCapability::Writer
+    );
+    assert_eq!(
+        classify(&["review", "sp2yt-1", "unknown", "1"]),
+        CliPersistenceCapability::Writer
+    );
+    assert_eq!(classify(&["review"]), CliPersistenceCapability::NotRequired);
+}
+
+#[test]
+fn transfer_organize_only_downgrades_a_valid_dry_run_shape() {
+    let classify = |values: &[&str]| OneShotCommand::Transfer.persistence_capability(&args(values));
+    assert_eq!(
+        classify(&["organize", "sp2yt-1", "--root", "/tmp/library", "--dry-run",]),
+        CliPersistenceCapability::ReadOnly
+    );
+    for values in [
+        &[
+            "organize",
+            "sp2yt-1",
+            "--root",
+            "/tmp/library",
+            "--apply",
+            "--yes",
+        ][..],
+        &[
+            "organize",
+            "sp2yt-1",
+            "--root",
+            "/tmp/library",
+            "--dry-run",
+            "--apply",
+            "--yes",
+        ][..],
+        &["organize", "sp2yt-1", "--dry-run"][..],
+        &[
+            "organize",
+            "sp2yt-1",
+            "--root",
+            "/tmp/library",
+            "--dry-run",
+            "--unknown",
+        ][..],
+    ] {
+        assert_eq!(classify(values), CliPersistenceCapability::Writer);
+    }
+}
+
+#[test]
+fn obvious_parse_errors_do_not_initialize_persistence() {
+    let tools = |values: &[&str]| OneShotCommand::Tools.persistence_capability(&args(values));
+    assert_eq!(tools(&["use"]), CliPersistenceCapability::NotRequired);
+    assert_eq!(tools(&["reset"]), CliPersistenceCapability::NotRequired);
+    assert_eq!(tools(&["use", "system"]), CliPersistenceCapability::Writer);
+    assert_eq!(
+        tools(&["use", "system", "extra"]),
+        CliPersistenceCapability::Writer
+    );
+    assert_eq!(
+        tools(&["reset", "--not-playback"]),
+        CliPersistenceCapability::Writer
+    );
+
+    let auth = |values: &[&str]| OneShotCommand::Auth.persistence_capability(&args(values));
+    assert_eq!(
+        auth(&["spotify", "--help"]),
+        CliPersistenceCapability::NotRequired
+    );
+    assert_eq!(
+        auth(&["spotify", "--client-id"]),
+        CliPersistenceCapability::NotRequired
+    );
+    assert_eq!(
+        auth(&["spotify", "--unknown"]),
+        CliPersistenceCapability::NotRequired
+    );
+    assert_eq!(
+        auth(&["spotify", "--client-id", "--help"]),
+        CliPersistenceCapability::Writer
+    );
+    assert_eq!(
+        auth(&["spotify", "--status"]),
+        CliPersistenceCapability::Writer
+    );
+    assert_eq!(
+        auth(&["spotify", "--logout"]),
+        CliPersistenceCapability::Writer
+    );
+    assert_eq!(auth(&["spotify"]), CliPersistenceCapability::Writer);
+}
+
+#[test]
+fn compatibility_corpus_preserves_parser_precedence() {
+    let cases: &[(OneShotCommand, &[&str], CliPersistenceCapability)] = &[
+        (
+            OneShotCommand::Auth,
+            &[],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Auth,
+            &["lastfm", "--help"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Auth,
+            &["listenbrainz"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Auth,
+            &["spotify", "--help", "--status"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Auth,
+            &["spotify", "--client-id", "--help"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Auth,
+            &["spotify", "--client-id", "client", "--help"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Auth,
+            &["spotify", "--logout", "--help"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["help"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["download", "--help"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["import", "--help"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["review"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["review", "job", "--all", "accept", "1"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["review", "job", "--help"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["organize", "job", "--root", "--apply", "--dry-run"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &[
+                "organize",
+                "job",
+                "--template",
+                "--apply",
+                "--root",
+                "/tmp/library",
+                "--dry-run",
+            ],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &[
+                "organize",
+                "--dry-run",
+                "--root",
+                "/tmp/one",
+                "job",
+                "--root",
+                "/tmp/two",
+            ],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &[
+                "organize",
+                "job",
+                "--root",
+                "/tmp/library",
+                "--dry-run",
+                "--apply",
+            ],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Tools,
+            &[],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Tools,
+            &["status", "--unknown", "ignored"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Tools,
+            &["use"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Tools,
+            &["use", "--help"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Tools,
+            &["unknown"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Doctor,
+            &[],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Doctor,
+            &["--help", "ignored"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Doctor,
+            &["privacy", "--cleanup"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Doctor,
+            &["privacy", "--cleanup", "extra"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Doctor,
+            &["privacy", "--help"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Update,
+            &["--help", "ignored"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+    ];
+
+    for &(command, values, expected) in cases {
+        assert_eq!(
+            command.persistence_capability(&args(values)),
+            expected,
+            "command {command:?}, args {values:?}"
+        );
+    }
+}
+
+#[derive(Clone, Copy)]
+struct DeterministicFuzz(u64);
+
+impl DeterministicFuzz {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.0
+    }
+
+    fn token(&mut self) -> String {
+        const TOKENS: &[&str] = &[
+            "",
+            "auth",
+            "spotify",
+            "lastfm",
+            "listenbrainz",
+            "list",
+            "jobs",
+            "sessions",
+            "session",
+            "report",
+            "review",
+            "download",
+            "organize",
+            "import",
+            "export",
+            "backup",
+            "resume",
+            "status",
+            "use",
+            "unpin",
+            "update",
+            "reset",
+            "diagnose",
+            "privacy",
+            "--cleanup",
+            "--client-id",
+            "--status",
+            "--logout",
+            "--help",
+            "-h",
+            "help",
+            "--all",
+            "--review",
+            "--accepted",
+            "--rejected",
+            "--skipped",
+            "--undecided",
+            "--root",
+            "--template",
+            "--dry-run",
+            "--apply",
+            "--yes",
+            "--unknown",
+            "sp2yt-1",
+            "/tmp/library",
+        ];
+        if !self.next().is_multiple_of(4) {
+            return TOKENS[self.next() as usize % TOKENS.len()].to_owned();
+        }
+
+        const CHARS: &[char] = &[
+            'a', 'Z', '0', '-', '_', '/', '\\', ' ', '\0', 'é', '한', '🦀', '\u{fffd}',
+        ];
+        let len = self.next() as usize % 24;
+        (0..len)
+            .map(|_| CHARS[self.next() as usize % CHARS.len()])
+            .collect()
+    }
+
+    fn argv(&mut self) -> Vec<String> {
+        let len = self.next() as usize % 12;
+        (0..len).map(|_| self.token()).collect()
+    }
+}
+
+fn model(command: OneShotCommand, args: &[String]) -> CliPersistenceCapability {
+    match command {
+        OneShotCommand::Auth => match args.first().map(String::as_str) {
+            Some("lastfm" | "listenbrainz") => CliPersistenceCapability::Writer,
+            Some("spotify") => model_spotify(&args[1..]),
+            _ => CliPersistenceCapability::NotRequired,
+        },
+        OneShotCommand::Transfer => model_transfer(args),
+        OneShotCommand::Doctor => {
+            if args == ["privacy", "--cleanup"] {
+                CliPersistenceCapability::Writer
+            } else if matches!(
+                args.first().map(String::as_str),
+                Some("--help" | "-h" | "help")
+            ) {
+                CliPersistenceCapability::NotRequired
+            } else {
+                CliPersistenceCapability::ReadOnly
+            }
+        }
+        OneShotCommand::Tools => match args.first().map(String::as_str) {
+            None | Some("status") => CliPersistenceCapability::ReadOnly,
+            Some("use" | "reset") if args.len() == 1 => CliPersistenceCapability::NotRequired,
+            Some("use" | "unpin" | "update" | "reset" | "diagnose") => {
+                CliPersistenceCapability::Writer
+            }
+            Some(_) => CliPersistenceCapability::NotRequired,
+        },
+        OneShotCommand::Update => CliPersistenceCapability::ReadOnly,
+    }
+}
+
+fn model_spotify(args: &[String]) -> CliPersistenceCapability {
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--client-id" if index + 1 < args.len() => index += 2,
+            "--status" | "--logout" => index += 1,
+            "--client-id" | "--help" | "-h" => {
+                return CliPersistenceCapability::NotRequired;
+            }
+            _ => return CliPersistenceCapability::NotRequired,
+        }
+    }
+    CliPersistenceCapability::Writer
+}
+
+fn model_transfer(args: &[String]) -> CliPersistenceCapability {
+    match args.first().map(String::as_str) {
+        Some("list" | "jobs" | "sessions" | "session" | "report" | "download") => {
+            CliPersistenceCapability::ReadOnly
+        }
+        Some("review") if args.len() == 1 => CliPersistenceCapability::NotRequired,
+        Some("review") => match args.get(2).map(String::as_str) {
+            None
+            | Some(
+                "--all" | "--review" | "--accepted" | "--rejected" | "--skipped" | "--undecided",
+            ) => CliPersistenceCapability::ReadOnly,
+            Some(_) => CliPersistenceCapability::Writer,
+        },
+        Some("organize") => model_organize(&args[1..]),
+        Some("import" | "export" | "backup" | "resume") => CliPersistenceCapability::Writer,
+        _ => CliPersistenceCapability::NotRequired,
+    }
+}
+
+fn model_organize(args: &[String]) -> CliPersistenceCapability {
+    let mut dry_run = false;
+    let mut apply = false;
+    let mut session_count = 0;
+    let mut root_count = 0;
+    let mut invalid = false;
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--dry-run" => dry_run = true,
+            "--apply" => apply = true,
+            "--yes" => {}
+            "--root" if index + 1 < args.len() => {
+                root_count += 1;
+                index += 1;
+            }
+            "--template" if index + 1 < args.len() => index += 1,
+            "--root" | "--template" | "--help" | "-h" => invalid = true,
+            other if other.starts_with('-') => invalid = true,
+            _ => session_count += 1,
+        }
+        index += 1;
+    }
+    if !invalid && session_count == 1 && root_count >= 1 && dry_run && !apply {
+        CliPersistenceCapability::ReadOnly
+    } else {
+        CliPersistenceCapability::Writer
+    }
+}
+
+#[test]
+fn classifier_matches_reference_model_across_deterministic_fuzz_corpus() {
+    const COMMANDS: [OneShotCommand; 5] = [
+        OneShotCommand::Auth,
+        OneShotCommand::Transfer,
+        OneShotCommand::Doctor,
+        OneShotCommand::Tools,
+        OneShotCommand::Update,
+    ];
+    let mut fuzz = DeterministicFuzz(0x6a09_e667_f3bc_c909);
+    for case in 0..25_000 {
+        let args = fuzz.argv();
+        for command in COMMANDS {
+            let actual = command.persistence_capability(&args);
+            assert_eq!(
+                actual,
+                model(command, &args),
+                "case {case}, command {command:?}, args {args:?}"
+            );
+            assert_eq!(
+                actual,
+                command.persistence_capability(&args),
+                "classification must be deterministic"
+            );
+        }
+    }
+}
+
+#[test]
+fn mutating_transfer_routes_never_downgrade_for_fuzzed_suffixes() {
+    let mut fuzz = DeterministicFuzz(0xbb67_ae85_84ca_a73b);
+    for route in ["import", "export", "backup", "resume"] {
+        for _ in 0..2_000 {
+            let mut candidate = vec![route.to_owned()];
+            candidate.extend(fuzz.argv());
+            assert_eq!(
+                OneShotCommand::Transfer.persistence_capability(&candidate),
+                CliPersistenceCapability::Writer,
+                "{candidate:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn fixed_auth_and_observational_transfer_routes_ignore_fuzzed_suffixes_safely() {
+    let mut fuzz = DeterministicFuzz(0x3c6e_f372_fe94_f82b);
+    for route in ["lastfm", "listenbrainz"] {
+        for _ in 0..2_000 {
+            let mut candidate = vec![route.to_owned()];
+            candidate.extend(fuzz.argv());
+            assert_eq!(
+                OneShotCommand::Auth.persistence_capability(&candidate),
+                CliPersistenceCapability::Writer,
+                "{candidate:?}"
+            );
+        }
+    }
+    for route in ["list", "jobs", "sessions", "session", "report", "download"] {
+        for _ in 0..2_000 {
+            let mut candidate = vec![route.to_owned()];
+            candidate.extend(fuzz.argv());
+            assert_eq!(
+                OneShotCommand::Transfer.persistence_capability(&candidate),
+                CliPersistenceCapability::ReadOnly,
+                "{candidate:?}"
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn non_unicode_unix_arguments_are_normalized_without_panicking() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let normalized = collect_lossy_cli_args([
+        OsString::from("organize"),
+        OsString::from_vec(vec![b's', b'p', 0xff, b'1']),
+        OsString::from("--root"),
+        OsString::from_vec(vec![b'/', 0xfe, b'x']),
+        OsString::from("--dry-run"),
+    ]);
+    assert_eq!(
+        OneShotCommand::Transfer.persistence_capability(&normalized),
+        CliPersistenceCapability::ReadOnly
+    );
+    let replaced = normalized
+        .iter()
+        .find(|arg| arg.contains('\u{fffd}'))
+        .expect("invalid bytes must be replaced");
+    for keyword in [
+        "--apply",
+        "--dry-run",
+        "--root",
+        "--template",
+        "--help",
+        "-h",
+    ] {
+        assert_ne!(replaced, keyword);
+    }
+
+    let invalid_action = collect_lossy_cli_args([
+        OsString::from("review"),
+        OsString::from("job"),
+        OsString::from_vec(vec![b'a', 0xff, b'c']),
+    ]);
+    assert_eq!(
+        OneShotCommand::Transfer.persistence_capability(&invalid_action),
+        CliPersistenceCapability::Writer
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn non_unicode_windows_arguments_are_normalized_without_panicking() {
+    use std::os::windows::ffi::OsStringExt;
+
+    let normalized = collect_lossy_cli_args([
+        OsString::from("spotify"),
+        OsString::from("--client-id"),
+        OsString::from_wide(&[0xd800]),
+    ]);
+    assert_eq!(
+        OneShotCommand::Auth.persistence_capability(&normalized),
+        CliPersistenceCapability::Writer
+    );
+    let replaced = normalized
+        .iter()
+        .find(|arg| arg.contains('\u{fffd}'))
+        .expect("unpaired surrogate must be replaced");
+    for keyword in ["--client-id", "--status", "--logout", "--help", "-h"] {
+        assert_ne!(replaced, keyword);
+    }
+
+    let invalid_action = collect_lossy_cli_args([
+        OsString::from("review"),
+        OsString::from("job"),
+        OsString::from_wide(&[0xd800]),
+    ]);
+    assert_eq!(
+        OneShotCommand::Transfer.persistence_capability(&invalid_action),
+        CliPersistenceCapability::Writer
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod api;
 pub mod app;
 pub mod artwork;
 pub mod auth_cli;
+pub mod cli_capability;
 pub mod config;
 pub mod daemon;
 pub mod data_export;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use yututui::{
-    auth_cli, daemon, doctor, i18n, media, persist, remote,
+    auth_cli,
+    cli_capability::{OneShotCommand, collect_lossy_cli_args, interactive_persistence_capability},
+    daemon, doctor, i18n, media, persist, remote,
     terminal_runtime::{self, StartupTrace},
     tools, transfer, tui, update, zoom,
 };
@@ -15,31 +17,28 @@ const ALREADY_RUNNING_NOTICE: &str = "ytt is already running.\n  \
                                       Control it:  ytt -r <command>   (e.g. `ytt -r pp`, `ytt -r next`)\n  \
                                       Stop it:     ytt -r quit";
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum CliPersistence {
-    None,
-    Reader,
-    Writer,
-}
-
-fn initialize_cli_persistence(command: &str, mode: CliPersistence) -> bool {
-    let initialized = match mode {
-        CliPersistence::None => return true,
-        CliPersistence::Reader => persist::initialize_persistence_reader(),
-        CliPersistence::Writer => persist::initialize_persistence_writer(false),
+fn initialize_cli_persistence(command: OneShotCommand, args: &[String]) -> bool {
+    let capability = command.persistence_capability(args);
+    if !capability.requires_persistence() {
+        return true;
+    }
+    let initialized = if capability.allows_writes() {
+        persist::initialize_persistence_writer(false)
+    } else {
+        persist::initialize_persistence_reader()
     };
     match initialized {
         Ok(_) => {
-            if mode == CliPersistence::Writer
+            if capability.allows_writes()
                 && let Err(error) = persist::preflight_all_startup_stores()
             {
-                eprintln!("ytt {command}: {error}");
+                eprintln!("ytt {}: {error}", command.label());
                 return false;
             }
             true
         }
         Err(error) => {
-            eprintln!("ytt {command}: {error}");
+            eprintln!("ytt {}: {error}", command.label());
             false
         }
     }
@@ -48,143 +47,15 @@ fn initialize_cli_persistence(command: &str, mode: CliPersistence) -> bool {
 fn initialize_interactive_persistence(
     new_instance: bool,
 ) -> std::io::Result<persist::PersistenceAccess> {
-    match interactive_persistence_mode(new_instance) {
-        CliPersistence::Reader => {
-            // `--new-instance` is an explicit observational secondary, even when no primary happens
-            // to be alive. Never opportunistically promote it to the shared-root writer: doing so
-            // makes the same command mutate or migrate state depending on startup timing.
-            persist::initialize_persistence_reader()
-        }
-        CliPersistence::Writer => persist::initialize_persistence_writer(false),
-        CliPersistence::None => unreachable!("interactive startup always resolves persistence"),
-    }
-}
-
-fn interactive_persistence_mode(new_instance: bool) -> CliPersistence {
-    if new_instance {
-        CliPersistence::Reader
+    let capability = interactive_persistence_capability(new_instance);
+    debug_assert!(capability.requires_persistence());
+    if capability.allows_writes() {
+        persist::initialize_persistence_writer(false)
     } else {
-        CliPersistence::Writer
-    }
-}
-
-fn auth_persistence(args: &[String]) -> CliPersistence {
-    match args.first().map(String::as_str) {
-        Some("lastfm" | "listenbrainz") => CliPersistence::Writer,
-        Some("spotify") => spotify_auth_persistence(&args[1..]),
-        _ => CliPersistence::None,
-    }
-}
-
-fn spotify_auth_persistence(args: &[String]) -> CliPersistence {
-    let mut it = args.iter().map(String::as_str);
-    while let Some(arg) = it.next() {
-        match arg {
-            // The command parser consumes the next token even when it looks like a flag.
-            "--client-id" if it.next().is_some() => {}
-            "--client-id" => return CliPersistence::None,
-            "--status" | "--logout" => {}
-            "--help" | "-h" => return CliPersistence::None,
-            // Unknown flags are rejected before Config/token access.
-            _ => return CliPersistence::None,
-        }
-    }
-    // Status can refresh credentials, logout removes them, and the default connect path may save
-    // both config and token state. Those valid or otherwise ambiguous forms require the writer.
-    CliPersistence::Writer
-}
-
-fn transfer_persistence(args: &[String]) -> CliPersistence {
-    match args.first().map(String::as_str) {
-        Some("list" | "jobs" | "sessions" | "session" | "report") => CliPersistence::Reader,
-        Some("review") => review_persistence(&args[1..]),
-        // This surface only builds and prints a plan; the parser requires `--dry-run` and has no
-        // apply path. Keeping even malformed invocations observational also preserves usage exits
-        // when another process owns the writer lease.
-        Some("download") => CliPersistence::Reader,
-        Some("organize") => organize_persistence(&args[1..]),
-        Some("import" | "export" | "backup" | "resume") => CliPersistence::Writer,
-        None | Some("--help" | "-h" | "help") => CliPersistence::None,
-        Some(_) => CliPersistence::None,
-    }
-}
-
-fn review_persistence(args: &[String]) -> CliPersistence {
-    let Some(_) = args.first() else {
-        return CliPersistence::None;
-    };
-    match args.get(1).map(String::as_str) {
-        None
-        | Some("--all" | "--review" | "--accepted" | "--rejected" | "--skipped" | "--undecided") => {
-            CliPersistence::Reader
-        }
-        // Known actions mutate, and an unrecognized second token enters the action parser. Keep
-        // that ambiguous path fail-closed under the writer lease rather than guessing from flags.
-        Some(_) => CliPersistence::Writer,
-    }
-}
-
-fn organize_persistence(args: &[String]) -> CliPersistence {
-    let mut dry_run = false;
-    let mut apply = false;
-    let mut has_session_id = false;
-    let mut has_root = false;
-    let mut invalid = false;
-    let mut it = args.iter().map(String::as_str);
-    while let Some(arg) = it.next() {
-        match arg {
-            "--dry-run" => dry_run = true,
-            "--apply" => apply = true,
-            "--yes" => {}
-            "--root" => {
-                if it.next().is_some() {
-                    has_root = true;
-                } else {
-                    invalid = true;
-                }
-            }
-            "--template" => {
-                if it.next().is_none() {
-                    invalid = true;
-                }
-            }
-            "--help" | "-h" => invalid = true,
-            other if other.starts_with('-') => invalid = true,
-            _ if has_session_id => invalid = true,
-            _ => has_session_id = true,
-        }
-    }
-
-    if !invalid && has_session_id && has_root && dry_run && !apply {
-        CliPersistence::Reader
-    } else {
-        // `--apply` is mutating. Malformed or otherwise ambiguous forms retain the conservative
-        // writer classification instead of duplicating the command parser's full validation here.
-        CliPersistence::Writer
-    }
-}
-
-fn tools_persistence(args: &[String]) -> CliPersistence {
-    match args.first().map(String::as_str) {
-        None | Some("status") => CliPersistence::Reader,
-        // These two parsers reject the missing-argument form before loading or saving state. Do
-        // not let writer-lease contention turn their stable usage exit (2) into an I/O exit (1).
-        Some("use" | "reset") if args.len() == 1 => CliPersistence::None,
-        Some("use" | "unpin" | "update" | "reset" | "diagnose") => CliPersistence::Writer,
-        Some(_) => CliPersistence::None,
-    }
-}
-
-fn doctor_persistence(args: &[String]) -> CliPersistence {
-    if matches!(args, [command, flag] if command == "privacy" && flag == "--cleanup") {
-        CliPersistence::Writer
-    } else if matches!(
-        args.first().map(String::as_str),
-        Some("--help" | "-h" | "help")
-    ) {
-        CliPersistence::None
-    } else {
-        CliPersistence::Reader
+        // `--new-instance` is an explicit observational secondary, even when no primary happens
+        // to be alive. Never opportunistically promote it to the shared-root writer: doing so
+        // makes the same command mutate or migrate state depending on startup timing.
+        persist::initialize_persistence_reader()
     }
 }
 
@@ -265,39 +136,27 @@ fn run() -> Result<()> {
             // with its status code. This path never builds the multi-thread runtime and
             // never touches terminal raw mode / the alternate screen.
             "-r" | "--remote" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
                 std::process::exit(remote::client::run(&rest));
             }
             // Headless daemon entrypoints must run before any TUI/terminal setup.
             "daemon" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
                 std::process::exit(daemon::run_cli(&rest));
             }
             // One-shot account connections (Last.fm approval flow, ListenBrainz token,
             // Spotify PKCE) - usable without a terminal UI, e.g. for daemon-only setups.
             "auth" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
-                if !initialize_cli_persistence("auth", auth_persistence(&rest)) {
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
+                if !initialize_cli_persistence(OneShotCommand::Auth, &rest) {
                     std::process::exit(1);
                 }
                 std::process::exit(auth_cli::run(&rest));
             }
             // Playlist transfer (Spotify ↔ YTM ↔ files) - batch jobs, never the TUI.
             "transfer" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
-                if !initialize_cli_persistence("transfer", transfer_persistence(&rest)) {
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
+                if !initialize_cli_persistence(OneShotCommand::Transfer, &rest) {
                     std::process::exit(1);
                 }
                 std::process::exit(transfer::cli::run(&rest));
@@ -305,21 +164,15 @@ fn run() -> Result<()> {
             // Portable settings/library export. This one-shot path never initializes the TUI;
             // it delegates to a capable live owner or snapshots persisted state when offline.
             "data" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
                 std::process::exit(data_cli::run(&rest));
             }
             "--new-instance" => new_instance = true,
             // One-shot environment diagnostic; never touches the terminal. Exits with its
             // own status code (non-zero if a required tool or directory is unusable).
             "doctor" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
-                if !initialize_cli_persistence("doctor", doctor_persistence(&rest)) {
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
+                if !initialize_cli_persistence(OneShotCommand::Doctor, &rest) {
                     std::process::exit(1);
                 }
                 std::process::exit(doctor::run_with_args(&rest));
@@ -327,11 +180,8 @@ fn run() -> Result<()> {
             // Managed yt-dlp maintenance (status / forced update) - same one-shot,
             // no-terminal shape as `doctor`.
             "tools" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
-                if !initialize_cli_persistence("tools", tools_persistence(&rest)) {
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
+                if !initialize_cli_persistence(OneShotCommand::Tools, &rest) {
                     std::process::exit(1);
                 }
                 std::process::exit(tools::cli::run(&rest));
@@ -339,11 +189,8 @@ fn run() -> Result<()> {
             // App update check - reports whether a newer YuTuTui! release exists and how to
             // upgrade for this install method. One-shot, no terminal, like `doctor`/`tools`.
             "update" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
-                if !initialize_cli_persistence("update", CliPersistence::Reader) {
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
+                if !initialize_cli_persistence(OneShotCommand::Update, &rest) {
                     std::process::exit(1);
                 }
                 std::process::exit(update::cli::run(&rest));
@@ -352,10 +199,7 @@ fn run() -> Result<()> {
             // the AppUserModelId so the Windows media flyout shows "YuTuTui!" + icon instead of
             // "Unknown app". Kept out of --help; errors out on other platforms.
             "register-media-identity" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
                 std::process::exit(media::identity::register_cli(&rest));
             }
             _ => {}
@@ -486,19 +330,22 @@ async fn async_main(new_instance: bool, mut startup: StartupTrace) -> Result<()>
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn args(values: &[&str]) -> Vec<String> {
-        values.iter().map(|value| (*value).to_owned()).collect()
-    }
+    use yututui::cli_capability::CliPersistenceCapability;
 
     #[test]
     fn explicit_new_instance_is_always_an_observational_reader() {
-        assert_eq!(interactive_persistence_mode(true), CliPersistence::Reader);
+        assert_eq!(
+            interactive_persistence_capability(true),
+            CliPersistenceCapability::ReadOnly
+        );
     }
 
     #[test]
     fn ordinary_interactive_owner_requests_the_writer_capability() {
-        assert_eq!(interactive_persistence_mode(false), CliPersistence::Writer);
+        assert_eq!(
+            interactive_persistence_capability(false),
+            CliPersistenceCapability::Writer
+        );
     }
 
     #[test]
@@ -520,135 +367,5 @@ mod tests {
             Some("WindowsTerminal.exe")
         ));
         assert!(!should_pause_explorer_launch(1, None));
-    }
-
-    #[test]
-    fn transfer_download_and_review_views_are_observational() {
-        assert_eq!(
-            transfer_persistence(&args(&["download", "sp2yt-1", "--accepted", "--dry-run"])),
-            CliPersistence::Reader
-        );
-        assert_eq!(
-            transfer_persistence(&args(&["review", "sp2yt-1"])),
-            CliPersistence::Reader
-        );
-        assert_eq!(
-            transfer_persistence(&args(&["review", "sp2yt-1", "--accepted"])),
-            CliPersistence::Reader
-        );
-        assert_eq!(
-            transfer_persistence(&args(&["review", "sp2yt-1", "accept", "1"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            transfer_persistence(&args(&["review", "sp2yt-1", "unknown", "1"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            transfer_persistence(&args(&["review"])),
-            CliPersistence::None
-        );
-    }
-
-    #[test]
-    fn transfer_organize_only_downgrades_a_valid_dry_run_shape() {
-        assert_eq!(
-            transfer_persistence(&args(&[
-                "organize",
-                "sp2yt-1",
-                "--root",
-                "/tmp/library",
-                "--dry-run"
-            ])),
-            CliPersistence::Reader
-        );
-        assert_eq!(
-            transfer_persistence(&args(&[
-                "organize",
-                "sp2yt-1",
-                "--root",
-                "/tmp/library",
-                "--apply",
-                "--yes"
-            ])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            transfer_persistence(&args(&[
-                "organize",
-                "sp2yt-1",
-                "--root",
-                "/tmp/library",
-                "--dry-run",
-                "--apply",
-                "--yes"
-            ])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            transfer_persistence(&args(&["organize", "sp2yt-1", "--dry-run"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            transfer_persistence(&args(&[
-                "organize",
-                "sp2yt-1",
-                "--root",
-                "/tmp/library",
-                "--dry-run",
-                "--unknown"
-            ])),
-            CliPersistence::Writer
-        );
-    }
-
-    #[test]
-    fn obvious_missing_tools_arguments_bypass_persistence_initialization() {
-        assert_eq!(tools_persistence(&args(&["use"])), CliPersistence::None);
-        assert_eq!(tools_persistence(&args(&["reset"])), CliPersistence::None);
-        assert_eq!(
-            tools_persistence(&args(&["use", "system"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            tools_persistence(&args(&["use", "system", "extra"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            tools_persistence(&args(&["reset", "--not-playback"])),
-            CliPersistence::Writer
-        );
-    }
-
-    #[test]
-    fn spotify_help_and_provable_parse_errors_bypass_persistence() {
-        assert_eq!(
-            auth_persistence(&args(&["spotify", "--help"])),
-            CliPersistence::None
-        );
-        assert_eq!(
-            auth_persistence(&args(&["spotify", "--client-id"])),
-            CliPersistence::None
-        );
-        assert_eq!(
-            auth_persistence(&args(&["spotify", "--unknown"])),
-            CliPersistence::None
-        );
-        assert_eq!(
-            auth_persistence(&args(&["spotify", "--client-id", "--help"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            auth_persistence(&args(&["spotify", "--status"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            auth_persistence(&args(&["spotify", "--logout"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            auth_persistence(&args(&["spotify"])),
-            CliPersistence::Writer
-        );
     }
 }

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -302,14 +302,49 @@ fn read_only_transfer_views_and_missing_tools_args_do_not_create_persistence_roo
             ][..],
             1,
         ),
+        (
+            "organize-consumed-apply-value",
+            &[
+                "transfer",
+                "organize",
+                "missing-session",
+                "--root",
+                "--apply",
+                "--dry-run",
+            ][..],
+            1,
+        ),
+        (
+            "review-filter-ignores-action-looking-suffix",
+            &[
+                "transfer",
+                "review",
+                "missing-session",
+                "--all",
+                "accept",
+                "1",
+            ][..],
+            1,
+        ),
         ("tools-use-missing", &["tools", "use"][..], 2),
         ("tools-reset-missing", &["tools", "reset"][..], 2),
         ("spotify-help", &["auth", "spotify", "--help"][..], 0),
+        (
+            "spotify-help-after-client-id",
+            &["auth", "spotify", "--client-id", "client", "--help"][..],
+            0,
+        ),
         (
             "spotify-client-id-missing",
             &["auth", "spotify", "--client-id"][..],
             2,
         ),
+        (
+            "doctor-privacy-help",
+            &["doctor", "privacy", "--help"][..],
+            0,
+        ),
+        ("update-help", &["update", "--help"][..], 0),
     ] {
         let root = isolated_root(name);
         let _ = std::fs::remove_dir_all(&root);
@@ -400,6 +435,63 @@ fn organize_dry_run_with_existing_state_preserves_config_and_session_tree() {
     assert_eq!(snapshot_tree(&data), data_before);
     assert!(!cache.exists(), "dry-run created cache state");
     assert!(!library_root.exists(), "dry-run created the target root");
+
+    let consumed_apply = isolated_command(
+        &root,
+        &[
+            "transfer",
+            "organize",
+            session_id,
+            "--template",
+            "--apply",
+            "--root",
+            &library_arg,
+            "--dry-run",
+        ],
+    )
+    .env("YTM_DATA_DIR", &data)
+    .output()
+    .expect("organize dry-run with a flag-looking template should run");
+    assert!(
+        consumed_apply.status.success(),
+        "stdout={}, stderr={}",
+        stdout(&consumed_apply),
+        stderr(&consumed_apply)
+    );
+    assert!(
+        stdout(&consumed_apply).contains("Template: --apply"),
+        "stdout={}",
+        stdout(&consumed_apply)
+    );
+    assert!(
+        !stdout(&consumed_apply).contains("Applied:"),
+        "flag-looking template was parsed as apply mode: stdout={}",
+        stdout(&consumed_apply)
+    );
+    assert_eq!(snapshot_tree(&config), config_before);
+    assert_eq!(snapshot_tree(&data), data_before);
+    assert!(!cache.exists(), "consumed --apply created cache state");
+    assert!(
+        !library_root.exists(),
+        "consumed --apply created the target root"
+    );
+
+    let review_filter = isolated_command(
+        &root,
+        &["transfer", "review", session_id, "--all", "accept", "1"],
+    )
+    .env("YTM_DATA_DIR", &data)
+    .output()
+    .expect("review filter with an action-looking suffix should run");
+    assert!(
+        review_filter.status.success(),
+        "stdout={}, stderr={}",
+        stdout(&review_filter),
+        stderr(&review_filter)
+    );
+    assert_eq!(snapshot_tree(&config), config_before);
+    assert_eq!(snapshot_tree(&data), data_before);
+    assert!(!cache.exists(), "review filter created cache state");
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- extracted CLI persistence decisions from `main.rs` into a typed, std-only `cli_capability` leaf module
- coupled each one-shot command's stable label to its capability classifier, removing free-form command/mode pairs
- made persistence/write policy exhaustive internally and non-exhaustive at the binary-facing API boundary
- centralized the existing lossy `OsString` normalization used by `ytt` and `ytt-dev`
- added deterministic differential fuzz coverage, golden precedence cases, fixed-route safety properties, and Unix/Windows non-Unicode boundaries
- added state-backed CLI smoke coverage proving flag-looking values and ignored review suffixes remain observational

## Why

CLI persistence initialization happens before command parsing so help and provable usage errors can bypass writer contention while ambiguous or mutating forms fail closed. Keeping that policy as ad hoc scanners in the binary made parser drift and future command growth difficult to audit. The typed classifier makes the capability choice explicit and forces any new state to choose its lease and preflight policy at compile time.

## Impact

There is no intended CLI, UI/UX, exit-code, help-text, persistence-format, or dependency change. Existing first-token routing, lossy argv behavior, parser precedence, writer preflight ordering, and `ytt`/`ytt-dev` identity remain unchanged.

## Validation

- canonical `~/.fable-harness/bin/run-gates .`: PASS (fmt, clippy, workspace tests, architecture)
- `cargo fmt --all --check`: PASS
- `cargo clippy --workspace --all-targets -- -D warnings`: PASS
- `cargo test --workspace`: PASS (3313 lib, 17 `ytt`, 17 `ytt-dev`, 18 CLI smoke)
- Windows GNU library/binary/test cross-check: PASS
- correctness, API-contract, test-quality, architecture, and stability reviews: no open blocker/high/medium findings
