### PR TITLE
Fix cargo-path update instruction to use the Git source

### DIFF
--- a/scripts/check-doc-honesty.sh
+++ b/scripts/check-doc-honesty.sh
@@ -20,6 +20,13 @@ for doc in README.md README.ko.md README.ja.md docs/index.html; do
   [ -f "$doc" ] && public_docs+=("$doc")
 done
 
+# While the crate is publish = false, no user-facing text may suggest the bare
+# crates.io install form (`cargo install yututui`) — it fails; only --git works.
+if grep -q '^publish = false' Cargo.toml &&
+  grep -rnE 'cargo install yututui([^-]|$)' src "${public_docs[@]}"; then
+  fail "crates.io install command suggested while Cargo.toml has publish = false (use --git)"
+fi
+
 if [ "${#public_docs[@]}" -gt 0 ] &&
   grep -nEi 'production[- ]ready|works everywhere|all terminals|stable API|full Windows support' \
     "${public_docs[@]}"; then

--- a/src/app/tests/update.rs
+++ b/src/app/tests/update.rs
@@ -29,7 +29,7 @@ fn first_seen_update_emits_desktop_notification_and_marks_seen() {
         Cmd::DesktopNotify { title, body }
             if title.contains("1.0.1")
                 && body.contains("Latest: v1.0.1")
-                && body.contains("cargo install yututui --force")
+                && body.contains("cargo install --git https://github.com/Ochichan/Yututui --force")
     )));
     assert!(cmds.iter().any(|cmd| matches!(
         cmd,

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -205,8 +205,11 @@ pub fn update_instructions(method: InstallMethod) -> UpdateInstructions {
             t!("Update with Nix.", "Nix로 업데이트하세요."),
         ),
         InstallMethod::Cargo => (
-            Some("cargo install yututui --force"),
-            t!("Reinstall with cargo.", "cargo로 재설치하세요."),
+            Some("cargo install --git https://github.com/Ochichan/Yututui --force"),
+            t!(
+                "Reinstall from the Git repository with cargo.",
+                "cargo로 Git 저장소에서 재설치하세요."
+            ),
         ),
         InstallMethod::InstallerUnix => (
             None,


### PR DESCRIPTION
## What
- `InstallMethod::Cargo` update guidance suggested `cargo install yututui --force`, which fails: `Cargo.toml` has `publish = false`, so the crate is not on crates.io (external review P0 finding).
- Replaced with `cargo install --git https://github.com/Ochichan/Yututui --force`; en/ko notes updated.
- Updated the assertion in `src/app/tests/update.rs`.
- New `check-doc-honesty.sh` gate: while `publish = false`, any bare `cargo install yututui` suggestion in `src/` or public READMEs fails CI (verified the regex matches both bad forms and not the `--git` form).

## Verification
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`: pass
- `cargo test --workspace`: pass (exit 0 with pipefail)
- `scripts/check-doc-honesty.sh`, `check-architecture.sh`, `check-file-size.sh`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bTzbz7FMcniENQptZfahm