### PR TITLE
Stabilize Beginner Mode onboarding flow

### DIFF
--- a/src/app/onboarding.rs
+++ b/src/app/onboarding.rs
@@ -8,8 +8,8 @@ pub enum BeginnerStep {
     #[default]
     Welcome,
     NavigationHelp,
-    Search,
     Player,
+    Search,
     Library,
     DjGem,
     Settings,
@@ -17,7 +17,17 @@ pub enum BeginnerStep {
 }
 
 impl BeginnerStep {
-    pub const COUNT: usize = 8;
+    const ORDER: [Self; 8] = [
+        Self::Welcome,
+        Self::NavigationHelp,
+        Self::Player,
+        Self::Search,
+        Self::Library,
+        Self::DjGem,
+        Self::Settings,
+        Self::Finish,
+    ];
+    pub const COUNT: usize = Self::ORDER.len();
 
     pub fn id(self) -> &'static str {
         match self {
@@ -47,42 +57,25 @@ impl BeginnerStep {
     }
 
     pub fn number(self) -> usize {
-        match self {
-            Self::Welcome => 1,
-            Self::NavigationHelp => 2,
-            Self::Search => 3,
-            Self::Player => 4,
-            Self::Library => 5,
-            Self::DjGem => 6,
-            Self::Settings => 7,
-            Self::Finish => 8,
-        }
+        self.order_index() + 1
     }
 
     fn next(self) -> Option<Self> {
-        Some(match self {
-            Self::Welcome => Self::NavigationHelp,
-            Self::NavigationHelp => Self::Search,
-            Self::Search => Self::Player,
-            Self::Player => Self::Library,
-            Self::Library => Self::DjGem,
-            Self::DjGem => Self::Settings,
-            Self::Settings => Self::Finish,
-            Self::Finish => return None,
-        })
+        Self::ORDER.get(self.order_index() + 1).copied()
     }
 
     fn previous(self) -> Option<Self> {
-        Some(match self {
-            Self::Welcome => return None,
-            Self::NavigationHelp => Self::Welcome,
-            Self::Search => Self::NavigationHelp,
-            Self::Player => Self::Search,
-            Self::Library => Self::Player,
-            Self::DjGem => Self::Library,
-            Self::Settings => Self::DjGem,
-            Self::Finish => Self::Settings,
-        })
+        self.order_index()
+            .checked_sub(1)
+            .and_then(|index| Self::ORDER.get(index))
+            .copied()
+    }
+
+    fn order_index(self) -> usize {
+        Self::ORDER
+            .iter()
+            .position(|step| *step == self)
+            .expect("BeginnerStep::ORDER must contain every step")
     }
 }
 
@@ -660,6 +653,28 @@ mod tests {
     }
 
     #[test]
+    fn ordered_steps_keep_numbers_and_forward_back_navigation_in_lockstep() {
+        let expected = [
+            BeginnerStep::Welcome,
+            BeginnerStep::NavigationHelp,
+            BeginnerStep::Player,
+            BeginnerStep::Search,
+            BeginnerStep::Library,
+            BeginnerStep::DjGem,
+            BeginnerStep::Settings,
+            BeginnerStep::Finish,
+        ];
+        assert_eq!(BeginnerStep::ORDER, expected);
+        assert_eq!(BeginnerStep::COUNT, expected.len());
+
+        for (index, step) in expected.iter().copied().enumerate() {
+            assert_eq!(step.number(), index + 1);
+            assert_eq!(step.previous(), index.checked_sub(1).map(|i| expected[i]));
+            assert_eq!(step.next(), expected.get(index + 1).copied());
+        }
+    }
+
+    #[test]
     fn steps_persist_once_and_resume_the_last_incomplete_step() {
         let mut app = beginner_app(BeginnerStep::Welcome);
         let cmds = app.activate_onboarding(OnboardingAction::Primary);
@@ -681,12 +696,31 @@ mod tests {
         let before = app.onboarding_observation();
         app.overlays.help_visible = true;
         let cmds = app.observe_beginner_tutorial(before);
-        assert_eq!(app.onboarding.step(), BeginnerStep::Search);
+        assert_eq!(app.onboarding.step(), BeginnerStep::Player);
+        assert!(app.onboarding.target_reached());
         assert_eq!(cmds.len(), 1);
         assert!(
             app.observe_beginner_tutorial(app.onboarding_observation())
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn fresh_player_step_continues_to_search_without_leaving_player_first() {
+        let mut app = beginner_app(BeginnerStep::Player);
+        assert_eq!(app.mode, Mode::Player);
+        assert!(app.onboarding.target_reached());
+
+        let cmds = app.activate_onboarding(OnboardingAction::Primary);
+
+        assert_eq!(app.mode, Mode::Player);
+        assert_eq!(app.onboarding.step(), BeginnerStep::Search);
+        assert!(!app.onboarding.target_reached());
+        assert_eq!(app.config.beginner_tutorial.next_step, "search");
+        assert!(matches!(
+            cmds.as_slice(),
+            [Cmd::Persist(PersistCmd::Config(_))]
+        ));
     }
 
     #[test]
@@ -711,8 +745,8 @@ mod tests {
     fn old_progress_normalizes_but_future_progress_is_preserved_and_suppressed() {
         let mut old = App::new(50);
         old.config.beginner_mode = true;
-        old.config.beginner_tutorial.content_version = 0;
-        old.config.beginner_tutorial.next_step = "old_step".to_owned();
+        old.config.beginner_tutorial.content_version = 1;
+        old.config.beginner_tutorial.next_step = "library".to_owned();
         old.prepare_beginner_onboarding(true);
         assert!(old.onboarding.visible());
         assert_eq!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,7 +40,7 @@ pub const SPEED_MAX: f64 = 2.0;
 /// Version of the interactive Beginner Mode walkthrough shipped by this build. Bump this only
 /// when the ordered steps or their completion contracts change; copy-only edits must not make a
 /// user repeat the tour.
-pub const BEGINNER_TUTORIAL_VERSION: u16 = 1;
+pub const BEGINNER_TUTORIAL_VERSION: u16 = 2;
 
 /// Persisted Beginner Mode walkthrough cursor. The step stays a string deliberately: a newer
 /// build may write a step this build does not know, and retaining that value lets the app decline

--- a/src/ui/views/onboarding.rs
+++ b/src/ui/views/onboarding.rs
@@ -614,44 +614,54 @@ fn with_ellipsis(text: &str, width: usize) -> String {
 fn place_coach(area: Rect, anchor: Option<Rect>, width: u16, height: u16) -> Rect {
     let width = width.min(area.width);
     let height = height.min(area.height);
-    let max_x = area.right().saturating_sub(width);
     let max_y = area.bottom().saturating_sub(height);
-    let clamp_x = |x: u16| x.clamp(area.x, max_x.max(area.x));
-    let clamp_y = |y: u16| y.clamp(area.y, max_y.max(area.y));
-    if let Some(anchor) = anchor {
-        let centered_x = clamp_x(
-            anchor
-                .x
-                .saturating_add(anchor.width / 2)
-                .saturating_sub(width / 2),
-        );
-        let centered_y = clamp_y(
-            anchor
-                .y
-                .saturating_add(anchor.height / 2)
-                .saturating_sub(height / 2),
-        );
-        let below = anchor.bottom().saturating_add(1);
-        if below.saturating_add(height) <= area.bottom() {
-            return Rect::new(centered_x, below, width, height);
-        }
-        if anchor.y >= area.y.saturating_add(height).saturating_add(1) {
-            return Rect::new(centered_x, anchor.y - height - 1, width, height);
-        }
-        let right = anchor.right().saturating_add(1);
-        if right.saturating_add(width) <= area.right() {
-            return Rect::new(right, centered_y, width, height);
-        }
-        if anchor.x >= area.x.saturating_add(width).saturating_add(1) {
-            return Rect::new(anchor.x - width - 1, centered_y, width, height);
-        }
-    }
-    Rect::new(
-        clamp_x(area.x + area.width.saturating_sub(width) / 2),
-        clamp_y(area.bottom().saturating_sub(height).saturating_sub(1)),
+    let x = area.x.saturating_add(area.width.saturating_sub(width) / 2);
+    let top = Rect::new(x, area.y.saturating_add(1).min(max_y), width, height);
+    let bottom = Rect::new(
+        x,
+        area.bottom()
+            .saturating_sub(height)
+            .saturating_sub(1)
+            .max(area.y),
         width,
         height,
+    );
+    let Some(anchor) = anchor else {
+        return bottom;
+    };
+    let exclusion = coach_anchor_exclusion(anchor, area);
+    let bottom_overlap = rect_overlap_area(bottom, exclusion);
+    if bottom_overlap == 0 {
+        return bottom;
+    }
+    let top_overlap = rect_overlap_area(top, exclusion);
+    if top_overlap < bottom_overlap {
+        top
+    } else {
+        bottom
+    }
+}
+
+fn coach_anchor_exclusion(anchor: Rect, area: Rect) -> Rect {
+    let anchor = anchor.intersection(area);
+    if anchor.is_empty() {
+        return anchor;
+    }
+    let left = anchor.x.saturating_sub(1).max(area.x);
+    let top = anchor.y.saturating_sub(1).max(area.y);
+    let right = anchor.right().saturating_add(1).min(area.right());
+    let bottom = anchor.bottom().saturating_add(1).min(area.bottom());
+    Rect::new(
+        left,
+        top,
+        right.saturating_sub(left),
+        bottom.saturating_sub(top),
     )
+}
+
+fn rect_overlap_area(a: Rect, b: Rect) -> u32 {
+    let overlap = a.intersection(b);
+    u32::from(overlap.width) * u32::from(overlap.height)
 }
 
 pub fn render_tool_setup(frame: &mut Frame, app: &App, area: Rect) {
@@ -778,26 +788,124 @@ pub fn render_tool_setup(frame: &mut Frame, app: &App, area: Rect) {
 
 #[cfg(test)]
 mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
     use super::*;
 
+    fn beginner_app_on(step: BeginnerStep, mode: Mode) -> App {
+        let mut app = App::new(50);
+        app.mode = mode;
+        app.config.beginner_mode = true;
+        app.config.beginner_tutorial.next_step = step.id().to_owned();
+        app.prepare_beginner_onboarding(true);
+        app
+    }
+
+    fn render_coach_rect(app: &App, width: u16, height: u16) -> Rect {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, app))
+            .unwrap();
+        app.hits
+            .rect_of_target(MouseTarget::Onboarding(OnboardingAction::Noop))
+            .expect("rendered Beginner coach")
+    }
+
     #[test]
-    fn coach_prefers_below_its_anchor() {
+    fn coach_uses_the_centered_bottom_lane_for_an_upper_anchor() {
         let area = Rect::new(4, 2, 100, 40);
         let anchor = Rect::new(40, 5, 12, 1);
         assert_eq!(
             place_coach(area, Some(anchor), 30, 10),
-            Rect::new(31, 7, 30, 10)
+            Rect::new(39, 31, 30, 10)
         );
     }
 
     #[test]
-    fn coach_uses_space_above_a_low_anchor() {
+    fn coach_uses_the_centered_top_lane_for_a_lower_anchor() {
         let area = Rect::new(0, 0, 80, 30);
         let anchor = Rect::new(35, 26, 10, 1);
         assert_eq!(
             place_coach(area, Some(anchor), 30, 10),
-            Rect::new(25, 15, 30, 10)
+            Rect::new(25, 1, 30, 10)
         );
+    }
+
+    #[test]
+    fn coach_does_not_follow_anchors_horizontally() {
+        let area = Rect::new(0, 0, 100, 30);
+        let left = place_coach(area, Some(Rect::new(2, 2, 8, 1)), 30, 10);
+        let right = place_coach(area, Some(Rect::new(90, 2, 8, 1)), 30, 10);
+        assert_eq!(left, Rect::new(35, 19, 30, 10));
+        assert_eq!(right, left);
+    }
+
+    #[test]
+    fn coach_chooses_the_smaller_overlap_when_both_lanes_are_constrained() {
+        let area = Rect::new(0, 0, 40, 12);
+        let anchor = Rect::new(5, 9, 30, 1);
+        assert_eq!(
+            place_coach(area, Some(anchor), 30, 8),
+            Rect::new(5, 1, 30, 8)
+        );
+    }
+
+    #[test]
+    fn coach_anchor_exclusion_keeps_a_one_cell_gap() {
+        let area = Rect::new(0, 0, 80, 30);
+        let anchor = Rect::new(25, 19, 30, 1);
+        let popup = place_coach(area, Some(anchor), 30, 10);
+        let exclusion = coach_anchor_exclusion(anchor, area);
+        assert!(popup.intersection(exclusion).is_empty());
+        assert_eq!(popup, Rect::new(25, 1, 30, 10));
+    }
+
+    #[test]
+    fn rendered_steps_stay_centered_and_use_only_the_two_coach_lanes() {
+        let _guard = crate::i18n::lock_for_test();
+        crate::i18n::set_language(crate::i18n::Language::English);
+        let cases = [
+            (
+                BeginnerStep::Player,
+                Mode::Player,
+                MouseTarget::VolumeArea,
+                true,
+            ),
+            (
+                BeginnerStep::Search,
+                Mode::Search,
+                MouseTarget::SearchInput,
+                false,
+            ),
+            (
+                BeginnerStep::Library,
+                Mode::Library,
+                MouseTarget::LibraryTab(LibraryTab::All),
+                false,
+            ),
+            (BeginnerStep::DjGem, Mode::Ai, MouseTarget::AiInput, true),
+        ];
+
+        for (step, mode, target, top_lane) in cases {
+            let app = beginner_app_on(step, mode);
+            let popup = render_coach_rect(&app, 80, 24);
+            let anchor = app.hits.rect_of_target(target).expect("coach anchor");
+
+            assert_eq!(popup.x, (80 - popup.width) / 2, "{step:?}");
+            if top_lane {
+                assert_eq!(popup.y, 1, "{step:?}");
+            } else {
+                assert_eq!(popup.bottom(), 23, "{step:?}");
+            }
+            assert!(
+                popup
+                    .intersection(coach_anchor_exclusion(anchor, Rect::new(0, 0, 80, 24)))
+                    .is_empty(),
+                "{step:?} coach covered its anchor: popup={popup:?} anchor={anchor:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Reorder Beginner Mode to `Welcome → Help → Player → Search → Library → DJ Gem → Settings → Finish`.
- Make one ordered step table authoritative for numbering and forward/back navigation.
- Bump the tutorial content version to 2 so active v1 tours restart coherently at Welcome.
- Keep the coach card horizontally centered and choose between stable top/bottom lanes while preserving a one-cell gap from its semantic anchor.
- Add state-machine, geometry, and rendered-surface regression coverage.

## Why

Fresh profiles open on Player, but the old `Search → Player` order forced the tour to move `Player → Search → Player`. The previous anchor-relative card placement could also move above, below, left, or right as anchors changed, making the guide feel visually unstable.

## User impact

The tour now follows the natural screen sequence without revisiting Player, and the guide card moves predictably between two centered lanes. Completed tours remain off; only active older-version tours restart from Welcome.

## Validation

- `cargo fmt --all --check`
- `cargo test app::onboarding::tests` — 14 passed
- `cargo test ui::views::onboarding::tests` — 10 passed
- `cargo test beginner` — 22 passed
- Isolated `cargo test --workspace -- --test-threads=1` — 3,402 library tests and 52 CLI tests passed
- Architecture, file-size, doc-honesty, ratatui-image patch, and unsafe-inventory checks passed
- Isolated tmux verification at 80×24, 32×14, 31×14, and 30×30 completed without playback or network search
- `cargo clippy --workspace --all-targets -- -D warnings -A clippy::collapsible-match` passed

## Baseline notes

The canonical harness wrapper was unavailable in this environment. Strict Clippy stops on two unchanged `origin/main` `collapsible_match` warnings in `src/app/search.rs` and `src/player/ipc/incoming.rs`. Default-parallel workspace tests can also expose an existing shared artifact-move test-registry race; each affected test passes alone and the complete isolated single-thread suite passes. This PR does not change those files or transfer code.