### PR TITLE
Single-source RUSTSEC exceptions in deny.toml

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -73,27 +73,17 @@ jobs:
 
       - name: Ensure supply-chain tools
         run: |
-          command -v cargo-audit >/dev/null || cargo install --locked cargo-audit
           command -v cargo-deny >/dev/null || cargo install --locked cargo-deny
 
-      - name: RustSec audit
-        run: |
-          cargo audit --deny warnings \
-            --ignore RUSTSEC-2024-0411 \
-            --ignore RUSTSEC-2024-0412 \
-            --ignore RUSTSEC-2024-0413 \
-            --ignore RUSTSEC-2024-0414 \
-            --ignore RUSTSEC-2024-0415 \
-            --ignore RUSTSEC-2024-0416 \
-            --ignore RUSTSEC-2024-0418 \
-            --ignore RUSTSEC-2024-0419 \
-            --ignore RUSTSEC-2024-0420 \
-            --ignore RUSTSEC-2024-0429 \
-            --ignore RUSTSEC-2024-0436 \
-            --ignore RUSTSEC-2024-0370
+      # RUSTSEC exceptions live in deny.toml [advisories].ignore — the single source
+      # of truth (the old cargo-audit step duplicated them as --ignore flags).
+      # --all-features widens ONLY this advisory scan to optional-feature deps
+      # (desktop tray stack); bans/licenses/sources keep the default graph.
+      - name: RustSec advisories (full feature graph)
+        run: cargo deny --all-features check advisories
 
       - name: Dependency policy
-        run: cargo deny check
+        run: cargo deny check bans licenses sources
 
       - name: GUI frontend (typecheck, test, build)
         run: |

--- a/deny.toml
+++ b/deny.toml
@@ -4,9 +4,29 @@ no-default-features = false
 
 [advisories]
 db-urls = ["https://github.com/rustsec/advisory-db"]
+# Single source of truth for RUSTSEC exceptions. CI runs advisories against the FULL
+# feature graph (`cargo deny --all-features check advisories`) so optional-feature
+# dependencies are covered too; bans/licenses/sources keep the default graph above.
+# Every entry carries: reachable path, why accepted, removal condition, review date.
+#
+# Nine gtk-rs GTK3 advisories below share one story: unmaintained bindings that enter
+# the graph only via the optional `desktop` feature's LINUX tray backend
+# (tray-icon/tao → libappindicator/muda → gtk3 stack). Shipped releases build the
+# tray companion for macOS/Windows only, which never link GTK. Remove when
+# tray-icon/tao drop GTK3. Review by 2026-10.
 ignore = [
-    # Transitive via lofty 0.24.0. RUSTSEC marks paste unmaintained but lists no safe upgrade.
-    "RUSTSEC-2024-0436",
+    { id = "RUSTSEC-2024-0411", reason = "gdkwayland-sys: unmaintained gtk3-rs; optional Linux tray path only, not in shipped artifacts" },
+    { id = "RUSTSEC-2024-0412", reason = "gdk: unmaintained gtk3-rs; optional Linux tray path only, not in shipped artifacts" },
+    { id = "RUSTSEC-2024-0413", reason = "atk: unmaintained gtk3-rs; optional Linux tray path only, not in shipped artifacts" },
+    { id = "RUSTSEC-2024-0414", reason = "gdkx11-sys: unmaintained gtk3-rs; optional Linux tray path only, not in shipped artifacts" },
+    { id = "RUSTSEC-2024-0415", reason = "gtk: unmaintained gtk3-rs; optional Linux tray path only, not in shipped artifacts" },
+    { id = "RUSTSEC-2024-0416", reason = "atk-sys: unmaintained gtk3-rs; optional Linux tray path only, not in shipped artifacts" },
+    { id = "RUSTSEC-2024-0418", reason = "gdk-sys: unmaintained gtk3-rs; optional Linux tray path only, not in shipped artifacts" },
+    { id = "RUSTSEC-2024-0419", reason = "gtk3-macros: unmaintained gtk3-rs; optional Linux tray path only, not in shipped artifacts" },
+    { id = "RUSTSEC-2024-0420", reason = "gtk-sys: unmaintained gtk3-rs; optional Linux tray path only, not in shipped artifacts" },
+    { id = "RUSTSEC-2024-0429", reason = "glib VariantStrIter unsoundness: same optional Linux tray path; the iterator APIs are never called here. Remove with the gtk3 block. Review 2026-10" },
+    { id = "RUSTSEC-2024-0370", reason = "proc-macro-error unmaintained, via glib-macros in the same optional Linux tray path. Remove with the gtk3 block. Review 2026-10" },
+    { id = "RUSTSEC-2024-0436", reason = "paste unmaintained, via lofty 0.24.0 (tag reading); RUSTSEC lists no safe upgrade. Remove when lofty drops paste. Review 2026-10" },
 ]
 yanked = "warn"
 


### PR DESCRIPTION
## What
External review P1: `cargo audit` ignored 12 RUSTSEC advisories inline (duplicated in ci-pr.yml and native-release-build.yml) while `deny.toml` tracked only 1 — no single place records why an exception exists or when it should die.

- All 12 advisories moved to `deny.toml [advisories].ignore` as `{ id, reason }` entries with dependency path, why accepted, removal condition, and a 2026-10 review date. (9× unmaintained gtk3-rs + glib unsound + proc-macro-error: all reachable only via the optional `desktop` feature's **Linux** tray backend, which shipped releases never build; paste via lofty.)
- ci-pr.yml: cargo-audit step and install removed. Advisories now run as `cargo deny --all-features check advisories` — **stricter than before**: the old `cargo deny check` used the default-features graph and never saw the gtk stack at all (that's why 1 ignore sufficed). bans/licenses/sources keep the default graph; widening it fails 20+ duplicate-crate bans for deps that never ship.
- native-release-build.yml still carries the old audit step — that file is a protected release surface; its cleanup rides in the release-surface follow-up PR once the user grants the release-surface sanction.

## Verification
- `cargo deny --all-features check advisories` → ok; `cargo deny check bans licenses sources` → ok (cargo-deny 0.19.6).
- Negative test: removing the RUSTSEC-2024-0415 ignore makes the advisories check FAIL — the full-graph scan genuinely bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bTzbz7FMcniENQptZfahm