### PR TITLE
Add SECURITY.md and release-verification docs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -45,6 +45,24 @@ Windows 直接インストーラ:
 irm https://raw.githubusercontent.com/Ochichan/Yututui/main/install.ps1 | iex
 ```
 
+<details>
+<summary><b>ダウンロードを検証する</b> <i>（任意）</i></summary>
+
+すべてのリリースに `checksums.txt`（SHA-256）と GitHub のビルド provenance attestation が付きます。
+動いているブランチ（main）ではなく最新リリースに固定したインストーラも使えます:
+
+```sh
+curl -fsSL https://github.com/Ochichan/Yututui/releases/latest/download/install.sh | bash
+
+# チェックサム（成果物と checksums.txt を同じフォルダに置いて）:
+sha256sum -c --ignore-missing checksums.txt        # macOS: shasum -a 256 -c
+
+# Provenance — このリポジトリのリリースワークフローが作った成果物である証明 (GitHub CLI):
+gh attestation verify yututui-linux-x64.tar.gz --repo Ochichan/Yututui
+```
+
+</details>
+
 Windows ではスタートメニューの **YuTuTui!** を選んでください。Tray 補助アプリが
 Windows Terminal を開いて `ytt` を起動し、Tray アイコンの右クリックメニューにも
 **Open Player** があります。`ytt.exe` の直接ダブルクリックにも対応し、終了後も
@@ -514,6 +532,12 @@ ytt tools unpin               # 通常の managed/system 選択に戻す
 アプリ自身の yt-dlp 呼び出しは、既定であなたの yt-dlp 設定ファイルを無視するので、シェルのダウンロード用オプションがパース出力を壊しません。アプリのパース呼び出しにも yt-dlp 設定を使うなら `YTM_YTDLP_USER_CONFIG=1`。mpv の `ytdl_hook` 経由の再生は引き続き yt-dlp 設定に従い、検索・プレイリスト取得・メタデータ・プリフェッチ解決・ダウンロードだけが既定で無視します。
 
 </details>
+
+## セキュリティ
+
+脆弱性を見つけたら、公開 issue ではなく
+[GitHub の非公開脆弱性報告](https://github.com/Ochichan/Yututui/security/advisories/new)を
+使ってください — サポート対象バージョンと成果物の検証方法は [SECURITY.md](SECURITY.md) にあります。
 
 ## 謝辞 & ライセンス
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -45,6 +45,24 @@ Windows 직접 설치:
 irm https://raw.githubusercontent.com/Ochichan/Yututui/main/install.ps1 | iex
 ```
 
+<details>
+<summary><b>다운로드 검증하기</b> <i>(선택)</i></summary>
+
+모든 릴리스에는 `checksums.txt`(SHA-256)와 GitHub 빌드 provenance attestation이 포함됩니다.
+움직이는 브랜치(main) 대신 최신 릴리스에 고정된 설치 스크립트를 쓸 수도 있어요:
+
+```sh
+curl -fsSL https://github.com/Ochichan/Yututui/releases/latest/download/install.sh | bash
+
+# 체크섬 (산출물과 checksums.txt를 같은 폴더에 두고):
+sha256sum -c --ignore-missing checksums.txt        # macOS: shasum -a 256 -c
+
+# Provenance — 이 저장소의 릴리스 워크플로가 만든 산출물인지 증명 (GitHub CLI):
+gh attestation verify yututui-linux-x64.tar.gz --repo Ochichan/Yututui
+```
+
+</details>
+
 Windows에서는 시작 메뉴의 **YuTuTui!** 를 누르세요. Tray 보조 앱이 Windows Terminal을
 열고 `ytt`를 실행하며, tray 아이콘 우클릭 메뉴에도 **플레이어 열기(Open Player)** 가
 있습니다. `ytt.exe`를 직접 더블클릭해도 되고, 종료 뒤 콘솔이 남아 오류를 읽을 수
@@ -511,6 +529,12 @@ ytt tools unpin               # 기본 managed/system 선택 정책으로 복귀
 앱 자체의 yt-dlp 호출은 기본적으로 여러분의 yt-dlp 설정 파일을 무시하므로, 셸 다운로드용 옵션이 파싱 출력을 깨지 않습니다. 앱 파싱 호출에도 yt-dlp 설정을 쓰려면 `YTM_YTDLP_USER_CONFIG=1`. mpv의 `ytdl_hook`을 통한 재생은 여전히 yt-dlp 설정을 따르고, 검색·플레이리스트 조회·메타데이터·프리페치 해석·다운로드만 기본적으로 무시합니다.
 
 </details>
+
+## 보안
+
+취약점을 찾으셨나요? 공개 이슈 대신
+[GitHub 비공개 취약점 신고](https://github.com/Ochichan/Yututui/security/advisories/new)를
+이용해 주세요 — 지원 버전과 산출물 검증 방법은 [SECURITY.md](SECURITY.md)에 있습니다.
 
 ## 감사 & 라이선스
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ Windows direct installer:
 irm https://raw.githubusercontent.com/Ochichan/Yututui/main/install.ps1 | iex
 ```
 
+<details>
+<summary><b>Verify what you download</b> <i>(optional)</i></summary>
+
+Every release ships `checksums.txt` (SHA-256) and GitHub build-provenance attestations.
+To avoid running an installer fetched from a moving branch, pin it to the latest release:
+
+```sh
+curl -fsSL https://github.com/Ochichan/Yututui/releases/latest/download/install.sh | bash
+
+# Checksums (artifact + checksums.txt in the same directory):
+sha256sum -c --ignore-missing checksums.txt        # macOS: shasum -a 256 -c
+
+# Provenance — proves the artifact came from this repo's release workflow (GitHub CLI):
+gh attestation verify yututui-linux-x64.tar.gz --repo Ochichan/Yututui
+```
+
+</details>
+
 On Windows, launch **YuTuTui!** from the Start Menu. The tray companion opens Windows Terminal
 and starts `ytt` for you; its right-click menu also has **Open Player**. Double-clicking
 `ytt.exe` directly is supported too, and the console stays open after exit so an error is not
@@ -518,6 +536,13 @@ ytt tools unpin               # return to normal managed/system selection
 The app's own yt-dlp calls ignore your yt-dlp config file by default, so options meant for shell downloads do not break parsed output. Set `YTM_YTDLP_USER_CONFIG=1` to re-enable your yt-dlp config for app-parsed calls. Playback through mpv's `ytdl_hook` still honors your yt-dlp config; only search, playlist fetches, metadata, prefetch resolution, and downloads ignore it by default.
 
 </details>
+
+## Security
+
+Found a vulnerability? Please use
+[GitHub private vulnerability reporting](https://github.com/Ochichan/Yututui/security/advisories/new)
+instead of a public issue — supported versions and artifact verification live in
+[SECURITY.md](SECURITY.md).
 
 ## Thanks & license
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report vulnerabilities privately via
+[GitHub private vulnerability reporting](https://github.com/Ochichan/Yututui/security/advisories/new)
+— **not** in a public issue or pull request.
+
+This is a solo-maintained project. You should normally hear back within **7 days**;
+confirmed issues are fixed in the next release (or an out-of-band release for anything
+severe). Please leave reasonable time for a fix before public disclosure.
+
+## Supported versions
+
+YuTuTui! is a fast-moving public beta. Only the **latest release** receives security
+fixes — older versions are not patched retroactively. Update paths for every install
+method are listed in the in-app update notice and the README.
+
+## What counts
+
+Especially interesting areas, given what the app handles:
+
+- Credential handling: auth cookies, API keys (e.g. Gemini, Last.fm/ListenBrainz),
+  OAuth tokens, and the personal-data export allowlist.
+- The local control endpoint / IPC surface (Unix socket permissions, token handling).
+- The managed yt-dlp downloader and its SHA-256 verification.
+- Release pipeline and packaging (Homebrew / Scoop / AUR artifacts).
+
+Crashes without a security impact are ordinary bugs — a regular issue is perfect
+for those.
+
+## Verifying release artifacts
+
+Every release ships a `checksums.txt` (SHA-256) and GitHub build-provenance
+attestations for its artifacts:
+
+```sh
+# Checksums (download the artifact and checksums.txt into the same directory):
+sha256sum -c --ignore-missing checksums.txt        # macOS: shasum -a 256 -c
+
+# Provenance — proves the artifact was built by this repository's release workflow:
+gh attestation verify yututui-linux-x64.tar.gz --repo Ochichan/Yututui
+```
+
+To avoid running an installer fetched from a moving branch, pin it to the latest
+release instead of `main`:
+
+```sh
+curl -fsSL https://github.com/Ochichan/Yututui/releases/latest/download/install.sh | bash
+```


### PR DESCRIPTION
## What
External review P2: no SECURITY.md anywhere; README's `curl .../main/install.sh | bash` fetches the installer from a mutable branch with no documented verification path, even though releases already ship `checksums.txt` and provenance attestations.

- New `SECURITY.md`: private vulnerability reporting (GitHub advisories), latest-release-only support policy, interesting scopes (credentials, IPC endpoint, managed yt-dlp, release pipeline), artifact verification.
- README en/ko/ja: collapsed **Verify what you download** block after the direct-installer commands (release-pinned installer URL, sha256 check, `gh attestation verify`), plus a short **Security** section linking SECURITY.md.

## Verification
- `https://github.com/Ochichan/Yututui/releases/latest/download/install.sh` → HTTP 200 (release assets include the installers).
- GitHub attestation API returns 1 attestation for the v1.6.33 linux-x64 artifact digest — the documented `gh attestation verify` command is real.
- `scripts/check-doc-honesty.sh`: pass. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bTzbz7FMcniENQptZfahm