### PR TITLE
Integrate open PRs: MPRIS, typed CLI persistence, and animation performance

### DIFF
--- a/crates/ratatui-image/PATCHES.md
+++ b/crates/ratatui-image/PATCHES.md
@@ -18,8 +18,10 @@ The fork is intentionally narrow and should stay easy to rebase onto a future up
 - Kitty rows damaged by overlay redraws can be marked for retransmission.
 - Sixel and iTerm2 encodes stamp the anchor cell with a monotonic redraw tag so freshly rebuilt
   protocols are not skipped by ratatui's diffing.
-- Konsole versions before 26.08 keep Kitty and Sixel capability queries disabled; 26.08 and newer
-  may select Sixel only after DA1 advertises it and the cell-size query returns usable dimensions.
+- KonsolePart versions before 26.04 keep Kitty and Sixel capability queries disabled. Konsole and
+  Yakuake on 26.04 and newer may select Sixel only after DA1 advertises it and the cell-size query
+  returns usable dimensions. This is best-effort on 26.04-26.07 because the upstream placement
+  cleanup landed for 26.08; users can force `YTM_TUI_IMAGE_PROTOCOL=halfblocks` if fragments linger.
 
 All local code changes should include a nearby `yututui patch` comment. CI runs
 `scripts/check-ratatui-image-patch.sh` to catch accidental removal of the path patch, base-version

--- a/crates/ratatui-image/src/picker.rs
+++ b/crates/ratatui-image/src/picker.rs
@@ -45,8 +45,8 @@ pub enum Capability {
 
 const STDIN_READ_TIMEOUT_MILLIS: u64 = 2000;
 
-// yututui patch: Konsole's 26.08 line includes the Sixel placement cleanup needed for TUI redraws.
-const KONSOLE_SIXEL_TUI_MIN_VERSION: u32 = 260_800;
+// yututui patch: allow a conservative, capability-gated Sixel probe on KDE 26.04+.
+const KONSOLE_SIXEL_TUI_MIN_VERSION: u32 = 260_400;
 
 #[derive(Clone, Debug)]
 pub struct Picker {
@@ -126,7 +126,7 @@ impl Picker {
         let wezterm_executable = env::var("WEZTERM_EXECUTABLE").ok();
         let konsole_version = env::var("KONSOLE_VERSION").ok();
         let term = env::var("TERM").ok();
-        let require_reported_cell_size_for_konsole_sixel = konsole_supports_sixel_tui_redraws(
+        let require_reported_cell_size_for_konsole_sixel = konsole_allows_capability_gated_sixel(
             wezterm_executable.as_deref(),
             konsole_version.as_deref(),
             term.as_deref(),
@@ -340,7 +340,7 @@ impl Picker {
     }
 }
 
-// yututui patch: keep older/unknown Konsole versions conservative, and capability-gate 26.08+.
+// yututui patch: keep older/unknown Konsole versions conservative, and capability-gate 26.04+.
 fn terminal_protocol_blacklist(
     wezterm_executable: Option<&str>,
     konsole_version: Option<&str>,
@@ -359,7 +359,7 @@ fn terminal_protocol_blacklist(
         return Vec::new();
     }
 
-    if konsole_supports_sixel_tui_redraws(wezterm_executable, konsole_version, term) {
+    if konsole_allows_capability_gated_sixel(wezterm_executable, konsole_version, term) {
         // Konsole's Kitty implementation still lacks Unicode placeholders. Sixel remains subject
         // to the normal DA1 capability and cell-size response checks below.
         vec![ProtocolType::Kitty]
@@ -368,7 +368,7 @@ fn terminal_protocol_blacklist(
     }
 }
 
-fn konsole_supports_sixel_tui_redraws(
+fn konsole_allows_capability_gated_sixel(
     wezterm_executable: Option<&str>,
     konsole_version: Option<&str>,
     term: Option<&str>,
@@ -812,35 +812,35 @@ mod tests {
             Case {
                 name: "invalid Konsole version stays conservative",
                 wezterm_executable: None,
-                konsole_version: Some("26.08"),
+                konsole_version: Some("26.04"),
                 term: Some("xterm-256color"),
                 expected: vec![ProtocolType::Kitty, ProtocolType::Sixel],
             },
             Case {
-                name: "Konsole before 26.08 stays conservative",
+                name: "Konsole before 26.04 stays conservative",
                 wezterm_executable: None,
-                konsole_version: Some("260799"),
+                konsole_version: Some("260399"),
                 term: Some("xterm-256color"),
                 expected: vec![ProtocolType::Kitty, ProtocolType::Sixel],
             },
             Case {
-                name: "Konsole 26.08 allows Sixel capability queries",
+                name: "Konsole 26.04 allows Sixel capability queries",
                 wezterm_executable: None,
-                konsole_version: Some("260800"),
-                term: Some("xterm-256color"),
+                konsole_version: Some("260400"),
+                term: Some("konsole-256color"),
                 expected: vec![ProtocolType::Kitty],
             },
             Case {
-                name: "newer Konsole allows Sixel capability queries",
+                name: "Yakuake KonsolePart hint works with a generic TERM",
                 wezterm_executable: None,
-                konsole_version: Some("260801"),
+                konsole_version: Some("260401"),
                 term: Some("xterm-256color"),
                 expected: vec![ProtocolType::Kitty],
             },
             Case {
                 name: "WezTerm policy wins over a new Konsole hint",
                 wezterm_executable: Some("wezterm-gui"),
-                konsole_version: Some("260800"),
+                konsole_version: Some("260400"),
                 term: Some("konsole-256color"),
                 expected: vec![ProtocolType::Kitty, ProtocolType::Sixel],
             },
@@ -874,11 +874,11 @@ mod tests {
             Parser::query(false, options)
         };
 
-        let old_konsole_query = query_for("260799");
+        let old_konsole_query = query_for("260399");
         assert!(!old_konsole_query.contains("_Gi="));
         assert!(!old_konsole_query.contains("\x1b[c"));
 
-        let new_konsole_query = query_for("260800");
+        let new_konsole_query = query_for("260400");
         assert!(!new_konsole_query.contains("_Gi="));
         assert!(new_konsole_query.contains("\x1b[c"));
     }
@@ -886,7 +886,7 @@ mod tests {
     #[test]
     fn test_terminal_blacklist_preserves_caller_entries() {
         let mut blacklist = vec![ProtocolType::Iterm2];
-        for protocol in terminal_protocol_blacklist(None, Some("260799"), None) {
+        for protocol in terminal_protocol_blacklist(None, Some("260399"), None) {
             if !blacklist.contains(&protocol) {
                 blacklist.push(protocol);
             }

--- a/docs/terminal-compatibility.md
+++ b/docs/terminal-compatibility.md
@@ -1,6 +1,6 @@
 # Terminal Compatibility
 
-Status: initial public-beta matrix, updated 2026-07-13. Entries marked
+Status: initial public-beta matrix, updated 2026-07-15. Entries marked
 `Expected` still need a dated ytm-tui smoke run before they are marketed as
 fully verified.
 
@@ -31,7 +31,7 @@ ytm-tui configuration.
 | Legacy conhost / bare cmd.exe | Unknown / Versioned | Expected partial | Version-dependent | Yes | Expected only in a desktop session with mpv | Unknown | Do not promise without a Windows build and terminal version. |
 | Ghostty | Expected via Kitty graphics | Expected | Expected; grapheme clustering is documented | Yes | Expected on macOS/Linux with mpv | Unknown unless OSC 66 lands or DECDHL probe passes | Windows support must be verified separately. |
 | foot | Expected via Sixel | Expected | Expected; package descriptions document IME through text-input-v3 | Yes | Expected on Linux GUI with mpv | Unknown | Wayland-only in normal use; verify on the target compositor. |
-| Konsole / Yakuake | Versioned: < 26.08 defaults to halfblocks; >= 26.08 is Expected via capability-gated Sixel | Expected | Expected | Yes | Expected on Linux GUI with mpv | Unknown | Yakuake inherits Konsole's terminal behavior. Sixel is selected only when DA1 advertises it and a real cell size is obtained; Kitty is not recommended. |
+| Konsole / Yakuake | Versioned: < 26.04 defaults to halfblocks; >= 26.04 is best-effort via capability-gated Sixel | Expected | Expected | Yes | Expected on Linux GUI with mpv | Unknown | Yakuake inherits KonsolePart's terminal behavior. Sixel is selected only when DA1 advertises it and a real cell size is obtained; Kitty is not recommended. |
 | mintty | Expected via Sixel | Expected | Expected | Yes | Expected on Windows desktop with mpv | Unknown | Probe longer, but Sixel is the first override to try. |
 | mlterm | Expected via Sixel | Expected | Expected | Yes | Expected on GUI OS with mpv | Unknown | Probe longer, but Sixel is the first override to try. |
 | VS Code integrated terminal | Fallback: halfblocks | Expected | Expected | Yes | Expected only through the host desktop session | Unknown | Keep conservative fallback unless a specific VS Code build is verified. |
@@ -44,12 +44,18 @@ ytm-tui configuration.
 - Album art uses `ratatui-image`, which can query Kitty, Sixel, iTerm2, and
   halfblock fallback protocols. If stdout is not a TTY, ytm-tui skips image
   probing and uses halfblocks.
-- Detected Konsole and Yakuake versions older than 26.08, or detected sessions
-  without a valid `KONSOLE_VERSION`, stay on halfblocks by default. Starting with 26.08,
+- Detected KonsolePart versions older than 26.04, or detected sessions without a
+  valid `KONSOLE_VERSION`, stay on halfblocks by default. Starting with 26.04,
   ytm-tui permits a Sixel probe and selects Sixel only when DA1 advertises the
-  capability and the terminal returns a real cell size. A missing response or
-  either failed check still falls back to halfblocks. Kitty is not part of the
-  normal Konsole/Yakuake path.
+  capability and the terminal returns a real cell size. Yakuake exports the
+  embedded KonsolePart version through the same variable, so this also works
+  when its `TERM` is a generic `xterm-256color`. A missing response or either
+  failed check still falls back to halfblocks. Kitty is not part of the normal
+  Konsole/Yakuake path.
+- Sixel on KonsolePart 26.04-26.07 is best-effort: the upstream fix that clears
+  lingering non-Kitty image placements during TUI redraws landed for
+  [Konsole 26.08](https://github.com/KDE/konsole/commit/a05e38fc6aa28ccb0e7875c82bd4d7a0b4e26cf5).
+  Set `YTM_TUI_IMAGE_PROTOCOL=halfblocks` if an older build leaves fragments.
 - Text zoom uses OSC 66 when the probe succeeds, `WT_SESSION` / DECDHL where
   applicable, and otherwise stays at 100%.
 - Keyboard enhancement intentionally omits `REPORT_ALL_KEYS_AS_ESCAPE_CODES` so
@@ -85,10 +91,11 @@ Recommended first override by terminal:
 | Konsole / Yakuake | `YTM_TUI_IMAGE_PROTOCOL=sixel` | None |
 | Unknown native hint | `YTM_TUI_IMAGE_PROTOCOL=kitty` | `iterm2`, `sixel` |
 
-On Konsole/Yakuake versions older than 26.08, manually forcing Sixel is an
+On KonsolePart versions older than 26.04, manually forcing Sixel is an
 experimental escape hatch: it bypasses the conservative default and may leave
 stale or broken image fragments. Do not use Kitty as the normal Konsole or
-Yakuake override.
+Yakuake override. On 26.04 and newer, force
+`YTM_TUI_IMAGE_PROTOCOL=halfblocks` to opt out if Sixel still misbehaves.
 
 ## Smoke Runbook
 

--- a/examples/tui_perf_control.rs
+++ b/examples/tui_perf_control.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
-use tokio::io::{AsyncRead, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::sync::mpsc;
 use tokio::time::{sleep, sleep_until, timeout};
 use yututui::remote::proto::{
@@ -1235,13 +1235,16 @@ async fn subscribe_and_confirm(
     Ok(reader)
 }
 
-async fn query_mpv_property(
-    reader: &mut BufReader<Stream>,
+async fn query_mpv_property<R>(
+    reader: &mut BufReader<R>,
     request_id: u64,
     property: &str,
     required: bool,
     wait: Duration,
-) -> Result<Option<Value>, String> {
+) -> Result<Option<Value>, String>
+where
+    R: AsyncRead + AsyncWrite + Unpin,
+{
     let mut payload = serde_json::to_vec(&json!({
         "command": ["get_property", property],
         "request_id": request_id,
@@ -1259,46 +1262,55 @@ async fn query_mpv_property(
         .await
         .map_err(|error| format!("flush mpv {property} query: {error}"))?;
     let deadline = Instant::now() + wait;
-    let remaining = deadline.saturating_duration_since(Instant::now());
-    if remaining.is_zero() {
-        return Err(format!("timed out waiting for mpv {property} query"));
-    }
     let mut line = Vec::new();
-    let outcome = timeout(
-        remaining,
-        yututui::util::io::read_bounded_line(reader, &mut line, IPC_LINE_CAP),
-    )
-    .await
-    .map_err(|_| format!("timed out waiting for mpv {property} query"))?
-    .map_err(|error| format!("read mpv {property} query: {error}"))?;
-    match outcome {
-        yututui::util::io::BoundedLine::Eof => {
+    loop {
+        line.clear();
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(format!("timed out waiting for mpv {property} query"));
+        }
+        let outcome = timeout(
+            remaining,
+            yututui::util::io::read_bounded_line(reader, &mut line, IPC_LINE_CAP),
+        )
+        .await
+        .map_err(|_| format!("timed out waiting for mpv {property} query"))?
+        .map_err(|error| format!("read mpv {property} query: {error}"))?;
+        match outcome {
+            yututui::util::io::BoundedLine::Eof => {
+                return Err(format!(
+                    "mpv cache query connection closed while reading {property}"
+                ));
+            }
+            yututui::util::io::BoundedLine::TooLarge => {
+                return Err(format!("mpv {property} query returned an oversized frame"));
+            }
+            yututui::util::io::BoundedLine::Line => {}
+        }
+        let response: Value = serde_json::from_slice(&line)
+            .map_err(|error| format!("parse mpv {property} query: {error}"))?;
+        match response.get("request_id") {
+            Some(actual) if actual.as_u64() == Some(request_id) => {}
+            None if response.get("event").and_then(Value::as_str).is_some() => continue,
+            actual => {
+                return Err(format!(
+                    "mpv {property} query returned an uncorrelated response \
+                     (expected request_id {request_id}, got {})",
+                    actual.unwrap_or(&Value::Null)
+                ));
+            }
+        }
+        if response.get("error").and_then(Value::as_str) == Some("success") {
+            return Ok(Some(response.get("data").cloned().unwrap_or(Value::Null)));
+        }
+        if required {
             return Err(format!(
-                "mpv cache query connection closed while reading {property}"
+                "required mpv {property} query failed: {}",
+                response.get("error").unwrap_or(&Value::Null)
             ));
         }
-        yututui::util::io::BoundedLine::TooLarge => {
-            return Err(format!("mpv {property} query returned an oversized frame"));
-        }
-        yututui::util::io::BoundedLine::Line => {}
+        return Ok(None);
     }
-    let response: Value = serde_json::from_slice(&line)
-        .map_err(|error| format!("parse mpv {property} query: {error}"))?;
-    if response.get("request_id").and_then(Value::as_u64) != Some(request_id) {
-        return Err(format!(
-            "mpv {property} query returned an uncorrelated response"
-        ));
-    }
-    if response.get("error").and_then(Value::as_str) == Some("success") {
-        return Ok(Some(response.get("data").cloned().unwrap_or(Value::Null)));
-    }
-    if required {
-        return Err(format!(
-            "required mpv {property} query failed: {}",
-            response.get("error").unwrap_or(&Value::Null)
-        ));
-    }
-    Ok(None)
 }
 
 fn narrow_demuxer_cache_state(state: Value) -> Result<Value, String> {
@@ -1349,25 +1361,25 @@ async fn poll_cache_telemetry(stream: Stream, tx: mpsc::Sender<IpcMessage>) {
             sleep_until(tokio::time::Instant::from_std(next_query)).await;
         }
         sequence = sequence.saturating_add(1);
-        let cache_speed = query_mpv_property(
-            &mut reader,
-            91_000,
-            "cache-speed",
-            false,
-            CACHE_QUERY_INTERVAL,
-        )
-        .await;
-        let cache_on_disk = query_mpv_property(
-            &mut reader,
-            91_001,
-            "cache-on-disk",
-            true,
-            CACHE_QUERY_INTERVAL,
-        )
-        .await;
         let result: Result<Vec<IpcEvent>, String> = async {
+            let cache_speed = query_mpv_property(
+                &mut reader,
+                91_000,
+                "cache-speed",
+                false,
+                CACHE_QUERY_INTERVAL,
+            )
+            .await?;
+            let cache_on_disk = query_mpv_property(
+                &mut reader,
+                91_001,
+                "cache-on-disk",
+                true,
+                CACHE_QUERY_INTERVAL,
+            )
+            .await?;
             let mut events = Vec::new();
-            if let Some(value) = cache_speed? {
+            if let Some(value) = cache_speed {
                 events.push(queried_property_event(
                     "cache-speed",
                     value,
@@ -1375,7 +1387,7 @@ async fn poll_cache_telemetry(stream: Stream, tx: mpsc::Sender<IpcMessage>) {
                     sequence,
                 ));
             }
-            if cache_on_disk?.and_then(|value| value.as_bool()) == Some(true) {
+            if cache_on_disk.and_then(|value| value.as_bool()) == Some(true) {
                 let state = query_mpv_property(
                     &mut reader,
                     91_002,
@@ -2235,6 +2247,110 @@ mod tests {
         ])
         .expect_err("multiple exact candidates must not be selected by iteration order");
         assert_eq!(ambiguity, 2);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mpv_property_query_skips_events_before_its_correlated_response() {
+        let (stream, mut peer) = tokio::io::duplex(4_096);
+        peer.write_all(
+            b"{\"event\":\"start-file\",\"playlist_entry_id\":2}\n\
+              {\"event\":\"file-loaded\"}\n\
+              {\"data\":1234,\"request_id\":91000,\"error\":\"success\"}\n",
+        )
+        .await
+        .expect("queue interleaved mpv frames");
+        let mut reader = BufReader::new(stream);
+
+        let value = query_mpv_property(
+            &mut reader,
+            91_000,
+            "cache-speed",
+            false,
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("unsolicited events must not consume the correlated response");
+
+        assert_eq!(value, Some(json!(1234)));
+        let mut peer = BufReader::new(peer);
+        let mut command = Vec::new();
+        assert!(matches!(
+            yututui::util::io::read_bounded_line(&mut peer, &mut command, IPC_LINE_CAP)
+                .await
+                .expect("read property query command"),
+            yututui::util::io::BoundedLine::Line
+        ));
+        assert_eq!(
+            serde_json::from_slice::<Value>(&command).expect("parse property query command"),
+            json!({
+                "command": ["get_property", "cache-speed"],
+                "request_id": 91_000,
+            })
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mpv_property_query_still_rejects_a_different_request_id() {
+        let (stream, mut peer) = tokio::io::duplex(1_024);
+        peer.write_all(
+            b"{\"event\":\"file-loaded\"}\n\
+              {\"data\":1234,\"request_id\":91001,\"error\":\"success\"}\n",
+        )
+        .await
+        .expect("queue mismatched mpv response");
+        let mut reader = BufReader::new(stream);
+
+        let error = query_mpv_property(
+            &mut reader,
+            91_000,
+            "cache-speed",
+            false,
+            Duration::from_secs(1),
+        )
+        .await
+        .expect_err("a response for another command must remain fail-closed");
+
+        assert!(error.contains("uncorrelated response"));
+        assert!(error.contains("expected request_id 91000"));
+        assert!(error.contains("got 91001"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mpv_property_query_events_do_not_extend_the_absolute_deadline() {
+        let (stream, mut peer) = tokio::io::duplex(1_024);
+        let (event_sent, event_observed) = tokio::sync::oneshot::channel();
+        let writer = tokio::spawn(async move {
+            sleep(Duration::from_millis(150)).await;
+            peer.write_all(b"{\"event\":\"file-loaded\",\"id\":91000}\n")
+                .await
+                .expect("write interleaved event");
+            let _ = event_sent.send(());
+            sleep(Duration::from_millis(500)).await;
+        });
+        let mut reader = BufReader::new(stream);
+        let started = Instant::now();
+
+        let error = query_mpv_property(
+            &mut reader,
+            91_000,
+            "cache-speed",
+            false,
+            Duration::from_millis(250),
+        )
+        .await
+        .expect_err("events without a correlated response must time out");
+        let elapsed = started.elapsed();
+        event_observed
+            .await
+            .expect("the event must arrive before the query deadline");
+        writer.abort();
+
+        assert!(error.contains("timed out waiting for mpv cache-speed query"));
+        assert!(elapsed >= Duration::from_millis(150));
+        assert!(
+            elapsed < Duration::from_millis(325),
+            "the interleaved event reset the absolute deadline: {elapsed:?}"
+        );
     }
 
     #[test]

--- a/examples/tui_perf_sampler.rs
+++ b/examples/tui_perf_sampler.rs
@@ -2,8 +2,10 @@
 //!
 //! The sampler must itself run in an interactive terminal (tmux on Unix, a local
 //! ConPTY/console on Windows). It launches exactly one `ytt`, follows only that PID's
-//! descendants, and writes NDJSON outside the measured terminal. No process-name-wide
-//! cleanup is ever performed.
+//! descendants, and writes NDJSON outside the measured terminal. On Unix the measured owner
+//! keeps its dedicated cleanup process group, but temporarily owns the terminal foreground so
+//! its raw-mode and capability probes cannot be job-control stopped. No process-name-wide cleanup
+//! is ever performed.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
@@ -22,6 +24,222 @@ use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, Signal, System, UpdateKind}
 const SCHEMA: &str = "ytt.tui-perf.samples.v1";
 const RESOURCE_SCHEMA: &str = "ytt.tui-perf.resources.v2";
 const CLEANUP_SCOPE: &str = "dedicated_owner_process_group_and_observed_exact_descendants";
+
+#[cfg(unix)]
+fn tcsetpgrp_blocking_sigttou(fd: libc::c_int, group: libc::pid_t) -> std::io::Result<()> {
+    let mut blocked = std::mem::MaybeUninit::<libc::sigset_t>::uninit();
+    // SAFETY: `blocked` points to writable storage for one sigset_t.
+    if unsafe { libc::sigemptyset(blocked.as_mut_ptr()) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: sigemptyset initialized the complete value above.
+    let mut blocked = unsafe { blocked.assume_init() };
+    // SAFETY: `blocked` is initialized and SIGTTOU is a valid signal number.
+    if unsafe { libc::sigaddset(&mut blocked, libc::SIGTTOU) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let mut previous = std::mem::MaybeUninit::<libc::sigset_t>::uninit();
+    // SAFETY: both mask pointers are valid; pthread_sigmask initializes `previous` on success.
+    let block_error =
+        unsafe { libc::pthread_sigmask(libc::SIG_BLOCK, &blocked, previous.as_mut_ptr()) };
+    if block_error != 0 {
+        return Err(std::io::Error::from_raw_os_error(block_error));
+    }
+    // SAFETY: the successful pthread_sigmask call initialized the complete previous mask.
+    let previous = unsafe { previous.assume_init() };
+    // SAFETY: the caller supplies a controlling-terminal fd and a positive process group.
+    let foreground_result = unsafe { libc::tcsetpgrp(fd, group) };
+    let foreground_error = (foreground_result != 0).then(std::io::Error::last_os_error);
+    // SAFETY: `previous` is the exact initialized mask returned above.
+    let restore_error =
+        unsafe { libc::pthread_sigmask(libc::SIG_SETMASK, &previous, std::ptr::null_mut()) };
+    if let Some(error) = foreground_error {
+        return Err(error);
+    }
+    if restore_error != 0 {
+        return Err(std::io::Error::from_raw_os_error(restore_error));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn child_claim_terminal_foreground(fd: libc::c_int) -> std::io::Result<()> {
+    // Only async-signal-safe libc calls run here: this function is called from `pre_exec` after
+    // fork and before exec, while the parent may have other threads.
+    // SAFETY: zero selects the calling child for both PID and process group.
+    if unsafe { libc::setpgid(0, 0) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: getpgrp has no preconditions and cannot fail.
+    let owner_group = unsafe { libc::getpgrp() };
+    tcsetpgrp_blocking_sigttou(fd, owner_group)
+}
+
+#[cfg(unix)]
+fn validate_sampler_foreground(
+    producer_group: libc::pid_t,
+    foreground_group: libc::pid_t,
+) -> Result<(), String> {
+    if producer_group <= 0 || foreground_group <= 0 {
+        return Err("terminal process-group identities must be positive".to_string());
+    }
+    if foreground_group != producer_group {
+        return Err(format!(
+            "sampler process group {producer_group} is not the terminal foreground group \
+             {foreground_group}"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+struct TerminalForegroundGuard {
+    fd: libc::c_int,
+    producer_group: libc::pid_t,
+    owner_group: Option<libc::pid_t>,
+    armed: bool,
+    restored: bool,
+}
+
+#[cfg(unix)]
+impl TerminalForegroundGuard {
+    fn prepare() -> Result<Self, String> {
+        let fd = libc::STDIN_FILENO;
+        // SAFETY: getpgrp has no preconditions and cannot fail.
+        let producer_group = unsafe { libc::getpgrp() };
+        // SAFETY: fd names inherited stdin, required by this sampler to be a controlling terminal.
+        let foreground_group = unsafe { libc::tcgetpgrp(fd) };
+        if foreground_group < 0 {
+            return Err(format!(
+                "inspect sampler terminal foreground group: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        validate_sampler_foreground(producer_group, foreground_group)?;
+        Ok(Self {
+            fd,
+            producer_group,
+            owner_group: None,
+            armed: false,
+            restored: false,
+        })
+    }
+
+    fn fd(&self) -> libc::c_int {
+        self.fd
+    }
+
+    fn arm(&mut self) {
+        self.armed = true;
+    }
+
+    fn confirm_owner(&mut self, owner_pid: u32) -> Result<(), String> {
+        let owner_group = libc::pid_t::try_from(owner_pid)
+            .map_err(|_| format!("owner PID {owner_pid} does not fit pid_t"))?;
+        self.owner_group = Some(owner_group);
+        // SAFETY: owner_group is the live child PID returned by Command::spawn.
+        let observed_owner_group = unsafe { libc::getpgid(owner_group) };
+        if observed_owner_group < 0 {
+            return Err(format!(
+                "inspect owner PID {owner_pid} process group: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        // SAFETY: fd remains the inherited controlling-terminal descriptor.
+        let foreground_group = unsafe { libc::tcgetpgrp(self.fd) };
+        if foreground_group < 0 {
+            return Err(format!(
+                "inspect owner terminal foreground group: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        if owner_group == self.producer_group
+            || observed_owner_group != owner_group
+            || foreground_group != owner_group
+        {
+            return Err(format!(
+                "owner foreground handoff mismatch: producer={}, owner={}, observed owner \
+                 group={}, foreground={foreground_group}",
+                self.producer_group, owner_group, observed_owner_group
+            ));
+        }
+        // A defensive SIGCONT closes any platform race that stopped the exact group before the
+        // child-side pre-exec handoff. Both the PGID and terminal foreground were verified above.
+        // SAFETY: a negative PID targets only the verified dedicated owner process group.
+        if unsafe { libc::kill(-owner_group, libc::SIGCONT) } != 0 {
+            return Err(format!(
+                "resume foreground owner process group {owner_group}: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        Ok(())
+    }
+
+    fn restore(&mut self) -> Result<(), String> {
+        if self.restored || !self.armed {
+            return Ok(());
+        }
+        // SAFETY: fd remains the inherited controlling-terminal descriptor.
+        let foreground_group = unsafe { libc::tcgetpgrp(self.fd) };
+        if foreground_group < 0 {
+            return Err(format!(
+                "inspect terminal before restoring sampler foreground: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        if foreground_group == self.producer_group {
+            self.restored = true;
+            return Ok(());
+        }
+        if self
+            .owner_group
+            .is_some_and(|owner_group| foreground_group != owner_group)
+        {
+            return Err(format!(
+                "refusing to replace unexpected terminal foreground group {foreground_group}; \
+                 expected owner {:?} or sampler {}",
+                self.owner_group, self.producer_group
+            ));
+        }
+        tcsetpgrp_blocking_sigttou(self.fd, self.producer_group).map_err(|error| {
+            format!(
+                "restore sampler terminal foreground group {}: {error}",
+                self.producer_group
+            )
+        })?;
+        // SAFETY: fd remains the same controlling-terminal descriptor just updated above.
+        let restored_group = unsafe { libc::tcgetpgrp(self.fd) };
+        if restored_group != self.producer_group {
+            return Err(format!(
+                "sampler terminal foreground restore did not stick: expected {}, observed \
+                 {restored_group}",
+                self.producer_group
+            ));
+        }
+        self.restored = true;
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+impl Drop for TerminalForegroundGuard {
+    fn drop(&mut self) {
+        let _ = self.restore();
+    }
+}
+
+#[cfg(unix)]
+fn merge_terminal_restore_error(
+    foreground: &mut TerminalForegroundGuard,
+    original: String,
+) -> String {
+    match foreground.restore() {
+        Ok(()) => original,
+        Err(restore) => {
+            format!("{original}; restoring sampler terminal foreground also failed: {restore}")
+        }
+    }
+}
 
 #[derive(Debug)]
 struct Args {
@@ -463,6 +681,8 @@ fn run(args: Args) -> Result<(), String> {
         &last_descendant_identities,
         false,
     )?;
+    #[cfg(unix)]
+    let mut terminal_foreground = TerminalForegroundGuard::prepare()?;
     let mut owner_command = Command::new(&args.binary);
     owner_command
         .args(&args.child_args)
@@ -471,21 +691,50 @@ fn run(args: Args) -> Result<(), String> {
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
     #[cfg(unix)]
-    owner_command.process_group(0);
-    let mut child = owner_command
-        .spawn()
-        .map_err(|e| format!("launch {}: {e}", args.binary.display()))?;
+    {
+        let terminal_fd = terminal_foreground.fd();
+        // SAFETY: the closure calls only async-signal-safe libc operations and constructs no
+        // heap-backed state between fork and exec.
+        unsafe {
+            owner_command.pre_exec(move || child_claim_terminal_foreground(terminal_fd));
+        }
+        terminal_foreground.arm();
+    }
+    let mut child = match owner_command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            let error = format!("launch {}: {error}", args.binary.display());
+            #[cfg(unix)]
+            let error = merge_terminal_restore_error(&mut terminal_foreground, error);
+            return Err(error);
+        }
+    };
     let root_pid = child.id();
+    macro_rules! fail_after_startup_cleanup {
+        ($partial:expr, $error:expr) => {{
+            let error = cleanup_after_startup_error(
+                &args,
+                &producer_identity,
+                $partial,
+                &mut child,
+                $error,
+            );
+            #[cfg(unix)]
+            let error = merge_terminal_restore_error(&mut terminal_foreground, error);
+            return Err(error);
+        }};
+    }
+    #[cfg(unix)]
+    match terminal_foreground.confirm_owner(root_pid) {
+        Ok(()) => {}
+        Err(error) => {
+            fail_after_startup_cleanup!(None, error);
+        }
+    };
     let partial_owner = match wait_for_partial_process_identity(root_pid, &mut child) {
         Ok(identity) => identity,
         Err(error) => {
-            return Err(cleanup_after_startup_error(
-                &args,
-                &producer_identity,
-                None,
-                &mut child,
-                error,
-            ));
+            fail_after_startup_cleanup!(None, error);
         }
     };
     if let Err(error) = write_live_identity(
@@ -498,24 +747,12 @@ fn run(args: Args) -> Result<(), String> {
         &last_descendant_identities,
         false,
     ) {
-        return Err(cleanup_after_startup_error(
-            &args,
-            &producer_identity,
-            Some(&partial_owner),
-            &mut child,
-            error,
-        ));
+        fail_after_startup_cleanup!(Some(&partial_owner), error);
     }
     let owner_identity = match wait_for_process_identity(root_pid, &binary_hash, &mut child) {
         Ok(identity) => identity,
         Err(error) => {
-            return Err(cleanup_after_startup_error(
-                &args,
-                &producer_identity,
-                Some(&partial_owner),
-                &mut child,
-                error,
-            ));
+            fail_after_startup_cleanup!(Some(&partial_owner), error);
         }
     };
     if let Err(error) = write_live_identity(
@@ -528,25 +765,13 @@ fn run(args: Args) -> Result<(), String> {
         &last_descendant_identities,
         false,
     ) {
-        return Err(cleanup_after_startup_error(
-            &args,
-            &producer_identity,
-            Some(&partial_owner),
-            &mut child,
-            error,
-        ));
+        fail_after_startup_cleanup!(Some(&partial_owner), error);
     }
 
     if let Some(path) = &args.pid_file
         && let Err(error) = write_pid_file(path, root_pid)
     {
-        return Err(cleanup_after_startup_error(
-            &args,
-            &producer_identity,
-            Some(&partial_owner),
-            &mut child,
-            error,
-        ));
+        fail_after_startup_cleanup!(Some(&partial_owner), error);
     }
     let barrier_result = if let Some(path) = &args.controller_ready_file {
         wait_for_controller_ready(
@@ -631,6 +856,17 @@ fn run(args: Args) -> Result<(), String> {
             Err(error) => format!(
                 "{error}; publishing completed cleanup proof also failed: {cleanup_proof_error}"
             ),
+        });
+    }
+    #[cfg(unix)]
+    if let Err(foreground_error) = terminal_foreground.restore() {
+        result = Err(match result {
+            Ok(()) => foreground_error,
+            Err(error) => {
+                format!(
+                    "{error}; restoring sampler terminal foreground also failed: {foreground_error}"
+                )
+            }
         });
     }
     if let Err(message) = &result {
@@ -2724,6 +2960,8 @@ mod tests {
     use std::process::Child;
     use std::sync::mpsc;
 
+    #[cfg(unix)]
+    use super::validate_sampler_foreground;
     use super::{
         Aggregate, Args, LiveProcessIdentity, MeasuredMpvProof, MpvIdentity, RoleSample,
         controller_ready_matches_exact_identity, cpu_interval_overlap,
@@ -2762,6 +3000,14 @@ mod tests {
                 let _ = child.wait();
             }
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn terminal_handoff_requires_the_sampler_to_start_in_foreground() {
+        assert!(validate_sampler_foreground(10, 10).is_ok());
+        assert!(validate_sampler_foreground(10, 12).is_err());
+        assert!(validate_sampler_foreground(0, 10).is_err());
     }
 
     #[test]

--- a/examples/tui_render_perf.rs
+++ b/examples/tui_render_perf.rs
@@ -193,8 +193,10 @@ fn usage() -> &'static str {
      Cases: player, search50, library999, ai_long, reducer_input, retro160x50, normal80x24, \
      local_empty60x16, local_scroll72x18, local_max120x30, local_filter_ko90x24, \
      canvas_art100x30, canvas_art160x50, canvas_art_lyrics100x30, \
-     canvas_art_lyrics160x50, animation_half100x30, animation_half_art_lyrics160x50, \
-     animation_heavy_half100x30, animation_heavy_half_art_lyrics160x50"
+     canvas_art_lyrics160x50, animation_control100x30, \
+     animation_control_art_lyrics160x50, animation_half100x30, \
+     animation_half_art_lyrics160x50, animation_heavy_half100x30, \
+     animation_heavy_half_art_lyrics160x50"
 }
 
 #[derive(Serialize)]
@@ -474,6 +476,24 @@ fn case_specs() -> Vec<CaseSpec> {
             height: 50,
             language: Language::English,
             build: canvas_art_lyrics_app,
+            update: canvas_interaction,
+        },
+        CaseSpec {
+            name: "animation_control100x30",
+            update_path: "app_update_msg_anim_tick",
+            width: 100,
+            height: 30,
+            language: Language::English,
+            build: animation_control_app,
+            update: canvas_interaction,
+        },
+        CaseSpec {
+            name: "animation_control_art_lyrics160x50",
+            update_path: "app_update_msg_anim_tick",
+            width: 160,
+            height: 50,
+            language: Language::English,
+            build: animation_control_art_lyrics_app,
             update: canvas_interaction,
         },
         CaseSpec {
@@ -819,7 +839,6 @@ fn configure_animation_half(app: &mut App) {
     a.starfield = true;
     a.visualizer = true;
     a.rain = true;
-    app.playback.paused = false;
 }
 
 fn configure_animation_heavy_half(app: &mut App) {
@@ -847,41 +866,48 @@ fn configure_animation_heavy_half(app: &mut App) {
     a.life = true;
     a.pipes = true;
     a.plasma = true;
-    app.playback.paused = false;
 }
 
-fn animation_half_app() -> App {
+fn animation_control_app() -> App {
     let mut app = player_app();
     // The fixture mutates queue/volume directly. Let the ordinary reducer observe that
     // steady state while animations are still disabled so the first measured AnimTick does
     // not synthesize track-intro/volume-flash effects that real runtime setup already saw.
     let _ = app.update(Msg::Noop);
+    app.playback.paused = false;
+    app
+}
+
+fn animation_control_art_lyrics_app() -> App {
+    let mut app = animation_control_app();
+    app.config.player_bar_position = Some(PlayerBarPosition::Bottom);
+    app.config.album_art = Some(true);
+    attach_art(&mut app);
+    attach_lyrics(&mut app);
+    app
+}
+
+fn animation_half_app() -> App {
+    let mut app = animation_control_app();
     configure_animation_half(&mut app);
     app
 }
 
 fn animation_half_art_lyrics_app() -> App {
-    let mut app = animation_half_app();
-    app.config.player_bar_position = Some(PlayerBarPosition::Bottom);
-    app.config.album_art = Some(true);
-    attach_art(&mut app);
-    attach_lyrics(&mut app);
+    let mut app = animation_control_art_lyrics_app();
+    configure_animation_half(&mut app);
     app
 }
 
 fn animation_heavy_half_app() -> App {
-    let mut app = player_app();
-    let _ = app.update(Msg::Noop);
+    let mut app = animation_control_app();
     configure_animation_heavy_half(&mut app);
     app
 }
 
 fn animation_heavy_half_art_lyrics_app() -> App {
-    let mut app = animation_heavy_half_app();
-    app.config.player_bar_position = Some(PlayerBarPosition::Bottom);
-    app.config.album_art = Some(true);
-    attach_art(&mut app);
-    attach_lyrics(&mut app);
+    let mut app = animation_control_art_lyrics_app();
+    configure_animation_heavy_half(&mut app);
     app
 }
 
@@ -1095,10 +1121,11 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use super::{
-        LOCAL_FILTER_STRIDE, LOCAL_LARGE_TRACKS, LOCAL_SCROLL_TRACKS, animation_half_app,
-        animation_heavy_half_app, case_specs, checkpoint_digest, local_empty_app,
-        local_filter_korean_app, local_max_app, local_scroll_app,
-        measure_update_to_draw_with_clock, percentile, reducer_input, search_app,
+        LOCAL_FILTER_STRIDE, LOCAL_LARGE_TRACKS, LOCAL_SCROLL_TRACKS, animation_control_app,
+        animation_control_art_lyrics_app, animation_half_app, animation_half_art_lyrics_app,
+        animation_heavy_half_app, animation_heavy_half_art_lyrics_app, case_specs,
+        checkpoint_digest, local_empty_app, local_filter_korean_app, local_max_app,
+        local_scroll_app, measure_update_to_draw_with_clock, percentile, reducer_input, search_app,
     };
     use yututui::app::App;
 
@@ -1149,6 +1176,31 @@ mod tests {
         .into_iter()
         .filter_map(|(name, enabled)| enabled.then_some(name))
         .collect()
+    }
+
+    fn assert_matching_art_lyrics_state(control: &App, animated: &App) {
+        assert_eq!(
+            animated.config.player_bar_position,
+            control.config.player_bar_position
+        );
+        assert_eq!(animated.config.album_art, control.config.album_art);
+        assert_eq!(animated.art.dims, control.art.dims);
+        assert_eq!(animated.art.picker.is_some(), control.art.picker.is_some());
+        assert_eq!(
+            animated.art.protocol.borrow().is_some(),
+            control.art.protocol.borrow().is_some()
+        );
+        assert_eq!(animated.lyrics.visible, control.lyrics.visible);
+
+        let control_track = control.lyrics.track.as_ref().expect("control lyrics");
+        let animated_track = animated.lyrics.track.as_ref().expect("animated lyrics");
+        assert_eq!(animated_track.video_id, control_track.video_id);
+        assert_eq!(animated_track.lines.len(), control_track.lines.len());
+        for (animated_line, control_line) in animated_track.lines.iter().zip(&*control_track.lines)
+        {
+            assert_eq!(animated_line.time.to_bits(), control_line.time.to_bits());
+            assert_eq!(animated_line.text, control_line.text);
+        }
     }
 
     #[test]
@@ -1255,9 +1307,11 @@ mod tests {
     }
 
     #[test]
-    fn half_animation_cases_and_profiles_are_exact_and_checkpoint_repeatable() {
+    fn animation_control_and_half_cases_are_state_matched_and_checkpoint_repeatable() {
         let cases = case_specs();
         for (name, width, height) in [
+            ("animation_control100x30", 100, 30),
+            ("animation_control_art_lyrics160x50", 160, 50),
             ("animation_half100x30", 100, 30),
             ("animation_half_art_lyrics160x50", 160, 50),
             ("animation_heavy_half100x30", 100, 30),
@@ -1270,6 +1324,26 @@ mod tests {
             assert_eq!((case.width, case.height), (width, height));
             assert_eq!(case.update_path, "app_update_msg_anim_tick");
         }
+
+        let control = animation_control_app();
+        assert!(!control.config.animations.master);
+        assert_eq!(control.config.animations.fps, 30);
+        assert!(control.config.animations.pause_unfocused);
+        assert!(enabled_animation_effects(&control).is_empty());
+        assert!(!control.playback.paused);
+
+        let art_lyrics_control = animation_control_art_lyrics_app();
+        assert!(!art_lyrics_control.config.animations.master);
+        assert!(enabled_animation_effects(&art_lyrics_control).is_empty());
+        assert_eq!(
+            art_lyrics_control.config.player_bar_position,
+            Some(yututui::config::PlayerBarPosition::Bottom)
+        );
+        assert_eq!(art_lyrics_control.config.album_art, Some(true));
+        assert!(art_lyrics_control.art.picker.is_some());
+        assert!(art_lyrics_control.art.protocol.borrow().is_some());
+        assert!(art_lyrics_control.lyrics.visible);
+        assert!(art_lyrics_control.lyrics.track.is_some());
 
         let balanced = animation_half_app();
         assert!(balanced.config.animations.master);
@@ -1300,6 +1374,7 @@ mod tests {
                 "bounce",
             ]
         );
+        assert_eq!(balanced.playback.paused, control.playback.paused);
 
         let heavy = animation_heavy_half_app();
         assert!(heavy.config.animations.master);
@@ -1329,6 +1404,13 @@ mod tests {
                 "pipes",
                 "plasma",
             ]
+        );
+        assert_eq!(heavy.playback.paused, control.playback.paused);
+
+        assert_matching_art_lyrics_state(&art_lyrics_control, &animation_half_art_lyrics_app());
+        assert_matching_art_lyrics_state(
+            &art_lyrics_control,
+            &animation_heavy_half_art_lyrics_app(),
         );
 
         let case = *cases

--- a/examples/tui_render_perf.rs
+++ b/examples/tui_render_perf.rs
@@ -193,7 +193,8 @@ fn usage() -> &'static str {
      Cases: player, search50, library999, ai_long, reducer_input, retro160x50, normal80x24, \
      local_empty60x16, local_scroll72x18, local_max120x30, local_filter_ko90x24, \
      canvas_art100x30, canvas_art160x50, canvas_art_lyrics100x30, \
-     canvas_art_lyrics160x50"
+     canvas_art_lyrics160x50, animation_half100x30, animation_half_art_lyrics160x50, \
+     animation_heavy_half100x30, animation_heavy_half_art_lyrics160x50"
 }
 
 #[derive(Serialize)]
@@ -237,6 +238,7 @@ struct CaseReport {
     batches: Vec<BatchReport>,
     buffer_style_digest: String,
     hit_map_digest: String,
+    checkpoint_digest: String,
 }
 
 #[derive(Serialize)]
@@ -475,6 +477,42 @@ fn case_specs() -> Vec<CaseSpec> {
             update: canvas_interaction,
         },
         CaseSpec {
+            name: "animation_half100x30",
+            update_path: "app_update_msg_anim_tick",
+            width: 100,
+            height: 30,
+            language: Language::English,
+            build: animation_half_app,
+            update: canvas_interaction,
+        },
+        CaseSpec {
+            name: "animation_half_art_lyrics160x50",
+            update_path: "app_update_msg_anim_tick",
+            width: 160,
+            height: 50,
+            language: Language::English,
+            build: animation_half_art_lyrics_app,
+            update: canvas_interaction,
+        },
+        CaseSpec {
+            name: "animation_heavy_half100x30",
+            update_path: "app_update_msg_anim_tick",
+            width: 100,
+            height: 30,
+            language: Language::English,
+            build: animation_heavy_half_app,
+            update: canvas_interaction,
+        },
+        CaseSpec {
+            name: "animation_heavy_half_art_lyrics160x50",
+            update_path: "app_update_msg_anim_tick",
+            width: 160,
+            height: 50,
+            language: Language::English,
+            build: animation_heavy_half_art_lyrics_app,
+            update: canvas_interaction,
+        },
+        CaseSpec {
             name: "local_empty60x16",
             update_path: "direct_fixture_state",
             width: 60,
@@ -520,6 +558,7 @@ fn run_case(
     draws_per_batch: usize,
 ) -> Result<CaseReport, String> {
     yututui::i18n::set_language(spec.language);
+    let checkpoint_digest = checkpoint_digest(spec)?;
     let mut app = (spec.build)();
     let backend = TestBackend::new(spec.width, spec.height);
     let mut terminal = Terminal::new(backend).map_err(|e| format!("create backend: {e}"))?;
@@ -590,7 +629,31 @@ fn run_case(
         batches,
         buffer_style_digest,
         hit_map_digest,
+        checkpoint_digest,
     })
+}
+
+fn checkpoint_digest(spec: CaseSpec) -> Result<String, String> {
+    const CHECKPOINTS: [usize; 6] = [0, 1, 29, 30, 59, 119];
+    let mut app = (spec.build)();
+    let backend = TestBackend::new(spec.width, spec.height);
+    let mut terminal =
+        Terminal::new(backend).map_err(|e| format!("create checkpoint backend: {e}"))?;
+    let mut hasher = DefaultHasher::new();
+    for step in 0..=CHECKPOINTS[CHECKPOINTS.len() - 1] {
+        if step > 0 {
+            (spec.update)(&mut app, step - 1);
+        }
+        terminal
+            .draw(|frame| yututui::ui::render(frame, &app))
+            .map_err(|e| format!("checkpoint draw: {e}"))?;
+        if CHECKPOINTS.contains(&step) {
+            step.hash(&mut hasher);
+            terminal.backend().buffer().hash(&mut hasher);
+            digest_hit_map(&app, spec.width, spec.height).hash(&mut hasher);
+        }
+    }
+    Ok(format!("{:016x}", hasher.finish()))
 }
 
 fn latency_histogram(sorted: &[u128]) -> Vec<LatencyBucket> {
@@ -683,6 +746,11 @@ fn canvas_art_app() -> App {
     app.config.animations.plasma = true;
     app.playback.paused = false;
 
+    attach_art(&mut app);
+    app
+}
+
+fn attach_art(app: &mut App) {
     let picker = Picker::halfblocks();
     let image = Arc::new(DynamicImage::new_rgba8(32, 32));
     let protocol = picker.new_resize_protocol_shared(image);
@@ -690,7 +758,6 @@ fn canvas_art_app() -> App {
     app.art.dims = (32, 32);
     app.art.picker = Some(picker);
     *app.art.protocol.borrow_mut() = Some(ThreadProtocol::new(tx, Some(protocol)));
-    app
 }
 
 fn canvas_art_lyrics_app() -> App {
@@ -698,13 +765,118 @@ fn canvas_art_lyrics_app() -> App {
     let video_id = app.queue.current().expect("fixture track").video_id.clone();
     app.lyrics.visible = true;
     app.lyrics.track = Some(TrackLyrics {
-        video_id,
+        video_id: video_id.into(),
         lines: vec![LyricLine {
             time: 0.0,
             text: "Deterministic performance fixture lyric".to_owned(),
         }]
         .into(),
     });
+    app
+}
+
+fn attach_lyrics(app: &mut App) {
+    let video_id = app.queue.current().expect("fixture track").video_id.clone();
+    app.lyrics.visible = true;
+    app.lyrics.track = Some(TrackLyrics {
+        video_id: video_id.into(),
+        lines: vec![
+            LyricLine {
+                time: 0.0,
+                text: "Deterministic performance fixture lyric".to_owned(),
+            },
+            LyricLine {
+                time: 60.0,
+                text: "Second deterministic performance fixture lyric".to_owned(),
+            },
+        ]
+        .into(),
+    });
+}
+
+fn configure_animation_half(app: &mut App) {
+    let a = &mut app.config.animations;
+    a.master = true;
+    a.fps = 30;
+    a.pause_unfocused = true;
+    a.track_intro = true;
+    a.toast = true;
+    a.volume_flash = true;
+    a.seek_flash = true;
+    a.selection = true;
+    a.caret = true;
+    a.activity = true;
+    a.popup_fade = true;
+    a.title = true;
+    a.heart = true;
+    a.seekbar = true;
+    a.spinner = true;
+    a.eq_bars = true;
+    a.controls = true;
+    a.border = true;
+    a.time_glow = true;
+    a.bounce = true;
+    a.starfield = true;
+    a.visualizer = true;
+    a.rain = true;
+    app.playback.paused = false;
+}
+
+fn configure_animation_heavy_half(app: &mut App) {
+    let a = &mut app.config.animations;
+    a.master = true;
+    a.fps = 30;
+    a.pause_unfocused = true;
+    a.title = true;
+    a.lyrics = true;
+    a.seekbar = true;
+    a.eq_bars = true;
+    a.controls = true;
+    a.border = true;
+    a.rain = true;
+    a.donut = true;
+    a.visualizer = true;
+    a.starfield = true;
+    a.comets = true;
+    a.snow = true;
+    a.fireflies = true;
+    a.cube = true;
+    a.aquarium = true;
+    a.waves = true;
+    a.fireworks = true;
+    a.life = true;
+    a.pipes = true;
+    a.plasma = true;
+    app.playback.paused = false;
+}
+
+fn animation_half_app() -> App {
+    let mut app = player_app();
+    configure_animation_half(&mut app);
+    app
+}
+
+fn animation_half_art_lyrics_app() -> App {
+    let mut app = animation_half_app();
+    app.config.player_bar_position = Some(PlayerBarPosition::Bottom);
+    app.config.album_art = Some(true);
+    attach_art(&mut app);
+    attach_lyrics(&mut app);
+    app
+}
+
+fn animation_heavy_half_app() -> App {
+    let mut app = player_app();
+    configure_animation_heavy_half(&mut app);
+    app
+}
+
+fn animation_heavy_half_art_lyrics_app() -> App {
+    let mut app = animation_heavy_half_app();
+    app.config.player_bar_position = Some(PlayerBarPosition::Bottom);
+    app.config.album_art = Some(true);
+    attach_art(&mut app);
+    attach_lyrics(&mut app);
     app
 }
 
@@ -918,10 +1090,61 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use super::{
-        LOCAL_FILTER_STRIDE, LOCAL_LARGE_TRACKS, LOCAL_SCROLL_TRACKS, case_specs, local_empty_app,
+        LOCAL_FILTER_STRIDE, LOCAL_LARGE_TRACKS, LOCAL_SCROLL_TRACKS, animation_half_app,
+        animation_heavy_half_app, case_specs, checkpoint_digest, local_empty_app,
         local_filter_korean_app, local_max_app, local_scroll_app,
         measure_update_to_draw_with_clock, percentile, reducer_input, search_app,
     };
+    use yututui::app::App;
+
+    fn enabled_animation_effects(app: &App) -> Vec<&'static str> {
+        let a = &app.config.animations;
+        [
+            ("title", a.title),
+            ("heart", a.heart),
+            ("seekbar", a.seekbar),
+            ("spinner", a.spinner),
+            ("eq_bars", a.eq_bars),
+            ("controls", a.controls),
+            ("border", a.border),
+            ("track_intro", a.track_intro),
+            ("lyrics", a.lyrics),
+            ("toast", a.toast),
+            ("volume_flash", a.volume_flash),
+            ("like_burst", a.like_burst),
+            ("seek_flash", a.seek_flash),
+            ("selection", a.selection),
+            ("stagger", a.stagger),
+            ("caret", a.caret),
+            ("tabs", a.tabs),
+            ("popup_fade", a.popup_fade),
+            ("activity", a.activity),
+            ("about_fx", a.about_fx),
+            ("time_glow", a.time_glow),
+            ("progress_sparkle", a.progress_sparkle),
+            ("border_chase", a.border_chase),
+            ("pause_flash", a.pause_flash),
+            ("error_shake", a.error_shake),
+            ("rain", a.rain),
+            ("donut", a.donut),
+            ("visualizer", a.visualizer),
+            ("starfield", a.starfield),
+            ("bounce", a.bounce),
+            ("comets", a.comets),
+            ("snow", a.snow),
+            ("fireflies", a.fireflies),
+            ("cube", a.cube),
+            ("aquarium", a.aquarium),
+            ("waves", a.waves),
+            ("fireworks", a.fireworks),
+            ("life", a.life),
+            ("pipes", a.pipes),
+            ("plasma", a.plasma),
+        ]
+        .into_iter()
+        .filter_map(|(name, enabled)| enabled.then_some(name))
+        .collect()
+    }
 
     #[test]
     fn percentile_uses_nearest_rank_upward() {
@@ -1024,5 +1247,92 @@ mod tests {
                 .unwrap_or_else(|| panic!("missing tracked performance TODO case {name}"));
             assert_eq!((case.width, case.height), (width, height));
         }
+    }
+
+    #[test]
+    fn half_animation_cases_and_profiles_are_exact_and_checkpoint_repeatable() {
+        let cases = case_specs();
+        for (name, width, height) in [
+            ("animation_half100x30", 100, 30),
+            ("animation_half_art_lyrics160x50", 160, 50),
+            ("animation_heavy_half100x30", 100, 30),
+            ("animation_heavy_half_art_lyrics160x50", 160, 50),
+        ] {
+            let case = cases
+                .iter()
+                .find(|case| case.name == name)
+                .unwrap_or_else(|| panic!("missing half-animation performance case {name}"));
+            assert_eq!((case.width, case.height), (width, height));
+            assert_eq!(case.update_path, "app_update_msg_anim_tick");
+        }
+
+        let balanced = animation_half_app();
+        assert!(balanced.config.animations.master);
+        assert_eq!(balanced.config.animations.fps, 30);
+        assert!(balanced.config.animations.pause_unfocused);
+        assert_eq!(
+            enabled_animation_effects(&balanced),
+            [
+                "title",
+                "heart",
+                "seekbar",
+                "spinner",
+                "eq_bars",
+                "controls",
+                "border",
+                "track_intro",
+                "toast",
+                "volume_flash",
+                "seek_flash",
+                "selection",
+                "caret",
+                "popup_fade",
+                "activity",
+                "time_glow",
+                "rain",
+                "visualizer",
+                "starfield",
+                "bounce",
+            ]
+        );
+
+        let heavy = animation_heavy_half_app();
+        assert!(heavy.config.animations.master);
+        assert_eq!(heavy.config.animations.fps, 30);
+        assert!(heavy.config.animations.pause_unfocused);
+        assert_eq!(
+            enabled_animation_effects(&heavy),
+            [
+                "title",
+                "seekbar",
+                "eq_bars",
+                "controls",
+                "border",
+                "lyrics",
+                "rain",
+                "donut",
+                "visualizer",
+                "starfield",
+                "comets",
+                "snow",
+                "fireflies",
+                "cube",
+                "aquarium",
+                "waves",
+                "fireworks",
+                "life",
+                "pipes",
+                "plasma",
+            ]
+        );
+
+        let case = *cases
+            .iter()
+            .find(|case| case.name == "animation_half100x30")
+            .expect("balanced half-animation case");
+        assert_eq!(
+            checkpoint_digest(case).expect("first checkpoint digest"),
+            checkpoint_digest(case).expect("second checkpoint digest")
+        );
     }
 }

--- a/examples/tui_render_perf.rs
+++ b/examples/tui_render_perf.rs
@@ -852,6 +852,10 @@ fn configure_animation_heavy_half(app: &mut App) {
 
 fn animation_half_app() -> App {
     let mut app = player_app();
+    // The fixture mutates queue/volume directly. Let the ordinary reducer observe that
+    // steady state while animations are still disabled so the first measured AnimTick does
+    // not synthesize track-intro/volume-flash effects that real runtime setup already saw.
+    let _ = app.update(Msg::Noop);
     configure_animation_half(&mut app);
     app
 }
@@ -867,6 +871,7 @@ fn animation_half_art_lyrics_app() -> App {
 
 fn animation_heavy_half_app() -> App {
     let mut app = player_app();
+    let _ = app.update(Msg::Noop);
     configure_animation_heavy_half(&mut app);
     app
 }

--- a/scripts/size-baseline.tsv
+++ b/scripts/size-baseline.tsv
@@ -8,6 +8,7 @@
 1600	src/ui/anim.rs
 1596	src/ui/views/settings.rs
 1559	src/ai/mod.rs
+1573	src/ui/anim/canvas.rs
 1527	src/queue.rs
 1525	src/runtime/tests.rs
 1516	src/desktop/gateway.rs

--- a/scripts/tui-perf-scenarios.json
+++ b/scripts/tui-perf-scenarios.json
@@ -451,7 +451,7 @@
     },
     {
       "id": "render_and_interaction",
-      "description": "20 warmups, then 20 by 200 updates plus draws, including deterministic App::update(Msg::Key) reducer input",
+      "description": "20 warmups, then 20 by 200 updates plus draws, including deterministic reducer input, total allocation no-regression, and strict matched-control incremental animation churn",
       "pairs": 7,
       "candidate_repeats": 0,
       "min_improved_pairs": 6,
@@ -565,10 +565,20 @@
         },
         "render.animation_half100x30.allocations_per_draw": {
           "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 0
+        },
+        "render.animation_half100x30.incremental_allocations_per_draw": {
+          "comparison": "ratio",
           "max_ratio": 0.85,
           "min_improved_pairs": 6
         },
         "render.animation_half100x30.allocated_bytes_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 0
+        },
+        "render.animation_half100x30.incremental_allocated_bytes_per_draw": {
           "comparison": "ratio",
           "max_ratio": 0.85,
           "min_improved_pairs": 6
@@ -585,10 +595,20 @@
         },
         "render.animation_half_art_lyrics160x50.allocations_per_draw": {
           "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 0
+        },
+        "render.animation_half_art_lyrics160x50.incremental_allocations_per_draw": {
+          "comparison": "ratio",
           "max_ratio": 0.85,
           "min_improved_pairs": 6
         },
         "render.animation_half_art_lyrics160x50.allocated_bytes_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 0
+        },
+        "render.animation_half_art_lyrics160x50.incremental_allocated_bytes_per_draw": {
           "comparison": "ratio",
           "max_ratio": 0.85,
           "min_improved_pairs": 6
@@ -605,10 +625,20 @@
         },
         "render.animation_heavy_half100x30.allocations_per_draw": {
           "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 0
+        },
+        "render.animation_heavy_half100x30.incremental_allocations_per_draw": {
+          "comparison": "ratio",
           "max_ratio": 0.85,
           "min_improved_pairs": 6
         },
         "render.animation_heavy_half100x30.allocated_bytes_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 0
+        },
+        "render.animation_heavy_half100x30.incremental_allocated_bytes_per_draw": {
           "comparison": "ratio",
           "max_ratio": 0.85,
           "min_improved_pairs": 6
@@ -625,10 +655,20 @@
         },
         "render.animation_heavy_half_art_lyrics160x50.allocations_per_draw": {
           "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 0
+        },
+        "render.animation_heavy_half_art_lyrics160x50.incremental_allocations_per_draw": {
+          "comparison": "ratio",
           "max_ratio": 0.85,
           "min_improved_pairs": 6
         },
         "render.animation_heavy_half_art_lyrics160x50.allocated_bytes_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 0
+        },
+        "render.animation_heavy_half_art_lyrics160x50.incremental_allocated_bytes_per_draw": {
           "comparison": "ratio",
           "max_ratio": 0.85,
           "min_improved_pairs": 6

--- a/scripts/tui-perf-scenarios.json
+++ b/scripts/tui-perf-scenarios.json
@@ -18,6 +18,29 @@
     "pool_operating_systems": false,
     "selectively_discard_noisy_pairs": false
   },
+  "animation_profiles": {
+    "balanced_half": {
+      "effects": [
+        "track_intro", "toast", "volume_flash", "seek_flash", "selection",
+        "caret", "activity", "popup_fade", "title", "heart", "seekbar",
+        "spinner", "eq_bars", "controls", "border", "time_glow", "bounce",
+        "starfield", "visualizer", "rain"
+      ],
+      "master": true,
+      "fps": 30,
+      "pause_unfocused": true
+    },
+    "heavy_half": {
+      "effects": [
+        "title", "lyrics", "seekbar", "eq_bars", "controls", "border", "rain",
+        "donut", "visualizer", "starfield", "comets", "snow", "fireflies",
+        "cube", "aquarium", "waves", "fireworks", "life", "pipes", "plasma"
+      ],
+      "master": true,
+      "fps": 30,
+      "pause_unfocused": true
+    }
+  },
   "sampling": {
     "interval_ms": 1000,
     "cpu_unit": "percent_of_one_logical_core",
@@ -533,7 +556,87 @@
         "render.local_max120x30.buffer_style_digest": { "comparison": "exact" },
         "render.local_max120x30.hit_map_digest": { "comparison": "exact" },
         "render.local_filter_ko90x24.buffer_style_digest": { "comparison": "exact" },
-        "render.local_filter_ko90x24.hit_map_digest": { "comparison": "exact" }
+        "render.local_filter_ko90x24.hit_map_digest": { "comparison": "exact" },
+        "render.animation_half100x30.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.animation_half100x30.allocations_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 0.85,
+          "min_improved_pairs": 6
+        },
+        "render.animation_half100x30.allocated_bytes_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 0.85,
+          "min_improved_pairs": 6
+        },
+        "render.animation_half100x30.buffer_style_digest": { "comparison": "exact" },
+        "render.animation_half100x30.hit_map_digest": { "comparison": "exact" },
+        "render.animation_half100x30.checkpoint_digest": { "comparison": "exact" },
+        "render.animation_half100x30.update_path": { "comparison": "exact" },
+        "render.animation_half_art_lyrics160x50.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.animation_half_art_lyrics160x50.allocations_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 0.85,
+          "min_improved_pairs": 6
+        },
+        "render.animation_half_art_lyrics160x50.allocated_bytes_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 0.85,
+          "min_improved_pairs": 6
+        },
+        "render.animation_half_art_lyrics160x50.buffer_style_digest": { "comparison": "exact" },
+        "render.animation_half_art_lyrics160x50.hit_map_digest": { "comparison": "exact" },
+        "render.animation_half_art_lyrics160x50.checkpoint_digest": { "comparison": "exact" },
+        "render.animation_half_art_lyrics160x50.update_path": { "comparison": "exact" },
+        "render.animation_heavy_half100x30.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.animation_heavy_half100x30.allocations_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 0.85,
+          "min_improved_pairs": 6
+        },
+        "render.animation_heavy_half100x30.allocated_bytes_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 0.85,
+          "min_improved_pairs": 6
+        },
+        "render.animation_heavy_half100x30.buffer_style_digest": { "comparison": "exact" },
+        "render.animation_heavy_half100x30.hit_map_digest": { "comparison": "exact" },
+        "render.animation_heavy_half100x30.checkpoint_digest": { "comparison": "exact" },
+        "render.animation_heavy_half100x30.update_path": { "comparison": "exact" },
+        "render.animation_heavy_half_art_lyrics160x50.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.animation_heavy_half_art_lyrics160x50.allocations_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 0.85,
+          "min_improved_pairs": 6
+        },
+        "render.animation_heavy_half_art_lyrics160x50.allocated_bytes_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 0.85,
+          "min_improved_pairs": 6
+        },
+        "render.animation_heavy_half_art_lyrics160x50.buffer_style_digest": { "comparison": "exact" },
+        "render.animation_heavy_half_art_lyrics160x50.hit_map_digest": { "comparison": "exact" },
+        "render.animation_heavy_half_art_lyrics160x50.checkpoint_digest": { "comparison": "exact" },
+        "render.animation_heavy_half_art_lyrics160x50.update_path": { "comparison": "exact" }
       }
     },
     {
@@ -614,6 +717,155 @@
           "comparison": "ratio",
           "max_ratio": 1.05,
           "min_improved_pairs": 0
+        }
+      }
+    },
+    {
+      "id": "animation_half_balanced",
+      "description": "Seven paired steady-playback runs with the fixed balanced 20-of-40 animation profile at 30 fps",
+      "pairs": 7,
+      "candidate_repeats": 0,
+      "min_improved_pairs": 6,
+      "warmup_s": 20,
+      "sample_s": 60,
+      "geometry": [[100, 30]],
+      "traffic_profile": "normal",
+      "requires_mpv": true,
+      "fixture_profile": "wav-18m",
+      "animation_profile": "balanced_half",
+      "expected_effective_mpv_cache_args": {
+        "--demuxer-max-bytes": "32MiB",
+        "--demuxer-max-back-bytes": "8MiB"
+      },
+      "seed_contract": {
+        "require_identical_tree": true,
+        "require_identical_cache_policy": true,
+        "expected_cache_policy": null
+      },
+      "controller": true,
+      "controller_load": "resume-session",
+      "pause_policy": "none",
+      "pause_hold_ms": 0,
+      "seeks_s": [],
+      "minimum_playback_progress_fraction": 0.8,
+      "time_pos_tail_tolerance_s": 2.0,
+      "metrics": {
+        "ytt.mean_cpu_percent": {
+          "comparison": "ratio",
+          "max_ratio": 0.8,
+          "min_improved_pairs": 6
+        },
+        "tree.mean_cpu_percent": {
+          "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 6
+        },
+        "ytt.mean_rss_bytes": {
+          "comparison": "ratio",
+          "max_ratio": 1.05,
+          "min_improved_pairs": 0
+        },
+        "tree.mean_rss_bytes": {
+          "comparison": "ratio",
+          "max_ratio": 1.05,
+          "min_improved_pairs": 0
+        },
+        "buffering_events": { "comparison": "no_increase", "max_delta": 0 },
+        "buffering_ms": { "comparison": "no_increase", "max_delta": 0 }
+      }
+    },
+    {
+      "id": "animation_half_heavy",
+      "description": "Seven paired steady-playback runs with the fixed heavy 20-of-40 animation profile at 30 fps",
+      "pairs": 7,
+      "candidate_repeats": 0,
+      "min_improved_pairs": 6,
+      "warmup_s": 20,
+      "sample_s": 60,
+      "geometry": [[160, 50]],
+      "traffic_profile": "normal",
+      "requires_mpv": true,
+      "fixture_profile": "wav-18m",
+      "animation_profile": "heavy_half",
+      "expected_effective_mpv_cache_args": {
+        "--demuxer-max-bytes": "32MiB",
+        "--demuxer-max-back-bytes": "8MiB"
+      },
+      "seed_contract": {
+        "require_identical_tree": true,
+        "require_identical_cache_policy": true,
+        "expected_cache_policy": null
+      },
+      "controller": true,
+      "controller_load": "resume-session",
+      "pause_policy": "none",
+      "pause_hold_ms": 0,
+      "seeks_s": [],
+      "minimum_playback_progress_fraction": 0.8,
+      "time_pos_tail_tolerance_s": 2.0,
+      "metrics": {
+        "ytt.mean_cpu_percent": {
+          "comparison": "ratio",
+          "max_ratio": 0.8,
+          "min_improved_pairs": 6
+        },
+        "tree.mean_cpu_percent": {
+          "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 6
+        },
+        "ytt.mean_rss_bytes": {
+          "comparison": "ratio",
+          "max_ratio": 1.05,
+          "min_improved_pairs": 0
+        },
+        "tree.mean_rss_bytes": {
+          "comparison": "ratio",
+          "max_ratio": 1.05,
+          "min_improved_pairs": 0
+        },
+        "buffering_events": { "comparison": "no_increase", "max_delta": 0 },
+        "buffering_ms": { "comparison": "no_increase", "max_delta": 0 }
+      }
+    },
+    {
+      "id": "animation_half_memory_soak",
+      "description": "Three paired 15-minute runs measuring ytt-owned RSS with the fixed balanced half-animation profile",
+      "pairs": 3,
+      "candidate_repeats": 0,
+      "min_improved_pairs": 0,
+      "warmup_s": 90,
+      "sample_s": 900,
+      "geometry": [[100, 30]],
+      "traffic_profile": "normal",
+      "requires_mpv": true,
+      "fixture_profile": "wav-2h",
+      "animation_profile": "balanced_half",
+      "expected_effective_mpv_cache_args": {
+        "--demuxer-max-bytes": "32MiB",
+        "--demuxer-max-back-bytes": "8MiB"
+      },
+      "seed_contract": {
+        "require_identical_tree": true,
+        "require_identical_cache_policy": true,
+        "expected_cache_policy": null
+      },
+      "controller": true,
+      "controller_load": "resume-session",
+      "pause_policy": "none",
+      "pause_hold_ms": 0,
+      "seeks_s": [],
+      "minimum_playback_progress_fraction": 0.8,
+      "time_pos_tail_tolerance_s": 2.0,
+      "metrics": {
+        "ytt.peak_rss_bytes": {
+          "comparison": "ratio",
+          "max_ratio": 1.05,
+          "min_improved_pairs": 0
+        },
+        "ytt.rss_slope_bytes_per_s": {
+          "comparison": "no_increase",
+          "max_delta": 0
         }
       }
     },

--- a/scripts/tui-perf-scenarios.json
+++ b/scripts/tui-perf-scenarios.json
@@ -557,6 +557,46 @@
         "render.local_max120x30.hit_map_digest": { "comparison": "exact" },
         "render.local_filter_ko90x24.buffer_style_digest": { "comparison": "exact" },
         "render.local_filter_ko90x24.hit_map_digest": { "comparison": "exact" },
+        "render.animation_control100x30.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.animation_control100x30.allocations_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 0
+        },
+        "render.animation_control100x30.allocated_bytes_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 0
+        },
+        "render.animation_control100x30.buffer_style_digest": { "comparison": "exact" },
+        "render.animation_control100x30.hit_map_digest": { "comparison": "exact" },
+        "render.animation_control100x30.checkpoint_digest": { "comparison": "exact" },
+        "render.animation_control100x30.update_path": { "comparison": "exact" },
+        "render.animation_control_art_lyrics160x50.p95_draw_ns": {
+          "comparison": "latency",
+          "max_ratio": 1.1,
+          "max_delta": 10000000,
+          "min_improved_pairs": 0
+        },
+        "render.animation_control_art_lyrics160x50.allocations_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 0
+        },
+        "render.animation_control_art_lyrics160x50.allocated_bytes_per_draw": {
+          "comparison": "ratio",
+          "max_ratio": 1.0,
+          "min_improved_pairs": 0
+        },
+        "render.animation_control_art_lyrics160x50.buffer_style_digest": { "comparison": "exact" },
+        "render.animation_control_art_lyrics160x50.hit_map_digest": { "comparison": "exact" },
+        "render.animation_control_art_lyrics160x50.checkpoint_digest": { "comparison": "exact" },
+        "render.animation_control_art_lyrics160x50.update_path": { "comparison": "exact" },
         "render.animation_half100x30.p95_draw_ns": {
           "comparison": "latency",
           "max_ratio": 1.1,
@@ -773,6 +813,7 @@
       "requires_mpv": true,
       "fixture_profile": "wav-18m",
       "animation_profile": "balanced_half",
+      "rate_factor_policy": "not_applicable",
       "expected_effective_mpv_cache_args": {
         "--demuxer-max-bytes": "32MiB",
         "--demuxer-max-back-bytes": "8MiB"
@@ -827,6 +868,7 @@
       "requires_mpv": true,
       "fixture_profile": "wav-18m",
       "animation_profile": "heavy_half",
+      "rate_factor_policy": "not_applicable",
       "expected_effective_mpv_cache_args": {
         "--demuxer-max-bytes": "32MiB",
         "--demuxer-max-back-bytes": "8MiB"
@@ -881,6 +923,7 @@
       "requires_mpv": true,
       "fixture_profile": "wav-2h",
       "animation_profile": "balanced_half",
+      "rate_factor_policy": "not_applicable",
       "expected_effective_mpv_cache_args": {
         "--demuxer-max-bytes": "32MiB",
         "--demuxer-max-back-bytes": "8MiB"

--- a/scripts/tui-perf.ps1
+++ b/scripts/tui-perf.ps1
@@ -353,7 +353,10 @@ function Run-ProcessScenario(
             ) "failed to materialize fixture playlist for $Label" | Out-Null
         }
 
-        if ($null -ne $script:ScenarioData.setting_leaf_overrides) {
+        if (
+            $null -ne $script:ScenarioData.setting_leaf_overrides -or
+            $null -ne $script:ScenarioData.animation_profile
+        ) {
             Invoke-PythonChecked @(
                 "apply-setting-overrides", "--scenarios", $Scenarios,
                 "--scenario", $Scenario, "--role", $Role,

--- a/scripts/tui-perf.py
+++ b/scripts/tui-perf.py
@@ -57,6 +57,11 @@ RUN_CONTRACT_SCHEMA = "ytt.tui-perf.run-contract.v1"
 MPV_SELECTION_SCHEMA = "ytt.tui-perf.mpv-selection.v1"
 SETTING_OVERRIDES_SCHEMA = "ytt.tui-perf.setting-overrides.v1"
 LONG_FORM_SETTING_LEAF = "audio.mpv.long_form_seek_optimization"
+RATE_FACTOR_POLICY_REQUIRED = "required"
+RATE_FACTOR_POLICY_NOT_APPLICABLE = "not_applicable"
+RATE_FACTOR_ANIMATION_NA_REASON = (
+    "animation resource profiles do not exercise long-form cache-rate admission"
+)
 ANIMATION_EFFECT_FIELDS = (
     "title",
     "heart",
@@ -1104,6 +1109,119 @@ def refresh_origin_main(candidate_root: Path) -> str:
     return str(run_git(candidate_root, "rev-parse", "origin/main^{commit}"))
 
 
+@contextlib.contextmanager
+def scoped_render_harness_overlay(
+    baseline_root: Path, candidate_root: Path, render: bool
+) -> Iterable[None]:
+    if not render:
+        yield
+        return
+
+    baseline_root = baseline_root.resolve()
+    candidate_root = candidate_root.resolve()
+    render_relative = "examples/tui_render_perf.rs"
+    candidate_harness = candidate_root / render_relative
+    baseline_harness = baseline_root / render_relative
+
+    try:
+        candidate_metadata = candidate_harness.lstat()
+    except OSError as error:
+        raise ValueError(
+            f"cannot inspect candidate render harness {candidate_harness}: {error}"
+        ) from error
+    if not stat.S_ISREG(candidate_metadata.st_mode):
+        raise ValueError(
+            f"candidate render harness must be a regular non-symlink file: "
+            f"{candidate_harness}"
+        )
+    candidate_bytes = candidate_harness.read_bytes()
+
+    baseline_staged_before = tracked_diff_paths(baseline_root, cached=True)
+    baseline_changed_before = tracked_diff_paths(baseline_root)
+    baseline_untracked_before = untracked_paths(baseline_root)
+    if baseline_staged_before or baseline_changed_before or baseline_untracked_before:
+        raise ValueError(
+            "baseline source must be clean before applying the scoped render harness "
+            f"overlay (staged={baseline_staged_before}, "
+            f"tracked={baseline_changed_before}, untracked={baseline_untracked_before})"
+        )
+
+    baseline_existed = os.path.lexists(baseline_harness)
+    baseline_bytes: bytes | None = None
+    baseline_mode: int | None = None
+    baseline_atime_ns: int | None = None
+    baseline_mtime_ns: int | None = None
+    if baseline_existed:
+        baseline_metadata = baseline_harness.lstat()
+        if not stat.S_ISREG(baseline_metadata.st_mode):
+            raise ValueError(
+                f"baseline render harness must be a regular non-symlink file: "
+                f"{baseline_harness}"
+            )
+        baseline_bytes = baseline_harness.read_bytes()
+        baseline_mode = stat.S_IMODE(baseline_metadata.st_mode)
+        baseline_atime_ns = baseline_metadata.st_atime_ns
+        baseline_mtime_ns = baseline_metadata.st_mtime_ns
+
+    try:
+        if baseline_bytes != candidate_bytes:
+            if not baseline_harness.parent.is_dir():
+                raise ValueError(
+                    f"baseline render harness parent is missing: "
+                    f"{baseline_harness.parent}"
+                )
+            baseline_harness.write_bytes(candidate_bytes)
+            if not baseline_existed:
+                os.chmod(
+                    baseline_harness, stat.S_IMODE(candidate_metadata.st_mode)
+                )
+        if baseline_harness.read_bytes() != candidate_bytes:
+            raise ValueError("failed to apply the scoped baseline render harness overlay")
+        yield
+    finally:
+        if baseline_existed:
+            if os.path.lexists(baseline_harness):
+                current_metadata = baseline_harness.lstat()
+                if not stat.S_ISREG(current_metadata.st_mode):
+                    raise ValueError(
+                        "cannot restore baseline render harness over a non-regular path"
+                    )
+            else:
+                baseline_harness.parent.mkdir(parents=True, exist_ok=True)
+            assert baseline_bytes is not None
+            assert baseline_mode is not None
+            assert baseline_atime_ns is not None
+            assert baseline_mtime_ns is not None
+            if not baseline_harness.exists() or baseline_harness.read_bytes() != baseline_bytes:
+                baseline_harness.write_bytes(baseline_bytes)
+            os.chmod(baseline_harness, baseline_mode)
+            os.utime(
+                baseline_harness,
+                ns=(baseline_atime_ns, baseline_mtime_ns),
+                follow_symlinks=False,
+            )
+        elif os.path.lexists(baseline_harness):
+            baseline_metadata = baseline_harness.lstat()
+            if not stat.S_ISREG(baseline_metadata.st_mode):
+                raise ValueError(
+                    "cannot remove scoped baseline render overlay from a non-regular path"
+                )
+            baseline_harness.unlink()
+
+        baseline_staged_after = tracked_diff_paths(baseline_root, cached=True)
+        baseline_changed_after = tracked_diff_paths(baseline_root)
+        baseline_untracked_after = untracked_paths(baseline_root)
+        if (
+            baseline_staged_after != baseline_staged_before
+            or baseline_changed_after != baseline_changed_before
+            or baseline_untracked_after != baseline_untracked_before
+        ):
+            raise ValueError(
+                "scoped baseline render harness overlay did not restore the caller's "
+                "worktree state"
+            )
+
+
 def validate_source_contract(
     baseline_root: Path,
     candidate_root: Path,
@@ -1154,54 +1272,27 @@ def validate_source_contract(
         raise ValueError(f"baseline source has staged changes: {baseline_staged}")
     baseline_changed = tracked_diff_paths(baseline_root)
     baseline_untracked = untracked_paths(baseline_root)
-    if render:
-        if not candidate_harness.is_file():
-            raise ValueError(f"candidate render harness is missing: {candidate_harness}")
-        if baseline_changed not in ([], [render_relative]):
-            raise ValueError(
-                "baseline may contain only the authenticated render harness overlay; found "
-                f"tracked changes {baseline_changed}"
-            )
-        if baseline_untracked not in ([], [render_relative]):
-            raise ValueError(
-                "baseline may contain only the untracked render harness; found "
-                f"{baseline_untracked}"
-            )
-        if (
-            (baseline_changed == [render_relative] or baseline_untracked == [render_relative])
-            and (
-                not baseline_harness.is_file()
-                or baseline_harness.read_bytes() != candidate_harness.read_bytes()
-            )
-        ):
-            raise ValueError(
-                "existing baseline render harness overlay is not byte-identical to candidate"
-            )
-        if not baseline_harness.exists():
-            baseline_harness.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(candidate_harness, baseline_harness)
-        elif not baseline_changed and not baseline_untracked:
-            if baseline_harness.read_bytes() != candidate_harness.read_bytes():
-                shutil.copyfile(candidate_harness, baseline_harness)
-        baseline_changed = tracked_diff_paths(baseline_root)
-        baseline_untracked = untracked_paths(baseline_root)
-    elif baseline_changed or baseline_untracked:
+    if baseline_changed or baseline_untracked:
         raise ValueError(
             "baseline source has tracked or untracked changes "
             f"(tracked={baseline_changed}, untracked={baseline_untracked})"
         )
-    if render and baseline_changed not in ([], [render_relative]):
-        raise ValueError(
-            "baseline render overlay changed unexpected tracked files: "
-            f"{baseline_changed}"
-        )
-    if render and baseline_untracked not in ([], [render_relative]):
-        raise ValueError(
-            "baseline render overlay changed unexpected untracked files: "
-            f"{baseline_untracked}"
-        )
-    if render and baseline_harness.read_bytes() != candidate_harness.read_bytes():
-        raise ValueError("baseline render harness is not byte-identical to candidate")
+    if render:
+        for role, harness in (
+            ("baseline", baseline_harness),
+            ("candidate", candidate_harness),
+        ):
+            try:
+                harness_metadata = harness.lstat()
+            except OSError as error:
+                raise ValueError(
+                    f"cannot inspect {role} render harness {harness}: {error}"
+                ) from error
+            if not stat.S_ISREG(harness_metadata.st_mode):
+                raise ValueError(
+                    f"{role} render harness must be a regular non-symlink file: "
+                    f"{harness}"
+                )
 
     baseline_identity = source_identity(baseline_root)
     candidate_identity = source_identity(candidate_root)
@@ -1745,13 +1836,21 @@ def harness_source_identities(
     identities: dict[str, Any] = {}
     for name in names:
         candidate = candidate_root / "examples" / name
-        identities[name] = {"candidate": identity_for_file(candidate)}
+        candidate_identity = identity_for_file(candidate)
+        identities[name] = {"candidate": candidate_identity}
         if render:
             baseline = baseline_root / "examples" / name
-            baseline_identity = identity_for_file(baseline)
-            if baseline_identity["sha256"] != identities[name]["candidate"]["sha256"]:
-                raise ValueError("baseline and candidate render harness sources differ")
-            identities[name]["baseline"] = baseline_identity
+            baseline_original = identity_for_file(baseline)
+            identities[name].update(
+                {
+                    "baseline_original": baseline_original,
+                    "baseline_effective": {
+                        "path": str(baseline.resolve()),
+                        "bytes": candidate_identity["bytes"],
+                        "sha256": candidate_identity["sha256"],
+                    },
+                }
+            )
     return identities
 
 
@@ -1864,7 +1963,17 @@ def validate_build_receipt(
             require_artifact_value(Path("<build-receipt>"), f"{label} {field}", artifact.get(field), current[field])
 
 
-def command_build(args: argparse.Namespace) -> int:
+def command_build(
+    args: argparse.Namespace,
+    *,
+    build_runner: Callable[
+        [Path, Path, list[str], dict[str, str], dict[str, Any]],
+        tuple[list[str], dict[str, Path]],
+    ] = run_fixed_cargo_build,
+    toolchain_capture: Callable[
+        [Path, Path, dict[str, str] | None], dict[str, dict[str, Any]]
+    ] = capture_build_toolchains,
+) -> int:
     if args.output.exists():
         raise ValueError("build receipt output must name a new path")
     document, _ = load_scenarios(args.scenarios)
@@ -1884,7 +1993,7 @@ def command_build(args: argparse.Namespace) -> int:
     )
     harness_sources = harness_source_identities(baseline_root, candidate_root, render)
     environment = controlled_build_environment()
-    toolchains = capture_build_toolchains(
+    toolchains = toolchain_capture(
         baseline_root, candidate_root, environment
     )
     toolchain = summarized_toolchain(toolchains["baseline"])
@@ -1899,13 +2008,18 @@ def command_build(args: argparse.Namespace) -> int:
     for role, selectors, mapping in build_specs(render):
         source_root = baseline_root if role == "baseline" else candidate_root
         target_dir = target_root / role
-        command, executables = run_fixed_cargo_build(
-            source_root,
-            target_dir,
-            selectors,
-            environment,
-            toolchains[role],
-        )
+        with scoped_render_harness_overlay(
+            baseline_root,
+            candidate_root,
+            render and role == "baseline",
+        ):
+            command, executables = build_runner(
+                source_root,
+                target_dir,
+                selectors,
+                environment,
+                toolchains[role],
+            )
         missing = sorted(set(mapping) - set(executables))
         if missing:
             raise ValueError(f"cargo did not report expected executables: {missing}")
@@ -2416,6 +2530,23 @@ def validate_scenarios(document: dict[str, Any]) -> None:
                 )
             if not requires_mpv:
                 raise ValueError(f"{name}.animation_profile requires playback")
+        rate_factor_policy = scenario.get("rate_factor_policy")
+        if animation_profile_name is not None:
+            if rate_factor_policy != RATE_FACTOR_POLICY_NOT_APPLICABLE:
+                raise ValueError(
+                    f"{name}.animation_profile requires explicit "
+                    "rate_factor_policy='not_applicable'"
+                )
+        elif requires_mpv:
+            if rate_factor_policy not in (None, RATE_FACTOR_POLICY_REQUIRED):
+                raise ValueError(
+                    f"{name}.rate_factor_policy must remain 'required' for "
+                    "non-animation playback"
+                )
+        elif rate_factor_policy not in (None, RATE_FACTOR_POLICY_NOT_APPLICABLE):
+            raise ValueError(
+                f"{name}.rate_factor_policy must be 'not_applicable' for non-playback"
+            )
         controller = scenario.get("controller")
         if not isinstance(controller, bool):
             raise ValueError(f"{name}.controller must be boolean")
@@ -2789,6 +2920,24 @@ def scenario_validation_self_test() -> None:
             lambda value: find_scenario(value, "animation_half_balanced").__setitem__(
                 "animation_profile", "unknown"
             ),
+        ),
+        (
+            "animation rate-factor policy omitted",
+            lambda value: find_scenario(value, "animation_half_balanced").pop(
+                "rate_factor_policy"
+            ),
+        ),
+        (
+            "unknown animation rate-factor policy",
+            lambda value: find_scenario(value, "animation_half_balanced").__setitem__(
+                "rate_factor_policy", "diagnostic"
+            ),
+        ),
+        (
+            "long-form rate-factor bypass",
+            lambda value: find_scenario(
+                value, "long_form_cold_warm_burst_auto"
+            ).__setitem__("rate_factor_policy", RATE_FACTOR_POLICY_NOT_APPLICABLE),
         ),
         (
             "non-finite fixture duration",
@@ -9062,10 +9211,10 @@ def merged_histogram(histograms: list[list[tuple[int, int]]]) -> list[tuple[int,
 
 
 RENDER_INCREMENTAL_ALLOCATION_CONTROLS = {
-    "animation_half100x30": "player",
-    "animation_half_art_lyrics160x50": "canvas_art_lyrics160x50",
-    "animation_heavy_half100x30": "player",
-    "animation_heavy_half_art_lyrics160x50": "canvas_art_lyrics160x50",
+    "animation_half100x30": "animation_control100x30",
+    "animation_half_art_lyrics160x50": "animation_control_art_lyrics160x50",
+    "animation_heavy_half100x30": "animation_control100x30",
+    "animation_heavy_half_art_lyrics160x50": "animation_control_art_lyrics160x50",
 }
 RENDER_INCREMENTAL_ALLOCATION_FIELDS = (
     "allocations_per_draw",
@@ -9074,15 +9223,57 @@ RENDER_INCREMENTAL_ALLOCATION_FIELDS = (
 
 
 def add_render_incremental_allocation_metrics(
-    metrics: dict[str, Any], case_names: set[str], path: Path
+    metrics: dict[str, Any], cases_by_name: dict[str, dict[str, Any]], path: Path
 ) -> None:
     for animation_case, control_case in RENDER_INCREMENTAL_ALLOCATION_CONTROLS.items():
-        if animation_case not in case_names:
+        if animation_case not in cases_by_name:
             continue
-        if control_case not in case_names:
+        if control_case not in cases_by_name:
             raise ValueError(
                 f"{path}: render case {animation_case!r} requires matched control "
                 f"render case {control_case!r}"
+            )
+        animation_document = cases_by_name[animation_case]
+        control_document = cases_by_name[control_case]
+        for field in ("width", "height"):
+            animation_value = animation_document.get(field)
+            control_value = control_document.get(field)
+            for case_name, value in (
+                (animation_case, animation_value),
+                (control_case, control_value),
+            ):
+                if (
+                    not isinstance(value, int)
+                    or isinstance(value, bool)
+                    or value <= 0
+                ):
+                    raise ValueError(
+                        f"{path}: matched render case {case_name!r} has invalid {field} "
+                        f"{value!r}"
+                    )
+            if animation_value != control_value:
+                raise ValueError(
+                    f"{path}: render case {animation_case!r} and matched control "
+                    f"{control_case!r} must have identical {field}; observed "
+                    f"{animation_value!r} and {control_value!r}"
+                )
+        animation_update_path = animation_document.get("update_path")
+        control_update_path = control_document.get("update_path")
+        if (
+            not isinstance(animation_update_path, str)
+            or not animation_update_path
+            or not isinstance(control_update_path, str)
+            or not control_update_path
+        ):
+            raise ValueError(
+                f"{path}: matched animation/control update_path values must be "
+                "non-empty strings"
+            )
+        if animation_update_path != control_update_path:
+            raise ValueError(
+                f"{path}: render case {animation_case!r} and matched control "
+                f"{control_case!r} must have identical update_path; observed "
+                f"{animation_update_path!r} and {control_update_path!r}"
             )
         animation_prefix = f"render.{animation_case}"
         control_prefix = f"render.{control_case}"
@@ -9107,16 +9298,16 @@ def add_render_incremental_allocation_metrics(
 
 def render_metrics_from_document(document: dict[str, Any], path: Path) -> dict[str, Any]:
     metrics: dict[str, Any] = {}
-    case_names: set[str] = set()
+    cases_by_name: dict[str, dict[str, Any]] = {}
     for case in document.get("cases", []):
         if not isinstance(case, dict):
             raise ValueError(f"{path}: render cases must contain only objects")
         case_name = case.get("name")
         if not isinstance(case_name, str) or not case_name:
             raise ValueError(f"{path}: render case name must be a non-empty string")
-        if case_name in case_names:
+        if case_name in cases_by_name:
             raise ValueError(f"{path}: duplicate render case name {case_name!r}")
-        case_names.add(case_name)
+        cases_by_name[case_name] = case
         batches = case.get("batches", [])
         if not batches:
             raise ValueError(f"{path}: render case {case.get('name')} has no batches")
@@ -9213,14 +9404,22 @@ def render_metrics_from_document(document: dict[str, Any], path: Path) -> dict[s
         metrics[f"{prefix}.update_path"] = case["update_path"]
         if case["update_path"] == "app_update_msg_key":
             metrics[f"{prefix}.p95_reducer_input_to_draw_ns"] = float(case_p95)
-    add_render_incremental_allocation_metrics(metrics, case_names, path)
+    add_render_incremental_allocation_metrics(metrics, cases_by_name, path)
     return metrics
 
 
 def render_incremental_allocation_metrics_self_test() -> None:
     path = Path("<render-incremental-allocation-self-test>")
 
-    def render_case(name: str, allocations: int, allocated_bytes: int) -> dict[str, Any]:
+    def render_case(
+        name: str,
+        allocations: int,
+        allocated_bytes: int,
+        *,
+        width: int = 100,
+        height: int = 30,
+        update_path: str = "app_update_msg_anim_tick",
+    ) -> dict[str, Any]:
         batch = {
             "draws": 10,
             "total_ns": 100,
@@ -9238,7 +9437,9 @@ def render_incremental_allocation_metrics_self_test() -> None:
         }
         return {
             "name": name,
-            "update_path": "app_update_msg_anim_tick",
+            "update_path": update_path,
+            "width": width,
+            "height": height,
             "measured_draws": 10,
             "total_draw_ns": 100,
             "mean_draw_ns": 10,
@@ -9259,11 +9460,29 @@ def render_incremental_allocation_metrics_self_test() -> None:
             "schema": "ytt.tui-perf.render.v1",
             "cases": [
                 render_case("animation_half100x30", 160, 1_600),
-                render_case("animation_half_art_lyrics160x50", 190, 2_900),
+                render_case(
+                    "animation_half_art_lyrics160x50",
+                    190,
+                    2_900,
+                    width=160,
+                    height=50,
+                ),
                 render_case("animation_heavy_half100x30", 140, 1_300),
-                render_case("animation_heavy_half_art_lyrics160x50", 180, 2_600),
-                render_case("player", 100, 1_000),
-                render_case("canvas_art_lyrics160x50", 120, 2_000),
+                render_case(
+                    "animation_heavy_half_art_lyrics160x50",
+                    180,
+                    2_600,
+                    width=160,
+                    height=50,
+                ),
+                render_case("animation_control100x30", 100, 1_000),
+                render_case(
+                    "animation_control_art_lyrics160x50",
+                    120,
+                    2_000,
+                    width=160,
+                    height=50,
+                ),
             ],
         }
 
@@ -9320,23 +9539,47 @@ def render_incremental_allocation_metrics_self_test() -> None:
     expect_rejected(
         "selected animation without control",
         selected_animation,
-        "requires matched control render case 'player'",
+        "requires matched control render case 'animation_control100x30'",
     )
 
-    missing_player = render_document()
-    missing_player["cases"] = [
-        case for case in missing_player["cases"] if case["name"] != "player"
+    missing_control = render_document()
+    missing_control["cases"] = [
+        case
+        for case in missing_control["cases"]
+        if case["name"] != "animation_control100x30"
     ]
-    expect_rejected("missing player control", missing_player, "'player'")
+    expect_rejected(
+        "missing 100x30 control",
+        missing_control,
+        "'animation_control100x30'",
+    )
 
     missing_art = render_document()
     missing_art["cases"] = [
         case
         for case in missing_art["cases"]
-        if case["name"] != "canvas_art_lyrics160x50"
+        if case["name"] != "animation_control_art_lyrics160x50"
     ]
     expect_rejected(
-        "missing art/lyrics control", missing_art, "'canvas_art_lyrics160x50'"
+        "missing art/lyrics control",
+        missing_art,
+        "'animation_control_art_lyrics160x50'",
+    )
+
+    mismatched_geometry = render_document()
+    mismatched_geometry["cases"][4]["width"] = 101
+    expect_rejected(
+        "mismatched control geometry",
+        mismatched_geometry,
+        "must have identical width",
+    )
+
+    mismatched_update_path = render_document()
+    mismatched_update_path["cases"][4]["update_path"] = "direct_fixture_state"
+    expect_rejected(
+        "mismatched control update path",
+        mismatched_update_path,
+        "must have identical update_path",
     )
 
     negative_allocations = render_document()
@@ -10295,6 +10538,70 @@ def rate_factor_evidence(
     }
 
 
+def rate_factor_gate_for_scenario(
+    scenario: dict[str, Any], rate_factor_runs: list[dict[str, Any]]
+) -> dict[str, Any]:
+    requires_mpv = scenario.get("requires_mpv") is True
+    policy = scenario.get("rate_factor_policy")
+    if policy is None:
+        policy = (
+            RATE_FACTOR_POLICY_REQUIRED
+            if requires_mpv
+            else RATE_FACTOR_POLICY_NOT_APPLICABLE
+        )
+    if policy not in {
+        RATE_FACTOR_POLICY_REQUIRED,
+        RATE_FACTOR_POLICY_NOT_APPLICABLE,
+    }:
+        raise ValueError(f"unsupported rate-factor policy {policy!r}")
+    if not requires_mpv and policy != RATE_FACTOR_POLICY_NOT_APPLICABLE:
+        raise ValueError("non-playback scenarios cannot require rate-factor evidence")
+    animation_profile = scenario.get("animation_profile")
+    if requires_mpv and policy == RATE_FACTOR_POLICY_NOT_APPLICABLE and (
+        not isinstance(animation_profile, str) or not animation_profile
+    ):
+        raise ValueError(
+            "playback rate-factor evidence may be not-applicable only for an "
+            "animation resource profile"
+        )
+
+    diagnostic_supported = bool(rate_factor_runs) and all(
+        run["supported"] for run in rate_factor_runs
+    )
+    diagnostic_pass = bool(rate_factor_runs) and all(
+        run["pass"] for run in rate_factor_runs
+    )
+    diagnostic_ship_eligible = bool(rate_factor_runs) and all(
+        run["ship_evidence_eligible"] for run in rate_factor_runs
+    )
+    required = policy == RATE_FACTOR_POLICY_REQUIRED
+    not_applicable_reason = None
+    if not required:
+        not_applicable_reason = (
+            RATE_FACTOR_ANIMATION_NA_REASON
+            if requires_mpv
+            else "scenario does not require mpv playback"
+        )
+    return {
+        "schema": "ytt.tui-perf.rate-factor-gate.v1",
+        "factor": RATE_SAFETY_FACTOR,
+        "factor_provenance": (
+            "src/player/long_form_seek.rs::CACHE_SPEED_SAFETY_FACTOR"
+        ),
+        "policy": policy,
+        "required": required,
+        "runs": rate_factor_runs,
+        "supported": diagnostic_supported,
+        "diagnostic_pass": diagnostic_pass,
+        "pass": diagnostic_pass if required else True,
+        "diagnostic_ship_evidence_eligible": diagnostic_ship_eligible,
+        "ship_evidence_eligible": diagnostic_ship_eligible if required else True,
+        "unsupported_is_ship_evidence": False,
+        "not_applicable": not required,
+        "not_applicable_reason": not_applicable_reason,
+    }
+
+
 def rate_factor_evidence_self_test() -> None:
     path = Path("<rate-factor-self-test>")
 
@@ -10349,6 +10656,38 @@ def rate_factor_evidence_self_test() -> None:
         Path(__file__).resolve().parent.parent / "src" / "player" / "long_form_seek.rs"
     ).read_text(encoding="utf-8")
     assert "const CACHE_SPEED_SAFETY_FACTOR: u64 = 2;" in production
+
+    unsupported_run = {
+        "supported": False,
+        "pass": False,
+        "ship_evidence_eligible": False,
+    }
+    required_gate = rate_factor_gate_for_scenario(
+        {"requires_mpv": True}, [unsupported_run]
+    )
+    assert required_gate["required"] is True
+    assert required_gate["pass"] is False
+    assert required_gate["ship_evidence_eligible"] is False
+
+    animation_gate = rate_factor_gate_for_scenario(
+        {
+            "requires_mpv": True,
+            "animation_profile": "balanced_half",
+            "rate_factor_policy": RATE_FACTOR_POLICY_NOT_APPLICABLE,
+        },
+        [unsupported_run],
+    )
+    assert animation_gate["not_applicable"] is True
+    assert animation_gate["diagnostic_pass"] is False
+    assert animation_gate["pass"] is True
+    assert animation_gate["ship_evidence_eligible"] is True
+    assert animation_gate["not_applicable_reason"] == RATE_FACTOR_ANIMATION_NA_REASON
+
+    non_playback_gate = rate_factor_gate_for_scenario(
+        {"requires_mpv": False}, []
+    )
+    assert non_playback_gate["not_applicable"] is True
+    assert non_playback_gate["pass"] is True
 
 
 def validate_cache_mode_evidence(
@@ -15287,9 +15626,102 @@ def command_self_test(_args: argparse.Namespace) -> int:
         )
         if completed.returncode != 0:
             raise AssertionError(f"self-test git clone failed: {completed.stderr.strip()}")
+        baseline_harness = baseline_source / "examples" / "tui_render_perf.rs"
+        baseline_original_bytes = baseline_harness.read_bytes()
+        baseline_original_metadata = baseline_harness.stat()
         validate_source_contract(
             baseline_source, candidate_source, render=True, refresh=True
         )
+        assert baseline_harness.read_bytes() == baseline_original_bytes
+        assert tracked_worktree_is_clean(baseline_source)
+        assert not untracked_paths(baseline_source)
+        harness_identities = harness_source_identities(
+            baseline_source, candidate_source, render=True
+        )["tui_render_perf.rs"]
+        assert harness_identities["baseline_original"]["sha256"] == hashlib.sha256(
+            baseline_original_bytes
+        ).hexdigest()
+        assert harness_identities["baseline_effective"]["sha256"] == sha256_file(
+            render_harness
+        )
+        assert harness_identities["candidate"]["sha256"] == sha256_file(
+            render_harness
+        )
+
+        with scoped_render_harness_overlay(
+            baseline_source, candidate_source, render=True
+        ):
+            assert baseline_harness.read_bytes() == render_harness.read_bytes()
+            assert tracked_diff_paths(baseline_source) == [
+                "examples/tui_render_perf.rs"
+            ]
+        restored_metadata = baseline_harness.stat()
+        assert baseline_harness.read_bytes() == baseline_original_bytes
+        assert stat.S_IMODE(restored_metadata.st_mode) == stat.S_IMODE(
+            baseline_original_metadata.st_mode
+        )
+        assert restored_metadata.st_mtime_ns == baseline_original_metadata.st_mtime_ns
+        assert tracked_worktree_is_clean(baseline_source)
+        assert not untracked_paths(baseline_source)
+
+        executable_identity = identity_for_file(Path(sys.executable))
+
+        def self_test_toolchain_capture(
+            baseline: Path,
+            candidate: Path,
+            _environment: dict[str, str] | None = None,
+        ) -> dict[str, dict[str, Any]]:
+            def identity(source: Path) -> dict[str, Any]:
+                return {
+                    "source_root": str(source.resolve()),
+                    "cargo": {"version": "cargo self-test"},
+                    "rustc": {
+                        "version": "rustc self-test",
+                        "selected_executable": executable_identity,
+                    },
+                }
+
+            return {"baseline": identity(baseline), "candidate": identity(candidate)}
+
+        def fail_baseline_build(
+            source_root: Path,
+            _target_dir: Path,
+            _selectors: list[str],
+            _environment: dict[str, str],
+            _toolchain: dict[str, Any],
+        ) -> tuple[list[str], dict[str, Path]]:
+            assert source_root == baseline_source.resolve()
+            assert baseline_harness.read_bytes() == render_harness.read_bytes()
+            assert tracked_diff_paths(baseline_source) == [
+                "examples/tui_render_perf.rs"
+            ]
+            raise ValueError("injected baseline cargo failure")
+
+        try:
+            command_build(
+                argparse.Namespace(
+                    scenarios=DEFAULT_SCENARIOS,
+                    scenario="render_and_interaction",
+                    baseline_root=baseline_source,
+                    candidate_root=candidate_source,
+                    output=root / "build-evidence" / "build.json",
+                    target_root=root / "build-target",
+                ),
+                build_runner=fail_baseline_build,
+                toolchain_capture=self_test_toolchain_capture,
+            )
+        except ValueError as error:
+            assert "injected baseline cargo failure" in str(error)
+        else:
+            raise AssertionError("injected baseline Cargo failure must be propagated")
+        restored_metadata = baseline_harness.stat()
+        assert baseline_harness.read_bytes() == baseline_original_bytes
+        assert stat.S_IMODE(restored_metadata.st_mode) == stat.S_IMODE(
+            baseline_original_metadata.st_mode
+        )
+        assert restored_metadata.st_mtime_ns == baseline_original_metadata.st_mtime_ns
+        assert tracked_worktree_is_clean(baseline_source)
+        assert not untracked_paths(baseline_source)
 
         (candidate_source / "Cargo.lock").write_text("dirty\n", encoding="utf-8")
         try:
@@ -15302,7 +15734,6 @@ def command_self_test(_args: argparse.Namespace) -> int:
             raise AssertionError("dirty candidate source must be rejected")
         (candidate_source / "Cargo.lock").write_text("lock\n", encoding="utf-8")
 
-        baseline_harness = baseline_source / "examples" / "tui_render_perf.rs"
         baseline_harness.write_text("fn main() { panic!(); }\n", encoding="utf-8")
         try:
             validate_source_contract(
@@ -15312,7 +15743,7 @@ def command_self_test(_args: argparse.Namespace) -> int:
             pass
         else:
             raise AssertionError("mismatched baseline render harness must be rejected")
-        baseline_harness.write_bytes(render_harness.read_bytes())
+        baseline_harness.write_bytes(baseline_original_bytes)
 
         ignored_config = candidate_source / ".cargo" / "config.toml"
         ignored_config.parent.mkdir()
@@ -15943,7 +16374,7 @@ def command_self_test(_args: argparse.Namespace) -> int:
                 "duplicate_key_cases": 1,
                 "aggregate_render_p95_cases": 2,
                 "render_incremental_allocation_metrics": 8,
-                "render_incremental_allocation_tamper_cases": 5,
+                "render_incremental_allocation_tamper_cases": 7,
                 "render_identity_tamper_cases": 2,
                 "checksum_tamper_cases": 1,
                 "checksum_shadow_inventory_cases": 1,
@@ -15959,14 +16390,16 @@ def command_self_test(_args: argparse.Namespace) -> int:
                 "sample_cpu_window_tamper_cases": 2,
                 "sample_jitter_weighting_cases": 1,
                 "control_buffering_tamper_cases": 1,
-                "scenario_schema_tamper_cases": 35,
+                "scenario_schema_tamper_cases": 38,
                 "control_operation_tamper_cases": 13,
                 "http_server_authenticated_shutdown_cases": 1,
                 "http_server_leading_dash_token_cases": 1,
                 "http_server_stale_pid_no_signal_cases": 1,
                 "sample_tree_topology_tamper_cases": 4,
                 "source_contract_tamper_cases": 3,
+                "baseline_render_overlay_restore_cases": 2,
                 "source_rate_bound_tamper_cases": 3,
+                "rate_factor_policy_cases": 3,
                 "toolchain_identity_tamper_cases": 3,
                 "cleanup_scope_tamper_cases": 1,
                 "raw_role_binding_cases": 1,
@@ -16243,36 +16676,7 @@ def command_compare(args: argparse.Namespace) -> int:
     if not results:
         raise ValueError(f"scenario {args.scenario} produced no metric comparisons")
 
-    if scenario["requires_mpv"]:
-        rate_factor_gate = {
-            "schema": "ytt.tui-perf.rate-factor-gate.v1",
-            "factor": RATE_SAFETY_FACTOR,
-            "factor_provenance": (
-                "src/player/long_form_seek.rs::CACHE_SPEED_SAFETY_FACTOR"
-            ),
-            "runs": rate_factor_runs,
-            "supported": bool(rate_factor_runs)
-            and all(run["supported"] for run in rate_factor_runs),
-            "pass": bool(rate_factor_runs)
-            and all(run["pass"] for run in rate_factor_runs),
-            "ship_evidence_eligible": bool(rate_factor_runs)
-            and all(run["ship_evidence_eligible"] for run in rate_factor_runs),
-            "unsupported_is_ship_evidence": False,
-        }
-    else:
-        rate_factor_gate = {
-            "schema": "ytt.tui-perf.rate-factor-gate.v1",
-            "factor": RATE_SAFETY_FACTOR,
-            "factor_provenance": (
-                "src/player/long_form_seek.rs::CACHE_SPEED_SAFETY_FACTOR"
-            ),
-            "runs": [],
-            "supported": False,
-            "pass": True,
-            "ship_evidence_eligible": True,
-            "unsupported_is_ship_evidence": False,
-            "not_applicable": True,
-        }
+    rate_factor_gate = rate_factor_gate_for_scenario(scenario, rate_factor_runs)
 
     seen_artifacts: dict[Path, str] = {}
     raw_artifacts = []
@@ -16384,9 +16788,15 @@ def markdown_report(report: dict[str, Any]) -> str:
         if report["ship_evidence_eligible"]
         else "Ship evidence: **NOT ELIGIBLE (fail-closed)**",
         "",
-        "Rate-factor gate: **PASS**"
-        if report["evidence"]["rate_factor_gate"]["pass"]
-        else "Rate-factor gate: **FAIL / UNSUPPORTED**",
+        (
+            "Rate-factor gate: **N/A**"
+            if report["evidence"]["rate_factor_gate"]["not_applicable"]
+            else (
+                "Rate-factor gate: **PASS**"
+                if report["evidence"]["rate_factor_gate"]["pass"]
+                else "Rate-factor gate: **FAIL / UNSUPPORTED**"
+            )
+        ),
         "",
         f"Incomplete A-I families: `{','.join(incomplete_families)}`",
         "",

--- a/scripts/tui-perf.py
+++ b/scripts/tui-perf.py
@@ -641,7 +641,11 @@ def stable_machine_id(system: str) -> str:
     raise ValueError(f"unsupported host system for stable machine identity: {system!r}")
 
 
-def stable_boot_id(system: str) -> str:
+def stable_boot_id(
+    system: str,
+    *,
+    identity_command: Callable[[list[str], str], str] = checked_identity_command,
+) -> str:
     if system == "Linux":
         path = Path("/proc/sys/kernel/random/boot_id")
         try:
@@ -652,13 +656,31 @@ def stable_boot_id(system: str) -> str:
             raise ValueError("Linux boot ID is missing or malformed")
         return f"linux-boot-id:{value}"
     if system == "Darwin":
-        output = checked_identity_command(
+        try:
+            value = identity_command(
+                ["/usr/sbin/sysctl", "-n", "kern.bootsessionuuid"],
+                "macOS boot session UUID",
+            ).strip().lower()
+        except ValueError:
+            value = ""
+        if (
+            re.fullmatch(
+                r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+                value,
+            )
+            and value != "00000000-0000-0000-0000-000000000000"
+        ):
+            return f"darwin-boot-session-uuid:{value}"
+        output = identity_command(
             ["/usr/sbin/sysctl", "-n", "kern.boottime"], "macOS boot time"
         )
-        match = re.search(r"sec\s*=\s*(\d+)\s*,\s*usec\s*=\s*(\d+)", output)
+        match = re.search(r"\bsec\s*=\s*(\d+)", output)
         if match is None:
             raise ValueError("macOS boot time is missing or malformed")
-        return f"darwin-boottime:{int(match.group(1))}:{int(match.group(2))}"
+        seconds = int(match.group(1))
+        if seconds <= 0:
+            raise ValueError("macOS boot time is missing or malformed")
+        return f"darwin-boottime:{seconds}"
     if system == "Windows":
         value = checked_identity_command(
             [
@@ -14733,6 +14755,86 @@ def host_identity_privacy_self_test() -> None:
             raise AssertionError("raw host identifier payload leaked into the serialized identity")
 
 
+def darwin_boot_identity_self_test() -> None:
+    def command_mock(
+        responses: dict[str, str | ValueError],
+    ) -> tuple[list[str], Callable[[list[str], str], str]]:
+        calls: list[str] = []
+
+        def command(command: list[str], _label: str) -> str:
+            if len(command) != 3 or command[:2] != ["/usr/sbin/sysctl", "-n"]:
+                raise AssertionError(f"unexpected Darwin boot identity command: {command!r}")
+            key = command[-1]
+            calls.append(key)
+            response = responses[key]
+            if isinstance(response, ValueError):
+                raise response
+            return response
+
+        return calls, command
+
+    first_uuid = "12345678-1234-4ABC-9DEF-1234567890AB"
+    second_uuid = "87654321-4321-4abc-8def-ba0987654321"
+    calls, command = command_mock({"kern.bootsessionuuid": first_uuid})
+    first_session = stable_boot_id("Darwin", identity_command=command)
+    assert first_session == f"darwin-boot-session-uuid:{first_uuid.lower()}"
+    assert calls == ["kern.bootsessionuuid"]
+
+    calls, command = command_mock(
+        {
+            "kern.bootsessionuuid": "malformed",
+            "kern.boottime": (
+                "{ sec = 1720000000, usec = 123456 } Tue Jul  2 00:00:00 2024"
+            ),
+        }
+    )
+    assert stable_boot_id("Darwin", identity_command=command) == (
+        "darwin-boottime:1720000000"
+    )
+    assert calls == ["kern.bootsessionuuid", "kern.boottime"]
+
+    calls, command = command_mock(
+        {
+            "kern.bootsessionuuid": ValueError("simulated sysctl failure"),
+            "kern.boottime": (
+                "{ sec = 1720000000, usec = 654321 } Tue Jul  2 00:00:00 2024"
+            ),
+        }
+    )
+    assert stable_boot_id("Darwin", identity_command=command) == (
+        "darwin-boottime:1720000000"
+    )
+    assert calls == ["kern.bootsessionuuid", "kern.boottime"]
+
+    _, first_fallback_command = command_mock(
+        {
+            "kern.bootsessionuuid": "malformed",
+            "kern.boottime": "{ sec = 1720000000, usec = 1 }",
+        }
+    )
+    _, second_fallback_command = command_mock(
+        {
+            "kern.bootsessionuuid": "malformed",
+            "kern.boottime": "{ sec = 1720000000, usec = 999999 }",
+        }
+    )
+    assert stable_boot_id("Darwin", identity_command=first_fallback_command) == (
+        stable_boot_id("Darwin", identity_command=second_fallback_command)
+    )
+
+    _, second_session_command = command_mock({"kern.bootsessionuuid": second_uuid})
+    assert first_session != stable_boot_id("Darwin", identity_command=second_session_command)
+    _, reboot_command = command_mock(
+        {
+            "kern.bootsessionuuid": "malformed",
+            "kern.boottime": "{ sec = 1720000001, usec = 1 }",
+        }
+    )
+    assert "darwin-boottime:1720000000" != stable_boot_id(
+        "Darwin", identity_command=reboot_command
+    )
+
+
 def macos_process_absence_probe_self_test() -> None:
     def existence_sequence(*results: bool) -> Callable[[int], bool]:
         remaining = iter(results)
@@ -14781,6 +14883,7 @@ def command_self_test(_args: argparse.Namespace) -> int:
     cleanup_integration_self_test()
     startup_cleanup_integration_self_test()
     host_identity_privacy_self_test()
+    darwin_boot_identity_self_test()
     macos_process_absence_probe_self_test()
     run_contract_integration_self_test()
     multi_geometry_run_contract_integration_self_test()

--- a/scripts/tui-perf.py
+++ b/scripts/tui-perf.py
@@ -9001,9 +9001,62 @@ def merged_histogram(histograms: list[list[tuple[int, int]]]) -> list[tuple[int,
     return sorted(merged.items())
 
 
+RENDER_INCREMENTAL_ALLOCATION_CONTROLS = {
+    "animation_half100x30": "player",
+    "animation_half_art_lyrics160x50": "canvas_art_lyrics160x50",
+    "animation_heavy_half100x30": "player",
+    "animation_heavy_half_art_lyrics160x50": "canvas_art_lyrics160x50",
+}
+RENDER_INCREMENTAL_ALLOCATION_FIELDS = (
+    "allocations_per_draw",
+    "allocated_bytes_per_draw",
+)
+
+
+def add_render_incremental_allocation_metrics(
+    metrics: dict[str, Any], case_names: set[str], path: Path
+) -> None:
+    for animation_case, control_case in RENDER_INCREMENTAL_ALLOCATION_CONTROLS.items():
+        if animation_case not in case_names:
+            continue
+        if control_case not in case_names:
+            raise ValueError(
+                f"{path}: render case {animation_case!r} requires matched control "
+                f"render case {control_case!r}"
+            )
+        animation_prefix = f"render.{animation_case}"
+        control_prefix = f"render.{control_case}"
+        for field in RENDER_INCREMENTAL_ALLOCATION_FIELDS:
+            animation_key = f"{animation_prefix}.{field}"
+            control_key = f"{control_prefix}.{field}"
+            animation_value = finite_non_negative_number(
+                metrics.get(animation_key), animation_key, path
+            )
+            control_value = finite_non_negative_number(
+                metrics.get(control_key), control_key, path
+            )
+            incremental = animation_value - control_value
+            if incremental < 0.0:
+                raise ValueError(
+                    f"{path}: render case {animation_case!r} has negative incremental "
+                    f"{field} relative to matched control case {control_case!r}: "
+                    f"{animation_value} - {control_value}"
+                )
+            metrics[f"{animation_prefix}.incremental_{field}"] = incremental
+
+
 def render_metrics_from_document(document: dict[str, Any], path: Path) -> dict[str, Any]:
     metrics: dict[str, Any] = {}
+    case_names: set[str] = set()
     for case in document.get("cases", []):
+        if not isinstance(case, dict):
+            raise ValueError(f"{path}: render cases must contain only objects")
+        case_name = case.get("name")
+        if not isinstance(case_name, str) or not case_name:
+            raise ValueError(f"{path}: render case name must be a non-empty string")
+        if case_name in case_names:
+            raise ValueError(f"{path}: duplicate render case name {case_name!r}")
+        case_names.add(case_name)
         batches = case.get("batches", [])
         if not batches:
             raise ValueError(f"{path}: render case {case.get('name')} has no batches")
@@ -9100,7 +9153,148 @@ def render_metrics_from_document(document: dict[str, Any], path: Path) -> dict[s
         metrics[f"{prefix}.update_path"] = case["update_path"]
         if case["update_path"] == "app_update_msg_key":
             metrics[f"{prefix}.p95_reducer_input_to_draw_ns"] = float(case_p95)
+    add_render_incremental_allocation_metrics(metrics, case_names, path)
     return metrics
+
+
+def render_incremental_allocation_metrics_self_test() -> None:
+    path = Path("<render-incremental-allocation-self-test>")
+
+    def render_case(name: str, allocations: int, allocated_bytes: int) -> dict[str, Any]:
+        batch = {
+            "draws": 10,
+            "total_ns": 100,
+            "mean_draw_ns": 10,
+            "p50_draw_ns": 10,
+            "p95_draw_ns": 10,
+            "max_draw_ns": 10,
+            "latency_histogram": [{"ns": 10, "count": 10}],
+            "allocations": allocations,
+            "reallocations": 0,
+            "allocated_bytes": allocated_bytes,
+            "deallocated_bytes": allocated_bytes,
+            "retained_bytes_delta": 0,
+            "peak_live_bytes_delta": allocated_bytes,
+        }
+        return {
+            "name": name,
+            "update_path": "app_update_msg_anim_tick",
+            "measured_draws": 10,
+            "total_draw_ns": 100,
+            "mean_draw_ns": 10,
+            "p50_draw_ns": 10,
+            "p95_draw_ns": 10,
+            "max_draw_ns": 10,
+            "latency_histogram": [{"ns": 10, "count": 10}],
+            "batches": [batch],
+            "buffer_style_digest": f"buffer-{name}",
+            "hit_map_digest": f"hits-{name}",
+            "checkpoint_digest": "0123456789abcdef",
+        }
+
+    def render_document() -> dict[str, Any]:
+        # Animation cases intentionally precede their controls to pin order-independent
+        # derivation after every raw case has been authenticated.
+        return {
+            "schema": "ytt.tui-perf.render.v1",
+            "cases": [
+                render_case("animation_half100x30", 160, 1_600),
+                render_case("animation_half_art_lyrics160x50", 190, 2_900),
+                render_case("animation_heavy_half100x30", 140, 1_300),
+                render_case("animation_heavy_half_art_lyrics160x50", 180, 2_600),
+                render_case("player", 100, 1_000),
+                render_case("canvas_art_lyrics160x50", 120, 2_000),
+            ],
+        }
+
+    metrics = render_metrics_from_document(render_document(), path)
+    expected = {
+        "render.animation_half100x30.incremental_allocations_per_draw": 6.0,
+        "render.animation_half100x30.incremental_allocated_bytes_per_draw": 60.0,
+        "render.animation_half_art_lyrics160x50.incremental_allocations_per_draw": 7.0,
+        "render.animation_half_art_lyrics160x50.incremental_allocated_bytes_per_draw": 90.0,
+        "render.animation_heavy_half100x30.incremental_allocations_per_draw": 4.0,
+        "render.animation_heavy_half100x30.incremental_allocated_bytes_per_draw": 30.0,
+        "render.animation_heavy_half_art_lyrics160x50.incremental_allocations_per_draw": 6.0,
+        "render.animation_heavy_half_art_lyrics160x50.incremental_allocated_bytes_per_draw": 60.0,
+    }
+    for name, value in expected.items():
+        require_artifact_value(path, name, metrics.get(name), value)
+
+    selected_non_animation = {
+        "schema": "ytt.tui-perf.render.v1",
+        "cases": [render_case("player", 100, 1_000)],
+    }
+    selected_metrics = render_metrics_from_document(selected_non_animation, path)
+    require_artifact_value(
+        path,
+        "selected non-animation allocation metric",
+        selected_metrics.get("render.player.allocations_per_draw"),
+        10.0,
+    )
+    if any(".incremental_" in name for name in selected_metrics):
+        raise AssertionError(
+            "selected non-animation render unexpectedly emitted incremental metrics"
+        )
+
+    def expect_rejected(
+        label: str, document: dict[str, Any], message_fragment: str
+    ) -> None:
+        try:
+            render_metrics_from_document(document, path)
+        except ValueError as error:
+            if message_fragment not in str(error):
+                raise AssertionError(
+                    f"incremental allocation self-test {label!r} failed for the wrong "
+                    f"reason: {error}"
+                ) from error
+        else:
+            raise AssertionError(
+                f"incremental allocation self-test accepted {label!r} tampering"
+            )
+
+    selected_animation = {
+        "schema": "ytt.tui-perf.render.v1",
+        "cases": [render_case("animation_half100x30", 160, 1_600)],
+    }
+    expect_rejected(
+        "selected animation without control",
+        selected_animation,
+        "requires matched control render case 'player'",
+    )
+
+    missing_player = render_document()
+    missing_player["cases"] = [
+        case for case in missing_player["cases"] if case["name"] != "player"
+    ]
+    expect_rejected("missing player control", missing_player, "'player'")
+
+    missing_art = render_document()
+    missing_art["cases"] = [
+        case
+        for case in missing_art["cases"]
+        if case["name"] != "canvas_art_lyrics160x50"
+    ]
+    expect_rejected(
+        "missing art/lyrics control", missing_art, "'canvas_art_lyrics160x50'"
+    )
+
+    negative_allocations = render_document()
+    negative_allocations["cases"][0]["batches"][0]["allocations"] = 90
+    expect_rejected(
+        "negative allocations delta",
+        negative_allocations,
+        "negative incremental allocations_per_draw",
+    )
+
+    negative_bytes = render_document()
+    negative_bytes["cases"][0]["batches"][0]["allocated_bytes"] = 900
+    negative_bytes["cases"][0]["batches"][0]["deallocated_bytes"] = 900
+    expect_rejected(
+        "negative allocated bytes delta",
+        negative_bytes,
+        "negative incremental allocated_bytes_per_draw",
+    )
 
 
 def metrics_from_file(path: Path) -> dict[str, Any]:
@@ -14525,6 +14719,7 @@ def command_self_test(_args: argparse.Namespace) -> int:
     control_extended_telemetry_self_test()
     rate_factor_evidence_self_test()
     fixture_output_contract_self_test()
+    render_incremental_allocation_metrics_self_test()
     windows_build_wrapper_self_test()
     sample_tree_topology_self_test()
     point, upper, ratios = paired_bootstrap_ratios([0.0, 0.0], [0.0, 0.0], 100, 7, 0.95)
@@ -15567,6 +15762,8 @@ def command_self_test(_args: argparse.Namespace) -> int:
                 "multi_geometry_contract_cases": 2,
                 "duplicate_key_cases": 1,
                 "aggregate_render_p95_cases": 2,
+                "render_incremental_allocation_metrics": 8,
+                "render_incremental_allocation_tamper_cases": 5,
                 "render_identity_tamper_cases": 2,
                 "checksum_tamper_cases": 1,
                 "checksum_shadow_inventory_cases": 1,

--- a/scripts/tui-perf.py
+++ b/scripts/tui-perf.py
@@ -57,6 +57,95 @@ RUN_CONTRACT_SCHEMA = "ytt.tui-perf.run-contract.v1"
 MPV_SELECTION_SCHEMA = "ytt.tui-perf.mpv-selection.v1"
 SETTING_OVERRIDES_SCHEMA = "ytt.tui-perf.setting-overrides.v1"
 LONG_FORM_SETTING_LEAF = "audio.mpv.long_form_seek_optimization"
+ANIMATION_EFFECT_FIELDS = (
+    "title",
+    "heart",
+    "seekbar",
+    "spinner",
+    "eq_bars",
+    "controls",
+    "border",
+    "track_intro",
+    "lyrics",
+    "toast",
+    "volume_flash",
+    "like_burst",
+    "seek_flash",
+    "selection",
+    "stagger",
+    "caret",
+    "tabs",
+    "popup_fade",
+    "activity",
+    "about_fx",
+    "time_glow",
+    "progress_sparkle",
+    "border_chase",
+    "pause_flash",
+    "error_shake",
+    "rain",
+    "donut",
+    "visualizer",
+    "starfield",
+    "bounce",
+    "comets",
+    "snow",
+    "fireflies",
+    "cube",
+    "aquarium",
+    "waves",
+    "fireworks",
+    "life",
+    "pipes",
+    "plasma",
+)
+ANIMATION_PROFILE_NAMES = ("balanced_half", "heavy_half")
+ANIMATION_PROFILE_EFFECTS = {
+    "balanced_half": (
+        "track_intro",
+        "toast",
+        "volume_flash",
+        "seek_flash",
+        "selection",
+        "caret",
+        "activity",
+        "popup_fade",
+        "title",
+        "heart",
+        "seekbar",
+        "spinner",
+        "eq_bars",
+        "controls",
+        "border",
+        "time_glow",
+        "bounce",
+        "starfield",
+        "visualizer",
+        "rain",
+    ),
+    "heavy_half": (
+        "title",
+        "lyrics",
+        "seekbar",
+        "eq_bars",
+        "controls",
+        "border",
+        "rain",
+        "donut",
+        "visualizer",
+        "starfield",
+        "comets",
+        "snow",
+        "fireflies",
+        "cube",
+        "aquarium",
+        "waves",
+        "fireworks",
+        "life",
+        "pipes",
+        "plasma",
+    ),
+}
 MPV_032_PINNED_COMMIT = "70b991749df389bcc0a4e145b5687233a03b4ed7"
 MPV_032_COMPAT_UPSTREAM_COMMIT = "1805681aaba22aa19a27ecfdb639c983d91f83e6"
 MPV_032_COMPAT_PATCHED_FILES = [
@@ -958,6 +1047,20 @@ def tracked_worktree_is_clean(root: Path) -> bool:
     return True
 
 
+def tracked_diff_paths(root: Path, *, cached: bool = False) -> list[str]:
+    arguments = ["diff"]
+    if cached:
+        arguments.append("--cached")
+    arguments.extend(["--name-only", "-z"])
+    raw = run_git(root, *arguments, binary=True)
+    assert isinstance(raw, bytes)
+    return sorted(
+        item.decode("utf-8", errors="surrogateescape")
+        for item in raw.split(b"\0")
+        if item
+    )
+
+
 def refresh_origin_main(candidate_root: Path) -> str:
     result = subprocess.run(
         [
@@ -1020,30 +1123,61 @@ def validate_source_contract(
             "baseline HEAD must equal the candidate repository's exact origin/main OID "
             f"{expected_baseline}"
         )
-    if not tracked_worktree_is_clean(baseline_root):
-        raise ValueError("baseline source has tracked or staged changes")
 
     render_relative = "examples/tui_render_perf.rs"
     candidate_harness = candidate_root / render_relative
     baseline_harness = baseline_root / render_relative
+    baseline_staged = tracked_diff_paths(baseline_root, cached=True)
+    if baseline_staged:
+        raise ValueError(f"baseline source has staged changes: {baseline_staged}")
+    baseline_changed = tracked_diff_paths(baseline_root)
     baseline_untracked = untracked_paths(baseline_root)
     if render:
         if not candidate_harness.is_file():
             raise ValueError(f"candidate render harness is missing: {candidate_harness}")
+        if baseline_changed not in ([], [render_relative]):
+            raise ValueError(
+                "baseline may contain only the authenticated render harness overlay; found "
+                f"tracked changes {baseline_changed}"
+            )
+        if baseline_untracked not in ([], [render_relative]):
+            raise ValueError(
+                "baseline may contain only the untracked render harness; found "
+                f"{baseline_untracked}"
+            )
+        if (
+            (baseline_changed == [render_relative] or baseline_untracked == [render_relative])
+            and (
+                not baseline_harness.is_file()
+                or baseline_harness.read_bytes() != candidate_harness.read_bytes()
+            )
+        ):
+            raise ValueError(
+                "existing baseline render harness overlay is not byte-identical to candidate"
+            )
         if not baseline_harness.exists():
             baseline_harness.parent.mkdir(parents=True, exist_ok=True)
             shutil.copyfile(candidate_harness, baseline_harness)
+        elif not baseline_changed and not baseline_untracked:
+            if baseline_harness.read_bytes() != candidate_harness.read_bytes():
+                shutil.copyfile(candidate_harness, baseline_harness)
+        baseline_changed = tracked_diff_paths(baseline_root)
         baseline_untracked = untracked_paths(baseline_root)
-    if baseline_untracked not in ([], [render_relative]):
+    elif baseline_changed or baseline_untracked:
         raise ValueError(
-            "baseline may contain only the untracked render harness; found "
+            "baseline source has tracked or untracked changes "
+            f"(tracked={baseline_changed}, untracked={baseline_untracked})"
+        )
+    if render and baseline_changed not in ([], [render_relative]):
+        raise ValueError(
+            "baseline render overlay changed unexpected tracked files: "
+            f"{baseline_changed}"
+        )
+    if render and baseline_untracked not in ([], [render_relative]):
+        raise ValueError(
+            "baseline render overlay changed unexpected untracked files: "
             f"{baseline_untracked}"
         )
-    if baseline_untracked == [render_relative]:
-        if not candidate_harness.is_file():
-            raise ValueError("candidate has no render harness to authenticate the baseline copy")
-        if baseline_harness.read_bytes() != candidate_harness.read_bytes():
-            raise ValueError("baseline untracked render harness is not byte-identical to candidate")
     if render and baseline_harness.read_bytes() != candidate_harness.read_bytes():
         raise ValueError("baseline render harness is not byte-identical to candidate")
 
@@ -1984,6 +2118,49 @@ def validate_scenarios(document: dict[str, Any]) -> None:
             "statistical_contract must preserve run/media-generation clustering, "
             "7-pair core, 3-pair fault/soak, and six independent OS x mpv cells"
         )
+    animation_profiles = document.get("animation_profiles")
+    if not isinstance(animation_profiles, dict) or set(animation_profiles) != set(
+        ANIMATION_PROFILE_NAMES
+    ):
+        raise ValueError(
+            "animation_profiles must declare exactly balanced_half and heavy_half"
+        )
+    for profile_name, expected_effects in ANIMATION_PROFILE_EFFECTS.items():
+        profile = animation_profiles.get(profile_name)
+        if not isinstance(profile, dict) or set(profile) != {
+            "effects",
+            "master",
+            "fps",
+            "pause_unfocused",
+        }:
+            raise ValueError(
+                f"animation_profiles.{profile_name} has an invalid schema"
+            )
+        effects = profile.get("effects")
+        if effects != list(expected_effects):
+            raise ValueError(
+                f"animation_profiles.{profile_name}.effects must preserve the fixed "
+                "20-effect profile"
+            )
+        if len(effects) * 2 != len(ANIMATION_EFFECT_FIELDS) or len(set(effects)) != len(
+            effects
+        ):
+            raise ValueError(
+                f"animation_profiles.{profile_name} must enable exactly half of the effects"
+            )
+        if not set(effects) <= set(ANIMATION_EFFECT_FIELDS):
+            raise ValueError(
+                f"animation_profiles.{profile_name} names an unknown animation effect"
+            )
+        if (
+            profile.get("master") is not True
+            or profile.get("fps") != 30
+            or profile.get("pause_unfocused") is not True
+        ):
+            raise ValueError(
+                f"animation_profiles.{profile_name} must use master=true, fps=30, "
+                "pause_unfocused=true"
+            )
     sampling = document.get("sampling")
     if not isinstance(sampling, dict):
         raise ValueError("sampling must be an object")
@@ -2204,9 +2381,24 @@ def validate_scenarios(document: dict[str, Any]) -> None:
         requires_mpv = scenario.get("requires_mpv")
         if not isinstance(requires_mpv, bool):
             raise ValueError(f"{name}.requires_mpv must be boolean")
+        animation_profile_name = scenario.get("animation_profile")
+        if animation_profile_name is not None:
+            if animation_profile_name not in animation_profiles:
+                raise ValueError(
+                    f"{name}.animation_profile references unknown profile "
+                    f"{animation_profile_name!r}"
+                )
+            if "setting_leaf_overrides" in scenario:
+                raise ValueError(
+                    f"{name} cannot combine animation_profile and setting_leaf_overrides"
+                )
+            if not requires_mpv:
+                raise ValueError(f"{name}.animation_profile requires playback")
         controller = scenario.get("controller")
         if not isinstance(controller, bool):
             raise ValueError(f"{name}.controller must be boolean")
+        if animation_profile_name is not None and not controller:
+            raise ValueError(f"{name}.animation_profile requires controller=true")
         pause_policy = scenario.get("pause_policy")
         if pause_policy not in {"none", "pause-resume"}:
             raise ValueError(f"{name}.pause_policy must be none or pause-resume")
@@ -2567,6 +2759,16 @@ def scenario_validation_self_test() -> None:
             lambda value: value["statistics"].__setitem__("baseline_cv_max", -0.1),
         ),
         (
+            "truncated balanced animation profile",
+            lambda value: value["animation_profiles"]["balanced_half"]["effects"].pop(),
+        ),
+        (
+            "unknown animation profile reference",
+            lambda value: find_scenario(value, "animation_half_balanced").__setitem__(
+                "animation_profile", "unknown"
+            ),
+        ),
+        (
             "non-finite fixture duration",
             lambda value: value["fixture"].__setitem__("duration_s", math.nan),
         ),
@@ -2740,6 +2942,43 @@ def find_scenario(document: dict[str, Any], name: str) -> dict[str, Any]:
         if scenario["id"] == name:
             return scenario
     raise ValueError(f"unknown scenario {name!r}")
+
+
+def animation_profile_setting_overrides(
+    document: dict[str, Any], profile_name: str
+) -> dict[str, Any]:
+    profile = document["animation_profiles"][profile_name]
+    enabled = set(profile["effects"])
+    overrides = {
+        f"animations.{field}": field in enabled
+        for field in ANIMATION_EFFECT_FIELDS
+    }
+    overrides.update(
+        {
+            "animations.master": profile["master"],
+            "animations.radio_master": None,
+            "animations.pause_unfocused": profile["pause_unfocused"],
+            "animations.fps": profile["fps"],
+        }
+    )
+    return overrides
+
+
+def setting_overrides_for_role(
+    document: dict[str, Any], scenario: dict[str, Any], role: str
+) -> dict[str, Any] | None:
+    animation_profile = scenario.get("animation_profile")
+    if animation_profile is not None:
+        return animation_profile_setting_overrides(document, animation_profile)
+    overrides_by_role = scenario.get("setting_leaf_overrides")
+    if overrides_by_role is None:
+        return None
+    if not isinstance(overrides_by_role, dict):
+        raise ValueError(f"scenario {scenario['id']!r} has malformed setting overrides")
+    overrides = overrides_by_role.get(role)
+    if not isinstance(overrides, dict) or not overrides:
+        raise ValueError(f"scenario {scenario['id']!r} has no {role} overrides")
+    return overrides
 
 
 def dotted(value: Any, path: str) -> Any:
@@ -4712,11 +4951,8 @@ def set_json_leaf(document: dict[str, Any], dotted_path: str, value: Any) -> Non
 def command_apply_setting_overrides(args: argparse.Namespace) -> int:
     scenario_document, scenario_hash = load_scenarios(args.scenarios)
     scenario = find_scenario(scenario_document, args.scenario)
-    overrides_by_role = scenario.get("setting_leaf_overrides")
-    if not isinstance(overrides_by_role, dict):
-        raise ValueError(f"scenario {args.scenario!r} has no setting leaf overrides")
-    overrides = overrides_by_role.get(args.role)
-    if not isinstance(overrides, dict) or not overrides:
+    overrides = setting_overrides_for_role(scenario_document, scenario, args.role)
+    if overrides is None:
         raise ValueError(f"scenario {args.scenario!r} has no {args.role} overrides")
 
     root = args.root.resolve()
@@ -4740,7 +4976,25 @@ def command_apply_setting_overrides(args: argparse.Namespace) -> int:
         leaf: json_leaf_state(document, leaf) for leaf in sorted(overrides)
     }
     for leaf, value in sorted(overrides.items()):
-        if leaf != LONG_FORM_SETTING_LEAF or value not in {"auto", "off", "on"}:
+        animation_field = leaf.removeprefix("animations.")
+        valid_animation_override = (
+            leaf.startswith("animations.")
+            and (
+                (animation_field in ANIMATION_EFFECT_FIELDS and isinstance(value, bool))
+                or (animation_field in {"master", "pause_unfocused"} and isinstance(value, bool))
+                or (animation_field == "radio_master" and value is None)
+                or (
+                    animation_field == "fps"
+                    and isinstance(value, int)
+                    and not isinstance(value, bool)
+                    and value == 30
+                )
+            )
+        )
+        if not (
+            (leaf == LONG_FORM_SETTING_LEAF and value in {"auto", "off", "on"})
+            or valid_animation_override
+        ):
             raise ValueError(f"unsupported setting override {leaf!r}={value!r}")
         set_json_leaf(document, leaf, value)
     atomic_json(config, document)
@@ -6175,6 +6429,7 @@ def validate_setting_overrides(
     path: Path,
     run_root: Path,
     scenario: dict[str, Any],
+    scenario_document: dict[str, Any],
     scenario_hash: str,
     role: str,
     launch_policy: dict[str, Any],
@@ -6191,7 +6446,9 @@ def validate_setting_overrides(
     require_artifact_value(
         path, "config path", manifest.get("config"), "stores/config/config.json"
     )
-    expected = scenario["setting_leaf_overrides"][role]
+    expected = setting_overrides_for_role(scenario_document, scenario, role)
+    if expected is None:
+        raise ValueError(f"{path}: scenario declares no setting overrides")
     require_artifact_value(path, "setting overrides", manifest.get("overrides"), expected)
     expected_values = {
         leaf: {"present": True, "value": value}
@@ -6276,6 +6533,7 @@ def setting_overrides_self_test() -> None:
             setting_path,
             run_root,
             scenario,
+            scenario_document,
             scenario_hash,
             "candidate",
             launch_policy,
@@ -6289,6 +6547,7 @@ def setting_overrides_self_test() -> None:
                 setting_path,
                 run_root,
                 scenario,
+                scenario_document,
                 scenario_hash,
                 "candidate",
                 launch_policy,
@@ -6297,6 +6556,52 @@ def setting_overrides_self_test() -> None:
             pass
         else:
             raise AssertionError("setting override snapshot tampering was accepted")
+
+    animation_scenario = find_scenario(scenario_document, "animation_half_balanced")
+    with tempfile.TemporaryDirectory(
+        prefix="ytt-perf-animation-overrides-self-test-"
+    ) as raw:
+        run_root = Path(raw) / "run"
+        home = run_root / "home"
+        config = home / "stores" / "config" / "config.json"
+        config.parent.mkdir(parents=True)
+        atomic_json(config, {"animations": {"plasma": True}})
+        setting_path = run_root / "setting-overrides.json"
+        with contextlib.redirect_stdout(io.StringIO()):
+            command_apply_setting_overrides(
+                argparse.Namespace(
+                    scenarios=DEFAULT_SCENARIOS,
+                    scenario=animation_scenario["id"],
+                    role="baseline",
+                    root=home,
+                    output=setting_path,
+                )
+            )
+            command_launch_policy(
+                argparse.Namespace(
+                    root=home,
+                    output=run_root / "launch-policy.json",
+                )
+            )
+        launch_policy, _artifacts = validate_launch_policy(
+            run_root / "launch-policy.json", run_root
+        )
+        validate_setting_overrides(
+            setting_path,
+            run_root,
+            animation_scenario,
+            scenario_document,
+            scenario_hash,
+            "baseline",
+            launch_policy,
+        )
+        applied = load_json_object(config)["animations"]
+        assert sum(bool(applied[field]) for field in ANIMATION_EFFECT_FIELDS) == 20
+        assert applied["plasma"] is False
+        assert applied["master"] is True
+        assert applied["fps"] == 30
+        assert applied["pause_unfocused"] is True
+        assert applied["radio_master"] is None
 
 
 def launch_policy_self_test() -> None:
@@ -8786,6 +9091,12 @@ def render_metrics_from_document(document: dict[str, Any], path: Path) -> dict[s
         metrics[f"{prefix}.p95_draw_ns"] = float(case_p95)
         metrics[f"{prefix}.buffer_style_digest"] = case["buffer_style_digest"]
         metrics[f"{prefix}.hit_map_digest"] = case["hit_map_digest"]
+        checkpoint_digest = case.get("checkpoint_digest")
+        if not isinstance(checkpoint_digest, str) or not re.fullmatch(r"[0-9a-f]{16}", checkpoint_digest):
+            raise ValueError(
+                f"{path}: render case {case.get('name')} checkpoint_digest is malformed"
+            )
+        metrics[f"{prefix}.checkpoint_digest"] = checkpoint_digest
         metrics[f"{prefix}.update_path"] = case["update_path"]
         if case["update_path"] == "app_update_msg_key":
             metrics[f"{prefix}.p95_reducer_input_to_draw_ns"] = float(case_p95)
@@ -12440,12 +12751,18 @@ def validate_process_directory(
         raise ValueError(f"{path}: missing launch-policy.json")
     launch_policy, launch_artifacts = validate_launch_policy(launch_policy_path, path)
     setting_artifacts: list[Path] = []
-    if "setting_leaf_overrides" in scenario:
+    if "setting_leaf_overrides" in scenario or "animation_profile" in scenario:
         setting_path = path / "setting-overrides.json"
         if not setting_path.is_file():
             raise ValueError(f"{path}: missing setting-overrides.json")
         setting_artifacts = validate_setting_overrides(
-            setting_path, path, scenario, scenario_hash, role, launch_policy
+            setting_path,
+            path,
+            scenario,
+            scenario_document,
+            scenario_hash,
+            role,
+            launch_policy,
         )
     artifacts = [
         samples_path,
@@ -14275,6 +14592,7 @@ def command_self_test(_args: argparse.Namespace) -> int:
             "batches": [render_batch, render_batch],
             "buffer_style_digest": "buffer",
             "hit_map_digest": "hits",
+            "checkpoint_digest": "0123456789abcdef",
         }],
     }
     render_metrics = render_metrics_from_document(render_document, Path("<self-test>"))
@@ -14341,6 +14659,7 @@ def command_self_test(_args: argparse.Namespace) -> int:
                 "latency_histogram": [{"ns": 5, "count": 3}],
                 "buffer_style_digest": "buffer",
                 "hit_map_digest": "hits",
+                "checkpoint_digest": "0123456789abcdef",
                 "batches": [
                     {
                         "draws": 3,
@@ -14557,15 +14876,23 @@ def command_self_test(_args: argparse.Namespace) -> int:
             encoding="utf-8",
         )
         (candidate_source / ".gitignore").write_text("/.cargo/\n", encoding="utf-8")
-        git_checked(candidate_source, "add", "Cargo.lock", "Cargo.toml", ".gitignore")
+        render_harness = candidate_source / "examples" / "tui_render_perf.rs"
+        render_harness.parent.mkdir()
+        render_harness.write_text("fn main() { /* origin */ }\n", encoding="utf-8")
+        git_checked(
+            candidate_source,
+            "add",
+            "Cargo.lock",
+            "Cargo.toml",
+            ".gitignore",
+            "examples/tui_render_perf.rs",
+        )
         git_checked(candidate_source, "-c", "commit.gpgsign=false", "commit", "-m", "main")
         remote_source.mkdir()
         git_checked(remote_source, "init", "--bare", "--initial-branch=main")
         git_checked(candidate_source, "remote", "add", "origin", str(remote_source))
         git_checked(candidate_source, "push", "-u", "origin", "main")
         git_checked(candidate_source, "switch", "-c", "candidate")
-        render_harness = candidate_source / "examples" / "tui_render_perf.rs"
-        render_harness.parent.mkdir()
         render_harness.write_text("fn main() {}\n", encoding="utf-8")
         git_checked(candidate_source, "add", "examples/tui_render_perf.rs")
         git_checked(
@@ -15255,7 +15582,7 @@ def command_self_test(_args: argparse.Namespace) -> int:
                 "sample_cpu_window_tamper_cases": 2,
                 "sample_jitter_weighting_cases": 1,
                 "control_buffering_tamper_cases": 1,
-                "scenario_schema_tamper_cases": 33,
+                "scenario_schema_tamper_cases": 35,
                 "control_operation_tamper_cases": 13,
                 "http_server_authenticated_shutdown_cases": 1,
                 "http_server_leading_dash_token_cases": 1,

--- a/scripts/tui-perf.py
+++ b/scripts/tui-perf.py
@@ -36,7 +36,7 @@ import threading
 import time
 import wave
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 from urllib.parse import urlsplit
 
 
@@ -5276,6 +5276,51 @@ def command_launch_policy(args: argparse.Namespace) -> int:
     return 0
 
 
+def macos_process_absent_or_zombie(
+    pid: int,
+    *,
+    existence_probe: Callable[[int], bool] | None = None,
+    state_probe: Callable[[int], tuple[int, str]] | None = None,
+) -> bool:
+    """Confirm a Darwin PID vanished or became a zombie without trusting one racy probe."""
+
+    def default_existence_probe(candidate: int) -> bool:
+        try:
+            os.kill(candidate, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
+    def default_state_probe(candidate: int) -> tuple[int, str]:
+        environment = controlled_build_environment()
+        environment["LC_ALL"] = "C"
+        completed = subprocess.run(
+            ["/bin/ps", "-p", str(candidate), "-o", "state="],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=environment,
+            check=False,
+        )
+        return completed.returncode, completed.stdout
+
+    exists = existence_probe or default_existence_probe
+    inspect_state = state_probe or default_state_probe
+    if not exists(pid):
+        return True
+    returncode, output = inspect_state(pid)
+    state = output.strip()
+    if returncode == 0 and state.startswith("Z"):
+        return True
+    if returncode != 0 or not state:
+        # The process can be reaped after the first existence probe. Only ESRCH on this
+        # second probe is proof of absence; a still-live but uninspectable PID fails closed.
+        return not exists(pid)
+    return False
+
+
 def unix_process_observation(pid: int, *, hash_executable: bool = True) -> dict[str, Any] | None:
     if pid <= 0:
         return None
@@ -5320,22 +5365,6 @@ def unix_process_observation(pid: int, *, hash_executable: bool = True) -> dict[
             libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
             length = libproc.proc_pidpath(pid, buffer, len(buffer))
             if length <= 0:
-                try:
-                    os.kill(pid, 0)
-                except ProcessLookupError:
-                    return None
-                environment = controlled_build_environment()
-                environment["LC_ALL"] = "C"
-                state = subprocess.run(
-                    ["/bin/ps", "-p", str(pid), "-o", "state="],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    env=environment,
-                    check=False,
-                )
-                if state.returncode == 0 and state.stdout.strip().startswith("Z"):
-                    return None
                 raise ValueError(f"proc_pidpath failed for PID {pid}")
             executable = Path(os.fsdecode(buffer.value)).resolve(strict=True)
             libc = ctypes.CDLL("/usr/lib/libSystem.B.dylib", use_errno=True)
@@ -5377,7 +5406,10 @@ def unix_process_observation(pid: int, *, hash_executable: bool = True) -> dict[
                 check=False,
             )
             if completed.returncode != 0 or not completed.stdout.strip():
-                return None
+                raise ValueError(
+                    f"ps start-time query failed for PID {pid}: "
+                    f"returncode={completed.returncode}, stderr={completed.stderr.strip()!r}"
+                )
             line = completed.stdout.strip()
             match = re.fullmatch(
                 r"(\w{3}\s+\w{3}\s+\d+\s+\d\d:\d\d:\d\d\s+\d{4})",
@@ -5396,11 +5428,17 @@ def unix_process_observation(pid: int, *, hash_executable: bool = True) -> dict[
             )
             relation_fields = relation.stdout.split()
             if relation.returncode != 0 or len(relation_fields) != 2:
-                return None
+                raise ValueError(
+                    f"ps relation query failed for PID {pid}: "
+                    f"returncode={relation.returncode}, fields={relation_fields!r}, "
+                    f"stderr={relation.stderr.strip()!r}"
+                )
             parent_pid, process_group_id = map(int, relation_fields)
         except ProcessLookupError:
             return None
         except (OSError, ValueError) as error:
+            if macos_process_absent_or_zombie(pid):
+                return None
             raise ValueError(f"cannot inspect macOS PID {pid}: {error}") from error
         return {
             "pid": pid,
@@ -14695,6 +14733,44 @@ def host_identity_privacy_self_test() -> None:
             raise AssertionError("raw host identifier payload leaked into the serialized identity")
 
 
+def macos_process_absence_probe_self_test() -> None:
+    def existence_sequence(*results: bool) -> Callable[[int], bool]:
+        remaining = iter(results)
+        return lambda _pid: next(remaining)
+
+    def missing_state(_pid: int) -> tuple[int, str]:
+        return 1, ""
+
+    def unexpected_state(_pid: int) -> tuple[int, str]:
+        raise AssertionError("state probe must not run for a confirmed-absent PID")
+
+    assert macos_process_absent_or_zombie(
+        42,
+        existence_probe=existence_sequence(True, False),
+        state_probe=missing_state,
+    )
+    assert not macos_process_absent_or_zombie(
+        42,
+        existence_probe=existence_sequence(True, True),
+        state_probe=missing_state,
+    )
+    assert macos_process_absent_or_zombie(
+        42,
+        existence_probe=existence_sequence(True),
+        state_probe=lambda _pid: (0, "Z"),
+    )
+    assert not macos_process_absent_or_zombie(
+        42,
+        existence_probe=existence_sequence(True),
+        state_probe=lambda _pid: (0, "S"),
+    )
+    assert macos_process_absent_or_zombie(
+        42,
+        existence_probe=existence_sequence(False),
+        state_probe=unexpected_state,
+    )
+
+
 def command_self_test(_args: argparse.Namespace) -> int:
     scenario_validation_self_test()
     tree_digest_self_test()
@@ -14705,6 +14781,7 @@ def command_self_test(_args: argparse.Namespace) -> int:
     cleanup_integration_self_test()
     startup_cleanup_integration_self_test()
     host_identity_privacy_self_test()
+    macos_process_absence_probe_self_test()
     run_contract_integration_self_test()
     multi_geometry_run_contract_integration_self_test()
     launch_policy_self_test()

--- a/scripts/tui-perf.sh
+++ b/scripts/tui-perf.sh
@@ -90,6 +90,9 @@ has_setting_overrides=false
 if python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" \
   --field setting_leaf_overrides >/dev/null 2>&1; then
   has_setting_overrides=true
+elif python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" \
+  --field animation_profile >/dev/null 2>&1; then
+  has_setting_overrides=true
 fi
 traffic_profile=$(python3 "$python_tool" scenario --scenarios "$scenarios" --id "$scenario" --field traffic_profile)
 source_rate_bound_bps=$(python3 "$python_tool" traffic \

--- a/src/app/artwork.rs
+++ b/src/app/artwork.rs
@@ -504,10 +504,21 @@ impl App {
             self.fx.popup = Some(self.fx_arm(w::POPUP_MS));
         }
 
-        // The synced-lyric line advanced → flash the newly-current line. Only tracked while
-        // the panel is visible on the player. Rendering and flash share the same index written by
-        // the 100 ms lyric clock, so interpolation cannot make their frames disagree.
-        if matches!(self.mode, Mode::Player) && self.lyrics.visible && on(a.lyrics) {
+        self.detect_lyrics_fx_when(on(a.lyrics));
+    }
+
+    /// Diff the synced-lyric row separately so the animation-clock fast path need not scan every
+    /// unrelated one-shot FX anchor. Reconciliation writes `active_index` immediately before
+    /// this call, keeping the rendered row and flash on the same animation turn.
+    pub(in crate::app) fn detect_lyrics_fx(&mut self) {
+        let a = self.animations();
+        self.detect_lyrics_fx_when(a.master && a.lyrics);
+    }
+
+    fn detect_lyrics_fx_when(&mut self, enabled: bool) {
+        use crate::ui::anim::fx_window as w;
+
+        if matches!(self.mode, Mode::Player) && self.lyrics.visible && enabled {
             let idx = self.current_loaded_lyrics().and(self.lyrics.active_index);
             if idx != self.fx.last_lyric_index {
                 self.fx.last_lyric_index = idx;

--- a/src/app/download.rs
+++ b/src/app/download.rs
@@ -223,13 +223,10 @@ impl App {
             .sources
             .get(&tracking_key)
             .and_then(|song| song.import_session_id.clone());
-        // Preserve the ordinary empty-path terminal behavior; import ownership must still be
-        // released so it cannot block the session's settled check forever.
-        let source = if saved || import_session_id.is_some() {
-            self.downloads.sources.remove(&tracking_key)
-        } else {
-            None
-        };
+        // A terminal completion no longer needs the source metadata, even when a worker reports
+        // an empty path. Retaining it until process exit leaks one full `Song` per such result.
+        // Capture import ownership first so its settled check still runs after removal.
+        let source = self.downloads.sources.remove(&tracking_key);
         if saved {
             let path_buf = PathBuf::from(&path);
             let local = source

--- a/src/app/lyrics_control.rs
+++ b/src/app/lyrics_control.rs
@@ -28,7 +28,7 @@ impl App {
             return None;
         }
         let track = self.lyrics.track.as_ref()?;
-        (track.video_id.as_str() == song.video_id.as_str() && !track.lines.is_empty())
+        (track.video_id.as_ref() == song.video_id.as_str() && !track.lines.is_empty())
             .then_some(track)
     }
 
@@ -203,7 +203,7 @@ impl App {
             return None;
         }
         let track = self.current_loaded_lyrics()?;
-        if track.video_id.as_str() != video_id {
+        if track.video_id.as_ref() != video_id {
             return None;
         }
         let timestamp = track.lines.get(line_index)?.time;

--- a/src/app/lyrics_mouse.rs
+++ b/src/app/lyrics_mouse.rs
@@ -9,7 +9,8 @@ impl App {
                 video_id,
                 line_index,
             } => {
-                let Some(position) = self.lyrics_line_seek_target(&video_id, line_index) else {
+                let Some(position) = self.lyrics_line_seek_target(video_id.as_ref(), line_index)
+                else {
                     return Vec::new();
                 };
                 self.player_intent(

--- a/src/app/media_reducer.rs
+++ b/src/app/media_reducer.rs
@@ -190,10 +190,14 @@ impl App {
                 // Same radio guard as SetShuffle — and never remote-trigger a re-sync. Also
                 // enforce the music-mode invariant: an OS widget can't enable repeat while
                 // autoplay streaming is on.
-                if self.current_is_radio_stream()
-                    || self.queue.repeat == mode
-                    || mode.set_blocked_by_streaming(self.autoplay_streaming)
-                {
+                if self.current_is_radio_stream() {
+                    return Vec::new();
+                }
+                if mode.set_blocked_by_streaming(self.autoplay_streaming) {
+                    self.show_repeat_streaming_conflict();
+                    return Vec::new();
+                }
+                if self.queue.repeat == mode {
                     return Vec::new();
                 }
                 self.queue.repeat = mode;
@@ -805,6 +809,56 @@ mod tests {
         assert!(cmds.iter().any(
             |c| matches!(c, Cmd::Persist(PersistCmd::Config(cfg)) if cfg.repeat == Repeat::One)
         ));
+        assert!(
+            app.update(Msg::Media(MediaCommand::SetRepeat(Repeat::One)))
+                .is_empty(),
+            "same repeat value must not churn persisted config"
+        );
+    }
+
+    #[test]
+    fn repeat_from_media_session_rejects_streaming_conflict_with_toast() {
+        let mut app = app_with_queue(3);
+        app.autoplay_streaming = true;
+        app.config.autoplay_streaming = Some(true);
+        app.status.text = "before".to_owned();
+        app.dirty = false;
+
+        let cmds = app.update(Msg::Media(MediaCommand::SetRepeat(Repeat::All)));
+
+        assert!(
+            cmds.is_empty(),
+            "a rejection must not persist or emit effects"
+        );
+        assert_eq!(app.queue.repeat, Repeat::Off);
+        assert_eq!(app.config.repeat, Repeat::Off);
+        assert!(app.autoplay_streaming);
+        assert_eq!(app.config.autoplay_streaming, Some(true));
+        assert!(matches!(
+            app.status.text.as_str(),
+            "Can't use repeat while autoplay is on" | "자동재생 중에는 반복을 켤 수 없어요"
+        ));
+        assert!(app.dirty, "the localized rejection notice must redraw");
+
+        // A legacy/inconsistent state may already contain both modes. Even an
+        // idempotent MPRIS write must explain why repeat is incompatible instead of
+        // silently disappearing behind the same-value no-op.
+        app.queue.repeat = Repeat::All;
+        app.config.repeat = Repeat::All;
+        app.status.text = "before same-value conflict".to_owned();
+        app.dirty = false;
+
+        let cmds = app.update(Msg::Media(MediaCommand::SetRepeat(Repeat::All)));
+
+        assert!(cmds.is_empty());
+        assert_eq!(app.queue.repeat, Repeat::All);
+        assert_eq!(app.config.repeat, Repeat::All);
+        assert!(app.autoplay_streaming);
+        assert!(matches!(
+            app.status.text.as_str(),
+            "Can't use repeat while autoplay is on" | "자동재생 중에는 반복을 켤 수 없어요"
+        ));
+        assert!(app.dirty, "same-value conflict notice must redraw");
     }
 
     #[test]

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -1130,7 +1130,7 @@ impl App {
     /// Whether we lack lyrics for the current track (so a fetch is warranted).
     pub(in crate::app) fn lyrics_stale(&self) -> bool {
         match (&self.lyrics.track, self.queue.current()) {
-            (Some(l), Some(cur)) => l.video_id != cur.video_id,
+            (Some(l), Some(cur)) => l.video_id.as_ref() != cur.video_id.as_str(),
             (None, Some(_)) => true,
             _ => false,
         }

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -96,6 +96,17 @@ pub(in crate::app) struct YidMemo {
 }
 
 impl App {
+    /// Show the shared music-mode rejection used when a local or media-session
+    /// control tries to enable repeat while autoplay streaming is active.
+    pub(in crate::app) fn show_repeat_streaming_conflict(&mut self) {
+        self.status.text = t!(
+            "Can't use repeat while autoplay is on",
+            "자동재생 중에는 반복을 켤 수 없어요"
+        )
+        .to_owned();
+        self.dirty = true;
+    }
+
     /// Handle an mpv playback error: self-heal a stale-yt-dlp extraction failure
     /// once, otherwise skip the bad track (with a circuit breaker after too many in a
     /// row). Extracted verbatim from the `PlayerMsg::Error` dispatch arm; the
@@ -710,12 +721,7 @@ impl App {
                     .repeat
                     .cycle_blocked_by_streaming(self.autoplay_streaming)
                 {
-                    self.status.text = t!(
-                        "Can't use repeat while autoplay is on",
-                        "자동재생 중에는 반복을 켤 수 없어요"
-                    )
-                    .to_owned();
-                    self.dirty = true;
+                    self.show_repeat_streaming_conflict();
                     return Vec::new();
                 }
                 self.queue.cycle_repeat();

--- a/src/app/reducer.rs
+++ b/src/app/reducer.rs
@@ -12,6 +12,10 @@ impl App {
     /// without each call site having to remember to arm a timer. See [`Self::status_visible`].
     pub fn update(&mut self, msg: impl Into<Msg>) -> Vec<Cmd> {
         let msg = msg.into();
+        if matches!(&msg, Msg::AnimTick) {
+            self.update_animation_tick();
+            return Vec::new();
+        }
         // Rendering is the only place that knows the real cell grid (text zoom can change it
         // without a terminal resize). Apply the bridged tier before routing this event so a
         // hidden Search/DJ input cannot consume the first global key after entering Mini.
@@ -82,6 +86,20 @@ impl App {
         self.sync_art_geometry();
         self.status_text_prev = status_before; // return the buffer's capacity for next turn
         cmds
+    }
+
+    /// Advance one animation-clock turn without running the general reducer observers. An
+    /// animation tick cannot change status, onboarding, playback, seek, or art geometry; synced
+    /// lyrics are the one wall-clock projection that still needs reconciling before its FX diff.
+    fn update_animation_tick(&mut self) {
+        // Preserve the general wrapper's pre-dispatch tier repair. `advance_animation` cannot
+        // change the tier, so the wrapper's second sync would be redundant on this path.
+        self.sync_ui_tier();
+        self.advance_animation();
+        if self.reconcile_lyrics_surface_at(Instant::now()) {
+            self.dirty = true;
+        }
+        self.detect_lyrics_fx();
     }
 
     fn dispatch(&mut self, msg: Msg) -> Vec<Cmd> {
@@ -233,12 +251,7 @@ impl App {
                     self.dirty = true;
                 }
             }
-            Msg::AnimTick => {
-                // Advance the logical animation phase on every configured tick, but only request
-                // an actual terminal redraw when the active effect mix is due. This keeps visual
-                // timing stable while cutting the expensive render/terminal/compositor path.
-                self.advance_animation();
-            }
+            Msg::AnimTick => unreachable!("animation ticks use the dedicated reducer fast path"),
             Msg::Focus(f) => {
                 // Terminal focus toggled. `animation_active()` reads `focused` to park the ~30 fps
                 // tick while we're hidden; one redraw repaints cleanly on the transition (freeze a
@@ -562,7 +575,10 @@ impl App {
                     if lines.is_empty() {
                         self.lyrics.delay_osd_until = None;
                     }
-                    self.lyrics.track = Some(TrackLyrics { video_id, lines });
+                    self.lyrics.track = Some(TrackLyrics {
+                        video_id: video_id.into(),
+                        lines,
+                    });
                     self.dirty = true;
                 }
             }

--- a/src/app/tests/animations.rs
+++ b/src/app/tests/animations.rs
@@ -136,7 +136,7 @@ fn all_animations_on_render_every_view_without_panic() {
     app.library.toggle_favorite(&cur); // liked → heart + burst path
     app.lyrics.visible = true;
     app.lyrics.track = Some(TrackLyrics {
-        video_id: cur.video_id.clone(),
+        video_id: cur.video_id.clone().into(),
         lines: (0..12)
             .map(|i| crate::lyrics::LyricLine {
                 time: f64::from(i) * 5.0,
@@ -629,6 +629,30 @@ fn canvas_animation_advances_phase_every_tick_but_caps_redraws() {
         redraws += usize::from(app.dirty);
     }
     assert_eq!(redraws, 20);
+}
+
+#[test]
+fn animation_tick_fast_path_skips_unrelated_fx_anchor_scans() {
+    let mut app = app_playing(1, 0);
+    app.config.animations.master = true;
+    app.config.animations.volume_flash = true;
+    app.fx.last_volume = app.playback.volume;
+    app.playback.volume = app.playback.volume.saturating_sub(5);
+    let anchor = app.fx.last_volume;
+
+    app.dirty = false;
+    app.update(Msg::AnimTick);
+
+    assert_eq!(app.anim_frame(), 1);
+    assert_eq!(app.fx.last_volume, anchor);
+    assert!(app.fx.volume.is_none());
+
+    app.update(Msg::Resize);
+    assert_eq!(app.fx.last_volume, app.playback.volume);
+    assert!(
+        app.fx.volume.is_some(),
+        "the next state-changing reducer turn still observes the volume delta"
+    );
 }
 
 #[test]

--- a/src/app/tests/downloads.rs
+++ b/src/app/tests/downloads.rs
@@ -885,6 +885,8 @@ fn import_batch_auto_organize_latches_refresh_behind_an_active_scan() {
 #[test]
 fn download_done_with_empty_path_does_not_save() {
     let mut app = App::new(100);
+    app.start_download(Song::remote("x", "Title", "Artist", "1:00"));
+    assert!(app.downloads.sources.contains_key("x"));
     let cmds = app.update(Msg::Download(DownloadMsg::Done {
         video_id: "x".to_owned(),
         path: "   ".to_owned(),
@@ -893,6 +895,10 @@ fn download_done_with_empty_path_does_not_save() {
         !cmds
             .iter()
             .any(|c| matches!(c, Cmd::Persist(PersistCmd::Downloads)))
+    );
+    assert!(
+        !app.downloads.sources.contains_key("x"),
+        "terminal empty-path results must release retained source metadata"
     );
 }
 

--- a/src/app/tests/lyrics_art_download.rs
+++ b/src/app/tests/lyrics_art_download.rs
@@ -39,7 +39,7 @@ fn lyrics_result_stored_only_for_current_track() {
         video_id: "stale".to_owned(),
         lines: lyric_lines(),
     });
-    assert_eq!(app.lyrics.track.as_ref().unwrap().video_id, "id0");
+    assert_eq!(app.lyrics.track.as_ref().unwrap().video_id.as_ref(), "id0");
 }
 
 #[test]

--- a/src/app/tests/lyrics_sync_controls.rs
+++ b/src/app/tests/lyrics_sync_controls.rs
@@ -60,7 +60,7 @@ fn keyboard_mouse_and_repeat_share_exact_100ms_steps() {
 
     assert!(
         app.on_mouse_target(MouseTarget::LyricsDelayLater {
-            video_id: "id0".to_owned(),
+            video_id: "id0".into(),
         })
         .is_empty()
     );
@@ -160,7 +160,7 @@ fn admitted_track_identity_alone_resets_the_session_delay() {
 #[test]
 fn hidden_empty_stale_live_and_unloaded_lyrics_fail_closed() {
     let target = || MouseTarget::LyricsLine {
-        video_id: "id0".to_owned(),
+        video_id: "id0".into(),
         line_index: 1,
     };
 
@@ -180,7 +180,7 @@ fn hidden_empty_stale_live_and_unloaded_lyrics_fail_closed() {
     assert!(
         stale
             .on_mouse_target(MouseTarget::LyricsLine {
-                video_id: "old-id".to_owned(),
+                video_id: "old-id".into(),
                 line_index: 1,
             })
             .is_empty()
@@ -188,7 +188,7 @@ fn hidden_empty_stale_live_and_unloaded_lyrics_fail_closed() {
     assert!(
         stale
             .on_mouse_target(MouseTarget::LyricsDelayEarlier {
-                video_id: "old-id".to_owned(),
+                video_id: "old-id".into(),
             })
             .is_empty()
     );
@@ -210,14 +210,14 @@ fn hidden_empty_stale_live_and_unloaded_lyrics_fail_closed() {
     live.lyrics.visible = true;
     live.playback.duration = Some(10.0);
     live.lyrics.track = Some(TrackLyrics {
-        video_id: current(&live).to_owned(),
+        video_id: current(&live).into(),
         lines: timed_lines(&[0.0, 5.0]),
     });
     live.update(Msg::Key(key(KeyCode::Char('z'))));
     assert_eq!(live.lyrics.delay.steps(), 0);
     assert!(
         live.on_mouse_target(MouseTarget::LyricsLine {
-            video_id: current(&live).to_owned(),
+            video_id: current(&live).into(),
             line_index: 1,
         })
         .is_empty()
@@ -232,7 +232,7 @@ fn lyric_click_mutates_position_only_after_admission_and_bumps_epoch_once() {
     let before_position = app.playback.time_pos;
     let before_epoch = app.playback.position_epoch;
     let cmds = app.on_mouse_target(MouseTarget::LyricsLine {
-        video_id: "id0".to_owned(),
+        video_id: "id0".into(),
         line_index: 1,
     });
     assert_eq!(seek_position(&cmds), Some(5.1));
@@ -254,7 +254,7 @@ fn lyric_click_mutates_position_only_after_admission_and_bumps_epoch_once() {
     let epoch = rejected.playback.position_epoch;
     let position = rejected.playback.time_pos;
     let cmds = rejected.on_mouse_target(MouseTarget::LyricsLine {
-        video_id: "id0".to_owned(),
+        video_id: "id0".into(),
         line_index: 1,
     });
     reject_player_transition(
@@ -403,14 +403,14 @@ fn osd_arms_refreshes_expires_reopens_and_blocks_click_through() {
     app.dirty = false;
     assert!(
         app.on_mouse_target(MouseTarget::LyricsDelayHandle {
-            video_id: "old-id".to_owned(),
+            video_id: "old-id".into(),
         })
         .is_empty()
     );
     assert!(app.lyrics.delay_osd_until.is_none());
     assert!(
         app.on_mouse_target(MouseTarget::LyricsDelayHandle {
-            video_id: "id0".to_owned(),
+            video_id: "id0".into(),
         })
         .is_empty()
     );
@@ -433,7 +433,7 @@ fn osd_arms_refreshes_expires_reopens_and_blocks_click_through() {
     assert_eq!(
         app.hits.target_at(blocker.rect.x + 2, blocker.rect.y),
         Some(MouseTarget::LyricsDelayEarlier {
-            video_id: "id0".to_owned()
+            video_id: "id0".into()
         })
     );
     let delay = app.lyrics.delay;
@@ -462,6 +462,35 @@ fn osd_arms_refreshes_expires_reopens_and_blocks_click_through() {
         app.hits.target_at(handle.rect.x, handle.rect.y),
         Some(MouseTarget::LyricsDelayHandle { .. })
     ));
+}
+
+#[test]
+fn rendered_lyric_targets_share_the_track_video_id_allocation() {
+    let app = synced_app(&[0.0, 5.0, 9.0], 5.05, 10.0);
+    let owner = app
+        .lyrics
+        .track
+        .as_ref()
+        .expect("loaded lyrics")
+        .video_id
+        .clone();
+    let _buffer = render_app_buffer(&app, 80, 24);
+    let mut shared_targets = 0usize;
+    let regions = app.hits.regions();
+    for region in regions.iter() {
+        let target_id = match &region.target {
+            MouseTarget::LyricsLine { video_id, .. }
+            | MouseTarget::LyricsDelayHandle { video_id }
+            | MouseTarget::LyricsDelayEarlier { video_id }
+            | MouseTarget::LyricsDelayLater { video_id } => Some(video_id),
+            _ => None,
+        };
+        if let Some(video_id) = target_id {
+            assert!(std::sync::Arc::ptr_eq(&owner, video_id));
+            shared_targets += 1;
+        }
+    }
+    assert!(shared_targets > 1, "expected lyric rows and an OSD target");
 }
 
 #[test]
@@ -494,6 +523,27 @@ fn lyric_clock_redraws_only_at_boundaries_and_parks_outside_active_player() {
     app.mode = Mode::Player;
     app.bridges.ui_tier.set(crate::ui::layout::UiTier::Mini);
     assert!(!app.lyrics_clock_active());
+}
+
+#[test]
+fn animation_tick_reconciles_the_lyric_row_before_arming_its_flash() {
+    let mut app = synced_app(&[0.0, 5.0], 1.0, 10.0);
+    app.config.animations.master = true;
+    app.config.animations.lyrics = true;
+    app.playback.time_pos = Some(5.1);
+    app.playback.time_pos_at = Some(Instant::now());
+    app.lyrics.active_index = Some(0);
+    app.fx.last_lyric_index = Some(0);
+    app.fx.lyric = None;
+    let expected_start = app.anim_frame().wrapping_add(1);
+
+    app.dirty = false;
+    app.update(Msg::AnimTick);
+
+    assert_eq!(app.lyrics.active_index, Some(1));
+    assert_eq!(app.fx.last_lyric_index, Some(1));
+    assert_eq!(app.fx.lyric, Some(expected_start));
+    assert!(app.dirty);
 }
 
 #[test]
@@ -533,7 +583,7 @@ fn render_targets_stay_visible_osd_wins_and_art_never_overlaps() {
                 assert_eq!(
                     app.hits.target_at(blocker.rect.x + 2, blocker.rect.y),
                     Some(MouseTarget::LyricsDelayEarlier {
-                        video_id: "id0".to_owned()
+                        video_id: "id0".into()
                     }),
                     "OSD button wins over the lyric row beneath it"
                 );

--- a/src/app/tests/player_composition.rs
+++ b/src/app/tests/player_composition.rs
@@ -16,7 +16,13 @@ fn bottom_player_with_art_and_lyrics() -> App {
     app.playback.time_pos_at = None;
     app.lyrics.visible = true;
     app.lyrics.track = Some(TrackLyrics {
-        video_id: app.queue.current().expect("current track").video_id.clone(),
+        video_id: app
+            .queue
+            .current()
+            .expect("current track")
+            .video_id
+            .clone()
+            .into(),
         lines: vec![crate::lyrics::LyricLine {
             time: 0.0,
             text: LYRIC_MARKER.to_owned(),

--- a/src/app/tests/queue_mutation_admission.rs
+++ b/src/app/tests/queue_mutation_admission.rs
@@ -285,7 +285,7 @@ fn current_range_busy_and_closed_preserve_queue_popup_and_playback_until_retry()
         app.queue_popup.cursor = 3;
         app.art.video_id = Some("art-id1".to_owned());
         app.lyrics.track = Some(TrackLyrics {
-            video_id: "id1".to_owned(),
+            video_id: "id1".into(),
             lines: Vec::new().into(),
         });
         let before_ids = ordered_ids(&app.queue);
@@ -309,7 +309,7 @@ fn current_range_busy_and_closed_preserve_queue_popup_and_playback_until_retry()
             app.lyrics
                 .track
                 .as_ref()
-                .map(|lyrics| lyrics.video_id.as_str()),
+                .map(|lyrics| lyrics.video_id.as_ref()),
             Some("id1")
         );
 

--- a/src/app/tests/track_transitions.rs
+++ b/src/app/tests/track_transitions.rs
@@ -24,7 +24,7 @@ fn busy_and_closed_next_leave_transition_state_unchanged() {
         let mut app = app_playing(3, 0);
         app.art.video_id = Some("art-id0".to_owned());
         app.lyrics.track = Some(TrackLyrics {
-            video_id: "id0".to_owned(),
+            video_id: "id0".into(),
             lines: Vec::new().into(),
         });
         let cursor = app.queue.cursor_pos();
@@ -92,7 +92,7 @@ fn next_preparation_leaves_all_transition_state_unchanged() {
     let mut app = app_playing(3, 0);
     app.art.video_id = Some("art-id0".to_owned());
     app.lyrics.track = Some(TrackLyrics {
-        video_id: "id0".to_owned(),
+        video_id: "id0".into(),
         lines: Vec::new().into(),
     });
     let cursor = app.queue.cursor_pos();

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -566,20 +566,20 @@ pub enum MouseTarget {
     /// A visible synced-lyric row. The owning track ID and original LRC index make stale frame
     /// targets fail closed instead of seeking a newly loaded track.
     LyricsLine {
-        video_id: String,
+        video_id: Arc<str>,
         line_index: usize,
     },
     /// The collapsed `[±]` handle. Carries its rendered track ID for the same stale-frame guard.
     LyricsDelayHandle {
-        video_id: String,
+        video_id: Arc<str>,
     },
     /// Expanded lyric-delay buttons. Keeping the rendered track ID prevents an old frame's OSD
     /// from adjusting a newly loaded song before the next frame replaces the hit map.
     LyricsDelayEarlier {
-        video_id: String,
+        video_id: Arc<str>,
     },
     LyricsDelayLater {
-        video_id: String,
+        video_id: Arc<str>,
     },
     /// Inert coverage for the expanded lyric-delay OSD's value and spacing. Action buttons are
     /// registered after it and win hit-testing; everything else is deliberately consumed.
@@ -952,7 +952,7 @@ pub enum Mode {
 
 /// Synced lyrics for one track (held while it's the current track).
 pub struct TrackLyrics {
-    pub video_id: String,
+    pub video_id: Arc<str>,
     pub lines: std::sync::Arc<[LyricLine]>,
 }
 

--- a/src/cli_capability.rs
+++ b/src/cli_capability.rs
@@ -1,0 +1,206 @@
+//! Typed persistence-capability classification for non-interactive CLI entrypoints.
+//!
+//! Classification deliberately runs before the command parser so help and provable usage errors
+//! can exit without contending for the writer lease. Ambiguous forms fail closed as writers; only
+//! syntactically provable observational forms are downgraded to read-only access.
+
+use std::ffi::OsString;
+
+#[must_use]
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CliPersistenceCapability {
+    NotRequired,
+    ReadOnly,
+    Writer,
+}
+
+impl CliPersistenceCapability {
+    pub const fn requires_persistence(self) -> bool {
+        match self {
+            Self::NotRequired => false,
+            Self::ReadOnly | Self::Writer => true,
+        }
+    }
+
+    pub const fn allows_writes(self) -> bool {
+        match self {
+            Self::NotRequired | Self::ReadOnly => false,
+            Self::Writer => true,
+        }
+    }
+}
+
+#[must_use]
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OneShotCommand {
+    Auth,
+    Transfer,
+    Doctor,
+    Tools,
+    Update,
+}
+
+impl OneShotCommand {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Auth => "auth",
+            Self::Transfer => "transfer",
+            Self::Doctor => "doctor",
+            Self::Tools => "tools",
+            Self::Update => "update",
+        }
+    }
+
+    pub fn persistence_capability(self, args: &[String]) -> CliPersistenceCapability {
+        match self {
+            Self::Auth => auth_persistence(args),
+            Self::Transfer => transfer_persistence(args),
+            Self::Doctor => doctor_persistence(args),
+            Self::Tools => tools_persistence(args),
+            Self::Update => CliPersistenceCapability::ReadOnly,
+        }
+    }
+}
+
+pub const fn interactive_persistence_capability(new_instance: bool) -> CliPersistenceCapability {
+    if new_instance {
+        CliPersistenceCapability::ReadOnly
+    } else {
+        CliPersistenceCapability::Writer
+    }
+}
+
+/// Preserve the CLI's existing lossy `OsString` boundary without exposing non-Unicode arguments
+/// to parsers that have always accepted owned UTF-8 strings.
+pub fn collect_lossy_cli_args(args: impl IntoIterator<Item = OsString>) -> Vec<String> {
+    args.into_iter()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect()
+}
+
+fn auth_persistence(args: &[String]) -> CliPersistenceCapability {
+    match args.first().map(String::as_str) {
+        Some("lastfm" | "listenbrainz") => CliPersistenceCapability::Writer,
+        Some("spotify") => spotify_auth_persistence(&args[1..]),
+        _ => CliPersistenceCapability::NotRequired,
+    }
+}
+
+fn spotify_auth_persistence(args: &[String]) -> CliPersistenceCapability {
+    let mut it = args.iter().map(String::as_str);
+    while let Some(arg) = it.next() {
+        match arg {
+            // The command parser consumes the next token even when it looks like a flag.
+            "--client-id" if it.next().is_some() => {}
+            "--client-id" => return CliPersistenceCapability::NotRequired,
+            "--status" | "--logout" => {}
+            "--help" | "-h" => return CliPersistenceCapability::NotRequired,
+            // Unknown flags are rejected before Config/token access.
+            _ => return CliPersistenceCapability::NotRequired,
+        }
+    }
+    // Status can refresh credentials, logout removes them, and the default connect path may save
+    // both config and token state. Those valid or otherwise ambiguous forms require the writer.
+    CliPersistenceCapability::Writer
+}
+
+fn transfer_persistence(args: &[String]) -> CliPersistenceCapability {
+    match args.first().map(String::as_str) {
+        Some("list" | "jobs" | "sessions" | "session" | "report") => {
+            CliPersistenceCapability::ReadOnly
+        }
+        Some("review") => review_persistence(&args[1..]),
+        // This surface only builds and prints a plan; the parser requires `--dry-run` and has no
+        // apply path. Keeping even malformed invocations observational also preserves usage exits
+        // when another process owns the writer lease.
+        Some("download") => CliPersistenceCapability::ReadOnly,
+        Some("organize") => organize_persistence(&args[1..]),
+        Some("import" | "export" | "backup" | "resume") => CliPersistenceCapability::Writer,
+        None | Some("--help" | "-h" | "help") => CliPersistenceCapability::NotRequired,
+        Some(_) => CliPersistenceCapability::NotRequired,
+    }
+}
+
+fn review_persistence(args: &[String]) -> CliPersistenceCapability {
+    let Some(_) = args.first() else {
+        return CliPersistenceCapability::NotRequired;
+    };
+    match args.get(1).map(String::as_str) {
+        None
+        | Some("--all" | "--review" | "--accepted" | "--rejected" | "--skipped" | "--undecided") => {
+            CliPersistenceCapability::ReadOnly
+        }
+        // Known actions mutate, and an unrecognized second token enters the action parser. Keep
+        // that ambiguous path fail-closed under the writer lease rather than guessing from flags.
+        Some(_) => CliPersistenceCapability::Writer,
+    }
+}
+
+fn organize_persistence(args: &[String]) -> CliPersistenceCapability {
+    let mut dry_run = false;
+    let mut apply = false;
+    let mut has_session_id = false;
+    let mut has_root = false;
+    let mut invalid = false;
+    let mut it = args.iter().map(String::as_str);
+    while let Some(arg) = it.next() {
+        match arg {
+            "--dry-run" => dry_run = true,
+            "--apply" => apply = true,
+            "--yes" => {}
+            "--root" => {
+                if it.next().is_some() {
+                    has_root = true;
+                } else {
+                    invalid = true;
+                }
+            }
+            "--template" => {
+                if it.next().is_none() {
+                    invalid = true;
+                }
+            }
+            "--help" | "-h" => invalid = true,
+            other if other.starts_with('-') => invalid = true,
+            _ if has_session_id => invalid = true,
+            _ => has_session_id = true,
+        }
+    }
+
+    if !invalid && has_session_id && has_root && dry_run && !apply {
+        CliPersistenceCapability::ReadOnly
+    } else {
+        // `--apply` is mutating. Malformed or otherwise ambiguous forms retain the conservative
+        // writer classification instead of duplicating the command parser's full validation here.
+        CliPersistenceCapability::Writer
+    }
+}
+
+fn tools_persistence(args: &[String]) -> CliPersistenceCapability {
+    match args.first().map(String::as_str) {
+        None | Some("status") => CliPersistenceCapability::ReadOnly,
+        // These two parsers reject the missing-argument form before loading or saving state. Do
+        // not let writer-lease contention turn their stable usage exit (2) into an I/O exit (1).
+        Some("use" | "reset") if args.len() == 1 => CliPersistenceCapability::NotRequired,
+        Some("use" | "unpin" | "update" | "reset" | "diagnose") => CliPersistenceCapability::Writer,
+        Some(_) => CliPersistenceCapability::NotRequired,
+    }
+}
+
+fn doctor_persistence(args: &[String]) -> CliPersistenceCapability {
+    if matches!(args, [command, flag] if command == "privacy" && flag == "--cleanup") {
+        CliPersistenceCapability::Writer
+    } else if matches!(
+        args.first().map(String::as_str),
+        Some("--help" | "-h" | "help")
+    ) {
+        CliPersistenceCapability::NotRequired
+    } else {
+        CliPersistenceCapability::ReadOnly
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/cli_capability/tests.rs
+++ b/src/cli_capability/tests.rs
@@ -1,0 +1,645 @@
+use super::*;
+
+fn args(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_owned()).collect()
+}
+
+#[test]
+fn interactive_instances_have_explicit_capabilities() {
+    assert_eq!(
+        interactive_persistence_capability(true),
+        CliPersistenceCapability::ReadOnly
+    );
+    assert_eq!(
+        interactive_persistence_capability(false),
+        CliPersistenceCapability::Writer
+    );
+}
+
+#[test]
+fn capability_policy_truth_table_is_explicit_and_write_implies_persistence() {
+    let cases = [
+        (CliPersistenceCapability::NotRequired, false, false),
+        (CliPersistenceCapability::ReadOnly, true, false),
+        (CliPersistenceCapability::Writer, true, true),
+    ];
+    for (capability, requires_persistence, allows_writes) in cases {
+        assert_eq!(
+            capability.requires_persistence(),
+            requires_persistence,
+            "{capability:?} persistence policy"
+        );
+        assert_eq!(
+            capability.allows_writes(),
+            allows_writes,
+            "{capability:?} write policy"
+        );
+        assert!(!capability.allows_writes() || capability.requires_persistence());
+    }
+}
+
+#[test]
+fn transfer_download_and_review_views_are_observational() {
+    let classify = |values: &[&str]| OneShotCommand::Transfer.persistence_capability(&args(values));
+    assert_eq!(
+        classify(&["download", "sp2yt-1", "--accepted", "--dry-run"]),
+        CliPersistenceCapability::ReadOnly
+    );
+    assert_eq!(
+        classify(&["review", "sp2yt-1"]),
+        CliPersistenceCapability::ReadOnly
+    );
+    assert_eq!(
+        classify(&["review", "sp2yt-1", "--accepted"]),
+        CliPersistenceCapability::ReadOnly
+    );
+    assert_eq!(
+        classify(&["review", "sp2yt-1", "accept", "1"]),
+        CliPersistenceCapability::Writer
+    );
+    assert_eq!(
+        classify(&["review", "sp2yt-1", "unknown", "1"]),
+        CliPersistenceCapability::Writer
+    );
+    assert_eq!(classify(&["review"]), CliPersistenceCapability::NotRequired);
+}
+
+#[test]
+fn transfer_organize_only_downgrades_a_valid_dry_run_shape() {
+    let classify = |values: &[&str]| OneShotCommand::Transfer.persistence_capability(&args(values));
+    assert_eq!(
+        classify(&["organize", "sp2yt-1", "--root", "/tmp/library", "--dry-run",]),
+        CliPersistenceCapability::ReadOnly
+    );
+    for values in [
+        &[
+            "organize",
+            "sp2yt-1",
+            "--root",
+            "/tmp/library",
+            "--apply",
+            "--yes",
+        ][..],
+        &[
+            "organize",
+            "sp2yt-1",
+            "--root",
+            "/tmp/library",
+            "--dry-run",
+            "--apply",
+            "--yes",
+        ][..],
+        &["organize", "sp2yt-1", "--dry-run"][..],
+        &[
+            "organize",
+            "sp2yt-1",
+            "--root",
+            "/tmp/library",
+            "--dry-run",
+            "--unknown",
+        ][..],
+    ] {
+        assert_eq!(classify(values), CliPersistenceCapability::Writer);
+    }
+}
+
+#[test]
+fn obvious_parse_errors_do_not_initialize_persistence() {
+    let tools = |values: &[&str]| OneShotCommand::Tools.persistence_capability(&args(values));
+    assert_eq!(tools(&["use"]), CliPersistenceCapability::NotRequired);
+    assert_eq!(tools(&["reset"]), CliPersistenceCapability::NotRequired);
+    assert_eq!(tools(&["use", "system"]), CliPersistenceCapability::Writer);
+    assert_eq!(
+        tools(&["use", "system", "extra"]),
+        CliPersistenceCapability::Writer
+    );
+    assert_eq!(
+        tools(&["reset", "--not-playback"]),
+        CliPersistenceCapability::Writer
+    );
+
+    let auth = |values: &[&str]| OneShotCommand::Auth.persistence_capability(&args(values));
+    assert_eq!(
+        auth(&["spotify", "--help"]),
+        CliPersistenceCapability::NotRequired
+    );
+    assert_eq!(
+        auth(&["spotify", "--client-id"]),
+        CliPersistenceCapability::NotRequired
+    );
+    assert_eq!(
+        auth(&["spotify", "--unknown"]),
+        CliPersistenceCapability::NotRequired
+    );
+    assert_eq!(
+        auth(&["spotify", "--client-id", "--help"]),
+        CliPersistenceCapability::Writer
+    );
+    assert_eq!(
+        auth(&["spotify", "--status"]),
+        CliPersistenceCapability::Writer
+    );
+    assert_eq!(
+        auth(&["spotify", "--logout"]),
+        CliPersistenceCapability::Writer
+    );
+    assert_eq!(auth(&["spotify"]), CliPersistenceCapability::Writer);
+}
+
+#[test]
+fn compatibility_corpus_preserves_parser_precedence() {
+    let cases: &[(OneShotCommand, &[&str], CliPersistenceCapability)] = &[
+        (
+            OneShotCommand::Auth,
+            &[],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Auth,
+            &["lastfm", "--help"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Auth,
+            &["listenbrainz"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Auth,
+            &["spotify", "--help", "--status"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Auth,
+            &["spotify", "--client-id", "--help"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Auth,
+            &["spotify", "--client-id", "client", "--help"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Auth,
+            &["spotify", "--logout", "--help"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["help"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["download", "--help"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["import", "--help"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["review"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["review", "job", "--all", "accept", "1"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["review", "job", "--help"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &["organize", "job", "--root", "--apply", "--dry-run"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &[
+                "organize",
+                "job",
+                "--template",
+                "--apply",
+                "--root",
+                "/tmp/library",
+                "--dry-run",
+            ],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &[
+                "organize",
+                "--dry-run",
+                "--root",
+                "/tmp/one",
+                "job",
+                "--root",
+                "/tmp/two",
+            ],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Transfer,
+            &[
+                "organize",
+                "job",
+                "--root",
+                "/tmp/library",
+                "--dry-run",
+                "--apply",
+            ],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Tools,
+            &[],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Tools,
+            &["status", "--unknown", "ignored"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Tools,
+            &["use"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Tools,
+            &["use", "--help"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Tools,
+            &["unknown"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Doctor,
+            &[],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Doctor,
+            &["--help", "ignored"],
+            CliPersistenceCapability::NotRequired,
+        ),
+        (
+            OneShotCommand::Doctor,
+            &["privacy", "--cleanup"],
+            CliPersistenceCapability::Writer,
+        ),
+        (
+            OneShotCommand::Doctor,
+            &["privacy", "--cleanup", "extra"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Doctor,
+            &["privacy", "--help"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+        (
+            OneShotCommand::Update,
+            &["--help", "ignored"],
+            CliPersistenceCapability::ReadOnly,
+        ),
+    ];
+
+    for &(command, values, expected) in cases {
+        assert_eq!(
+            command.persistence_capability(&args(values)),
+            expected,
+            "command {command:?}, args {values:?}"
+        );
+    }
+}
+
+#[derive(Clone, Copy)]
+struct DeterministicFuzz(u64);
+
+impl DeterministicFuzz {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.0
+    }
+
+    fn token(&mut self) -> String {
+        const TOKENS: &[&str] = &[
+            "",
+            "auth",
+            "spotify",
+            "lastfm",
+            "listenbrainz",
+            "list",
+            "jobs",
+            "sessions",
+            "session",
+            "report",
+            "review",
+            "download",
+            "organize",
+            "import",
+            "export",
+            "backup",
+            "resume",
+            "status",
+            "use",
+            "unpin",
+            "update",
+            "reset",
+            "diagnose",
+            "privacy",
+            "--cleanup",
+            "--client-id",
+            "--status",
+            "--logout",
+            "--help",
+            "-h",
+            "help",
+            "--all",
+            "--review",
+            "--accepted",
+            "--rejected",
+            "--skipped",
+            "--undecided",
+            "--root",
+            "--template",
+            "--dry-run",
+            "--apply",
+            "--yes",
+            "--unknown",
+            "sp2yt-1",
+            "/tmp/library",
+        ];
+        if !self.next().is_multiple_of(4) {
+            return TOKENS[self.next() as usize % TOKENS.len()].to_owned();
+        }
+
+        const CHARS: &[char] = &[
+            'a', 'Z', '0', '-', '_', '/', '\\', ' ', '\0', 'é', '한', '🦀', '\u{fffd}',
+        ];
+        let len = self.next() as usize % 24;
+        (0..len)
+            .map(|_| CHARS[self.next() as usize % CHARS.len()])
+            .collect()
+    }
+
+    fn argv(&mut self) -> Vec<String> {
+        let len = self.next() as usize % 12;
+        (0..len).map(|_| self.token()).collect()
+    }
+}
+
+fn model(command: OneShotCommand, args: &[String]) -> CliPersistenceCapability {
+    match command {
+        OneShotCommand::Auth => match args.first().map(String::as_str) {
+            Some("lastfm" | "listenbrainz") => CliPersistenceCapability::Writer,
+            Some("spotify") => model_spotify(&args[1..]),
+            _ => CliPersistenceCapability::NotRequired,
+        },
+        OneShotCommand::Transfer => model_transfer(args),
+        OneShotCommand::Doctor => {
+            if args == ["privacy", "--cleanup"] {
+                CliPersistenceCapability::Writer
+            } else if matches!(
+                args.first().map(String::as_str),
+                Some("--help" | "-h" | "help")
+            ) {
+                CliPersistenceCapability::NotRequired
+            } else {
+                CliPersistenceCapability::ReadOnly
+            }
+        }
+        OneShotCommand::Tools => match args.first().map(String::as_str) {
+            None | Some("status") => CliPersistenceCapability::ReadOnly,
+            Some("use" | "reset") if args.len() == 1 => CliPersistenceCapability::NotRequired,
+            Some("use" | "unpin" | "update" | "reset" | "diagnose") => {
+                CliPersistenceCapability::Writer
+            }
+            Some(_) => CliPersistenceCapability::NotRequired,
+        },
+        OneShotCommand::Update => CliPersistenceCapability::ReadOnly,
+    }
+}
+
+fn model_spotify(args: &[String]) -> CliPersistenceCapability {
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--client-id" if index + 1 < args.len() => index += 2,
+            "--status" | "--logout" => index += 1,
+            "--client-id" | "--help" | "-h" => {
+                return CliPersistenceCapability::NotRequired;
+            }
+            _ => return CliPersistenceCapability::NotRequired,
+        }
+    }
+    CliPersistenceCapability::Writer
+}
+
+fn model_transfer(args: &[String]) -> CliPersistenceCapability {
+    match args.first().map(String::as_str) {
+        Some("list" | "jobs" | "sessions" | "session" | "report" | "download") => {
+            CliPersistenceCapability::ReadOnly
+        }
+        Some("review") if args.len() == 1 => CliPersistenceCapability::NotRequired,
+        Some("review") => match args.get(2).map(String::as_str) {
+            None
+            | Some(
+                "--all" | "--review" | "--accepted" | "--rejected" | "--skipped" | "--undecided",
+            ) => CliPersistenceCapability::ReadOnly,
+            Some(_) => CliPersistenceCapability::Writer,
+        },
+        Some("organize") => model_organize(&args[1..]),
+        Some("import" | "export" | "backup" | "resume") => CliPersistenceCapability::Writer,
+        _ => CliPersistenceCapability::NotRequired,
+    }
+}
+
+fn model_organize(args: &[String]) -> CliPersistenceCapability {
+    let mut dry_run = false;
+    let mut apply = false;
+    let mut session_count = 0;
+    let mut root_count = 0;
+    let mut invalid = false;
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--dry-run" => dry_run = true,
+            "--apply" => apply = true,
+            "--yes" => {}
+            "--root" if index + 1 < args.len() => {
+                root_count += 1;
+                index += 1;
+            }
+            "--template" if index + 1 < args.len() => index += 1,
+            "--root" | "--template" | "--help" | "-h" => invalid = true,
+            other if other.starts_with('-') => invalid = true,
+            _ => session_count += 1,
+        }
+        index += 1;
+    }
+    if !invalid && session_count == 1 && root_count >= 1 && dry_run && !apply {
+        CliPersistenceCapability::ReadOnly
+    } else {
+        CliPersistenceCapability::Writer
+    }
+}
+
+#[test]
+fn classifier_matches_reference_model_across_deterministic_fuzz_corpus() {
+    const COMMANDS: [OneShotCommand; 5] = [
+        OneShotCommand::Auth,
+        OneShotCommand::Transfer,
+        OneShotCommand::Doctor,
+        OneShotCommand::Tools,
+        OneShotCommand::Update,
+    ];
+    let mut fuzz = DeterministicFuzz(0x6a09_e667_f3bc_c909);
+    for case in 0..25_000 {
+        let args = fuzz.argv();
+        for command in COMMANDS {
+            let actual = command.persistence_capability(&args);
+            assert_eq!(
+                actual,
+                model(command, &args),
+                "case {case}, command {command:?}, args {args:?}"
+            );
+            assert_eq!(
+                actual,
+                command.persistence_capability(&args),
+                "classification must be deterministic"
+            );
+        }
+    }
+}
+
+#[test]
+fn mutating_transfer_routes_never_downgrade_for_fuzzed_suffixes() {
+    let mut fuzz = DeterministicFuzz(0xbb67_ae85_84ca_a73b);
+    for route in ["import", "export", "backup", "resume"] {
+        for _ in 0..2_000 {
+            let mut candidate = vec![route.to_owned()];
+            candidate.extend(fuzz.argv());
+            assert_eq!(
+                OneShotCommand::Transfer.persistence_capability(&candidate),
+                CliPersistenceCapability::Writer,
+                "{candidate:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn fixed_auth_and_observational_transfer_routes_ignore_fuzzed_suffixes_safely() {
+    let mut fuzz = DeterministicFuzz(0x3c6e_f372_fe94_f82b);
+    for route in ["lastfm", "listenbrainz"] {
+        for _ in 0..2_000 {
+            let mut candidate = vec![route.to_owned()];
+            candidate.extend(fuzz.argv());
+            assert_eq!(
+                OneShotCommand::Auth.persistence_capability(&candidate),
+                CliPersistenceCapability::Writer,
+                "{candidate:?}"
+            );
+        }
+    }
+    for route in ["list", "jobs", "sessions", "session", "report", "download"] {
+        for _ in 0..2_000 {
+            let mut candidate = vec![route.to_owned()];
+            candidate.extend(fuzz.argv());
+            assert_eq!(
+                OneShotCommand::Transfer.persistence_capability(&candidate),
+                CliPersistenceCapability::ReadOnly,
+                "{candidate:?}"
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn non_unicode_unix_arguments_are_normalized_without_panicking() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let normalized = collect_lossy_cli_args([
+        OsString::from("organize"),
+        OsString::from_vec(vec![b's', b'p', 0xff, b'1']),
+        OsString::from("--root"),
+        OsString::from_vec(vec![b'/', 0xfe, b'x']),
+        OsString::from("--dry-run"),
+    ]);
+    assert_eq!(
+        OneShotCommand::Transfer.persistence_capability(&normalized),
+        CliPersistenceCapability::ReadOnly
+    );
+    let replaced = normalized
+        .iter()
+        .find(|arg| arg.contains('\u{fffd}'))
+        .expect("invalid bytes must be replaced");
+    for keyword in [
+        "--apply",
+        "--dry-run",
+        "--root",
+        "--template",
+        "--help",
+        "-h",
+    ] {
+        assert_ne!(replaced, keyword);
+    }
+
+    let invalid_action = collect_lossy_cli_args([
+        OsString::from("review"),
+        OsString::from("job"),
+        OsString::from_vec(vec![b'a', 0xff, b'c']),
+    ]);
+    assert_eq!(
+        OneShotCommand::Transfer.persistence_capability(&invalid_action),
+        CliPersistenceCapability::Writer
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn non_unicode_windows_arguments_are_normalized_without_panicking() {
+    use std::os::windows::ffi::OsStringExt;
+
+    let normalized = collect_lossy_cli_args([
+        OsString::from("spotify"),
+        OsString::from("--client-id"),
+        OsString::from_wide(&[0xd800]),
+    ]);
+    assert_eq!(
+        OneShotCommand::Auth.persistence_capability(&normalized),
+        CliPersistenceCapability::Writer
+    );
+    let replaced = normalized
+        .iter()
+        .find(|arg| arg.contains('\u{fffd}'))
+        .expect("unpaired surrogate must be replaced");
+    for keyword in ["--client-id", "--status", "--logout", "--help", "-h"] {
+        assert_ne!(replaced, keyword);
+    }
+
+    let invalid_action = collect_lossy_cli_args([
+        OsString::from("review"),
+        OsString::from("job"),
+        OsString::from_wide(&[0xd800]),
+    ]);
+    assert_eq!(
+        OneShotCommand::Transfer.persistence_capability(&invalid_action),
+        CliPersistenceCapability::Writer
+    );
+}

--- a/src/daemon/parity_tests.rs
+++ b/src/daemon/parity_tests.rs
@@ -25,6 +25,7 @@ use crate::api::Song;
 use crate::app::{App, Cmd, Msg, PlayerControl, PlayerMsg};
 use crate::config::Config;
 use crate::library::Library;
+use crate::media::MediaCommand;
 use crate::queue::{Queue, QueueSnapshot, Repeat};
 use crate::remote::proto::{
     GuiSettingChange, InstanceMode, PlayerModel, QueueModel, RateChange, RemoteCommand,
@@ -751,6 +752,105 @@ async fn daemon_conflict_disables_remain_allowed() {
         assert!(effects.is_empty());
         assert!(status.streaming);
         assert_eq!(status.repeat, Repeat::Off);
+    }
+}
+
+#[tokio::test]
+async fn media_option_commands_keep_both_owners_in_lockstep() {
+    let (mut app, mut engine) = hermetic_pair();
+    for (step, command) in [
+        ("media shuffle on", MediaCommand::SetShuffle(true)),
+        ("media shuffle same-value", MediaCommand::SetShuffle(true)),
+        ("media shuffle off", MediaCommand::SetShuffle(false)),
+        ("media repeat all", MediaCommand::SetRepeat(Repeat::All)),
+        ("media repeat one", MediaCommand::SetRepeat(Repeat::One)),
+        ("media repeat off", MediaCommand::SetRepeat(Repeat::Off)),
+        ("media volume fractional", MediaCommand::SetVolume(0.37)),
+        ("media volume upper clamp", MediaCommand::SetVolume(9.0)),
+        ("media volume lower clamp", MediaCommand::SetVolume(-3.0)),
+        ("media volume NaN", MediaCommand::SetVolume(f64::NAN)),
+        (
+            "media volume infinity",
+            MediaCommand::SetVolume(f64::INFINITY),
+        ),
+    ] {
+        let app_commands = app.update(Msg::Media(command.clone()));
+        admit_app_player_intents(&mut app, app_commands);
+        let (shutdown, effects) = engine.handle_media(command).await;
+        assert!(!shutdown, "{step} requested shutdown");
+        assert!(effects.is_empty(), "{step} emitted daemon effects");
+        assert_parity(step, &app, &engine);
+    }
+}
+
+#[tokio::test]
+async fn media_repeat_streaming_conflict_rejects_in_lockstep() {
+    let (mut app, mut engine) = hermetic_pair();
+    app.autoplay_streaming = true;
+    app.config.autoplay_streaming = Some(true);
+    app.status.text = "before".to_owned();
+    app.dirty = false;
+    let (response, shutdown, _) = engine
+        .handle_remote(RemoteCommand::Streaming {
+            state: ToggleState::On,
+        })
+        .await;
+    assert!(response.ok && !shutdown, "test setup must enable streaming");
+    assert_parity("media repeat streaming setup", &app, &engine);
+
+    let app_commands = app.update(Msg::Media(MediaCommand::SetRepeat(Repeat::All)));
+    let (shutdown, effects) = engine
+        .handle_media(MediaCommand::SetRepeat(Repeat::All))
+        .await;
+
+    assert!(app_commands.is_empty(), "App rejection emitted effects");
+    assert!(!shutdown);
+    assert!(effects.is_empty(), "daemon rejection emitted effects");
+    assert!(matches!(
+        app.status.text.as_str(),
+        "Can't use repeat while autoplay is on" | "자동재생 중에는 반복을 켤 수 없어요"
+    ));
+    assert!(app.dirty, "the App rejection toast must redraw");
+    assert_parity("media repeat streaming rejection", &app, &engine);
+
+    // Legacy sessions may restore both modes enabled; turning repeat off must recover
+    // the invariant in both owners without disabling streaming.
+    let (mut app, _) = hermetic_pair();
+    app.autoplay_streaming = true;
+    app.config.autoplay_streaming = Some(true);
+    app.queue.repeat = Repeat::One;
+    let mut engine = engine_with_modes(Repeat::One, true).await;
+    let _ = app.update(Msg::Media(MediaCommand::SetRepeat(Repeat::Off)));
+    let (shutdown, effects) = engine
+        .handle_media(MediaCommand::SetRepeat(Repeat::Off))
+        .await;
+    assert!(!shutdown && effects.is_empty());
+    assert!(app.autoplay_streaming && app.queue.repeat == Repeat::Off);
+    assert_parity("media repeat legacy disable", &app, &engine);
+}
+
+#[tokio::test]
+async fn media_shuffle_and_repeat_are_radio_noops_in_lockstep() {
+    let (mut app, mut engine) = hermetic_pair();
+    let mut station = Song::remote("radio", "Radio", "", "");
+    station.playable = Some(crate::api::PlayableRef::RadioStream {
+        url: "https://radio.example/stream".to_owned(),
+    });
+    let mut queue = Queue::default();
+    queue.set(vec![station], 0);
+    let snapshot = queue.snapshot();
+    app.queue.restore_snapshot(snapshot.clone());
+    engine.restore_queue_snapshot(snapshot, RNG_SEED);
+
+    for (step, command) in [
+        ("radio media shuffle", MediaCommand::SetShuffle(true)),
+        ("radio media repeat", MediaCommand::SetRepeat(Repeat::All)),
+    ] {
+        assert!(app.update(Msg::Media(command.clone())).is_empty());
+        let (shutdown, effects) = engine.handle_media(command).await;
+        assert!(!shutdown);
+        assert!(effects.is_empty());
+        assert_parity(step, &app, &engine);
     }
 }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const KONSOLE_SIXEL_TUI_MIN_VERSION: u32 = 260_800;
+const KONSOLE_SIXEL_TUI_MIN_VERSION: u32 = 260_400;
 
 #[path = "doctor/directory_probe.rs"]
 mod directory_probe;
@@ -1312,11 +1312,15 @@ mod tests {
                 "halfblocks"
             );
             assert_eq!(
-                terminal_image_protocol(Some("xterm-256color"), None, false, Some("260799")),
+                terminal_image_protocol(Some("xterm-256color"), None, false, Some("260399")),
                 "halfblocks"
             );
             assert_eq!(
-                terminal_image_protocol(Some("xterm-256color"), None, false, Some("260800")),
+                terminal_image_protocol(Some("konsole-256color"), None, false, Some("260400")),
+                "sixel_versioned"
+            );
+            assert_eq!(
+                terminal_image_protocol(Some("xterm-256color"), None, false, Some("260401")),
                 "sixel_versioned"
             );
             assert_eq!(
@@ -1401,7 +1405,7 @@ mod tests {
             );
         });
 
-        with_terminal_env(&[("KONSOLE_VERSION", Some("260800"))], || {
+        with_terminal_env(&[("KONSOLE_VERSION", Some("260400"))], || {
             assert!(terminal_native_image_hint(None, None, false));
             assert_eq!(
                 terminal_image_override_suggestions(None, None, false),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod api;
 pub mod app;
 pub mod artwork;
 pub mod auth_cli;
+pub mod cli_capability;
 pub mod config;
 pub mod daemon;
 pub mod data_export;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use yututui::{
-    auth_cli, daemon, doctor, i18n, media, persist, remote,
+    auth_cli,
+    cli_capability::{OneShotCommand, collect_lossy_cli_args, interactive_persistence_capability},
+    daemon, doctor, i18n, media, persist, remote,
     terminal_runtime::{self, StartupTrace},
     tools, transfer, tui, update, zoom,
 };
@@ -15,31 +17,28 @@ const ALREADY_RUNNING_NOTICE: &str = "ytt is already running.\n  \
                                       Control it:  ytt -r <command>   (e.g. `ytt -r pp`, `ytt -r next`)\n  \
                                       Stop it:     ytt -r quit";
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum CliPersistence {
-    None,
-    Reader,
-    Writer,
-}
-
-fn initialize_cli_persistence(command: &str, mode: CliPersistence) -> bool {
-    let initialized = match mode {
-        CliPersistence::None => return true,
-        CliPersistence::Reader => persist::initialize_persistence_reader(),
-        CliPersistence::Writer => persist::initialize_persistence_writer(false),
+fn initialize_cli_persistence(command: OneShotCommand, args: &[String]) -> bool {
+    let capability = command.persistence_capability(args);
+    if !capability.requires_persistence() {
+        return true;
+    }
+    let initialized = if capability.allows_writes() {
+        persist::initialize_persistence_writer(false)
+    } else {
+        persist::initialize_persistence_reader()
     };
     match initialized {
         Ok(_) => {
-            if mode == CliPersistence::Writer
+            if capability.allows_writes()
                 && let Err(error) = persist::preflight_all_startup_stores()
             {
-                eprintln!("ytt {command}: {error}");
+                eprintln!("ytt {}: {error}", command.label());
                 return false;
             }
             true
         }
         Err(error) => {
-            eprintln!("ytt {command}: {error}");
+            eprintln!("ytt {}: {error}", command.label());
             false
         }
     }
@@ -48,143 +47,15 @@ fn initialize_cli_persistence(command: &str, mode: CliPersistence) -> bool {
 fn initialize_interactive_persistence(
     new_instance: bool,
 ) -> std::io::Result<persist::PersistenceAccess> {
-    match interactive_persistence_mode(new_instance) {
-        CliPersistence::Reader => {
-            // `--new-instance` is an explicit observational secondary, even when no primary happens
-            // to be alive. Never opportunistically promote it to the shared-root writer: doing so
-            // makes the same command mutate or migrate state depending on startup timing.
-            persist::initialize_persistence_reader()
-        }
-        CliPersistence::Writer => persist::initialize_persistence_writer(false),
-        CliPersistence::None => unreachable!("interactive startup always resolves persistence"),
-    }
-}
-
-fn interactive_persistence_mode(new_instance: bool) -> CliPersistence {
-    if new_instance {
-        CliPersistence::Reader
+    let capability = interactive_persistence_capability(new_instance);
+    debug_assert!(capability.requires_persistence());
+    if capability.allows_writes() {
+        persist::initialize_persistence_writer(false)
     } else {
-        CliPersistence::Writer
-    }
-}
-
-fn auth_persistence(args: &[String]) -> CliPersistence {
-    match args.first().map(String::as_str) {
-        Some("lastfm" | "listenbrainz") => CliPersistence::Writer,
-        Some("spotify") => spotify_auth_persistence(&args[1..]),
-        _ => CliPersistence::None,
-    }
-}
-
-fn spotify_auth_persistence(args: &[String]) -> CliPersistence {
-    let mut it = args.iter().map(String::as_str);
-    while let Some(arg) = it.next() {
-        match arg {
-            // The command parser consumes the next token even when it looks like a flag.
-            "--client-id" if it.next().is_some() => {}
-            "--client-id" => return CliPersistence::None,
-            "--status" | "--logout" => {}
-            "--help" | "-h" => return CliPersistence::None,
-            // Unknown flags are rejected before Config/token access.
-            _ => return CliPersistence::None,
-        }
-    }
-    // Status can refresh credentials, logout removes them, and the default connect path may save
-    // both config and token state. Those valid or otherwise ambiguous forms require the writer.
-    CliPersistence::Writer
-}
-
-fn transfer_persistence(args: &[String]) -> CliPersistence {
-    match args.first().map(String::as_str) {
-        Some("list" | "jobs" | "sessions" | "session" | "report") => CliPersistence::Reader,
-        Some("review") => review_persistence(&args[1..]),
-        // This surface only builds and prints a plan; the parser requires `--dry-run` and has no
-        // apply path. Keeping even malformed invocations observational also preserves usage exits
-        // when another process owns the writer lease.
-        Some("download") => CliPersistence::Reader,
-        Some("organize") => organize_persistence(&args[1..]),
-        Some("import" | "export" | "backup" | "resume") => CliPersistence::Writer,
-        None | Some("--help" | "-h" | "help") => CliPersistence::None,
-        Some(_) => CliPersistence::None,
-    }
-}
-
-fn review_persistence(args: &[String]) -> CliPersistence {
-    let Some(_) = args.first() else {
-        return CliPersistence::None;
-    };
-    match args.get(1).map(String::as_str) {
-        None
-        | Some("--all" | "--review" | "--accepted" | "--rejected" | "--skipped" | "--undecided") => {
-            CliPersistence::Reader
-        }
-        // Known actions mutate, and an unrecognized second token enters the action parser. Keep
-        // that ambiguous path fail-closed under the writer lease rather than guessing from flags.
-        Some(_) => CliPersistence::Writer,
-    }
-}
-
-fn organize_persistence(args: &[String]) -> CliPersistence {
-    let mut dry_run = false;
-    let mut apply = false;
-    let mut has_session_id = false;
-    let mut has_root = false;
-    let mut invalid = false;
-    let mut it = args.iter().map(String::as_str);
-    while let Some(arg) = it.next() {
-        match arg {
-            "--dry-run" => dry_run = true,
-            "--apply" => apply = true,
-            "--yes" => {}
-            "--root" => {
-                if it.next().is_some() {
-                    has_root = true;
-                } else {
-                    invalid = true;
-                }
-            }
-            "--template" => {
-                if it.next().is_none() {
-                    invalid = true;
-                }
-            }
-            "--help" | "-h" => invalid = true,
-            other if other.starts_with('-') => invalid = true,
-            _ if has_session_id => invalid = true,
-            _ => has_session_id = true,
-        }
-    }
-
-    if !invalid && has_session_id && has_root && dry_run && !apply {
-        CliPersistence::Reader
-    } else {
-        // `--apply` is mutating. Malformed or otherwise ambiguous forms retain the conservative
-        // writer classification instead of duplicating the command parser's full validation here.
-        CliPersistence::Writer
-    }
-}
-
-fn tools_persistence(args: &[String]) -> CliPersistence {
-    match args.first().map(String::as_str) {
-        None | Some("status") => CliPersistence::Reader,
-        // These two parsers reject the missing-argument form before loading or saving state. Do
-        // not let writer-lease contention turn their stable usage exit (2) into an I/O exit (1).
-        Some("use" | "reset") if args.len() == 1 => CliPersistence::None,
-        Some("use" | "unpin" | "update" | "reset" | "diagnose") => CliPersistence::Writer,
-        Some(_) => CliPersistence::None,
-    }
-}
-
-fn doctor_persistence(args: &[String]) -> CliPersistence {
-    if matches!(args, [command, flag] if command == "privacy" && flag == "--cleanup") {
-        CliPersistence::Writer
-    } else if matches!(
-        args.first().map(String::as_str),
-        Some("--help" | "-h" | "help")
-    ) {
-        CliPersistence::None
-    } else {
-        CliPersistence::Reader
+        // `--new-instance` is an explicit observational secondary, even when no primary happens
+        // to be alive. Never opportunistically promote it to the shared-root writer: doing so
+        // makes the same command mutate or migrate state depending on startup timing.
+        persist::initialize_persistence_reader()
     }
 }
 
@@ -265,39 +136,27 @@ fn run() -> Result<()> {
             // with its status code. This path never builds the multi-thread runtime and
             // never touches terminal raw mode / the alternate screen.
             "-r" | "--remote" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
                 std::process::exit(remote::client::run(&rest));
             }
             // Headless daemon entrypoints must run before any TUI/terminal setup.
             "daemon" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
                 std::process::exit(daemon::run_cli(&rest));
             }
             // One-shot account connections (Last.fm approval flow, ListenBrainz token,
             // Spotify PKCE) - usable without a terminal UI, e.g. for daemon-only setups.
             "auth" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
-                if !initialize_cli_persistence("auth", auth_persistence(&rest)) {
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
+                if !initialize_cli_persistence(OneShotCommand::Auth, &rest) {
                     std::process::exit(1);
                 }
                 std::process::exit(auth_cli::run(&rest));
             }
             // Playlist transfer (Spotify ↔ YTM ↔ files) - batch jobs, never the TUI.
             "transfer" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
-                if !initialize_cli_persistence("transfer", transfer_persistence(&rest)) {
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
+                if !initialize_cli_persistence(OneShotCommand::Transfer, &rest) {
                     std::process::exit(1);
                 }
                 std::process::exit(transfer::cli::run(&rest));
@@ -305,21 +164,15 @@ fn run() -> Result<()> {
             // Portable settings/library export. This one-shot path never initializes the TUI;
             // it delegates to a capable live owner or snapshots persisted state when offline.
             "data" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
                 std::process::exit(data_cli::run(&rest));
             }
             "--new-instance" => new_instance = true,
             // One-shot environment diagnostic; never touches the terminal. Exits with its
             // own status code (non-zero if a required tool or directory is unusable).
             "doctor" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
-                if !initialize_cli_persistence("doctor", doctor_persistence(&rest)) {
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
+                if !initialize_cli_persistence(OneShotCommand::Doctor, &rest) {
                     std::process::exit(1);
                 }
                 std::process::exit(doctor::run_with_args(&rest));
@@ -327,11 +180,8 @@ fn run() -> Result<()> {
             // Managed yt-dlp maintenance (status / forced update) - same one-shot,
             // no-terminal shape as `doctor`.
             "tools" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
-                if !initialize_cli_persistence("tools", tools_persistence(&rest)) {
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
+                if !initialize_cli_persistence(OneShotCommand::Tools, &rest) {
                     std::process::exit(1);
                 }
                 std::process::exit(tools::cli::run(&rest));
@@ -339,11 +189,8 @@ fn run() -> Result<()> {
             // App update check - reports whether a newer YuTuTui! release exists and how to
             // upgrade for this install method. One-shot, no terminal, like `doctor`/`tools`.
             "update" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
-                if !initialize_cli_persistence("update", CliPersistence::Reader) {
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
+                if !initialize_cli_persistence(OneShotCommand::Update, &rest) {
                     std::process::exit(1);
                 }
                 std::process::exit(update::cli::run(&rest));
@@ -352,10 +199,7 @@ fn run() -> Result<()> {
             // the AppUserModelId so the Windows media flyout shows "YuTuTui!" + icon instead of
             // "Unknown app". Kept out of --help; errors out on other platforms.
             "register-media-identity" => {
-                let rest: Vec<String> = std::env::args_os()
-                    .skip(2)
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
                 std::process::exit(media::identity::register_cli(&rest));
             }
             _ => {}
@@ -486,19 +330,22 @@ async fn async_main(new_instance: bool, mut startup: StartupTrace) -> Result<()>
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn args(values: &[&str]) -> Vec<String> {
-        values.iter().map(|value| (*value).to_owned()).collect()
-    }
+    use yututui::cli_capability::CliPersistenceCapability;
 
     #[test]
     fn explicit_new_instance_is_always_an_observational_reader() {
-        assert_eq!(interactive_persistence_mode(true), CliPersistence::Reader);
+        assert_eq!(
+            interactive_persistence_capability(true),
+            CliPersistenceCapability::ReadOnly
+        );
     }
 
     #[test]
     fn ordinary_interactive_owner_requests_the_writer_capability() {
-        assert_eq!(interactive_persistence_mode(false), CliPersistence::Writer);
+        assert_eq!(
+            interactive_persistence_capability(false),
+            CliPersistenceCapability::Writer
+        );
     }
 
     #[test]
@@ -520,135 +367,5 @@ mod tests {
             Some("WindowsTerminal.exe")
         ));
         assert!(!should_pause_explorer_launch(1, None));
-    }
-
-    #[test]
-    fn transfer_download_and_review_views_are_observational() {
-        assert_eq!(
-            transfer_persistence(&args(&["download", "sp2yt-1", "--accepted", "--dry-run"])),
-            CliPersistence::Reader
-        );
-        assert_eq!(
-            transfer_persistence(&args(&["review", "sp2yt-1"])),
-            CliPersistence::Reader
-        );
-        assert_eq!(
-            transfer_persistence(&args(&["review", "sp2yt-1", "--accepted"])),
-            CliPersistence::Reader
-        );
-        assert_eq!(
-            transfer_persistence(&args(&["review", "sp2yt-1", "accept", "1"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            transfer_persistence(&args(&["review", "sp2yt-1", "unknown", "1"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            transfer_persistence(&args(&["review"])),
-            CliPersistence::None
-        );
-    }
-
-    #[test]
-    fn transfer_organize_only_downgrades_a_valid_dry_run_shape() {
-        assert_eq!(
-            transfer_persistence(&args(&[
-                "organize",
-                "sp2yt-1",
-                "--root",
-                "/tmp/library",
-                "--dry-run"
-            ])),
-            CliPersistence::Reader
-        );
-        assert_eq!(
-            transfer_persistence(&args(&[
-                "organize",
-                "sp2yt-1",
-                "--root",
-                "/tmp/library",
-                "--apply",
-                "--yes"
-            ])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            transfer_persistence(&args(&[
-                "organize",
-                "sp2yt-1",
-                "--root",
-                "/tmp/library",
-                "--dry-run",
-                "--apply",
-                "--yes"
-            ])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            transfer_persistence(&args(&["organize", "sp2yt-1", "--dry-run"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            transfer_persistence(&args(&[
-                "organize",
-                "sp2yt-1",
-                "--root",
-                "/tmp/library",
-                "--dry-run",
-                "--unknown"
-            ])),
-            CliPersistence::Writer
-        );
-    }
-
-    #[test]
-    fn obvious_missing_tools_arguments_bypass_persistence_initialization() {
-        assert_eq!(tools_persistence(&args(&["use"])), CliPersistence::None);
-        assert_eq!(tools_persistence(&args(&["reset"])), CliPersistence::None);
-        assert_eq!(
-            tools_persistence(&args(&["use", "system"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            tools_persistence(&args(&["use", "system", "extra"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            tools_persistence(&args(&["reset", "--not-playback"])),
-            CliPersistence::Writer
-        );
-    }
-
-    #[test]
-    fn spotify_help_and_provable_parse_errors_bypass_persistence() {
-        assert_eq!(
-            auth_persistence(&args(&["spotify", "--help"])),
-            CliPersistence::None
-        );
-        assert_eq!(
-            auth_persistence(&args(&["spotify", "--client-id"])),
-            CliPersistence::None
-        );
-        assert_eq!(
-            auth_persistence(&args(&["spotify", "--unknown"])),
-            CliPersistence::None
-        );
-        assert_eq!(
-            auth_persistence(&args(&["spotify", "--client-id", "--help"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            auth_persistence(&args(&["spotify", "--status"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            auth_persistence(&args(&["spotify", "--logout"])),
-            CliPersistence::Writer
-        );
-        assert_eq!(
-            auth_persistence(&args(&["spotify"])),
-            CliPersistence::Writer
-        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -479,6 +479,10 @@ async fn async_main(new_instance: bool, mut startup: StartupTrace) -> Result<()>
         cli_identity().1,
     )
     .await;
+    // Keep a failed frame's buffered remainder on the alternate screen during normal teardown.
+    // Successful draws flush at ratatui's normal frame boundary; the panic-safe writer separately
+    // discards its remainder while unwinding, after ratatui's panic hook has already restored.
+    drop(terminal);
     tui::restore(mouse);
     result
 }

--- a/src/media/mpris.rs
+++ b/src/media/mpris.rs
@@ -531,6 +531,7 @@ impl mpris_server::PlayerInterface for Player {
 mod tests {
     use super::*;
     use crate::media::{MediaCaps, MediaTrack};
+    use crate::util::delivery::DeliveryReceipt;
 
     #[test]
     fn track_id_escapes_per_spec() {
@@ -572,6 +573,110 @@ mod tests {
             player.send_zbus(MediaCommand::Pause),
             Err(zbus::Error::Failure(message)) if message.contains("busy")
         ));
+    }
+
+    #[tokio::test]
+    async fn writable_playback_options_read_and_forward_exact_values() {
+        let mut snapshot = MediaSnapshot::idle();
+        snapshot.shuffle = true;
+        snapshot.repeat = Repeat::All;
+        snapshot.volume = 0.37;
+
+        let commands = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&commands);
+        let player = Player {
+            sink: Arc::new(move |command| {
+                captured.lock().unwrap().push(command);
+                Ok(DeliveryReceipt::Enqueued)
+            }),
+            state: Arc::new(Mutex::new(snapshot)),
+        };
+
+        assert!(
+            mpris_server::PlayerInterface::shuffle(&player)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            mpris_server::PlayerInterface::loop_status(&player)
+                .await
+                .unwrap(),
+            LoopStatus::Playlist
+        );
+        assert_eq!(
+            mpris_server::PlayerInterface::volume(&player)
+                .await
+                .unwrap(),
+            0.37
+        );
+
+        for (repeat, expected) in [
+            (Repeat::Off, LoopStatus::None),
+            (Repeat::One, LoopStatus::Track),
+            (Repeat::All, LoopStatus::Playlist),
+        ] {
+            player.state.lock().unwrap().repeat = repeat;
+            assert_eq!(
+                mpris_server::PlayerInterface::loop_status(&player)
+                    .await
+                    .unwrap(),
+                expected
+            );
+        }
+
+        mpris_server::PlayerInterface::set_shuffle(&player, false)
+            .await
+            .unwrap();
+        for loop_status in [LoopStatus::None, LoopStatus::Track, LoopStatus::Playlist] {
+            mpris_server::PlayerInterface::set_loop_status(&player, loop_status)
+                .await
+                .unwrap();
+        }
+        for volume in [-0.5, 0.0, 0.37, 1.0, 1.5] {
+            mpris_server::PlayerInterface::set_volume(&player, volume)
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(
+            *commands.lock().unwrap(),
+            vec![
+                MediaCommand::SetShuffle(false),
+                MediaCommand::SetRepeat(Repeat::Off),
+                MediaCommand::SetRepeat(Repeat::One),
+                MediaCommand::SetRepeat(Repeat::All),
+                MediaCommand::SetVolume(-0.5),
+                MediaCommand::SetVolume(0.0),
+                MediaCommand::SetVolume(0.37),
+                MediaCommand::SetVolume(1.0),
+                MediaCommand::SetVolume(1.5),
+            ]
+        );
+    }
+
+    #[test]
+    fn option_changes_emit_exact_mpris_properties() {
+        let mut snapshot = MediaSnapshot::idle();
+        snapshot.rate = 1.25;
+        snapshot.volume = 0.75;
+        snapshot.shuffle = true;
+        snapshot.repeat = Repeat::One;
+
+        assert_eq!(
+            changed_properties(
+                &snapshot,
+                MediaChanges {
+                    options: true,
+                    ..MediaChanges::default()
+                }
+            ),
+            vec![
+                Property::Rate(1.25),
+                Property::Volume(0.75),
+                Property::Shuffle(true),
+                Property::LoopStatus(LoopStatus::Track),
+            ]
+        );
     }
 
     #[test]

--- a/src/terminal_runtime/runner.rs
+++ b/src/terminal_runtime/runner.rs
@@ -362,6 +362,16 @@ fn ime_scrub_requires_full_draw(app: &App, reducer_turn_unrendered: bool) -> boo
     ) || !app.ime_scrub_local_projection_fresh()
 }
 
+/// Remember reducer turns whose state has not reached a successful full draw yet. Animation ticks
+/// are the exception: their draw credit deliberately leaves some ticks unrendered, and `dirty`
+/// already sends due ticks through [`draw_full_app_frame`]. Preserve an older pending turn, but do
+/// not let a skipped animation tick make the independent IME scrub clock bypass that cadence.
+fn arm_unrendered_reducer_turn(reducer_turn_unrendered: &mut bool, msg: &Msg) {
+    if !matches!(msg, Msg::AnimTick) {
+        *reducer_turn_unrendered = true;
+    }
+}
+
 #[cfg(windows)]
 fn is_transient_terminal_draw_error(error: &std::io::Error) -> bool {
     // Windows Terminal can briefly reject console writes while its taskbar/window state is
@@ -1377,7 +1387,7 @@ pub async fn run(
         // facet: OS media and remote clients interpolate elapsed independently, while seeks bump
         // `position_epoch` through a different message. Skip both hashes on this high-rate path.
         let media_before = observer_plan.project_state.then(|| app.media_fingerprint());
-        reducer_turn_unrendered = true;
+        arm_unrendered_reducer_turn(&mut reducer_turn_unrendered, &msg);
         for msg in std::iter::once(msg).chain(paired_progress) {
             if shutdown.is_triggered() {
                 handles.begin_player_shutdown(&mut app);

--- a/src/terminal_runtime/runner.rs
+++ b/src/terminal_runtime/runner.rs
@@ -344,24 +344,18 @@ fn ime_scrub_state_requires_full_draw(
     reducer_turn_unrendered: bool,
     dirty: bool,
     clear_before_draw_pending: bool,
-    animation_active: bool,
     radio_stream_active: bool,
 ) -> bool {
-    reducer_turn_unrendered
-        || dirty
-        || clear_before_draw_pending
-        || animation_active
-        || radio_stream_active
+    reducer_turn_unrendered || dirty || clear_before_draw_pending || radio_stream_active
 }
 
 fn ime_scrub_requires_full_draw(app: &App, reducer_turn_unrendered: bool) -> bool {
+    // Animation ticks own animation redraw cadence. The IME clock may scrub the current terminal
+    // buffer between them, but must not turn its independent 80 ms period into extra full frames.
     ime_scrub_state_requires_full_draw(
         reducer_turn_unrendered,
         app.dirty,
         app.clear_before_draw_pending(),
-        // Active animation renders can depend on wall-clock interpolation between reducer ticks.
-        // Keep origin's 80 ms full redraw in those windows so visible timing remains exact.
-        app.animation_active(),
         // Live-radio rendering reads `cache_time_at.elapsed()` for its stale-edge verdict, even
         // when the stream was started outside dedicated Radio mode.
         app.current_is_radio_stream(),

--- a/src/terminal_runtime/runner/tests.rs
+++ b/src/terminal_runtime/runner/tests.rs
@@ -274,27 +274,35 @@ async fn ime_scrub_clock_retains_the_permanent_origin_period() {
 }
 
 #[test]
-fn ime_scrub_gate_fails_closed_for_state_and_wall_clock_rendering() {
+fn ime_scrub_gate_fails_closed_for_state_and_radio_wall_clock_rendering() {
     assert!(!ime_scrub_state_requires_full_draw(
-        false, false, false, false, false
+        false, false, false, false
     ));
     assert!(ime_scrub_state_requires_full_draw(
-        true, false, false, false, false
+        true, false, false, false
     ));
     assert!(ime_scrub_state_requires_full_draw(
-        false, true, false, false, false
+        false, true, false, false
     ));
     assert!(
-        ime_scrub_state_requires_full_draw(false, false, true, false, false),
+        ime_scrub_state_requires_full_draw(false, false, true, false),
         "a pending native-image clear must go through the consuming full-draw path"
     );
     assert!(
-        ime_scrub_state_requires_full_draw(false, false, false, true, false),
-        "animation-active views retain origin's wall-clock full draws"
-    );
-    assert!(
-        ime_scrub_state_requires_full_draw(false, false, false, false, true),
+        ime_scrub_state_requires_full_draw(false, false, false, true),
         "live-radio stale-edge rendering retains origin's wall-clock full draws"
+    );
+}
+
+#[test]
+fn active_animation_uses_the_fast_ime_scrub_between_animation_ticks() {
+    let mut app = ambient_animation_app();
+    assert!(app.animation_active());
+    app.dirty = false;
+
+    assert!(
+        !ime_scrub_requires_full_draw(&app, false),
+        "IME cleanup must not add redraws between the configured animation ticks"
     );
 }
 

--- a/src/terminal_runtime/runner/tests.rs
+++ b/src/terminal_runtime/runner/tests.rs
@@ -295,15 +295,36 @@ fn ime_scrub_gate_fails_closed_for_state_and_radio_wall_clock_rendering() {
 }
 
 #[test]
-fn active_animation_uses_the_fast_ime_scrub_between_animation_ticks() {
+fn skipped_capped_animation_tick_does_not_arm_an_ime_full_draw() {
     let mut app = ambient_animation_app();
     assert!(app.animation_active());
+    assert_eq!(app.animation_draw_fps(), 12);
     app.dirty = false;
+    let mut reducer_turn_unrendered = false;
+
+    let msg = Msg::AnimTick;
+    arm_unrendered_reducer_turn(&mut reducer_turn_unrendered, &msg);
+    app.update(msg);
 
     assert!(
-        !ime_scrub_requires_full_draw(&app, false),
-        "IME cleanup must not add redraws between the configured animation ticks"
+        !app.dirty,
+        "the first 12/30-credit tick is intentionally skipped"
     );
+    assert!(!reducer_turn_unrendered);
+    assert!(
+        !ime_scrub_requires_full_draw(&app, reducer_turn_unrendered),
+        "the IME clock must not add a full draw outside the animation cadence"
+    );
+
+    // An animation tick may not erase a meaningful earlier reducer turn that has not rendered.
+    reducer_turn_unrendered = true;
+    app.dirty = false;
+    let msg = Msg::AnimTick;
+    arm_unrendered_reducer_turn(&mut reducer_turn_unrendered, &msg);
+    app.update(msg);
+    assert!(!app.dirty, "the second 12/30-credit tick is also skipped");
+    assert!(reducer_turn_unrendered);
+    assert!(ime_scrub_requires_full_draw(&app, reducer_turn_unrendered));
 }
 
 #[test]
@@ -318,14 +339,18 @@ fn reducer_turn_gate_catches_visible_updates_that_do_not_set_dirty() {
         method: crate::update::InstallMethod::Cargo,
     };
 
-    let _ = app.update(Msg::UpdateChecked(status));
+    let msg = Msg::UpdateChecked(status);
+    let mut reducer_turn_unrendered = false;
+    arm_unrendered_reducer_turn(&mut reducer_turn_unrendered, &msg);
+    let _ = app.update(msg);
 
     assert!(
         !app.dirty,
         "this persistent surface update intentionally skips dirty"
     );
     assert!(app.overlays.update_status.is_some());
-    assert!(ime_scrub_requires_full_draw(&app, true));
+    assert!(reducer_turn_unrendered);
+    assert!(ime_scrub_requires_full_draw(&app, reducer_turn_unrendered));
     assert!(
         !ime_scrub_requires_full_draw(&app, false),
         "after a successful full draw the same stable non-Local state may use the fast path"

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -18,10 +18,58 @@ use ratatui::{Frame, Terminal};
 
 use crate::zoom::{ZoomBackend, ZoomHandle};
 
-/// The app's terminal: a [`CrosstermBackend`] wrapped in the OSC 66 text-zoom layer.
-/// At zoom 1 (always, on terminals without the text sizing protocol) the wrapper is a
-/// transparent pass-through of ratatui's `DefaultTerminal`.
-pub type AppTerminal = Terminal<ZoomBackend<io::Stdout>>;
+/// Reusable terminal output buffer that never leaks a partial frame after panic restoration.
+///
+/// Normal drop retains `BufWriter`'s best-effort flush. During unwinding, ratatui's panic hook has
+/// already restored the terminal before locals are dropped, so the pending bytes are detached and
+/// discarded instead of being emitted onto the restored screen.
+pub struct PanicSafeBufWriter<W: Write> {
+    inner: Option<io::BufWriter<W>>,
+}
+
+impl<W: Write> PanicSafeBufWriter<W> {
+    fn new(writer: W) -> Self {
+        Self {
+            inner: Some(io::BufWriter::new(writer)),
+        }
+    }
+
+    fn inner_mut(&mut self) -> &mut io::BufWriter<W> {
+        self.inner
+            .as_mut()
+            .expect("buffered writer is present until drop")
+    }
+}
+
+impl<W: Write> Write for PanicSafeBufWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner_mut().write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner_mut().flush()
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.inner_mut().write_vectored(bufs)
+    }
+}
+
+impl<W: Write> Drop for PanicSafeBufWriter<W> {
+    fn drop(&mut self) {
+        if std::thread::panicking()
+            && let Some(buffered) = self.inner.take()
+        {
+            let (_writer, pending) = buffered.into_parts();
+            drop(pending);
+        }
+    }
+}
+
+/// The app's terminal: a buffered [`CrosstermBackend`] wrapped in the OSC 66 text-zoom layer.
+/// Ratatui's terminal flush remains the frame boundary while the reusable buffer coalesces the
+/// backend's many small writes. At zoom 1 the zoom wrapper is a transparent pass-through.
+pub type AppTerminal = Terminal<ZoomBackend<PanicSafeBufWriter<io::Stdout>>>;
 
 /// Outcome of the low-cost terminal-owned IME preedit scrub.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -47,7 +95,7 @@ pub fn init(mouse: bool, zoom: ZoomHandle) -> io::Result<AppTerminal> {
     // in `restore()` — exactly as they were.
     drop(ratatui::try_init()?);
     let terminal = Terminal::new(ZoomBackend::new(
-        CrosstermBackend::new(io::stdout()),
+        CrosstermBackend::new(PanicSafeBufWriter::new(io::stdout())),
         zoom.clone(),
     ))?;
     if mouse {
@@ -323,12 +371,13 @@ mod tests {
     use ratatui::backend::{Backend, ClearType, CrosstermBackend, TestBackend, WindowSize};
     use ratatui::buffer::Cell;
     use ratatui::layout::{Position, Rect, Size};
+    use ratatui::style::{Color, Modifier};
     use ratatui::widgets::Paragraph;
     use ratatui::{Terminal, TerminalOptions, Viewport};
 
     use super::{
-        ImeScrubResult, draw_frame_after_explicit_clear, draw_frame_inner, draw_frame_with_output,
-        scrub_ime_preedit_with_output, scrub_unchanged_terminal,
+        ImeScrubResult, PanicSafeBufWriter, draw_frame_after_explicit_clear, draw_frame_inner,
+        draw_frame_with_output, scrub_ime_preedit_with_output, scrub_unchanged_terminal,
     };
     use crate::zoom::{ZoomBackend, ZoomHandle, ZoomMode};
 
@@ -356,6 +405,213 @@ mod tests {
         fn flush(&mut self) -> io::Result<()> {
             Ok(())
         }
+    }
+
+    #[derive(Clone, Debug, Default, PartialEq, Eq)]
+    struct WriteStats {
+        bytes: Vec<u8>,
+        write_calls: usize,
+        flush_calls: usize,
+    }
+
+    /// Models the writer directly underneath `BufWriter` and records only non-empty writes. In
+    /// production these are entries into stdout's shared writer; any further syscall batching is
+    /// an implementation detail of `Stdout` rather than an invariant asserted by these tests.
+    #[derive(Clone, Default)]
+    struct CountingWriter(Arc<Mutex<WriteStats>>);
+
+    impl CountingWriter {
+        fn snapshot(&self) -> WriteStats {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    impl Write for CountingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if !buf.is_empty() {
+                let mut stats = self.0.lock().unwrap();
+                stats.bytes.extend_from_slice(buf);
+                stats.write_calls += 1;
+            }
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.0.lock().unwrap().flush_calls += 1;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn panic_safe_buffered_writer_flushes_pending_bytes_on_normal_drop() {
+        let sink = CountingWriter::default();
+        {
+            let mut writer = PanicSafeBufWriter::new(sink.clone());
+            writer.write_all(b"normal remainder").unwrap();
+            assert_eq!(sink.snapshot(), WriteStats::default());
+        }
+
+        let stats = sink.snapshot();
+        assert_eq!(stats.bytes, b"normal remainder");
+        assert_eq!(stats.write_calls, 1);
+    }
+
+    #[test]
+    fn panic_safe_buffered_writer_discards_pending_bytes_during_unwind() {
+        let sink = CountingWriter::default();
+        let panic_sink = sink.clone();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let mut writer = PanicSafeBufWriter::new(panic_sink.clone());
+            writer.write_all(b"panic remainder").unwrap();
+            assert_eq!(panic_sink.snapshot(), WriteStats::default());
+            panic!("exercise panic-safe writer drop");
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(sink.snapshot(), WriteStats::default());
+    }
+
+    fn normal_scale_backend<W: Write>(writer: W) -> ZoomBackend<W> {
+        ZoomBackend::new(CrosstermBackend::new(writer), ZoomHandle::default())
+    }
+
+    fn representative_cells() -> Vec<(u16, u16, Cell)> {
+        let symbols = [
+            "A",
+            "한",
+            "b",
+            "界",
+            "\x1b_Gi=7,a=q\x1b\\",
+            "c",
+            "🙂",
+            "d",
+            "é",
+            "Z",
+        ];
+        symbols
+            .into_iter()
+            .enumerate()
+            .map(|(index, symbol)| {
+                let mut cell = Cell::default();
+                cell.set_symbol(symbol);
+                cell.fg = if index % 2 == 0 {
+                    Color::Rgb(220, 80, 120)
+                } else {
+                    Color::Cyan
+                };
+                cell.bg = if index % 3 == 0 {
+                    Color::Rgb(10, 20, 30)
+                } else {
+                    Color::Reset
+                };
+                cell.underline_color = if index % 4 == 0 {
+                    Color::Yellow
+                } else {
+                    Color::Reset
+                };
+                cell.modifier = match index % 4 {
+                    0 => Modifier::BOLD,
+                    1 => Modifier::ITALIC,
+                    2 => Modifier::UNDERLINED | Modifier::REVERSED,
+                    _ => Modifier::empty(),
+                };
+                (index as u16 * 2, (index / 5) as u16, cell)
+            })
+            .collect()
+    }
+
+    fn draw_representative_cells<W: Write>(backend: &mut ZoomBackend<W>) {
+        let cells = representative_cells();
+        backend
+            .draw(cells.iter().map(|(x, y, cell)| (*x, *y, cell)))
+            .unwrap();
+    }
+
+    #[test]
+    fn buffered_normal_scale_output_matches_unbuffered_bytes() {
+        let direct_sink = CountingWriter::default();
+        let mut direct = normal_scale_backend(direct_sink.clone());
+        draw_representative_cells(&mut direct);
+        direct.flush().unwrap();
+
+        let buffered_sink = CountingWriter::default();
+        let mut buffered = normal_scale_backend(PanicSafeBufWriter::new(buffered_sink.clone()));
+        draw_representative_cells(&mut buffered);
+        buffered.flush().unwrap();
+
+        let direct = direct_sink.snapshot();
+        let buffered = buffered_sink.snapshot();
+        assert_eq!(buffered.bytes, direct.bytes);
+        let output = String::from_utf8(buffered.bytes).unwrap();
+        assert!(output.contains("한"), "wide glyph must reach the writer");
+        assert!(
+            output.contains("\x1b_Gi=7,a=q\x1b\\"),
+            "raw image escape must reach the writer verbatim"
+        );
+        assert!(
+            output.contains("\x1b["),
+            "styled cells must emit terminal style escapes"
+        );
+    }
+
+    #[test]
+    fn buffered_normal_scale_coalesces_writes_until_backend_flush() {
+        let direct_sink = CountingWriter::default();
+        let mut direct = normal_scale_backend(direct_sink.clone());
+        draw_representative_cells(&mut direct);
+        direct.flush().unwrap();
+        let direct = direct_sink.snapshot();
+
+        let buffered_sink = CountingWriter::default();
+        let mut buffered = normal_scale_backend(PanicSafeBufWriter::new(buffered_sink.clone()));
+        draw_representative_cells(&mut buffered);
+        assert_eq!(
+            buffered_sink.snapshot(),
+            WriteStats::default(),
+            "a sub-capacity frame must remain pending until ratatui's backend flush boundary"
+        );
+        buffered.flush().unwrap();
+        let buffered = buffered_sink.snapshot();
+
+        assert_eq!(buffered.bytes, direct.bytes);
+        assert_eq!(buffered.flush_calls, 1);
+        assert_eq!(direct.flush_calls, 1);
+        assert_eq!(
+            buffered.write_calls, 1,
+            "the representative frame fits in one BufWriter batch"
+        );
+        assert!(
+            buffered.write_calls * 4 <= direct.write_calls,
+            "expected at least a 4x reduction: buffered={}, direct={}",
+            buffered.write_calls,
+            direct.write_calls
+        );
+    }
+
+    #[test]
+    fn terminal_draw_drains_the_reusable_buffer_at_each_frame_boundary() {
+        let sink = CountingWriter::default();
+        let backend = normal_scale_backend(PanicSafeBufWriter::new(sink.clone()));
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Fixed(Rect::new(0, 0, 8, 1)),
+            },
+        )
+        .unwrap();
+
+        let initialized = sink.snapshot();
+        terminal.draw(|frame| render_text(frame, "first")).unwrap();
+        let first = sink.snapshot();
+        assert!(first.flush_calls > initialized.flush_calls);
+        assert_eq!(first.write_calls, initialized.write_calls + 1);
+        assert!(first.bytes.len() > initialized.bytes.len());
+
+        terminal.draw(|frame| render_text(frame, "second")).unwrap();
+        let second = sink.snapshot();
+        assert!(second.flush_calls > first.flush_calls);
+        assert_eq!(second.write_calls, first.write_calls + 1);
+        assert!(second.bytes.len() > first.bytes.len());
     }
 
     struct IoTestBackend {

--- a/src/ui/anim.rs
+++ b/src/ui/anim.rs
@@ -165,6 +165,49 @@ fn put_char(buf: &mut Buffer, x: u16, y: u16, ch: char, style: Style) {
 
 // ── element-level effects ───────────────────────────────────────────────────
 
+const TITLE_SEPARATOR: &str = " — ";
+const TITLE_LOOP_GAP: &str = "   •   ";
+
+fn title_body_chars<'a>(title: &'a str, artist: &'a str) -> impl Iterator<Item = char> + 'a {
+    title
+        .chars()
+        .chain(TITLE_SEPARATOR.chars())
+        .chain(artist.chars())
+}
+
+fn title_body(title: &str, artist: &str) -> String {
+    let mut body = String::with_capacity(
+        title
+            .len()
+            .saturating_add(TITLE_SEPARATOR.len())
+            .saturating_add(artist.len()),
+    );
+    body.push_str(title);
+    body.push_str(TITLE_SEPARATOR);
+    body.push_str(artist);
+    body
+}
+
+fn title_col_window(title: &str, artist: &str, start_col: usize, width: usize) -> String {
+    let one_loop = || title_body_chars(title, artist).chain(TITLE_LOOP_GAP.chars());
+    let mut out = String::with_capacity(width);
+    let mut col = 0usize;
+    let mut taken = 0usize;
+    for ch in one_loop().chain(one_loop()) {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if col < start_col {
+            col += ch_width;
+            continue;
+        }
+        if taken + ch_width > width {
+            break;
+        }
+        out.push(ch);
+        taken += ch_width;
+    }
+    out
+}
+
 /// Build the animated now-playing title line, or `None` when neither the title-shimmer nor the
 /// heart-pulse flag is on (the caller then renders its plain title unchanged). Handles three
 /// combinations: heart-only (pulse the `♥`, plain body), title-only (shimmer + marquee, static
@@ -200,22 +243,24 @@ pub fn title_line(
         spans.push(Span::styled("♥ ", style));
     }
 
-    let body = format!("{title} — {artist}");
     if a.title {
         let base = app.theme.color(R::TextPrimary);
         let bright = app.theme.color(R::Accent);
         let used = if liked { 2 } else { 0 };
         let avail = (width as usize).saturating_sub(used);
-        let total = UnicodeWidthStr::width(body.as_str());
+        let total = UnicodeWidthStr::width(title)
+            .saturating_add(UnicodeWidthStr::width(TITLE_SEPARATOR))
+            .saturating_add(UnicodeWidthStr::width(artist));
 
         // Long titles scroll; short ones sit still. `•`-separated wrap-around for a clean loop.
         let window = if total > avail && avail > 4 {
-            let loop_s = format!("{body}   •   ");
-            let period = UnicodeWidthStr::width(loop_s.as_str()).max(1);
+            let period = total
+                .saturating_add(UnicodeWidthStr::width(TITLE_LOOP_GAP))
+                .max(1);
             let start = (f / 4) as usize % period;
-            col_window(&format!("{loop_s}{loop_s}"), start, avail)
+            title_col_window(title, artist, start, avail)
         } else {
-            body
+            title_body(title, artist)
         };
 
         // A bright band sweeps across the characters (shimmer). Outside the ~6-cell band
@@ -252,7 +297,7 @@ pub fn title_line(
     } else {
         // Heart-only: the body stays exactly as the plain path would render it.
         spans.push(Span::styled(
-            body,
+            title_body(title, artist),
             app.theme.style(R::TextPrimary).add_modifier(Modifier::BOLD),
         ));
     }
@@ -293,7 +338,7 @@ pub fn controls_style(app: &App, base: Style) -> Style {
 /// A short spinner glyph for the front of the status line, or `None` when the `spinner` flag is
 /// off. Frames come from the well-known `throbber-widgets-tui` braille set — or its classic
 /// `|/-\` ASCII set in retro mode, where a console font rarely covers braille.
-pub fn spinner_prefix(app: &App) -> Option<String> {
+pub fn spinner_prefix(app: &App) -> Option<&'static str> {
     let a = app.animations();
     if !(a.master && a.spinner) {
         return None;
@@ -304,7 +349,7 @@ pub fn spinner_prefix(app: &App) -> Option<String> {
         throbber_widgets_tui::BRAILLE_EIGHT.symbols
     };
     let i = (app.anim_frame() / 2) as usize % syms.len();
-    Some(syms[i].to_owned())
+    Some(syms[i])
 }
 
 /// One-cell bar levels: eighth-blocks normally; a CP437 shade ramp in retro mode, where the
@@ -624,9 +669,13 @@ pub fn status_toast_line(app: &App, width: u16) -> Option<Line<'static>> {
 /// liked. Drawn over the title row and the blank gap rows directly above/below it; the row of
 /// cells the title text itself occupies (`occupied_cols`, centered) is left untouched so the
 /// words never glitch.
-pub fn like_burst_overlay(frame: &mut Frame, app: &App, area: Rect, occupied_cols: u16) {
+pub(in crate::ui) fn like_burst_active(app: &App, width: u16) -> bool {
     let a = app.animations();
-    if !(a.master && a.like_burst) || area.width < 12 {
+    a.master && a.like_burst && width >= 12 && fx_t(app, app.fx.like, fx_window::LIKE_MS).is_some()
+}
+
+pub fn like_burst_overlay(frame: &mut Frame, app: &App, area: Rect, occupied_cols: u16) {
+    if !like_burst_active(app, area.width) {
         return;
     }
     let Some(t) = fx_t(app, app.fx.like, fx_window::LIKE_MS) else {
@@ -797,22 +846,19 @@ pub fn popup_fade_overlay(frame: &mut Frame, app: &App, area: Rect) {
 /// Animated trailing dots for an in-progress label (`Searching`, `…thinking`): cycles
 /// `∅ → . → .. → ...` about three times a second, padded to a fixed three cells so the line
 /// never shifts. `None` when the flag is off (callers keep their static `…`).
-pub fn activity_dots(app: &App) -> Option<String> {
+pub fn activity_dots(app: &App) -> Option<&'static str> {
     let a = app.animations();
     if !(a.master && a.activity) {
         return None;
     }
     let step = (app.anim_frame() / app.anim_ms_frames(350).max(1)) % 4;
-    let mut s = ".".repeat(step as usize);
-    while s.len() < 3 {
-        s.push(' ');
-    }
-    Some(s)
+    const DOTS: [&str; 4] = ["   ", ".  ", ".. ", "..."];
+    Some(DOTS[step as usize])
 }
 
 /// A spinner glyph standing in for the `⬇` of a *running* download's status tag, so live
 /// progress reads as activity at a glance. `None` when the flag is off (the static `⬇` stays).
-pub fn download_spinner(app: &App) -> Option<String> {
+pub fn download_spinner(app: &App) -> Option<&'static str> {
     let a = app.animations();
     if !(a.master && a.activity) {
         return None;
@@ -823,7 +869,7 @@ pub fn download_spinner(app: &App) -> Option<String> {
         throbber_widgets_tui::BRAILLE_EIGHT.symbols
     };
     let i = (app.anim_frame() / 2) as usize % syms.len();
-    Some(syms[i].to_owned())
+    Some(syms[i])
 }
 
 /// The current synced-lyric line's style: breathes toward the accent, with a bright flash as
@@ -1085,16 +1131,40 @@ mod tests {
         assert_ne!(controls_style(&app, base).fg, base.fg);
 
         app.config.retro_mode = true;
-        assert!(matches!(
-            spinner_prefix(&app).as_deref(),
-            Some("|" | "/" | "-" | "\\")
-        ));
+        assert!(matches!(spinner_prefix(&app), Some("|" | "/" | "-" | "\\")));
         assert!(
             eq_bars(&app)
                 .expect("retro bars")
                 .chars()
                 .all(|ch| ['.', ':', '░', '▒', '▓', '█'].contains(&ch))
         );
+    }
+
+    #[test]
+    fn title_window_matches_the_previous_composed_string_bytes() {
+        for (title, artist) in [
+            ("A Very Long Animated Title", "Artist"),
+            ("긴 애니메이션 제목", "가수"),
+            ("Cafe\u{301} Mix", "DJ Wide 界"),
+        ] {
+            let body = format!("{title}{TITLE_SEPARATOR}{artist}");
+            let loop_s = format!("{body}{TITLE_LOOP_GAP}");
+            let period = UnicodeWidthStr::width(loop_s.as_str()).max(1);
+            for avail in [5usize, 9, 14, 23] {
+                if UnicodeWidthStr::width(body.as_str()) <= avail {
+                    continue;
+                }
+                for frame in [0u64, 4, 20, 76, 240] {
+                    let start = (frame / 4) as usize % period;
+                    let expected = col_window(&format!("{loop_s}{loop_s}"), start, avail);
+                    assert_eq!(
+                        title_col_window(title, artist, start, avail),
+                        expected,
+                        "title={title:?} artist={artist:?} frame={frame} avail={avail}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/ui/anim.rs
+++ b/src/ui/anim.rs
@@ -168,13 +168,6 @@ fn put_char(buf: &mut Buffer, x: u16, y: u16, ch: char, style: Style) {
 const TITLE_SEPARATOR: &str = " — ";
 const TITLE_LOOP_GAP: &str = "   •   ";
 
-fn title_body_chars<'a>(title: &'a str, artist: &'a str) -> impl Iterator<Item = char> + 'a {
-    title
-        .chars()
-        .chain(TITLE_SEPARATOR.chars())
-        .chain(artist.chars())
-}
-
 fn title_body(title: &str, artist: &str) -> String {
     let mut body = String::with_capacity(
         title
@@ -188,25 +181,49 @@ fn title_body(title: &str, artist: &str) -> String {
     body
 }
 
-fn title_col_window(title: &str, artist: &str, start_col: usize, width: usize) -> String {
-    let one_loop = || title_body_chars(title, artist).chain(TITLE_LOOP_GAP.chars());
-    let mut out = String::with_capacity(width);
+/// Visit the title body's visible characters without first composing an owned window. A
+/// scrolling window walks two body+gap loops, matching `col_window`'s wrap allowance; `None`
+/// visits the unabridged body used by a title that already fits.
+fn for_each_title_window_char(
+    title: &str,
+    artist: &str,
+    window: Option<(usize, usize)>,
+    mut visit: impl FnMut(char),
+) {
+    let sources = [
+        title,
+        TITLE_SEPARATOR,
+        artist,
+        TITLE_LOOP_GAP,
+        title,
+        TITLE_SEPARATOR,
+        artist,
+        TITLE_LOOP_GAP,
+    ];
+    let source_count = if window.is_some() { sources.len() } else { 3 };
+    let (start_col, width) = window.unwrap_or((0, usize::MAX));
     let mut col = 0usize;
     let mut taken = 0usize;
-    for ch in one_loop().chain(one_loop()) {
-        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if col < start_col {
-            col += ch_width;
-            continue;
+    for source in &sources[..source_count] {
+        for ch in source.chars() {
+            let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if col < start_col {
+                col += ch_width;
+                continue;
+            }
+            if taken + ch_width > width {
+                return;
+            }
+            visit(ch);
+            taken += ch_width;
         }
-        if taken + ch_width > width {
-            break;
-        }
-        out.push(ch);
-        taken += ch_width;
     }
-    out
 }
+
+// The shimmer is non-base only inside a six-column band. At most six positive-width
+// characters plus the base runs on either side can therefore produce distinct contiguous
+// styles; the optional heart needs one more span.
+const TITLE_MAX_STYLE_RUNS: usize = 8;
 
 /// Build the animated now-playing title line, or `None` when neither the title-shimmer nor the
 /// heart-pulse flag is on (the caller then renders its plain title unchanged). Handles three
@@ -224,7 +241,12 @@ pub fn title_line(
         return None;
     }
     let f = app.anim_frame();
-    let mut spans: Vec<Span<'static>> = Vec::new();
+    let span_capacity = if a.title {
+        TITLE_MAX_STYLE_RUNS + usize::from(liked)
+    } else {
+        1 + usize::from(liked)
+    };
+    let mut spans: Vec<Span<'static>> = Vec::with_capacity(span_capacity);
 
     // Leading heart marker (only when the track is favourited), pulsing if `heart` is on.
     if liked {
@@ -258,42 +280,33 @@ pub fn title_line(
                 .saturating_add(UnicodeWidthStr::width(TITLE_LOOP_GAP))
                 .max(1);
             let start = (f / 4) as usize % period;
-            title_col_window(title, artist, start, avail)
+            Some((start, avail))
         } else {
-            title_body(title, artist)
+            None
         };
 
         // A bright band sweeps across the characters (shimmer). Outside the ~6-cell band
         // the interpolation factor is exactly 0, so the whole tail shares one Style —
         // group equal-style runs into one Span each instead of one heap String per char
-        // (this runs at the animation FPS). Cell output is identical either way.
-        let span_len = window.chars().count() as f64 + 8.0;
+        // (this runs at the animation FPS). Visit the source strings twice instead of allocating
+        // an intermediate window: once to size the phase and once to build only the owned runs
+        // required by the returned `Line<'static>`.
+        let mut visible_chars = 0usize;
+        for_each_title_window_char(title, artist, window, |_| visible_chars += 1);
+        let span_len = visible_chars as f64 + 8.0;
         let head = (f as f64 / 2.0) % span_len;
         let mut col = 0.0f64;
-        let mut run = String::new();
-        let mut run_style: Option<Style> = None;
-        for ch in window.chars() {
+        let mut builder = RunBuilder::new(spans);
+        for_each_title_window_char(title, artist, window, |ch| {
             let d = (col - head).abs();
             let b = (1.0 - d / 3.0).clamp(0.0, 1.0);
             let style = Style::default()
                 .fg(lerp_color(base, bright, b))
                 .add_modifier(Modifier::BOLD);
-            if run_style != Some(style) {
-                if let Some(prev) = run_style.take()
-                    && !run.is_empty()
-                {
-                    spans.push(Span::styled(std::mem::take(&mut run), prev));
-                }
-                run_style = Some(style);
-            }
-            run.push(ch);
+            builder.push(ch, style);
             col += UnicodeWidthChar::width(ch).unwrap_or(1) as f64;
-        }
-        if let Some(style) = run_style
-            && !run.is_empty()
-        {
-            spans.push(Span::styled(run, style));
-        }
+        });
+        spans = builder.finish();
     } else {
         // Heart-only: the body stays exactly as the plain path would render it.
         spans.push(Span::styled(
@@ -357,6 +370,9 @@ pub fn spinner_prefix(app: &App) -> Option<&'static str> {
 /// instead of height, which is how DOS-era meters drew it anyway.
 const BLOCKS: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
 const RETRO_BLOCKS: [char; 8] = ['.', ':', '░', '░', '▒', '▒', '▓', '█'];
+const EQ_BAR_COUNT: usize = 5;
+const EQ_SEPARATOR_MAX_BYTES: usize = 4;
+const EQ_BARS_UTF8_CAPACITY: usize = EQ_BAR_COUNT * 3 + EQ_SEPARATOR_MAX_BYTES;
 
 fn bar_blocks(app: &App) -> &'static [char; 8] {
     if app.retro_mode() {
@@ -375,8 +391,11 @@ pub fn eq_bars(app: &App) -> Option<String> {
     }
     let blocks = bar_blocks(app);
     let f = app.anim_frame();
-    let mut s = String::with_capacity(5);
-    for i in 0..5u64 {
+    // Every normal/retro bar glyph is at most three UTF-8 bytes. Reserving columns (`5`) made
+    // the normal five-glyph string grow twice (5 -> 10 -> 20); reserve its byte ceiling plus the
+    // widest separator that `control_box` prefixes in place after this returns.
+    let mut s = String::with_capacity(EQ_BARS_UTF8_CAPACITY);
+    for i in 0..EQ_BAR_COUNT as u64 {
         let t = wave(f + i * 7, 16 + i * 3) * 0.6 + wave(f * 2 + i * 5, 9 + i) * 0.4;
         let idx = (t * (blocks.len() - 1) as f64).round() as usize;
         s.push(blocks[idx.min(blocks.len() - 1)]);
@@ -1023,6 +1042,81 @@ mod tests {
             .join("")
     }
 
+    fn line_cells(line: &Line<'_>) -> Vec<(char, Style)> {
+        line.spans
+            .iter()
+            .flat_map(|span| {
+                span.content
+                    .chars()
+                    .map(move |ch| (ch, line.style.patch(span.style)))
+            })
+            .collect()
+    }
+
+    /// Cell/style oracle for the allocation-heavy title implementation that first composed an
+    /// owned body/window and then walked its characters. Keeping this test-only reference makes
+    /// the optimized visitor prove the exact rendered contract without restoring its hot-path
+    /// allocations.
+    fn previous_title_cells(
+        app: &App,
+        title: &str,
+        artist: &str,
+        liked: bool,
+        width: u16,
+    ) -> Vec<(char, Style)> {
+        let a = app.animations();
+        let f = app.anim_frame();
+        let mut cells = Vec::new();
+        if liked {
+            let style = if a.heart {
+                let t = wave(f, 28);
+                Style::default()
+                    .fg(lerp_color(
+                        app.theme.color(R::Error),
+                        app.theme.color(R::AccentAlt),
+                        t,
+                    ))
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                app.theme.style(R::TextPrimary).add_modifier(Modifier::BOLD)
+            };
+            cells.extend([('♥', style), (' ', style)]);
+        }
+
+        let body = format!("{title}{TITLE_SEPARATOR}{artist}");
+        if !a.title {
+            let style = app.theme.style(R::TextPrimary).add_modifier(Modifier::BOLD);
+            cells.extend(body.chars().map(|ch| (ch, style)));
+            return cells;
+        }
+
+        let used = if liked { 2 } else { 0 };
+        let avail = usize::from(width).saturating_sub(used);
+        let window = if UnicodeWidthStr::width(body.as_str()) > avail && avail > 4 {
+            let loop_s = format!("{body}{TITLE_LOOP_GAP}");
+            let period = UnicodeWidthStr::width(loop_s.as_str()).max(1);
+            let start = (f / 4) as usize % period;
+            col_window(&format!("{loop_s}{loop_s}"), start, avail)
+        } else {
+            body
+        };
+        let base = app.theme.color(R::TextPrimary);
+        let bright = app.theme.color(R::Accent);
+        let span_len = window.chars().count() as f64 + 8.0;
+        let head = (f as f64 / 2.0) % span_len;
+        let mut col = 0.0f64;
+        for ch in window.chars() {
+            let d = (col - head).abs();
+            let glow = (1.0 - d / 3.0).clamp(0.0, 1.0);
+            let style = Style::default()
+                .fg(lerp_color(base, bright, glow))
+                .add_modifier(Modifier::BOLD);
+            cells.push((ch, style));
+            col += UnicodeWidthChar::width(ch).unwrap_or(1) as f64;
+        }
+        cells
+    }
+
     fn render_with(
         app: &App,
         width: u16,
@@ -1141,7 +1235,7 @@ mod tests {
     }
 
     #[test]
-    fn title_window_matches_the_previous_composed_string_bytes() {
+    fn title_window_visitor_matches_the_previous_composed_string_bytes() {
         for (title, artist) in [
             ("A Very Long Animated Title", "Artist"),
             ("긴 애니메이션 제목", "가수"),
@@ -1154,15 +1248,95 @@ mod tests {
                 if UnicodeWidthStr::width(body.as_str()) <= avail {
                     continue;
                 }
-                for frame in [0u64, 4, 20, 76, 240] {
-                    let start = (frame / 4) as usize % period;
+                // `start = 1` deliberately lands inside the first double-width Korean glyph;
+                // `start = 4` reaches the combining-mark case. These preserve the old
+                // column-window edge semantics, not just ordinary ASCII boundaries.
+                for start in [0usize, 1, 2, 3, 4, 5, period / 2, period - 1] {
                     let expected = col_window(&format!("{loop_s}{loop_s}"), start, avail);
+                    let mut actual = String::new();
+                    for_each_title_window_char(title, artist, Some((start, avail)), |ch| {
+                        actual.push(ch);
+                    });
                     assert_eq!(
-                        title_col_window(title, artist, start, avail),
-                        expected,
-                        "title={title:?} artist={artist:?} frame={frame} avail={avail}"
+                        actual, expected,
+                        "title={title:?} artist={artist:?} start={start} avail={avail}"
                     );
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn title_line_matches_previous_cells_and_styles_across_frames() {
+        let _guard = crate::i18n::lock_for_test();
+        for (title_on, heart_on) in [(true, false), (true, true), (false, true)] {
+            let mut app = App::new(100);
+            app.config.animations.master = true;
+            app.config.animations.title = title_on;
+            app.config.animations.heart = heart_on;
+            let mut advanced = 0;
+            for target in [0u64, 1, 4, 17, 76, 240] {
+                advance_frames(&mut app, target - advanced);
+                advanced = target;
+                for (title, artist) in [
+                    ("A Very Long Animated Title", "Artist"),
+                    ("긴 애니메이션 제목", "가수"),
+                    ("Cafe\u{301} Mix", "DJ Wide 界"),
+                    ("", ""),
+                ] {
+                    for liked in [false, true] {
+                        for width in [3u16, 5, 14, 40, 100] {
+                            let line = title_line(&app, title, artist, liked, width)
+                                .expect("enabled title line");
+                            assert_eq!(line.alignment, Some(Alignment::Center));
+                            assert_eq!(
+                                line_cells(&line),
+                                previous_title_cells(&app, title, artist, liked, width),
+                                "title={title:?} artist={artist:?} frame={} width={width} liked={liked} title_on={title_on} heart_on={heart_on}",
+                                app.anim_frame()
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn title_line_keeps_static_owned_output() {
+        let mut app = App::new(100);
+        app.config.animations.master = true;
+        app.config.animations.title = true;
+        let line: Line<'static> = {
+            let title = String::from("ephemeral title");
+            let artist = String::from("ephemeral artist");
+            title_line(&app, &title, &artist, false, 40).expect("enabled title line")
+        };
+        assert_eq!(line_text(&line), "ephemeral title — ephemeral artist");
+    }
+
+    #[test]
+    fn eq_bars_match_the_previous_formula_without_utf8_growth() {
+        let mut app = App::new(100);
+        app.config.animations.master = true;
+        app.config.animations.eq_bars = true;
+        for retro in [false, true] {
+            app.config.retro_mode = retro;
+            for _ in 0..80 {
+                let blocks = bar_blocks(&app);
+                let f = app.anim_frame();
+                let expected: String = (0..EQ_BAR_COUNT as u64)
+                    .map(|i| {
+                        let t =
+                            wave(f + i * 7, 16 + i * 3) * 0.6 + wave(f * 2 + i * 5, 9 + i) * 0.4;
+                        let idx = (t * (blocks.len() - 1) as f64).round() as usize;
+                        blocks[idx.min(blocks.len() - 1)]
+                    })
+                    .collect();
+                let actual = eq_bars(&app).expect("enabled EQ bars");
+                assert_eq!(actual, expected);
+                assert!(actual.capacity() >= actual.len() + EQ_SEPARATOR_MAX_BYTES);
+                advance_frames(&mut app, 1);
             }
         }
     }

--- a/src/ui/anim/canvas.rs
+++ b/src/ui/anim/canvas.rs
@@ -465,6 +465,10 @@ fn focal_placements(
     cube_on: bool,
     donut_on: bool,
 ) -> FocalPlacement {
+    if !cube_on && !donut_on {
+        return (None, None);
+    }
+
     let key = FocalPlacementKey {
         player_rect,
         art_mask,
@@ -1310,6 +1314,30 @@ mod tests {
             .with(Cell::get)
             .expect("last cache entry");
         assert_eq!(cached.0.player_rect, cases[2].0);
+    }
+
+    #[test]
+    fn disabled_focal_effects_bypass_the_thread_local_cache() {
+        let key = FocalPlacementKey {
+            player_rect: Rect::new(1, 2, 30, 10),
+            art_mask: Some(Rect::new(3, 4, 8, 5)),
+            lyrics_rect: None,
+            cube_on: true,
+            donut_on: false,
+        };
+        let placement = (Some(Rect::new(1, 2, 12, 6)), None);
+        let previous = FOCAL_PLACEMENT_CACHE.with(|cache| cache.replace(Some((key, placement))));
+
+        let result = focal_placements(Rect::new(9, 8, 70, 20), None, None, false, false);
+        let cached = FOCAL_PLACEMENT_CACHE.with(Cell::get);
+        FOCAL_PLACEMENT_CACHE.with(|cache| cache.set(previous));
+
+        assert_eq!(result, (None, None));
+        assert_eq!(
+            cached,
+            Some((key, placement)),
+            "the disabled fast path must not enter or evict the TLS cache"
+        );
     }
 
     /// Every canvas effect must (a) never write a cell outside the zone it was given, and

--- a/src/ui/anim/canvas.rs
+++ b/src/ui/anim/canvas.rs
@@ -625,6 +625,13 @@ thread_local! {
 /// Classic matrix digital rain: each column is an independently-falling head with a fading green
 /// trail. Speed / length / phase are hashed from the column index so columns desync but stay
 /// stable frame to frame.
+fn rain_visible_k_bounds(head: u64, len: u64, height: u64) -> Option<(u64, u64)> {
+    let last_visible_row = height.checked_sub(1)?;
+    let first = head.saturating_sub(last_visible_row);
+    let last = head.min(len);
+    (first <= last).then_some((first, last))
+}
+
 fn rain(canvas: &mut CanvasWriter<'_>, _app: &App, zone: Rect, f: u64) {
     let h = u64::from(zone.height);
     RAIN_SCRATCH.with(|scratch| {
@@ -652,14 +659,14 @@ fn rain(canvas: &mut CanvasWriter<'_>, _app: &App, zone: Rect, f: u64) {
         for (i, column) in scratch.columns.iter().enumerate() {
             let x = zone.left() + i as u16;
             let head = (f / column.speed + column.offset) % column.period;
-            for k in 0..=column.len {
-                if head < k {
-                    continue;
-                }
+            // Intersect the trail (`0..=len`) with the only k values whose
+            // `row = head - k` lies inside `0..h`. Iterating that intersection in ascending k
+            // preserves the previous write order while avoiding the off-screen prefix/suffix.
+            let Some((first, last)) = rain_visible_k_bounds(head, column.len, h) else {
+                continue;
+            };
+            for k in first..=last {
                 let row = head - k;
-                if row >= h {
-                    continue;
-                }
                 let y = zone.top() + row as u16;
                 let g = RAIN_GLYPHS[(hash32(
                     column
@@ -742,6 +749,12 @@ fn starfield(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
 
 /// A decorative (non-audio-reactive) spectrum: bars rising from the bottom strip of the zone, each
 /// mixing two waves, coloured from the gauge colour up to the accent.
+fn visualizer_row_plan(full: u16, frac: f64, strip: u16) -> (u16, Option<u16>) {
+    let full_end = full.min(strip);
+    let partial = (full < strip && frac > 0.05).then_some(full);
+    (full_end, partial)
+}
+
 fn visualizer(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let blocks = bar_blocks(app);
     let strip = (zone.height / 3).clamp(2, 8);
@@ -767,19 +780,30 @@ fn visualizer(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
         let cells = t * f64::from(strip);
         let full = cells.floor() as u16;
         let frac = cells - f64::from(full);
-        for row in 0..strip {
+        // Only full cells plus at most one fractional cap can write. Keep their original
+        // bottom-up order without scanning the empty tail of the strip.
+        let (full_end, partial) = visualizer_row_plan(full, frac, strip);
+        for row in 0..full_end {
             let yy = baseline - 1 - i32::from(row);
             if yy < top {
                 break;
             }
             let y = yy as u16;
             let color = row_colors[row as usize];
-            if row < full {
-                canvas.put_fg(x, y, '█', color);
-            } else if row == full && frac > 0.05 {
-                let idx = (frac * (blocks.len() - 1) as f64).round() as usize;
-                canvas.put_fg(x, y, blocks[idx.min(blocks.len() - 1)], color);
+            canvas.put_fg(x, y, '█', color);
+        }
+        if let Some(row) = partial {
+            let yy = baseline - 1 - i32::from(row);
+            if yy < top {
+                continue;
             }
+            let idx = (frac * (blocks.len() - 1) as f64).round() as usize;
+            canvas.put_fg(
+                x,
+                yy as u16,
+                blocks[idx.min(blocks.len() - 1)],
+                row_colors[row as usize],
+            );
         }
     }
 }
@@ -1017,6 +1041,211 @@ mod tests {
         }
         for (actual, expected) in wave_9_table().iter().zip((0..9).map(|i| wave(i, 9))) {
             assert_eq!(actual.to_bits(), expected.to_bits());
+        }
+    }
+
+    /// Allocation-free reference for the former rain loop, which scanned the complete trail and
+    /// rejected its off-screen prefix and suffix one k at a time.
+    fn previous_rain(canvas: &mut CanvasWriter<'_>, _app: &App, zone: Rect, f: u64) {
+        let h = u64::from(zone.height);
+        let h_mod = h.max(1) as u32;
+        for col in 0..u64::from(zone.width) {
+            let speed = 1 + u64::from(hash32(col) % 3);
+            let len = 4 + u64::from(hash32(col.wrapping_mul(2_654_435_761)) % h_mod);
+            let period = h + len + 3;
+            let offset = u64::from(hash32(col ^ 0x9E37_79B9)) % period;
+            let x = zone.left() + col as u16;
+            let head = (f / speed + offset) % period;
+            for k in 0..=len {
+                if head < k {
+                    continue;
+                }
+                let row = head - k;
+                if row >= h {
+                    continue;
+                }
+                let y = zone.top() + row as u16;
+                let glyph =
+                    RAIN_GLYPHS[(hash32(col.wrapping_mul(31).wrapping_add(row).wrapping_add(f / 6))
+                        as usize)
+                        % RAIN_GLYPHS.len()];
+                let color = if k == 0 {
+                    Color::Rgb(200, 255, 200)
+                } else {
+                    let b = 1.0 - k as f64 / len as f64;
+                    Color::Rgb((30.0 * b) as u8, (60.0 + 180.0 * b) as u8, (40.0 * b) as u8)
+                };
+                canvas.put_fg(x, y, glyph, color);
+            }
+        }
+    }
+
+    /// Reference for the former visualizer row scan. It deliberately visits all strip rows and
+    /// lets the two predicates decide whether each row writes.
+    fn previous_visualizer(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
+        let blocks = bar_blocks(app);
+        let strip = (zone.height / 3).clamp(2, 8);
+        let baseline = i32::from(zone.bottom());
+        let top = i32::from(zone.top());
+        let filled = app.theme.color(R::GaugeFilled);
+        let accent = app.theme.color(R::Accent);
+        let wave14 = wave_14_table();
+        let wave9 = wave_9_table();
+        let row_colors: [Color; 8] = std::array::from_fn(|i| {
+            let row = i as u16;
+            if row < strip {
+                lerp_color(filled, accent, f64::from(row + 1) / f64::from(strip))
+            } else {
+                Color::Reset
+            }
+        });
+        for bx in 0..zone.width {
+            let x = zone.left() + bx;
+            let phase = u64::from(bx) * 3;
+            let t = wave14[((f + phase) % 14) as usize] * 0.6
+                + wave9[((f * 2 + phase) % 9) as usize] * 0.4;
+            let cells = t * f64::from(strip);
+            let full = cells.floor() as u16;
+            let frac = cells - f64::from(full);
+            for row in 0..strip {
+                let yy = baseline - 1 - i32::from(row);
+                if yy < top {
+                    break;
+                }
+                let y = yy as u16;
+                let color = row_colors[row as usize];
+                if row < full {
+                    canvas.put_fg(x, y, '█', color);
+                } else if row == full && frac > 0.05 {
+                    let idx = (frac * (blocks.len() - 1) as f64).round() as usize;
+                    canvas.put_fg(x, y, blocks[idx.min(blocks.len() - 1)], color);
+                }
+            }
+        }
+    }
+
+    fn render_direct_effect(
+        app: &App,
+        zone: Rect,
+        art_mask: Option<Rect>,
+        frame: u64,
+        effect: fn(&mut CanvasWriter<'_>, &App, Rect, u64),
+    ) -> Buffer {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 72, 32));
+        for (index, cell) in buffer.content.iter_mut().enumerate() {
+            let background = if index.is_multiple_of(2) {
+                Color::Blue
+            } else {
+                Color::Magenta
+            };
+            cell.set_style(
+                Style::default()
+                    .fg(Color::White)
+                    .bg(background)
+                    .add_modifier(Modifier::ITALIC),
+            );
+        }
+        let mut canvas = CanvasWriter::new(&mut buffer, art_mask);
+        effect(&mut canvas, app, zone, frame);
+        buffer
+    }
+
+    #[test]
+    fn rain_visible_k_bounds_match_previous_filter_and_write_order() {
+        for height in 0..=32u64 {
+            for len in 0..=height + 5 {
+                for head in 0..=height + len + 5 {
+                    let mut expected = (0..=len).filter_map(|k| {
+                        if head < k {
+                            return None;
+                        }
+                        let row = head - k;
+                        (row < height).then_some((k, row))
+                    });
+                    if let Some((first, last)) = rain_visible_k_bounds(head, len, height) {
+                        for k in first..=last {
+                            assert_eq!(expected.next(), Some((k, head - k)));
+                        }
+                    }
+                    assert_eq!(
+                        expected.next(),
+                        None,
+                        "height={height} len={len} head={head}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn visualizer_row_plan_matches_previous_scan_and_write_order() {
+        for strip in 0..=8u16 {
+            for full in 0..=10u16 {
+                for frac in [0.0, 0.049_999, 0.05, 0.050_001, 0.5, 0.999] {
+                    let expected: Vec<(u16, bool)> = (0..strip)
+                        .filter_map(|row| {
+                            if row < full {
+                                Some((row, false))
+                            } else if row == full && frac > 0.05 {
+                                Some((row, true))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    let (full_end, partial) = visualizer_row_plan(full, frac, strip);
+                    let actual: Vec<(u16, bool)> = (0..full_end)
+                        .map(|row| (row, false))
+                        .chain(partial.map(|row| (row, true)))
+                        .collect();
+                    assert_eq!(actual, expected, "strip={strip} full={full} frac={frac}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn bounded_rain_and_visualizer_match_previous_buffers() {
+        let _guard = crate::i18n::lock_for_test();
+        let zones = [
+            Rect::new(3, 2, 4, 2),
+            Rect::new(3, 2, 37, 13),
+            Rect::new(1, 1, 68, 29),
+        ];
+        let frames = [0, 1, 2, 5, 11, 23, 47, 89, 137, 251];
+        for retro in [false, true] {
+            let mut app = App::new(100);
+            app.config.retro_mode = retro;
+            for zone in zones {
+                let masks = [
+                    None,
+                    Some(Rect::new(
+                        zone.x + zone.width / 3,
+                        zone.y + zone.height / 3,
+                        (zone.width / 3).max(1),
+                        (zone.height / 3).max(1),
+                    )),
+                ];
+                for art_mask in masks {
+                    for frame in frames {
+                        let previous =
+                            render_direct_effect(&app, zone, art_mask, frame, previous_rain);
+                        let bounded = render_direct_effect(&app, zone, art_mask, frame, rain);
+                        assert_eq!(
+                            bounded, previous,
+                            "rain retro={retro} zone={zone:?} mask={art_mask:?} frame={frame}"
+                        );
+
+                        let previous =
+                            render_direct_effect(&app, zone, art_mask, frame, previous_visualizer);
+                        let bounded = render_direct_effect(&app, zone, art_mask, frame, visualizer);
+                        assert_eq!(
+                            bounded, previous,
+                            "visualizer retro={retro} zone={zone:?} mask={art_mask:?} frame={frame}"
+                        );
+                    }
+                }
+            }
         }
     }
 

--- a/src/ui/anim/canvas.rs
+++ b/src/ui/anim/canvas.rs
@@ -1,7 +1,8 @@
 //! Canvas composition and first-wave effects. [`render_canvas_composite`] paints each enabled
 //! effect once in its assigned coordinate space and hard-masks album art for every write.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
+use std::mem::size_of;
 use std::sync::OnceLock;
 
 use ratatui::Frame;
@@ -43,6 +44,19 @@ impl<'a> CanvasWriter<'a> {
             return;
         }
         put_char(self.buffer, x, y, ch, style);
+    }
+
+    /// Patch only a cell's character and foreground colour while preserving its background and
+    /// modifiers. Most canvas effects use exactly `Style::default().fg(fg)`; keeping that intent
+    /// explicit avoids constructing and merging a temporary [`Style`] for every sparse glyph.
+    pub(super) fn put_fg(&mut self, x: u16, y: u16, ch: char, fg: Color) {
+        if self.masked(x, y) {
+            return;
+        }
+        if let Some(cell) = self.buffer.cell_mut((x, y)) {
+            cell.set_char(ch);
+            cell.fg = fg;
+        }
     }
 
     /// Write a cell already proven visible by [`Self::visible_spans`]. Callers must keep the
@@ -108,6 +122,77 @@ impl<'a> CanvasWriter<'a> {
             (false, false) => ([CellSpan::default(); 2], 0),
         }
     }
+}
+
+const SCRATCH_SHRINK_MIN_EXCESS_BYTES: usize = 64 * 1024;
+
+/// Prepare a reusable scratch vector for a geometry-derived rebuild. Capacity is retained across
+/// ordinary size changes unless it is both four times the new need and at least 64 KiB excessive.
+/// This keeps resize churn low while eventually returning memory after a very large terminal is
+/// replaced by a much smaller one.
+pub(super) fn reset_scratch_vec<T>(values: &mut Vec<T>, needed: usize) {
+    let element_bytes = size_of::<T>();
+    let capacity_bytes = values.capacity().saturating_mul(element_bytes);
+    let needed_bytes = needed.saturating_mul(element_bytes);
+    let shrink_threshold = needed_bytes
+        .saturating_mul(4)
+        .max(needed_bytes.saturating_add(SCRATCH_SHRINK_MIN_EXCESS_BYTES));
+    if element_bytes != 0 && capacity_bytes > shrink_threshold {
+        *values = Vec::with_capacity(needed);
+    } else {
+        values.clear();
+        values.reserve(needed);
+    }
+}
+
+/// Resize a scratch vector while retaining the same overlapping prefix as [`Vec::resize`]. This
+/// is required for the donut's historical first frame after geometry changes; only capacity may
+/// change when the old allocation is far larger than the new grid.
+fn resize_scratch_vec_preserving<T: Clone>(values: &mut Vec<T>, needed: usize, fill: T) {
+    let element_bytes = size_of::<T>();
+    let capacity_bytes = values.capacity().saturating_mul(element_bytes);
+    let needed_bytes = needed.saturating_mul(element_bytes);
+    let shrink_threshold = needed_bytes
+        .saturating_mul(4)
+        .max(needed_bytes.saturating_add(SCRATCH_SHRINK_MIN_EXCESS_BYTES));
+    if element_bytes != 0 && capacity_bytes > shrink_threshold {
+        let retained = values.len().min(needed);
+        let mut replacement = Vec::with_capacity(needed);
+        replacement.extend_from_slice(&values[..retained]);
+        replacement.resize(needed, fill);
+        *values = replacement;
+    } else {
+        values.resize(needed, fill);
+    }
+}
+
+fn fixed_wave_table<const N: usize>() -> [f64; N] {
+    std::array::from_fn(|i| wave(i as u64, N as u64))
+}
+
+pub(super) fn wave_24_table() -> &'static [f64; 24] {
+    static TABLE: OnceLock<[f64; 24]> = OnceLock::new();
+    TABLE.get_or_init(fixed_wave_table::<24>)
+}
+
+pub(super) fn wave_70_table() -> &'static [f64; 70] {
+    static TABLE: OnceLock<[f64; 70]> = OnceLock::new();
+    TABLE.get_or_init(fixed_wave_table::<70>)
+}
+
+pub(super) fn wave_110_table() -> &'static [f64; 110] {
+    static TABLE: OnceLock<[f64; 110]> = OnceLock::new();
+    TABLE.get_or_init(fixed_wave_table::<110>)
+}
+
+fn wave_14_table() -> &'static [f64; 14] {
+    static TABLE: OnceLock<[f64; 14]> = OnceLock::new();
+    TABLE.get_or_init(fixed_wave_table::<14>)
+}
+
+fn wave_9_table() -> &'static [f64; 9] {
+    static TABLE: OnceLock<[f64; 9]> = OnceLock::new();
+    TABLE.get_or_init(fixed_wave_table::<9>)
 }
 
 const MAX_FREE_RECTS: usize = 16;
@@ -297,13 +382,32 @@ fn best_single(options: &RectList<MAX_FOCAL_OPTIONS>) -> Option<Rect> {
         .max_by_key(|rect| rect_score(*rect))
 }
 
-fn focal_placements(
+type FocalPlacement = (Option<Rect>, Option<Rect>);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FocalPlacementKey {
     player_rect: Rect,
     art_mask: Option<Rect>,
     lyrics_rect: Option<Rect>,
     cube_on: bool,
     donut_on: bool,
-) -> (Option<Rect>, Option<Rect>) {
+}
+
+thread_local! {
+    /// Exactly one entry is enough for steady-state rendering, where geometry and toggles are
+    /// unchanged for thousands of frames. A different player surface simply evicts it.
+    static FOCAL_PLACEMENT_CACHE: Cell<Option<(FocalPlacementKey, FocalPlacement)>> = const {
+        Cell::new(None)
+    };
+}
+
+fn focal_placements_uncached(
+    player_rect: Rect,
+    art_mask: Option<Rect>,
+    lyrics_rect: Option<Rect>,
+    cube_on: bool,
+    donut_on: bool,
+) -> FocalPlacement {
     if !cube_on && !donut_on {
         return (None, None);
     }
@@ -352,6 +456,33 @@ fn focal_placements(
     }
     let donut = focal_options(&free, 10, 5);
     (None, best_single(&donut))
+}
+
+fn focal_placements(
+    player_rect: Rect,
+    art_mask: Option<Rect>,
+    lyrics_rect: Option<Rect>,
+    cube_on: bool,
+    donut_on: bool,
+) -> FocalPlacement {
+    let key = FocalPlacementKey {
+        player_rect,
+        art_mask,
+        lyrics_rect,
+        cube_on,
+        donut_on,
+    };
+    FOCAL_PLACEMENT_CACHE.with(|cache| {
+        if let Some((cached_key, placement)) = cache.get()
+            && cached_key == key
+        {
+            return placement;
+        }
+        let placement =
+            focal_placements_uncached(player_rect, art_mask, lyrics_rect, cube_on, donut_on);
+        cache.set(Some((key, placement)));
+        placement
+    })
 }
 
 fn supports(zone: Rect, min_width: u16, min_height: u16) -> bool {
@@ -501,8 +632,7 @@ fn rain(canvas: &mut CanvasWriter<'_>, _app: &App, zone: Rect, f: u64) {
         if scratch.width != zone.width || scratch.height != zone.height {
             scratch.width = zone.width;
             scratch.height = zone.height;
-            scratch.columns.clear();
-            scratch.columns.reserve(usize::from(zone.width));
+            reset_scratch_vec(&mut scratch.columns, usize::from(zone.width));
             let h_mod = h.max(1) as u32;
             for col in 0..u64::from(zone.width) {
                 let speed = 1 + u64::from(hash32(col) % 3);
@@ -545,7 +675,7 @@ fn rain(canvas: &mut CanvasWriter<'_>, _app: &App, zone: Rect, f: u64) {
                     let b = 1.0 - k as f64 / column.len as f64;
                     Color::Rgb((30.0 * b) as u8, (60.0 + 180.0 * b) as u8, (40.0 * b) as u8)
                 };
-                canvas.put(x, y, g, Style::default().fg(color));
+                canvas.put_fg(x, y, g, color);
             }
         }
     });
@@ -580,15 +710,14 @@ fn starfield(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let count = ((w * u32::from(zone.height)) / 40).clamp(6, 60);
     let dim = app.theme.color(R::TextSubtle);
     let bright = app.theme.color(R::AccentAlt);
-    let wave24: [f64; 24] = std::array::from_fn(|i| wave(i as u64, 24));
+    let wave24 = wave_24_table();
     STAR_SCRATCH.with(|scratch| {
         let mut scratch = scratch.borrow_mut();
         if scratch.width != zone.width || scratch.height != zone.height || scratch.count != count {
             scratch.width = zone.width;
             scratch.height = zone.height;
             scratch.count = count;
-            scratch.stars.clear();
-            scratch.stars.reserve(count as usize);
+            reset_scratch_vec(&mut scratch.stars, count as usize);
             for i in 0..u64::from(count) {
                 let x = (hash32(i * 2 + 1) % w) as u16;
                 let speed = 1 + u64::from(hash32(i * 3 + 2) % 4);
@@ -606,7 +735,7 @@ fn starfield(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
             let y = zone.top() + (h - 1 - yv) as u16;
             let g = STAR_GLYPHS[(hash32(i * 7 + f / 20) as usize) % STAR_GLYPHS.len()];
             let color = lerp_color(dim, bright, wave24[((f + i * 5) % 24) as usize]);
-            canvas.put(zone.left() + star.x, y, g, Style::default().fg(color));
+            canvas.put_fg(zone.left() + star.x, y, g, color);
         }
     });
 }
@@ -620,18 +749,14 @@ fn visualizer(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let top = i32::from(zone.top());
     let filled = app.theme.color(R::GaugeFilled);
     let accent = app.theme.color(R::Accent);
-    let wave14: [f64; 14] = std::array::from_fn(|i| wave(i as u64, 14));
-    let wave9: [f64; 9] = std::array::from_fn(|i| wave(i as u64, 9));
-    let row_styles: [Style; 8] = std::array::from_fn(|i| {
+    let wave14 = wave_14_table();
+    let wave9 = wave_9_table();
+    let row_colors: [Color; 8] = std::array::from_fn(|i| {
         let row = i as u16;
         if row < strip {
-            Style::default().fg(lerp_color(
-                filled,
-                accent,
-                f64::from(row + 1) / f64::from(strip),
-            ))
+            lerp_color(filled, accent, f64::from(row + 1) / f64::from(strip))
         } else {
-            Style::default()
+            Color::Reset
         }
     });
     for bx in 0..zone.width {
@@ -648,12 +773,12 @@ fn visualizer(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
                 break;
             }
             let y = yy as u16;
-            let style = row_styles[row as usize];
+            let color = row_colors[row as usize];
             if row < full {
-                canvas.put(x, y, '█', style);
+                canvas.put_fg(x, y, '█', color);
             } else if row == full && frac > 0.05 {
                 let idx = (frac * (blocks.len() - 1) as f64).round() as usize;
-                canvas.put(x, y, blocks[idx.min(blocks.len() - 1)], style);
+                canvas.put_fg(x, y, blocks[idx.min(blocks.len() - 1)], color);
             }
         }
     }
@@ -701,16 +826,16 @@ fn donut(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
     let steps = donut_trig_steps();
     let base = app.theme.color(R::Accent);
     let bright = app.theme.color(R::AccentAlt);
-    let styles: [Style; 12] = std::array::from_fn(|ci| {
+    let colors: [Color; 12] = std::array::from_fn(|ci| {
         let t = ci as f64 / (DONUT_LUM.len() - 1) as f64;
-        Style::default().fg(lerp_color(base, bright, t))
+        lerp_color(base, bright, t)
     });
 
     DONUT_SCRATCH.with(|scratch| {
         let mut scratch = scratch.borrow_mut();
         if scratch.zbuf.len() != cells {
-            scratch.zbuf.resize(cells, 0.0);
-            scratch.out.resize(cells, 0);
+            resize_scratch_vec_preserving(&mut scratch.zbuf, cells, 0.0);
+            resize_scratch_vec_preserving(&mut scratch.out, cells, 0);
         } else {
             scratch.zbuf.fill(0.0);
             scratch.out.fill(0);
@@ -746,11 +871,11 @@ fn donut(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64) {
                     continue;
                 }
                 let ci = (v as usize - 1).min(DONUT_LUM.len() - 1);
-                canvas.put(
+                canvas.put_fg(
                     zone.left() + xx as u16,
                     zone.top() + yy as u16,
                     DONUT_LUM[ci] as char,
-                    styles[ci],
+                    colors[ci],
                 );
             }
         }
@@ -836,6 +961,126 @@ mod tests {
             })
             .unwrap();
         terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn foreground_writer_matches_fg_only_style_patching() {
+        let area = Rect::new(0, 0, 6, 4);
+        let mask = Rect::new(2, 1, 2, 2);
+        let mut styled = Buffer::empty(area);
+        for cell in &mut styled.content {
+            cell.set_style(
+                Style::default()
+                    .bg(Color::Blue)
+                    .add_modifier(Modifier::ITALIC),
+            );
+        }
+        let mut foreground = styled.clone();
+        {
+            let mut writer = CanvasWriter::new(&mut styled, Some(mask));
+            for (x, y, ch, color) in [
+                (1, 1, 'a', Color::Red),
+                (2, 1, 'b', Color::Green),
+                (4, 3, 'c', Color::Yellow),
+                (9, 9, 'd', Color::Cyan),
+            ] {
+                writer.put(x, y, ch, Style::default().fg(color));
+            }
+        }
+        {
+            let mut writer = CanvasWriter::new(&mut foreground, Some(mask));
+            for (x, y, ch, color) in [
+                (1, 1, 'a', Color::Red),
+                (2, 1, 'b', Color::Green),
+                (4, 3, 'c', Color::Yellow),
+                (9, 9, 'd', Color::Cyan),
+            ] {
+                writer.put_fg(x, y, ch, color);
+            }
+        }
+        assert_eq!(foreground, styled);
+    }
+
+    #[test]
+    fn fixed_wave_tables_are_bit_identical_to_direct_evaluation() {
+        for (actual, expected) in wave_24_table().iter().zip((0..24).map(|i| wave(i, 24))) {
+            assert_eq!(actual.to_bits(), expected.to_bits());
+        }
+        for (actual, expected) in wave_70_table().iter().zip((0..70).map(|i| wave(i, 70))) {
+            assert_eq!(actual.to_bits(), expected.to_bits());
+        }
+        for (actual, expected) in wave_110_table().iter().zip((0..110).map(|i| wave(i, 110))) {
+            assert_eq!(actual.to_bits(), expected.to_bits());
+        }
+        for (actual, expected) in wave_14_table().iter().zip((0..14).map(|i| wave(i, 14))) {
+            assert_eq!(actual.to_bits(), expected.to_bits());
+        }
+        for (actual, expected) in wave_9_table().iter().zip((0..9).map(|i| wave(i, 9))) {
+            assert_eq!(actual.to_bits(), expected.to_bits());
+        }
+    }
+
+    #[test]
+    fn scratch_capacity_downsize_has_four_x_and_64_kib_hysteresis() {
+        let mut retained = Vec::<u8>::with_capacity(64 * 1024);
+        let retained_capacity = retained.capacity();
+        reset_scratch_vec(&mut retained, 1);
+        assert_eq!(retained.capacity(), retained_capacity);
+        assert!(retained.is_empty());
+
+        let mut downsized = Vec::<u8>::with_capacity(70 * 1024);
+        let oversized_capacity = downsized.capacity();
+        reset_scratch_vec(&mut downsized, 1);
+        assert!(downsized.capacity() < oversized_capacity);
+        assert!(downsized.capacity() >= 1);
+        assert!(downsized.is_empty());
+    }
+
+    #[test]
+    fn preserving_resize_matches_vec_resize_prefix_while_downsizing_capacity() {
+        let mut expected = Vec::with_capacity(80 * 1024);
+        expected.extend(0..70 * 1024u32);
+        let mut actual = expected.clone();
+        actual.reserve(80 * 1024);
+        let oversized_capacity = actual.capacity();
+
+        expected.resize(32, u32::MAX);
+        resize_scratch_vec_preserving(&mut actual, 32, u32::MAX);
+
+        assert_eq!(actual, expected);
+        assert!(actual.capacity() < oversized_capacity);
+    }
+
+    #[test]
+    fn one_entry_focal_cache_matches_uncached_placements_and_evicts() {
+        FOCAL_PLACEMENT_CACHE.with(|cache| cache.set(None));
+        let cases = [
+            (
+                Rect::new(0, 0, 100, 30),
+                Some(Rect::new(4, 6, 30, 12)),
+                Some(Rect::new(58, 5, 36, 18)),
+                true,
+                true,
+            ),
+            (Rect::new(3, 4, 22, 6), None, None, true, true),
+            (
+                Rect::new(1, 2, 30, 5),
+                None,
+                Some(Rect::new(1, 2, 30, 5)),
+                false,
+                true,
+            ),
+        ];
+        for (player, art, lyrics, cube, donut) in cases {
+            let expected = focal_placements_uncached(player, art, lyrics, cube, donut);
+            assert_eq!(focal_placements(player, art, lyrics, cube, donut), expected);
+            let cached = FOCAL_PLACEMENT_CACHE.with(Cell::get).expect("cache entry");
+            assert_eq!(cached.1, expected);
+        }
+        let cached = FOCAL_PLACEMENT_CACHE
+            .with(Cell::get)
+            .expect("last cache entry");
+        assert_eq!(cached.0.player_rect, cases[2].0);
     }
 
     /// Every canvas effect must (a) never write a cell outside the zone it was given, and

--- a/src/ui/anim/canvas_ext.rs
+++ b/src/ui/anim/canvas_ext.rs
@@ -7,10 +7,12 @@
 //! and each effect degrades in retro mode either at the source (forked glyph sets) or through
 //! the CP437 scrubber. Nothing here allocates per frame beyond tiny fixed buffers.
 
+use std::cell::RefCell;
+
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 
-use super::canvas::CanvasWriter;
+use super::canvas::{CanvasWriter, wave_24_table, wave_70_table, wave_110_table};
 use super::{hash32, lerp_color, wave};
 use crate::app::App;
 use crate::theme::ThemeRole as R;
@@ -69,11 +71,11 @@ pub(super) fn comets(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u6
                     lerp_color(tail_base, dim, fade),
                 )
             };
-            canvas.put(
+            canvas.put_fg(
                 (i64::from(zone.left()) + x) as u16,
                 (i64::from(zone.top()) + y) as u16,
                 glyph,
-                Style::default().fg(color),
+                color,
             );
         }
     }
@@ -116,16 +118,50 @@ pub(super) fn snow(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64)
             continue;
         }
         let color = lerp_color(dim, bright, class as f64 / 3.0);
-        canvas.put(
+        canvas.put_fg(
             zone.left() + x as u16,
             zone.top() + yv as u16,
             glyphs[3 - class],
-            Style::default().fg(color),
+            color,
         );
     }
 }
 
 // ── fireflies ───────────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy, Debug, Default)]
+struct FireflyDescriptor {
+    wx: f64,
+    wy: f64,
+    px: f64,
+    py: f64,
+    breath_phase: u64,
+}
+
+impl FireflyDescriptor {
+    fn for_index(i: u64) -> Self {
+        let s = |k: u64| f64::from(hash32(i * 11 + k));
+        Self {
+            wx: 0.008 + (s(1) % 100.0) / 9000.0,
+            wy: 0.011 + (s(2) % 100.0) / 8000.0,
+            px: (s(3) % 628.0) / 100.0,
+            py: (s(4) % 628.0) / 100.0,
+            breath_phase: u64::from(hash32(i * 17 + 9) % 120),
+        }
+    }
+}
+
+#[derive(Default)]
+struct FireflyScratch {
+    width: u16,
+    height: u16,
+    count: u32,
+    flies: [FireflyDescriptor; 24],
+}
+
+thread_local! {
+    static FIREFLY_SCRATCH: RefCell<FireflyScratch> = RefCell::new(FireflyScratch::default());
+}
 
 /// Fireflies wandering on smooth per-fly Lissajous paths, each breathing between the subtle
 /// text colour and a warm glow on its own phase — the calm counterpart to the starfield.
@@ -143,31 +179,38 @@ pub(super) fn fireflies(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f:
     } else {
         ('●', '·')
     };
-    for i in 0..u64::from(count) {
-        // Two incommensurate angular speeds per axis make the path wander without looping
-        // visibly; amplitudes keep every fly comfortably inside the zone.
-        let s = |k: u64| f64::from(hash32(i * 11 + k));
-        let wx = 0.008 + (s(1) % 100.0) / 9000.0;
-        let wy = 0.011 + (s(2) % 100.0) / 8000.0;
-        let px = (s(3) % 628.0) / 100.0;
-        let py = (s(4) % 628.0) / 100.0;
-        let x = (w / 2.0) + (f as f64 * wx + px).sin() * (w / 2.0 - 1.0);
-        let y = (h / 2.0) + (f as f64 * wy + py).sin() * (h / 2.0 - 0.6);
-        let xi = x.floor().clamp(0.0, w - 1.0) as u16;
-        let yi = y.floor().clamp(0.0, h - 1.0) as u16;
-        // Slow personal breath; fully dark part of the cycle leaves the cell alone.
-        let b = wave(f + u64::from(hash32(i * 17 + 9) % 120), 110);
-        if b < 0.2 {
-            continue;
+    let breath_wave = wave_110_table();
+    FIREFLY_SCRATCH.with(|scratch| {
+        let mut scratch = scratch.borrow_mut();
+        if scratch.width != zone.width || scratch.height != zone.height || scratch.count != count {
+            scratch.width = zone.width;
+            scratch.height = zone.height;
+            scratch.count = count;
+            for (i, descriptor) in scratch.flies[..count as usize].iter_mut().enumerate() {
+                *descriptor = FireflyDescriptor::for_index(i as u64);
+            }
         }
-        let glyph = if b > 0.62 { bright_glyph } else { dim_glyph };
-        canvas.put(
-            zone.left() + xi,
-            zone.top() + yi,
-            glyph,
-            Style::default().fg(lerp_color(dim, glow, b)),
-        );
-    }
+        for descriptor in &scratch.flies[..count as usize] {
+            // Two incommensurate angular speeds per axis make the path wander without looping
+            // visibly; amplitudes keep every fly comfortably inside the zone.
+            let x = (w / 2.0) + (f as f64 * descriptor.wx + descriptor.px).sin() * (w / 2.0 - 1.0);
+            let y = (h / 2.0) + (f as f64 * descriptor.wy + descriptor.py).sin() * (h / 2.0 - 0.6);
+            let xi = x.floor().clamp(0.0, w - 1.0) as u16;
+            let yi = y.floor().clamp(0.0, h - 1.0) as u16;
+            // Slow personal breath; fully dark part of the cycle leaves the cell alone.
+            let b = breath_wave[((f + descriptor.breath_phase) % 110) as usize];
+            if b < 0.2 {
+                continue;
+            }
+            let glyph = if b > 0.62 { bright_glyph } else { dim_glyph };
+            canvas.put_fg(
+                zone.left() + xi,
+                zone.top() + yi,
+                glyph,
+                lerp_color(dim, glow, b),
+            );
+        }
+    });
 }
 
 // ── wireframe cube ──────────────────────────────────────────────────────────
@@ -238,11 +281,17 @@ pub(super) fn cube(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64)
         }
         // depth runs ~[dist-√3, dist+√3]; map near→bright.
         let t = ((depth - (dist - 1.8)) / 3.6).clamp(0.0, 1.0);
-        let mut style = Style::default().fg(lerp_color(near, far, t));
+        let color = lerp_color(near, far, t);
         if bold {
-            style = style.add_modifier(Modifier::BOLD);
+            canvas.put(
+                zone.left() + x as u16,
+                zone.top() + y as u16,
+                glyph,
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            );
+        } else {
+            canvas.put_fg(zone.left() + x as u16, zone.top() + y as u16, glyph, color);
         }
-        canvas.put(zone.left() + x as u16, zone.top() + y as u16, glyph, style);
     };
 
     for &(a, b) in &CUBE_EDGES {
@@ -284,6 +333,8 @@ pub(super) fn aquarium(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: 
         return;
     }
     let retro = app.retro_mode();
+    let bob_wave = wave_70_table();
+    let bubble_wave = wave_24_table();
 
     // Fish: one per ~3 rows, capped so a huge zone doesn't become a trawler's net.
     let fish_count = (h / 3).clamp(2, 5);
@@ -303,7 +354,7 @@ pub(super) fn aquarium(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: 
         let pos = ((f / speed + u64::from(hash32(i * 13 + 6))) % span) as i64 - len;
         let x0 = if rightward { pos } else { w - len - pos };
         // A subtle vertical bob so the tank feels alive without lane collisions.
-        let bob = if wave(f + i * 9, 70) > 0.75 && lane + 1 < zone.height {
+        let bob = if bob_wave[((f + i * 9) % 70) as usize] > 0.75 && lane + 1 < zone.height {
             1
         } else {
             0
@@ -316,12 +367,7 @@ pub(super) fn aquarium(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: 
             if x < 0 || x >= w {
                 continue;
             }
-            canvas.put(
-                zone.left() + x as u16,
-                zone.top() + lane + bob,
-                ch,
-                Style::default().fg(color),
-            );
+            canvas.put_fg(zone.left() + x as u16, zone.top() + lane + bob, ch, color);
         }
     }
 
@@ -343,17 +389,17 @@ pub(super) fn aquarium(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: 
         }
         let y = (h - 1 - yv) as u16;
         let base_x = i64::from(hash32(i * 29 + 7) % u32::from(zone.width));
-        let x = base_x + ((wave(f + seed, 24) - 0.5) * 2.0).round() as i64;
+        let x = base_x + ((bubble_wave[((f + seed) % 24) as usize] - 0.5) * 2.0).round() as i64;
         if x < 0 || x >= w {
             continue;
         }
         // Bubbles grow as they rise: dot → ring near the surface.
         let stage = ((yv * 3) / h.max(1)).min(2) as usize;
-        canvas.put(
+        canvas.put_fg(
             zone.left() + x as u16,
             zone.top() + y,
             glyphs[2 - stage],
-            Style::default().fg(lerp_color(dim, bright, yv as f64 / h as f64)),
+            lerp_color(dim, bright, yv as f64 / h as f64),
         );
     }
 }
@@ -386,26 +432,79 @@ pub(super) fn waves(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64
         let freq = 0.22 - li * 0.03;
         let phase = f as f64 * (0.06 + li * 0.02);
         let color = lerp_color(surf, deep, li / f64::from(layers.max(1)));
-        let style = Style::default().fg(color);
         for x in 0..w {
             let sway = (f64::from(x) * freq + phase).sin() * amp;
             let y = base - sway.round() as i32;
             if y < i32::from(top) || y > i32::from(bottom) {
                 continue;
             }
-            canvas.put(zone.left() + x, y as u16, crest_glyph, style);
+            canvas.put_fg(zone.left() + x, y as u16, crest_glyph, color);
             // Foam: rare bright flecks dancing on the front crest only.
             if layer == 0
                 && hash32(u64::from(x) * 37 + f / 8).is_multiple_of(23)
                 && y > i32::from(top)
             {
-                canvas.put(
-                    zone.left() + x,
-                    (y - 1) as u16,
-                    foam_glyph,
-                    Style::default().fg(foam_color),
-                );
+                canvas.put_fg(zone.left() + x, (y - 1) as u16, foam_glyph, foam_color);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::buffer::Buffer;
+
+    fn render_fireflies(app: &App, zone: Rect, frame: u64) -> Buffer {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 80, 30));
+        let mut canvas = CanvasWriter::new(&mut buffer, None);
+        fireflies(&mut canvas, app, zone, frame);
+        buffer
+    }
+
+    #[test]
+    fn cached_firefly_descriptors_match_the_original_formulas() {
+        for i in 0..24u64 {
+            let descriptor = FireflyDescriptor::for_index(i);
+            let s = |k: u64| f64::from(hash32(i * 11 + k));
+            assert_eq!(
+                descriptor.wx.to_bits(),
+                (0.008 + (s(1) % 100.0) / 9000.0).to_bits()
+            );
+            assert_eq!(
+                descriptor.wy.to_bits(),
+                (0.011 + (s(2) % 100.0) / 8000.0).to_bits()
+            );
+            assert_eq!(descriptor.px.to_bits(), ((s(3) % 628.0) / 100.0).to_bits());
+            assert_eq!(descriptor.py.to_bits(), ((s(4) % 628.0) / 100.0).to_bits());
+            assert_eq!(descriptor.breath_phase, u64::from(hash32(i * 17 + 9) % 120));
+        }
+    }
+
+    #[test]
+    fn firefly_cache_reuses_identical_output_and_rekeys_on_resize() {
+        FIREFLY_SCRATCH.with(|scratch| *scratch.borrow_mut() = FireflyScratch::default());
+        let app = App::new(100);
+        let first_zone = Rect::new(3, 2, 60, 20);
+        let first = render_fireflies(&app, first_zone, 47);
+        let warm = render_fireflies(&app, first_zone, 47);
+        assert_eq!(warm, first);
+
+        let second_zone = Rect::new(3, 2, 30, 10);
+        render_fireflies(&app, second_zone, 48);
+        FIREFLY_SCRATCH.with(|scratch| {
+            let scratch = scratch.borrow();
+            assert_eq!(scratch.width, second_zone.width);
+            assert_eq!(scratch.height, second_zone.height);
+            assert_eq!(scratch.count, 6);
+            for (i, descriptor) in scratch.flies[..scratch.count as usize].iter().enumerate() {
+                let expected = FireflyDescriptor::for_index(i as u64);
+                assert_eq!(descriptor.wx.to_bits(), expected.wx.to_bits());
+                assert_eq!(descriptor.wy.to_bits(), expected.wy.to_bits());
+                assert_eq!(descriptor.px.to_bits(), expected.px.to_bits());
+                assert_eq!(descriptor.py.to_bits(), expected.py.to_bits());
+                assert_eq!(descriptor.breath_phase, expected.breath_phase);
+            }
+        });
     }
 }

--- a/src/ui/anim/canvas_ext.rs
+++ b/src/ui/anim/canvas_ext.rs
@@ -160,7 +160,9 @@ struct FireflyScratch {
 }
 
 thread_local! {
-    static FIREFLY_SCRATCH: RefCell<FireflyScratch> = RefCell::new(FireflyScratch::default());
+    // Keep the large descriptor array off every native thread's static TLS block. The box is
+    // created only on the render thread, and only after an eligible firefly surface is active.
+    static FIREFLY_SCRATCH: RefCell<Option<Box<FireflyScratch>>> = const { RefCell::new(None) };
 }
 
 /// Fireflies wandering on smooth per-fly Lissajous paths, each breathing between the subtle
@@ -180,8 +182,9 @@ pub(super) fn fireflies(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f:
         ('●', '·')
     };
     let breath_wave = wave_110_table();
-    FIREFLY_SCRATCH.with(|scratch| {
-        let mut scratch = scratch.borrow_mut();
+    FIREFLY_SCRATCH.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        let scratch = slot.get_or_insert_with(|| Box::new(FireflyScratch::default()));
         if scratch.width != zone.width || scratch.height != zone.height || scratch.count != count {
             scratch.width = zone.width;
             scratch.height = zone.height;
@@ -482,8 +485,20 @@ mod tests {
     }
 
     #[test]
+    fn firefly_cache_is_lazy_until_the_first_eligible_surface() {
+        FIREFLY_SCRATCH.with(|slot| *slot.borrow_mut() = None);
+        let app = App::new(100);
+
+        render_fireflies(&app, Rect::new(3, 2, 7, 3), 47);
+        FIREFLY_SCRATCH.with(|slot| assert!(slot.borrow().is_none()));
+
+        render_fireflies(&app, Rect::new(3, 2, 8, 3), 47);
+        FIREFLY_SCRATCH.with(|slot| assert!(slot.borrow().is_some()));
+    }
+
+    #[test]
     fn firefly_cache_reuses_identical_output_and_rekeys_on_resize() {
-        FIREFLY_SCRATCH.with(|scratch| *scratch.borrow_mut() = FireflyScratch::default());
+        FIREFLY_SCRATCH.with(|slot| *slot.borrow_mut() = None);
         let app = App::new(100);
         let first_zone = Rect::new(3, 2, 60, 20);
         let first = render_fireflies(&app, first_zone, 47);
@@ -492,8 +507,9 @@ mod tests {
 
         let second_zone = Rect::new(3, 2, 30, 10);
         render_fireflies(&app, second_zone, 48);
-        FIREFLY_SCRATCH.with(|scratch| {
-            let scratch = scratch.borrow();
+        FIREFLY_SCRATCH.with(|slot| {
+            let slot = slot.borrow();
+            let scratch = slot.as_deref().expect("eligible surface creates cache");
             assert_eq!(scratch.width, second_zone.width);
             assert_eq!(scratch.height, second_zone.height);
             assert_eq!(scratch.count, 6);

--- a/src/ui/anim/canvas_sim.rs
+++ b/src/ui/anim/canvas_sim.rs
@@ -60,7 +60,9 @@ struct FireworkScratch {
 }
 
 thread_local! {
-    static FIREWORK_SCRATCH: RefCell<FireworkScratch> = RefCell::new(FireworkScratch::default());
+    // Keep both particle descriptor arrays off every native thread's static TLS block. The box is
+    // created only on the render thread, and only after an eligible fireworks surface is active.
+    static FIREWORK_SCRATCH: RefCell<Option<Box<FireworkScratch>>> = const { RefCell::new(None) };
 }
 
 /// One launcher's state within its cycle, all derived from `f`: a rocket climbs from the
@@ -74,8 +76,9 @@ pub(super) fn fireworks(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f:
     }
     let retro = app.retro_mode();
     let period = 130u64;
-    FIREWORK_SCRATCH.with(|scratch| {
-        let mut scratch = scratch.borrow_mut();
+    FIREWORK_SCRATCH.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        let scratch = slot.get_or_insert_with(|| Box::new(FireworkScratch::default()));
         for launcher in 0..2u64 {
             let lf = f + launcher * (period / 2); // half-cycle offset between the two
             let cycle = lf / period;
@@ -614,22 +617,36 @@ mod tests {
     }
 
     #[test]
+    fn firework_cache_is_lazy_until_the_first_eligible_surface() {
+        FIREWORK_SCRATCH.with(|slot| *slot.borrow_mut() = None);
+        let app = App::new(100);
+
+        render_effect(&app, Rect::new(4, 2, 15, 6), None, 35, fireworks);
+        FIREWORK_SCRATCH.with(|slot| assert!(slot.borrow().is_none()));
+
+        render_effect(&app, Rect::new(4, 2, 16, 6), None, 35, fireworks);
+        FIREWORK_SCRATCH.with(|slot| assert!(slot.borrow().is_some()));
+    }
+
+    #[test]
     fn firework_cache_reuses_identical_output_and_rekeys_by_cycle() {
-        FIREWORK_SCRATCH.with(|scratch| *scratch.borrow_mut() = FireworkScratch::default());
+        FIREWORK_SCRATCH.with(|slot| *slot.borrow_mut() = None);
         let app = App::new(100);
         let zone = Rect::new(4, 2, 40, 14);
         let first = render_effect(&app, zone, None, 35, fireworks);
         let warm = render_effect(&app, zone, None, 35, fireworks);
         assert_eq!(warm, first);
-        let old_seeds = FIREWORK_SCRATCH.with(|scratch| {
-            let scratch = scratch.borrow();
+        let old_seeds = FIREWORK_SCRATCH.with(|slot| {
+            let slot = slot.borrow();
+            let scratch = slot.as_deref().expect("eligible surface creates cache");
             assert!(scratch.launchers.iter().all(|cache| cache.valid));
             [scratch.launchers[0].seed, scratch.launchers[1].seed]
         });
 
         render_effect(&app, zone, None, 165, fireworks);
-        FIREWORK_SCRATCH.with(|scratch| {
-            let scratch = scratch.borrow();
+        FIREWORK_SCRATCH.with(|slot| {
+            let slot = slot.borrow();
+            let scratch = slot.as_deref().expect("cache remains available");
             assert_ne!(scratch.launchers[0].seed, old_seeds[0]);
             assert_ne!(scratch.launchers[1].seed, old_seeds[1]);
         });

--- a/src/ui/anim/canvas_sim.rs
+++ b/src/ui/anim/canvas_sim.rs
@@ -10,9 +10,9 @@
 use std::cell::RefCell;
 
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Style};
+use ratatui::style::Color;
 
-use super::canvas::CanvasWriter;
+use super::canvas::{CanvasWriter, reset_scratch_vec};
 use super::{ease_out_cubic, hash32, lerp_color};
 use crate::app::App;
 use crate::theme::ThemeRole as R;
@@ -20,6 +20,48 @@ use crate::theme::ThemeRole as R;
 // ── fireworks ───────────────────────────────────────────────────────────────
 
 const FIREWORK_PALETTE: [R; 5] = [R::Accent, R::AccentAlt, R::Success, R::Warning, R::Error];
+const FIREWORK_PARTICLE_COUNT: usize = 24;
+
+#[derive(Clone, Copy, Debug, Default)]
+struct FireworkParticle {
+    burn_roll: u64,
+    angle_cos: f64,
+    angle_sin: f64,
+}
+
+impl FireworkParticle {
+    fn new(seed: u32, particle: u64) -> Self {
+        let burn_roll = u64::from(hash32(particle * 53 + u64::from(seed))) % 100;
+        let jitter = f64::from(hash32(particle * 31 + u64::from(seed)) % 100) / 700.0;
+        let angle =
+            (particle as f64 / FIREWORK_PARTICLE_COUNT as f64 + jitter) * std::f64::consts::TAU;
+        // Keep the original evaluation order instead of using `sin_cos`, whose last bits may
+        // differ on some targets.
+        let angle_cos = angle.cos();
+        let angle_sin = angle.sin();
+        Self {
+            burn_roll,
+            angle_cos,
+            angle_sin,
+        }
+    }
+}
+
+#[derive(Default)]
+struct FireworkLauncherCache {
+    valid: bool,
+    seed: u32,
+    particles: [FireworkParticle; FIREWORK_PARTICLE_COUNT],
+}
+
+#[derive(Default)]
+struct FireworkScratch {
+    launchers: [FireworkLauncherCache; 2],
+}
+
+thread_local! {
+    static FIREWORK_SCRATCH: RefCell<FireworkScratch> = RefCell::new(FireworkScratch::default());
+}
 
 /// One launcher's state within its cycle, all derived from `f`: a rocket climbs from the
 /// bottom, then a radial burst blooms at the apex, droops under gravity and fades out.
@@ -32,88 +74,94 @@ pub(super) fn fireworks(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f:
     }
     let retro = app.retro_mode();
     let period = 130u64;
-    for launcher in 0..2u64 {
-        let lf = f + launcher * (period / 2); // half-cycle offset between the two
-        let cycle = lf / period;
-        let t = (lf % period) as i64;
-        let seed = hash32(cycle.wrapping_mul(97) + launcher * 41);
-        let launch_x = 2 + i64::from(seed % (zone.width.saturating_sub(4)).max(1) as u32);
-        let apex_y = 1 + i64::from(hash32(u64::from(seed) + 11) % ((h / 3).max(1) as u32));
-        let climb = (h - apex_y).max(1);
-        let color = app
-            .theme
-            .color(FIREWORK_PALETTE[(seed as usize / 7) % FIREWORK_PALETTE.len()]);
+    FIREWORK_SCRATCH.with(|scratch| {
+        let mut scratch = scratch.borrow_mut();
+        for launcher in 0..2u64 {
+            let lf = f + launcher * (period / 2); // half-cycle offset between the two
+            let cycle = lf / period;
+            let t = (lf % period) as i64;
+            let seed = hash32(cycle.wrapping_mul(97) + launcher * 41);
+            let launch_x = 2 + i64::from(seed % (zone.width.saturating_sub(4)).max(1) as u32);
+            let apex_y = 1 + i64::from(hash32(u64::from(seed) + 11) % ((h / 3).max(1) as u32));
+            let climb = (h - apex_y).max(1);
+            let color = app
+                .theme
+                .color(FIREWORK_PALETTE[(seed as usize / 7) % FIREWORK_PALETTE.len()]);
 
-        if t < climb {
-            // Ascent: a bright head with a two-cell ember tail, wiggling one column.
-            let y = h - 1 - t;
-            let x = launch_x + ((t / 5) % 2) - ((t / 7) % 2);
-            for k in 0..3i64 {
-                let yy = y + k;
-                if yy >= h || x < 0 || x >= w {
+            if t < climb {
+                // Ascent: a bright head with a two-cell ember tail, wiggling one column.
+                let y = h - 1 - t;
+                let x = launch_x + ((t / 5) % 2) - ((t / 7) % 2);
+                for k in 0..3i64 {
+                    let yy = y + k;
+                    if yy >= h || x < 0 || x >= w {
+                        continue;
+                    }
+                    let (g, c) = match k {
+                        0 => {
+                            if retro {
+                                ('^', Color::Rgb(255, 255, 220))
+                            } else {
+                                ('▲', Color::Rgb(255, 255, 220))
+                            }
+                        }
+                        1 => ('|', color),
+                        _ => ('.', app.theme.color(R::TextSubtle)),
+                    };
+                    canvas.put_fg(
+                        (i64::from(zone.left()) + x) as u16,
+                        (i64::from(zone.top()) + yy) as u16,
+                        g,
+                        c,
+                    );
+                }
+                continue;
+            }
+
+            // Burst: particles fly out radially, decelerating, drooping, and dying young→old.
+            let bt = (t - climb) as f64 / (period as f64 - climb as f64);
+            let spread = ease_out_cubic(bt);
+            let radius = 2.0 + spread * (w.min(h * 2) as f64 * 0.28);
+            let cache = &mut scratch.launchers[launcher as usize];
+            if !cache.valid || cache.seed != seed {
+                cache.valid = true;
+                cache.seed = seed;
+                for (particle, descriptor) in cache.particles.iter_mut().enumerate() {
+                    *descriptor = FireworkParticle::new(seed, particle as u64);
+                }
+            }
+            for descriptor in &cache.particles {
+                // Sparks burn out one by one over the back half of the bloom.
+                if bt > 0.5 && descriptor.burn_roll < ((bt - 0.5) * 220.0) as u64 {
                     continue;
                 }
-                let (g, c) = match k {
-                    0 => {
-                        if retro {
-                            ('^', Color::Rgb(255, 255, 220))
-                        } else {
-                            ('▲', Color::Rgb(255, 255, 220))
-                        }
-                    }
-                    1 => ('|', color),
-                    _ => ('.', app.theme.color(R::TextSubtle)),
+                let droop = spread * spread * 2.5; // gravity pulls the whole shell down
+                let x = launch_x as f64 + descriptor.angle_cos * radius;
+                let y = apex_y as f64 + descriptor.angle_sin * radius * 0.45 + droop;
+                if x < 0.0 || x >= w as f64 || y < 0.0 || y >= h as f64 {
+                    continue;
+                }
+                let (glyph, bright) = if bt < 0.25 {
+                    (if retro { '*' } else { '✦' }, 1.0)
+                } else if bt < 0.6 {
+                    ('*', 0.75)
+                } else {
+                    ('.', 0.4)
                 };
-                canvas.put(
-                    (i64::from(zone.left()) + x) as u16,
-                    (i64::from(zone.top()) + yy) as u16,
-                    g,
-                    Style::default().fg(c),
+                let c = lerp_color(
+                    app.theme.color(R::TextSubtle),
+                    color,
+                    bright * (1.0 - bt * 0.5),
+                );
+                canvas.put_fg(
+                    (i64::from(zone.left()) + x as i64) as u16,
+                    (i64::from(zone.top()) + y as i64) as u16,
+                    glyph,
+                    c,
                 );
             }
-            continue;
         }
-
-        // Burst: particles fly out radially, decelerating, drooping, and dying young→old.
-        let bt = (t - climb) as f64 / (period as f64 - climb as f64);
-        let spread = ease_out_cubic(bt);
-        let radius = 2.0 + spread * (w.min(h * 2) as f64 * 0.28);
-        let particles = 24u64;
-        for p in 0..particles {
-            // Sparks burn out one by one over the back half of the bloom.
-            if bt > 0.5
-                && u64::from(hash32(p * 53 + u64::from(seed))) % 100 < ((bt - 0.5) * 220.0) as u64
-            {
-                continue;
-            }
-            let jitter = f64::from(hash32(p * 31 + u64::from(seed)) % 100) / 700.0;
-            let ang = (p as f64 / particles as f64 + jitter) * std::f64::consts::TAU;
-            let droop = spread * spread * 2.5; // gravity pulls the whole shell down
-            let x = launch_x as f64 + ang.cos() * radius;
-            let y = apex_y as f64 + ang.sin() * radius * 0.45 + droop;
-            if x < 0.0 || x >= w as f64 || y < 0.0 || y >= h as f64 {
-                continue;
-            }
-            let (glyph, bright) = if bt < 0.25 {
-                (if retro { '*' } else { '✦' }, 1.0)
-            } else if bt < 0.6 {
-                ('*', 0.75)
-            } else {
-                ('.', 0.4)
-            };
-            let c = lerp_color(
-                app.theme.color(R::TextSubtle),
-                color,
-                bright * (1.0 - bt * 0.5),
-            );
-            canvas.put(
-                (i64::from(zone.left()) + x as i64) as u16,
-                (i64::from(zone.top()) + y as i64) as u16,
-                glyph,
-                Style::default().fg(c),
-            );
-        }
-    }
+    });
 }
 
 // ── Game of Life ────────────────────────────────────────────────────────────
@@ -161,10 +209,15 @@ pub(super) fn life(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64)
         let mut scratch = scratch.borrow_mut();
         let s = &mut *scratch;
         let cells = w * h;
-        if s.width != zone.width || s.height != zone.height || f < s.last_step {
+        let geometry_changed = s.width != zone.width || s.height != zone.height;
+        if geometry_changed || f < s.last_step {
             // Resize — or a frame-counter context change (f went backwards) — restarts the show.
             s.width = zone.width;
             s.height = zone.height;
+            if geometry_changed {
+                reset_scratch_vec(&mut s.age, cells);
+                reset_scratch_vec(&mut s.next, cells);
+            }
             s.age.resize(cells, 0);
             s.age.fill(0);
             s.next.resize(cells, 0);
@@ -313,17 +366,25 @@ pub(super) fn pipes(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u64
         let s = &mut *scratch;
         let cells = w * h;
         let clogged = s.filled * 10 >= cells * 6;
-        if s.width != zone.width || s.height != zone.height || f < s.last_f || clogged {
+        let geometry_changed = s.width != zone.width || s.height != zone.height;
+        if geometry_changed || f < s.last_f || clogged {
             s.width = zone.width;
             s.height = zone.height;
+            if geometry_changed {
+                reset_scratch_vec(&mut s.cells, cells);
+            }
             s.cells.resize(cells, 0);
             s.cells.fill(0);
             s.filled = 0;
             s.epoch = s.epoch.wrapping_add(1);
             let epoch = s.epoch;
             let pipe_count = (w / 24 + 2).min(5);
-            s.heads.clear();
-            s.heads.reserve(pipe_count);
+            if geometry_changed {
+                reset_scratch_vec(&mut s.heads, pipe_count);
+            } else {
+                s.heads.clear();
+                s.heads.reserve(pipe_count);
+            }
             for i in 0..pipe_count {
                 let seed = hash32(epoch.wrapping_mul(31) + i as u64);
                 s.heads.push((
@@ -452,6 +513,15 @@ pub(super) fn plasma(canvas: &mut CanvasWriter<'_>, app: &App, zone: Rect, f: u6
 
     PLASMA_SCRATCH.with(|scratch| {
         let mut scratch = scratch.borrow_mut();
+        if scratch.col_wave.len() != w {
+            reset_scratch_vec(&mut scratch.col_wave, w);
+        }
+        if scratch.row_wave.len() != h {
+            reset_scratch_vec(&mut scratch.row_wave, h);
+        }
+        if scratch.diag_wave.len() != w + h {
+            reset_scratch_vec(&mut scratch.diag_wave, w + h);
+        }
         scratch.col_wave.resize(w, 0.0);
         scratch.row_wave.resize(h, 0.0);
         scratch.diag_wave.resize(w + h, 0.0);
@@ -523,6 +593,137 @@ mod tests {
             }
         }
         count
+    }
+
+    #[test]
+    fn cached_firework_particles_match_the_original_formulas() {
+        for seed in [0, 1, 0xDEAD_BEEF] {
+            for particle in 0..FIREWORK_PARTICLE_COUNT as u64 {
+                let descriptor = FireworkParticle::new(seed, particle);
+                assert_eq!(
+                    descriptor.burn_roll,
+                    u64::from(hash32(particle * 53 + u64::from(seed))) % 100
+                );
+                let jitter = f64::from(hash32(particle * 31 + u64::from(seed)) % 100) / 700.0;
+                let angle = (particle as f64 / FIREWORK_PARTICLE_COUNT as f64 + jitter)
+                    * std::f64::consts::TAU;
+                assert_eq!(descriptor.angle_cos.to_bits(), angle.cos().to_bits());
+                assert_eq!(descriptor.angle_sin.to_bits(), angle.sin().to_bits());
+            }
+        }
+    }
+
+    #[test]
+    fn firework_cache_reuses_identical_output_and_rekeys_by_cycle() {
+        FIREWORK_SCRATCH.with(|scratch| *scratch.borrow_mut() = FireworkScratch::default());
+        let app = App::new(100);
+        let zone = Rect::new(4, 2, 40, 14);
+        let first = render_effect(&app, zone, None, 35, fireworks);
+        let warm = render_effect(&app, zone, None, 35, fireworks);
+        assert_eq!(warm, first);
+        let old_seeds = FIREWORK_SCRATCH.with(|scratch| {
+            let scratch = scratch.borrow();
+            assert!(scratch.launchers.iter().all(|cache| cache.valid));
+            [scratch.launchers[0].seed, scratch.launchers[1].seed]
+        });
+
+        render_effect(&app, zone, None, 165, fireworks);
+        FIREWORK_SCRATCH.with(|scratch| {
+            let scratch = scratch.borrow();
+            assert_ne!(scratch.launchers[0].seed, old_seeds[0]);
+            assert_ne!(scratch.launchers[1].seed, old_seeds[1]);
+        });
+    }
+
+    #[test]
+    fn geometry_resets_downsize_large_state_without_changing_life_or_pipes_epochs() {
+        const LARGE_CELLS: usize = 80 * 1024;
+        LIFE_SCRATCH.with(|scratch| {
+            let mut age = Vec::with_capacity(LARGE_CELLS);
+            age.resize(LARGE_CELLS, 1);
+            let next = vec![0; LARGE_CELLS];
+            *scratch.borrow_mut() = LifeScratch {
+                width: 400,
+                height: 200,
+                age,
+                next,
+                last_step: 0,
+                epoch: 7,
+            };
+        });
+        let app = App::new(100);
+        let zone = Rect::new(4, 2, 40, 14);
+        render_effect(&app, zone, None, 0, life);
+        LIFE_SCRATCH.with(|scratch| {
+            let scratch = scratch.borrow();
+            assert_eq!(scratch.epoch, 8);
+            assert_eq!(scratch.age.len(), usize::from(zone.width * zone.height));
+            assert_eq!(scratch.next.len(), usize::from(zone.width * zone.height));
+            assert!(scratch.age.capacity() < LARGE_CELLS);
+            assert!(scratch.next.capacity() < LARGE_CELLS);
+        });
+
+        PIPES_SCRATCH.with(|scratch| {
+            let mut cells = Vec::with_capacity(LARGE_CELLS);
+            cells.resize(LARGE_CELLS, 1);
+            let mut heads = Vec::with_capacity(16 * 1024);
+            heads.resize(16 * 1024, (0, 0, 0));
+            *scratch.borrow_mut() = PipesScratch {
+                width: 400,
+                height: 200,
+                cells,
+                heads,
+                filled: 1,
+                last_f: 0,
+                epoch: 11,
+            };
+        });
+        render_effect(&app, zone, None, 1, pipes);
+        PIPES_SCRATCH.with(|scratch| {
+            let scratch = scratch.borrow();
+            assert_eq!(scratch.epoch, 12);
+            assert_eq!(scratch.cells.len(), usize::from(zone.width * zone.height));
+            assert!(scratch.cells.capacity() < LARGE_CELLS);
+            assert!(scratch.heads.capacity() < 16 * 1024);
+        });
+    }
+
+    #[test]
+    fn plasma_downsizes_large_vectors_only_when_geometry_changes() {
+        const LARGE_LEN: usize = 10 * 1024;
+        PLASMA_SCRATCH.with(|scratch| {
+            *scratch.borrow_mut() = PlasmaScratch {
+                col_wave: vec![0.0; LARGE_LEN],
+                row_wave: vec![0.0; LARGE_LEN],
+                diag_wave: vec![0.0; LARGE_LEN],
+            };
+        });
+        let app = App::new(100);
+        let zone = Rect::new(4, 2, 40, 14);
+        render_effect(&app, zone, None, 1, plasma);
+        let capacities = PLASMA_SCRATCH.with(|scratch| {
+            let scratch = scratch.borrow();
+            assert!(scratch.col_wave.capacity() < LARGE_LEN);
+            assert!(scratch.row_wave.capacity() < LARGE_LEN);
+            assert!(scratch.diag_wave.capacity() < LARGE_LEN);
+            (
+                scratch.col_wave.capacity(),
+                scratch.row_wave.capacity(),
+                scratch.diag_wave.capacity(),
+            )
+        });
+        render_effect(&app, zone, None, 2, plasma);
+        PLASMA_SCRATCH.with(|scratch| {
+            let scratch = scratch.borrow();
+            assert_eq!(
+                (
+                    scratch.col_wave.capacity(),
+                    scratch.row_wave.capacity(),
+                    scratch.diag_wave.capacity(),
+                ),
+                capacities
+            );
+        });
     }
 
     #[test]

--- a/src/ui/buttons.rs
+++ b/src/ui/buttons.rs
@@ -142,6 +142,58 @@ struct SegmentRenderOptions {
     center_vertically: bool,
 }
 
+// Every in-tree control strip fits comfortably in this budget. Keeping the measured
+// display widths inline avoids one heap allocation on each render; synthetic/plugin-like
+// strips beyond the budget still get an exact-length backing slice.
+const INLINE_SEGMENT_WIDTHS: usize = 32;
+
+enum SegmentWidths {
+    Inline {
+        values: [u16; INLINE_SEGMENT_WIDTHS],
+        len: usize,
+    },
+    Heap(Box<[u16]>),
+}
+
+impl SegmentWidths {
+    fn measure(segments: &[Seg<'_>]) -> (Self, u16) {
+        let mut widths = if segments.len() <= INLINE_SEGMENT_WIDTHS {
+            Self::Inline {
+                values: [0; INLINE_SEGMENT_WIDTHS],
+                len: segments.len(),
+            }
+        } else {
+            Self::Heap(vec![0; segments.len()].into_boxed_slice())
+        };
+        let mut total = 0u16;
+        for (slot, seg) in widths.as_mut_slice().iter_mut().zip(segments) {
+            let width = text_width(seg.text);
+            *slot = width;
+            total = total.saturating_add(width);
+        }
+        (widths, total)
+    }
+
+    fn as_slice(&self) -> &[u16] {
+        match self {
+            Self::Inline { values, len } => &values[..*len],
+            Self::Heap(values) => values,
+        }
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [u16] {
+        match self {
+            Self::Inline { values, len } => &mut values[..*len],
+            Self::Heap(values) => values,
+        }
+    }
+
+    #[cfg(test)]
+    fn is_heap(&self) -> bool {
+        matches!(self, Self::Heap(_))
+    }
+}
+
 fn render_segments_inner(
     frame: &mut Frame,
     app: &App,
@@ -149,13 +201,7 @@ fn render_segments_inner(
     segments: &[Seg<'_>],
     opts: SegmentRenderOptions,
 ) {
-    let mut widths = Vec::with_capacity(segments.len());
-    let mut total = 0u16;
-    for seg in segments {
-        let width = text_width(seg.text);
-        total = total.saturating_add(width);
-        widths.push(width);
-    }
+    let (widths, total) = SegmentWidths::measure(segments);
     let mut x = match opts.alignment {
         Alignment::Center => area.x + area.width.saturating_sub(total) / 2,
         Alignment::Right => area.x + area.width.saturating_sub(total),
@@ -163,7 +209,7 @@ fn render_segments_inner(
     };
 
     let mut spans = Vec::with_capacity(segments.len());
-    for (seg, width) in segments.iter().zip(widths) {
+    for (seg, width) in segments.iter().zip(widths.as_slice().iter().copied()) {
         let style = if let Some(target) = seg.target.clone() {
             // The rect hugs the text, plus any `hit_pad` cells of flanking air —
             // clamped to `area` so padding never escapes the strip's row.
@@ -609,8 +655,76 @@ pub fn render_help_button(frame: &mut Frame, app: &App, area: Rect) {
 
 #[cfg(test)]
 mod tests {
-    use super::{nav_label, text_width};
-    use crate::app::Mode;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::{Alignment, Rect};
+    use ratatui::style::Style;
+
+    use super::{
+        INLINE_SEGMENT_WIDTHS, Seg, SegmentWidths, nav_label, render_segments, text_width,
+    };
+    use crate::app::{App, Mode, MouseTarget};
+    use crate::keymap::Action;
+
+    #[test]
+    fn segment_width_scratch_uses_heap_only_beyond_inline_budget() {
+        let inline = (0..INLINE_SEGMENT_WIDTHS)
+            .map(|_| Seg::label("한"))
+            .collect::<Vec<_>>();
+        let (widths, total) = SegmentWidths::measure(&inline);
+        assert!(!widths.is_heap());
+        assert_eq!(widths.as_slice(), vec![2; INLINE_SEGMENT_WIDTHS]);
+        assert_eq!(total, (INLINE_SEGMENT_WIDTHS as u16) * 2);
+
+        let heap = (0..=INLINE_SEGMENT_WIDTHS)
+            .map(|_| Seg::label("✨"))
+            .collect::<Vec<_>>();
+        let (widths, total) = SegmentWidths::measure(&heap);
+        assert!(widths.is_heap());
+        assert_eq!(widths.as_slice(), vec![2; INLINE_SEGMENT_WIDTHS + 1]);
+        assert_eq!(total, ((INLINE_SEGMENT_WIDTHS + 1) as u16) * 2);
+    }
+
+    #[test]
+    fn heap_backed_unicode_strip_keeps_rendered_cells_and_hit_rects_aligned() {
+        let mut segments = (0..30).map(|_| Seg::label("a")).collect::<Vec<_>>();
+        segments.push(Seg::button(MouseTarget::Global(Action::ToggleHelp), "한"));
+        segments.push(Seg::label("·"));
+        segments.push(Seg::button(MouseTarget::MouseHelp, "✨"));
+        assert!(segments.len() > INLINE_SEGMENT_WIDTHS);
+
+        let app = App::new(100);
+        let backend = TestBackend::new(40, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_segments(
+                    frame,
+                    &app,
+                    Rect::new(2, 1, 38, 1),
+                    &segments,
+                    Style::default(),
+                    Style::default(),
+                    Alignment::Left,
+                );
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        for x in 2..32 {
+            assert_eq!(buffer[(x, 1)].symbol(), "a");
+        }
+        assert_eq!(buffer[(32, 1)].symbol(), "한");
+        assert_eq!(buffer[(34, 1)].symbol(), "·");
+        assert_eq!(buffer[(35, 1)].symbol(), "✨");
+
+        let help = Some(MouseTarget::Global(Action::ToggleHelp));
+        assert_eq!(app.hits.target_at(32, 1), help);
+        assert_eq!(app.hits.target_at(33, 1), help);
+        assert_eq!(app.hits.target_at(34, 1), None);
+        assert_eq!(app.hits.target_at(35, 1), Some(MouseTarget::MouseHelp));
+        assert_eq!(app.hits.target_at(36, 1), Some(MouseTarget::MouseHelp));
+    }
 
     #[test]
     fn sparkle_and_blank_nav_slot_are_both_two_cells() {

--- a/src/ui/control_box.rs
+++ b/src/ui/control_box.rs
@@ -44,6 +44,7 @@ pub fn render_at(
     // message covers the title (nothing to celebrate over) — drawn after the neighbours so the
     // sparks sit on top of the blank gap rows.
     if app.status.text.is_empty()
+        && crate::ui::anim::like_burst_active(app, title.width)
         && let Some(s) = app.queue.current()
     {
         let title_text = app.display_title(s);
@@ -386,7 +387,8 @@ fn fitted_status_line_parts(app: &App, width: u16, animated: bool) -> (u16, Stat
     };
     if app.beginner_labels_enabled() {
         // Shed keycaps and decoration before names, then use compact labels only when necessary.
-        [
+        let mut parts = StatusLineParts::with_capacity(16);
+        for (gap, minimal, labels) in [
             ("    ", false, StatusLabelTier::BeginnerKeys),
             ("  ", false, StatusLabelTier::BeginnerKeys),
             (" ", false, StatusLabelTier::BeginnerKeys),
@@ -395,27 +397,30 @@ fn fitted_status_line_parts(app: &App, width: u16, animated: bool) -> (u16, Stat
             (" ", false, StatusLabelTier::BeginnerNames),
             (" ", true, StatusLabelTier::BeginnerNames),
             (" ", true, StatusLabelTier::Compact),
-        ]
-        .into_iter()
-        .map(|(gap, minimal, labels)| {
-            (
-                buttons::text_width(gap),
-                status_line_parts_with_labels(app, gap, minimal, animated, labels),
-            )
-        })
-        .find(|(_, parts)| fits(parts))
-        .unwrap_or_else(|| (1, status_line_parts(app, " ", true, animated)))
+        ] {
+            parts =
+                status_line_parts_with_labels_reusing(app, gap, minimal, animated, labels, parts);
+            if fits(&parts) {
+                return (buttons::text_width(gap), parts);
+            }
+        }
+        (1, parts)
     } else {
-        [("    ", false), ("  ", false), (" ", false), (" ", true)]
-            .into_iter()
-            .map(|(gap, minimal)| {
-                (
-                    buttons::text_width(gap),
-                    status_line_parts(app, gap, minimal, animated),
-                )
-            })
-            .find(|(_, parts)| fits(parts))
-            .unwrap_or_else(|| (1, status_line_parts(app, " ", true, animated)))
+        let mut parts = StatusLineParts::with_capacity(16);
+        for (gap, minimal) in [("    ", false), ("  ", false), (" ", false), (" ", true)] {
+            parts = status_line_parts_with_labels_reusing(
+                app,
+                gap,
+                minimal,
+                animated,
+                StatusLabelTier::Compact,
+                parts,
+            );
+            if fits(&parts) {
+                return (buttons::text_width(gap), parts);
+            }
+        }
+        (1, parts)
     }
 }
 
@@ -429,6 +434,7 @@ fn fitted_status_line_parts(app: &App, width: u16, animated: bool) -> (u16, Stat
 /// drop away, so the clickable toggles never fall off the right edge.
 /// `animated` is false in the docked box's static (off-Player) forms: the clock-driven
 /// decorations (spinner, VU bars) drop instead of freezing mid-frame.
+#[cfg(test)]
 fn status_line_parts(
     app: &App,
     gap: &'static str,
@@ -437,7 +443,7 @@ fn status_line_parts(
 ) -> StatusLineParts {
     status_line_parts_with_labels(app, gap, minimal, animated, StatusLabelTier::Compact)
 }
-
+#[cfg(test)]
 fn status_line_parts_with_labels(
     app: &App,
     gap: &'static str,
@@ -445,8 +451,26 @@ fn status_line_parts_with_labels(
     animated: bool,
     labels: StatusLabelTier,
 ) -> StatusLineParts {
+    status_line_parts_with_labels_reusing(
+        app,
+        gap,
+        minimal,
+        animated,
+        labels,
+        StatusLineParts::with_capacity(16),
+    )
+}
+
+fn status_line_parts_with_labels_reusing(
+    app: &App,
+    gap: &'static str,
+    minimal: bool,
+    animated: bool,
+    labels: StatusLabelTier,
+    mut parts: StatusLineParts,
+) -> StatusLineParts {
     let retro = app.retro_mode();
-    let mut parts = StatusLineParts::with_capacity(16);
+    parts.clear();
     // A braille throbber leads the line when the spinner animation is on (no-op otherwise). It's a
     // plain label, so `render_segments` keeps every later hit rect aligned to its rendered text.
     if (!minimal || !labels.beginner())
@@ -829,7 +853,7 @@ fn status_line_parts_with_labels(
     {
         let tag = match state {
             DownloadState::Running(p) => {
-                let head = crate::ui::anim::download_spinner(app).unwrap_or_else(|| "⬇".to_owned());
+                let head = crate::ui::anim::download_spinner(app).unwrap_or("⬇");
                 format!("{head} {p}%")
             }
             DownloadState::Done => "⬇ ✓".to_owned(),
@@ -925,10 +949,7 @@ pub(in crate::ui) fn render_controls(frame: &mut Frame, app: &App, area: Rect, a
         Seg::label(&vol),
         Seg::button(MouseTarget::Player(Action::VolUp), volume_up),
     ];
-    let widths: Vec<u16> = segments
-        .iter()
-        .map(|s| buttons::text_width(s.text))
-        .collect();
+    let widths: [u16; 10] = std::array::from_fn(|index| buttons::text_width(segments[index].text));
     let total = widths.iter().copied().sum::<u16>();
     let volume_offset = widths[..6].iter().copied().sum::<u16>();
     let volume_width = widths[6..].iter().copied().sum::<u16>();

--- a/src/ui/control_box.rs
+++ b/src/ui/control_box.rs
@@ -797,9 +797,14 @@ fn status_line_parts_with_labels_reusing(
     // Faux VU bars trail the EQ label when the EQ-bars animation is on (no-op otherwise).
     if !minimal
         && animated
-        && let Some(bars) = crate::ui::anim::eq_bars(app)
+        && let Some(mut bars) = crate::ui::anim::eq_bars(app)
     {
-        parts.push((None, Cow::Owned(format!("{gap}{bars}"))));
+        // `eq_bars` already owns this frame's five-glyph buffer. Prefix the separator in
+        // place instead of formatting it into a second allocation and immediately dropping
+        // the original. This keeps the single label segment (and therefore its exact cells)
+        // unchanged.
+        bars.insert_str(0, gap);
+        parts.push((None, Cow::Owned(bars)));
     }
     if app.streaming_active() {
         // Show the station's mode (Focused/Balanced/Discovery) as a click target that opens the
@@ -901,7 +906,11 @@ pub(in crate::ui) fn render_controls(frame: &mut Frame, app: &App, area: Rect, a
     };
     let plain_down = " - ";
     let plain_up = " + ";
-    let (beginner_down, beginner_up) = beginner::volume_buttons(app);
+    // Resolving display keycaps allocates two strings. The legacy/non-beginner path never
+    // displays them, so do not build them on every animated frame just to discard them.
+    let beginner_buttons = app
+        .beginner_labels_enabled()
+        .then(|| beginner::volume_buttons(app));
     let tight_transport_width = 13u16;
     let cluster_width = |label: &str, down: &str, up: &str| {
         buttons::text_width(label)
@@ -912,24 +921,14 @@ pub(in crate::ui) fn render_controls(frame: &mut Frame, app: &App, area: Rect, a
     let fits_tight = |label: &str, down: &str, up: &str| {
         tight_transport_width.saturating_add(cluster_width(label, down, up)) <= area.width
     };
-    let (volume_label, volume_down, volume_up) = if app.beginner_labels_enabled()
-        && fits_tight(beginner_volume_label, &beginner_down, &beginner_up)
-    {
-        (
-            beginner_volume_label,
-            beginner_down.as_str(),
-            beginner_up.as_str(),
-        )
-    } else if app.beginner_labels_enabled()
-        && fits_tight(compact_volume_label, &beginner_down, &beginner_up)
-    {
-        (
-            compact_volume_label,
-            beginner_down.as_str(),
-            beginner_up.as_str(),
-        )
-    } else {
-        (compact_volume_label, plain_down, plain_up)
+    let (volume_label, volume_down, volume_up) = match beginner_buttons.as_ref() {
+        Some((down, up)) if fits_tight(beginner_volume_label, down, up) => {
+            (beginner_volume_label, down.as_str(), up.as_str())
+        }
+        Some((down, up)) if fits_tight(compact_volume_label, down, up) => {
+            (compact_volume_label, down.as_str(), up.as_str())
+        }
+        _ => (compact_volume_label, plain_down, plain_up),
     };
     let full = 21u16.saturating_add(cluster_width(volume_label, volume_down, volume_up));
     let (gap, vol_gap) = if full <= area.width {

--- a/src/ui/views/audio_output_picker.rs
+++ b/src/ui/views/audio_output_picker.rs
@@ -67,7 +67,7 @@ fn render_status(frame: &mut Frame, app: &App, area: Rect) {
         format!(
             "{}{}",
             t!("Detecting devices", "장치 탐지 중"),
-            crate::ui::anim::activity_dots(app).unwrap_or_else(|| "…".to_owned())
+            crate::ui::anim::activity_dots(app).unwrap_or("…")
         )
     } else {
         let count = app

--- a/src/ui/views/local.rs
+++ b/src/ui/views/local.rs
@@ -381,21 +381,23 @@ fn render_rows(frame: &mut Frame, app: &App, local_rows: &LocalRowsSnapshot, are
         let body_w = row_width.saturating_sub(delete_width) as usize;
         let marker = if selected { "> " } else { "  " };
         let text = app.local_row_text_at(local_rows, i);
-        let text = if selected {
-            crate::ui::anim::selected_marquee(
+        let body = if selected {
+            let mut body = crate::ui::anim::selected_marquee(
                 app,
                 ScrollSurface::Library,
                 i,
                 text.as_ref(),
                 body_w.saturating_sub(3),
-            )
+            );
+            body.reserve(marker.len());
+            body.insert_str(0, marker);
+            crate::ui::text::truncate_owned_to_width(body, body_w.saturating_sub(1))
         } else {
-            text.to_string()
+            let mut body = String::with_capacity(marker.len().saturating_add(text.len()));
+            body.push_str(marker);
+            body.push_str(text.as_ref());
+            crate::ui::text::truncate_owned_to_width(body, body_w.saturating_sub(1))
         };
-        let body = crate::ui::text::truncate_owned_to_width(
-            format!("{marker}{text}"),
-            body_w.saturating_sub(1),
-        );
         let style = if selected {
             crate::ui::anim::selection_style(
                 app,

--- a/src/ui/views/player_lyrics.rs
+++ b/src/ui/views/player_lyrics.rs
@@ -1,5 +1,6 @@
 //! Synced-lyrics rendering and its frame-local mouse hit map.
 
+use std::sync::Arc;
 use std::time::Instant;
 
 use ratatui::Frame;
@@ -56,7 +57,7 @@ pub(super) fn render(frame: &mut Frame, app: &App, area: Rect) {
         app.register_mouse_button(
             rect,
             MouseTarget::LyricsLine {
-                video_id: track.video_id.clone(),
+                video_id: Arc::clone(&track.video_id),
                 line_index,
             },
         );
@@ -83,7 +84,7 @@ fn render_empty(frame: &mut Frame, app: &App, area: Rect, dim: Style) {
     frame.render_widget(Paragraph::new(centered(&message, dim)), area);
 }
 
-fn render_delay_osd(frame: &mut Frame, app: &App, area: Rect, video_id: &str) {
+fn render_delay_osd(frame: &mut Frame, app: &App, area: Rect, video_id: &Arc<str>) {
     if area.width < 3 || area.height == 0 {
         return;
     }
@@ -91,9 +92,12 @@ fn render_delay_osd(frame: &mut Frame, app: &App, area: Rect, video_id: &str) {
         .lyrics
         .delay_osd_until
         .is_some_and(|deadline| deadline > Instant::now());
+    if !expanded {
+        return render_handle(frame, app, area, video_id);
+    }
     let value = delay_label(app);
     let expanded_label = format!("[ − {value} + ]");
-    if !expanded || expanded_label.width() > usize::from(area.width) {
+    if expanded_label.width() > usize::from(area.width) {
         return render_handle(frame, app, area, video_id);
     }
 
@@ -123,18 +127,18 @@ fn render_delay_osd(frame: &mut Frame, app: &App, area: Rect, video_id: &str) {
     app.register_mouse_button(
         Rect::new(rect.x + 2, rect.y, 1, 1),
         MouseTarget::LyricsDelayEarlier {
-            video_id: video_id.to_owned(),
+            video_id: Arc::clone(video_id),
         },
     );
     app.register_mouse_button(
         Rect::new(rect.right() - 3, rect.y, 1, 1),
         MouseTarget::LyricsDelayLater {
-            video_id: video_id.to_owned(),
+            video_id: Arc::clone(video_id),
         },
     );
 }
 
-fn render_handle(frame: &mut Frame, app: &App, area: Rect, video_id: &str) {
+fn render_handle(frame: &mut Frame, app: &App, area: Rect, video_id: &Arc<str>) {
     let rect = Rect::new(area.right() - 3, area.bottom() - 1, 3, 1);
     let style = Style::default()
         .fg(app.theme.color(R::Accent))
@@ -144,7 +148,7 @@ fn render_handle(frame: &mut Frame, app: &App, area: Rect, video_id: &str) {
     app.register_mouse_button(
         rect,
         MouseTarget::LyricsDelayHandle {
-            video_id: video_id.to_owned(),
+            video_id: Arc::clone(video_id),
         },
     );
 }
@@ -160,8 +164,6 @@ fn delay_label(app: &App) -> String {
     }
 }
 
-fn centered(text: &str, style: Style) -> Line<'static> {
-    Line::from(text.to_owned())
-        .style(style)
-        .alignment(Alignment::Center)
+fn centered(text: &str, style: Style) -> Line<'_> {
+    Line::from(text).style(style).alignment(Alignment::Center)
 }

--- a/src/util/format.rs
+++ b/src/util/format.rs
@@ -1,14 +1,22 @@
 //! Display formatting helpers.
 
-/// Format a number of seconds as `M:SS` (or `H:MM:SS` past an hour).
-pub fn time(secs: f64) -> String {
+use std::fmt::Write as _;
+
+fn push_time(out: &mut String, secs: f64) {
     let total = secs.max(0.0) as u64;
     let (h, m, s) = (total / 3600, (total % 3600) / 60, total % 60);
     if h > 0 {
-        format!("{h}:{m:02}:{s:02}")
+        write!(out, "{h}:{m:02}:{s:02}").expect("writing to String cannot fail");
     } else {
-        format!("{m}:{s:02}")
+        write!(out, "{m}:{s:02}").expect("writing to String cannot fail");
     }
+}
+
+/// Format a number of seconds as `M:SS` (or `H:MM:SS` past an hour).
+pub fn time(secs: f64) -> String {
+    let mut out = String::with_capacity(8);
+    push_time(&mut out, secs);
+    out
 }
 
 /// Filled fraction (`0.0..=1.0`) of the seekbar gauge for `pos`/`dur` seconds. An absent or
@@ -28,11 +36,14 @@ pub fn seekbar_ratio(pos: Option<f64>, dur: Option<f64>) -> f64 {
 /// known (mpv reports position before length on a fresh load), matching the gauge's empty
 /// bar from [`seekbar_ratio`].
 pub fn seekbar_label(pos: Option<f64>, dur: Option<f64>) -> String {
-    let right = match dur {
-        Some(d) if d > 0.0 => time(d),
-        _ => "--:--".to_owned(),
-    };
-    format!("{} / {right}", time(pos.unwrap_or(0.0)))
+    let mut out = String::with_capacity(20);
+    push_time(&mut out, pos.unwrap_or(0.0));
+    out.push_str(" / ");
+    match dur {
+        Some(d) if d > 0.0 => push_time(&mut out, d),
+        _ => out.push_str("--:--"),
+    }
+    out
 }
 
 /// The nominal timeshift depth one full seekbar width represents on a live radio stream.
@@ -46,16 +57,23 @@ const RADIO_RENDER_WINDOW_SECS: f64 = 600.0;
 /// behind it sits and labels the gap (`-Ns`). With no position at all this falls back to
 /// the ordinary unknown-duration label so a connecting stream looks like today.
 pub fn radio_seekbar(pos: Option<f64>, behind: Option<f64>, synced: Option<bool>) -> (f64, String) {
-    let elapsed = time(pos.unwrap_or(0.0));
     match (pos, behind, synced) {
         (_, Some(b), Some(false)) => {
             // Coalesce a non-finite `behind` (mirrors the app's other ratio paths) so a NaN
             // can't reach the Gauge ratio and panic ratatui — here it was only safe by accident.
             let b = crate::util::finite_or(b, 0.0);
             let ratio = (1.0 - b / RADIO_RENDER_WINDOW_SECS).clamp(0.05, 1.0);
-            (ratio, format!("{elapsed} · -{}s", b as i64))
+            let mut label = String::with_capacity(24);
+            push_time(&mut label, pos.unwrap_or(0.0));
+            write!(label, " · -{}s", b as i64).expect("writing to String cannot fail");
+            (ratio, label)
         }
-        (_, Some(_), _) | (Some(_), None, _) => (1.0, format!("{elapsed} · LIVE")),
+        (_, Some(_), _) | (Some(_), None, _) => {
+            let mut label = String::with_capacity(16);
+            push_time(&mut label, pos.unwrap_or(0.0));
+            label.push_str(" · LIVE");
+            (1.0, label)
+        }
         (None, None, _) => (0.0, seekbar_label(pos, None)),
     }
 }

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -658,7 +658,11 @@ fn doctor_terminal_json_reports_capabilities_without_config_or_runtime_startup()
             .output()
             .expect("Konsole doctor terminal JSON")
     };
-    for (version, expected) in [("260799", "halfblocks"), ("260800", "sixel_versioned")] {
+    for (version, expected) in [
+        ("260399", "halfblocks"),
+        ("260400", "sixel_versioned"),
+        ("260401", "sixel_versioned"),
+    ] {
         let output = run_konsole_doctor(version);
         assert!(output.status.success(), "stderr: {}", stderr(&output));
         let json: serde_json::Value =

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -302,14 +302,49 @@ fn read_only_transfer_views_and_missing_tools_args_do_not_create_persistence_roo
             ][..],
             1,
         ),
+        (
+            "organize-consumed-apply-value",
+            &[
+                "transfer",
+                "organize",
+                "missing-session",
+                "--root",
+                "--apply",
+                "--dry-run",
+            ][..],
+            1,
+        ),
+        (
+            "review-filter-ignores-action-looking-suffix",
+            &[
+                "transfer",
+                "review",
+                "missing-session",
+                "--all",
+                "accept",
+                "1",
+            ][..],
+            1,
+        ),
         ("tools-use-missing", &["tools", "use"][..], 2),
         ("tools-reset-missing", &["tools", "reset"][..], 2),
         ("spotify-help", &["auth", "spotify", "--help"][..], 0),
+        (
+            "spotify-help-after-client-id",
+            &["auth", "spotify", "--client-id", "client", "--help"][..],
+            0,
+        ),
         (
             "spotify-client-id-missing",
             &["auth", "spotify", "--client-id"][..],
             2,
         ),
+        (
+            "doctor-privacy-help",
+            &["doctor", "privacy", "--help"][..],
+            0,
+        ),
+        ("update-help", &["update", "--help"][..], 0),
     ] {
         let root = isolated_root(name);
         let _ = std::fs::remove_dir_all(&root);
@@ -400,6 +435,63 @@ fn organize_dry_run_with_existing_state_preserves_config_and_session_tree() {
     assert_eq!(snapshot_tree(&data), data_before);
     assert!(!cache.exists(), "dry-run created cache state");
     assert!(!library_root.exists(), "dry-run created the target root");
+
+    let consumed_apply = isolated_command(
+        &root,
+        &[
+            "transfer",
+            "organize",
+            session_id,
+            "--template",
+            "--apply",
+            "--root",
+            &library_arg,
+            "--dry-run",
+        ],
+    )
+    .env("YTM_DATA_DIR", &data)
+    .output()
+    .expect("organize dry-run with a flag-looking template should run");
+    assert!(
+        consumed_apply.status.success(),
+        "stdout={}, stderr={}",
+        stdout(&consumed_apply),
+        stderr(&consumed_apply)
+    );
+    assert!(
+        stdout(&consumed_apply).contains("Template: --apply"),
+        "stdout={}",
+        stdout(&consumed_apply)
+    );
+    assert!(
+        !stdout(&consumed_apply).contains("Applied:"),
+        "flag-looking template was parsed as apply mode: stdout={}",
+        stdout(&consumed_apply)
+    );
+    assert_eq!(snapshot_tree(&config), config_before);
+    assert_eq!(snapshot_tree(&data), data_before);
+    assert!(!cache.exists(), "consumed --apply created cache state");
+    assert!(
+        !library_root.exists(),
+        "consumed --apply created the target root"
+    );
+
+    let review_filter = isolated_command(
+        &root,
+        &["transfer", "review", session_id, "--all", "accept", "1"],
+    )
+    .env("YTM_DATA_DIR", &data)
+    .output()
+    .expect("review filter with an action-looking suffix should run");
+    assert!(
+        review_filter.status.success(),
+        "stdout={}, stderr={}",
+        stdout(&review_filter),
+        stderr(&review_filter)
+    );
+    assert_eq!(snapshot_tree(&config), config_before);
+    assert_eq!(snapshot_tree(&data), data_before);
+    assert!(!cache.exists(), "review filter created cache state");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This draft integrates all currently open pull requests into one branch while preserving each PR's commit history:

- #69 — harden MPRIS controls and enable KDE 26.04+ Sixel probing
- #70 — type and fuzz CLI persistence capability classification
- #71 — reduce animation CPU and render allocation churn

## Integrated review fixes

The combined review found and fixed five issues in #71:

- use state- and geometry-matched controls for incremental render allocation comparisons
- mark generic rate-factor gating as not applicable for animation scenarios that do not exercise long-form cache admission, while keeping playback fail-closed
- scope the baseline render-harness overlay to the baseline Cargo build and restore bytes, mode, timestamps, and Git cleanliness even on failure
- prevent capped AnimTick events from arming an unrelated IME full draw, while preserving a previously armed reducer turn
- bypass the thread-local focal-placement cache when both focal animations are disabled

The one-line file-size ratchet entry for src/ui/anim/canvas.rs is re-blessed separately.

## Review result

- #69: no actionable correctness findings; playback-mode parity and KDE/Sixel guards were checked.
- #70: no actionable findings; typed classifier behavior remains equivalent and focused CLI tests pass.
- #71: the five issues above are fixed. Its original Quality gates failure was only the file-size ratchet; Linux and dependency-review checks passed.
- The three original PR heads were re-fetched immediately before publishing and were unchanged. No additional open PRs appeared.

## Validation

- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- canonical project gate: ~/.fable-harness/bin/run-gates .
- python3 scripts/tui-perf.py validate --scenarios scripts/tui-perf-scenarios.json (13 scenarios)
- python3 scripts/tui-perf.py self-test
- cargo test --example tui_render_perf (7 tests)
- isolated tmux TUI verification: startup rendering, animation toggle, 30-column layout, and clean Ctrl+Q exit; no playback started

Canonical gate log: /Users/ochi/.fable-harness/logs/gates/yututui-20260715-072605.log

## Measurement note

The render controls were corrected during review, so prior incremental-allocation comparisons should not be reused as evidence. A fresh paired performance run should be used for any quantitative claim based on those controls.

The original draft PRs remain open for human disposition; this draft does not close them.