### PR TITLE
Type playback recovery lifecycles

### DIFF
--- a/src/app/player_recovery.rs
+++ b/src/app/player_recovery.rs
@@ -16,8 +16,7 @@ pub struct SourceRecoveryPlan {
     expected_loaded_video_id: Option<String>,
     logical_generation: u64,
     origin_file_generation: u64,
-    episode_id: crate::player::recovery::RecoveryEpisodeId,
-    transport_epoch: crate::player::recovery::TransportIntentEpoch,
+    ticket: crate::player::recovery::RecoveryTicket,
     position_secs: f64,
     paused: bool,
 }
@@ -78,7 +77,7 @@ impl App {
         let expected_video_id = song.video_id.clone();
         let logical_generation = self.prefetch.source_logical_generation;
         let origin_file_generation = self.prefetch.source_file_generation;
-        let (episode_id, transport_epoch) = self.prefetch.source_recovery.begin_episode(
+        let ticket = self.prefetch.source_recovery.begin_ticket(
             error,
             logical_generation,
             origin_file_generation,
@@ -91,20 +90,17 @@ impl App {
             expected_loaded_video_id: self.prefetch.loaded_video_id.clone(),
             logical_generation,
             origin_file_generation,
-            episode_id,
-            transport_epoch,
+            ticket,
             position_secs,
             paused: self.playback.paused,
         };
-        let request = crate::player::recovery::LoadWithResume {
-            url: watch_url,
+        let request = crate::player::recovery::LoadWithResume::source_recovery(
+            watch_url,
             position_secs,
-            paused: plan.paused,
-            source_context: crate::player::MediaSourceContext::OnDemand,
-            episode_id,
-            transport_epoch,
-            force_ram_only: false,
-        };
+            plan.paused,
+            crate::player::MediaSourceContext::OnDemand,
+            ticket,
+        );
         Some(self.player_intent(
             "source_recovery",
             PlayerCmd::LoadWithResume(request),
@@ -121,11 +117,10 @@ impl App {
         ) && self.prefetch.loaded_video_id == plan.expected_loaded_video_id
             && self.prefetch.source_logical_generation == plan.logical_generation
             && self.prefetch.source_file_generation == plan.origin_file_generation
-            && self.prefetch.source_recovery.accepts_resolved_source(
-                plan.episode_id,
+            && self.prefetch.source_recovery.accepts_ticket(
+                plan.ticket,
                 plan.logical_generation,
                 plan.origin_file_generation,
-                plan.transport_epoch,
             )
     }
 
@@ -141,19 +136,14 @@ impl App {
             "loaded track changed before source-recovery commit"
         );
         assert!(
-            self.prefetch.source_recovery.accepts_resolved_source(
-                plan.episode_id,
+            self.prefetch.source_recovery.accepts_ticket(
+                plan.ticket,
                 plan.logical_generation,
                 plan.origin_file_generation,
-                plan.transport_epoch,
             ),
             "source-recovery correlation changed before commit"
         );
-        assert!(
-            self.prefetch
-                .source_recovery
-                .finish_episode(plan.episode_id)
-        );
+        assert!(self.prefetch.source_recovery.finish_ticket(plan.ticket));
         crate::player::diagnostics::source_recovery_outcome(
             crate::player::diagnostics::SourceRecoveryOutcome::AdmissionAccepted,
         );
@@ -189,7 +179,7 @@ impl App {
     pub(crate) fn reject_source_recovery(&mut self, plan: &SourceRecoveryPlan) {
         self.prefetch
             .source_recovery
-            .cancel_unadmitted_episode(plan.episode_id);
+            .cancel_unadmitted_ticket(plan.ticket);
         crate::player::diagnostics::source_recovery_outcome(
             crate::player::diagnostics::SourceRecoveryOutcome::AdmissionRejected,
         );

--- a/src/app/player_transport.rs
+++ b/src/app/player_transport.rs
@@ -88,7 +88,7 @@ impl App {
         );
 
         let mut cmds = self.recorder_teardown();
-        let mut restore = Vec::new();
+        let restore = Vec::new();
         let Some(song) = self.queue.current().cloned() else {
             cmds.push(Cmd::PlayerControl(PlayerControl::Restart { restore }));
             return cmds;
@@ -106,22 +106,20 @@ impl App {
             }
         };
 
-        self.prefetch.last_load_prefetched = false;
-        restore.push(PlayerCmd::LoadWithResume(
-            crate::player::recovery::LoadWithResume::emergency(
-                target,
-                position_secs,
-                paused,
-                crate::player::MediaSourceContext::from_live(song.is_radio_station()),
-            ),
-        ));
         let af = match self.settings.as_deref() {
             Some(st) => eq::build_af_string(&st.draft.eq_bands, st.draft.normalize),
             None => self.current_af(),
         };
-        if let Some(af) = af {
-            restore.push(PlayerCmd::SetAudioFilter(af));
-        }
+        let restore = crate::player::recovery::TransportRestorePlan::resume_ram_only_if_loaded(
+            self.prefetch.loaded_video_id.as_deref(),
+            &song.video_id,
+            target,
+            position_secs,
+            paused,
+            crate::player::MediaSourceContext::from_live(song.is_radio_station()),
+        )
+        .into_commands(af);
+        self.prefetch.last_load_prefetched = false;
         cmds.push(Cmd::PlayerControl(PlayerControl::Restart { restore }));
         cmds
     }
@@ -159,7 +157,7 @@ impl App {
         );
 
         let mut cmds = self.recorder_teardown();
-        let mut restore = Vec::new();
+        let restore = Vec::new();
         let Some(song) = self.queue.current().cloned() else {
             cmds.push(Cmd::PlayerControl(PlayerControl::Restart { restore }));
             return cmds;
@@ -185,21 +183,19 @@ impl App {
             }
         };
 
-        self.prefetch.last_load_prefetched = false;
-        restore.push(PlayerCmd::load(
-            target,
-            crate::player::MediaSourceContext::from_live(song.is_radio_station()),
-        ));
         let af = match self.settings.as_deref() {
             Some(st) => eq::build_af_string(&st.draft.eq_bands, st.draft.normalize),
             None => self.current_af(),
         };
-        if let Some(af) = af {
-            restore.push(PlayerCmd::SetAudioFilter(af));
-        }
-        if was_paused {
-            restore.push(PlayerCmd::CyclePause);
-        }
+        let restore = crate::player::recovery::TransportRestorePlan::reload_if_loaded(
+            self.prefetch.loaded_video_id.as_deref(),
+            &song.video_id,
+            target,
+            was_paused,
+            crate::player::MediaSourceContext::from_live(song.is_radio_station()),
+        )
+        .into_commands(af);
+        self.prefetch.last_load_prefetched = false;
         cmds.push(Cmd::PlayerControl(PlayerControl::Restart { restore }));
         cmds
     }

--- a/src/app/tests/transport_recovery.rs
+++ b/src/app/tests/transport_recovery.rs
@@ -83,6 +83,27 @@ fn transport_recovery_without_a_current_track_restarts_with_an_empty_restore_bat
 }
 
 #[test]
+fn stopped_current_item_is_not_resurrected_by_a_late_transport_close() {
+    let mut app = app_playing(1, 0);
+    app.commit_playback_cleared();
+    assert_eq!(
+        current(&app),
+        "id0",
+        "stop deliberately preserves the queue"
+    );
+    assert_eq!(app.prefetch.loaded_video_id, None);
+
+    let cmds = app.update(PlayerMsg::TransportClosed("late close".to_owned()));
+
+    assert!(matches!(
+        cmds.as_slice(),
+        [Cmd::PlayerControl(PlayerControl::Restart { restore })] if restore.is_empty()
+    ));
+    assert_no_load(&cmds);
+    assert_eq!(app.prefetch.loaded_video_id, None);
+}
+
+#[test]
 fn cache_emergency_preserves_position_once_and_requests_a_forced_ram_resume() {
     let mut app = app_playing(1, 0);
     app.playback.paused = true;
@@ -111,7 +132,7 @@ fn cache_emergency_preserves_position_once_and_requests_a_forced_ram_resume() {
         .expect("cache emergency restart must carry a correlated resume");
     assert!((request.position_secs - 3_600.25).abs() < f64::EPSILON);
     assert!(request.paused);
-    assert!(request.force_ram_only);
+    assert!(request.forces_ram_only());
     assert_eq!(
         request.source_context,
         crate::player::MediaSourceContext::OnDemand
@@ -154,7 +175,7 @@ fn cache_emergency_cannot_overwrite_a_newer_same_generation_seek_or_pause() {
         .expect("cache emergency restart must retain the newest owner transport");
     assert!((request.position_secs - 3_630.0).abs() < f64::EPSILON);
     assert!(request.paused);
-    assert!(request.force_ram_only);
+    assert!(request.forces_ram_only());
     assert_eq!(app.playback.time_pos, Some(3_630.0));
     assert!(app.playback.paused);
     assert_eq!(app.playback.position_epoch, admitted_epoch + 1);
@@ -186,7 +207,7 @@ fn replacement_cache_emergency_replays_new_item_ram_only_without_old_position() 
     assert_eq!(current(&app), "id1");
     assert_eq!(request.position_secs, 0.0);
     assert!(!request.paused);
-    assert!(request.force_ram_only);
+    assert!(request.forces_ram_only());
     assert!(request.url.contains("id1"), "must replay the new item");
 }
 

--- a/src/daemon/engine.rs
+++ b/src/daemon/engine.rs
@@ -44,7 +44,9 @@ use delivery::{record_player_delivery, require_player_delivery};
 use engine_session::data_dir;
 pub(super) use gui_search::RequesterKey;
 use gui_search::{GuiSearchAdmission, GuiSearchIndex};
+#[cfg(test)]
 use transport::TransportRecovery;
+use transport::TransportRecoveryState;
 
 // Autoplay/streaming policy + volume bounds are single-sourced with the TUI App in
 // `crate::playback_policy`, so a threshold can't drift between the two playback owners.
@@ -127,15 +129,12 @@ pub struct DaemonEngine {
     signals: Signals,
     station: StationStore,
     loaded_video_id: Option<String>,
-    /// A dead transport's current-track identity and pause bit. The next explicit load
-    /// consumes it without duplicating history/signals and restores the pause state.
-    transport_recovery: Option<TransportRecovery>,
+    /// One explicit lifecycle owns both the automatic-restart gate and any current-track replay
+    /// payload, so contradictory armed/pending combinations cannot be represented.
+    transport_recovery: TransportRecoveryState,
     /// Monotonic identity for scheduled transport retries. Stale retry events must never
     /// restart a newer player lifetime.
     transport_recovery_generation: u64,
-    /// One-shot crash-loop gate. Only a normal (non-recovery) load rearms it; merely
-    /// recreating mpv or receiving late telemetry from the dead actor does not.
-    transport_auto_recovery_armed: bool,
     /// Shared one-shot arbiter for same-item stale-source replacement. Its logical generation
     /// advances only on ordinary loads; a recovery replacement advances the file generation
     /// without rearming the item latch.
@@ -331,9 +330,8 @@ impl DaemonEngine {
             signals,
             station,
             loaded_video_id: None,
-            transport_recovery: None,
+            transport_recovery: TransportRecoveryState::Armed,
             transport_recovery_generation: 0,
-            transport_auto_recovery_armed: true,
             source_recovery: crate::player::recovery::RecoveryPlanner::default(),
             source_logical_generation: 0,
             source_file_generation: 0,
@@ -395,6 +393,18 @@ impl DaemonEngine {
         self.loaded_video_id = Some(video_id.to_owned());
         self.playback.time_pos = Some(position);
         self.playback.duration = Some(duration);
+        rx
+    }
+
+    #[cfg(test)]
+    pub(crate) fn queue_transport_recovery_parity_player(
+        &mut self,
+    ) -> tokio::sync::mpsc::Receiver<PlayerCmd> {
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        self.test_player_starts.push_back(PlayerRuntime {
+            handle: PlayerHandle::test_handle(tx),
+            _guard: None,
+        });
         rx
     }
 
@@ -2510,8 +2520,7 @@ impl DaemonEngine {
         }
         self.reset_idle_playback();
         self.loaded_video_id = None;
-        self.transport_recovery = None;
-        self.transport_auto_recovery_armed = true;
+        self.transport_recovery.rearm_after_normal_load_or_stop();
     }
 
     fn reset_idle_playback(&mut self) {

--- a/src/daemon/engine/tests.rs
+++ b/src/daemon/engine/tests.rs
@@ -42,9 +42,8 @@ pub(in crate::daemon) fn engine_with_queue(ids: &[&str]) -> DaemonEngine {
         signals: Signals::default(),
         station: StationStore::default(),
         loaded_video_id: None,
-        transport_recovery: None,
+        transport_recovery: TransportRecoveryState::Armed,
         transport_recovery_generation: 0,
-        transport_auto_recovery_armed: true,
         source_recovery: crate::player::recovery::RecoveryPlanner::default(),
         source_logical_generation: 0,
         source_file_generation: 0,
@@ -992,22 +991,22 @@ async fn remote_commands_cover_no_load_branches_and_gui_search_dispatch() {
     assert!(response.ok);
     assert!(engine.config.gemini_api_key.is_none());
 
-    engine.transport_recovery = Some(TransportRecovery {
-        video_id: "queued-before-quit".to_owned(),
-        paused: false,
-        position_secs: None,
-        force_ram_only: false,
-        generation: 9,
-        attempts: 0,
-    });
-    engine.transport_auto_recovery_armed = true;
+    let _player_rx = install_accepting_player(&mut engine);
+    engine.loaded_video_id = Some("queued-before-quit".to_owned());
+    let generation = engine
+        .handle_transport_closed("queued before quit".to_owned())
+        .expect("loaded transport close should schedule recovery");
+    assert!(matches!(
+        &engine.transport_recovery,
+        TransportRecoveryState::Recovering(recovery)
+            if recovery.generation == generation && recovery.attempts == 0
+    ));
     let (response, shutdown, effects) = engine.handle_remote(RemoteCommand::Quit).await;
     assert!(response.ok);
     assert!(shutdown);
     assert!(effects.is_empty());
     assert!(engine.loaded_video_id.is_none());
-    assert!(engine.transport_recovery.is_none());
-    assert!(!engine.transport_auto_recovery_armed);
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Shutdown);
 }
 
 #[tokio::test]
@@ -1088,21 +1087,19 @@ async fn media_commands_ignore_invalid_or_disabled_operations() {
     assert!(engine.playback.paused);
     assert_eq!(engine.playback.position_epoch, epoch);
 
-    engine.transport_recovery = Some(TransportRecovery {
-        video_id: "queued-before-media-quit".to_owned(),
-        paused: false,
-        position_secs: None,
-        force_ram_only: false,
-        generation: 11,
-        attempts: 0,
-    });
-    engine.transport_auto_recovery_armed = true;
+    let generation = engine
+        .handle_transport_closed("queued before media quit".to_owned())
+        .expect("loaded transport close should schedule recovery");
+    assert!(matches!(
+        &engine.transport_recovery,
+        TransportRecoveryState::Recovering(recovery)
+            if recovery.generation == generation && recovery.attempts == 0
+    ));
     let (shutdown, effects) = engine.handle_media(crate::media::MediaCommand::Quit).await;
     assert!(shutdown);
     assert!(effects.is_empty());
     assert!(engine.loaded_video_id.is_none());
-    assert!(engine.transport_recovery.is_none());
-    assert!(!engine.transport_auto_recovery_armed);
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Shutdown);
 }
 
 #[tokio::test]

--- a/src/daemon/engine/transport.rs
+++ b/src/daemon/engine/transport.rs
@@ -10,8 +10,66 @@ pub(super) struct TransportRecovery {
     pub(super) attempts: u8,
 }
 
+/// Owner-loop lifecycle for automatic player replacement.
+///
+/// The former `Option<TransportRecovery>` plus `transport_auto_recovery_armed` boolean allowed
+/// tests and future call sites to construct contradictory combinations.  Keeping the payload in
+/// the state which owns it makes every gate transition exhaustive and keeps shutdown absorbing.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum TransportRecoveryState {
+    Armed,
+    Recovering(TransportRecovery),
+    Disarmed,
+    Shutdown,
+}
+
+impl TransportRecoveryState {
+    /// Consume the one-shot arm when a loaded item exists. A close from a replacement lifetime
+    /// retires any pending payload and remains disarmed; shutdown is permanently absorbing.
+    fn begin(&mut self, recovery: Option<TransportRecovery>) -> bool {
+        let previous = std::mem::replace(self, Self::Disarmed);
+        let (next, started) = match previous {
+            Self::Armed => match recovery {
+                Some(recovery) => (Self::Recovering(recovery), true),
+                None => (Self::Armed, false),
+            },
+            Self::Recovering(_) => (Self::Disarmed, false),
+            Self::Disarmed => (Self::Disarmed, false),
+            Self::Shutdown => (Self::Shutdown, false),
+        };
+        *self = next;
+        started
+    }
+
+    fn finish_recovery(&mut self) {
+        *self = match self {
+            Self::Armed => Self::Armed,
+            Self::Recovering(_) => Self::Disarmed,
+            Self::Disarmed => Self::Disarmed,
+            Self::Shutdown => Self::Shutdown,
+        };
+    }
+
+    pub(super) fn rearm_after_normal_load_or_stop(&mut self) {
+        *self = match self {
+            Self::Armed | Self::Recovering(_) | Self::Disarmed => Self::Armed,
+            Self::Shutdown => Self::Shutdown,
+        };
+    }
+
+    fn suppress_for_shutdown(&mut self) {
+        *self = Self::Shutdown;
+    }
+}
+
 const TRANSPORT_RECOVERY_MAX_ATTEMPTS: u8 = 2;
 const TRANSPORT_RECOVERY_RETRY_DELAY: Duration = Duration::from_millis(75);
+
+#[derive(Clone, Copy)]
+enum LoadCurrentIntent {
+    Ordinary,
+    TransportRecovery,
+}
 
 impl DaemonEngine {
     fn begin_source_logical_item(&mut self) {
@@ -47,39 +105,36 @@ impl DaemonEngine {
         };
         let logical_generation = self.source_logical_generation;
         let origin_file_generation = self.source_file_generation;
-        let Some((episode_id, transport_epoch)) =
+        let Some(ticket) =
             self.source_recovery
-                .begin_episode(error, logical_generation, origin_file_generation)
+                .begin_ticket(error, logical_generation, origin_file_generation)
         else {
             return false;
         };
         crate::player::diagnostics::source_recovery_attempt(failure.id());
-        let request = crate::player::recovery::LoadWithResume {
+        let request = crate::player::recovery::LoadWithResume::source_recovery(
             url,
             position_secs,
-            paused: self.playback.paused,
-            source_context: crate::player::MediaSourceContext::OnDemand,
-            episode_id,
-            transport_epoch,
-            force_ram_only: false,
-        };
+            self.playback.paused,
+            crate::player::MediaSourceContext::OnDemand,
+            ticket,
+        );
         if let Err(delivery) =
             self.send_active_player_command("source_recovery", PlayerCmd::LoadWithResume(request))
         {
-            self.source_recovery.cancel_unadmitted_episode(episode_id);
+            self.source_recovery.cancel_unadmitted_ticket(ticket);
             crate::player::diagnostics::source_recovery_outcome(
                 crate::player::diagnostics::SourceRecoveryOutcome::AdmissionRejected,
             );
             self.last_error = Some(delivery.to_string());
             return false;
         }
-        assert!(self.source_recovery.accepts_resolved_source(
-            episode_id,
+        assert!(self.source_recovery.accepts_ticket(
+            ticket,
             logical_generation,
             origin_file_generation,
-            transport_epoch,
         ));
-        assert!(self.source_recovery.finish_episode(episode_id));
+        assert!(self.source_recovery.finish_ticket(ticket));
         crate::player::diagnostics::source_recovery_outcome(
             crate::player::diagnostics::SourceRecoveryOutcome::AdmissionAccepted,
         );
@@ -95,8 +150,7 @@ impl DaemonEngine {
     /// External signal handling calls this from the owner loop after the out-of-band latch wins,
     /// so a TransportClosed already waiting in the bounded event lane cannot recreate mpv.
     pub(crate) fn suppress_transport_recovery_for_shutdown(&mut self) {
-        self.transport_recovery = None;
-        self.transport_auto_recovery_armed = false;
+        self.transport_recovery.suppress_for_shutdown();
         if let Some(player) = self.player.take() {
             let PlayerRuntime { handle, _guard } = player;
             drop(handle);
@@ -126,26 +180,23 @@ impl DaemonEngine {
         let loaded_video_id = self.loaded_video_id.take();
         self.transport_recovery_generation = self.transport_recovery_generation.wrapping_add(1);
         let generation = self.transport_recovery_generation;
-        let should_recover = loaded_video_id.is_some() && self.transport_auto_recovery_armed;
-        self.transport_recovery = if should_recover {
-            self.transport_auto_recovery_armed = false;
-            loaded_video_id.map(|video_id| TransportRecovery {
+        let had_loaded_video = loaded_video_id.is_some();
+        let should_recover = self
+            .transport_recovery
+            .begin(loaded_video_id.map(|video_id| TransportRecovery {
                 video_id,
                 paused,
                 position_secs: None,
                 force_ram_only: false,
                 generation,
                 attempts: 0,
-            })
-        } else {
-            if loaded_video_id.is_some() && !self.transport_auto_recovery_armed {
-                tracing::error!(
-                    generation,
-                    "suppressed repeated daemon player restart before playback became stable"
-                );
-            }
-            None
-        };
+            }));
+        if had_loaded_video && !should_recover {
+            tracing::error!(
+                generation,
+                "suppressed repeated daemon player restart before playback became stable"
+            );
+        }
         self.playback.time_pos = None;
         self.playback.time_pos_at = None;
         self.playback.duration = None;
@@ -196,20 +247,16 @@ impl DaemonEngine {
         let loaded_video_id = self.loaded_video_id.take();
         self.transport_recovery_generation = self.transport_recovery_generation.wrapping_add(1);
         let generation = self.transport_recovery_generation;
-        let should_recover = loaded_video_id.is_some() && self.transport_auto_recovery_armed;
-        self.transport_recovery = if should_recover {
-            self.transport_auto_recovery_armed = false;
-            loaded_video_id.map(|video_id| TransportRecovery {
+        let should_recover = self
+            .transport_recovery
+            .begin(loaded_video_id.map(|video_id| TransportRecovery {
                 video_id,
                 paused,
                 position_secs,
                 force_ram_only: true,
                 generation,
                 attempts: 0,
-            })
-        } else {
-            None
-        };
+            }));
         self.playback.time_pos = position_secs;
         self.playback.time_pos_at = None;
         self.bump_position_epoch(PositionEpochReason::TransportRecovery);
@@ -228,19 +275,22 @@ impl DaemonEngine {
         &mut self,
         generation: u64,
     ) -> Vec<EngineEffect> {
-        let attempt = match self.transport_recovery.as_mut() {
-            Some(recovery)
+        let attempt = match &mut self.transport_recovery {
+            TransportRecoveryState::Recovering(recovery)
                 if recovery.generation == generation
                     && recovery.attempts < TRANSPORT_RECOVERY_MAX_ATTEMPTS =>
             {
                 recovery.attempts += 1;
                 recovery.attempts
             }
-            _ => return Vec::new(),
+            TransportRecoveryState::Recovering(_)
+            | TransportRecoveryState::Armed
+            | TransportRecoveryState::Disarmed
+            | TransportRecoveryState::Shutdown => return Vec::new(),
         };
 
         let result = match self.ensure_player().await {
-            Ok(()) => self.load_current_loaded(),
+            Ok(()) => self.load_current_loaded_for(LoadCurrentIntent::TransportRecovery),
             Err(error) => Err(error),
         };
         if result.is_ok() {
@@ -251,9 +301,15 @@ impl DaemonEngine {
         let error = result.expect_err("failed recovery result was checked");
         let detail = sanitize::sanitize_error_text(error.to_string());
         self.last_error = Some(format!("mpv transport recovery failed: {detail}"));
-        let retry = self.transport_recovery.as_ref().is_some_and(|recovery| {
-            recovery.generation == generation && recovery.attempts < TRANSPORT_RECOVERY_MAX_ATTEMPTS
-        });
+        let retry = match &self.transport_recovery {
+            TransportRecoveryState::Recovering(recovery) => {
+                recovery.generation == generation
+                    && recovery.attempts < TRANSPORT_RECOVERY_MAX_ATTEMPTS
+            }
+            TransportRecoveryState::Armed
+            | TransportRecoveryState::Disarmed
+            | TransportRecoveryState::Shutdown => false,
+        };
         if retry {
             tracing::warn!(
                 generation,
@@ -277,9 +333,14 @@ impl DaemonEngine {
         }
     }
 
-    /// Load the queue cursor into an already-created player. A same-track transport
-    /// recovery restores pause after `loadfile` and deliberately skips history/signals.
+    /// Admit an ordinary queue load into an already-created player and rearm transport recovery.
+    /// Automatic replacement uses the typed recovery intent below so it cannot replay a
+    /// different queue item or duplicate history/signals.
     pub(super) fn load_current_loaded(&mut self) -> Result<(), EngineError> {
+        self.load_current_loaded_for(LoadCurrentIntent::Ordinary)
+    }
+
+    fn load_current_loaded_for(&mut self, intent: LoadCurrentIntent) -> Result<(), EngineError> {
         let Some(song) = self.queue.current().cloned() else {
             self.stop_playback();
             return Ok(());
@@ -300,64 +361,82 @@ impl DaemonEngine {
             }
         };
 
-        let recovery = self
-            .transport_recovery
-            .as_ref()
-            .filter(|recovery| recovery.video_id == song.video_id)
-            .cloned();
+        let recovery = match (&self.transport_recovery, intent) {
+            (
+                TransportRecoveryState::Recovering(recovery),
+                LoadCurrentIntent::TransportRecovery,
+            ) => Some(recovery.clone()),
+            (
+                TransportRecoveryState::Armed
+                | TransportRecoveryState::Disarmed
+                | TransportRecoveryState::Shutdown,
+                LoadCurrentIntent::TransportRecovery,
+            )
+            | (_, LoadCurrentIntent::Ordinary) => None,
+        };
         let recovery_paused = recovery.as_ref().map(|recovery| recovery.paused);
         let recovery_position = recovery
             .as_ref()
             .and_then(|recovery| recovery.position_secs);
-        let is_transport_recovery = recovery.is_some();
-        let force_ram_only = recovery
-            .as_ref()
-            .is_some_and(|recovery| recovery.force_ram_only);
-        let mut commands = if force_ram_only {
-            vec![PlayerCmd::LoadWithResume(
-                crate::player::recovery::LoadWithResume::emergency(
-                    target,
-                    recovery_position.unwrap_or(0.0),
-                    recovery_paused.unwrap_or(true),
-                    crate::player::MediaSourceContext::from_live(song.is_radio_station()),
-                ),
-            )]
-        } else {
-            vec![PlayerCmd::load(
-                target,
-                crate::player::MediaSourceContext::from_live(song.is_radio_station()),
-            )]
+        let planned_loaded_video_id = match intent {
+            LoadCurrentIntent::TransportRecovery => {
+                recovery.as_ref().map(|recovery| recovery.video_id.as_str())
+            }
+            LoadCurrentIntent::Ordinary => match &self.transport_recovery {
+                TransportRecoveryState::Shutdown => None,
+                TransportRecoveryState::Armed
+                | TransportRecoveryState::Recovering(_)
+                | TransportRecoveryState::Disarmed => Some(song.video_id.as_str()),
+            },
         };
-        if recovery_paused == Some(true)
-            && !recovery
-                .as_ref()
-                .is_some_and(|recovery| recovery.force_ram_only)
+        let source_context = crate::player::MediaSourceContext::from_live(song.is_radio_station());
+        let restore = if recovery
+            .as_ref()
+            .is_some_and(|recovery| recovery.force_ram_only)
         {
-            commands.push(PlayerCmd::CyclePause);
-        }
-        self.send_active_player_batch("load_current", commands)?;
+            crate::player::recovery::TransportRestorePlan::resume_ram_only_if_loaded(
+                planned_loaded_video_id,
+                &song.video_id,
+                target,
+                recovery_position.unwrap_or(0.0),
+                recovery_paused.unwrap_or(true),
+                source_context,
+            )
+        } else {
+            crate::player::recovery::TransportRestorePlan::reload_if_loaded(
+                planned_loaded_video_id,
+                &song.video_id,
+                target,
+                recovery_paused.unwrap_or(false),
+                source_context,
+            )
+        };
+        self.send_active_player_batch("load_current", restore.into_commands(None))?;
 
         self.playback.paused = recovery_paused.unwrap_or(false);
         self.playback.time_pos = recovery_position;
         self.playback.time_pos_at = None;
-        if !is_transport_recovery {
+        if matches!(intent, LoadCurrentIntent::Ordinary) {
             self.bump_position_epoch(PositionEpochReason::TrackRestart);
         }
         self.playback.duration = None;
         self.loaded_video_id = Some(song.video_id.clone());
-        self.transport_recovery = None;
 
-        if recovery_paused.is_none() {
-            self.begin_source_logical_item();
-            self.transport_auto_recovery_armed = true;
-            self.library.record_play(&song);
-            self.save_library("daemon library history");
-            // History changed: a subscribed GUI's paged library view is stale.
-            self.library_invalidations = self.library_invalidations.wrapping_add(1);
-        } else {
-            self.source_file_generation = self.source_file_generation.wrapping_add(1);
-            self.source_recovery.supersede_transport();
-            self.last_error = None;
+        match intent {
+            LoadCurrentIntent::Ordinary => {
+                self.transport_recovery.rearm_after_normal_load_or_stop();
+                self.begin_source_logical_item();
+                self.library.record_play(&song);
+                self.save_library("daemon library history");
+                // History changed: a subscribed GUI's paged library view is stale.
+                self.library_invalidations = self.library_invalidations.wrapping_add(1);
+            }
+            LoadCurrentIntent::TransportRecovery => {
+                self.transport_recovery.finish_recovery();
+                self.source_file_generation = self.source_file_generation.wrapping_add(1);
+                self.source_recovery.supersede_transport();
+                self.last_error = None;
+            }
         }
         self.save_session();
         Ok(())

--- a/src/daemon/engine/transport_tests.rs
+++ b/src/daemon/engine/transport_tests.rs
@@ -180,8 +180,7 @@ async fn transport_terminal_automatically_restarts_and_replays_without_duplicate
         "pause intent must survive transport loss"
     );
     assert_eq!(engine.playback.position_epoch, epoch + 1);
-    assert_eq!(engine.transport_recovery, None);
-    assert!(!engine.transport_auto_recovery_armed);
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Disarmed);
     assert!(
         !engine
             .last_error
@@ -193,6 +192,104 @@ async fn transport_terminal_automatically_restarts_and_replays_without_duplicate
     assert_eq!(engine.library.history.len(), history_len);
     assert_eq!(engine.signals.play_count("seed"), play_count);
     assert_eq!(engine.signals.artist_weight("artist"), artist_weight);
+}
+
+#[tokio::test]
+async fn normal_load_rearms_transport_recovery_after_a_stable_replacement() {
+    let mut engine = super::tests::engine_with_queue(&["seed"]);
+    engine.loaded_video_id = Some("seed".to_owned());
+    engine.playback.paused = false;
+    let _old_rx = install_test_player(&mut engine);
+    let mut first_replacement_rx = queue_test_player_start(&mut engine);
+
+    assert!(
+        engine
+            .handle_player_event(PlayerEvent::TransportClosed("first".to_owned()))
+            .await
+            .is_empty()
+    );
+    assert_setup_then_load(&mut first_replacement_rx, false).await;
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Disarmed);
+
+    engine
+        .load_current_loaded()
+        .expect("ordinary load should be admitted");
+    assert!(matches!(
+        recv_player_command(&mut first_replacement_rx).await,
+        PlayerCmd::Load(_)
+    ));
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Armed);
+
+    let mut second_replacement_rx = queue_test_player_start(&mut engine);
+    assert!(
+        engine
+            .handle_player_event(PlayerEvent::TransportClosed("second".to_owned()))
+            .await
+            .is_empty()
+    );
+    assert_setup_then_load(&mut second_replacement_rx, false).await;
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Disarmed);
+}
+
+#[tokio::test]
+async fn ordinary_load_supersedes_an_automatic_recovery_for_a_different_item() {
+    let mut engine = super::tests::engine_with_queue(&["old", "new"]);
+    engine.loaded_video_id = Some("old".to_owned());
+    let old_rx = install_test_player(&mut engine);
+    let mut replacement_rx = queue_test_player_start(&mut engine);
+
+    let generation = engine
+        .handle_transport_closed("old transport".to_owned())
+        .expect("loaded transport close should schedule recovery");
+    assert!(old_rx.is_closed());
+    assert_eq!(
+        engine.queue.next(false).map(|song| song.video_id.as_str()),
+        Some("new")
+    );
+
+    let effects = engine.attempt_transport_recovery(generation).await;
+    assert!(matches!(
+        effects.as_slice(),
+        [EngineEffect::TransportRecoveryRetry {
+            generation: retry_generation,
+            ..
+        }] if *retry_generation == generation
+    ));
+    assert_eq!(engine.loaded_video_id, None);
+    assert!(matches!(
+        &engine.transport_recovery,
+        TransportRecoveryState::Recovering(recovery)
+            if recovery.video_id == "old" && recovery.attempts == 1
+    ));
+    assert!(matches!(
+        recv_player_command(&mut replacement_rx).await,
+        PlayerCmd::SetVolume(50)
+    ));
+    assert!(matches!(
+        recv_player_command(&mut replacement_rx).await,
+        PlayerCmd::SetAudioFilter(_)
+    ));
+    assert!(
+        replacement_rx.try_recv().is_err(),
+        "automatic recovery must not load a different queue item"
+    );
+
+    engine
+        .load_current_loaded()
+        .expect("ordinary load should supersede stale recovery");
+    assert!(matches!(
+        recv_player_command(&mut replacement_rx).await,
+        PlayerCmd::Load(_)
+    ));
+    assert_eq!(engine.loaded_video_id.as_deref(), Some("new"));
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Armed);
+    assert!(
+        engine
+            .attempt_transport_recovery(generation)
+            .await
+            .is_empty()
+    );
+    assert!(replacement_rx.try_recv().is_err());
 }
 
 #[tokio::test]
@@ -233,7 +330,7 @@ async fn cache_emergency_restarts_once_at_exact_position_forced_to_ram_only() {
     };
     assert!((request.position_secs - 3_600.25).abs() < f64::EPSILON);
     assert!(request.paused);
-    assert!(request.force_ram_only);
+    assert!(request.forces_ram_only());
     assert_eq!(
         request.source_context,
         crate::player::MediaSourceContext::OnDemand
@@ -285,7 +382,7 @@ async fn cache_emergency_cannot_overwrite_newer_same_generation_daemon_transport
     };
     assert_eq!(request.position_secs, 3_630.0);
     assert!(request.paused);
-    assert!(request.force_ram_only);
+    assert!(request.forces_ram_only());
     assert!(replacement_rx.try_recv().is_err());
 }
 
@@ -343,6 +440,23 @@ async fn cache_emergency_freeze_bumps_epoch_even_when_recovery_delivery_exhausts
         epoch + 1,
         "failed recovery attempts must not defer or duplicate the freeze epoch"
     );
+    assert!(matches!(
+        &engine.transport_recovery,
+        TransportRecoveryState::Recovering(recovery)
+            if recovery.generation == generation && recovery.attempts == 2
+    ));
+
+    let exhausted = engine.transport_recovery.clone();
+    assert!(
+        engine
+            .attempt_transport_recovery(generation)
+            .await
+            .is_empty()
+    );
+    assert_eq!(
+        engine.transport_recovery, exhausted,
+        "an exhausted recovery generation must be inert"
+    );
 }
 
 #[tokio::test]
@@ -396,7 +510,7 @@ async fn replacement_cache_emergency_replays_new_item_without_old_position() {
     };
     assert_eq!(request.position_secs, 0.0);
     assert!(!request.paused);
-    assert!(request.force_ram_only);
+    assert!(request.forces_ram_only());
     assert!(request.url.contains("new"), "must replay the new item");
 }
 
@@ -428,7 +542,7 @@ async fn stop_cache_emergency_retires_actor_without_replaying_queue_current() {
     assert!(effects.is_empty());
     assert!(old_rx.is_closed());
     assert!(engine.player.is_none());
-    assert!(engine.transport_recovery.is_none());
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Armed);
     assert_eq!(engine.loaded_video_id, None);
 }
 
@@ -448,12 +562,44 @@ async fn shutdown_suppression_prevents_a_queued_transport_terminal_from_replacin
     assert!(effects.is_empty());
     assert!(old_rx.is_closed());
     assert!(engine.player.is_none());
-    assert!(engine.transport_recovery.is_none());
-    assert!(!engine.transport_auto_recovery_armed);
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Shutdown);
     assert_eq!(
         engine.test_player_starts.len(),
         1,
         "the queued replacement must remain unused during shutdown"
+    );
+}
+
+#[tokio::test]
+async fn shutdown_suppression_cancels_an_already_scheduled_transport_retry() {
+    let mut engine = super::tests::engine_with_queue(&["seed"]);
+    engine.loaded_video_id = Some("seed".to_owned());
+    let old_rx = install_test_player(&mut engine);
+    let _unused_replacement_rx = queue_test_player_start(&mut engine);
+
+    let generation = engine
+        .handle_transport_closed("scheduled before shutdown".to_owned())
+        .expect("loaded transport close should schedule recovery");
+    assert!(old_rx.is_closed());
+    assert!(matches!(
+        &engine.transport_recovery,
+        TransportRecoveryState::Recovering(recovery)
+            if recovery.generation == generation && recovery.attempts == 0
+    ));
+
+    engine.suppress_transport_recovery_for_shutdown();
+    assert!(
+        engine
+            .attempt_transport_recovery(generation)
+            .await
+            .is_empty()
+    );
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Shutdown);
+    assert!(engine.player.is_none());
+    assert_eq!(
+        engine.test_player_starts.len(),
+        1,
+        "shutdown must not consume the queued replacement"
     );
 }
 
@@ -472,6 +618,56 @@ async fn transport_recovery_keeps_playing_state_without_pause_toggle() {
     assert!(effects.is_empty());
     assert_setup_then_load(&mut replacement_rx, false).await;
     assert!(!engine.playback.paused);
+}
+
+#[tokio::test]
+async fn closed_replacement_startup_is_retried_once_then_becomes_inert() {
+    let mut engine = super::tests::engine_with_queue(&["seed"]);
+    engine.loaded_video_id = Some("seed".to_owned());
+    let _old_rx = install_test_player(&mut engine);
+
+    let (first_closed, first_rx) = test_player(1);
+    drop(first_rx);
+    engine.test_player_starts.push_back(first_closed);
+    let effects = engine
+        .handle_player_event(PlayerEvent::TransportClosed("first".to_owned()))
+        .await;
+    let generation = match effects.as_slice() {
+        [EngineEffect::TransportRecoveryRetry { generation, .. }] => *generation,
+        _ => panic!("closed replacement setup must schedule exactly one retry"),
+    };
+    assert!(engine.player.is_none());
+    assert!(matches!(
+        &engine.transport_recovery,
+        TransportRecoveryState::Recovering(recovery)
+            if recovery.generation == generation && recovery.attempts == 1
+    ));
+
+    let (second_closed, second_rx) = test_player(1);
+    drop(second_rx);
+    engine.test_player_starts.push_back(second_closed);
+    assert!(
+        engine
+            .attempt_transport_recovery(generation)
+            .await
+            .is_empty()
+    );
+    assert!(engine.player.is_none());
+    assert!(matches!(
+        &engine.transport_recovery,
+        TransportRecoveryState::Recovering(recovery)
+            if recovery.generation == generation && recovery.attempts == 2
+    ));
+
+    let exhausted = engine.transport_recovery.clone();
+    assert!(
+        engine
+            .attempt_transport_recovery(generation)
+            .await
+            .is_empty()
+    );
+    assert_eq!(engine.transport_recovery, exhausted);
+    assert!(engine.player.is_none());
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -514,7 +710,7 @@ async fn saturated_recovery_batch_is_retried_atomically_after_capacity_returns()
     assert_eq!(engine.playback.position_epoch, epoch + 1);
     assert_eq!(
         engine.transport_recovery,
-        Some(TransportRecovery {
+        TransportRecoveryState::Recovering(TransportRecovery {
             video_id: "seed".to_owned(),
             paused: true,
             position_secs: None,
@@ -545,8 +741,71 @@ async fn saturated_recovery_batch_is_retried_atomically_after_capacity_returns()
         PlayerCmd::CyclePause
     ));
     assert_eq!(engine.loaded_video_id.as_deref(), Some("seed"));
-    assert_eq!(engine.transport_recovery, None);
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Disarmed);
     assert_eq!(engine.playback.position_epoch, epoch + 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn replacement_close_while_retry_is_pending_disarms_the_recovery_generation() {
+    let mut engine = super::tests::engine_with_queue(&["seed"]);
+    engine.loaded_video_id = Some("seed".to_owned());
+    engine.playback.paused = true;
+    let _old_rx = install_test_player(&mut engine);
+
+    let (tx, replacement_rx) = tokio::sync::mpsc::channel(1);
+    let handle = PlayerHandle::test_handle(tx);
+    assert!(handle.send(PlayerCmd::Stop).is_ok(), "fill actor lane");
+    for _ in 0..crate::player::pending::PLAYER_PENDING_MAX - 3 {
+        assert!(
+            handle.send(PlayerCmd::Stop).is_ok(),
+            "leave setup capacity but saturate the recovery batch"
+        );
+    }
+    engine.test_player_starts.push_back(PlayerRuntime {
+        handle,
+        _guard: None,
+    });
+
+    let effects = engine
+        .handle_player_event(PlayerEvent::TransportClosed("first".to_owned()))
+        .await;
+    let generation = match effects.as_slice() {
+        [EngineEffect::TransportRecoveryRetry { generation, .. }] => *generation,
+        _ => panic!("failed first restore must schedule one retry"),
+    };
+    assert!(engine.player.is_some());
+    assert!(matches!(
+        &engine.transport_recovery,
+        TransportRecoveryState::Recovering(recovery)
+            if recovery.generation == generation && recovery.attempts == 1
+    ));
+    drop(replacement_rx);
+
+    let _unused_second_replacement = queue_test_player_start(&mut engine);
+    assert!(
+        engine
+            .handle_player_event(PlayerEvent::TransportClosed(
+                "replacement died before retry".to_owned(),
+            ))
+            .await
+            .is_empty()
+    );
+    assert!(engine.player.is_none());
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Disarmed);
+    assert_eq!(
+        engine.test_player_starts.len(),
+        1,
+        "a replacement terminal must not consume another player start"
+    );
+
+    assert!(
+        engine
+            .attempt_transport_recovery(generation)
+            .await
+            .is_empty()
+    );
+    assert!(engine.player.is_none());
+    assert_eq!(engine.test_player_starts.len(), 1);
 }
 
 #[tokio::test]
@@ -563,14 +822,14 @@ async fn replacement_that_closes_before_progress_cannot_enter_a_restart_loop() {
     assert!(effects.is_empty());
     let first_generation = engine.transport_recovery_generation;
     assert!(engine.player.is_some());
-    assert!(!engine.transport_auto_recovery_armed);
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Disarmed);
 
     let effects = engine
         .handle_player_event(PlayerEvent::TransportClosed("replacement died".to_owned()))
         .await;
     assert!(effects.is_empty());
     assert!(engine.player.is_none());
-    assert_eq!(engine.transport_recovery, None);
+    assert_eq!(engine.transport_recovery, TransportRecoveryState::Disarmed);
     assert!(engine.test_player_starts.is_empty());
 
     // A stale scheduled retry is inert too; it cannot recreate the replacement.
@@ -583,55 +842,29 @@ async fn replacement_that_closes_before_progress_cannot_enter_a_restart_loop() {
     assert!(engine.player.is_none());
 }
 
-#[tokio::test(flavor = "current_thread")]
-async fn paused_transport_recovery_rejects_the_whole_batch_before_load_is_visible() {
+#[tokio::test]
+async fn stale_retry_cannot_mutate_a_newer_transport_recovery_generation() {
     let mut engine = super::tests::engine_with_queue(&["seed"]);
     engine.loaded_video_id = Some("seed".to_owned());
-    engine.playback.paused = true;
-    let epoch = engine.playback.position_epoch;
+    let old_rx = install_test_player(&mut engine);
+    let _unused_replacement_rx = queue_test_player_start(&mut engine);
+    let newer_generation = engine
+        .handle_transport_closed("newer generation".to_owned())
+        .expect("loaded transport close should schedule recovery");
+    assert!(old_rx.is_closed());
+    let newer_recovery = engine.transport_recovery.clone();
 
-    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-    let handle = PlayerHandle::test_handle(tx);
-    assert!(handle.send(PlayerCmd::Stop).is_ok(), "fill actor lane");
-    // Keep the drainer blocked on the full actor lane and leave room for only one more
-    // semantic command. Recovery needs two, so `send_batch` must publish neither.
-    for _ in 0..crate::player::pending::PLAYER_PENDING_MAX - 1 {
-        assert!(
-            handle.send(PlayerCmd::Stop).is_ok(),
-            "fill semantic backlog"
-        );
-    }
-    engine.player = Some(PlayerRuntime {
-        handle,
-        _guard: None,
-    });
-    engine.transport_recovery = Some(TransportRecovery {
-        video_id: "seed".to_owned(),
-        paused: true,
-        position_secs: None,
-        force_ram_only: false,
-        generation: 1,
-        attempts: 1,
-    });
-    engine.loaded_video_id = None;
-
-    assert!(engine.load_current_loaded().is_err());
-    assert_eq!(engine.loaded_video_id, None);
-    assert_eq!(engine.playback.position_epoch, epoch);
-    assert_eq!(
-        engine.transport_recovery,
-        Some(TransportRecovery {
-            video_id: "seed".to_owned(),
-            paused: true,
-            position_secs: None,
-            force_ram_only: false,
-            generation: 1,
-            attempts: 1,
-        })
-    );
-    assert!(matches!(rx.try_recv(), Ok(PlayerCmd::Stop)));
     assert!(
-        rx.try_recv().is_err(),
-        "recovery Load prefix must not be visible"
+        engine
+            .attempt_transport_recovery(newer_generation.wrapping_sub(1))
+            .await
+            .is_empty()
+    );
+    assert_eq!(engine.transport_recovery, newer_recovery);
+    assert!(engine.player.is_none());
+    assert_eq!(
+        engine.test_player_starts.len(),
+        1,
+        "a stale retry must not start a player for the newer generation"
     );
 }

--- a/src/daemon/parity_tests.rs
+++ b/src/daemon/parity_tests.rs
@@ -393,6 +393,155 @@ async fn midtrack_source_recovery_trace_and_epoch_match_in_both_owners() {
     assert_eq!(engine_position_epoch, engine_epoch + 1);
 }
 
+fn app_transport_restore(app: &mut App, reason: &str) -> Vec<crate::player::PlayerCmd> {
+    app.update(PlayerMsg::TransportClosed(reason.to_owned()))
+        .into_iter()
+        .find_map(|command| match command {
+            Cmd::PlayerControl(PlayerControl::Restart { restore }) => Some(restore),
+            _ => None,
+        })
+        .expect("App transport loss must request one replacement player")
+}
+
+async fn recv_parity_player_command(
+    receiver: &mut tokio::sync::mpsc::Receiver<crate::player::PlayerCmd>,
+) -> crate::player::PlayerCmd {
+    tokio::time::timeout(std::time::Duration::from_secs(1), receiver.recv())
+        .await
+        .expect("player command timed out")
+        .expect("player command lane closed")
+}
+
+#[tokio::test]
+async fn loaded_transport_loss_has_the_same_restore_trace_and_projection_in_both_owners() {
+    let (mut app, mut engine) = hermetic_pair();
+    app.install_seek_parity_state("b", 42.0, 225.0);
+    app.playback.paused = true;
+    let app_epoch = app.playback.position_epoch;
+
+    let old_engine_player = engine.install_seek_parity_player("b", 42.0, 225.0);
+    assert!(
+        engine
+            .handle_player_event(crate::player::PlayerEvent::Paused(true))
+            .await
+            .is_empty()
+    );
+    let (_, engine_epoch) = engine.seek_parity_projection();
+    let mut replacement_player = engine.queue_transport_recovery_parity_player();
+
+    let app_restore = app_transport_restore(&mut app, "unexpected EOF");
+    let engine_effects = engine
+        .handle_player_event(crate::player::PlayerEvent::TransportClosed(
+            "unexpected EOF".to_owned(),
+        ))
+        .await;
+
+    assert!(engine_effects.is_empty());
+    assert!(old_engine_player.is_closed());
+    assert!(matches!(
+        recv_parity_player_command(&mut replacement_player).await,
+        crate::player::PlayerCmd::SetVolume(_)
+    ));
+    assert!(matches!(
+        recv_parity_player_command(&mut replacement_player).await,
+        crate::player::PlayerCmd::SetAudioFilter(_)
+    ));
+
+    let app_load = match app_restore.as_slice() {
+        [
+            crate::player::PlayerCmd::Load(load),
+            crate::player::PlayerCmd::CyclePause,
+        ] => load,
+        _ => panic!("paused App recovery must restore exactly Load then CyclePause"),
+    };
+    let engine_load = match recv_parity_player_command(&mut replacement_player).await {
+        crate::player::PlayerCmd::Load(load) => load,
+        _ => panic!("paused daemon recovery must restore Load after player setup"),
+    };
+    assert_eq!(app_load, &engine_load);
+    assert!(matches!(
+        recv_parity_player_command(&mut replacement_player).await,
+        crate::player::PlayerCmd::CyclePause
+    ));
+    assert!(
+        replacement_player.try_recv().is_err(),
+        "daemon recovery emitted an unexpected command after CyclePause"
+    );
+
+    assert_eq!(app.playback.time_pos, None);
+    let (engine_position, engine_position_epoch) = engine.seek_parity_projection();
+    assert_eq!(engine_position, None);
+    assert!(app.playback.paused);
+    assert_eq!(app.playback.position_epoch, app_epoch + 1);
+    assert_eq!(engine_position_epoch, engine_epoch + 1);
+    assert_parity("loaded transport recovery", &app, &engine);
+}
+
+#[tokio::test]
+async fn stopped_current_item_is_not_resurrected_by_late_transport_loss_in_either_owner() {
+    let (mut app, mut engine) = hermetic_pair();
+    app.install_seek_parity_state("b", 42.0, 225.0);
+    app.playback.paused = false;
+    let app_epoch = app.playback.position_epoch;
+
+    let mut engine_player = engine.install_seek_parity_player("b", 42.0, 225.0);
+    assert!(
+        engine
+            .handle_player_event(crate::player::PlayerEvent::Paused(false))
+            .await
+            .is_empty()
+    );
+    let (_, engine_epoch) = engine.seek_parity_projection();
+
+    let app_stop = app.update(Msg::Media(MediaCommand::Stop));
+    assert!(
+        app_stop
+            .iter()
+            .flat_map(Cmd::player_commands)
+            .any(|command| matches!(command, crate::player::PlayerCmd::Stop)),
+        "App media Stop must reach the player before clearing loaded identity"
+    );
+    admit_app_player_intents(&mut app, app_stop);
+    let (shutdown, engine_effects) = engine.handle_media(MediaCommand::Stop).await;
+    assert!(!shutdown);
+    assert!(engine_effects.is_empty());
+    assert!(matches!(
+        recv_parity_player_command(&mut engine_player).await,
+        crate::player::PlayerCmd::Stop
+    ));
+    assert!(engine_player.is_closed());
+
+    assert_eq!(app.playback.time_pos, None);
+    let (engine_position, engine_position_epoch) = engine.seek_parity_projection();
+    assert_eq!(engine_position, None);
+    assert!(app.playback.paused);
+    assert_eq!(app.playback.position_epoch, app_epoch + 1);
+    assert_eq!(engine_position_epoch, engine_epoch + 1);
+
+    let app_restore = app_transport_restore(&mut app, "late close after Stop");
+    let engine_effects = engine
+        .handle_player_event(crate::player::PlayerEvent::TransportClosed(
+            "late close after Stop".to_owned(),
+        ))
+        .await;
+
+    assert!(
+        app_restore.is_empty(),
+        "App must not reload the queue cursor after Stop cleared loaded identity"
+    );
+    assert!(engine_effects.is_empty());
+    let app_media = app.media_snapshot();
+    let engine_media = engine.media_snapshot();
+    assert!(!app_media.caps.can_seek);
+    assert!(!engine_media.caps.can_seek);
+    assert_eq!(app_media.status, crate::media::MediaPlaybackStatus::Paused);
+    assert_eq!(
+        engine_media.status,
+        crate::media::MediaPlaybackStatus::Paused
+    );
+    assert_parity("late transport close after Stop", &app, &engine);
+}
+
 fn assert_reply_before_player_event(
     owner: &str,
     frame_id: u64,

--- a/src/player/ipc.rs
+++ b/src/player/ipc.rs
@@ -1052,7 +1052,7 @@ async fn dispatch_validated_load(
     if load
         .resume
         .as_ref()
-        .is_some_and(|resume| resume.force_ram_only)
+        .is_some_and(super::recovery::LoadWithResume::forces_ram_only)
         && let Some(cache) = state.cache.as_mut()
     {
         cache.force_next_media_ram_only();

--- a/src/player/ipc/command_queue.rs
+++ b/src/player/ipc/command_queue.rs
@@ -171,7 +171,7 @@ fn accept_actor_command(
             && validation
                 .resume
                 .as_ref()
-                .is_some_and(|resume| resume.episode_id.get() != 0)
+                .is_some_and(super::recovery::LoadWithResume::is_source_recovery)
             && state.active_file_generation == Some(state.issued_file_generation)
             && state.file_loaded_generation == Some(state.issued_file_generation)
             && state.playback_ready_generation == Some(state.issued_file_generation);

--- a/src/player/ipc/incoming.rs
+++ b/src/player/ipc/incoming.rs
@@ -98,7 +98,7 @@ fn record_resume_outcome(
     resume: Option<&super::recovery::LoadWithResume>,
     outcome: super::diagnostics::SourceRecoveryOutcome,
 ) {
-    if resume.is_some_and(|resume| resume.episode_id.get() != 0) {
+    if resume.is_some_and(super::recovery::LoadWithResume::is_source_recovery) {
         super::diagnostics::source_recovery_outcome(outcome);
     }
 }
@@ -175,7 +175,7 @@ fn install_resume_telemetry(
         buffered_near_target: None,
         latest_seek_position: None,
         terminal_deadline: None,
-        source_recovery: request.episode_id.get() != 0,
+        source_recovery: request.is_source_recovery(),
     });
 }
 
@@ -186,7 +186,7 @@ fn cancel_resume_post_load_if_superseded(state: &mut DispatchState, command: &Pl
     let source_recovery = state
         .pending_resume
         .as_ref()
-        .is_some_and(|pending| pending.request.episode_id.get() != 0)
+        .is_some_and(|pending| pending.request.is_source_recovery())
         || state
             .resume_telemetry
             .as_ref()

--- a/src/player/ipc/tests.rs
+++ b/src/player/ipc/tests.rs
@@ -7,18 +7,16 @@ mod seek_dispatch;
 
 fn recovery_request(position_secs: f64, paused: bool) -> super::super::recovery::LoadWithResume {
     let mut planner = super::super::recovery::RecoveryPlanner::default();
-    let (episode_id, transport_epoch) = planner
-        .begin_episode("HTTP error 403 Forbidden", 11, 7)
+    let ticket = planner
+        .begin_ticket("HTTP error 403 Forbidden", 11, 7)
         .expect("fixture error is conservatively recoverable");
-    super::super::recovery::LoadWithResume {
-        url: "https://example.invalid/fresh-source".to_owned(),
+    super::super::recovery::LoadWithResume::source_recovery(
+        "https://example.invalid/fresh-source".to_owned(),
         position_secs,
         paused,
-        source_context: super::super::MediaSourceContext::OnDemand,
-        episode_id,
-        transport_epoch,
-        force_ram_only: false,
-    }
+        super::super::MediaSourceContext::OnDemand,
+        ticket,
+    )
 }
 
 fn emergency_request(position_secs: f64, paused: bool) -> super::super::recovery::LoadWithResume {

--- a/src/player/ipc/tests/recovery_flow.rs
+++ b/src/player/ipc/tests/recovery_flow.rs
@@ -206,7 +206,7 @@ async fn emergency_recovery_validation_retains_load_and_force_ram_only_after_use
         pending
             .resume
             .as_ref()
-            .is_some_and(|resume| resume.force_ram_only)
+            .is_some_and(super::super::super::recovery::LoadWithResume::forces_ram_only)
     );
     assert!(pending.resume.as_ref().is_some_and(|resume| {
         (resume.position_secs - 120.0).abs() < f64::EPSILON && !resume.paused

--- a/src/player/recovery.rs
+++ b/src/player/recovery.rs
@@ -9,13 +9,42 @@ impl RecoveryEpisodeId {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct TransportIntentEpoch(u64);
 
 impl TransportIntentEpoch {
     pub const fn get(self) -> u64 {
         self.0
     }
+}
+
+/// Correlation captured when one source-recovery episode begins.
+///
+/// Keeping the episode and transport epoch in one value prevents callers from accidentally
+/// pairing identities from different attempts.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct RecoveryTicket {
+    episode_id: RecoveryEpisodeId,
+    transport_epoch: TransportIntentEpoch,
+}
+
+impl RecoveryTicket {
+    pub(crate) const fn episode_id(self) -> RecoveryEpisodeId {
+        self.episode_id
+    }
+
+    pub(crate) const fn transport_epoch(self) -> TransportIntentEpoch {
+        self.transport_epoch
+    }
+}
+
+/// Why one physical media replacement must restore transport state after `file-loaded`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum ResumeOrigin {
+    /// Same logical item with a freshly resolved source URL.
+    SourceRecovery(RecoveryTicket),
+    /// Cache-safety recycle which must force this replacement media to RAM only.
+    CacheSafetyRamOnly,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -28,12 +57,28 @@ pub struct LoadWithResume {
     pub source_context: super::MediaSourceContext,
     pub episode_id: RecoveryEpisodeId,
     pub transport_epoch: TransportIntentEpoch,
-    /// Emergency disk-safety recycle: the replacement actor must keep this one media in RAM
-    /// even when the persisted/requested policy remains Auto or On.
-    pub(crate) force_ram_only: bool,
+    origin: ResumeOrigin,
 }
 
 impl LoadWithResume {
+    pub(crate) fn source_recovery(
+        url: String,
+        position_secs: f64,
+        paused: bool,
+        source_context: super::MediaSourceContext,
+        ticket: RecoveryTicket,
+    ) -> Self {
+        Self {
+            url,
+            position_secs,
+            paused,
+            source_context,
+            episode_id: ticket.episode_id(),
+            transport_epoch: ticket.transport_epoch(),
+            origin: ResumeOrigin::SourceRecovery(ticket),
+        }
+    }
+
     pub(crate) fn emergency(
         url: String,
         position_secs: f64,
@@ -45,13 +90,102 @@ impl LoadWithResume {
             position_secs,
             paused,
             source_context,
-            // Emergency recycle is actor-owned rather than a source-resolution episode. The
-            // zero identities are never admitted to RecoveryPlanner and exist only so the one
-            // correlated file-loaded resume representation remains shared.
+            // Retained public compatibility values. Semantics now come only from `origin`.
             episode_id: RecoveryEpisodeId(0),
             transport_epoch: TransportIntentEpoch(0),
-            force_ram_only: true,
+            origin: ResumeOrigin::CacheSafetyRamOnly,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn recovery_ticket(&self) -> Option<RecoveryTicket> {
+        match self.origin {
+            ResumeOrigin::SourceRecovery(ticket) => Some(ticket),
+            ResumeOrigin::CacheSafetyRamOnly => None,
+        }
+    }
+
+    pub(crate) const fn is_source_recovery(&self) -> bool {
+        matches!(self.origin, ResumeOrigin::SourceRecovery(_))
+    }
+
+    pub(crate) const fn forces_ram_only(&self) -> bool {
+        matches!(self.origin, ResumeOrigin::CacheSafetyRamOnly)
+    }
+}
+
+/// Ordered physical replay after an owner retires an unsafe or disconnected player.
+///
+/// The plan is shared by the standalone App and daemon so pause is always restored after the
+/// replacement load, while a cache-safety resume remains one correlated command.
+#[derive(Clone, PartialEq)]
+pub(crate) enum TransportRestorePlan {
+    Idle,
+    Reload {
+        load: super::PlaybackLoad,
+        paused: bool,
+    },
+    ResumeRamOnly(LoadWithResume),
+}
+
+impl TransportRestorePlan {
+    #[cfg(test)]
+    pub(crate) const fn idle() -> Self {
+        Self::Idle
+    }
+
+    pub(crate) fn reload_if_loaded(
+        loaded_video_id: Option<&str>,
+        current_video_id: &str,
+        url: String,
+        paused: bool,
+        source_context: super::MediaSourceContext,
+    ) -> Self {
+        if loaded_video_id != Some(current_video_id) {
+            return Self::Idle;
+        }
+        Self::Reload {
+            load: super::PlaybackLoad::new(url, source_context),
+            paused,
+        }
+    }
+
+    pub(crate) fn resume_ram_only_if_loaded(
+        loaded_video_id: Option<&str>,
+        current_video_id: &str,
+        url: String,
+        position_secs: f64,
+        paused: bool,
+        source_context: super::MediaSourceContext,
+    ) -> Self {
+        if loaded_video_id != Some(current_video_id) {
+            return Self::Idle;
+        }
+        Self::ResumeRamOnly(LoadWithResume::emergency(
+            url,
+            position_secs,
+            paused,
+            source_context,
+        ))
+    }
+
+    /// Materialize the only legal replay ordering. Owner-specific setup may supply its current
+    /// audio filter, which stays between the load and a separate pause restoration.
+    pub(crate) fn into_commands(self, audio_filter: Option<String>) -> Vec<super::PlayerCmd> {
+        let (mut commands, restore_pause) = match self {
+            Self::Idle => return Vec::new(),
+            Self::Reload { load, paused } => (vec![super::PlayerCmd::Load(load)], paused),
+            Self::ResumeRamOnly(request) => {
+                (vec![super::PlayerCmd::LoadWithResume(request)], false)
+            }
+        };
+        if let Some(audio_filter) = audio_filter {
+            commands.push(super::PlayerCmd::SetAudioFilter(audio_filter));
+        }
+        if restore_pause {
+            commands.push(super::PlayerCmd::CyclePause);
+        }
+        commands
     }
 }
 
@@ -149,13 +283,34 @@ struct Episode {
     transport_epoch: TransportIntentEpoch,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum RecoveryEpisodeState {
+    #[default]
+    Eligible,
+    Active(Episode),
+    Consumed {
+        logical_item_generation: u64,
+    },
+}
+
+impl RecoveryEpisodeState {
+    const fn attempted_generation(self) -> Option<u64> {
+        match self {
+            Self::Eligible => None,
+            Self::Active(episode) => Some(episode.logical_item_generation),
+            Self::Consumed {
+                logical_item_generation,
+            } => Some(logical_item_generation),
+        }
+    }
+}
+
 /// Owner-side episode and transport-intent arbiter.
 #[derive(Default)]
 pub struct RecoveryPlanner {
     next_episode: u64,
     transport_epoch: u64,
-    attempted_item_generation: Option<u64>,
-    active: Option<Episode>,
+    episode: RecoveryEpisodeState,
 }
 
 impl RecoveryPlanner {
@@ -165,15 +320,19 @@ impl RecoveryPlanner {
 
     /// Call after admitting a newer user seek, play/pause, Load, Stop, or track change.
     pub fn supersede_transport(&mut self) -> TransportIntentEpoch {
-        self.transport_epoch = self.transport_epoch.wrapping_add(1);
-        self.active = None;
+        self.transport_epoch = self.transport_epoch.saturating_add(1);
+        if let RecoveryEpisodeState::Active(active) = self.episode {
+            self.episode = RecoveryEpisodeState::Consumed {
+                logical_item_generation: active.logical_item_generation,
+            };
+        }
         TransportIntentEpoch(self.transport_epoch)
     }
 
     /// A logical queue-item change resets the one-attempt latch and invalidates pending work.
     pub fn begin_logical_item(&mut self, logical_item_generation: u64) {
-        if self.attempted_item_generation != Some(logical_item_generation) {
-            self.attempted_item_generation = None;
+        if self.episode.attempted_generation() != Some(logical_item_generation) {
+            self.episode = RecoveryEpisodeState::Eligible;
         }
         self.supersede_transport();
     }
@@ -184,21 +343,37 @@ impl RecoveryPlanner {
         logical_item_generation: u64,
         origin_file_generation: u64,
     ) -> Option<(RecoveryEpisodeId, TransportIntentEpoch)> {
+        self.begin_ticket(error, logical_item_generation, origin_file_generation)
+            .map(|ticket| (ticket.episode_id, ticket.transport_epoch))
+    }
+
+    pub(crate) fn begin_ticket(
+        &mut self,
+        error: &str,
+        logical_item_generation: u64,
+        origin_file_generation: u64,
+    ) -> Option<RecoveryTicket> {
         classify_source_failure(error)?;
-        if self.attempted_item_generation == Some(logical_item_generation) || self.active.is_some()
-        {
-            return None;
+        match self.episode {
+            RecoveryEpisodeState::Active(_) => return None,
+            RecoveryEpisodeState::Consumed {
+                logical_item_generation: attempted,
+            } if attempted == logical_item_generation => return None,
+            RecoveryEpisodeState::Eligible | RecoveryEpisodeState::Consumed { .. } => {}
         }
-        self.next_episode = self.next_episode.wrapping_add(1);
+        self.next_episode = self.next_episode.checked_add(1)?;
+        let episode_id = RecoveryEpisodeId(self.next_episode);
         let episode = Episode {
-            id: RecoveryEpisodeId(self.next_episode),
+            id: episode_id,
             logical_item_generation,
             origin_file_generation,
             transport_epoch: TransportIntentEpoch(self.transport_epoch),
         };
-        self.attempted_item_generation = Some(logical_item_generation);
-        self.active = Some(episode);
-        Some((episode.id, episode.transport_epoch))
+        self.episode = RecoveryEpisodeState::Active(episode);
+        Some(RecoveryTicket {
+            episode_id,
+            transport_epoch: episode.transport_epoch,
+        })
     }
 
     /// Async resolution may complete only while every captured identity remains current.
@@ -209,38 +384,89 @@ impl RecoveryPlanner {
         origin_file_generation: u64,
         transport_epoch: TransportIntentEpoch,
     ) -> bool {
-        self.active.is_some_and(|episode| {
-            episode.id == episode_id
+        self.accepts_ticket(
+            RecoveryTicket {
+                episode_id,
+                transport_epoch,
+            },
+            logical_item_generation,
+            origin_file_generation,
+        )
+    }
+
+    pub(crate) fn accepts_ticket(
+        &self,
+        ticket: RecoveryTicket,
+        logical_item_generation: u64,
+        origin_file_generation: u64,
+    ) -> bool {
+        matches!(self.episode, RecoveryEpisodeState::Active(episode) if {
+            episode.id == ticket.episode_id
                 && episode.logical_item_generation == logical_item_generation
                 && episode.origin_file_generation == origin_file_generation
-                && episode.transport_epoch == transport_epoch
-                && transport_epoch == TransportIntentEpoch(self.transport_epoch)
+                && episode.transport_epoch == ticket.transport_epoch
+                && ticket.transport_epoch == TransportIntentEpoch(self.transport_epoch)
         })
     }
 
     pub fn finish_episode(&mut self, episode_id: RecoveryEpisodeId) -> bool {
-        if self.active.is_some_and(|episode| episode.id == episode_id) {
-            self.active = None;
-            true
-        } else {
-            false
+        let Some(ticket) = self.active_ticket() else {
+            return false;
+        };
+        if ticket.episode_id != episode_id {
+            return false;
         }
+        self.finish_ticket(ticket)
+    }
+
+    pub(crate) fn finish_ticket(&mut self, ticket: RecoveryTicket) -> bool {
+        let RecoveryEpisodeState::Active(active) = self.episode else {
+            return false;
+        };
+        if active.id != ticket.episode_id || active.transport_epoch != ticket.transport_epoch {
+            return false;
+        }
+        self.episode = RecoveryEpisodeState::Consumed {
+            logical_item_generation: active.logical_item_generation,
+        };
+        true
     }
 
     /// Roll back an episode whose semantic command never entered the player lane. No retry was
     /// attempted, so the same logical item remains eligible for a later admission attempt.
     pub fn cancel_unadmitted_episode(&mut self, episode_id: RecoveryEpisodeId) -> bool {
-        if self.active.is_some_and(|episode| episode.id == episode_id) {
-            self.active = None;
-            self.attempted_item_generation = None;
-            true
-        } else {
-            false
+        let Some(ticket) = self.active_ticket() else {
+            return false;
+        };
+        if ticket.episode_id != episode_id {
+            return false;
         }
+        self.cancel_unadmitted_ticket(ticket)
+    }
+
+    pub(crate) fn cancel_unadmitted_ticket(&mut self, ticket: RecoveryTicket) -> bool {
+        let RecoveryEpisodeState::Active(active) = self.episode else {
+            return false;
+        };
+        if active.id != ticket.episode_id || active.transport_epoch != ticket.transport_epoch {
+            return false;
+        }
+        self.episode = RecoveryEpisodeState::Eligible;
+        true
     }
 
     pub fn active_episode(&self) -> Option<RecoveryEpisodeId> {
-        self.active.map(|episode| episode.id)
+        self.active_ticket().map(|ticket| ticket.episode_id)
+    }
+
+    pub(crate) fn active_ticket(&self) -> Option<RecoveryTicket> {
+        match self.episode {
+            RecoveryEpisodeState::Active(episode) => Some(RecoveryTicket {
+                episode_id: episode.id,
+                transport_epoch: episode.transport_epoch,
+            }),
+            RecoveryEpisodeState::Eligible | RecoveryEpisodeState::Consumed { .. } => None,
+        }
     }
 }
 
@@ -293,11 +519,11 @@ mod tests {
     fn one_episode_survives_retry_generation_but_not_a_second_failure() {
         let mut planner = RecoveryPlanner::default();
         planner.begin_logical_item(4);
-        let (episode, epoch) = planner
-            .begin_episode("HTTP 403", 4, 11)
+        let ticket = planner
+            .begin_ticket("HTTP 403", 4, 11)
             .expect("first failure should recover");
-        assert!(planner.accepts_resolved_source(episode, 4, 11, epoch));
-        assert!(planner.finish_episode(episode));
+        assert!(planner.accepts_ticket(ticket, 4, 11));
+        assert!(planner.finish_ticket(ticket));
         assert!(planner.begin_episode("HTTP 410", 4, 12).is_none());
 
         planner.begin_logical_item(5);
@@ -307,32 +533,182 @@ mod tests {
     #[test]
     fn newer_transport_intent_invalidates_async_resolution() {
         let mut planner = RecoveryPlanner::default();
-        let (episode, epoch) = planner
-            .begin_episode("connection reset", 9, 20)
+        let ticket = planner
+            .begin_ticket("connection reset", 9, 20)
             .expect("episode");
         planner.supersede_transport();
-        assert!(!planner.accepts_resolved_source(episode, 9, 20, epoch));
+        assert!(!planner.accepts_ticket(ticket, 9, 20));
         assert_eq!(planner.active_episode(), None);
+        assert!(
+            planner.begin_episode("connection reset", 9, 21).is_none(),
+            "a newer transport intent invalidates but does not rearm the same logical item"
+        );
     }
 
     #[test]
     fn stale_item_or_file_identity_is_rejected() {
         let mut planner = RecoveryPlanner::default();
-        let (episode, epoch) = planner
-            .begin_episode("premature EOF", 7, 30)
+        let ticket = planner
+            .begin_ticket("premature EOF", 7, 30)
             .expect("episode");
-        assert!(!planner.accepts_resolved_source(episode, 8, 30, epoch));
-        assert!(!planner.accepts_resolved_source(episode, 7, 31, epoch));
+        assert!(!planner.accepts_ticket(ticket, 8, 30));
+        assert!(!planner.accepts_ticket(ticket, 7, 31));
     }
 
     #[test]
     fn rejected_admission_does_not_consume_the_item_attempt() {
         let mut planner = RecoveryPlanner::default();
         planner.begin_logical_item(7);
-        let (episode, _) = planner
-            .begin_episode("HTTP 403", 7, 30)
+        let ticket = planner
+            .begin_ticket("HTTP 403", 7, 30)
             .expect("first admission plan");
-        assert!(planner.cancel_unadmitted_episode(episode));
+        assert!(planner.cancel_unadmitted_ticket(ticket));
         assert!(planner.begin_episode("HTTP 403", 7, 30).is_some());
+    }
+
+    #[test]
+    fn stale_ticket_mutators_cannot_finish_or_cancel_the_new_active_episode() {
+        let mut planner = RecoveryPlanner::default();
+        let stale = planner
+            .begin_ticket("HTTP 403", 7, 30)
+            .expect("first ticket");
+        assert!(planner.cancel_unadmitted_ticket(stale));
+        let current = planner
+            .begin_ticket("HTTP 403", 7, 30)
+            .expect("replacement ticket after rejected admission");
+        assert_ne!(stale, current);
+
+        assert!(!planner.finish_ticket(stale));
+        assert!(!planner.cancel_unadmitted_ticket(stale));
+        assert_eq!(planner.active_ticket(), Some(current));
+        assert!(planner.accepts_ticket(current, 7, 30));
+    }
+
+    #[test]
+    fn public_episode_api_preserves_finish_and_unadmitted_cancel_semantics() {
+        let mut planner = RecoveryPlanner::default();
+        let (episode, epoch) = planner
+            .begin_episode("HTTP 403", 4, 10)
+            .expect("public begin wrapper");
+        assert!(planner.accepts_resolved_source(episode, 4, 10, epoch));
+        assert_eq!(planner.active_episode(), Some(episode));
+        assert!(planner.finish_episode(episode));
+        assert!(planner.begin_episode("HTTP 410", 4, 11).is_none());
+
+        planner.begin_logical_item(5);
+        let (episode, _) = planner
+            .begin_episode("HTTP 410", 5, 12)
+            .expect("new logical item is eligible");
+        assert!(planner.cancel_unadmitted_episode(episode));
+        assert!(planner.begin_episode("HTTP 410", 5, 12).is_some());
+    }
+
+    #[test]
+    fn episode_identity_exhaustion_never_wraps_to_the_emergency_sentinel() {
+        let mut planner = RecoveryPlanner {
+            next_episode: u64::MAX,
+            ..RecoveryPlanner::default()
+        };
+
+        assert!(planner.begin_ticket("HTTP 403", 1, 1).is_none());
+        assert_eq!(planner.active_ticket(), None);
+    }
+
+    #[test]
+    fn resume_origin_replaces_zero_sentinels_and_ram_only_flags() {
+        let mut planner = RecoveryPlanner::default();
+        let ticket = planner
+            .begin_ticket("HTTP 403", 1, 2)
+            .expect("source recovery ticket");
+        let source = LoadWithResume::source_recovery(
+            "source".to_owned(),
+            12.0,
+            false,
+            super::super::MediaSourceContext::OnDemand,
+            ticket,
+        );
+        assert_eq!(source.recovery_ticket(), Some(ticket));
+        assert!(source.is_source_recovery());
+        assert!(!source.forces_ram_only());
+        assert_ne!(ticket.episode_id().get(), 0);
+
+        let cache = LoadWithResume::emergency(
+            "cache".to_owned(),
+            13.0,
+            true,
+            super::super::MediaSourceContext::OnDemand,
+        );
+        assert_eq!(cache.recovery_ticket(), None);
+        assert!(!cache.is_source_recovery());
+        assert!(cache.forces_ram_only());
+    }
+
+    #[test]
+    fn transport_restore_plan_has_one_exhaustive_command_ordering() {
+        let filter = || Some("lavfi=[volume=1]".to_owned());
+        assert!(
+            TransportRestorePlan::idle()
+                .into_commands(filter())
+                .is_empty()
+        );
+
+        let playing = TransportRestorePlan::reload_if_loaded(
+            Some("playing"),
+            "playing",
+            "playing".to_owned(),
+            false,
+            super::super::MediaSourceContext::OnDemand,
+        )
+        .into_commands(None);
+        assert!(matches!(
+            playing.as_slice(),
+            [super::super::PlayerCmd::Load(_)]
+        ));
+
+        let paused = TransportRestorePlan::reload_if_loaded(
+            Some("paused"),
+            "paused",
+            "paused".to_owned(),
+            true,
+            super::super::MediaSourceContext::OnDemand,
+        )
+        .into_commands(filter());
+        assert!(matches!(
+            paused.as_slice(),
+            [
+                super::super::PlayerCmd::Load(_),
+                super::super::PlayerCmd::SetAudioFilter(value),
+                super::super::PlayerCmd::CyclePause,
+            ] if value == "lavfi=[volume=1]"
+        ));
+
+        let ram_only = TransportRestorePlan::resume_ram_only_if_loaded(
+            Some("resume"),
+            "resume",
+            "resume".to_owned(),
+            42.0,
+            true,
+            super::super::MediaSourceContext::OnDemand,
+        )
+        .into_commands(filter());
+        assert!(matches!(
+            ram_only.as_slice(),
+            [
+                super::super::PlayerCmd::LoadWithResume(request),
+                super::super::PlayerCmd::SetAudioFilter(value),
+            ] if request.forces_ram_only() && request.paused && value == "lavfi=[volume=1]"
+        ));
+
+        assert!(
+            TransportRestorePlan::reload_if_loaded(
+                None,
+                "stopped",
+                "must-not-load".to_owned(),
+                false,
+                super::super::MediaSourceContext::OnDemand,
+            )
+            .into_commands(None)
+            .is_empty()
+        );
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -36,9 +36,7 @@ use player_delivery::{
     PENDING_PLAYER_CMDS_MAX, PENDING_PLAYER_INTENTS_MAX, PlayerRestartDecision,
     admit_player_intent, reject_pending_player_intents, settle_player_intent,
 };
-use player_delivery::{
-    PendingPlayerCmds, PendingPlayerIntents, PlayerRestartGate, report_player_delivery,
-};
+use player_delivery::{PendingPlayerIntents, RuntimePlayerLifecycle, report_player_delivery};
 use task_set::RuntimeTaskSet;
 
 pub use ingress::{
@@ -596,14 +594,10 @@ pub fn remote_sink(
 
 pub struct RuntimeHandles {
     worker_tx: RuntimeSender,
-    player_handle: Option<PlayerHandle>,
-    /// Runtime-owned restore commands are kept apart from user intents so restore is always
-    /// admitted first when a replacement actor becomes ready.
-    pending_player_cmds: PendingPlayerCmds,
+    /// Typed owner lifecycle keeps handle/guard ownership, restart budget, and the ordered
+    /// restore batch in one reachable state.
+    player: RuntimePlayerLifecycle<PlayerHandle, crate::player::Mpv>,
     pending_player_intents: PendingPlayerIntents,
-    player_failed: bool,
-    player_restart: PlayerRestartGate,
-    _mpv_guard: Option<crate::player::Mpv>,
     /// Command sender for the *current* video overlay's IPC client. Replaced wholesale
     /// on every `Cmd::VideoConnect` (each spawn generation gets a fresh client); rejected
     /// sends are surfaced through the common player-delivery status path.
@@ -674,12 +668,8 @@ impl RuntimeHandles {
     ) -> Self {
         Self {
             worker_tx,
-            player_handle: None,
-            pending_player_cmds: PendingPlayerCmds::default(),
+            player: RuntimePlayerLifecycle::default(),
             pending_player_intents: PendingPlayerIntents::default(),
-            player_failed: false,
-            player_restart: PlayerRestartGate::default(),
-            _mpv_guard: None,
             video_handle: None,
             api_handle,
             lyrics_handle,
@@ -858,11 +848,7 @@ impl RuntimeHandles {
         }
         match cmd {
             Cmd::PlayerControl(PlayerControl::Restart { restore }) => {
-                let restart_started = self.handle_player_transport_closed(app);
-                if restart_started && !restore.is_empty() {
-                    let result = self.admit_player_restore_batch(restore);
-                    report_player_delivery(app, "transport_restore", result);
-                }
+                self.handle_player_transport_closed(app, restore);
             }
             Cmd::PlayerControl(PlayerControl::Intent(intent)) => {
                 self.dispatch_player_intent(app, intent);

--- a/src/runtime/player_delivery.rs
+++ b/src/runtime/player_delivery.rs
@@ -50,10 +50,6 @@ impl PendingPlayerCmds {
         self.cmds.drain(..).collect()
     }
 
-    pub(super) fn clear(&mut self) {
-        self.cmds.clear();
-    }
-
     #[cfg(test)]
     pub(super) fn len(&self) -> usize {
         self.cmds.len()
@@ -201,6 +197,27 @@ pub(super) fn reject_pending_player_intents(
         .collect()
 }
 
+/// Admit replacement restore as one barrier before the user transaction deferred during startup.
+///
+/// `PendingPlayerIntents` admits at most one whole transaction, so collecting its follow-ups
+/// preserves the same reducer/dispatch order while making the recovery-before-user boundary one
+/// directly testable operation.
+pub(super) fn admit_ready_player_work(
+    player: &crate::player::PlayerHandle,
+    app: &mut App,
+    restore: Vec<PlayerCmd>,
+    pending: &mut PendingPlayerIntents,
+) -> Vec<Cmd> {
+    if !restore.is_empty() {
+        report_player_delivery(app, "transport_restore", player.send_batch(restore));
+    }
+    pending
+        .drain()
+        .into_iter()
+        .flat_map(|intent| admit_player_intent(player, app, intent))
+        .collect()
+}
+
 /// Atomically close the owner-side player admission boundary for process teardown.
 ///
 /// The handle must drop before the process guard: closing the command lane first tells the IPC
@@ -208,30 +225,53 @@ pub(super) fn reject_pending_player_intents(
 /// unavailable so correlated remote callers do not wait through the slower actor/persistence
 /// cleanup which follows owner-loop exit.
 pub(super) fn begin_player_shutdown_state<H, G>(
-    restart: &mut PlayerRestartGate,
-    player_failed: &mut bool,
-    player_handle: &mut Option<H>,
-    mpv_guard: &mut Option<G>,
-    pending_cmds: &mut PendingPlayerCmds,
+    player: &mut RuntimePlayerLifecycle<H, G>,
     pending_intents: &mut PendingPlayerIntents,
     app: &mut App,
 ) -> Vec<Cmd> {
-    restart.suppress_for_shutdown();
-    *player_failed = true;
-    drop(player_handle.take());
-    drop(mpv_guard.take());
-    pending_cmds.clear();
+    player.begin_shutdown();
     let mut follow_ups = reject_pending_player_intents(pending_intents, app);
     follow_ups.extend(app.settle_recorder_owner_shutdown());
     follow_ups
 }
 
+pub(super) struct ActivePlayer<H, G> {
+    handle: H,
+    guard: G,
+}
+
+impl<H, G> ActivePlayer<H, G> {
+    fn new(handle: H, guard: G) -> Self {
+        Self { handle, guard }
+    }
+
+    /// Close actor ingress before dropping the process guard which kills mpv.
+    fn retire(self) {
+        drop(self.handle);
+        drop(self.guard);
+    }
+}
+
+/// Complete runtime ownership for the primary audio player.
+///
+/// Each variant is one reachable owner-loop phase. Keeping the live handle and process guard in
+/// `ActivePlayer`, and the restore batch inside replacement startup, makes invalid flag/Option
+/// combinations unrepresentable.
 #[derive(Default)]
-pub(super) struct PlayerRestartGate {
-    requested: bool,
-    in_flight: bool,
-    used: bool,
-    shutdown: bool,
+pub(super) enum RuntimePlayerLifecycle<H, G> {
+    #[default]
+    StartingInitial,
+    LiveInitial(ActivePlayer<H, G>),
+    FailedInitial,
+    RestartQueued {
+        restore: PendingPlayerCmds,
+    },
+    StartingReplacement {
+        restore: PendingPlayerCmds,
+    },
+    LiveReplacement(ActivePlayer<H, G>),
+    FailedReplacement,
+    Shutdown,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -242,42 +282,174 @@ pub(super) enum PlayerRestartDecision {
     Suppressed,
 }
 
-impl PlayerRestartGate {
-    pub(super) fn request(&mut self) -> PlayerRestartDecision {
-        if self.shutdown {
-            return PlayerRestartDecision::Suppressed;
+pub(super) enum PlayerAdmission<'a, H> {
+    Live(&'a H),
+    Deferred,
+    Closed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PlayerStartupKind {
+    Initial,
+    Replacement,
+}
+
+impl PlayerStartupKind {
+    const fn is_replacement(self) -> bool {
+        matches!(self, Self::Replacement)
+    }
+}
+
+pub(super) enum PlayerStartupCompletion<E> {
+    Ready {
+        kind: PlayerStartupKind,
+        restore: Vec<PlayerCmd>,
+    },
+    Failed {
+        kind: PlayerStartupKind,
+        error: E,
+    },
+    Discarded,
+}
+
+impl<H, G> RuntimePlayerLifecycle<H, G> {
+    pub(super) fn admission(&self) -> PlayerAdmission<'_, H> {
+        match self {
+            Self::LiveInitial(player) | Self::LiveReplacement(player) => {
+                PlayerAdmission::Live(&player.handle)
+            }
+            Self::StartingInitial
+            | Self::RestartQueued { .. }
+            | Self::StartingReplacement { .. } => PlayerAdmission::Deferred,
+            Self::FailedInitial | Self::FailedReplacement | Self::Shutdown => {
+                PlayerAdmission::Closed
+            }
         }
-        if self.requested || self.in_flight {
-            return PlayerRestartDecision::AlreadyPending;
-        }
-        if self.used {
-            return PlayerRestartDecision::Exhausted;
-        }
-        self.used = true;
-        self.requested = true;
-        PlayerRestartDecision::Start
     }
 
-    pub(super) fn take_request(&mut self) -> bool {
-        if self.shutdown {
-            self.requested = false;
-            return false;
+    pub(super) fn handle(&self) -> Option<&H> {
+        match self.admission() {
+            PlayerAdmission::Live(handle) => Some(handle),
+            PlayerAdmission::Deferred | PlayerAdmission::Closed => None,
         }
-        if !std::mem::take(&mut self.requested) {
-            return false;
-        }
-        self.in_flight = true;
-        true
     }
 
-    pub(super) fn complete_start(&mut self) -> bool {
-        std::mem::take(&mut self.in_flight)
+    pub(super) fn request_restart(
+        &mut self,
+        commands: Vec<PlayerCmd>,
+    ) -> (PlayerRestartDecision, Option<DeliveryResult>) {
+        let state = std::mem::replace(self, Self::Shutdown);
+        match state {
+            Self::StartingInitial | Self::FailedInitial => {
+                let mut restore = PendingPlayerCmds::default();
+                let delivery = (!commands.is_empty()).then(|| restore.push_batch(commands));
+                *self = Self::RestartQueued { restore };
+                (PlayerRestartDecision::Start, delivery)
+            }
+            Self::LiveInitial(player) => {
+                player.retire();
+                let mut restore = PendingPlayerCmds::default();
+                let delivery = (!commands.is_empty()).then(|| restore.push_batch(commands));
+                *self = Self::RestartQueued { restore };
+                (PlayerRestartDecision::Start, delivery)
+            }
+            Self::RestartQueued { restore } => {
+                *self = Self::RestartQueued { restore };
+                (PlayerRestartDecision::AlreadyPending, None)
+            }
+            Self::StartingReplacement { restore } => {
+                *self = Self::StartingReplacement { restore };
+                (PlayerRestartDecision::AlreadyPending, None)
+            }
+            Self::LiveReplacement(player) => {
+                player.retire();
+                *self = Self::FailedReplacement;
+                (PlayerRestartDecision::Exhausted, None)
+            }
+            Self::FailedReplacement => {
+                *self = Self::FailedReplacement;
+                (PlayerRestartDecision::Exhausted, None)
+            }
+            Self::Shutdown => {
+                *self = Self::Shutdown;
+                (PlayerRestartDecision::Suppressed, None)
+            }
+        }
     }
 
-    /// Permanently close the automatic-replacement gate for process teardown.
-    pub(super) fn suppress_for_shutdown(&mut self) {
-        self.shutdown = true;
-        self.requested = false;
+    pub(super) fn take_restart_request(&mut self) -> bool {
+        let state = std::mem::replace(self, Self::Shutdown);
+        match state {
+            Self::RestartQueued { restore } => {
+                *self = Self::StartingReplacement { restore };
+                true
+            }
+            state => {
+                *self = state;
+                false
+            }
+        }
+    }
+
+    pub(super) fn complete_start<E>(
+        &mut self,
+        result: Result<(H, G), E>,
+    ) -> PlayerStartupCompletion<E> {
+        let state = std::mem::replace(self, Self::Shutdown);
+        match (state, result) {
+            (Self::StartingInitial, Ok((handle, guard))) => {
+                *self = Self::LiveInitial(ActivePlayer::new(handle, guard));
+                PlayerStartupCompletion::Ready {
+                    kind: PlayerStartupKind::Initial,
+                    restore: Vec::new(),
+                }
+            }
+            (Self::StartingInitial, Err(error)) => {
+                *self = Self::FailedInitial;
+                PlayerStartupCompletion::Failed {
+                    kind: PlayerStartupKind::Initial,
+                    error,
+                }
+            }
+            (Self::StartingReplacement { mut restore }, Ok((handle, guard))) => {
+                let restore = restore.drain();
+                *self = Self::LiveReplacement(ActivePlayer::new(handle, guard));
+                PlayerStartupCompletion::Ready {
+                    kind: PlayerStartupKind::Replacement,
+                    restore,
+                }
+            }
+            (Self::StartingReplacement { .. }, Err(error)) => {
+                *self = Self::FailedReplacement;
+                PlayerStartupCompletion::Failed {
+                    kind: PlayerStartupKind::Replacement,
+                    error,
+                }
+            }
+            (state, Ok((handle, guard))) => {
+                ActivePlayer::new(handle, guard).retire();
+                *self = state;
+                PlayerStartupCompletion::Discarded
+            }
+            (state, Err(_)) => {
+                *self = state;
+                PlayerStartupCompletion::Discarded
+            }
+        }
+    }
+
+    /// Permanently close admission and retire any live player in handle-before-guard order.
+    pub(super) fn begin_shutdown(&mut self) {
+        let state = std::mem::replace(self, Self::Shutdown);
+        match state {
+            Self::LiveInitial(player) | Self::LiveReplacement(player) => player.retire(),
+            Self::StartingInitial
+            | Self::FailedInitial
+            | Self::RestartQueued { .. }
+            | Self::StartingReplacement { .. }
+            | Self::FailedReplacement
+            | Self::Shutdown => {}
+        }
     }
 }
 
@@ -287,8 +459,8 @@ impl super::RuntimeHandles {
     /// while a newer Load/Stop must recover solely from the owner's committed destination.
     pub fn reconcile_cache_safety_event(&self, event: &mut crate::player::PlayerEvent) {
         let current_generation = self
-            .player_handle
-            .as_ref()
+            .player
+            .handle()
             .map(crate::player::PlayerHandle::current_file_generation);
         reconcile_cache_safety_event(event, current_generation);
     }
@@ -298,12 +470,12 @@ impl super::RuntimeHandles {
             return true;
         };
         let current_generation = self
-            .player_handle
-            .as_ref()
+            .player
+            .handle()
             .map(crate::player::PlayerHandle::current_file_generation);
         let current = self
-            .player_handle
-            .as_ref()
+            .player
+            .handle()
             .is_some_and(|player| player.event_is_current(event));
         if !current {
             tracing::debug!(
@@ -315,49 +487,22 @@ impl super::RuntimeHandles {
         current
     }
 
-    pub(super) fn admit_player_restore_batch(
-        &mut self,
-        commands: Vec<PlayerCmd>,
-    ) -> DeliveryResult {
-        if let Some(player) = &self.player_handle {
-            player.send_batch(commands)
-        } else if self.player_failed {
-            Err(DeliveryError::Closed)
-        } else {
-            self.pending_player_cmds.push_batch(commands)
-        }
-    }
-
     pub(super) fn dispatch_player_intent(&mut self, app: &mut App, intent: Box<PlayerIntent>) {
-        let follow_ups = if let Some(player) = &self.player_handle {
-            admit_player_intent(player, app, *intent)
-        } else if self.player_failed {
-            settle_player_intent(app, *intent, Err(DeliveryError::Closed))
-        } else {
-            match self.pending_player_intents.push(intent) {
+        let follow_ups = match self.player.admission() {
+            PlayerAdmission::Live(player) => admit_player_intent(player, app, *intent),
+            PlayerAdmission::Closed => {
+                settle_player_intent(app, *intent, Err(DeliveryError::Closed))
+            }
+            PlayerAdmission::Deferred => match self.pending_player_intents.push(intent) {
                 Ok(receipt) => {
                     tracing::trace!(?receipt, "player intent deferred until player readiness");
                     return;
                 }
                 Err((error, intent)) => settle_player_intent(app, *intent, Err(error)),
-            }
+            },
         };
         for follow_up in follow_ups {
             self.dispatch(app, follow_up);
-        }
-    }
-
-    fn settle_pending_player_intents(&mut self, app: &mut App) {
-        let pending = self.pending_player_intents.drain();
-        for intent in pending {
-            let player = self
-                .player_handle
-                .as_ref()
-                .expect("pending intents settle only after a player is installed");
-            let follow_ups = admit_player_intent(player, app, intent);
-            for follow_up in follow_ups {
-                self.dispatch(app, follow_up);
-            }
         }
     }
 
@@ -373,15 +518,12 @@ impl super::RuntimeHandles {
         result: Result<(crate::player::PlayerHandle, crate::player::Mpv), String>,
         app: &mut App,
     ) {
-        let was_recovery = self.player_restart.complete_start();
-        match result {
-            Ok((handle, guard)) => {
-                self.player_failed = false;
-                // Install the live actor before settling any deferred intent. A commit may
-                // produce a follow-up player command, which must target this actor immediately
-                // instead of being re-deferred behind later startup work.
-                self.player_handle = Some(handle);
-                self._mpv_guard = Some(guard);
+        match self.player.complete_start(result) {
+            PlayerStartupCompletion::Ready { kind, restore } => {
+                let was_recovery = kind.is_replacement();
+                // The lifecycle installs the live actor before settling any deferred intent. A
+                // commit may produce a follow-up player command, which must target this actor
+                // immediately instead of being re-deferred behind later startup work.
                 if was_recovery {
                     app.set_status_info(crate::t!(
                         "Player connection restored",
@@ -391,8 +533,8 @@ impl super::RuntimeHandles {
                 report_player_delivery(
                     app,
                     "set_volume",
-                    self.player_handle
-                        .as_ref()
+                    self.player
+                        .handle()
                         .expect("player handle was installed above")
                         .send(PlayerCmd::SetVolume(app.playback.volume)),
                 );
@@ -400,8 +542,8 @@ impl super::RuntimeHandles {
                     report_player_delivery(
                         app,
                         "set_speed",
-                        self.player_handle
-                            .as_ref()
+                        self.player
+                            .handle()
                             .expect("player handle was installed above")
                             .send(PlayerCmd::SetProperty {
                                 name: "speed".to_owned(),
@@ -414,8 +556,8 @@ impl super::RuntimeHandles {
                     report_player_delivery(
                         app,
                         "set_audio_filter",
-                        self.player_handle
-                            .as_ref()
+                        self.player
+                            .handle()
                             .expect("player handle was installed above")
                             .send(PlayerCmd::SetAudioFilter(af)),
                     );
@@ -424,35 +566,33 @@ impl super::RuntimeHandles {
                     report_player_delivery(
                         app,
                         "load",
-                        self.player_handle
-                            .as_ref()
+                        self.player
+                            .handle()
                             .expect("player handle was installed above")
                             .load(url, crate::player::MediaSourceContext::OnDemand),
                     );
                 }
-                let restore = self.pending_player_cmds.drain();
-                if !restore.is_empty() {
-                    // Recovery state is one atomic barrier ahead of every user intent accepted
-                    // while the replacement actor was starting.
-                    let result = self
-                        .player_handle
-                        .as_ref()
-                        .expect("player handle was installed above")
-                        .send_batch(restore);
-                    report_player_delivery(app, "transport_restore", result);
+                let follow_ups = admit_ready_player_work(
+                    self.player
+                        .handle()
+                        .expect("player handle was installed above"),
+                    app,
+                    restore,
+                    &mut self.pending_player_intents,
+                );
+                for follow_up in follow_ups {
+                    self.dispatch(app, follow_up);
                 }
-                self.settle_pending_player_intents(app);
                 if was_recovery {
                     // Only this readiness result can retire the recorder failure latch: the
-                    // restart gate proves it belongs to the replacement generation, and all
+                    // lifecycle proves it belongs to the replacement generation, and all
                     // queued restore work has already been admitted to that live actor.
                     app.recorder_player_restart_completed(true);
                 }
             }
-            Err(e) => {
+            PlayerStartupCompletion::Failed { kind, error: e } => {
+                let was_recovery = kind.is_replacement();
                 tracing::error!(error = %e, "failed to start mpv");
-                self.player_failed = true;
-                self.pending_player_cmds.clear();
                 // Every deferred caller receives the same authoritative terminal result. No
                 // reducer state or remote success was published while readiness was unknown.
                 self.reject_pending_player_intents(app);
@@ -472,22 +612,29 @@ impl super::RuntimeHandles {
                     ));
                 }
             }
+            PlayerStartupCompletion::Discarded => {
+                tracing::debug!("discarded player readiness outside its lifecycle phase");
+            }
         }
     }
 
-    pub(super) fn handle_player_transport_closed(&mut self, app: &mut App) -> bool {
-        // Close the command channel before dropping the process guard. The actor treats that
-        // ordering as intentional shutdown, while its already-emitted TransportClosed remains
-        // the final event from the old, single active actor.
-        drop(self.player_handle.take());
-        drop(self._mpv_guard.take());
+    pub(super) fn handle_player_transport_closed(
+        &mut self,
+        app: &mut App,
+        restore: Vec<PlayerCmd>,
+    ) -> bool {
+        // Requesting replacement retires any live player in handle-before-guard order and moves
+        // the ordered restore batch into the same lifecycle transition.
+        let (decision, restore_delivery) = self.player.request_restart(restore);
         for effect in app.settle_recorder_player_retired() {
             self.dispatch(app, effect);
         }
 
-        match self.player_restart.request() {
+        match decision {
             PlayerRestartDecision::Start => {
-                self.player_failed = false;
+                if let Some(result) = restore_delivery {
+                    report_player_delivery(app, "transport_restore", result);
+                }
                 true
             }
             PlayerRestartDecision::AlreadyPending => {
@@ -495,8 +642,6 @@ impl super::RuntimeHandles {
                 false
             }
             PlayerRestartDecision::Exhausted => {
-                self.player_failed = true;
-                self.pending_player_cmds.clear();
                 self.reject_pending_player_intents(app);
                 app.set_status_error(crate::t!(
                     "Player stopped after the replacement also disconnected",
@@ -521,15 +666,8 @@ impl super::RuntimeHandles {
         // point onward retain their exact event in the task outbox. Consequently no later actor
         // event can enter the main queue and overtake that fallback during the final drain.
         self.worker_tx.close_admission();
-        let follow_ups = begin_player_shutdown_state(
-            &mut self.player_restart,
-            &mut self.player_failed,
-            &mut self.player_handle,
-            &mut self._mpv_guard,
-            &mut self.pending_player_cmds,
-            &mut self.pending_player_intents,
-            app,
-        );
+        let follow_ups =
+            begin_player_shutdown_state(&mut self.player, &mut self.pending_player_intents, app);
         for follow_up in follow_ups {
             self.dispatch(app, follow_up);
         }
@@ -547,7 +685,7 @@ impl super::RuntimeHandles {
     /// Consume the one automatic restart request. The runner replaces its readiness slot,
     /// which drops any obsolete startup result before launching the sole replacement actor.
     pub fn take_player_restart_request(&mut self) -> bool {
-        self.player_restart.take_request()
+        self.player.take_restart_request()
     }
 }
 

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -1,4 +1,5 @@
 use super::ingress::RuntimeTelemetrySlot;
+use super::player_delivery::PendingPlayerCmds;
 use super::*;
 use crate::remote::proto::RemoteCommand;
 use crate::util::event_policy::{EventKey, EventLane, EventPolicy};
@@ -537,31 +538,6 @@ fn accepted_video_load_leaves_overlay_pause_ownership_unchanged() {
     assert!(follow_ups.is_empty());
     assert!(app.playback.paused);
     assert!(app.video_pause_owned_for_test());
-}
-
-#[test]
-fn player_restart_gate_allows_one_replacement_and_prevents_loops() {
-    let mut gate = PlayerRestartGate::default();
-    assert_eq!(gate.request(), PlayerRestartDecision::Start);
-    assert_eq!(gate.request(), PlayerRestartDecision::AlreadyPending);
-    assert!(gate.take_request());
-    assert_eq!(gate.request(), PlayerRestartDecision::AlreadyPending);
-    assert!(gate.complete_start());
-    assert_eq!(gate.request(), PlayerRestartDecision::Exhausted);
-    assert!(!gate.take_request());
-}
-
-#[test]
-fn player_restart_gate_owner_exit_suppresses_queued_and_future_replacements() {
-    let mut gate = PlayerRestartGate::default();
-    assert_eq!(gate.request(), PlayerRestartDecision::Start);
-
-    // Models a TransportClosed reduced immediately before either normal Quit committed or the
-    // out-of-band latch won. Owner exit must revoke it before the runner's sole spawn point.
-    gate.suppress_for_shutdown();
-    assert!(!gate.take_request());
-    assert_eq!(gate.request(), PlayerRestartDecision::Suppressed);
-    assert!(!gate.take_request());
 }
 
 #[test]

--- a/src/runtime/tests/player_startup.rs
+++ b/src/runtime/tests/player_startup.rs
@@ -1,9 +1,98 @@
 use super::*;
 use crate::app::{PendingRemoteReply, PlayerCommit, PlayerIntent, RemoteReplyPlan};
 use crate::runtime::player_delivery::{
-    PendingPlayerCmds, PendingPlayerIntents, PlayerRestartDecision, PlayerRestartGate,
-    begin_player_shutdown_state,
+    PendingPlayerIntents, PlayerAdmission, PlayerStartupCompletion, PlayerStartupKind,
+    RuntimePlayerLifecycle, admit_ready_player_work, begin_player_shutdown_state,
 };
+
+type DropLog = std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>;
+type TestLifecycle = RuntimePlayerLifecycle<&'static str, &'static str>;
+
+struct DropOrder {
+    label: &'static str,
+    log: DropLog,
+}
+
+impl DropOrder {
+    fn new(label: &'static str, log: &DropLog) -> Self {
+        Self {
+            label,
+            log: std::sync::Arc::clone(log),
+        }
+    }
+}
+
+impl Drop for DropOrder {
+    fn drop(&mut self) {
+        self.log
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(self.label);
+    }
+}
+
+fn live_initial_lifecycle() -> TestLifecycle {
+    let mut player = RuntimePlayerLifecycle::default();
+    assert!(matches!(
+        player.complete_start::<&'static str>(Ok(("initial-handle", "initial-guard"))),
+        PlayerStartupCompletion::Ready {
+            kind: PlayerStartupKind::Initial,
+            restore,
+        } if restore.is_empty()
+    ));
+    player
+}
+
+fn restart_queued_lifecycle() -> TestLifecycle {
+    let mut player = live_initial_lifecycle();
+    assert_eq!(
+        player.request_restart(Vec::new()).0,
+        PlayerRestartDecision::Start
+    );
+    player
+}
+
+fn starting_replacement_lifecycle() -> TestLifecycle {
+    let mut player = restart_queued_lifecycle();
+    assert!(player.take_restart_request());
+    player
+}
+
+fn live_replacement_lifecycle() -> TestLifecycle {
+    let mut player = starting_replacement_lifecycle();
+    assert!(matches!(
+        player.complete_start::<&'static str>(Ok(("replacement-handle", "replacement-guard"))),
+        PlayerStartupCompletion::Ready {
+            kind: PlayerStartupKind::Replacement,
+            restore,
+        } if restore.is_empty()
+    ));
+    player
+}
+
+fn failed_initial_lifecycle() -> TestLifecycle {
+    let mut player = RuntimePlayerLifecycle::default();
+    assert!(matches!(
+        player.complete_start::<&'static str>(Err("initial failure")),
+        PlayerStartupCompletion::Failed {
+            kind: PlayerStartupKind::Initial,
+            error: "initial failure",
+        }
+    ));
+    player
+}
+
+fn failed_replacement_lifecycle() -> TestLifecycle {
+    let mut player = starting_replacement_lifecycle();
+    assert!(matches!(
+        player.complete_start::<&'static str>(Err("replacement failure")),
+        PlayerStartupCompletion::Failed {
+            kind: PlayerStartupKind::Replacement,
+            error: "replacement failure",
+        }
+    ));
+    player
+}
 
 fn seek_intent(position: f64, remote_reply: Option<PendingRemoteReply>) -> Box<PlayerIntent> {
     Box::new(PlayerIntent {
@@ -131,36 +220,258 @@ fn startup_failure_rejects_the_deferred_intent_without_state_commit() {
 }
 
 #[test]
-fn shutdown_retires_active_player_before_slow_cleanup_and_replies_to_pending_intents() {
-    #[derive(Clone)]
-    struct DropOrder {
-        label: &'static str,
-        log: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
-    }
+fn lifecycle_initial_success_installs_a_live_player_without_restore_work() {
+    let mut player: TestLifecycle = RuntimePlayerLifecycle::default();
 
-    impl Drop for DropOrder {
-        fn drop(&mut self) {
-            self.log
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .push(self.label);
+    assert!(matches!(player.admission(), PlayerAdmission::Deferred));
+    assert!(matches!(
+        player.complete_start::<&'static str>(Ok(("handle", "guard"))),
+        PlayerStartupCompletion::Ready {
+            kind: PlayerStartupKind::Initial,
+            restore,
+        } if restore.is_empty()
+    ));
+
+    assert!(matches!(
+        player.admission(),
+        PlayerAdmission::Live(handle) if *handle == "handle"
+    ));
+    assert!(matches!(player, RuntimePlayerLifecycle::LiveInitial(_)));
+}
+
+#[test]
+fn lifecycle_initial_failure_closes_admission_but_still_allows_one_replacement() {
+    let mut player: TestLifecycle = RuntimePlayerLifecycle::default();
+
+    assert!(matches!(
+        player.complete_start::<&'static str>(Err("mpv unavailable")),
+        PlayerStartupCompletion::Failed {
+            kind: PlayerStartupKind::Initial,
+            error: "mpv unavailable",
         }
-    }
+    ));
+    assert!(matches!(player.admission(), PlayerAdmission::Closed));
+    assert!(matches!(player, RuntimePlayerLifecycle::FailedInitial));
 
+    let (decision, delivery) = player.request_restart(Vec::new());
+    assert_eq!(decision, PlayerRestartDecision::Start);
+    assert!(delivery.is_none());
+    assert!(matches!(
+        player,
+        RuntimePlayerLifecycle::RestartQueued { .. }
+    ));
+}
+
+#[test]
+fn lifecycle_replacement_start_failure_is_terminal_for_the_automatic_retry_budget() {
+    let mut player = starting_replacement_lifecycle();
+
+    assert!(matches!(
+        player.complete_start::<&'static str>(Err("replacement failed")),
+        PlayerStartupCompletion::Failed {
+            kind: PlayerStartupKind::Replacement,
+            error: "replacement failed",
+        }
+    ));
+    assert!(matches!(player.admission(), PlayerAdmission::Closed));
+    assert!(matches!(player, RuntimePlayerLifecycle::FailedReplacement));
+    let (decision, delivery) = player.request_restart(vec![PlayerCmd::Stop]);
+    assert_eq!(decision, PlayerRestartDecision::Exhausted);
+    assert!(delivery.is_none());
+}
+
+#[test]
+fn lifecycle_replacement_preserves_restore_order_and_ignores_duplicate_requests() {
+    let mut player = live_initial_lifecycle();
+    let restore = vec![
+        PlayerCmd::SetVolume(10),
+        PlayerCmd::SetAudioFilter("lavfi=[volume=1]".to_owned()),
+        PlayerCmd::CyclePause,
+    ];
+
+    let (decision, delivery) = player.request_restart(restore);
+    assert_eq!(decision, PlayerRestartDecision::Start);
+    assert!(delivery.is_some_and(|result| result.is_ok()));
+    assert!(matches!(
+        player,
+        RuntimePlayerLifecycle::RestartQueued { .. }
+    ));
+
+    let (decision, delivery) = player.request_restart(vec![PlayerCmd::SetVolume(99)]);
+    assert_eq!(decision, PlayerRestartDecision::AlreadyPending);
+    assert!(delivery.is_none());
+    assert!(player.take_restart_request());
+    assert!(matches!(
+        player,
+        RuntimePlayerLifecycle::StartingReplacement { .. }
+    ));
+
+    let (decision, delivery) = player.request_restart(vec![PlayerCmd::Stop]);
+    assert_eq!(decision, PlayerRestartDecision::AlreadyPending);
+    assert!(delivery.is_none());
+    assert!(!player.take_restart_request());
+
+    let completion =
+        player.complete_start::<&'static str>(Ok(("replacement-handle", "replacement-guard")));
+    let PlayerStartupCompletion::Ready {
+        kind: PlayerStartupKind::Replacement,
+        restore,
+    } = completion
+    else {
+        panic!("replacement readiness must install the queued generation");
+    };
+    assert!(matches!(
+        restore.as_slice(),
+        [
+            PlayerCmd::SetVolume(10),
+            PlayerCmd::SetAudioFilter(filter),
+            PlayerCmd::CyclePause,
+        ] if filter == "lavfi=[volume=1]"
+    ));
+    assert!(matches!(
+        player.admission(),
+        PlayerAdmission::Live(handle) if *handle == "replacement-handle"
+    ));
+    assert!(matches!(player, RuntimePlayerLifecycle::LiveReplacement(_)));
+}
+
+#[test]
+fn lifecycle_replacement_disconnect_exhausts_the_single_retry_and_retires_in_order() {
     let drops = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-    let mut handle = Some(DropOrder {
-        label: "handle",
-        log: std::sync::Arc::clone(&drops),
-    });
-    let mut guard = Some(DropOrder {
-        label: "guard",
-        log: std::sync::Arc::clone(&drops),
-    });
-    let mut gate = PlayerRestartGate::default();
-    assert_eq!(gate.request(), PlayerRestartDecision::Start);
-    let mut failed = false;
-    let mut pending_cmds = PendingPlayerCmds::default();
-    assert!(pending_cmds.push(PlayerCmd::SetVolume(10)).is_ok());
+    let mut player = RuntimePlayerLifecycle::default();
+    assert!(matches!(
+        player.complete_start::<&'static str>(Ok((
+            DropOrder::new("initial-handle", &drops),
+            DropOrder::new("initial-guard", &drops),
+        ))),
+        PlayerStartupCompletion::Ready {
+            kind: PlayerStartupKind::Initial,
+            ..
+        }
+    ));
+    assert_eq!(
+        player.request_restart(Vec::new()).0,
+        PlayerRestartDecision::Start
+    );
+    assert!(player.take_restart_request());
+    assert!(matches!(
+        player.complete_start::<&'static str>(Ok((
+            DropOrder::new("replacement-handle", &drops),
+            DropOrder::new("replacement-guard", &drops),
+        ))),
+        PlayerStartupCompletion::Ready {
+            kind: PlayerStartupKind::Replacement,
+            ..
+        }
+    ));
+
+    assert_eq!(
+        player.request_restart(Vec::new()).0,
+        PlayerRestartDecision::Exhausted
+    );
+    assert!(matches!(player.admission(), PlayerAdmission::Closed));
+    assert!(matches!(player, RuntimePlayerLifecycle::FailedReplacement));
+    assert_eq!(
+        player.request_restart(Vec::new()).0,
+        PlayerRestartDecision::Exhausted
+    );
+    assert_eq!(
+        *drops
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
+        [
+            "initial-handle",
+            "initial-guard",
+            "replacement-handle",
+            "replacement-guard",
+        ]
+    );
+}
+
+#[test]
+fn lifecycle_shutdown_absorbs_every_owner_phase() {
+    let mut shutdown = RuntimePlayerLifecycle::default();
+    shutdown.begin_shutdown();
+    let states = vec![
+        ("starting_initial", RuntimePlayerLifecycle::default()),
+        ("live_initial", live_initial_lifecycle()),
+        ("failed_initial", failed_initial_lifecycle()),
+        ("restart_queued", restart_queued_lifecycle()),
+        ("starting_replacement", starting_replacement_lifecycle()),
+        ("live_replacement", live_replacement_lifecycle()),
+        ("failed_replacement", failed_replacement_lifecycle()),
+        ("shutdown", shutdown),
+    ];
+
+    for (phase, mut player) in states {
+        player.begin_shutdown();
+        player.begin_shutdown();
+        assert!(
+            matches!(player, RuntimePlayerLifecycle::Shutdown),
+            "phase {phase} did not enter shutdown"
+        );
+        assert!(matches!(player.admission(), PlayerAdmission::Closed));
+        assert!(player.handle().is_none());
+        assert_eq!(
+            player.request_restart(vec![PlayerCmd::Stop]).0,
+            PlayerRestartDecision::Suppressed,
+            "phase {phase} admitted a restart after shutdown"
+        );
+        assert!(!player.take_restart_request());
+        assert!(matches!(
+            player.complete_start::<&'static str>(Ok(("late-handle", "late-guard"))),
+            PlayerStartupCompletion::Discarded
+        ));
+        assert!(matches!(
+            player.complete_start::<&'static str>(Err("late failure")),
+            PlayerStartupCompletion::Discarded
+        ));
+        assert!(matches!(player, RuntimePlayerLifecycle::Shutdown));
+    }
+}
+
+#[test]
+fn lifecycle_discards_late_replacement_readiness_handle_before_guard() {
+    let drops = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut player: RuntimePlayerLifecycle<DropOrder, DropOrder> =
+        RuntimePlayerLifecycle::default();
+    assert_eq!(
+        player.request_restart(vec![PlayerCmd::SetVolume(10)]).0,
+        PlayerRestartDecision::Start
+    );
+    assert!(player.take_restart_request());
+    player.begin_shutdown();
+
+    assert!(matches!(
+        player.complete_start::<&'static str>(Ok((
+            DropOrder::new("late-handle", &drops),
+            DropOrder::new("late-guard", &drops),
+        ))),
+        PlayerStartupCompletion::Discarded
+    ));
+    assert!(matches!(player, RuntimePlayerLifecycle::Shutdown));
+    assert_eq!(
+        *drops
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
+        ["late-handle", "late-guard"]
+    );
+}
+
+#[test]
+fn shutdown_retires_active_player_before_slow_cleanup_and_replies_to_pending_intents() {
+    let drops = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut player = RuntimePlayerLifecycle::default();
+    assert!(matches!(
+        player.complete_start::<&'static str>(Ok((
+            DropOrder::new("handle", &drops),
+            DropOrder::new("guard", &drops),
+        ))),
+        PlayerStartupCompletion::Ready {
+            kind: PlayerStartupKind::Initial,
+            restore,
+        } if restore.is_empty()
+    ));
     let mut pending_intents = PendingPlayerIntents::default();
     let (reply, mut reply_rx) = tokio::sync::oneshot::channel();
     assert!(
@@ -176,27 +487,19 @@ fn shutdown_retires_active_player_before_slow_cleanup_and_replies_to_pending_int
     );
     let mut app = App::new(50);
 
-    let follow_ups = begin_player_shutdown_state(
-        &mut gate,
-        &mut failed,
-        &mut handle,
-        &mut guard,
-        &mut pending_cmds,
-        &mut pending_intents,
-        &mut app,
-    );
+    let follow_ups = begin_player_shutdown_state(&mut player, &mut pending_intents, &mut app);
     drops
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .push("slow_cleanup");
 
     assert!(follow_ups.is_empty());
-    assert!(failed);
-    assert!(handle.is_none());
-    assert!(guard.is_none());
-    assert_eq!(pending_cmds.len(), 0);
     assert_eq!(pending_intents.len(), 0);
-    assert_eq!(gate.request(), PlayerRestartDecision::Suppressed);
+    assert!(matches!(player, RuntimePlayerLifecycle::Shutdown));
+    assert_eq!(
+        player.request_restart(vec![PlayerCmd::SetVolume(10)]).0,
+        PlayerRestartDecision::Suppressed
+    );
     assert_eq!(
         *drops
             .lock()
@@ -356,10 +659,12 @@ async fn recovery_restore_batch_reaches_player_before_deferred_user_intent() {
         ),
         PlayerCmd::SetAudioFilter("lavfi=[volume=1]".to_owned()),
     ];
-    assert!(player.send_batch(restore).is_ok());
-
     let mut app = App::new(50);
-    assert!(admit_player_intent(&player, &mut app, *seek_intent(15.0, None)).is_empty());
+    let mut pending = PendingPlayerIntents::default();
+    assert!(pending.push(seek_intent(15.0, None)).is_ok());
+
+    assert!(admit_ready_player_work(&player, &mut app, restore, &mut pending).is_empty());
+    assert_eq!(pending.len(), 0);
 
     assert!(matches!(
         rx.recv().await,


### PR DESCRIPTION
## Summary

- model runtime player ownership, restart, and shutdown as an explicit lifecycle enum
- model daemon transport recovery as Armed, Recovering, Disarmed, and Shutdown states
- share typed recovery tickets and restore ordering across App and daemon
- prevent a stopped queue item from being resurrected by a late transport-close event
- add transition, fault-injection, and App/daemon parity coverage

## Why

Playback recovery state was spread across optional values and booleans, while App recovery trusted queue.current without proving that the item was still loaded. That allowed invalid state combinations and the stopped-track resurrection bug.

## Impact

Internal refactor only. Controls, rendering, status strings, persistence formats, and other UI/UX behavior are unchanged. Recovery ordering and retry/shutdown behavior are now constrained by types and regression-tested.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (3,367 library tests plus CLI and integration suites)
- architecture, file-size, documentation-honesty, ratatui-image patch, and unsafe-inventory checks

The clean worktree does not contain the gitignored `.claude/harness/project-profile.json`, so the canonical wrapper could not load it. The commands defined by that profile were run directly and all passed.