### PR TITLE
Pin actions to commit SHAs and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Keeps the SHA-pinned actions in .github/workflows/ current (the `# vN` comments
+# next to each pin tell dependabot the intended track). Cargo deps are intentionally
+# NOT managed here: cargo-deny gates advisories/bans in CI and lockfile bumps are
+# done deliberately per release.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -34,7 +34,7 @@ jobs:
     # Match debian-ts custom labels; OS/arch come from the runner automatically.
     runs-on: [self-hosted, debian, yututui]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Persist cargo target dir
         run: |
@@ -46,8 +46,9 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Format
@@ -73,7 +74,10 @@ jobs:
 
       - name: Ensure supply-chain tools
         run: |
-          command -v cargo-deny >/dev/null || cargo install --locked cargo-deny
+          # Pinned so a runner-cached older/newer binary can't change what the gate means.
+          want="0.19.6"
+          have="$(cargo deny --version 2>/dev/null | awk '{print $2}')" || have=""
+          [ "$have" = "$want" ] || cargo install --locked cargo-deny --version "$want"
 
       # RUSTSEC exceptions live in deny.toml [advisories].ignore — the single source
       # of truth (the old cargo-audit step duplicated them as --ignore flags).
@@ -112,8 +116,8 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/dependency-review-action@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           fail-on-severity: high
 
@@ -123,7 +127,7 @@ jobs:
     # Match debian-ts custom labels; OS/arch come from the runner automatically.
     runs-on: [self-hosted, debian, yututui]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Persist cargo target dir
         run: |
@@ -135,8 +139,9 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
+          toolchain: stable
           components: clippy
 
       - name: Install Linux system dependencies
@@ -173,11 +178,12 @@ jobs:
     runs-on: [self-hosted, windows, x64, yututui]
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
+          toolchain: stable
           components: clippy
 
       - name: Clippy (warnings = errors)
@@ -199,7 +205,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, yututui]
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Persist cargo target dir
         run: |
@@ -210,8 +216,9 @@ jobs:
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
+          toolchain: stable
           components: clippy
 
       - name: Clippy (warnings = errors)

--- a/.github/workflows/release-preflight-1.6.33.yml
+++ b/.github/workflows/release-preflight-1.6.33.yml
@@ -22,11 +22,13 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
+        with:
+          toolchain: stable
       - name: Verify locked package version
         shell: bash
         run: |
@@ -55,11 +57,11 @@ jobs:
     needs: release-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Download platform artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: yututui-*
           merge-multiple: true
@@ -130,7 +132,7 @@ jobs:
           test -s install.sh
           test -s install.ps1
       - name: Upload complete preflight bundle
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: yututui-1.6.33-preflight
           if-no-files-found: error


### PR DESCRIPTION
## What
External review P1 (supply chain): all workflows used mutable action tags and unpinned tool installs.

- `ci-pr.yml` + `release-preflight-1.6.33.yml`: every `uses:` pinned to a full commit SHA with a `# vN` track comment (dependabot reads those to propose bumps).
- `dtolnay/rust-toolchain` pinned to the current `stable`-branch SHA **plus** an explicit `toolchain: stable` input — with a SHA ref the action can no longer infer the channel from the tag name.
- cargo-deny pinned to 0.19.6; the ensure-step now compares `cargo deny --version` so a stale preinstalled binary on a self-hosted runner gets replaced instead of silently winning.
- New `.github/dependabot.yml`: `github-actions` ecosystem, weekly (cargo ecosystem deliberately excluded — advisories/bans are gated by cargo-deny, and lockfile bumps happen per release).
- `build.yml` / `native-release-build.yml` are protected release surfaces — same treatment lands in a follow-up once the release-surface sanction is granted.

**Stacked on #88** (both edit `ci-pr.yml`); merges after it, base auto-retargets to main.

## Verification
- `actionlint`: only pre-existing findings (custom self-hosted runner labels, SC2129 style in untouched blocks); nothing on the new pins/inputs/dependabot.
- SHAs resolved from GitHub refs: checkout v5 → 93cb6efe…, dependency-review v5 → a1d282b3…, download-artifact v7 → 37930b1c…, upload-artifact v6 → b7c566a7…, rust-toolchain stable → 4be7066a….

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bTzbz7FMcniENQptZfahm