### PR TITLE
Pin release-workflow actions and single-source their advisories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ name: build
 # PKGBUILD to their external repos (see packaging/README.md).
 #
 # Daily PR / main merge gates live in ci-pr.yml (debian-ts self-hosted). This entrypoint is
-# release-only; native-release-build.yml is also called by the scoped 1.6.32 preflight PR.
+# release-only; native-release-build.yml is also called by the current release-preflight workflow.
 
 on:
   push:
@@ -41,7 +41,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Verify tag matches Cargo version
         run: |
           tag="${GITHUB_REF_NAME#v}"
@@ -51,7 +51,7 @@ jobs:
             echo "::error::release tag v$tag does not match Cargo.toml version $version"
             exit 1
           fi
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           merge-multiple: true
       - name: Verify release artifact scope
@@ -100,13 +100,13 @@ jobs:
         # awk extractors in the publish jobs match the Windows line too.
         run: cat ./*.sha256 | sed 's/ \*/  /' | sort -k2 > checksums.txt
       - name: Attest release artifacts
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-path: |
             yututui-*.tar.gz
             yututui-*.zip
             checksums.txt
-      - uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
@@ -117,7 +117,7 @@ jobs:
             checksums.txt
       # Hand checksums.txt to the packaging jobs as an artifact, so they don't round-trip the
       # Releases API right after publish (avoids an asset-propagation race).
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: checksums
           path: checksums.txt
@@ -133,8 +133,8 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v7
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: checksums
       - name: Render formula
@@ -171,8 +171,8 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v7
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: checksums
       - name: Render manifest
@@ -205,7 +205,7 @@ jobs:
     env:
       AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Render PKGBUILD
         run: |
           sed "s/__VERSION__/${GITHUB_REF_NAME#v}/g" packaging/aur/PKGBUILD.tmpl > PKGBUILD
@@ -214,7 +214,7 @@ jobs:
       # regenerates .SRCINFO and pushes to ssh://aur@aur.archlinux.org/yututui-bin.git.
       - name: Publish to AUR
         if: env.AUR_SSH_PRIVATE_KEY != ''
-        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
+        uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3
         with:
           pkgname: yututui-bin
           pkgbuild: ./PKGBUILD

--- a/.github/workflows/native-release-build.yml
+++ b/.github/workflows/native-release-build.yml
@@ -18,12 +18,13 @@ jobs:
     name: Quality gates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
+          toolchain: stable
           components: rustfmt, clippy
       - name: Format
         run: cargo fmt --check
@@ -45,29 +46,18 @@ jobs:
           --features crossterm,tokio
           --all-targets -- -D warnings
       - name: Install supply-chain tools
-        run: cargo install --locked cargo-audit cargo-deny
-      - name: RustSec audit
-        run: |
-          cargo audit --deny warnings \
-            --ignore RUSTSEC-2024-0411 \
-            --ignore RUSTSEC-2024-0412 \
-            --ignore RUSTSEC-2024-0413 \
-            --ignore RUSTSEC-2024-0414 \
-            --ignore RUSTSEC-2024-0415 \
-            --ignore RUSTSEC-2024-0416 \
-            --ignore RUSTSEC-2024-0418 \
-            --ignore RUSTSEC-2024-0419 \
-            --ignore RUSTSEC-2024-0420 \
-            --ignore RUSTSEC-2024-0429 \
-            --ignore RUSTSEC-2024-0436 \
-            --ignore RUSTSEC-2024-0370
+        run: cargo install --locked cargo-deny --version 0.19.6
+      # RUSTSEC exceptions live in deny.toml [advisories].ignore (single source of
+      # truth); --all-features widens only the advisory scan to optional-feature deps.
+      - name: RustSec advisories (full feature graph)
+        run: cargo deny --all-features check advisories
       - name: Dependency policy
-        run: cargo deny check
+        run: cargo deny check bans licenses sources
       # --- Non-shipping GUI/frontend contract gates (docs/gui/04 §5) ---
       # The full GUI app is not published in this release. These still run so the protocol and
       # future frontend do not drift while the shipped surface remains TUI + tray.
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
       - name: GUI frontend (typecheck, test, build)
@@ -98,10 +88,10 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
-      - uses: actions/dependency-review-action@v5
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           fail-on-severity: high
 
@@ -138,7 +128,7 @@ jobs:
             bin: ytt
             archive: yututui-linux-arm64.tar.gz
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 
@@ -163,8 +153,9 @@ jobs:
           brew install mpv
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
           components: clippy
 
@@ -545,7 +536,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ matrix.archive }}
           path: |


### PR DESCRIPTION
## ⚠ Merge order
**Merge #88 first** — the advisory step here reads the 12-entry ignore list that #88 adds to deny.toml. (Recommended order: #88 → #89 → #91 → this.)

## What
Release-surface counterpart of #89/#88, done under the user-granted release-surface sanction (granted this session):

- `build.yml` + `native-release-build.yml`: every `uses:` pinned to a full commit SHA with `# vN` comments (checkout v5, download-artifact v7, upload-artifact v6, attest-build-provenance v3, gh-release v3, deploy-aur v4.1.3, setup-node v6, dependency-review v5, rust-toolchain stable — annotated tags dereferenced to commit SHAs).
- Pinned `dtolnay/rust-toolchain` gets explicit `toolchain: stable` inputs (both call sites).
- `native-release-build.yml`: cargo-audit step + inline 12-advisory ignore list removed → `cargo deny --all-features check advisories` (deny.toml is the single source); cargo-deny pinned to 0.19.6; `cargo deny check` scoped to `bans licenses sources`.
- `build.yml:14` stale "1.6.32 preflight" comment → version-agnostic.

No trigger, secret, permission, or publish-step changes — pins and the advisory-gate swap only.

## Verification
- `actionlint` on both files: only pre-existing runner-label noise; nothing on the changed lines.
- `cargo deny --all-features check advisories` + `cargo deny check bans licenses sources` verified green locally on the #88 branch (cargo-deny 0.19.6), including the negative un-ignore test.
- Diff: +28/−37 across the two files, reviewed line-by-line — publish jobs (homebrew/scoop/AUR) untouched except SHA pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bTzbz7FMcniENQptZfahm