### PR TITLE
Add guided second-launch UX

### DIFF
--- a/packaging/linux/yututui.desktop
+++ b/packaging/linux/yututui.desktop
@@ -16,3 +16,6 @@ Icon=yututui
 Categories=AudioVideo;Audio;Player;
 Keywords=youtube;music;player;tui;terminal;
 StartupNotify=false
+# Desktop Entry spec 1.5 hint: shells shouldn't offer "New Window" — a second launch
+# routes to the running player via the in-app second-launch chooser instead.
+SingleMainWindow=true

--- a/scripts/check-unsafe-inventory.sh
+++ b/scripts/check-unsafe-inventory.sh
@@ -31,6 +31,7 @@ is_allowed() {
     src/media/smtc.rs) return 0 ;;
     src/player/guardian.rs) return 0 ;;
     src/player/lifetime.rs) return 0 ;;
+    src/second_launch/focus_windows.rs) return 0 ;;
     src/test_util/env.rs) return 0 ;;
     src/util/process.rs) return 0 ;;
     src/util/runtime.rs) return 0 ;;

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,9 @@ pub use audio::{
     MpvAudioRuntimeConfig,
 };
 pub use spotify::SpotifyImportMode;
-pub use storage::{default_cookies_file, default_download_dir, default_recording_dir};
+pub use storage::{
+    default_cookies_file, default_download_dir, default_recording_dir, peek_saved_language,
+};
 pub use visual::{AlbumArtQuality, PlayerBarPosition, VideoOverlay};
 
 pub(crate) use storage::config_path;

--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -185,6 +185,38 @@ pub(crate) fn config_path() -> Option<PathBuf> {
     crate::paths::config_dir().map(|d| d.join("config.json"))
 }
 
+/// Read-only peek at the saved UI language for pre-persistence surfaces.
+///
+/// The second-launch chooser renders before the writer lease exists, so it must not go
+/// through `Config::load` (which can migrate, repair, and write). A 2-field serde read of
+/// the current config is enough: `retro_mode` forces English exactly like
+/// `Config::effective_language`. Any failure — missing file, oversize, corrupt JSON —
+/// falls back to English. Saves are atomic temp+rename, so a torn read cannot happen.
+pub fn peek_saved_language() -> crate::i18n::Language {
+    config_path()
+        .map(|path| peek_saved_language_at(&path))
+        .unwrap_or_default()
+}
+
+pub(super) fn peek_saved_language_at(path: &std::path::Path) -> crate::i18n::Language {
+    #[derive(Default, serde::Deserialize)]
+    struct Peek {
+        #[serde(default)]
+        language: crate::i18n::Language,
+        #[serde(default)]
+        retro_mode: bool,
+    }
+    let Ok(bytes) = crate::util::safe_fs::read_no_symlink_limited(path, MAX_CONFIG_BYTES) else {
+        return crate::i18n::Language::English;
+    };
+    let peek: Peek = serde_json::from_slice(&bytes).unwrap_or_default();
+    if peek.retro_mode {
+        crate::i18n::Language::English
+    } else {
+        peek.language
+    }
+}
+
 pub(super) fn old_config_path() -> Option<PathBuf> {
     // Never import the original app's config while a config-dir override is active (a non-blank
     // env override — mirroring `paths::config_dir`'s blank-is-unset rule — or the test sandbox):

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1098,3 +1098,34 @@ fn effective_dj_gem_language_resolves_retro_auto_and_concrete() {
     };
     assert_eq!(cfg.effective_dj_gem_language(), DjGemLanguage::English);
 }
+
+#[test]
+fn peek_saved_language_never_writes_and_mirrors_effective_language() {
+    let dir = std::env::temp_dir().join(format!("ytm-lang-peek-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("config.json");
+    let peek = storage::peek_saved_language_at;
+
+    // Missing file → English, and the peek must not create it.
+    assert_eq!(peek(&path), Language::English);
+    assert!(!path.exists(), "a peek must never write a config file");
+
+    // Saved Korean → Korean.
+    std::fs::write(&path, r#"{"language":"korean"}"#).unwrap();
+    assert_eq!(peek(&path), Language::Korean);
+
+    // Retro mode forces English, mirroring `Config::effective_language`.
+    std::fs::write(&path, r#"{"language":"korean","retro_mode":true}"#).unwrap();
+    assert_eq!(peek(&path), Language::English);
+
+    // Corrupt JSON and oversize files degrade to English without touching the file
+    // (unlike `Config::load`, which would set the file aside and rewrite it).
+    std::fs::write(&path, "{not json").unwrap();
+    assert_eq!(peek(&path), Language::English);
+    std::fs::write(&path, "x".repeat(2 * 1024 * 1024)).unwrap();
+    assert_eq!(peek(&path), Language::English);
+    assert_eq!(std::fs::read(&path).unwrap().len(), 2 * 1024 * 1024);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src/desktop/gateway/tests.rs
+++ b/src/desktop/gateway/tests.rs
@@ -12,6 +12,7 @@ fn test_instance(endpoint: String, token: &str) -> InstanceFile {
         mode: InstanceMode::Daemon,
         protocol_version: PROTOCOL_VERSION,
         capabilities: vec!["events-v8".to_string()],
+        host_terminal: None,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod romanize;
 pub mod runtime;
 pub mod scrobble;
 pub mod search_source;
+pub mod second_launch;
 pub mod session;
 pub mod settings;
 pub mod signals;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use yututui::{
     auth_cli,
     cli_capability::{OneShotCommand, collect_lossy_cli_args, interactive_persistence_capability},
-    daemon, doctor, i18n, media, persist, player, remote,
+    daemon, doctor, i18n, media, persist, player, remote, second_launch,
     terminal_runtime::{self, StartupTrace},
     tools, transfer, tui, update, zoom,
 };
@@ -13,9 +13,6 @@ use std::time::Duration;
 /// grace only prevents a timed-out `spawn_blocking` closure from making `Runtime::drop` wait
 /// without a bound; normal shutdown should have no work left by the time it starts.
 const RUNTIME_SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
-const ALREADY_RUNNING_NOTICE: &str = "ytt is already running.\n  \
-                                      Control it:  ytt -r <command>   (e.g. `ytt -r pp`, `ytt -r next`)\n  \
-                                      Stop it:     ytt -r quit";
 
 fn initialize_cli_persistence(command: OneShotCommand, args: &[String]) -> bool {
     let capability = command.persistence_capability(args);
@@ -45,18 +42,41 @@ fn initialize_cli_persistence(command: OneShotCommand, args: &[String]) -> bool 
 }
 
 fn initialize_interactive_persistence(
-    new_instance: bool,
+    read_only: bool,
 ) -> std::io::Result<persist::PersistenceAccess> {
-    let capability = interactive_persistence_capability(new_instance);
+    let capability = interactive_persistence_capability(read_only);
     debug_assert!(capability.requires_persistence());
     if capability.allows_writes() {
         persist::initialize_persistence_writer(false)
     } else {
-        // `--new-instance` is an explicit observational secondary, even when no primary happens
-        // to be alive. Never opportunistically promote it to the shared-root writer: doing so
-        // makes the same command mutate or migrate state depending on startup timing.
+        // `--new-instance` (and the chooser's read-only path) is an explicit observational
+        // secondary, even when no primary happens to be alive. Never opportunistically promote
+        // it to the shared-root writer: doing so makes the same command mutate or migrate
+        // state depending on startup timing.
         persist::initialize_persistence_reader()
     }
+}
+
+/// Bounded retry over [`initialize_interactive_persistence`] for the restart takeover.
+/// `initialize_writer_state` leaves the process lease `Uninitialized` on a failed acquire,
+/// so retrying is safe.
+fn initialize_interactive_persistence_with_retry(
+    read_only: bool,
+    attempts: u32,
+) -> std::io::Result<persist::PersistenceAccess> {
+    let mut last = None;
+    for attempt in 0..attempts.max(1) {
+        match initialize_interactive_persistence(read_only) {
+            Ok(access) => return Ok(access),
+            Err(error) => {
+                last = Some(error);
+                if attempt + 1 < attempts {
+                    std::thread::sleep(Duration::from_millis(300));
+                }
+            }
+        }
+    }
+    Err(last.expect("at least one attempt always runs"))
 }
 
 mod data_cli;
@@ -272,23 +292,46 @@ fn pause_explorer_console(result: &Result<()>) {
 
 async fn async_main(new_instance: bool, mut startup: StartupTrace) -> Result<()> {
     // Single-instance guard + control socket. Done BEFORE the terminal is touched so the
-    // "already running" notice prints to a clean screen and, critically, before any config
-    // loader can migrate or repair state. `--new-instance` skips the guard and binds a private
+    // second-launch UX renders on a clean screen and, critically, before any config loader
+    // can migrate or repair state. `--new-instance` skips the guard and binds a private
     // socket; a bind failure degrades to running without remote control rather than refusing.
-    let remote = match remote::bind_or_detect(new_instance).await {
+    let (remote, read_only, via_restart) = match remote::bind_or_detect(new_instance).await {
         remote::BindOutcome::AlreadyRunning => {
-            eprintln!("{ALREADY_RUNNING_NOTICE}");
-            return Ok(());
+            match second_launch::handle_already_running().await {
+                second_launch::Outcome::Exit => return Ok(()),
+                second_launch::Outcome::Continue { remote, read_only } => {
+                    (remote.map(|server| *server), read_only, !read_only)
+                }
+            }
         }
-        remote::BindOutcome::Bound(server) => Some(*server),
-        remote::BindOutcome::Unavailable => None,
+        remote::BindOutcome::Bound(server) => (Some(*server), new_instance, false),
+        remote::BindOutcome::Unavailable => (None, new_instance, false),
     };
+    // Advertise where this TUI lives so a later second launch can focus this terminal.
+    // Only the interactive player: the daemon path never attaches a hint, and a private
+    // `--new-instance` socket never publishes the descriptor anyway.
+    let remote = remote.map(|server| {
+        #[cfg_attr(not(windows), allow(unused_mut))]
+        let mut hint = remote::proto::HostTerminalHint::capture_from_env();
+        #[cfg(windows)]
+        {
+            hint.console_hwnd = second_launch::focus_windows::console_hwnd();
+            hint.terminal_host_pid = second_launch::focus_windows::terminal_host_pid();
+        }
+        server.with_host_terminal(hint)
+    });
     startup.mark("remote_bound");
 
     // The primary owner must hold one process-wide writer lease before Config::load can migrate
     // anything. A deliberate secondary player remains available, but only as strict read-only;
     // normal owners and mutating CLI paths fail rather than accepting state a newer epoch discards.
-    let persistence_access = initialize_interactive_persistence(new_instance)?;
+    // A restart takeover retries briefly: the old owner's lease provably dies with its process
+    // (we already waited for pid exit), but the OS can lag releasing the lock file.
+    let persistence_access = if via_restart {
+        initialize_interactive_persistence_with_retry(read_only, 3)?
+    } else {
+        initialize_interactive_persistence(read_only)?
+    };
     let (cfg, persistent_state) = persist::load_verified_startup_state()?;
     startup.mark("config_loaded");
     // Apply the saved UI language before anything renders, so the first frame is already
@@ -362,15 +405,6 @@ mod tests {
             interactive_persistence_capability(false),
             CliPersistenceCapability::Writer
         );
-    }
-
-    #[test]
-    fn already_running_notice_keeps_controls_without_advertising_new_instance() {
-        assert!(ALREADY_RUNNING_NOTICE.contains("Control it:"));
-        assert!(ALREADY_RUNNING_NOTICE.contains("ytt -r <command>"));
-        assert!(ALREADY_RUNNING_NOTICE.contains("Stop it:"));
-        assert!(ALREADY_RUNNING_NOTICE.contains("ytt -r quit"));
-        assert!(!ALREADY_RUNNING_NOTICE.contains("--new-instance"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,10 +325,12 @@ async fn async_main(new_instance: bool, mut startup: StartupTrace) -> Result<()>
     // The primary owner must hold one process-wide writer lease before Config::load can migrate
     // anything. A deliberate secondary player remains available, but only as strict read-only;
     // normal owners and mutating CLI paths fail rather than accepting state a newer epoch discards.
-    // A restart takeover retries briefly: the old owner's lease provably dies with its process
-    // (we already waited for pid exit), but the OS can lag releasing the lock file.
+    // A restart takeover retries for a few seconds: the restart sequence waits for the
+    // owner's pid to exit when the descriptor names one, but a stale/foreign descriptor
+    // degrades that wait to a fixed grace — the flock lease is then the only arbiter, and
+    // the old owner may still be flushing behind its already-released socket.
     let persistence_access = if via_restart {
-        initialize_interactive_persistence_with_retry(read_only, 3)?
+        initialize_interactive_persistence_with_retry(read_only, 10)?
     } else {
         initialize_interactive_persistence(read_only)?
     };

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -112,31 +112,46 @@ fn emit_native(title: String, body: String) {
     #[cfg(all(target_os = "macos", panic = "abort"))]
     {
         let _ = (title, body);
-        return;
     }
     #[cfg(not(all(target_os = "macos", panic = "abort")))]
-    std::thread::spawn(move || {
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let mut n = notify_rust::Notification::new();
-            n.appname("YuTuTui!").summary(&title).body(&body);
-            #[cfg(target_os = "windows")]
-            {
-                // Attribute the toast to us (matches the SMTC registration) instead of PowerShell.
-                n.app_id(crate::media::identity::APP_USER_MODEL_ID);
-            }
-            let _ = n.show();
-        }));
-    });
+    std::thread::spawn(move || show_native(&title, &body));
+}
+
+#[cfg(not(all(target_os = "macos", panic = "abort")))]
+fn show_native(title: &str, body: &str) {
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut n = notify_rust::Notification::new();
+        n.appname("YuTuTui!").summary(title).body(body);
+        #[cfg(target_os = "windows")]
+        {
+            // Attribute the toast to us (matches the SMTC registration) instead of PowerShell.
+            n.app_id(crate::media::identity::APP_USER_MODEL_ID);
+        }
+        let _ = n.show();
+    }));
 }
 
 /// Emit a native desktop toast without terminal capability detection. Desktop-shell commands use
 /// this path when no WebView is visible, so a rejected tray-menu action never disappears into the
-/// log. The second-launch no-tty path uses it the same way (a Finder/.app launch has no terminal
-/// to print to). Best-effort and non-blocking, like the recording notification fallback above.
+/// log. Best-effort and non-blocking, like the recording notification fallback above.
 /// Note the macOS abort-build gap documented on [`emit_native`] — macOS callers that must be
 /// heard in release builds need their own `osascript` fallback.
+#[cfg(feature = "desktop")]
 pub(crate) fn emit_native_notification(title: &str, body: &str) {
     emit_native(title.to_owned(), body.to_owned());
+}
+
+/// Like [`emit_native_notification`] but delivered on the calling thread: `show()` completes
+/// (or fails) before this returns. The second-launch no-tty path uses this because it exits
+/// the process immediately afterwards — a detached notify thread would be killed before the
+/// D-Bus/WinRT round-trip finishes and the toast would silently vanish.
+pub(crate) fn emit_native_notification_blocking(title: &str, body: &str) {
+    #[cfg(all(target_os = "macos", panic = "abort"))]
+    {
+        let _ = (title, body);
+    }
+    #[cfg(not(all(target_os = "macos", panic = "abort")))]
+    show_native(title, body);
 }
 
 #[cfg(test)]

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -131,8 +131,10 @@ fn emit_native(title: String, body: String) {
 
 /// Emit a native desktop toast without terminal capability detection. Desktop-shell commands use
 /// this path when no WebView is visible, so a rejected tray-menu action never disappears into the
-/// log. Best-effort and non-blocking, like the recording notification fallback above.
-#[cfg(feature = "desktop")]
+/// log. The second-launch no-tty path uses it the same way (a Finder/.app launch has no terminal
+/// to print to). Best-effort and non-blocking, like the recording notification fallback above.
+/// Note the macOS abort-build gap documented on [`emit_native`] — macOS callers that must be
+/// heard in release builds need their own `osascript` fallback.
 pub(crate) fn emit_native_notification(title: &str, body: &str) {
     emit_native(title.to_owned(), body.to_owned());
 }

--- a/src/remote/client.rs
+++ b/src/remote/client.rs
@@ -601,6 +601,7 @@ impl From<InstanceFile> for SanitizedInfo {
             mode,
             protocol_version,
             mut capabilities,
+            host_terminal: _,
         } = instance;
         capabilities
             .retain(|capability| !reflects_descriptor_secret(capability, &endpoint, &token));

--- a/src/remote/client/tests.rs
+++ b/src/remote/client/tests.rs
@@ -22,6 +22,7 @@ fn test_instance(endpoint: String) -> InstanceFile {
         created_unix: 1,
         mode: InstanceMode::StandaloneTui,
         protocol_version: PROTOCOL_VERSION,
+        host_terminal: None,
         capabilities: vec![
             "remote-control".to_string(),
             "status".to_string(),

--- a/src/remote/endpoint.rs
+++ b/src/remote/endpoint.rs
@@ -339,6 +339,7 @@ mod tests {
             mode: InstanceMode::Daemon,
             protocol_version: PROTOCOL_VERSION,
             capabilities: vec!["status".to_string()],
+            host_terminal: None,
         }
     }
 

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use sessions::{
     SessionLine, SessionTuning, SubscribeIngress, test_command_reply, test_register,
 };
 
-pub use server::{BindOutcome, RemoteReply, RemoteServer, bind_or_detect};
+pub use server::{BindOutcome, RemoteReply, RemoteServer, await_primary_release, bind_or_detect};
 pub(crate) use settlement::{WireSettlement, WireSettlements};
 
 const QUICK_REPLY_TIMEOUT: Duration = Duration::from_secs(2);

--- a/src/remote/proto/freeze.rs
+++ b/src/remote/proto/freeze.rs
@@ -380,6 +380,8 @@ fn golden_v7_instance_file_is_byte_stable_and_parses() {
         mode: InstanceMode::StandaloneTui,
         protocol_version: 7,
         capabilities: vec!["remote-control".to_string(), "status".to_string()],
+        // Byte-stability proof: an absent hint must serialize to the exact golden line.
+        host_terminal: None,
     };
     let line = serde_json::to_string(&file).unwrap();
     assert_eq!(

--- a/src/remote/proto/mod.rs
+++ b/src/remote/proto/mod.rs
@@ -398,15 +398,187 @@ pub struct InstanceFile {
     pub protocol_version: u8,
     #[serde(default)]
     pub capabilities: Vec<String>,
+    /// Best-effort identity of the terminal hosting the primary TUI, captured at publish
+    /// time. Absent for daemons, secondaries, and descriptors written by older builds;
+    /// consumers must treat every field as a hint that may be stale.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_terminal: Option<HostTerminalHint>,
 }
 
 fn legacy_protocol_version() -> u8 {
     PROTOCOL_VERSION_V7
 }
 
+/// Where the primary TUI's terminal lives, so a second launch can try to focus it.
+///
+/// Every field is optional and additive: serialization skips absent fields, which keeps
+/// the descriptor byte-stable for older readers (see `freeze::v7_lines_with_unknown_
+/// future_fields_still_parse`). Values are session-local window/session identifiers —
+/// nothing here is a secret beyond what the 0600 descriptor already protects.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostTerminalHint {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub term_program: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub term: Option<String>,
+    /// X11 window id of the hosting terminal (`$WINDOWID`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub windowid: Option<String>,
+    /// Windows Terminal session (`$WT_SESSION`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wt_session: Option<String>,
+    /// `$KONSOLE_DBUS_SERVICE`; `org.kde.yakuake` identifies a Yakuake-hosted session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub konsole_dbus_service: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub konsole_dbus_session: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guake_tab_uuid: Option<String>,
+    /// `$TMUX` — report-only; a second launch never yanks another tmux client.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tmux: Option<String>,
+    /// Controlling tty path (Linux best-effort, via /proc/self/fd/0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tty: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wayland: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub x11: Option<bool>,
+    /// `$SSH_CONNECTION` present — the terminal is on another machine; skip focusing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssh: Option<bool>,
+    /// Windows: `GetConsoleWindow()` at startup (classic conhost consoles).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub console_hwnd: Option<u64>,
+    /// Windows: pid of the terminal-host ancestor (Windows Terminal), when identifiable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_host_pid: Option<u32>,
+}
+
+impl HostTerminalHint {
+    /// Capture the env-derived fields. The Windows-only window fields are filled in by
+    /// the caller (they need Win32 calls that live outside the protocol layer).
+    pub fn capture_from_env() -> Self {
+        Self::capture_with(|k| std::env::var(k).ok().filter(|v| !v.is_empty()))
+    }
+
+    pub fn capture_with(env: impl Fn(&str) -> Option<String>) -> Self {
+        let flag = |k: &str| env(k).is_some().then_some(true);
+        Self {
+            term_program: env("TERM_PROGRAM"),
+            term: env("TERM"),
+            windowid: env("WINDOWID"),
+            wt_session: env("WT_SESSION"),
+            konsole_dbus_service: env("KONSOLE_DBUS_SERVICE"),
+            konsole_dbus_session: env("KONSOLE_DBUS_SESSION"),
+            guake_tab_uuid: env("GUAKE_TAB_UUID"),
+            tmux: env("TMUX"),
+            tty: capture_tty(),
+            wayland: flag("WAYLAND_DISPLAY"),
+            x11: flag("DISPLAY"),
+            ssh: flag("SSH_CONNECTION"),
+            console_hwnd: None,
+            terminal_host_pid: None,
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn capture_tty() -> Option<String> {
+    std::fs::read_link("/proc/self/fd/0")
+        .ok()
+        .map(|p| p.to_string_lossy().into_owned())
+        .filter(|p| p.starts_with("/dev/"))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn capture_tty() -> Option<String> {
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn host_terminal_hint_round_trips_and_stays_absent_when_none() {
+        let mut file = InstanceFile {
+            app_pid: 7,
+            endpoint: "sock".to_string(),
+            token: "tok".to_string(),
+            created_unix: 1,
+            mode: InstanceMode::StandaloneTui,
+            protocol_version: PROTOCOL_VERSION,
+            capabilities: vec!["status".to_string()],
+            host_terminal: None,
+        };
+        let line = serde_json::to_string(&file).unwrap();
+        assert!(
+            !line.contains("host_terminal"),
+            "absent hint must not appear on the wire: {line}"
+        );
+
+        file.host_terminal = Some(HostTerminalHint {
+            term_program: Some("WezTerm".to_string()),
+            windowid: Some("0x1234".to_string()),
+            x11: Some(true),
+            ..HostTerminalHint::default()
+        });
+        let line = serde_json::to_string(&file).unwrap();
+        let back: InstanceFile = serde_json::from_str(&line).unwrap();
+        assert_eq!(back.host_terminal, file.host_terminal);
+        assert!(
+            !line.contains("wt_session"),
+            "absent hint fields must be skipped too: {line}"
+        );
+    }
+
+    #[test]
+    fn legacy_descriptor_without_host_terminal_parses_as_none() {
+        let legacy = r#"{"app_pid":7,"endpoint":"sock","token":"tok","created_unix":1,"mode":"standalone_tui","protocol_version":7,"capabilities":[]}"#;
+        let back: InstanceFile = serde_json::from_str(legacy).unwrap();
+        assert_eq!(back.host_terminal, None);
+    }
+
+    #[test]
+    fn host_terminal_hint_captures_env_shapes() {
+        let env_of = |vars: &'static [(&'static str, &'static str)]| {
+            move |k: &str| {
+                vars.iter()
+                    .find(|(name, _)| *name == k)
+                    .map(|(_, v)| (*v).to_string())
+            }
+        };
+
+        let yakuake = HostTerminalHint::capture_with(env_of(&[
+            ("KONSOLE_DBUS_SERVICE", "org.kde.yakuake"),
+            ("DISPLAY", ":0"),
+            ("TERM", "xterm-256color"),
+        ]));
+        assert_eq!(
+            yakuake.konsole_dbus_service.as_deref(),
+            Some("org.kde.yakuake")
+        );
+        assert_eq!(yakuake.x11, Some(true));
+        assert_eq!(yakuake.wayland, None);
+        assert_eq!(yakuake.ssh, None);
+
+        let ssh = HostTerminalHint::capture_with(env_of(&[(
+            "SSH_CONNECTION",
+            "10.0.0.1 22 10.0.0.2 22",
+        )]));
+        assert_eq!(ssh.ssh, Some(true));
+        assert_eq!(ssh.term_program, None);
+
+        let empty_is_absent = HostTerminalHint::capture_with(|_| None);
+        assert_eq!(
+            empty_is_absent,
+            HostTerminalHint {
+                tty: capture_tty(),
+                ..HostTerminalHint::default()
+            }
+        );
+    }
 
     #[test]
     fn toggle_state_resolves() {

--- a/src/remote/server.rs
+++ b/src/remote/server.rs
@@ -34,7 +34,7 @@ use super::endpoint;
 #[cfg(all(test, unix))]
 use super::proto::PROTOCOL_VERSION_V7;
 use super::proto::{
-    HelloRequest, InstanceFile, InstanceMode, PROTOCOL_VERSION,
+    HelloRequest, HostTerminalHint, InstanceFile, InstanceMode, PROTOCOL_VERSION,
     RETAINED_REQUEST_OUTCOMES_CAPABILITY, RemoteCommand, RemoteRequest, RemoteResponse, Topic,
 };
 use super::sessions::{RemoteSessionHub, RemoteSessionRef, SessionTuning, run_session};
@@ -147,12 +147,20 @@ pub struct RemoteServer {
     owns_instance_file: bool,
     mode: InstanceMode,
     capabilities: Vec<String>,
+    /// Terminal identity advertised in the descriptor so a second launch can try to focus
+    /// the hosting window. Only the interactive TUI attaches one; daemons stay `None`.
+    host_terminal: Option<HostTerminalHint>,
 }
 
 impl RemoteServer {
     pub fn with_instance_metadata(mut self, mode: InstanceMode, capabilities: Vec<String>) -> Self {
         self.mode = mode;
         self.capabilities = capabilities;
+        self
+    }
+
+    pub fn with_host_terminal(mut self, hint: HostTerminalHint) -> Self {
+        self.host_terminal = Some(hint);
         self
     }
 
@@ -206,6 +214,7 @@ impl RemoteServer {
             mode: self.mode,
             protocol_version: PROTOCOL_VERSION,
             capabilities: self.capabilities.clone(),
+            host_terminal: self.host_terminal.clone(),
         });
         endpoint_lease.publish_instance(advertisement);
         (
@@ -435,6 +444,7 @@ pub async fn bind_or_detect(new_instance: bool) -> BindOutcome {
                 owns_instance_file: false,
                 mode: InstanceMode::StandaloneTui,
                 capabilities: default_capabilities(),
+                host_terminal: None,
             })),
             Err(e) => {
                 tracing::warn!(error = %e, "remote: secondary instance could not bind; no remote control");
@@ -504,7 +514,30 @@ pub async fn bind_or_detect(new_instance: bool) -> BindOutcome {
         owns_instance_file: true,
         mode: InstanceMode::StandaloneTui,
         capabilities: default_capabilities(),
+        host_terminal: None,
     }))
+}
+
+/// Wait (bounded) for the primary endpoint to stop answering, polling every 250ms.
+///
+/// Used by the second-launch restart path after sending `Quit`: `true` means the old
+/// owner's socket went quiet within `deadline`. This keeps [`probe_alive`] private.
+pub async fn await_primary_release(deadline: Duration) -> bool {
+    let Ok(ep) = endpoint::socket_endpoint() else {
+        return false;
+    };
+    let legacy_ep = endpoint::legacy_primary_endpoint_for_probe();
+    let end = tokio::time::Instant::now() + deadline;
+    loop {
+        let live = probe_alive(&ep).await || (legacy_ep != ep && probe_alive(&legacy_ep).await);
+        if !live {
+            return true;
+        }
+        if tokio::time::Instant::now() >= end {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
 }
 
 fn default_capabilities() -> Vec<String> {

--- a/src/remote/server/one_shot_tests.rs
+++ b/src/remote/server/one_shot_tests.rs
@@ -403,6 +403,7 @@ async fn retiring_guard_cannot_unlink_a_fast_successor() {
         mode: InstanceMode::StandaloneTui,
         protocol_version: PROTOCOL_VERSION,
         capabilities: Vec::new(),
+        host_terminal: None,
     };
     crate::util::safe_fs::write_private_atomic_json(&descriptor, &old_identity).unwrap();
     let endpoint_lease = Arc::new(EndpointLease::new(
@@ -432,6 +433,7 @@ async fn retiring_guard_cannot_unlink_a_fast_successor() {
         mode: InstanceMode::StandaloneTui,
         protocol_version: PROTOCOL_VERSION,
         capabilities: Vec::new(),
+        host_terminal: None,
     };
     crate::util::safe_fs::write_private_atomic_json(&descriptor, &successor_identity).unwrap();
 
@@ -474,6 +476,7 @@ async fn late_guard_cleanup_preserves_a_rebound_successor_inode() {
         mode: InstanceMode::StandaloneTui,
         protocol_version: PROTOCOL_VERSION,
         capabilities: Vec::new(),
+        host_terminal: None,
     };
     crate::util::safe_fs::write_private_atomic_json(&descriptor, &old_identity).unwrap();
     let endpoint_lease = Arc::new(EndpointLease::new(
@@ -515,6 +518,7 @@ async fn late_guard_cleanup_preserves_a_rebound_successor_inode() {
         mode: InstanceMode::StandaloneTui,
         protocol_version: PROTOCOL_VERSION,
         capabilities: Vec::new(),
+        host_terminal: None,
     };
     crate::util::safe_fs::write_private_atomic_json(&descriptor, &successor_identity).unwrap();
 
@@ -560,6 +564,7 @@ async fn repeated_accept_failures_self_revoke_the_published_endpoint() {
         mode: InstanceMode::StandaloneTui,
         protocol_version: PROTOCOL_VERSION,
         capabilities: Vec::new(),
+        host_terminal: None,
     };
     endpoint_lease.publish_instance_at(descriptor.clone(), old_identity);
     let mut guard = InstanceGuard {
@@ -628,6 +633,7 @@ async fn failed_accept_owner_cannot_overwrite_or_unlink_a_fast_successor() {
         mode: InstanceMode::StandaloneTui,
         protocol_version: PROTOCOL_VERSION,
         capabilities: Vec::new(),
+        host_terminal: None,
     };
     crate::util::safe_fs::write_private_atomic_json(&descriptor, &successor_identity).unwrap();
 
@@ -639,6 +645,7 @@ async fn failed_accept_owner_cannot_overwrite_or_unlink_a_fast_successor() {
         mode: InstanceMode::StandaloneTui,
         protocol_version: PROTOCOL_VERSION,
         capabilities: Vec::new(),
+        host_terminal: None,
     };
     // Production publication is serialized by the lease. Since failure already won, this call
     // must not overwrite the successor descriptor, and inode matching must preserve its socket.

--- a/src/remote/server/startup_cleanup_tests.rs
+++ b/src/remote/server/startup_cleanup_tests.rs
@@ -38,6 +38,7 @@ async fn dropping_bound_server_before_start_releases_lease_or_recovery_failure_e
         owns_instance_file: true,
         mode: InstanceMode::StandaloneTui,
         capabilities: Vec::new(),
+        host_terminal: None,
     };
 
     drop(server);

--- a/src/second_launch/chooser.rs
+++ b/src/second_launch/chooser.rs
@@ -1,0 +1,161 @@
+//! The pre-alternate-screen chooser a second interactive launch renders.
+//!
+//! Deliberately primitive: plain `println!` plus raw-mode single-key reads, no ratatui and
+//! no alternate screen. It runs before the art-picker probe and `tui::init`, and the
+//! restart path re-enters normal startup afterwards — so it must leave the terminal in
+//! exactly the cooked state it found it in (RAII guard below).
+
+use std::io::Write;
+use std::time::{Duration, Instant};
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+
+use crate::t;
+
+pub const CHOOSER_TIMEOUT: Duration = Duration::from_secs(30);
+const POLL_TICK: Duration = Duration::from_millis(250);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Choice {
+    Focus,
+    Restart,
+    NewInstance,
+    Quit,
+}
+
+/// Key → choice, `None` keeps polling. Pure so the mapping is testable without a tty.
+pub fn map_key(key: KeyEvent) -> Option<Choice> {
+    if key.modifiers.contains(KeyModifiers::CONTROL) {
+        return match key.code {
+            KeyCode::Char('c') | KeyCode::Char('C') => Some(Choice::Quit),
+            _ => None,
+        };
+    }
+    match key.code {
+        KeyCode::Enter => Some(Choice::Focus),
+        KeyCode::Char('r') | KeyCode::Char('R') => Some(Choice::Restart),
+        KeyCode::Char('n') | KeyCode::Char('N') => Some(Choice::NewInstance),
+        KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => Some(Choice::Quit),
+        _ => None,
+    }
+}
+
+/// Restores cooked mode on every exit path, including panics while a key is pending.
+struct RawModeGuard;
+
+impl RawModeGuard {
+    fn enable() -> std::io::Result<Self> {
+        crossterm::terminal::enable_raw_mode()?;
+        Ok(Self)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = crossterm::terminal::disable_raw_mode();
+    }
+}
+
+/// Render the menu and block for a decision. Timeout and read errors quit.
+///
+/// Blocking by design — call from `spawn_blocking`, never on a runtime worker.
+pub fn prompt(timeout: Duration) -> std::io::Result<Choice> {
+    println!(
+        "{}",
+        t!(
+            "YuTuTui! is already running.",
+            "YuTuTui!가 이미 실행 중입니다."
+        )
+    );
+    println!();
+    println!(
+        "{}",
+        t!(
+            "  [Enter] Switch to the running player",
+            "  [Enter] 실행 중인 플레이어로 전환"
+        )
+    );
+    println!(
+        "{}",
+        t!(
+            "  [r]     Restart here (quit the running player and take over)",
+            "  [r]     여기서 다시 시작 (실행 중인 플레이어를 종료하고 인계)"
+        )
+    );
+    println!(
+        "{}",
+        t!(
+            "  [n]     Open a second read-only player",
+            "  [n]     읽기 전용 두 번째 플레이어 열기"
+        )
+    );
+    let deadline = Instant::now() + timeout;
+    let _raw = RawModeGuard::enable()?;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            print_countdown_line(Duration::ZERO);
+            println!("\r");
+            return Ok(Choice::Quit);
+        }
+        print_countdown_line(remaining);
+        if crossterm::event::poll(POLL_TICK.min(remaining))? {
+            match crossterm::event::read()? {
+                Event::Key(key) if key.is_press() => {
+                    if let Some(choice) = map_key(key) {
+                        // Terminate the countdown line before cooked-mode output resumes.
+                        println!("\r");
+                        return Ok(choice);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn print_countdown_line(remaining: Duration) {
+    let seconds = remaining.as_secs();
+    // Raw mode: carriage return only, no cursor addressing. Trailing spaces clear the
+    // previous (possibly longer) rendering of the counter.
+    print!(
+        "\r{}  ",
+        t!(
+            format!("  [q]     Quit (auto-quits in {seconds}s)"),
+            format!("  [q]     종료 ({seconds}초 후 자동 종료)")
+        )
+    );
+    let _ = std::io::stdout().flush();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn keys_map_to_choices_and_unknown_keys_keep_polling() {
+        assert_eq!(map_key(key(KeyCode::Enter)), Some(Choice::Focus));
+        assert_eq!(map_key(key(KeyCode::Char('r'))), Some(Choice::Restart));
+        assert_eq!(map_key(key(KeyCode::Char('R'))), Some(Choice::Restart));
+        assert_eq!(map_key(key(KeyCode::Char('n'))), Some(Choice::NewInstance));
+        assert_eq!(map_key(key(KeyCode::Char('N'))), Some(Choice::NewInstance));
+        assert_eq!(map_key(key(KeyCode::Char('q'))), Some(Choice::Quit));
+        assert_eq!(map_key(key(KeyCode::Char('Q'))), Some(Choice::Quit));
+        assert_eq!(map_key(key(KeyCode::Esc)), Some(Choice::Quit));
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            Some(Choice::Quit)
+        );
+        assert_eq!(map_key(key(KeyCode::Char('x'))), None);
+        assert_eq!(map_key(key(KeyCode::Tab)), None);
+        // A modified letter is not a plain choice key.
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+            None
+        );
+    }
+}

--- a/src/second_launch/chooser.rs
+++ b/src/second_launch/chooser.rs
@@ -23,8 +23,16 @@ pub enum Choice {
     Quit,
 }
 
+/// Who owns the primary socket. A headless daemon has no terminal to focus, and quitting
+/// it kills a background service — the menu must say so instead of pretending it's a TUI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OwnerKind {
+    Tui,
+    Daemon,
+}
+
 /// Key → choice, `None` keeps polling. Pure so the mapping is testable without a tty.
-pub fn map_key(key: KeyEvent) -> Option<Choice> {
+pub fn map_key(key: KeyEvent, owner: OwnerKind) -> Option<Choice> {
     if key.modifiers.contains(KeyModifiers::CONTROL) {
         return match key.code {
             KeyCode::Char('c') | KeyCode::Char('C') => Some(Choice::Quit),
@@ -32,7 +40,11 @@ pub fn map_key(key: KeyEvent) -> Option<Choice> {
         };
     }
     match key.code {
-        KeyCode::Enter => Some(Choice::Focus),
+        // With a daemon owner there is nothing to focus; Enter stays the safe default.
+        KeyCode::Enter => Some(match owner {
+            OwnerKind::Tui => Choice::Focus,
+            OwnerKind::Daemon => Choice::Quit,
+        }),
         KeyCode::Char('r') | KeyCode::Char('R') => Some(Choice::Restart),
         KeyCode::Char('n') | KeyCode::Char('N') => Some(Choice::NewInstance),
         KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => Some(Choice::Quit),
@@ -59,29 +71,53 @@ impl Drop for RawModeGuard {
 /// Render the menu and block for a decision. Timeout and read errors quit.
 ///
 /// Blocking by design — call from `spawn_blocking`, never on a runtime worker.
-pub fn prompt(timeout: Duration) -> std::io::Result<Choice> {
-    println!(
-        "{}",
-        t!(
-            "YuTuTui! is already running.",
-            "YuTuTui!가 이미 실행 중입니다."
-        )
-    );
-    println!();
-    println!(
-        "{}",
-        t!(
-            "  [Enter] Switch to the running player",
-            "  [Enter] 실행 중인 플레이어로 전환"
-        )
-    );
-    println!(
-        "{}",
-        t!(
-            "  [r]     Restart here (quit the running player and take over)",
-            "  [r]     여기서 다시 시작 (실행 중인 플레이어를 종료하고 인계)"
-        )
-    );
+/// Accepted exposure: the terminal sits in raw mode for up to the whole timeout, and an
+/// external SIGTERM/SIGKILL during that window leaves the shell raw (no signal hooks
+/// exist this early). Same class as any pre-`tui::init` kill, just a longer window.
+pub fn prompt(timeout: Duration, owner: OwnerKind) -> std::io::Result<Choice> {
+    match owner {
+        OwnerKind::Tui => {
+            println!(
+                "{}",
+                t!(
+                    "YuTuTui! is already running.",
+                    "YuTuTui!가 이미 실행 중입니다."
+                )
+            );
+            println!();
+            println!(
+                "{}",
+                t!(
+                    "  [Enter] Switch to the running player",
+                    "  [Enter] 실행 중인 플레이어로 전환"
+                )
+            );
+            println!(
+                "{}",
+                t!(
+                    "  [r]     Restart here (quit the running player and take over)",
+                    "  [r]     여기서 다시 시작 (실행 중인 플레이어를 종료하고 인계)"
+                )
+            );
+        }
+        OwnerKind::Daemon => {
+            println!(
+                "{}",
+                t!(
+                    "YuTuTui! is already running as a background daemon.",
+                    "YuTuTui!가 이미 백그라운드 데몬으로 실행 중입니다."
+                )
+            );
+            println!();
+            println!(
+                "{}",
+                t!(
+                    "  [r]     Stop the background daemon and play here instead",
+                    "  [r]     백그라운드 데몬을 종료하고 여기서 재생"
+                )
+            );
+        }
+    }
     println!(
         "{}",
         t!(
@@ -102,7 +138,7 @@ pub fn prompt(timeout: Duration) -> std::io::Result<Choice> {
         if crossterm::event::poll(POLL_TICK.min(remaining))? {
             match crossterm::event::read()? {
                 Event::Key(key) if key.is_press() => {
-                    if let Some(choice) = map_key(key) {
+                    if let Some(choice) = map_key(key, owner) {
                         // Terminate the countdown line before cooked-mode output resumes.
                         println!("\r");
                         return Ok(choice);
@@ -138,24 +174,52 @@ mod tests {
 
     #[test]
     fn keys_map_to_choices_and_unknown_keys_keep_polling() {
-        assert_eq!(map_key(key(KeyCode::Enter)), Some(Choice::Focus));
-        assert_eq!(map_key(key(KeyCode::Char('r'))), Some(Choice::Restart));
-        assert_eq!(map_key(key(KeyCode::Char('R'))), Some(Choice::Restart));
-        assert_eq!(map_key(key(KeyCode::Char('n'))), Some(Choice::NewInstance));
-        assert_eq!(map_key(key(KeyCode::Char('N'))), Some(Choice::NewInstance));
-        assert_eq!(map_key(key(KeyCode::Char('q'))), Some(Choice::Quit));
-        assert_eq!(map_key(key(KeyCode::Char('Q'))), Some(Choice::Quit));
-        assert_eq!(map_key(key(KeyCode::Esc)), Some(Choice::Quit));
+        let tui = OwnerKind::Tui;
+        assert_eq!(map_key(key(KeyCode::Enter), tui), Some(Choice::Focus));
+        assert_eq!(map_key(key(KeyCode::Char('r')), tui), Some(Choice::Restart));
+        assert_eq!(map_key(key(KeyCode::Char('R')), tui), Some(Choice::Restart));
         assert_eq!(
-            map_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            map_key(key(KeyCode::Char('n')), tui),
+            Some(Choice::NewInstance)
+        );
+        assert_eq!(
+            map_key(key(KeyCode::Char('N')), tui),
+            Some(Choice::NewInstance)
+        );
+        assert_eq!(map_key(key(KeyCode::Char('q')), tui), Some(Choice::Quit));
+        assert_eq!(map_key(key(KeyCode::Char('Q')), tui), Some(Choice::Quit));
+        assert_eq!(map_key(key(KeyCode::Esc), tui), Some(Choice::Quit));
+        assert_eq!(
+            map_key(
+                KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+                tui
+            ),
             Some(Choice::Quit)
         );
-        assert_eq!(map_key(key(KeyCode::Char('x'))), None);
-        assert_eq!(map_key(key(KeyCode::Tab)), None);
+        assert_eq!(map_key(key(KeyCode::Char('x')), tui), None);
+        assert_eq!(map_key(key(KeyCode::Tab), tui), None);
         // A modified letter is not a plain choice key.
         assert_eq!(
-            map_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+            map_key(
+                KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
+                tui
+            ),
             None
+        );
+    }
+
+    #[test]
+    fn daemon_owner_makes_enter_the_safe_quit_never_a_kill() {
+        let daemon = OwnerKind::Daemon;
+        assert_eq!(map_key(key(KeyCode::Enter), daemon), Some(Choice::Quit));
+        // Stopping the daemon stays an explicit, spelled-out keypress.
+        assert_eq!(
+            map_key(key(KeyCode::Char('r')), daemon),
+            Some(Choice::Restart)
+        );
+        assert_eq!(
+            map_key(key(KeyCode::Char('n')), daemon),
+            Some(Choice::NewInstance)
         );
     }
 }

--- a/src/second_launch/focus.rs
+++ b/src/second_launch/focus.rs
@@ -1,0 +1,387 @@
+//! Best-effort "bring the running player's terminal to the front" ladder.
+//!
+//! Planning is pure ([`focus_plan`]) so unit tests pin the exact commands per OS without
+//! spawning anything; [`run_ladder`] executes steps in order and stops at the first
+//! success. Every step is a hint that may be stale (a recorded `$WINDOWID` can outlive
+//! its window), so executors validate liveness where the platform allows and callers
+//! always fall through to a notification when the ladder reports failure.
+//!
+//! Focus-stealing reality check: only the process the user just launched (us) holds a
+//! focus grant, and even then Wayland compositors and the Windows foreground lock may
+//! degrade activation to a taskbar/attention flash. That degraded outcome is accepted —
+//! never fought with hacks.
+
+use std::time::Duration;
+
+use crate::remote::proto::HostTerminalHint;
+use crate::util::process::{ProcessProfile, std_command};
+
+/// How long a single ladder step may run. A hung `qdbus` must not stall the chooser.
+const STEP_TIMEOUT: Duration = Duration::from_millis(1500);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FocusStep {
+    /// Spawn `program args…`; exit status 0 counts as success.
+    Exec {
+        program: &'static str,
+        args: Vec<String>,
+    },
+    /// Query `program args…`; success only if it exits 0 AND prints `expect_stdout`
+    /// (trimmed). Used to detect "already visible" dropdown states without toggling.
+    ExecExpect {
+        program: &'static str,
+        args: Vec<String>,
+        expect_stdout: &'static str,
+    },
+    /// Win32 SetForegroundWindow resolution (see `focus_windows`).
+    #[cfg(windows)]
+    Win32Foreground {
+        console_hwnd: Option<u64>,
+        terminal_host_pid: Option<u32>,
+        app_pid: Option<u32>,
+    },
+}
+
+/// Build the per-OS ladder. Pure: no environment reads, no process spawns.
+pub fn focus_plan(hint: Option<&HostTerminalHint>, app_pid: Option<u32>) -> Vec<FocusStep> {
+    let Some(hint) = hint else {
+        #[cfg(windows)]
+        {
+            // Old descriptors carry no hint, but the app pid alone can still find a window.
+            return app_pid
+                .map(|pid| {
+                    vec![FocusStep::Win32Foreground {
+                        console_hwnd: None,
+                        terminal_host_pid: None,
+                        app_pid: Some(pid),
+                    }]
+                })
+                .unwrap_or_default();
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = app_pid;
+            return Vec::new();
+        }
+    };
+    if hint.ssh == Some(true) {
+        // The hosting terminal is on another machine; nothing local can focus it.
+        return Vec::new();
+    }
+    platform_plan(hint, app_pid)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn platform_plan(hint: &HostTerminalHint, _app_pid: Option<u32>) -> Vec<FocusStep> {
+    let mut steps = Vec::new();
+    if hint.konsole_dbus_service.as_deref() == Some("org.kde.yakuake") {
+        // Yakuake only exposes a *toggle*. Probe visibility first: `true` means the
+        // dropdown is already on screen — report success without hiding it. If the probe
+        // itself fails (API drift), accept toggle semantics as documented best-effort.
+        steps.push(FocusStep::ExecExpect {
+            program: "qdbus",
+            args: vec![
+                "org.kde.yakuake".into(),
+                "/yakuake/MainWindow_1".into(),
+                "org.qtproject.Qt.QWidget.visible".into(),
+            ],
+            expect_stdout: "true",
+        });
+        steps.push(FocusStep::Exec {
+            program: "qdbus",
+            args: vec![
+                "org.kde.yakuake".into(),
+                "/yakuake/window".into(),
+                "org.kde.yakuake.toggleWindowState".into(),
+            ],
+        });
+    }
+    if hint.guake_tab_uuid.is_some() {
+        // `--show`, never toggle: repeated activations must not hide an open Guake.
+        steps.push(FocusStep::Exec {
+            program: "guake",
+            args: vec!["--show".into()],
+        });
+    }
+    if hint.x11 == Some(true)
+        && let Some(windowid) = hint.windowid.as_deref()
+    {
+        steps.push(FocusStep::Exec {
+            program: "wmctrl",
+            args: vec!["-i".into(), "-a".into(), windowid.to_string()],
+        });
+        steps.push(FocusStep::Exec {
+            program: "xdotool",
+            args: vec!["windowactivate".into(), windowid.to_string()],
+        });
+    }
+    // Wayland without a dropdown match: activation needs an xdg-activation token tied to
+    // recent input in OUR window — which a bare launcher process cannot mint for another
+    // surface. Fall through to the notification instead of fighting the compositor.
+    steps
+}
+
+#[cfg(target_os = "macos")]
+fn platform_plan(hint: &HostTerminalHint, _app_pid: Option<u32>) -> Vec<FocusStep> {
+    let mut steps = Vec::new();
+    if let Some(bundle) = hint
+        .term_program
+        .as_deref()
+        .and_then(|program| terminal_bundle_id(program, hint.term.as_deref()))
+    {
+        steps.push(FocusStep::Exec {
+            program: "open",
+            args: vec!["-b".into(), bundle.to_string()],
+        });
+    }
+    if hint.term_program.as_deref() == Some("iTerm.app") {
+        // Hotkey-window reveal via AppleScript is version-fragile; plain activation plus
+        // the notification is the reliable floor.
+        steps.push(FocusStep::Exec {
+            program: "osascript",
+            args: vec![
+                "-e".into(),
+                r#"tell application "iTerm2" to activate"#.into(),
+            ],
+        });
+    }
+    steps
+}
+
+#[cfg(windows)]
+fn platform_plan(hint: &HostTerminalHint, app_pid: Option<u32>) -> Vec<FocusStep> {
+    // `wt -w _quake` is deliberately absent: it summons the quake window whether or not
+    // the TUI lives there. The recorded HWND / host-pid resolution below focuses the
+    // actual hosting window, quake-hosted sessions included.
+    vec![FocusStep::Win32Foreground {
+        console_hwnd: hint.console_hwnd,
+        terminal_host_pid: hint.terminal_host_pid,
+        app_pid,
+    }]
+}
+
+/// Map `$TERM_PROGRAM` (plus `$TERM` for kitty, which sets no TERM_PROGRAM) to the
+/// LaunchServices bundle id `open -b` activates.
+#[cfg(any(target_os = "macos", test))]
+pub(crate) fn terminal_bundle_id(term_program: &str, term: Option<&str>) -> Option<&'static str> {
+    match term_program {
+        "Apple_Terminal" => Some("com.apple.Terminal"),
+        "iTerm.app" => Some("com.googlecode.iterm2"),
+        "ghostty" | "Ghostty" => Some("com.mitchellh.ghostty"),
+        "WezTerm" => Some("com.github.wez.wezterm"),
+        "WarpTerminal" => Some("dev.warp.Warp-Stable"),
+        "kitty" => Some("net.kovidgoyal.kitty"),
+        _ if term.is_some_and(|t| t.contains("kitty")) => Some("net.kovidgoyal.kitty"),
+        _ => None,
+    }
+}
+
+/// Execute steps in order; the first success wins.
+pub fn run_ladder(steps: Vec<FocusStep>) -> bool {
+    steps.into_iter().any(run_step)
+}
+
+fn run_step(step: FocusStep) -> bool {
+    match step {
+        FocusStep::Exec { program, args } => {
+            run_bounded(program, &args).is_some_and(|(status_ok, _)| status_ok)
+        }
+        FocusStep::ExecExpect {
+            program,
+            args,
+            expect_stdout,
+        } => run_bounded(program, &args)
+            .is_some_and(|(status_ok, stdout)| status_ok && stdout.trim() == expect_stdout),
+        #[cfg(windows)]
+        FocusStep::Win32Foreground {
+            console_hwnd,
+            terminal_host_pid,
+            app_pid,
+        } => super::focus_windows::bring_to_foreground(console_hwnd, terminal_host_pid, app_pid),
+    }
+}
+
+/// Spawn with null stdin, captured stdout, and a hard kill at [`STEP_TIMEOUT`].
+fn run_bounded(program: &str, args: &[String]) -> Option<(bool, String)> {
+    let mut child = std_command(program, ProcessProfile::DesktopOpen)
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+    let deadline = std::time::Instant::now() + STEP_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let mut stdout = String::new();
+                if let Some(mut pipe) = child.stdout.take() {
+                    use std::io::Read;
+                    let _ = pipe.read_to_string(&mut stdout);
+                }
+                return Some((status.success(), stdout));
+            }
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hint() -> HostTerminalHint {
+        HostTerminalHint::default()
+    }
+
+    #[test]
+    fn ssh_sessions_and_missing_hints_produce_an_empty_plan_on_unix() {
+        let ssh = HostTerminalHint {
+            ssh: Some(true),
+            windowid: Some("0x1".into()),
+            x11: Some(true),
+            ..hint()
+        };
+        assert!(focus_plan(Some(&ssh), Some(1)).is_empty());
+        #[cfg(not(windows))]
+        assert!(focus_plan(None, Some(1)).is_empty());
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn yakuake_probe_precedes_toggle_and_windowid_steps() {
+        let yakuake = HostTerminalHint {
+            konsole_dbus_service: Some("org.kde.yakuake".into()),
+            windowid: Some("0x2a".into()),
+            x11: Some(true),
+            ..hint()
+        };
+        let plan = focus_plan(Some(&yakuake), None);
+        assert_eq!(plan.len(), 4);
+        assert!(matches!(
+            &plan[0],
+            FocusStep::ExecExpect {
+                program: "qdbus",
+                expect_stdout: "true",
+                ..
+            }
+        ));
+        assert!(
+            matches!(&plan[1], FocusStep::Exec { program: "qdbus", args }
+            if args.iter().any(|a| a.contains("toggleWindowState")))
+        );
+        assert!(
+            matches!(&plan[2], FocusStep::Exec { program: "wmctrl", args }
+            if args == &vec!["-i".to_string(), "-a".to_string(), "0x2a".to_string()])
+        );
+        assert!(matches!(
+            &plan[3],
+            FocusStep::Exec {
+                program: "xdotool",
+                ..
+            }
+        ));
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn guake_uses_show_never_toggle_and_wayland_skips_x11_tools() {
+        let guake_on_wayland = HostTerminalHint {
+            guake_tab_uuid: Some("uuid".into()),
+            windowid: Some("0x2a".into()),
+            wayland: Some(true),
+            ..hint()
+        };
+        let plan = focus_plan(Some(&guake_on_wayland), None);
+        assert_eq!(
+            plan,
+            vec![FocusStep::Exec {
+                program: "guake",
+                args: vec!["--show".into()],
+            }],
+            "wayland without x11 must not plan wmctrl/xdotool; guake must use --show"
+        );
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn plain_konsole_relies_on_windowid_not_bespoke_dbus() {
+        let konsole = HostTerminalHint {
+            konsole_dbus_service: Some("org.kde.konsole-1234".into()),
+            windowid: Some("0x99".into()),
+            x11: Some(true),
+            ..hint()
+        };
+        let plan = focus_plan(Some(&konsole), None);
+        assert!(
+            plan.iter().all(|step| !matches!(
+                step,
+                FocusStep::Exec {
+                    program: "qdbus",
+                    ..
+                }
+            )),
+            "only yakuake gets a qdbus step"
+        );
+        assert_eq!(plan.len(), 2);
+    }
+
+    #[test]
+    fn macos_bundle_map_covers_known_terminals() {
+        assert_eq!(
+            terminal_bundle_id("Apple_Terminal", None),
+            Some("com.apple.Terminal")
+        );
+        assert_eq!(
+            terminal_bundle_id("iTerm.app", None),
+            Some("com.googlecode.iterm2")
+        );
+        assert_eq!(
+            terminal_bundle_id("WezTerm", None),
+            Some("com.github.wez.wezterm")
+        );
+        assert_eq!(
+            terminal_bundle_id("", Some("xterm-kitty")),
+            Some("net.kovidgoyal.kitty")
+        );
+        assert_eq!(terminal_bundle_id("SomethingNew", None), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_plan_is_a_single_resolution_step_even_without_a_hint() {
+        let with_hint = HostTerminalHint {
+            console_hwnd: Some(42),
+            terminal_host_pid: Some(7),
+            ..hint()
+        };
+        assert_eq!(
+            focus_plan(Some(&with_hint), Some(99)),
+            vec![FocusStep::Win32Foreground {
+                console_hwnd: Some(42),
+                terminal_host_pid: Some(7),
+                app_pid: Some(99),
+            }]
+        );
+        assert_eq!(
+            focus_plan(None, Some(99)),
+            vec![FocusStep::Win32Foreground {
+                console_hwnd: None,
+                terminal_host_pid: None,
+                app_pid: Some(99),
+            }]
+        );
+    }
+}

--- a/src/second_launch/focus_windows.rs
+++ b/src/second_launch/focus_windows.rs
@@ -1,0 +1,140 @@
+//! Win32 half of the focus ladder (`cfg(windows)` only; unsafe-inventory allowlisted).
+//!
+//! Two capture helpers record the hosting window at primary startup, and one resolver
+//! brings it back to the foreground from a second launch. The second launch was just
+//! started by the user, so it holds the interactive foreground grant —
+//! `SetForegroundWindow` from here is exactly the sanctioned hand-off; when the OS still
+//! refuses (foreground lock), the taskbar flash it substitutes is the accepted floor.
+
+use windows::Win32::Foundation::{HWND, LPARAM};
+use windows::Win32::UI::WindowsAndMessaging::{
+    EnumWindows, GetWindowThreadProcessId, IsIconic, IsWindow, IsWindowVisible, SW_RESTORE,
+    SetForegroundWindow, ShowWindow,
+};
+use windows::core::BOOL;
+
+/// The classic-conhost console window hosting this process, if any. For Windows Terminal
+/// sessions this returns the hidden pseudo-console window — that's why
+/// [`terminal_host_pid`] exists.
+pub fn console_hwnd() -> Option<u64> {
+    use windows_sys::Win32::System::Console::GetConsoleWindow;
+    // SAFETY: GetConsoleWindow takes no arguments and returns null when the process has
+    // no console; no pointer is dereferenced.
+    let hwnd = unsafe { GetConsoleWindow() };
+    if hwnd.is_null() {
+        None
+    } else {
+        Some(hwnd as usize as u64)
+    }
+}
+
+/// Walk up the parent chain (bounded) looking for the Windows Terminal host process.
+/// Mirrors the `explorer_double_click_launch` sysinfo pattern in `main.rs`.
+pub fn terminal_host_pid() -> Option<u32> {
+    use sysinfo::{Pid, ProcessesToUpdate, System};
+    let mut system = System::new();
+    let mut current = Pid::from_u32(std::process::id());
+    for _ in 0..5 {
+        system.refresh_processes(ProcessesToUpdate::Some(&[current]), true);
+        let process = system.process(current)?;
+        if process
+            .name()
+            .to_string_lossy()
+            .eq_ignore_ascii_case("WindowsTerminal.exe")
+        {
+            return Some(current.as_u32());
+        }
+        current = process.parent()?;
+    }
+    None
+}
+
+/// Resolve the best window for the recorded identity and bring it to the foreground.
+///
+/// Resolution order: a still-live recorded console HWND (classic consoles — that IS the
+/// terminal window), else the first visible top-level window of the recorded Windows
+/// Terminal host pid, else one owned by the player's own pid (exotic hosts). Returns
+/// `false` when nothing resolved; a foreground-lock refusal after a successful resolve
+/// still counts as attempted (the OS flashes the taskbar for us).
+pub fn bring_to_foreground(
+    console_hwnd: Option<u64>,
+    terminal_host_pid: Option<u32>,
+    app_pid: Option<u32>,
+) -> bool {
+    let target = resolve_target(console_hwnd, terminal_host_pid, app_pid);
+    let Some(hwnd) = target else {
+        return false;
+    };
+    // SAFETY: `hwnd` was validated as a live window by `resolve_target` moments ago; both
+    // calls tolerate a window that died in between by returning FALSE, which we accept.
+    unsafe {
+        if IsIconic(hwnd).as_bool() {
+            let _ = ShowWindow(hwnd, SW_RESTORE);
+        }
+        let _ = SetForegroundWindow(hwnd);
+    }
+    true
+}
+
+fn resolve_target(
+    console_hwnd: Option<u64>,
+    terminal_host_pid: Option<u32>,
+    app_pid: Option<u32>,
+) -> Option<HWND> {
+    if let Some(recorded) = console_hwnd {
+        let hwnd = HWND(recorded as usize as *mut core::ffi::c_void);
+        // SAFETY: IsWindow/GetWindowThreadProcessId only inspect the handle table; a
+        // stale or reused handle yields FALSE / pid 0 rather than UB.
+        let live = unsafe {
+            IsWindow(Some(hwnd)).as_bool() && {
+                let mut pid = 0u32;
+                GetWindowThreadProcessId(hwnd, Some(&mut pid)) != 0 && pid != 0
+            }
+        };
+        if live {
+            return Some(hwnd);
+        }
+    }
+    if let Some(pid) = terminal_host_pid
+        && let Some(hwnd) = first_visible_window_of_pid(pid)
+    {
+        return Some(hwnd);
+    }
+    if let Some(pid) = app_pid
+        && let Some(hwnd) = first_visible_window_of_pid(pid)
+    {
+        return Some(hwnd);
+    }
+    None
+}
+
+fn first_visible_window_of_pid(pid: u32) -> Option<HWND> {
+    struct Search {
+        pid: u32,
+        found: Option<HWND>,
+    }
+    unsafe extern "system" fn visit(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        // SAFETY: `lparam` is the address of the `Search` on `first_visible_window_of_pid`'s
+        // stack, which outlives the synchronous EnumWindows call that invokes this visitor.
+        let search = unsafe { &mut *(lparam.0 as *mut Search) };
+        let mut window_pid = 0u32;
+        // SAFETY: `hwnd` is provided live by EnumWindows; the out pointer is valid for
+        // the duration of the call.
+        let matched = unsafe {
+            GetWindowThreadProcessId(hwnd, Some(&mut window_pid)) != 0
+                && window_pid == search.pid
+                && IsWindowVisible(hwnd).as_bool()
+        };
+        if matched {
+            search.found = Some(hwnd);
+            return BOOL(0); // stop enumerating
+        }
+        BOOL(1)
+    }
+    let mut search = Search { pid, found: None };
+    // SAFETY: the callback only touches `search`, which lives across this synchronous
+    // call; EnumWindows reports "callback stopped early" as an error we deliberately
+    // ignore (stopping early is our success path).
+    let _ = unsafe { EnumWindows(Some(visit), LPARAM(&mut search as *mut Search as isize)) };
+    search.found
+}

--- a/src/second_launch/mod.rs
+++ b/src/second_launch/mod.rs
@@ -1,0 +1,214 @@
+//! What a second interactive `ytt` launch does instead of silently bowing out.
+//!
+//! The single-instance guard is the remote socket (`remote::bind_or_detect`). Historically
+//! a second launch printed [`ALREADY_RUNNING_NOTICE`] and exited — which, from a desktop
+//! icon, looks like the app refusing to start (the launcher terminal flashes and closes;
+//! the macOS `.app` runs with no terminal at all, so the notice lands nowhere). This module
+//! branches on how the process was launched:
+//!
+//! - both stdin and stdout are ttys → an interactive chooser in that terminal
+//!   ([`chooser`]): focus the running player, restart in place, open a read-only second
+//!   player, or quit;
+//! - no stdio is a tty (Finder/`.app`/GUI launches) → best-effort focus of the hosting
+//!   terminal ([`focus`]) plus a desktop notification ([`notify_fallback`]);
+//! - anything piped/mixed → exactly the old one-line notice.
+//!
+//! Everything here runs BEFORE persistence initialization and terminal setup — the same
+//! ordering contract as the guard itself (`src/main.rs`), so nothing may write config or
+//! touch the alternate screen.
+
+pub mod chooser;
+pub mod focus;
+#[cfg(windows)]
+pub mod focus_windows;
+pub mod notify_fallback;
+pub mod restart;
+
+use crate::remote;
+use crate::remote::proto::InstanceFile;
+use crate::t;
+
+pub const ALREADY_RUNNING_NOTICE: &str = "ytt is already running.\n  \
+                                          Control it:  ytt -r <command>   (e.g. `ytt -r pp`, `ytt -r next`)\n  \
+                                          Stop it:     ytt -r quit";
+
+/// How a second launch should present itself, decided purely from stdio shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecondLaunchUx {
+    /// A human is looking at this terminal: render the chooser in it.
+    InteractiveChooser,
+    /// No terminal anywhere (Finder/.app/GUI launch): focus + desktop notification.
+    FocusAndNotify,
+    /// Piped or redirected: keep the historical plain notice on stderr.
+    NoticeOnly,
+}
+
+pub fn classify(stdin_tty: bool, stdout_tty: bool, stderr_tty: bool) -> SecondLaunchUx {
+    match (stdin_tty, stdout_tty, stderr_tty) {
+        (true, true, _) => SecondLaunchUx::InteractiveChooser,
+        (false, false, false) => SecondLaunchUx::FocusAndNotify,
+        _ => SecondLaunchUx::NoticeOnly,
+    }
+}
+
+/// What `async_main` does after the guard said `AlreadyRunning`.
+pub enum Outcome {
+    Exit,
+    /// Continue into normal startup with this (possibly absent) remote server.
+    /// `read_only` mirrors `--new-instance` persistence semantics.
+    Continue {
+        remote: Option<Box<remote::RemoteServer>>,
+        read_only: bool,
+    },
+}
+
+/// Entry point for the `AlreadyRunning` branch of the interactive TUI launch.
+///
+/// Daemon, one-shot, and `-r` verbs never reach this: they are dispatched in `run()`
+/// before `async_main`.
+pub async fn handle_already_running() -> Outcome {
+    // Strict reader: a missing/foreign descriptor only downgrades the focus ladder and
+    // the notification location text, never the flow itself.
+    let instance = remote::endpoint::read_current_instance().ok();
+    // The chooser renders before Config::load may run, so peek the saved language with a
+    // read-only probe; failures fall back to English.
+    crate::i18n::set_language(crate::config::peek_saved_language());
+
+    use std::io::IsTerminal;
+    let ux = classify(
+        std::io::stdin().is_terminal(),
+        std::io::stdout().is_terminal(),
+        std::io::stderr().is_terminal(),
+    );
+    match ux {
+        SecondLaunchUx::NoticeOnly => {
+            eprintln!("{ALREADY_RUNNING_NOTICE}");
+            Outcome::Exit
+        }
+        SecondLaunchUx::FocusAndNotify => {
+            let focused = run_focus(instance.as_ref());
+            // Always notify: even a successful silent focus should tell the user why no
+            // new player appeared. Keep the stderr notice too — it may be a log file.
+            notify_fallback::notify_already_running(instance.as_ref(), focused);
+            eprintln!("{ALREADY_RUNNING_NOTICE}");
+            Outcome::Exit
+        }
+        SecondLaunchUx::InteractiveChooser => run_chooser(instance.as_ref()).await,
+    }
+}
+
+async fn run_chooser(instance: Option<&InstanceFile>) -> Outcome {
+    let choice = tokio::task::spawn_blocking(|| chooser::prompt(chooser::CHOOSER_TIMEOUT))
+        .await
+        .ok()
+        .and_then(Result::ok)
+        .unwrap_or(chooser::Choice::Quit);
+    match choice {
+        chooser::Choice::Focus => {
+            if run_focus(instance) {
+                println!(
+                    "{}",
+                    t!(
+                        "Switched to the running player.",
+                        "실행 중인 플레이어로 전환했습니다."
+                    )
+                );
+            } else {
+                println!(
+                    "{}",
+                    t!(
+                        "Could not switch to the running player.",
+                        "실행 중인 플레이어로 전환하지 못했습니다."
+                    )
+                );
+                println!("{ALREADY_RUNNING_NOTICE}");
+            }
+            Outcome::Exit
+        }
+        chooser::Choice::Restart => match restart::restart_into_primary(instance).await {
+            restart::RestartResult::TookOver { remote } => Outcome::Continue {
+                remote,
+                read_only: false,
+            },
+            restart::RestartResult::LostRace => {
+                println!(
+                    "{}",
+                    t!(
+                        "Another player took over first; leaving it in control.",
+                        "다른 플레이어가 먼저 시작되어 그쪽에 제어를 넘깁니다."
+                    )
+                );
+                Outcome::Exit
+            }
+            restart::RestartResult::OldOwnerStuck => {
+                println!(
+                    "{}",
+                    t!(
+                        "The running player did not exit. Close it manually and run ytt again.",
+                        "실행 중인 플레이어가 종료되지 않았습니다. 직접 종료한 뒤 ytt를 다시 실행하세요."
+                    )
+                );
+                Outcome::Exit
+            }
+        },
+        chooser::Choice::NewInstance => {
+            // The explicit `--new-instance` path: bind a private pid-qualified endpoint and
+            // stay a strict read-only observer (never promoted to the writer).
+            let remote = match remote::bind_or_detect(true).await {
+                remote::BindOutcome::Bound(server) => Some(server),
+                _ => None,
+            };
+            Outcome::Continue {
+                remote,
+                read_only: true,
+            }
+        }
+        chooser::Choice::Quit => Outcome::Exit,
+    }
+}
+
+fn run_focus(instance: Option<&InstanceFile>) -> bool {
+    let Some(instance) = instance else {
+        return false;
+    };
+    let plan = focus::focus_plan(instance.host_terminal.as_ref(), Some(instance.app_pid));
+    focus::run_ladder(plan)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn already_running_notice_keeps_controls_without_advertising_new_instance() {
+        assert!(ALREADY_RUNNING_NOTICE.contains("Control it:"));
+        assert!(ALREADY_RUNNING_NOTICE.contains("ytt -r <command>"));
+        assert!(ALREADY_RUNNING_NOTICE.contains("Stop it:"));
+        assert!(ALREADY_RUNNING_NOTICE.contains("ytt -r quit"));
+        assert!(!ALREADY_RUNNING_NOTICE.contains("--new-instance"));
+    }
+
+    #[test]
+    fn classification_covers_every_stdio_shape() {
+        // A human-visible terminal needs both a readable stdin and a writable stdout.
+        assert_eq!(
+            classify(true, true, true),
+            SecondLaunchUx::InteractiveChooser
+        );
+        assert_eq!(
+            classify(true, true, false),
+            SecondLaunchUx::InteractiveChooser
+        );
+        // GUI launches have no terminal anywhere.
+        assert_eq!(
+            classify(false, false, false),
+            SecondLaunchUx::FocusAndNotify
+        );
+        // Every piped/mixed shape keeps the historical notice.
+        assert_eq!(classify(true, false, true), SecondLaunchUx::NoticeOnly);
+        assert_eq!(classify(true, false, false), SecondLaunchUx::NoticeOnly);
+        assert_eq!(classify(false, true, true), SecondLaunchUx::NoticeOnly);
+        assert_eq!(classify(false, true, false), SecondLaunchUx::NoticeOnly);
+        assert_eq!(classify(false, false, true), SecondLaunchUx::NoticeOnly);
+    }
+}

--- a/src/second_launch/mod.rs
+++ b/src/second_launch/mod.rs
@@ -86,10 +86,16 @@ pub async fn handle_already_running() -> Outcome {
             Outcome::Exit
         }
         SecondLaunchUx::FocusAndNotify => {
-            let focused = run_focus(instance.as_ref());
-            // Always notify: even a successful silent focus should tell the user why no
-            // new player appeared. Keep the stderr notice too — it may be a log file.
-            notify_fallback::notify_already_running(instance.as_ref(), focused);
+            // Fully-redirected launches are also (false, false, false) — a cron job or
+            // systemd unit must keep the old inert contract, not steal focus and toast.
+            // A GUI launcher always runs inside a graphical session; on unix that means
+            // DISPLAY/WAYLAND_DISPLAY is set (macOS aside, where Aqua needs no env).
+            if has_gui_session() {
+                let focused = run_focus(instance.as_ref());
+                // Always notify: even a successful silent focus should tell the user why
+                // no new player appeared. Keep the stderr notice too — it may be a log.
+                notify_fallback::notify_already_running(instance.as_ref(), focused);
+            }
             eprintln!("{ALREADY_RUNNING_NOTICE}");
             Outcome::Exit
         }
@@ -97,12 +103,31 @@ pub async fn handle_already_running() -> Outcome {
     }
 }
 
+fn has_gui_session() -> bool {
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let set = |k: &str| std::env::var_os(k).is_some_and(|v| !v.is_empty());
+        set("DISPLAY") || set("WAYLAND_DISPLAY")
+    }
+    #[cfg(any(not(unix), target_os = "macos"))]
+    {
+        true
+    }
+}
+
 async fn run_chooser(instance: Option<&InstanceFile>) -> Outcome {
-    let choice = tokio::task::spawn_blocking(|| chooser::prompt(chooser::CHOOSER_TIMEOUT))
-        .await
-        .ok()
-        .and_then(Result::ok)
-        .unwrap_or(chooser::Choice::Quit);
+    let owner = match instance.map(|instance| instance.mode) {
+        Some(crate::remote::proto::InstanceMode::Daemon) => chooser::OwnerKind::Daemon,
+        // A TUI owner or an unreadable descriptor: offer the full menu (focus degrades
+        // gracefully to the printed notice when there is nothing to focus).
+        _ => chooser::OwnerKind::Tui,
+    };
+    let choice =
+        tokio::task::spawn_blocking(move || chooser::prompt(chooser::CHOOSER_TIMEOUT, owner))
+            .await
+            .ok()
+            .and_then(Result::ok)
+            .unwrap_or(chooser::Choice::Quit);
     match choice {
         chooser::Choice::Focus => {
             if run_focus(instance) {

--- a/src/second_launch/notify_fallback.rs
+++ b/src/second_launch/notify_fallback.rs
@@ -19,7 +19,9 @@ pub fn notify_already_running(instance: Option<&InstanceFile>, focused: bool) {
             return;
         }
     }
-    crate::notify::emit_native_notification("YuTuTui!", &body);
+    // Blocking on purpose: the process exits right after this, and a detached notify
+    // thread would be killed before the toast reaches the OS.
+    crate::notify::emit_native_notification_blocking("YuTuTui!", &body);
 }
 
 /// "already running in <where>" with a best-effort location. Pure and tested.

--- a/src/second_launch/notify_fallback.rs
+++ b/src/second_launch/notify_fallback.rs
@@ -1,0 +1,163 @@
+//! Desktop notification for launches with no terminal to print to.
+//!
+//! A Finder/`.app`/GUI second launch has no tty: the focus ladder runs first, and this
+//! notification then explains why no new player window appeared — the same convention the
+//! platforms themselves use when they deny a focus request (GNOME's "app is ready"
+//! notification, Windows' taskbar flash).
+//!
+//! macOS release builds compile the notify-rust backend out (`panic = "abort"` no-op in
+//! `crate::notify`), so this module shells out to `osascript` there instead.
+
+use crate::remote::proto::InstanceFile;
+use crate::t;
+
+pub fn notify_already_running(instance: Option<&InstanceFile>, focused: bool) {
+    let body = notification_body(instance, focused);
+    #[cfg(target_os = "macos")]
+    {
+        if macos_osascript_notification(&body) {
+            return;
+        }
+    }
+    crate::notify::emit_native_notification("YuTuTui!", &body);
+}
+
+/// "already running in <where>" with a best-effort location. Pure and tested.
+pub(crate) fn notification_body(instance: Option<&InstanceFile>, focused: bool) -> String {
+    let hint = instance.and_then(|instance| instance.host_terminal.as_ref());
+    let location_en;
+    let location_ko;
+    if hint.is_some_and(|h| h.tmux.is_some()) {
+        location_en = " in tmux".to_string();
+        location_ko = " tmux에서".to_string();
+    } else if let Some(name) = hint.and_then(|h| pretty_terminal_name(h.term_program.as_deref())) {
+        location_en = format!(" in {name}");
+        location_ko = format!(" {name}에서");
+    } else {
+        location_en = " in another terminal".to_string();
+        location_ko = " 다른 터미널에서".to_string();
+    }
+    let mut body = t!(
+        format!("YuTuTui! is already running{location_en}."),
+        format!("YuTuTui!가 이미{location_ko} 실행 중입니다.")
+    );
+    if focused {
+        body.push(' ');
+        body.push_str(t!("Switched to it.", "해당 창으로 전환했습니다."));
+    }
+    // Same hygiene as the recording notifications: never let captured env strings smuggle
+    // control bytes into a notification payload.
+    body.chars().filter(|c| !c.is_control()).collect()
+}
+
+fn pretty_terminal_name(term_program: Option<&str>) -> Option<&'static str> {
+    match term_program? {
+        "Apple_Terminal" => Some("Terminal"),
+        "iTerm.app" => Some("iTerm2"),
+        "ghostty" | "Ghostty" => Some("Ghostty"),
+        "WezTerm" => Some("WezTerm"),
+        "WarpTerminal" => Some("Warp"),
+        "kitty" => Some("kitty"),
+        "vscode" => Some("VS Code"),
+        "tmux" => Some("tmux"),
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_osascript_notification(body: &str) -> bool {
+    use crate::util::process::{ProcessProfile, std_command};
+    let script = format!(
+        "display notification {} with title \"YuTuTui!\"",
+        applescript_string(body)
+    );
+    std_command("osascript", ProcessProfile::DesktopOpen)
+        .args(["-e", &script])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+/// AppleScript string literal escaping (mirror of the desktop shell's helper — that one
+/// lives behind the `desktop` feature and is not compiled into `ytt`).
+#[cfg(any(target_os = "macos", test))]
+fn applescript_string(input: &str) -> String {
+    let escaped = input.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote::proto::HostTerminalHint;
+
+    fn instance_with(hint: HostTerminalHint) -> InstanceFile {
+        InstanceFile {
+            app_pid: 7,
+            endpoint: "sock".into(),
+            token: "tok".into(),
+            created_unix: 1,
+            mode: Default::default(),
+            protocol_version: crate::remote::proto::PROTOCOL_VERSION,
+            capabilities: Vec::new(),
+            host_terminal: Some(hint),
+        }
+    }
+
+    #[test]
+    fn body_names_the_terminal_in_both_languages() {
+        let instance = instance_with(HostTerminalHint {
+            term_program: Some("WezTerm".into()),
+            ..Default::default()
+        });
+        let _guard = crate::i18n::lock_for_test();
+        for (lang, expect) in [
+            (
+                crate::i18n::Language::English,
+                "already running in WezTerm.",
+            ),
+            (crate::i18n::Language::Korean, "WezTerm에서 실행 중입니다."),
+        ] {
+            crate::i18n::set_language(lang);
+            assert!(
+                notification_body(Some(&instance), false).contains(expect),
+                "missing {expect:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn tmux_beats_terminal_name_and_unknown_degrades_gracefully() {
+        let _guard = crate::i18n::lock_for_test();
+        let tmuxed = instance_with(HostTerminalHint {
+            term_program: Some("WezTerm".into()),
+            tmux: Some("/tmp/tmux-1000/default,42,0".into()),
+            ..Default::default()
+        });
+        assert!(notification_body(Some(&tmuxed), false).contains("in tmux"));
+
+        let unknown = instance_with(HostTerminalHint::default());
+        assert!(notification_body(Some(&unknown), false).contains("in another terminal"));
+        assert!(notification_body(None, false).contains("in another terminal"));
+    }
+
+    #[test]
+    fn focused_outcome_is_mentioned_and_control_bytes_are_stripped() {
+        let _guard = crate::i18n::lock_for_test();
+        let sneaky = instance_with(HostTerminalHint {
+            term_program: Some("WezTerm".into()),
+            tmux: Some("\x1b]0;evil\x07".into()),
+            ..Default::default()
+        });
+        let body = notification_body(Some(&sneaky), true);
+        assert!(body.contains("Switched to it."));
+        assert!(!body.chars().any(char::is_control));
+    }
+
+    #[test]
+    fn applescript_string_escapes_quotes_and_backslashes() {
+        assert_eq!(applescript_string(r#"a"b\c"#), r#""a\"b\\c""#);
+    }
+}

--- a/src/second_launch/restart.rs
+++ b/src/second_launch/restart.rs
@@ -42,7 +42,13 @@ pub enum RestartResult {
 }
 
 pub async fn restart_into_primary(old: Option<&InstanceFile>) -> RestartResult {
-    restart_with_budget(old, RestartBudget::default()).await
+    // The caller's snapshot predates the chooser, which can sit for its whole timeout —
+    // the primary may have handed over in the meantime. Quit targets whatever currently
+    // owns the socket, so the exit wait must track the CURRENT owner's pid, not the
+    // snapshot's (a long-gone pid degrades the wait to nothing while the real owner is
+    // still flushing). The stale snapshot remains the fallback location hint only.
+    let fresh = crate::remote::endpoint::read_current_instance().ok();
+    restart_with_budget(fresh.as_ref().or(old), RestartBudget::default()).await
 }
 
 async fn restart_with_budget(old: Option<&InstanceFile>, budget: RestartBudget) -> RestartResult {

--- a/src/second_launch/restart.rs
+++ b/src/second_launch/restart.rs
@@ -1,0 +1,171 @@
+//! The chooser's `[r]` path: ask the running player to quit, wait until it is truly
+//! gone, then take over as the primary.
+//!
+//! Ordering matters here. The old owner's teardown releases its socket *before* it
+//! flushes persistence (`complete_owner_teardown`), and the single-writer lease is only
+//! released at process exit — so a socket going quiet is NOT permission to initialize
+//! persistence. The sequence therefore waits for the old *process* to exit (when its pid
+//! is known) before reporting takeover, and never force-kills: a stuck owner is reported,
+//! not displaced.
+
+use std::time::Duration;
+
+use crate::remote;
+use crate::remote::proto::{InstanceFile, RemoteCommand};
+use crate::t;
+
+pub struct RestartBudget {
+    pub quit_ack: Duration,
+    pub socket_release: Duration,
+    pub process_exit: Duration,
+}
+
+impl Default for RestartBudget {
+    fn default() -> Self {
+        Self {
+            quit_ack: Duration::from_secs(3),
+            socket_release: Duration::from_secs(10),
+            process_exit: Duration::from_secs(15),
+        }
+    }
+}
+
+pub enum RestartResult {
+    /// We are the new primary (or run degraded without remote control, like any startup).
+    TookOver {
+        remote: Option<Box<remote::RemoteServer>>,
+    },
+    /// Someone else bound the socket between the old owner's exit and our rebind.
+    LostRace,
+    /// The old owner did not release/exit within budget. Nothing was killed.
+    OldOwnerStuck,
+}
+
+pub async fn restart_into_primary(old: Option<&InstanceFile>) -> RestartResult {
+    restart_with_budget(old, RestartBudget::default()).await
+}
+
+async fn restart_with_budget(old: Option<&InstanceFile>, budget: RestartBudget) -> RestartResult {
+    println!(
+        "{}",
+        t!(
+            "Asking the running player to quit…",
+            "실행 중인 플레이어에 종료를 요청하는 중…"
+        )
+    );
+    match tokio::time::timeout(budget.quit_ack, remote::client::send(RemoteCommand::Quit)).await {
+        Ok(Ok(_)) | Ok(Err(remote::client::ClientError::NoRunningInstance)) => {}
+        Ok(Err(first_error)) => {
+            // One retry after a beat: the owner may have been mid-teardown already.
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            match tokio::time::timeout(budget.quit_ack, remote::client::send(RemoteCommand::Quit))
+                .await
+            {
+                Ok(Ok(_)) | Ok(Err(remote::client::ClientError::NoRunningInstance)) => {}
+                Ok(Err(_)) | Err(_) => {
+                    tracing::warn!(error = ?first_error, "restart: quit request failed twice");
+                    return RestartResult::OldOwnerStuck;
+                }
+            }
+        }
+        Err(_) => return RestartResult::OldOwnerStuck,
+    }
+
+    if !remote::await_primary_release(budget.socket_release).await {
+        return RestartResult::OldOwnerStuck;
+    }
+
+    // The writer-lease guarantee: only process exit proves the old owner finished
+    // flushing. Without a pid (foreign/absent descriptor) a fixed grace is the best
+    // available approximation.
+    match old.map(|instance| instance.app_pid) {
+        Some(pid) => {
+            if !await_process_exit(pid, budget.process_exit).await {
+                return RestartResult::OldOwnerStuck;
+            }
+        }
+        None => tokio::time::sleep(Duration::from_secs(1)).await,
+    }
+
+    match remote::bind_or_detect(false).await {
+        remote::BindOutcome::Bound(server) => RestartResult::TookOver {
+            remote: Some(server),
+        },
+        remote::BindOutcome::AlreadyRunning => RestartResult::LostRace,
+        remote::BindOutcome::Unavailable => RestartResult::TookOver { remote: None },
+    }
+}
+
+async fn await_process_exit(pid: u32, deadline: Duration) -> bool {
+    poll_until(deadline, Duration::from_millis(250), move || {
+        !process_is_alive(pid)
+    })
+    .await
+}
+
+fn process_is_alive(pid: u32) -> bool {
+    use sysinfo::{Pid, ProcessesToUpdate, System};
+    let mut system = System::new();
+    let pid = Pid::from_u32(pid);
+    system.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
+    system.process(pid).is_some()
+}
+
+/// Poll `probe` every `interval` until it returns true or `deadline` elapses.
+/// Checks the probe first so an already-true condition never sleeps.
+async fn poll_until(
+    deadline: Duration,
+    interval: Duration,
+    mut probe: impl FnMut() -> bool,
+) -> bool {
+    let end = tokio::time::Instant::now() + deadline;
+    loop {
+        if probe() {
+            return true;
+        }
+        if tokio::time::Instant::now() >= end {
+            return false;
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn poll_until_returns_immediately_when_already_true() {
+        let mut calls = 0;
+        let hit = poll_until(Duration::from_secs(5), Duration::from_millis(250), || {
+            calls += 1;
+            true
+        })
+        .await;
+        assert!(hit);
+        assert_eq!(calls, 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn poll_until_gives_up_at_the_deadline() {
+        let hit = poll_until(Duration::from_secs(2), Duration::from_millis(250), || false).await;
+        assert!(!hit);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn poll_until_sees_a_late_flip() {
+        let mut calls = 0;
+        let hit = poll_until(Duration::from_secs(5), Duration::from_millis(250), || {
+            calls += 1;
+            calls >= 4
+        })
+        .await;
+        assert!(hit);
+        assert_eq!(calls, 4);
+    }
+
+    #[test]
+    fn own_process_reads_as_alive() {
+        assert!(process_is_alive(std::process::id()));
+    }
+}

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -135,6 +135,7 @@ fn isolated_instance(root: &Path, protocol_version: u8, capabilities: Vec<String
         mode: InstanceMode::Daemon,
         protocol_version,
         capabilities,
+        host_terminal: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace the ambiguous second-launch notice-and-exit path with a context-aware flow: an interactive chooser for terminal launches, focus plus native notification for GUI/no-TTY launches, and the historical inert notice for piped launches.
- Advertise terminal ownership metadata and add platform-specific focus strategies for Linux, macOS, and Windows.
- Add a safe restart/takeover path that waits for the current owner and socket lease without force-killing, while preserving read-only secondary mode.
- Harden daemon, headless, notification, and stale-owner behavior, and mark the Linux desktop entry as a single-main-window application.

## Why

Launching `ytt` again while an instance was already running only printed a notice and exited. From desktop launchers this looked like the application had failed to start, and users had no direct way to focus the existing instance or explicitly restart it.

## User impact

Second launches now explain the active-owner state and offer appropriate recovery actions. TUI owners can be focused, restart remains explicit and lease-safe, daemon owners default to safe quit, and headless scripted launches retain non-interactive behavior.

## Root cause

The previous single-instance guard detected the existing owner but did not carry enough terminal metadata or expose an interaction path beyond exiting.

## Validation

- PASS: `cargo fmt --all --check`
- PASS: vendored crossterm format and clippy gates
- PASS: architecture, file-size, documentation, patch, and unsafe-inventory gates
- BLOCKED locally: workspace clippy/tests stopped before compiling the branch because OpenSSL was not discoverable through `pkg-config`
- TIMEOUT locally: vendored crossterm all-features tests exceeded the 300-second harness limit after many tests passed

Canonical gate log: `/home/wmochi/.fable-harness/logs/gates/yututui-20260717-042728.log`