### PR TITLE
feat(whygem): add per-track recommendation provenance

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -94,6 +94,7 @@ the window grows again. Nothing to configure; it just follows the window.
 | `Shift+L` | Lyrics, synced to the music; click a visible line to seek there |
 | `z` / `Shift+Z` | Show lyrics 0.1s earlier / later |
 | `v` | Music video in a floating window |
+| `w` | Explain the selected queue recommendation, or the current track |
 | `Ctrl+Q` | Quit |
 
 When synced lyrics load, **`[ − 0.0s + ]`** appears at the lower right for three seconds. After it folds to **`[±]`**, click the handle to reopen it for three seconds; **`−/+`** fine-tunes the lyrics earlier / later in 0.1-second steps. Clicking any visible lyric line seeks to its synced position.
@@ -114,8 +115,10 @@ On any song, press **`d`**: it's saved as a proper music file (cover art and tit
 
 DJ Gem is the app's built-in music brain. It's optional and needs a free Gemini API key from Google — everything else in the app works without it.
 
-- **Endless station:** press **`Ctrl+R`** and it keeps the queue filled with songs that fit what you're hearing. Press **`w`** and it explains, in plain language, why it picked each one.
+- **Endless station:** press **`Ctrl+R`** and it keeps the queue filled with songs that fit what you're hearing.
 - **Ask in words:** press **`g`** and type things like *"play some quiet piano"* or *"make me a rainy-day playlist"* — it can build the playlist right into your Library.
+
+Recommended tracks carry a clickable **`?`** in the queue and beside Now Playing. With the queue open, **`w`** explains the selected row; otherwise it explains the current track. The card always shows where the recommendation came from. When DJ Gem supplied model detail it also shows the track's role, plain-language reasons and optional confidence; local station picks and other recommendations without that detail show their source alone.
 
 To switch it on: get a free Gemini API key from Google, then paste it in **Settings → DJ Gem** and enable it.
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Actual cover images drawn right in the terminal (Kitty/Sixel/iTerm2, auto-detect
 
 ### DJ Gem streaming
 
-**`Ctrl+R`** builds an endless station around what you're hearing — **`w`** explains, in plain language, why it picked each song.
+**`Ctrl+R`** builds an endless station around what you're hearing. Recommended tracks carry a clickable **`?`** in the queue and beside Now Playing. Press **`w`** with the queue open to explain its selected row; anywhere else, it explains the current track. The card always names the recommendation source and, when DJ Gem supplied them, adds its role, plain-language reasons and confidence. Picks made without model detail show the source alone.
 
 > 🖼️ *GIF coming soon.*
 <!-- 📸 TO FILL: add docs/media/djgem.gif, delete the "coming soon" line above, then uncomment:
@@ -326,6 +326,7 @@ Press **`?`** in-app for the complete live cheat sheet — it reflects *your* bi
 | `Backspace` / `Ctrl+Backspace` | Delete a character / previous word in a text field |
 | `Ctrl+H` | Return to the Player (on legacy ambiguous terminals, the safe text-edit fallback takes priority) |
 | `Ctrl+R` | DJ Gem streaming |
+| `w` | Explain the selected queue recommendation, or the current track |
 | `g` | DJ Gem assistant |
 | `o` | Settings |
 | `Ctrl+Q` | Quit |

--- a/gui/src/lib/stores/keymap.svelte.ts
+++ b/gui/src/lib/stores/keymap.svelte.ts
@@ -165,7 +165,7 @@ const SEED_ROWS: SeedRow[] = [
   ['global', 'toggle_about', 'About YuTuTui!', 'f1'],
   ['global', 'toggle_animations', 'Toggle animations', 'A'],
   ['global', 'toggle_control_box', 'Collapse / expand player bar', 'B'],
-  ['global', 'why_ai', 'Why these DJ Gem picks', 'w'],
+  ['global', 'why_ai', 'Why this pick', 'w'],
   ['global', 'text_zoom_in', 'Text size up', 'ctrl+='],
   ['global', 'text_zoom_out', 'Text size down', 'ctrl+-'],
   ['global', 'toggle_zoom_wheel_lock', 'Ctrl+wheel zoom lock', 'ctrl+l'],

--- a/scripts/app-fields.allow
+++ b/scripts/app-fields.allow
@@ -59,5 +59,6 @@ theme
 tool_setup
 transfer_running
 video
+why_gem
 yid_scan_memo
 zoom

--- a/src/ai/actor.rs
+++ b/src/ai/actor.rs
@@ -102,8 +102,9 @@ impl AiHandle {
     }
 
     /// Kick off a one-shot streaming rerank; the result returns as [`AiEvent::StreamingPicks`].
-    pub fn rerank(&self, seed_video_id: String, prompt: String) -> DeliveryResult {
+    pub fn rerank(&self, request_id: u64, seed_video_id: String, prompt: String) -> DeliveryResult {
         self.send(AiCmd::Rerank {
+            request_id,
             seed_video_id,
             prompt,
         })
@@ -204,9 +205,10 @@ impl AiActor {
                 cmd = rx.recv() => match cmd {
                     Some(AiCmd::Ask { prompt, context }) => self.converse(prompt, *context).await,
                     Some(AiCmd::Rerank {
+                        request_id,
                         seed_video_id,
                         prompt,
-                    }) => self.rerank(seed_video_id, prompt).await,
+                    }) => self.rerank(request_id, seed_video_id, prompt).await,
                     Some(AiCmd::SummarizeFeedback { digest }) => {
                         self.summarize_feedback(digest).await
                     }
@@ -420,11 +422,12 @@ impl AiActor {
     /// failure (timeout, error, block, unparseable JSON), and the reducer then degrades to the
     /// local pick. The model can never invent a track — it picks opaque `cid`s, and the reducer
     /// resolves each one against the candidate pack this call was built from.
-    async fn rerank(&mut self, seed_video_id: String, prompt: String) {
+    async fn rerank(&mut self, request_id: u64, seed_video_id: String, prompt: String) {
         let _guard = ThinkingGuard(self.emit.clone());
         let req = build_rerank_request(&prompt);
         let (picks, conf) = self.rerank_call(&req).await.unwrap_or_default();
         self.emit(AiEvent::StreamingPicks {
+            request_id,
             seed_video_id,
             picks,
             conf,

--- a/src/ai/model_control.rs
+++ b/src/ai/model_control.rs
@@ -186,7 +186,7 @@ mod tests {
         let (handle, mut rx, mut model_rx) = test_handle(1, GeminiModel::FlashLite);
         assert!(
             handle
-                .rerank("queued".to_owned(), "work".to_owned())
+                .rerank(1, "queued".to_owned(), "work".to_owned())
                 .is_ok()
         );
         assert_eq!(
@@ -211,14 +211,14 @@ mod tests {
 
         assert!(matches!(rx.try_recv(), Ok(AiCmd::Rerank { .. })));
         assert_eq!(
-            handle.rerank("later".to_owned(), "work".to_owned()),
+            handle.rerank(2, "later".to_owned(), "work".to_owned()),
             Err(DeliveryError::Busy),
             "free queue capacity must not let work overtake the pending model"
         );
         assert_eq!(model_rx.take_latest(), GeminiModel::Latest);
         assert!(
             handle
-                .rerank("after".to_owned(), "apply".to_owned())
+                .rerank(3, "after".to_owned(), "apply".to_owned())
                 .is_ok()
         );
     }
@@ -230,7 +230,7 @@ mod tests {
         drop(model_rx);
 
         assert_eq!(
-            handle.rerank("closed".to_owned(), "work".to_owned()),
+            handle.rerank(4, "closed".to_owned(), "work".to_owned()),
             Err(DeliveryError::Closed)
         );
         assert_eq!(
@@ -238,7 +238,7 @@ mod tests {
             Err(DeliveryError::Closed)
         );
         assert_eq!(
-            handle.rerank("still".to_owned(), "closed".to_owned()),
+            handle.rerank(5, "still".to_owned(), "closed".to_owned()),
             Err(DeliveryError::Closed),
             "a rejected model update must not create a phantom Busy state"
         );

--- a/src/ai/protocol.rs
+++ b/src/ai/protocol.rs
@@ -17,6 +17,7 @@ pub enum AiCmd {
     /// One-shot streaming rerank over a local candidate pack (the autoplay path); the model picks
     /// opaque cids the reducer resolves back to tracks.
     Rerank {
+        request_id: u64,
         seed_video_id: String,
         prompt: String,
     },
@@ -52,6 +53,7 @@ pub enum AiEvent {
     },
     PlayPlaylist(String),
     StreamingPicks {
+        request_id: u64,
         seed_video_id: String,
         picks: Vec<AiPick>,
         conf: Option<f32>,

--- a/src/ai/tests.rs
+++ b/src/ai/tests.rs
@@ -62,14 +62,16 @@ fn ai_handle_sends_each_command_without_mutating_payloads() {
 
     assert!(
         handle
-            .rerank("seed-video".to_owned(), "CANDS...".to_owned())
+            .rerank(17, "seed-video".to_owned(), "CANDS...".to_owned())
             .is_ok()
     );
     match rx.try_recv().unwrap() {
         AiCmd::Rerank {
+            request_id,
             seed_video_id,
             prompt,
         } => {
+            assert_eq!(request_id, 17);
             assert_eq!(seed_video_id, "seed-video");
             assert_eq!(prompt, "CANDS...");
         }

--- a/src/api/actor.rs
+++ b/src/api/actor.rs
@@ -275,6 +275,7 @@ where
                 emit(event);
             }
             ApiCmd::Streaming {
+                request_id,
                 seed,
                 seed_video_id,
                 exclude_ids,
@@ -412,12 +413,14 @@ where
                     };
                     tracing::warn!(seed = %seed, %error, "streaming search yielded nothing");
                     ApiEvent::StreamingError {
+                        request_id,
                         seed_video_id,
                         error,
                     }
                 } else {
                     tracing::info!(count = candidates.len(), seed = %seed, "streaming results");
                     ApiEvent::StreamingResults {
+                        request_id,
                         seed_video_id,
                         candidates,
                     }
@@ -425,6 +428,7 @@ where
                 emit(event);
             }
             ApiCmd::StreamingPreflight {
+                request_id,
                 seed_video_id,
                 picks,
                 fallback,
@@ -434,6 +438,7 @@ where
                 let songs =
                     ytmusic::preflight_streaming_picks(picks, fallback, mode, &config).await;
                 emit(ApiEvent::StreamingPreflighted {
+                    request_id,
                     seed_video_id,
                     songs,
                 });

--- a/src/api/protocol.rs
+++ b/src/api/protocol.rs
@@ -44,6 +44,7 @@ pub enum ApiCmd {
         config: SearchConfig,
     },
     Streaming {
+        request_id: u64,
         seed: String,
         seed_video_id: String,
         exclude_ids: Vec<String>,
@@ -52,6 +53,7 @@ pub enum ApiCmd {
         config: SearchConfig,
     },
     StreamingPreflight {
+        request_id: u64,
         seed_video_id: String,
         picks: Vec<Song>,
         fallback: Vec<Song>,
@@ -190,14 +192,17 @@ pub enum ApiEvent {
         error: String,
     },
     StreamingResults {
+        request_id: u64,
         seed_video_id: String,
         candidates: Vec<(Song, CandidateSource)>,
     },
     StreamingPreflighted {
+        request_id: u64,
         seed_video_id: String,
         songs: Vec<Song>,
     },
     StreamingError {
+        request_id: u64,
         seed_video_id: String,
         error: String,
     },
@@ -283,8 +288,12 @@ impl ApiHandle {
         })
     }
 
+    // This actor-boundary method mirrors the typed command field-for-field so correlation and
+    // seed context cannot be accidentally dropped at call sites.
+    #[allow(clippy::too_many_arguments)]
     pub fn streaming(
         &self,
+        request_id: u64,
         seed: impl Into<String>,
         seed_video_id: impl Into<String>,
         exclude_ids: Vec<String>,
@@ -293,6 +302,7 @@ impl ApiHandle {
         config: SearchConfig,
     ) -> Result<(), ApiEnqueueError> {
         self.enqueue(ApiCmd::Streaming {
+            request_id,
             seed: seed.into(),
             seed_video_id: seed_video_id.into(),
             exclude_ids,
@@ -304,6 +314,7 @@ impl ApiHandle {
 
     pub fn streaming_preflight(
         &self,
+        request_id: u64,
         seed_video_id: impl Into<String>,
         picks: Vec<Song>,
         fallback: Vec<Song>,
@@ -311,6 +322,7 @@ impl ApiHandle {
         config: StreamingConfig,
     ) -> Result<(), ApiEnqueueError> {
         self.enqueue(ApiCmd::StreamingPreflight {
+            request_id,
             seed_video_id: seed_video_id.into(),
             picks,
             fallback,

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -351,6 +351,7 @@ fn api_handle_enqueues_all_command_kinds_with_payloads() {
         .unwrap();
     handle
         .streaming(
+            66,
             "seed",
             "seed-id",
             vec!["old".to_owned()],
@@ -361,6 +362,7 @@ fn api_handle_enqueues_all_command_kinds_with_payloads() {
         .unwrap();
     handle
         .streaming_preflight(
+            77,
             "seed-id",
             vec![Song::remote("a", "A", "x", "1:00")],
             vec![Song::remote("b", "B", "x", "1:00")],
@@ -395,6 +397,7 @@ fn api_handle_enqueues_all_command_kinds_with_payloads() {
     assert!(matches!(
         bulk_rx.try_recv().unwrap(),
         ApiCmd::Streaming {
+            request_id: 66,
             limit: 12,
             mode: StreamingMode::Discovery,
             ..
@@ -403,6 +406,7 @@ fn api_handle_enqueues_all_command_kinds_with_payloads() {
     assert!(matches!(
         bulk_rx.try_recv().unwrap(),
         ApiCmd::StreamingPreflight {
+            request_id: 77,
             mode: StreamingMode::Focused,
             ..
         }

--- a/src/app/ai_reducer.rs
+++ b/src/app/ai_reducer.rs
@@ -257,12 +257,15 @@ impl App {
             .suggestions_selected
             .min(self.ai.suggestions.len() - 1);
         let requested_songs = self.ai.suggestions.clone();
+        let origin = super::why_gem::dj_gem_origin_model();
+        let why_gem = super::why_gem::models_for_songs(&requested_songs, &[], &origin);
         self.replace_queue_and_load(
             requested_songs,
             start,
             None,
             QueueReplacementOptions {
                 romanize_all: true,
+                why_gem: Some(why_gem),
                 ..QueueReplacementOptions::default()
             },
         )

--- a/src/app/artwork.rs
+++ b/src/app/artwork.rs
@@ -600,7 +600,10 @@ impl App {
             | flag(self.queue_popup.open, ART_OVERLAY_QUEUE_BIT)
             | flag(self.overlays.help_visible, ART_OVERLAY_HELP_BIT)
             | flag(self.overlays.about_visible, ART_OVERLAY_ABOUT_BIT)
-            | flag(self.overlays.why_ai_visible, ART_OVERLAY_WHY_AI_BIT)
+            | flag(
+                self.overlays.why_gem_video_id.is_some(),
+                ART_OVERLAY_WHY_AI_BIT,
+            )
             | flag(
                 self.overlays.key_conflict.is_some(),
                 ART_OVERLAY_KEY_CONFLICT_BIT,

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -63,6 +63,7 @@ impl App {
             },
             romanization: RomanizationRuntime::default(),
             streaming: StreamingRuntime::default(),
+            why_gem: crate::why_gem::WhyGemLedger::default(),
             consecutive_play_errors: 0,
             playlists: Arc::new(Playlists::default()),
             station: StationStore::default(),

--- a/src/app/context_menu.rs
+++ b/src/app/context_menu.rs
@@ -215,7 +215,7 @@ impl App {
         self.overlays.help_visible
             || self.overlays.mouse_help_visible
             || self.overlays.about_visible
-            || self.overlays.why_ai_visible
+            || self.overlays.why_gem_video_id.is_some()
             || self.overlays.now_playing_overlay.is_some()
             || self.overlays.key_conflict.is_some()
             || self.overlays.pending_settings_confirm.is_some()

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -444,9 +444,9 @@ impl App {
             return Some(self.recording_settings_key(k));
         }
 
-        // The "Why DJ Gem" overlay behaves like the About card: while it's up, swallow input; its own
-        // toggle (`w`) / Esc / Back dismiss it, and Quit still works.
-        if self.overlays.why_ai_visible {
+        // The per-track WhyGem card behaves like the About card: while it is up, swallow input;
+        // its own toggle (`w`) / Esc / Back dismiss it, and Quit still works.
+        if self.overlays.why_gem_video_id.is_some() {
             if matches!(self.keymap.global_action(chord), Some(Action::Quit)) {
                 return Some(self.quit_app());
             }
@@ -457,8 +457,7 @@ impl App {
                     Some(Action::Back)
                 );
             if close {
-                self.overlays.why_ai_visible = false;
-                self.dirty = true;
+                self.close_why_gem();
             }
             return Some(Vec::new());
         }
@@ -486,20 +485,7 @@ impl App {
                     return Some(Vec::new());
                 }
                 Action::WhyAi => {
-                    // Only worth an overlay if a prior DJ Gem rerank left something to explain;
-                    // otherwise nudge the user with a transient note instead of an empty card.
-                    if self.streaming.last_explain.is_some() {
-                        self.overlays.why_ai_visible = true;
-                    } else {
-                        self.status.kind = StatusKind::Info;
-                        self.status.text = t!(
-                            "No DJ Gem streaming picks to explain yet.",
-                            "아직 설명할 DJ Gem 라디오 선곡이 없어요.",
-                            "説明できるDJ Gemの選曲はまだありません。"
-                        )
-                        .to_owned();
-                    }
-                    self.dirty = true;
+                    self.open_selected_why_gem();
                     return Some(Vec::new());
                 }
                 Action::ToggleAnimations => return Some(self.toggle_animations()),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -147,6 +147,7 @@ pub use track_transition::TrackTransitionPlan;
 mod video_transition;
 pub use video_transition::{VideoFinishPlan, VideoOpenPlan};
 pub(in crate::app) mod prefetch;
+mod why_gem;
 pub use player::PlayerMsg;
 mod playlists_reducer;
 mod queue;
@@ -357,6 +358,9 @@ pub struct App {
     /// Streaming autoplay runtime: cooldown clock, in-flight pool flag, a handed-off DJ Gem rerank,
     /// and the empty-extend circuit-breaker counter.
     pub streaming: StreamingRuntime,
+    /// Session-only per-video provenance for recommendation-added queue tracks. The shared
+    /// ledger implementation keeps App and daemon lifecycle semantics in lockstep.
+    pub(crate) why_gem: crate::why_gem::WhyGemLedger<crate::remote::proto::WhyGemModel>,
     /// Consecutive mpv playback errors with no track playing in between, for the
     /// auto-skip circuit breaker (see [`MAX_CONSECUTIVE_PLAY_ERRORS`]).
     consecutive_play_errors: u8,

--- a/src/app/mode_switch.rs
+++ b/src/app/mode_switch.rs
@@ -44,7 +44,7 @@ impl App {
         self.search.source = search.normalized_source(self.search.source);
         if self.radio_dedicated_mode {
             self.dropdowns.search_source_open = false;
-            self.overlays.why_ai_visible = false;
+            self.close_why_gem();
         }
     }
 

--- a/src/app/mode_transition.rs
+++ b/src/app/mode_transition.rs
@@ -321,8 +321,7 @@ impl App {
         self.queue_popup.cursor = 0;
         self.queue_popup.anchor = 0;
         self.search_filter.close();
-        self.streaming.pending = false;
-        self.streaming.pending_rerank = None;
+        self.cancel_pending_streaming_recommendation();
         self.ai.thinking = false;
         self.art.force_clear_next_frame = true;
         self.dirty = true;

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -125,6 +125,10 @@ impl App {
 
     /// Double-click activates a list row; other targets retain single-click behavior.
     pub(in crate::app) fn on_mouse_double_click(&mut self, col: u16, row: u16) -> Vec<Cmd> {
+        if self.interaction.why_gem_click.take() == Some((col, row)) {
+            self.dirty = true;
+            return Vec::new();
+        }
         if self.beginner_coach_hit(col, row) {
             return Vec::new();
         }
@@ -142,6 +146,7 @@ impl App {
             || self.overlays.context_menu.is_some()
             || self.overlays.mouse_help_visible
             || self.overlays.about_visible
+            || self.overlays.why_gem_video_id.is_some()
             || self.overlays.key_conflict.is_some()
             || self.radio_mode.pending_radio_mode_confirm.is_some()
             || self.local_mode.pending_confirm.is_some()
@@ -221,6 +226,12 @@ impl App {
 
     /// Extend the active pointer gesture while preserving its original surface.
     pub(in crate::app) fn on_mouse_drag(&mut self, col: u16, row: u16) -> Vec<Cmd> {
+        // An outside press closes WhyGem immediately, but that press still owns the pointer
+        // gesture. Keep consuming its subsequent drag events so the newly exposed queue/list
+        // cannot move underneath the dismissed modal before button-up.
+        if self.overlays.why_gem_video_id.is_some() || self.interaction.why_gem_click.is_some() {
+            return Vec::new();
+        }
         if self.beginner_coach_hit(col, row) {
             return Vec::new();
         }
@@ -333,6 +344,11 @@ impl App {
         self.interaction.context_menu_press = false;
         self.interaction.drag_selection = None;
         self.interaction.drag_scrollbar = None;
+        if self.overlays.why_gem_video_id.is_some() {
+            self.cancel_seekbar_scrub();
+            self.interaction.ai_transcript_drag = None;
+            return Vec::new();
+        }
         let seek_cmds = self.commit_seekbar_scrub();
 
         if let Some(drag) = self.interaction.ai_transcript_drag.take() {
@@ -394,6 +410,9 @@ impl App {
         row: u16,
         ctrl: bool,
     ) -> Vec<Cmd> {
+        if self.overlays.why_gem_video_id.is_some() {
+            return Vec::new();
+        }
         if self.local_find_mouse_scroll_modal(up, MOUSE_SCROLL_LINES) {
             return Vec::new();
         }

--- a/src/app/mouse_routing.rs
+++ b/src/app/mouse_routing.rs
@@ -25,9 +25,22 @@ impl App {
         self.interaction.context_menu_press = false;
         self.interaction.context_menu_click = None;
         self.interaction.color_picker_click = None;
+        self.interaction.why_gem_click = None;
         self.interaction.pending_double_click_selection = None;
         if let Some(cmds) = self.audio_output_picker_mouse_click(col, row) {
             return cmds;
+        }
+        // WhyGem is a true modal. Its inert card region consumes inside clicks; clicking anywhere
+        // outside closes the card and is also consumed, so the covered queue/player never acts.
+        if self.overlays.why_gem_video_id.is_some() {
+            self.interaction.why_gem_click = Some((col, row));
+            if !matches!(
+                self.mouse_target_at(col, row),
+                Some(MouseTarget::WhyGemCard)
+            ) {
+                self.close_why_gem();
+            }
+            return Vec::new();
         }
         // The context menu is a small modal: a row click executes it, while every outside
         // click closes and is consumed so it can never activate the covered surface.
@@ -342,9 +355,15 @@ impl App {
                     rect,
                 }) => return self.on_scrollbar_press(ScrollSurface::Queue, rect, row),
                 Some(MouseButtonRegion {
-                    target: t @ (MouseTarget::QueueRow(_) | MouseTarget::QueueDel(_)),
+                    target:
+                        t @ (MouseTarget::QueueRow(_)
+                        | MouseTarget::QueueWhyGem(_)
+                        | MouseTarget::QueueDel(_)),
                     ..
                 }) => {
+                    if matches!(&t, MouseTarget::QueueWhyGem(_)) {
+                        self.interaction.why_gem_click = Some((col, row));
+                    }
                     return self.on_mouse_target(t);
                 }
                 _ => return Vec::new(),
@@ -356,6 +375,9 @@ impl App {
             }
             if matches!(region.target, MouseTarget::SettingsColorSwatch(_)) {
                 self.interaction.color_picker_click = Some((col, row));
+            }
+            if matches!(&region.target, MouseTarget::Global(Action::WhyAi)) {
+                self.interaction.why_gem_click = Some((col, row));
             }
             // Ctrl/Cmd+click on a list row toggles it in/out of the multi-selection.
             if multi && let MouseTarget::ListRow(i) = region.target {
@@ -415,6 +437,7 @@ impl App {
             | MouseTarget::ToolSetupRetry
             | MouseTarget::ToolSetupLater) => self.activate_tool_setup(target),
             MouseTarget::Onboarding(action) => self.activate_onboarding(action),
+            MouseTarget::WhyGemCard => Vec::new(),
             MouseTarget::Global(Action::ToggleHelp) => {
                 self.overlays.help_visible = true;
                 self.overlays.mouse_help_visible = false;
@@ -426,6 +449,10 @@ impl App {
             MouseTarget::Global(Action::ToggleAnimations) => self.toggle_animations(),
             // The ▲/▼ at the right of the footer hint — same handler as the `B` shortcut.
             MouseTarget::Global(Action::ToggleControlBox) => self.toggle_control_box(),
+            MouseTarget::Global(Action::WhyAi) => {
+                self.open_selected_why_gem();
+                Vec::new()
+            }
             MouseTarget::Global(_) => Vec::new(),
             MouseTarget::Player(action) if self.player_controls_live() => {
                 self.on_player_action(action)
@@ -677,6 +704,11 @@ impl App {
                 Vec::new()
             }
             MouseTarget::QueueRow(_) => Vec::new(),
+            MouseTarget::QueueWhyGem(i) if self.queue_popup.open => {
+                self.open_why_gem_at(i);
+                Vec::new()
+            }
+            MouseTarget::QueueWhyGem(_) => Vec::new(),
             // The `✗` button on a queue row removes just that track.
             MouseTarget::QueueDel(i) if self.queue_popup.open => self.remove_queue_range(i, i),
             MouseTarget::QueueDel(_) => Vec::new(),

--- a/src/app/onboarding.rs
+++ b/src/app/onboarding.rs
@@ -289,7 +289,7 @@ impl App {
             || self.overlays.help_visible
             || self.overlays.mouse_help_visible
             || self.overlays.about_visible
-            || self.overlays.why_ai_visible
+            || self.overlays.why_gem_video_id.is_some()
             || self.overlays.now_playing_overlay.is_some()
             || self.overlays.key_conflict.is_some()
             || self.overlays.pending_settings_confirm.is_some()

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -522,6 +522,9 @@ impl App {
     }
 
     pub(in crate::app) fn select_streaming_mode(&mut self, mode: StreamingMode) -> Vec<Cmd> {
+        if self.config.streaming.mode != mode {
+            self.cancel_pending_streaming_recommendation();
+        }
         self.config.streaming.mode = mode;
         self.dropdowns.streaming_open = false;
         self.dropdowns.search_source_open = false;
@@ -868,6 +871,7 @@ impl App {
     /// Into an empty queue it just becomes the sole track. This is the unified Enter / double-
     /// click "play" gesture in both the Library and the Search results.
     pub(in crate::app) fn play_now(&mut self, song: Song) -> Vec<Cmd> {
+        let requested_song = song.clone();
         let (plan, outcome) = self.queue.prepare_play_now_many(vec![song]);
         debug_assert_eq!(outcome.requested(), 1);
         if outcome.added() == 0 {
@@ -878,7 +882,7 @@ impl App {
             return Vec::new();
         }
         debug_assert_eq!(outcome.selected_cursor(), Some(plan.cursor_pos()));
-        self.load_prepared_queue_mutation(plan, Vec::new())
+        self.load_prepared_queue_mutation(plan, vec![requested_song], outcome.added())
     }
 
     /// Play several tracks now without wiping the queue: insert them immediately after the
@@ -898,7 +902,7 @@ impl App {
             return Vec::new();
         }
         debug_assert_eq!(outcome.selected_cursor(), Some(plan.cursor_pos()));
-        self.load_prepared_queue_mutation(plan, requested_songs)
+        self.load_prepared_queue_mutation(plan, requested_songs, outcome.added())
     }
 
     /// Add `song` to the queue without interrupting playback — the unified `\` / right-click
@@ -930,7 +934,7 @@ impl App {
                 return Vec::new();
             }
             debug_assert_eq!(outcome.selected_cursor(), Some(plan.cursor_pos()));
-            return self.load_prepared_queue_mutation(plan, queued_songs);
+            return self.load_prepared_queue_mutation(plan, queued_songs, outcome.added());
         }
 
         let enqueue_next = self.config.effective_enqueue_next();
@@ -946,6 +950,12 @@ impl App {
             self.dirty = true;
             return Vec::new();
         }
+        self.forget_why_gem_ids(
+            queued_songs
+                .iter()
+                .take(added)
+                .map(|song| song.video_id.as_str()),
+        );
         let cmds = self.request_romanization_for_songs(&queued_songs);
         let first_title = self.display_title(&queued_songs[0]).into_owned();
         // A track is already playing → queue it by policy, with no interruption.

--- a/src/app/queue.rs
+++ b/src/app/queue.rs
@@ -57,6 +57,7 @@ impl App {
             crate::queue::QueueRemovalPlayback::Unchanged => {
                 self.queue.commit_mutation(mutation);
                 self.commit_queue_removal_ui(outcome.popup_cursor());
+                self.reconcile_why_gem();
                 self.dirty = true;
                 Vec::new()
             }

--- a/src/app/reducer.rs
+++ b/src/app/reducer.rs
@@ -37,6 +37,10 @@ impl App {
         // leftover `Info` color from a previous green toast.
         self.status.kind = StatusKind::Error;
         let mut cmds = self.dispatch(msg);
+        // A refill is scoped to the exact queue membership/order snapshot it started from.
+        // Observe revisions after every owner reduction so an admitted manual replacement cannot
+        // leave an old same-seed chain eligible merely because that video id is still present.
+        self.reconcile_pending_streaming_recommendation();
         // Local Find owns derived data from the index, downloaded fallback, playlists and search
         // options. Observe those revisions centrally so changes made while Find stays open
         // cannot leave a stale corpus visible until the user happens to type another key.
@@ -92,6 +96,10 @@ impl App {
             self.fx.cancel();
         }
         self.cancel_stale_seekbar_scrub();
+        // Queue membership is the lifetime boundary for session-only WhyGem provenance. Run this
+        // after every non-animation owner turn so every mutation path (key, mouse, remote, AI,
+        // mode switch, admitted player transition) shares the same stale-entry cleanup.
+        self.reconcile_why_gem();
         self.sync_art_overlay_state();
         self.sync_art_geometry();
         self.status_text_prev = status_before; // return the buffer's capacity for next turn
@@ -598,43 +606,113 @@ impl App {
                 }
             }
             StreamingMsg::Results {
+                request_id,
                 seed_video_id,
                 candidates,
             } => {
+                // A pool result cannot belong to a chain that has already advanced to rerank or
+                // metadata preflight. Dropping it without settling the live stage prevents an old
+                // same-seed response from reopening or overwriting newer work.
+                if !self.streaming.pending
+                    || self.streaming.pending_pool_request_id != Some(request_id)
+                    || self.streaming.pending_rerank.is_some()
+                    || self.streaming.pending_why_gem.is_some()
+                {
+                    return Vec::new();
+                }
                 self.streaming.pending = false;
+                self.streaming.pending_pool_request_id = None;
                 if self.streaming_active() && self.queue.contains_video_id(&seed_video_id) {
                     // With a key + reranker enabled, hand the model a diverse local shortlist to
                     // reorder (ids only); otherwise rank the pool purely locally. Either way the
                     // pool went through scoring + MMR + cooldown — never taken verbatim.
                     if self.ai.available && self.config.streaming.ai.enabled {
-                        return self.start_ai_rerank(&seed_video_id, candidates);
+                        return self.start_ai_rerank(request_id, &seed_video_id, candidates);
                     }
                     let picks = self.plan_local_streaming(&seed_video_id, candidates);
-                    return self.extend_sanitized_streaming(&seed_video_id, picks, &[]);
+                    return self.extend_sanitized_streaming(request_id, &seed_video_id, picks, &[]);
                 } else {
+                    self.cancel_pending_streaming_recommendation();
                     self.dirty = true;
                 }
             }
             StreamingMsg::Preflighted {
+                request_id,
                 seed_video_id,
                 songs,
             } => {
+                let matches_pending =
+                    self.streaming
+                        .pending_why_gem
+                        .as_ref()
+                        .is_some_and(|pending| {
+                            pending.request_id == request_id
+                                && pending.seed_video_id == seed_video_id
+                        });
+                if !matches_pending {
+                    return Vec::new();
+                }
+                let why_gem = self
+                    .streaming
+                    .pending_why_gem
+                    .take()
+                    .expect("matching preflight provenance");
                 self.streaming.pending = false;
                 if self.streaming_active() && self.queue.contains_video_id(&seed_video_id) {
-                    return self.extend_queue_from_streaming(songs);
+                    let origin = super::why_gem::streaming_origin_model(why_gem.mode);
+                    let models =
+                        super::why_gem::models_for_songs(&songs, &why_gem.detailed, &origin);
+                    return self.extend_queue_with_preflight_why_gem(songs, models);
+                }
+                self.cancel_pending_streaming_recommendation();
+                self.dirty = true;
+            }
+            StreamingMsg::PreflightError {
+                request_id,
+                seed_video_id,
+                error,
+            } => {
+                let matches_pending =
+                    self.streaming
+                        .pending_why_gem
+                        .as_ref()
+                        .is_some_and(|pending| {
+                            pending.request_id == request_id
+                                && pending.seed_video_id == seed_video_id
+                        });
+                if !matches_pending {
+                    return Vec::new();
+                }
+                self.cancel_pending_streaming_recommendation();
+                if self.streaming_active() && self.queue.contains_video_id(&seed_video_id) {
+                    return self.note_streaming_failure(format!(
+                        "{}: {error}",
+                        t!("Autoplay failed", "자동재생 실패", "自動再生に失敗")
+                    ));
                 }
                 self.dirty = true;
             }
             StreamingMsg::AiPicks {
+                request_id,
                 seed_video_id,
                 picks,
                 conf,
-            } => return self.on_streaming_ai_picks(seed_video_id, picks, conf),
+            } => return self.on_streaming_ai_picks(request_id, seed_video_id, picks, conf),
             StreamingMsg::Error {
+                request_id,
                 seed_video_id,
                 error,
             } => {
-                self.streaming.pending = false;
+                // `Error` is a candidate-pool failure. Once a newer chain has advanced beyond
+                // that stage it is stale, even when the user is still on the same seed.
+                if !self.streaming.pending
+                    || self.streaming.pending_pool_request_id != Some(request_id)
+                    || self.streaming.pending_rerank.is_some()
+                    || self.streaming.pending_why_gem.is_some()
+                {
+                    return Vec::new();
+                }
+                self.cancel_pending_streaming_recommendation();
                 if self.streaming_active() && self.queue.contains_video_id(&seed_video_id) {
                     return self.note_streaming_failure(format!(
                         "{}: {error}",
@@ -651,6 +729,12 @@ impl App {
     fn handle_ai(&mut self, am: AiMsg) -> Vec<Cmd> {
         match am {
             AiMsg::Thinking(on) => {
+                // A canceled rerank still emits its guard's trailing `Thinking(false)`. If a newer
+                // generation already owns the rerank slot, that old telemetry must not hide the
+                // current spinner; the matching `AiPicks` path settles it explicitly.
+                if !on && self.streaming.pending_rerank.is_some() {
+                    return Vec::new();
+                }
                 self.ai.thinking = on;
                 self.bridges.ai_transcript_scroll.scroll_to_end();
                 self.dirty = true;
@@ -669,19 +753,22 @@ impl App {
             }
             AiMsg::PlayTracks(songs) => {
                 if !songs.is_empty() {
+                    let origin = super::why_gem::dj_gem_origin_model();
+                    let why_gem = super::why_gem::models_for_songs(&songs, &[], &origin);
                     return self.replace_queue_and_load(
                         songs,
                         0,
                         None,
                         QueueReplacementOptions {
                             romanize_all: true,
+                            why_gem: Some(why_gem),
                             ..QueueReplacementOptions::default()
                         },
                     );
                 }
             }
             AiMsg::Enqueue(songs) => {
-                return self.extend_queue_from_streaming(songs);
+                return self.extend_queue_from_dj_gem(songs);
             }
             AiMsg::Suggestions(songs) => {
                 let cmds = self.request_romanization_for_songs(&songs);
@@ -734,6 +821,9 @@ impl App {
                     explore.as_deref(),
                     &avoid_artists,
                 );
+                if self.config.streaming.mode != profile.explore.to_mode() {
+                    self.cancel_pending_streaming_recommendation();
+                }
                 self.config.streaming.mode = profile.explore.to_mode();
                 self.station.active = Some(profile);
                 self.dirty = true;

--- a/src/app/remote_reducer.rs
+++ b/src/app/remote_reducer.rs
@@ -359,6 +359,9 @@ impl App {
                 })
             }
             RemoteSettingChange::StreamingMode { value } => {
+                if self.config.streaming.mode != value {
+                    self.cancel_pending_streaming_recommendation();
+                }
                 self.config.streaming.mode = value;
                 self.status.text = format!("Curating style: {}", value.label());
                 self.dirty = true;
@@ -373,6 +376,9 @@ impl App {
             RemoteSettingChange::StreamingSource { value } => {
                 let search = self.config.effective_search();
                 let source = search.normalized_streaming_source(value);
+                if self.config.search.streaming_source != source {
+                    self.cancel_pending_streaming_recommendation();
+                }
                 self.config.search.streaming_source = source;
                 self.status.text = format!("Streaming source: {}", source.label());
                 self.dirty = true;
@@ -435,8 +441,8 @@ impl App {
                 self.config.ai_enabled = Some(value);
                 if !value {
                     self.ai.available = false;
-                    self.ai.thinking = false;
-                    self.streaming.pending_rerank = None;
+                    self.cancel_pending_streaming_recommendation();
+                    self.streaming.ai_cache.clear();
                 }
                 self.status.text = format!("DJ Gem: {}", if value { "on" } else { "off" });
                 self.dirty = true;
@@ -878,24 +884,37 @@ mod tests {
         let mut app = two_track_app();
         app.autoplay_streaming = true;
         app.ai.available = true;
+        let pending = app.force_autoplay_extend();
+        assert!(
+            pending
+                .iter()
+                .any(|cmd| matches!(cmd, Cmd::StreamingFallback { .. }))
+        );
 
         let (resp, _) = app.apply_remote(RemoteCommand::SetSetting {
             change: RemoteSettingChange::AiEnabled { value: false },
         });
         assert!(resp.ok);
         assert!(!app.ai.available);
+        assert!(!app.streaming.pending);
+        assert!(app.streaming.pending_pool_request_id.is_none());
+        assert!(app.streaming.pending_queue_revision.is_none());
 
-        let before = app.queue.len();
+        app.streaming.pending = true;
+        app.streaming.pending_pool_request_id = Some(2);
+        app.streaming.pending_queue_revision = Some(app.queue.rev());
         let cmds = app.update(StreamingMsg::Results {
+            request_id: 2,
             seed_video_id: "id0".to_owned(),
             candidates: vec![(
-                Song::remote("cand1", "Candidate", "B", "3:00"),
+                Song::remote("cand1", "Candidate", "C", "3:00"),
                 CandidateSource::YtdlpStreaming,
             )],
         });
 
         assert!(cmds.iter().all(|cmd| !matches!(cmd, Cmd::AiRerank { .. })));
-        assert!(app.queue.len() > before);
+        assert!(app.streaming.pending_rerank.is_none());
+        assert!(!app.ai.thinking);
     }
 
     #[test]
@@ -1389,6 +1408,35 @@ mod tests {
         cmds.extend(follow_ups);
         assert_eq!(app.queue.len(), 1);
         assert_eq!(app.queue.current().unwrap().video_id, "id1");
+    }
+
+    #[test]
+    fn non_current_remove_replaces_a_stale_refill_in_the_same_owner_turn() {
+        let mut app = two_track_app();
+        app.autoplay_streaming = true;
+        let old = app.force_autoplay_extend();
+        let old_request_id = old
+            .iter()
+            .find_map(|cmd| match cmd {
+                Cmd::StreamingFallback { request_id, .. } => Some(*request_id),
+                _ => None,
+            })
+            .expect("initial refill generation");
+
+        let (response, cmds) = app.apply_remote(RemoteCommand::QueueRemove { position: 1 });
+
+        assert!(response.ok);
+        assert_eq!(app.queue.len(), 1);
+        let new_request_id = cmds
+            .iter()
+            .find_map(|cmd| match cmd {
+                Cmd::StreamingFallback { request_id, .. } => Some(*request_id),
+                _ => None,
+            })
+            .expect("same-turn replacement refill");
+        assert_ne!(new_request_id, old_request_id);
+        assert_eq!(app.streaming.pending_pool_request_id, Some(new_request_id));
+        assert_eq!(app.streaming.pending_queue_revision, Some(app.queue.rev()));
     }
 
     #[test]

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -780,7 +780,10 @@ impl App {
                 cmds
             }
             PlaylistIntent::Enqueue => {
+                let manual_video_ids: Vec<String> =
+                    songs.iter().map(|song| song.video_id.clone()).collect();
                 let added = self.queue.extend(songs);
+                self.forget_why_gem_ids(manual_video_ids.iter().take(added).map(String::as_str));
                 self.status.kind = StatusKind::Info;
                 self.status.text = match crate::i18n::current() {
                     crate::i18n::Language::Korean => format!("{added}곡을 대기열에 추가함"),

--- a/src/app/session_restore.rs
+++ b/src/app/session_restore.rs
@@ -40,6 +40,7 @@ impl App {
     }
 
     fn seed_restored_queue(&mut self, song: Song) {
+        self.clear_why_gem();
         self.queue.set(vec![song], 0);
         self.seed_restored_playback_state();
     }
@@ -78,6 +79,9 @@ impl App {
     /// Restore an exact queue snapshot when one exists; fall back to the legacy library-history
     /// restore path for old session files.
     pub fn restore_last_session_from_cache(&mut self, cache: &crate::session::SessionCache) {
+        // WhyGem is deliberately session-only; restored queue IDs must never inherit rationale
+        // from an earlier in-process queue or from the persisted session cache.
+        self.clear_why_gem();
         self.radio_mode.normal_mode_queue = cache.normal_queue.clone();
         self.radio_mode.radio_mode_queue = cache.radio_queue.clone();
         self.local_mode.normal_mode_queue = cache.normal_queue.clone();

--- a/src/app/settings_reducer/commit.rs
+++ b/src/app/settings_reducer/commit.rs
@@ -272,6 +272,10 @@ impl App {
         self.audio.bands = d.eq_bands;
         self.audio.preset = d.eq_preset;
         self.audio.normalize = d.normalize;
+        let old_autoplay_streaming = self.autoplay_streaming;
+        let old_streaming_mode = self.config.streaming.mode;
+        let old_streaming_ai_enabled = self.config.streaming.ai.enabled;
+        let old_streaming_source = self.config.effective_search().streaming_source;
         // This is the post-admission commit boundary only: do not reset the streaming failure
         // counter or start a refill from here.
         self.autoplay_streaming = d.autoplay_streaming;
@@ -303,6 +307,22 @@ impl App {
         };
         let old_zoom = self.zoom.percent();
         d.apply_to(&mut self.config);
+        let streaming_generation_changed = (old_autoplay_streaming && !self.autoplay_streaming)
+            || old_streaming_mode != self.config.streaming.mode
+            || old_streaming_ai_enabled != self.config.streaming.ai.enabled
+            || old_streaming_source != self.config.effective_search().streaming_source
+            || old_ai_enabled != self.config.effective_ai_enabled()
+            || old_key != self.config.gemini_api_key
+            || model_changed;
+        if streaming_generation_changed {
+            self.cancel_pending_streaming_recommendation();
+        }
+        if old_ai_enabled != self.config.effective_ai_enabled()
+            || old_key != self.config.gemini_api_key
+            || model_changed
+        {
+            self.streaming.ai_cache.clear();
+        }
         let album_art_quality_changed = self.config.album_art_quality != old_album_art_quality;
         // Push the resolved DJ Gem reply language to the AI actor. The UI language was set live
         // as the user cycled it; this global isn't, so it's resolved and applied here on save

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -590,22 +590,29 @@ pub struct StreamingRuntime {
     /// True while the streaming candidate-pool fetch is in flight (both the DJ Gem and non-DJ Gem paths
     /// fetch the same pool first).
     pub pending: bool,
+    /// Exact generation of the candidate-pool request represented by [`Self::pending`].
+    pub(crate) pending_pool_request_id: Option<u64>,
+    /// Queue membership/order snapshot at refill start. Any admitted manual mutation invalidates
+    /// the entire chain even when it leaves the same seed video id present.
+    pub(crate) pending_queue_revision: Option<u64>,
     /// An DJ Gem rerank handed off to the assistant actor, awaiting its `StreamingMsg::AiPicks`. Holds
     /// the shortlist (to validate the returned ids against) and the local pick (the fallback).
     pub pending_rerank: Option<PendingRerank>,
     /// Consecutive empty streaming extends, for the autoplay circuit breaker.
     pub consecutive_failures: u8,
-    /// The last DJ Gem rerank's resolved explanation (picks → role + reasons + confidence), stashed
-    /// when `StreamingMsg::AiPicks` resolves so the "Why DJ Gem" overlay (`w`) can show why these tracks
-    /// were chosen. `None` until the first DJ Gem rerank lands.
-    pub last_explain: Option<StreamingAiExplain>,
+    /// Detailed per-video provenance carried across the asynchronous metadata-preflight boundary.
+    /// It is consumed only by the matching seed result and discarded on stale/error paths.
+    pub(crate) pending_why_gem: Option<super::why_gem::PendingWhyGemBatch>,
+    /// Monotonic owner-local generation carried through one complete refill chain (candidate pool,
+    /// optional DJ Gem rerank, and metadata preflight). Every async response must match it.
+    pub(crate) next_request_id: u64,
     /// Ordered recent listening outcomes (plays / skips / likes / dislikes), newest at the back,
     /// bounded to the last [`SESSION_EVENTS_CAP`]. Drives the reranker's recovery context.
     pub session_events: std::collections::VecDeque<SessionEvent>,
-    /// TTL cache of resolved DJ Gem rerank orderings, keyed by [`streaming::ai_cache_key`]. Each value is
-    /// the DJ Gem's chosen `video_id` ordering plus when it was stored; a rapid identical refill
-    /// replays it instead of spending another call. Pruned by TTL on every insert (stays tiny).
-    pub ai_cache: HashMap<u64, (Vec<String>, Instant)>,
+    /// TTL cache of resolved DJ Gem rerank orderings and their normalized per-pick provenance,
+    /// keyed by [`streaming::ai_cache_key`]. A rapid identical refill can therefore reproduce the
+    /// same WhyGem card without another model call. Pruned by TTL on every insert (stays tiny).
+    pub(crate) ai_cache: HashMap<u64, (Vec<super::why_gem::WhyGemPick>, Instant)>,
     /// Cached co-occurrence graph keyed by [`Signals::play_log_generation`], so streaming refills don't
     /// rebuild the same nested HashMap when listening history has not changed.
     pub cooc_cache: Option<(u64, Cooc)>,
@@ -845,6 +852,10 @@ pub struct Interaction {
     /// double-click arrives so the second press cannot be reinterpreted by a newly opened popup
     /// or click through after the first press closes it.
     pub(in crate::app) color_picker_click: Option<(u16, u16)>,
+    /// Coordinates of a WhyGem-opening or WhyGem-owned press. Retained across button-up so the
+    /// translator's paired double-click cannot close a newly opened card or activate the surface
+    /// exposed by an outside-dismiss press.
+    pub(in crate::app) why_gem_click: Option<(u16, u16)>,
     /// Multi-selection hidden by the latest plain Search/Library row press while the input
     /// translator waits to learn whether that press is the first half of a double-click.
     pub(in crate::app) pending_double_click_selection: Option<PendingDoubleClickSelection>,
@@ -1214,10 +1225,15 @@ pub struct Overlays {
     /// Result of the background app-update check (`None` until it completes / when disabled).
     /// When `available`, the About card shows an upgrade notice and the nav brand gets a dot.
     pub update_status: Option<crate::update::UpdateStatus>,
-    /// Whether the "Why DJ Gem" overlay is showing. Opened by `Action::WhyAi` (`w`) when the last
-    /// autoplay-streaming refill went through the DJ Gem reranker; lists why each track was chosen (slot
-    /// role + reason codes + confidence). Esc / `w` / Back dismiss it, like the About card.
-    pub why_ai_visible: bool,
+    /// The video id whose per-track WhyGem card is open. `None` means closed. Queue-row and
+    /// Now Playing affordances set the exact target; Esc / `w` / Back dismiss it.
+    pub why_gem_video_id: Option<String>,
+    /// Play-order index selected when the card opened. Provenance remains shared by video id,
+    /// while this occurrence pointer keeps duplicate rows' displayed title/artist exact.
+    pub(crate) why_gem_queue_index: Option<usize>,
+    /// Queue revision paired with `why_gem_queue_index`. Any membership/order mutation closes the
+    /// card rather than silently retargeting an indistinguishable duplicate occurrence.
+    pub(crate) why_gem_queue_revision: Option<u64>,
     /// The "what's playing" (지듣노) overlay — the radio identify card with favorite /
     /// ask-DJ Gem actions. `None` = closed. Opened by `Action::IdentifyNowPlaying` (`i`).
     pub now_playing_overlay: Option<NowPlayingOverlay>,

--- a/src/app/streaming_reducer.rs
+++ b/src/app/streaming_reducer.rs
@@ -20,6 +20,7 @@ pub enum StreamingMsg {
     /// came from (real YTM watch-playlist vs anonymous yt-dlp search) so the local engine can
     /// weight provenance and prefer the better source on dedup.
     Results {
+        request_id: u64,
         seed_video_id: String,
         candidates: Vec<(Song, CandidateSource)>,
     },
@@ -27,11 +28,20 @@ pub enum StreamingMsg {
     /// last gate before enqueueing; it can drop risky public-YouTube candidates and top up from
     /// fallback picks.
     Preflighted {
+        request_id: u64,
         seed_video_id: String,
         songs: Vec<Song>,
     },
+    /// A final metadata-preflight request could not be admitted to the API actor. Kept separate
+    /// from pool-fetch errors so only the exact pending generation can be settled.
+    PreflightError {
+        request_id: u64,
+        seed_video_id: String,
+        error: String,
+    },
     /// The non-DJ Gem streaming fallback failed to fetch related tracks.
     Error {
+        request_id: u64,
         seed_video_id: String,
         error: String,
     },
@@ -39,6 +49,7 @@ pub enum StreamingMsg {
     /// opaque pack `cid`; the reducer resolves cids→tracks via the stashed `cid_map`, validates
     /// against the shortlist, and tops up from the local pick.
     AiPicks {
+        request_id: u64,
         seed_video_id: String,
         picks: Vec<AiPick>,
         /// The model's self-reported confidence in [0,1], if it returned one.
@@ -58,12 +69,11 @@ impl App {
     /// the `StreamingMsg::AiPicks` dispatch arm.
     pub(in crate::app) fn on_streaming_ai_picks(
         &mut self,
+        request_id: u64,
         seed_video_id: String,
         picks: Vec<AiPick>,
         conf: Option<f32>,
     ) -> Vec<Cmd> {
-        self.ai.thinking = false;
-        self.dirty = true;
         // Only consume `pending_rerank` when this result is for it (a stale/duplicate
         // message for some other seed leaves the current rerank untouched). When it does
         // match but the seed is no longer queued (the user skipped/cleared mid-think),
@@ -72,9 +82,13 @@ impl App {
             .streaming
             .pending_rerank
             .as_ref()
-            .is_some_and(|p| p.seed_video_id == seed_video_id);
-        if ours
-            && let Some(pending) = self.streaming.pending_rerank.take()
+            .is_some_and(|p| p.request_id == request_id && p.seed_video_id == seed_video_id);
+        if !ours {
+            return Vec::new();
+        }
+        self.ai.thinking = false;
+        self.dirty = true;
+        if let Some(pending) = self.streaming.pending_rerank.take()
             && self.streaming_active()
             && self.queue.contains_video_id(&seed_video_id)
         {
@@ -85,12 +99,11 @@ impl App {
                     "streaming DJ Gem rerank confidence"
                 );
             }
-            // Resolve the model's opaque cids back to real tracks once, keeping its order. A
-            // cid that isn't in the pack (a hallucinated id) is dropped here; `merge_ai_picks`
-            // then re-validates against the shortlist and tops up from the local pick. The
-            // same resolution feeds the "Why DJ Gem" overlay (title + role + reasons), which must
-            // outlive the `pending_rerank` we're about to drop.
-            let resolved: Vec<(String, ExplainPick)> = picks
+            // Resolve the model's opaque cids back to real tracks once, keeping its order. A cid
+            // that is not in the pack is dropped here; the resolved pick metadata travels with
+            // the id until the final queue-admission boundary.
+            let mut resolved_ids = HashSet::new();
+            let resolved: Vec<(String, AiPick)> = picks
                 .iter()
                 .filter_map(|p| {
                     let vid = pending
@@ -99,14 +112,9 @@ impl App {
                         .find(|m| m.cid == p.cid)?
                         .video_id
                         .clone();
-                    let song = pending.shortlist.iter().find(|s| s.video_id == vid)?;
-                    let pick = ExplainPick {
-                        title: self.display_title(song).into_owned(),
-                        artist: self.display_artist(song).into_owned(),
-                        role: p.role.clone(),
-                        reasons: p.reasons.clone(),
-                    };
-                    Some((vid, pick))
+                    (resolved_ids.insert(vid.clone())
+                        && pending.shortlist.iter().any(|s| s.video_id == vid))
+                    .then(|| (vid, p.clone()))
                 })
                 .collect();
             let ids: Vec<String> = resolved.iter().map(|(vid, _)| vid.clone()).collect();
@@ -114,17 +122,26 @@ impl App {
                 resolved.iter().map(|(_, pick)| pick.role.clone()).collect();
             let recipe_ok =
                 streaming::ai_roles_match_recipe(&roles, pending.mode, &self.config.streaming);
+            let normalized_conf = conf
+                .filter(|value| value.is_finite())
+                .map(|value| value.clamp(0.0, 1.0));
             let effective_conf = if recipe_ok {
-                conf
+                normalized_conf
             } else {
-                Some(conf.unwrap_or(0.35).min(0.40))
+                Some(normalized_conf.unwrap_or(0.35).min(0.40))
             };
-            if !resolved.is_empty() {
-                self.streaming.last_explain = Some(StreamingAiExplain {
-                    conf: effective_conf,
-                    picks: resolved.into_iter().map(|(_, p)| p).collect(),
-                });
-            }
+            let ai_slots =
+                streaming::ai_slots_for_confidence(self.config.streaming.ai.picks, effective_conf);
+            let detailed: Vec<why_gem::WhyGemPick> = resolved
+                .iter()
+                .take(ai_slots)
+                .map(|(video_id, pick)| {
+                    why_gem::WhyGemPick::new(
+                        video_id.clone(),
+                        why_gem::model_from_ai_pick(pick, effective_conf),
+                    )
+                })
+                .collect();
             let picks = streaming::merge_ai_picks_with_confidence(
                 &ids,
                 &pending.shortlist,
@@ -135,10 +152,17 @@ impl App {
             // Cache the validated ordering so a rapid identical refill replays it without a
             // second call. Skip empty results (a failed rerank) so the next refill retries.
             if !ids.is_empty() && recipe_ok && effective_conf.unwrap_or(0.0) >= 0.45 {
-                self.ai_cache_store(pending.cache_key, ids);
+                self.ai_cache_store(pending.cache_key, detailed.clone());
             }
-            return self.extend_sanitized_streaming(&seed_video_id, picks, &pending.local_pick);
+            return self.extend_sanitized_streaming_with_details(
+                request_id,
+                &seed_video_id,
+                picks,
+                &pending.local_pick,
+                detailed,
+            );
         }
+        self.cancel_pending_streaming_recommendation();
         Vec::new()
     }
 
@@ -154,25 +178,42 @@ impl App {
     }
 
     fn autoplay_extend(&mut self, force: bool) -> Vec<Cmd> {
+        // Queue mutations can call this again in the same owner turn, before the top-level
+        // reducer's post-dispatch reconciliation. Retire that stale generation first so it does
+        // not block the replacement request. A canceled in-flight request also gets this one
+        // chance to bypass its own cooldown; the ordinary queue-length gate still applies.
+        let replaced_stale_refill = self.reconcile_pending_streaming_recommendation();
         // `streaming_active()` (not the raw preference) so a top-up never fires in dedicated
         // Radio/Local Deck mode or while a live station plays; the shared planner's station
         // guard stays as a defensive backstop.
         // One refill in flight at a time: the pool fetch (`streaming.pending`) or, when the DJ Gem
         // reranks the fetched pool, that rerank call (`ai_thinking`).
-        let refill_pending = self.streaming.pending || (self.ai.available && self.ai.thinking);
+        let refill_pending = self.streaming.pending
+            || self.streaming.pending_rerank.is_some()
+            || self.streaming.pending_why_gem.is_some()
+            || self.streaming.pending_queue_revision.is_some()
+            || (self.ai.available && self.ai.thinking);
         let Some(refill) = streaming::plan_autoplay_refill(
             self.streaming_active(),
             refill_pending,
             force,
             self.queue.remaining(),
-            self.streaming.last_extend.map(|t| t.elapsed()),
+            if replaced_stale_refill {
+                None
+            } else {
+                self.streaming.last_extend.map(|t| t.elapsed())
+            },
             self.queue.current(),
         ) else {
             return Vec::new();
         };
         let exclude_ids = self.streaming_exclude_ids(&refill.seed_video_id);
+        self.streaming.next_request_id = self.streaming.next_request_id.wrapping_add(1).max(1);
+        let request_id = self.streaming.next_request_id;
         self.streaming.last_extend = Some(Instant::now());
         self.streaming.pending = true;
+        self.streaming.pending_pool_request_id = Some(request_id);
+        self.streaming.pending_queue_revision = Some(self.queue.rev());
         self.status.text = t!(
             "Autoplay: finding related tracks",
             "자동재생: 관련 곡을 찾는 중",
@@ -181,6 +222,7 @@ impl App {
         .to_owned();
         self.dirty = true;
         vec![Cmd::StreamingFallback {
+            request_id,
             seed: refill.seed,
             seed_video_id: refill.seed_video_id,
             exclude_ids,
@@ -195,6 +237,7 @@ impl App {
     /// command. If the pool yields no rerankable shortlist, it enqueues the local pick directly.
     pub(in crate::app) fn start_ai_rerank(
         &mut self,
+        request_id: u64,
         seed_video_id: &str,
         mut candidates: Vec<(Song, CandidateSource)>,
     ) -> Vec<Cmd> {
@@ -231,14 +274,14 @@ impl App {
         if shortlist.is_empty() {
             // Nothing to rerank → fall straight to the local pick (itself possibly empty, which
             // trips the circuit breaker via `extend_queue_from_streaming`).
-            return self.extend_sanitized_streaming(seed_video_id, local_pick, &[]);
+            return self.extend_sanitized_streaming(request_id, seed_video_id, local_pick, &[]);
         }
         // Smart gate: skip the DJ Gem call when the local pick is already confident and the listener
         // isn't skipping — saves the spend + latency. `smart_gate=false` restores always-on DJ Gem.
         let skip_streak = self.streaming_skip_streak();
         if !streaming::should_call_ai(&shortlist, skip_streak, &self.config.streaming) {
             tracing::debug!(skip_streak, "streaming DJ Gem gated → confident local pick");
-            return self.extend_sanitized_streaming(seed_video_id, local_pick, &[]);
+            return self.extend_sanitized_streaming(request_id, seed_video_id, local_pick, &[]);
         }
         // Result cache: a rapid identical refill (same seed artist, mode, recent ids, and candidate
         // set) replays the last resolved ordering instead of spending another call. Keyed on the
@@ -266,8 +309,9 @@ impl App {
             profile_version: profile.profile_version,
             prompt_recipe_hash: recipe_hash,
         });
-        if let Some(cached_ids) = self.ai_cache_lookup(cache_key) {
+        if let Some(cached) = self.ai_cache_lookup(cache_key) {
             tracing::debug!("streaming DJ Gem cache hit → replaying cached order");
+            let cached_ids: Vec<String> = cached.iter().map(|pick| pick.video_id.clone()).collect();
             let shortlist_songs: Vec<Song> = shortlist.iter().map(|c| c.song.clone()).collect();
             let merged = streaming::merge_ai_picks(
                 &cached_ids,
@@ -275,12 +319,19 @@ impl App {
                 &local_pick,
                 self.config.streaming.ai.picks,
             );
-            return self.extend_sanitized_streaming(seed_video_id, merged, &local_pick);
+            return self.extend_sanitized_streaming_with_details(
+                request_id,
+                seed_video_id,
+                merged,
+                &local_pick,
+                cached,
+            );
         }
         let (prompt, cid_map) =
             self.ai_rerank_prompt(seed_video_id, &shortlist, st.mode, recovery_line.as_deref());
         let shortlist_songs: Vec<Song> = shortlist.into_iter().map(|c| c.song).collect();
         self.streaming.pending_rerank = Some(PendingRerank {
+            request_id,
             seed_video_id: seed_video_id.to_owned(),
             mode: st.mode,
             shortlist: shortlist_songs,
@@ -297,13 +348,14 @@ impl App {
         .to_owned();
         self.dirty = true;
         vec![Cmd::AiRerank {
+            request_id,
             seed_video_id: seed_video_id.to_owned(),
             prompt,
         }]
     }
 
     /// A cached DJ Gem rerank ordering for `key`, if one is stored and still within [`AI_CACHE_TTL`].
-    fn ai_cache_lookup(&self, key: u64) -> Option<Vec<String>> {
+    fn ai_cache_lookup(&self, key: u64) -> Option<Vec<why_gem::WhyGemPick>> {
         self.streaming
             .ai_cache
             .get(&key)
@@ -312,11 +364,11 @@ impl App {
     }
 
     /// Store a resolved DJ Gem rerank ordering, pruning expired entries first so the map stays tiny.
-    pub(in crate::app) fn ai_cache_store(&mut self, key: u64, ids: Vec<String>) {
+    pub(in crate::app) fn ai_cache_store(&mut self, key: u64, picks: Vec<why_gem::WhyGemPick>) {
         self.streaming
             .ai_cache
             .retain(|_, (_, at)| at.elapsed() < AI_CACHE_TTL);
-        self.streaming.ai_cache.insert(key, (ids, Instant::now()));
+        self.streaming.ai_cache.insert(key, (picks, Instant::now()));
     }
 
     /// The compact, evidence-rich rerank prompt plus the `cid → video_id` map for resolving the
@@ -529,35 +581,75 @@ impl App {
     }
 
     pub(in crate::app) fn extend_queue_from_streaming(&mut self, songs: Vec<Song>) -> Vec<Cmd> {
+        let origin = why_gem::streaming_origin_model(self.config.streaming.mode);
+        let models = why_gem::models_for_songs(&songs, &[], &origin);
+        self.extend_queue_with_why_gem(songs, models, true)
+    }
+
+    pub(in crate::app) fn extend_queue_from_dj_gem(&mut self, songs: Vec<Song>) -> Vec<Cmd> {
+        if songs.is_empty() {
+            return Vec::new();
+        }
+        let origin = why_gem::dj_gem_origin_model();
+        let models = why_gem::models_for_songs(&songs, &[], &origin);
+        self.extend_queue_with_why_gem(songs, models, false)
+    }
+
+    pub(in crate::app) fn extend_queue_with_preflight_why_gem(
+        &mut self,
+        songs: Vec<Song>,
+        models: Vec<why_gem::WhyGemPick>,
+    ) -> Vec<Cmd> {
+        self.extend_queue_with_why_gem(songs, models, true)
+    }
+
+    fn extend_queue_with_why_gem(
+        &mut self,
+        songs: Vec<Song>,
+        models: Vec<why_gem::WhyGemPick>,
+        streaming_refill: bool,
+    ) -> Vec<Cmd> {
         let queued_songs = songs.clone();
-        let added = self.queue.extend(songs);
+        let requested = songs.len();
+        let was_idle = self.prefetch.loaded_video_id.is_none();
+        let (added, mut idle_plan) = if was_idle {
+            let (plan, outcome) = self.queue.prepare_idle_enqueue(songs);
+            debug_assert_eq!(outcome.requested(), requested);
+            (outcome.added(), Some(plan))
+        } else {
+            (self.queue.extend(songs), None)
+        };
         if added == 0 {
-            return self.note_streaming_failure(
-                t!(
-                    "Autoplay found no new tracks",
-                    "자동재생이 새 곡을 찾지 못했어요",
-                    "自動再生で新しい曲が見つかりませんでした"
+            return if streaming_refill {
+                self.cancel_pending_streaming_recommendation();
+                self.note_streaming_failure(
+                    t!(
+                        "Autoplay found no new tracks",
+                        "자동재생이 새 곡을 찾지 못했어요",
+                        "自動再生で新しい曲が見つかりませんでした"
+                    )
+                    .to_owned(),
                 )
-                .to_owned(),
+            } else {
+                self.status.kind = StatusKind::Error;
+                self.status.text =
+                    t!("Queue is full", "큐가 가득 찼어요", "キューがいっぱいです").to_owned();
+                self.dirty = true;
+                Vec::new()
+            };
+        }
+        let accepted_models: Vec<why_gem::WhyGemPick> = models.into_iter().take(added).collect();
+        if let Some(plan) = idle_plan.take() {
+            return self.load_prepared_recommendation_queue_mutation(
+                plan,
+                queued_songs,
+                accepted_models,
+                added,
+                streaming_refill,
             );
         }
-        self.streaming.consecutive_failures = 0;
-        self.status.text = match crate::i18n::current() {
-            crate::i18n::Language::Korean => format!("{added}곡을 대기열에 추가함"),
-            crate::i18n::Language::Japanese => format!("{added}曲をキューに追加しました"),
-            _ => format!("Queued {added} track(s)"),
-        };
-        // A successful top-up is a positive confirmation, not an error — render it green.
-        self.status.kind = StatusKind::Info;
-        self.dirty = true;
-        // If the seed track ended before this refill landed (e.g. a 1-song queue with streaming
-        // on), the player is idle — pick up the freshly queued track so playback resumes
-        // instead of staying stopped at the finished song.
-        if self.prefetch.loaded_video_id.is_none() && self.queue.remaining() > 0 {
-            let mut cmds = self.advance(true);
-            cmds.extend(self.request_romanization_for_songs(&queued_songs));
-            return cmds;
-        }
+        self.commit_recommendation_queue_success(added, streaming_refill);
+        self.upsert_why_gem_picks(&accepted_models);
         // Still playing: pre-resolve the now-known next track's stream so the EOF→next hop is
         // instant (mirrors load_song's peek-next prefetch).
         let mut cmds = self.request_romanization_for_songs(&queued_songs);
@@ -576,6 +668,52 @@ impl App {
         cmds
     }
 
+    /// Project a successful recommendation append. Idle refills call this only from their
+    /// admitted player transition; direct appends call it immediately after the queue mutation.
+    pub(in crate::app) fn commit_recommendation_queue_success(
+        &mut self,
+        added: usize,
+        streaming_refill: bool,
+    ) {
+        if streaming_refill {
+            self.streaming.consecutive_failures = 0;
+        }
+        self.status.text = match crate::i18n::current() {
+            crate::i18n::Language::Korean => format!("{added}곡을 대기열에 추가함"),
+            crate::i18n::Language::Japanese => format!("{added}曲をキューに追加しました"),
+            _ => format!("Queued {added} track(s)"),
+        };
+        self.status.kind = StatusKind::Info;
+        self.dirty = true;
+    }
+
+    /// Invalidate every async stage of the current autoplay refill. The actors may still deliver
+    /// their already-admitted work, but the generation checks at each reducer boundary will drop
+    /// those responses without consuming a newer same-seed request.
+    pub(in crate::app) fn cancel_pending_streaming_recommendation(&mut self) {
+        self.streaming.pending = false;
+        self.streaming.pending_pool_request_id = None;
+        self.streaming.pending_queue_revision = None;
+        let canceled_rerank = self.streaming.pending_rerank.take().is_some();
+        self.streaming.pending_why_gem = None;
+        if canceled_rerank {
+            self.ai.thinking = false;
+        }
+    }
+
+    /// Cancel an autoplay chain whose exact queue snapshot no longer exists. Returns whether a
+    /// request was retired so a same-turn replacement can ignore only that request's cooldown.
+    pub(in crate::app) fn reconcile_pending_streaming_recommendation(&mut self) -> bool {
+        let stale = self
+            .streaming
+            .pending_queue_revision
+            .is_some_and(|revision| revision != self.queue.rev());
+        if stale {
+            self.cancel_pending_streaming_recommendation();
+        }
+        stale
+    }
+
     /// Set autoplay-streaming, resetting the failure circuit-breaker whenever it is (re)enabled
     /// so a stale count left over from a previous auto-disable can't immediately trip it off
     /// again. The single home all three enable sites (key toggle, remote, DJ-Gem) route through,
@@ -584,6 +722,8 @@ impl App {
         self.autoplay_streaming = on;
         if on {
             self.streaming.consecutive_failures = 0;
+        } else {
+            self.cancel_pending_streaming_recommendation();
         }
     }
 
@@ -595,7 +735,7 @@ impl App {
             if self.streaming.consecutive_failures >= AUTOPLAY_MAX_FAILURES {
                 self.autoplay_streaming = false;
                 disabled = true;
-                self.streaming.pending = false;
+                self.cancel_pending_streaming_recommendation();
                 self.status.text = t!(
                     "Autoplay stopped (no related tracks found)",
                     "자동재생을 멈췄어요 (관련 곡을 찾지 못함)",
@@ -659,9 +799,27 @@ impl App {
 
     pub(in crate::app) fn extend_sanitized_streaming(
         &mut self,
+        request_id: u64,
         seed_video_id: &str,
         songs: Vec<Song>,
         fallback: &[Song],
+    ) -> Vec<Cmd> {
+        self.extend_sanitized_streaming_with_details(
+            request_id,
+            seed_video_id,
+            songs,
+            fallback,
+            Vec::new(),
+        )
+    }
+
+    pub(in crate::app) fn extend_sanitized_streaming_with_details(
+        &mut self,
+        request_id: u64,
+        seed_video_id: &str,
+        songs: Vec<Song>,
+        fallback: &[Song],
+        detailed: Vec<why_gem::WhyGemPick>,
     ) -> Vec<Cmd> {
         let sanitized = streaming::sanitize_final_picks(
             songs,
@@ -677,6 +835,12 @@ impl App {
                 &self.config.streaming,
             )
         {
+            self.streaming.pending_why_gem = Some(why_gem::PendingWhyGemBatch {
+                request_id,
+                seed_video_id: seed_video_id.to_owned(),
+                mode: self.config.streaming.mode,
+                detailed,
+            });
             self.streaming.pending = true;
             self.status.kind = StatusKind::Info;
             self.status.text = t!(
@@ -687,6 +851,7 @@ impl App {
             .to_owned();
             self.dirty = true;
             return vec![Cmd::StreamingPreflight {
+                request_id,
                 seed_video_id: seed_video_id.to_owned(),
                 picks: sanitized,
                 fallback: fallback.to_vec(),
@@ -694,7 +859,13 @@ impl App {
                 config: self.config.streaming.clone(),
             }];
         }
-        self.extend_queue_from_streaming(sanitized)
+        self.streaming.pending_why_gem = None;
+        if detailed.is_empty() {
+            return self.extend_queue_from_streaming(sanitized);
+        }
+        let origin = why_gem::streaming_origin_model(self.config.streaming.mode);
+        let models = why_gem::models_for_songs(&sanitized, &detailed, &origin);
+        self.extend_queue_with_why_gem(sanitized, models, true)
     }
 
     fn augment_streaming_candidates(

--- a/src/app/tests/ai.rs
+++ b/src/app/tests/ai.rs
@@ -381,7 +381,7 @@ fn ai_streaming_circuit_breaker_disables_after_repeated_empties() {
     let mut app = app_playing(1, 0);
     app.autoplay_streaming = true;
     for _ in 0..AUTOPLAY_MAX_FAILURES {
-        app.update(AiMsg::Enqueue(Vec::new())); // resolves nothing
+        app.extend_queue_from_streaming(Vec::new()); // an autoplay refill resolved nothing
     }
     assert!(
         !app.autoplay_streaming,
@@ -455,9 +455,12 @@ fn ai_streaming_hands_a_local_shortlist_to_the_reranker() {
     app.library_mut().record_play(&current); // current can be present in history; don't duplicate it.
     app.ai.available = true;
     app.autoplay_streaming = true;
+    app.streaming.pending = true;
+    app.streaming.pending_pool_request_id = Some(1);
 
     // The fetched pool flows through the local engine; a diverse shortlist goes to the DJ Gem.
     let cmds = app.update(StreamingMsg::Results {
+        request_id: 1,
         seed_video_id: "id0".to_owned(),
         candidates: vec![
             (
@@ -477,6 +480,10 @@ fn ai_streaming_hands_a_local_shortlist_to_the_reranker() {
 
     let (seed_id, prompt) = ai_rerank(&cmds).expect("a DJ Gem rerank command");
     assert_eq!(seed_id, "id0");
+    assert!(
+        cmds.iter()
+            .any(|cmd| matches!(cmd, Cmd::AiRerank { request_id: 1, .. }))
+    );
     // Compact protocol header + candidate pack.
     assert!(prompt.contains("TASK|streaming_next"));
     assert!(prompt.contains("CANDS"));
@@ -497,6 +504,13 @@ fn ai_streaming_hands_a_local_shortlist_to_the_reranker() {
         app.streaming.pending_rerank.is_some(),
         "shortlist + local pick stashed for validation"
     );
+    assert_eq!(
+        app.streaming
+            .pending_rerank
+            .as_ref()
+            .map(|pending| pending.request_id),
+        Some(1)
+    );
     assert!(!app.streaming.pending, "the pool fetch is done");
 }
 
@@ -510,10 +524,13 @@ fn smart_gate_skips_the_ai_call_and_enqueues_the_local_pick() {
     // as confident, so this test isolates the gated local path.
     app.config.streaming.ai.smart_gate = true;
     app.config.streaming.ai.ambiguity_gap = -1.0;
+    app.streaming.pending = true;
+    app.streaming.pending_pool_request_id = Some(1);
 
     let before = app.queue.len();
     let src = CandidateSource::YtdlpStreaming;
     let cmds = app.update(StreamingMsg::Results {
+        request_id: 1,
         seed_video_id: "id0".to_owned(),
         candidates: vec![
             (Song::remote("cand1", "Track One", "band one", "3:00"), src),
@@ -551,6 +568,8 @@ fn ai_result_cache_replays_an_identical_refill_without_a_second_call() {
     app.autoplay_streaming = true;
     // Force the call through the gate so this exercises the cache, not the smart gate.
     app.config.streaming.ai.ambiguity_gap = 1.0;
+    app.streaming.pending = true;
+    app.streaming.pending_pool_request_id = Some(1);
 
     let src = CandidateSource::YtdlpStreaming;
     let candidates = vec![
@@ -565,6 +584,7 @@ fn ai_result_cache_replays_an_identical_refill_without_a_second_call() {
     // First refill misses the cache → a DJ Gem call goes out, the rerank is stashed, and (on the DJ Gem
     // path) the queue is left untouched, so the next refill recomputes the *same* cache key.
     let cmds = app.update(StreamingMsg::Results {
+        request_id: 1,
         seed_video_id: "id0".to_owned(),
         candidates: candidates.clone(),
     });
@@ -579,14 +599,24 @@ fn ai_result_cache_replays_an_identical_refill_without_a_second_call() {
 
     // Seed the cache as if that rerank had resolved to `cached_id`, then clear the in-flight flags
     // (queue/history untouched → the next identical refill keys to the same entry).
-    app.ai_cache_store(key, vec![cached_id.clone()]);
+    app.ai_cache_store(
+        key,
+        vec![why_gem::WhyGemPick::new(
+            cached_id.clone(),
+            why_gem::dj_gem_origin_model(),
+        )],
+    );
     app.streaming.pending_rerank = None;
     app.ai.thinking = false;
     app.streaming.pending = false;
+    app.streaming.pending_pool_request_id = None;
     app.streaming.last_extend = None;
 
     // Second identical refill hits the cache → no call; the cached ordering is enqueued directly.
+    app.streaming.pending = true;
+    app.streaming.pending_pool_request_id = Some(2);
     let cmds = app.update(StreamingMsg::Results {
+        request_id: 2,
         seed_video_id: "id0".to_owned(),
         candidates,
     });
@@ -605,6 +635,10 @@ fn ai_result_cache_replays_an_identical_refill_without_a_second_call() {
     assert!(
         app.queue.contains_video_id(&cached_id),
         "cached ordering enqueued"
+    );
+    assert!(
+        app.why_gem_for(&cached_id).is_some(),
+        "cache hit restores per-track provenance"
     );
 }
 
@@ -764,6 +798,7 @@ fn streaming_ai_picks_enqueue_validated_ids_and_top_up_from_local() {
     app.autoplay_streaming = true;
     app.ai.thinking = true;
     app.streaming.pending_rerank = Some(PendingRerank {
+        request_id: 1,
         seed_video_id: "id0".to_owned(),
         mode: crate::streaming::StreamingMode::Balanced,
         shortlist: vec![
@@ -789,6 +824,7 @@ fn streaming_ai_picks_enqueue_validated_ids_and_top_up_from_local() {
 
     // DJ Gem picks one valid cid + one hallucinated cid (dropped); the gap tops up from local.
     app.update(StreamingMsg::AiPicks {
+        request_id: 1,
         seed_video_id: "id0".to_owned(),
         picks: vec![
             AiPick {
@@ -822,12 +858,13 @@ fn streaming_ai_picks_enqueue_validated_ids_and_top_up_from_local() {
 }
 
 #[test]
-fn streaming_ai_picks_for_a_stale_seed_are_ignored() {
+fn streaming_ai_picks_require_the_exact_same_seed_generation() {
     let mut app = app_playing(2, 0);
     app.ai.available = true;
     app.autoplay_streaming = true;
     app.ai.thinking = true;
     app.streaming.pending_rerank = Some(PendingRerank {
+        request_id: 2,
         seed_video_id: "current-seed".to_owned(),
         mode: crate::streaming::StreamingMode::Balanced,
         shortlist: vec![Song::remote("s1", "S1", "a", "3:00")],
@@ -839,9 +876,10 @@ fn streaming_ai_picks_for_a_stale_seed_are_ignored() {
         cache_key: 0,
     });
 
-    // A result for a different (older) seed must not consume the in-flight rerank.
+    // An older result for the same seed must not consume the newer in-flight rerank.
     app.update(StreamingMsg::AiPicks {
-        seed_video_id: "old-seed".to_owned(),
+        request_id: 1,
+        seed_video_id: "current-seed".to_owned(),
         picks: vec![AiPick {
             cid: "c1".to_owned(),
             role: None,
@@ -853,17 +891,196 @@ fn streaming_ai_picks_for_a_stale_seed_are_ignored() {
         app.streaming.pending_rerank.is_some(),
         "stale result leaves the current rerank intact"
     );
+    assert!(
+        app.ai.thinking,
+        "stale result leaves the current spinner intact"
+    );
+    app.update(AiMsg::Thinking(false));
+    assert!(
+        app.ai.thinking,
+        "a canceled generation's trailing telemetry cannot hide the current spinner"
+    );
     assert!(!app.queue.contains_video_id("s1"));
 }
 
 #[test]
-fn why_ai_overlay_explains_the_last_ai_rerank() {
+fn metadata_preflight_commits_only_returned_details_and_marks_topups_by_origin() {
+    let mut app = app_playing(2, 0);
+    app.autoplay_streaming = true;
+    app.streaming.pending = true;
+    app.streaming.pending_why_gem = Some(why_gem::PendingWhyGemBatch {
+        request_id: 41,
+        seed_video_id: "id0".to_owned(),
+        mode: crate::streaming::StreamingMode::Balanced,
+        detailed: vec![
+            why_gem::WhyGemPick::new(
+                "kept",
+                crate::remote::proto::WhyGemModel {
+                    slot: "bridge".to_owned(),
+                    reasons: vec!["tr".to_owned()],
+                    confidence: serde_json::Number::from_f64(0.8),
+                },
+            ),
+            why_gem::WhyGemPick::new(
+                "dropped",
+                crate::remote::proto::WhyGemModel {
+                    slot: "discovery".to_owned(),
+                    reasons: vec!["nov".to_owned()],
+                    confidence: serde_json::Number::from_f64(0.8),
+                },
+            ),
+        ],
+    });
+
+    app.update(StreamingMsg::Preflighted {
+        request_id: 41,
+        seed_video_id: "id0".to_owned(),
+        songs: vec![
+            Song::remote("kept", "Kept", "Artist", "3:00"),
+            Song::remote("topup", "Topup", "Artist", "3:00"),
+        ],
+    });
+
+    assert_eq!(
+        app.why_gem_for("kept").map(|model| model.slot.as_str()),
+        Some("bridge")
+    );
+    assert_eq!(
+        app.why_gem_for("topup").map(|model| model.slot.as_str()),
+        Some("Balanced")
+    );
+    assert!(app.why_gem_for("dropped").is_none());
+    assert!(app.streaming.pending_why_gem.is_none());
+}
+
+#[test]
+fn metadata_preflight_requires_the_exact_same_seed_generation() {
+    let mut app = app_playing(2, 0);
+    app.autoplay_streaming = true;
+    app.streaming.pending = true;
+    app.streaming.pending_why_gem = Some(why_gem::PendingWhyGemBatch {
+        request_id: 52,
+        seed_video_id: "id0".to_owned(),
+        mode: crate::streaming::StreamingMode::Balanced,
+        detailed: vec![why_gem::WhyGemPick::new(
+            "new",
+            crate::remote::proto::WhyGemModel {
+                slot: "bridge".to_owned(),
+                reasons: vec!["tr".to_owned()],
+                confidence: serde_json::Number::from_f64(0.8),
+            },
+        )],
+    });
+
+    app.update(StreamingMsg::Preflighted {
+        request_id: 51,
+        seed_video_id: "id0".to_owned(),
+        songs: vec![Song::remote("old", "Old", "Artist", "3:00")],
+    });
+
+    assert!(
+        app.streaming.pending,
+        "stale response must not settle live work"
+    );
+    assert_eq!(
+        app.streaming
+            .pending_why_gem
+            .as_ref()
+            .map(|pending| pending.request_id),
+        Some(52)
+    );
+    assert!(!app.queue.contains_video_id("old"));
+
+    app.update(StreamingMsg::Preflighted {
+        request_id: 52,
+        seed_video_id: "id0".to_owned(),
+        songs: vec![Song::remote("new", "New", "Artist", "3:00")],
+    });
+
+    assert!(!app.streaming.pending);
+    assert!(app.streaming.pending_why_gem.is_none());
+    assert!(app.queue.contains_video_id("new"));
+    assert_eq!(
+        app.why_gem_for("new").map(|model| model.slot.as_str()),
+        Some("bridge")
+    );
+}
+
+#[test]
+fn low_confidence_rerank_marks_only_model_owned_slots_as_detailed() {
+    let mut app = app_playing(2, 0);
+    app.ai.available = true;
+    app.autoplay_streaming = true;
+    app.ai.thinking = true;
+    app.config.streaming.ai.picks = 3;
+    app.streaming.pending_rerank = Some(PendingRerank {
+        request_id: 1,
+        seed_video_id: "id0".to_owned(),
+        mode: crate::streaming::StreamingMode::Balanced,
+        shortlist: vec![
+            Song::remote("s1", "S1", "a", "3:00"),
+            Song::remote("s2", "S2", "b", "3:00"),
+            Song::remote("s3", "S3", "c", "3:00"),
+        ],
+        local_pick: vec![
+            Song::remote("s2", "S2", "b", "3:00"),
+            Song::remote("s3", "S3", "c", "3:00"),
+        ],
+        cid_map: vec![
+            crate::streaming::PackedCand {
+                cid: "c1".to_owned(),
+                video_id: "s1".to_owned(),
+            },
+            crate::streaming::PackedCand {
+                cid: "c2".to_owned(),
+                video_id: "s2".to_owned(),
+            },
+        ],
+        cache_key: 0,
+    });
+
+    app.update(StreamingMsg::AiPicks {
+        request_id: 1,
+        seed_video_id: "id0".to_owned(),
+        picks: vec![
+            AiPick {
+                cid: "c1".to_owned(),
+                role: Some("core".to_owned()),
+                reasons: vec!["u".to_owned()],
+            },
+            AiPick {
+                cid: "c2".to_owned(),
+                role: Some("bridge".to_owned()),
+                reasons: vec!["tr".to_owned()],
+            },
+        ],
+        conf: Some(0.2),
+    });
+
+    assert_eq!(
+        app.why_gem_for("s1").map(|model| model.slot.as_str()),
+        Some("core")
+    );
+    assert_eq!(
+        app.why_gem_for("s2").map(|model| model.slot.as_str()),
+        Some("Balanced"),
+        "a local confidence top-up must not inherit unused model rationale"
+    );
+    assert_eq!(
+        app.why_gem_for("s3").map(|model| model.slot.as_str()),
+        Some("Balanced")
+    );
+}
+
+#[test]
+fn why_gem_records_final_rerank_per_track_and_targets_the_queue_selection() {
     let _guard = crate::i18n::lock_for_test();
     let mut app = app_playing(2, 0); // queue id0 (current), id1
     app.ai.available = true;
     app.autoplay_streaming = true;
     app.ai.thinking = true;
     app.streaming.pending_rerank = Some(PendingRerank {
+        request_id: 1,
         seed_video_id: "id0".to_owned(),
         mode: crate::streaming::StreamingMode::Balanced,
         shortlist: vec![
@@ -885,6 +1102,7 @@ fn why_ai_overlay_explains_the_last_ai_rerank() {
     });
 
     app.update(StreamingMsg::AiPicks {
+        request_id: 1,
         seed_video_id: "id0".to_owned(),
         picks: vec![
             AiPick {
@@ -901,45 +1119,50 @@ fn why_ai_overlay_explains_the_last_ai_rerank() {
         conf: Some(0.75),
     });
 
-    // The explanation is stashed, with cids resolved to real tracks in the model's order.
-    let explain = app
-        .streaming
-        .last_explain
-        .as_ref()
-        .expect("explanation stashed for the overlay");
-    assert_eq!(explain.conf, Some(0.75));
-    assert_eq!(explain.picks.len(), 2);
-    assert_eq!(explain.picks[0].title, "First Song");
-    assert_eq!(explain.picks[0].artist, "Artist One");
-    assert_eq!(explain.picks[0].role.as_deref(), Some("bridge"));
-    assert_eq!(explain.picks[0].reasons, vec!["tr", "u"]);
-    assert_eq!(explain.picks[1].title, "Second Song");
+    let first = app.why_gem_for("s1").expect("final first pick recorded");
+    assert_eq!(first.slot, "bridge");
+    assert_eq!(first.reasons, ["tr", "u"]);
+    assert_eq!(
+        first
+            .confidence
+            .as_ref()
+            .and_then(serde_json::Number::as_f64),
+        Some(0.75)
+    );
+    let second = app.why_gem_for("s2").expect("final second pick recorded");
+    assert_eq!(second.slot, "core");
 
-    // `w` opens the overlay; `w` again dismisses it.
-    assert!(!app.overlays.why_ai_visible);
-    let mut cmds = app.apply_radio_mode_confirm(RadioModeConfirm::Enter);
-    admit_player_transition(&mut app, &mut cmds);
-    assert!(app.radio_dedicated_mode);
+    // With Queue open, `w` targets its selected row rather than the current track.
+    app.open_queue_popup();
+    app.queue_popup.cursor = app
+        .queue
+        .ordered_iter()
+        .position(|song| song.video_id == "s1")
+        .expect("s1 is queued");
     app.update(Msg::Key(key(KeyCode::Char('w'))));
-    assert!(
-        app.overlays.why_ai_visible,
-        "w opens the Why-DJ Gem overlay in Radio mode"
+    assert_eq!(
+        app.overlays.why_gem_video_id.as_deref(),
+        Some("s1"),
+        "w opens the selected row's card"
     );
     app.update(Msg::Key(key(KeyCode::Char('w'))));
-    assert!(!app.overlays.why_ai_visible, "w again dismisses it");
+    assert!(
+        app.overlays.why_gem_video_id.is_none(),
+        "w again dismisses it"
+    );
 }
 
 #[test]
-fn why_ai_without_a_rerank_shows_a_note_not_an_overlay() {
+fn why_gem_without_provenance_shows_a_note_not_an_overlay() {
     let _guard = crate::i18n::lock_for_test();
     let mut app = app_playing(2, 0);
     app.status.text.clear();
-    assert!(app.streaming.last_explain.is_none());
+    assert!(app.why_gem.is_empty());
 
     app.update(Msg::Key(key(KeyCode::Char('w'))));
     assert!(
-        !app.overlays.why_ai_visible,
-        "no overlay opens without a prior DJ Gem rerank"
+        app.overlays.why_gem_video_id.is_none(),
+        "no overlay opens without provenance for the contextual track"
     );
     assert!(
         !app.status.text.is_empty(),
@@ -948,44 +1171,36 @@ fn why_ai_without_a_rerank_shows_a_note_not_an_overlay() {
 }
 
 #[test]
-fn why_ai_overlay_renders_the_resolved_picks() {
+fn why_gem_w_targets_the_current_track_when_queue_is_closed() {
     let _guard = crate::i18n::lock_for_test();
     let mut app = app_playing(2, 0);
-    app.streaming.last_explain = Some(StreamingAiExplain {
-        conf: Some(0.82),
-        picks: vec![
-            ExplainPick {
-                title: "Bridge Track".to_owned(),
-                artist: "Some Artist".to_owned(),
-                role: Some("bridge".to_owned()),
-                reasons: vec!["tr".to_owned(), "u".to_owned()],
-            },
-            ExplainPick {
-                title: "Core Track".to_owned(),
-                artist: "Another Artist".to_owned(),
-                role: Some("core".to_owned()),
-                reasons: vec![],
-            },
-        ],
-    });
-    app.overlays.why_ai_visible = true;
-
-    let backend = TestBackend::new(80, 24);
-    let mut terminal = Terminal::new(backend).unwrap();
-    terminal.draw(|f| crate::ui::render(f, &app)).unwrap(); // must not panic
-    let buf = terminal.backend().buffer().clone();
-    let text: String = buf
-        .content()
-        .iter()
-        .map(|c| c.symbol().to_owned())
-        .collect();
-    assert!(
-        text.contains("Bridge Track"),
-        "overlay shows the first resolved track"
+    app.why_gem.upsert(
+        "id0".to_owned(),
+        why_gem::streaming_origin_model(crate::streaming::StreamingMode::Balanced),
     );
-    assert!(
-        text.contains("Core Track"),
-        "overlay shows the second resolved track"
+    app.update(Msg::Key(key(KeyCode::Char('w'))));
+    assert_eq!(app.overlays.why_gem_video_id.as_deref(), Some("id0"));
+}
+
+#[test]
+fn dj_queue_replacement_installs_provenance_only_after_player_admission() {
+    let mut app = app_playing(2, 0);
+    app.why_gem.upsert(
+        "id0".to_owned(),
+        why_gem::streaming_origin_model(crate::streaming::StreamingMode::Balanced),
+    );
+
+    let mut cmds = app.update(AiMsg::PlayTracks(vec![Song::remote(
+        "dj", "DJ Pick", "Artist", "3:00",
+    )]));
+    assert!(app.why_gem_for("id0").is_some());
+    assert!(app.why_gem_for("dj").is_none());
+
+    admit_player_transition(&mut app, &mut cmds);
+    assert!(app.why_gem_for("id0").is_none());
+    assert_eq!(
+        app.why_gem_for("dj").map(|model| model.slot.as_str()),
+        Some(why_gem::DJ_GEM_SLOT)
     );
 }
 
@@ -1016,18 +1231,125 @@ fn autoplay_uses_streaming_fallback_without_ai_key() {
 }
 
 #[test]
+fn same_seed_refill_generation_survives_off_on_without_accepting_old_pool() {
+    let mut app = app_playing(1, 0);
+    app.set_autoplay_streaming(true);
+    let first = app.force_autoplay_extend();
+    let first_id = streaming_fallback_request_id(&first).expect("first refill generation");
+
+    app.set_autoplay_streaming(false);
+    assert!(app.streaming.pending_pool_request_id.is_none());
+    assert!(app.streaming.pending_queue_revision.is_none());
+    app.set_autoplay_streaming(true);
+    let second = app.force_autoplay_extend();
+    let second_id = streaming_fallback_request_id(&second).expect("second refill generation");
+    assert_ne!(first_id, second_id);
+
+    app.update(StreamingMsg::Results {
+        request_id: first_id,
+        seed_video_id: "id0".to_owned(),
+        candidates: vec![(
+            Song::remote("old", "Old", "old artist", "3:00"),
+            CandidateSource::WatchPlaylist,
+        )],
+    });
+    assert!(!app.queue.contains_video_id("old"));
+    assert!(app.streaming.pending);
+    assert_eq!(app.streaming.pending_pool_request_id, Some(second_id));
+
+    app.update(StreamingMsg::Results {
+        request_id: second_id,
+        seed_video_id: "id0".to_owned(),
+        candidates: vec![(
+            Song::remote("new", "New", "new artist", "3:00"),
+            CandidateSource::WatchPlaylist,
+        )],
+    });
+    assert!(app.queue.contains_video_id("new"));
+    assert!(app.streaming.pending_queue_revision.is_none());
+}
+
+#[test]
+fn admitted_same_seed_manual_replacement_replaces_the_old_refill_generation() {
+    let mut app = app_playing(1, 0);
+    app.set_autoplay_streaming(true);
+    let refill = app.force_autoplay_extend();
+    let request_id = streaming_fallback_request_id(&refill).expect("refill generation");
+
+    let mut replacement = app.replace_queue_and_load(
+        vec![Song::remote("id0", "Replacement", "new artist", "3:00")],
+        0,
+        None,
+        QueueReplacementOptions::default(),
+    );
+    admit_player_transition(&mut app, &mut replacement);
+    assert!(app.queue.contains_video_id("id0"));
+    let replacement_request_id =
+        streaming_fallback_request_id(&replacement).expect("replacement refill generation");
+    assert_ne!(replacement_request_id, request_id);
+    assert_eq!(
+        app.streaming.pending_pool_request_id,
+        Some(replacement_request_id)
+    );
+    assert_eq!(app.streaming.pending_queue_revision, Some(app.queue.rev()));
+
+    app.update(StreamingMsg::Results {
+        request_id,
+        seed_video_id: "id0".to_owned(),
+        candidates: vec![(
+            Song::remote("stale", "Stale", "old artist", "3:00"),
+            CandidateSource::WatchPlaylist,
+        )],
+    });
+    assert!(!app.queue.contains_video_id("stale"));
+    assert_eq!(
+        app.streaming.pending_pool_request_id,
+        Some(replacement_request_id),
+        "the old response must not consume the replacement generation"
+    );
+}
+
+#[test]
+fn streaming_mode_change_cancels_every_refill_stage() {
+    let mut app = app_playing(1, 0);
+    app.set_autoplay_streaming(true);
+    let _ = app.force_autoplay_extend();
+    app.ai.thinking = true;
+    app.streaming.pending_rerank = Some(PendingRerank {
+        request_id: 1,
+        seed_video_id: "id0".to_owned(),
+        mode: crate::streaming::StreamingMode::Balanced,
+        shortlist: Vec::new(),
+        local_pick: Vec::new(),
+        cid_map: Vec::new(),
+        cache_key: 0,
+    });
+
+    app.select_streaming_mode(crate::streaming::StreamingMode::Discovery);
+
+    assert!(!app.streaming.pending);
+    assert!(app.streaming.pending_pool_request_id.is_none());
+    assert!(app.streaming.pending_rerank.is_none());
+    assert!(app.streaming.pending_why_gem.is_none());
+    assert!(app.streaming.pending_queue_revision.is_none());
+    assert!(!app.ai.thinking);
+}
+
+#[test]
 fn streaming_results_run_through_local_engine_and_clear_pending() {
     let _guard = crate::i18n::lock_for_test();
     fastrand::seed(7);
     let mut app = app_playing(2, 0);
     app.autoplay_streaming = true;
     app.streaming.pending = true;
+    app.streaming.pending_pool_request_id = Some(1);
 
     // The local engine excludes the seed (id0) and the already-queued track (id1), dedups
     // the repeated id2, and ranks the rest. Distinct artists + normal durations keep the
     // two survivors out of the artist-cooldown / duration hard filters, so both enqueue.
     let src = CandidateSource::YtdlpStreaming;
     app.update(StreamingMsg::Results {
+        request_id: 1,
         seed_video_id: "id0".to_owned(),
         candidates: vec![
             (Song::remote("id0", "current", "a", "3:00"), src), // == seed, dropped
@@ -1057,7 +1379,9 @@ fn streaming_error_uses_circuit_breaker() {
 
     for _ in 0..AUTOPLAY_MAX_FAILURES {
         app.streaming.pending = true;
+        app.streaming.pending_pool_request_id = Some(1);
         app.update(StreamingMsg::Error {
+            request_id: 1,
             seed_video_id: "id0".to_owned(),
             error: "yt-dlp failed".to_owned(),
         });

--- a/src/app/tests/animations.rs
+++ b/src/app/tests/animations.rs
@@ -57,7 +57,11 @@ fn overlays_do_not_park_animations_but_focus_still_does() {
     );
     app.overlays.about_visible = false;
 
-    app.overlays.why_ai_visible = true;
+    app.why_gem.upsert(
+        "id0".to_owned(),
+        why_gem::streaming_origin_model(crate::streaming::StreamingMode::Balanced),
+    );
+    app.open_why_gem_at(0);
     assert!(
         app.animation_active(),
         "Why-DJ Gem overlay should not pause the background animation"

--- a/src/app/tests/art_overlay.rs
+++ b/src/app/tests/art_overlay.rs
@@ -15,7 +15,15 @@ fn named_overlay_transitions_request_one_full_clear_when_native_art_is_active() 
         app.overlays.about_visible = open;
     }
     fn set_why_ai(app: &mut App, open: bool) {
-        app.overlays.why_ai_visible = open;
+        if open {
+            app.why_gem.upsert(
+                "id0".to_owned(),
+                why_gem::streaming_origin_model(crate::streaming::StreamingMode::Balanced),
+            );
+            app.open_why_gem_at(0);
+        } else {
+            app.close_why_gem();
+        }
     }
 
     for (name, set_open) in [
@@ -327,26 +335,17 @@ fn popup_surfaces_render_opaque_backgrounds_with_transparent_theme() {
     assert_opaque_rect(&buf, centered_fixed(modal_area, 60, 25));
 
     let mut why = app_playing(2, 0);
-    why.streaming.last_explain = Some(StreamingAiExplain {
-        conf: Some(0.82),
-        picks: vec![
-            ExplainPick {
-                title: "Bridge Track".to_owned(),
-                artist: "Some Artist".to_owned(),
-                role: Some("bridge".to_owned()),
-                reasons: vec!["tr".to_owned()],
-            },
-            ExplainPick {
-                title: "Core Track".to_owned(),
-                artist: "Another Artist".to_owned(),
-                role: Some("core".to_owned()),
-                reasons: vec![],
-            },
-        ],
-    });
-    why.overlays.why_ai_visible = true;
+    why.why_gem.upsert(
+        "id0".to_owned(),
+        crate::remote::proto::WhyGemModel {
+            slot: "bridge".to_owned(),
+            reasons: vec!["tr".to_owned()],
+            confidence: serde_json::Number::from_f64(0.82),
+        },
+    );
+    why.open_why_gem_at(0);
     let buf = render_app_buffer(&why, modal_area.width, modal_area.height);
-    assert_opaque_rect(&buf, centered_fixed(modal_area, 72, 9));
+    assert_opaque_rect(&buf, centered_fixed(modal_area, 68, 9));
 
     let mut conflict = app_playing(1, 0);
     conflict.overlays.key_conflict = Some(Conflict {

--- a/src/app/tests/local.rs
+++ b/src/app/tests/local.rs
@@ -1183,6 +1183,7 @@ fn local_deck_switch_stops_playback_and_restores_cached_queues() {
     app.playback.paused = false;
     app.streaming.pending = true;
     app.streaming.pending_rerank = Some(PendingRerank {
+        request_id: 1,
         seed_video_id: "id1".to_owned(),
         shortlist: Vec::new(),
         local_pick: Vec::new(),

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -73,4 +73,5 @@ mod track_transitions;
 mod transport_recovery;
 mod update;
 mod video;
+mod why_gem_mouse;
 mod zoom_retro_nav;

--- a/src/app/tests/playlist_search.rs
+++ b/src/app/tests/playlist_search.rs
@@ -105,13 +105,21 @@ fn playlist_tracks_play_replaces_the_queue() {
 fn playlist_tracks_enqueue_appends_to_the_queue() {
     let _guard = crate::i18n::lock_for_test();
     let mut app = app_playing(2, 0);
+    app.why_gem.upsert(
+        "id1".to_owned(),
+        why_gem::streaming_origin_model(crate::streaming::StreamingMode::Balanced),
+    );
     app.update(Msg::PlaylistTracks {
         title: "Rainy Mix".to_owned(),
         intent: crate::api::PlaylistIntent::Enqueue,
-        songs: vec![Song::remote("zzz11111111", "t", "a", "0:10")],
+        songs: vec![Song::remote("id1", "t", "a", "0:10")],
     });
     assert_eq!(app.queue.len(), 3);
     assert_eq!(current(&app), "id0", "current track is untouched");
+    assert!(
+        !app.why_gem.contains("id1"),
+        "a manually enqueued duplicate must not inherit recommendation provenance"
+    );
 }
 
 #[test]

--- a/src/app/tests/queue_mutation_admission.rs
+++ b/src/app/tests/queue_mutation_admission.rs
@@ -118,9 +118,13 @@ fn idle_enqueue_busy_and_closed_leave_append_retryable_and_commit_once() {
 fn play_now_partial_capacity_and_romanization_commit_only_after_admission() {
     let mut app = app_playing(998, 0);
     app.config.romanized_titles = Some(true);
+    app.why_gem.upsert(
+        "id500".to_owned(),
+        why_gem::streaming_origin_model(crate::streaming::StreamingMode::Balanced),
+    );
     let requested = vec![
         Song::remote("cap00000001", "첫 번째", "가수", "3:00"),
-        Song::remote("cap00000002", "두 번째", "가수", "3:00"),
+        Song::remote("id500", "두 번째", "가수", "3:00"),
         Song::remote("cap00000003", "세 번째", "가수", "3:00"),
     ];
     let before_rev = app.queue.rev();
@@ -145,8 +149,12 @@ fn play_now_partial_capacity_and_romanization_commit_only_after_admission() {
     assert_eq!(app.queue.len(), 999);
     assert_eq!(current(&app), "cap00000001");
     assert!(app.queue.video_ids().any(|id| id == "cap00000001"));
-    assert!(!app.queue.video_ids().any(|id| id == "cap00000002"));
+    assert_eq!(app.queue.video_ids().filter(|id| *id == "id500").count(), 1);
     assert!(!app.queue.video_ids().any(|id| id == "cap00000003"));
+    assert!(
+        app.why_gem.contains("id500"),
+        "a cap-rejected duplicate must not erase the existing queue row's provenance"
+    );
     assert_ne!(app.queue.rev(), before_rev);
     assert_eq!(app.playback.position_epoch, before_epoch + 1);
     assert!(

--- a/src/app/tests/radio_mode.rs
+++ b/src/app/tests/radio_mode.rs
@@ -127,6 +127,7 @@ fn radio_mode_switch_stops_playback_restores_cached_queues_and_themes() {
     app.playback.paused = false;
     app.streaming.pending = true;
     app.streaming.pending_rerank = Some(PendingRerank {
+        request_id: 1,
         seed_video_id: "id1".to_owned(),
         shortlist: Vec::new(),
         local_pick: Vec::new(),
@@ -242,6 +243,7 @@ fn radio_mode_busy_and_closed_preserve_the_complete_switch_for_retry() {
         app.playback.paused = false;
         app.streaming.pending = true;
         app.streaming.pending_rerank = Some(PendingRerank {
+            request_id: 1,
             seed_video_id: "id1".to_owned(),
             shortlist: Vec::new(),
             local_pick: Vec::new(),

--- a/src/app/tests/render_hit_targets.rs
+++ b/src/app/tests/render_hit_targets.rs
@@ -681,9 +681,13 @@ fn art_overlay_mask_tracks_each_popup_independently() {
     app.overlays.about_visible = true;
     assert_eq!(app.art_overlay_mask(), ART_OVERLAY_ABOUT_BIT);
     app.overlays.about_visible = false;
-    app.overlays.why_ai_visible = true;
+    app.why_gem.upsert(
+        "id0".to_owned(),
+        why_gem::streaming_origin_model(crate::streaming::StreamingMode::Balanced),
+    );
+    app.open_why_gem_at(0);
     assert_eq!(app.art_overlay_mask(), ART_OVERLAY_WHY_AI_BIT);
-    app.overlays.why_ai_visible = false;
+    app.close_why_gem();
     app.show_tool_setup(ToolSetupContext::Startup, vec!["mpv"]);
     assert_eq!(app.art_overlay_mask(), ART_OVERLAY_TOOL_SETUP_BIT);
     app.tool_setup = None;

--- a/src/app/tests/settings_ui.rs
+++ b/src/app/tests/settings_ui.rs
@@ -531,9 +531,20 @@ fn curating_mode_cycles_on_the_ai_tab_and_persists_to_ai_enabled() {
         CuratingMode::YtNative
     );
     assert!(app.status.text.contains("Curating mode:"));
+    app.autoplay_streaming = true;
+    app.settings.as_mut().unwrap().draft.autoplay_streaming = true;
+    let refill = app.force_autoplay_extend();
+    assert!(
+        refill
+            .iter()
+            .any(|cmd| matches!(cmd, Cmd::StreamingFallback { .. }))
+    );
     // Close → the AI rerank flag is now off.
     let cmds = update_and_admit(&mut app, Msg::Key(key(KeyCode::Esc)));
     assert!(!app.config.streaming.ai.enabled);
+    assert!(!app.streaming.pending);
+    assert!(app.streaming.pending_pool_request_id.is_none());
+    assert!(app.streaming.pending_queue_revision.is_none());
     assert!(
         cmds.iter()
             .any(|c| matches!(c, Cmd::Persist(PersistCmd::Config(_))))

--- a/src/app/tests/streaming_extend.rs
+++ b/src/app/tests/streaming_extend.rs
@@ -9,6 +9,52 @@ fn streaming_extend_resumes_playback_when_idle() {
     admit_player_transition(&mut app, &mut cmds);
     assert_loads_video(&cmds, "b");
     assert_eq!(app.prefetch.loaded_video_id.as_deref(), Some("b"));
+    assert_eq!(app.streaming.consecutive_failures, 0);
+    assert_eq!(
+        app.why_gem_for("b").map(|model| model.slot.as_str()),
+        Some("Balanced")
+    );
+}
+
+#[test]
+fn idle_streaming_success_waits_for_player_admission() {
+    use crate::util::delivery::DeliveryError;
+
+    let mut app = App::new(100);
+    app.queue.set(vec![Song::remote("a", "A", "x", "1:00")], 0);
+    app.prefetch.loaded_video_id = None;
+    app.streaming.consecutive_failures = 2;
+    app.streaming.pending_queue_revision = Some(app.queue.rev());
+    app.status.kind = StatusKind::Info;
+    app.status.text = "waiting for admission".to_owned();
+
+    let cmds = app.extend_queue_from_streaming(vec![Song::remote("b", "B", "y", "2:00")]);
+
+    assert_eq!(app.queue.len(), 1);
+    assert_eq!(app.streaming.consecutive_failures, 2);
+    assert_eq!(app.status.kind, StatusKind::Info);
+    assert_eq!(app.status.text, "waiting for admission");
+    assert!(app.why_gem_for("b").is_none());
+    assert!(reject_player_transition(&mut app, cmds, DeliveryError::Busy).is_empty());
+    assert!(
+        app.streaming.pending_queue_revision.is_none(),
+        "rejected idle admission terminates the refill generation"
+    );
+    assert_eq!(app.queue.len(), 1);
+    assert_eq!(app.streaming.consecutive_failures, 2);
+    assert_eq!(app.status.kind, StatusKind::Error);
+    assert_ne!(
+        app.status.text, "Queued 1 track(s)",
+        "a rejected player intent must not publish the success toast"
+    );
+    assert!(app.why_gem_for("b").is_none());
+
+    let mut retry = app.extend_queue_from_streaming(vec![Song::remote("b", "B", "y", "2:00")]);
+    admit_player_transition(&mut app, &mut retry);
+    assert!(app.queue.contains_video_id("b"));
+    assert_eq!(app.streaming.consecutive_failures, 0);
+    assert_ne!(app.status.text, "waiting for admission");
+    assert!(app.why_gem_for("b").is_some());
 }
 
 #[test]

--- a/src/app/tests/support.rs
+++ b/src/app/tests/support.rs
@@ -400,12 +400,20 @@ pub(super) fn streaming_fallback(cmds: &[Cmd]) -> Option<(&str, &str, &[String])
     })
 }
 
+pub(super) fn streaming_fallback_request_id(cmds: &[Cmd]) -> Option<u64> {
+    cmds.iter().find_map(|cmd| match cmd {
+        Cmd::StreamingFallback { request_id, .. } => Some(*request_id),
+        _ => None,
+    })
+}
+
 /// The `(seed_video_id, prompt)` of the `AiRerank` command among `cmds`, if any.
 pub(super) fn ai_rerank(cmds: &[Cmd]) -> Option<(&str, &str)> {
     cmds.iter().find_map(|c| match c {
         Cmd::AiRerank {
             seed_video_id,
             prompt,
+            ..
         } => Some((seed_video_id.as_str(), prompt.as_str())),
         _ => None,
     })

--- a/src/app/tests/why_gem_mouse.rs
+++ b/src/app/tests/why_gem_mouse.rs
@@ -1,0 +1,86 @@
+use super::*;
+
+fn add_why_gem(app: &mut App, video_id: &str) {
+    app.why_gem.upsert(
+        video_id.to_owned(),
+        why_gem::streaming_origin_model(crate::streaming::StreamingMode::Balanced),
+    );
+}
+
+#[test]
+fn paired_double_click_does_not_close_a_card_opened_from_a_queue_row() {
+    let mut app = app_playing(10, 0);
+    add_why_gem(&mut app, "id9");
+    app.open_queue_popup();
+    render_app(&app);
+    let (col, row) = button_center(&app, MouseTarget::QueueWhyGem(9));
+
+    app.update(Msg::MouseClick {
+        col,
+        row,
+        multi: false,
+    });
+    assert_eq!(app.overlays.why_gem_video_id.as_deref(), Some("id9"));
+    assert_eq!(app.overlays.why_gem_queue_index, Some(9));
+
+    render_app(&app);
+    let cmds = app.update(Msg::MouseDoubleClick { col, row });
+    assert!(cmds.is_empty());
+    assert_eq!(app.overlays.why_gem_video_id.as_deref(), Some("id9"));
+    assert_eq!(current(&app), "id0");
+}
+
+#[test]
+fn paired_outside_double_click_cannot_activate_the_exposed_queue_row() {
+    let mut app = app_playing(10, 0);
+    add_why_gem(&mut app, "id0");
+    app.open_queue_popup();
+    app.open_why_gem_at(0);
+    render_app(&app);
+    let (col, row) = button_center(&app, MouseTarget::QueueRow(9));
+    assert_eq!(
+        app.mouse_target_at(col, row),
+        Some(MouseTarget::QueueRow(9)),
+        "fixture row must sit outside the centered WhyGem card"
+    );
+
+    let first = app.update(Msg::MouseClick {
+        col,
+        row,
+        multi: false,
+    });
+    assert!(first.is_empty());
+    assert!(app.overlays.why_gem_video_id.is_none());
+
+    let second = app.update(Msg::MouseDoubleClick { col, row });
+    assert!(second.is_empty(), "paired second press must be consumed");
+    assert_eq!(current(&app), "id0");
+    assert!(app.queue_popup.open);
+}
+
+#[test]
+fn outside_dismiss_gesture_cannot_drag_the_exposed_queue_selection() {
+    let mut app = app_playing(10, 0);
+    add_why_gem(&mut app, "id0");
+    app.open_queue_popup();
+    app.open_why_gem_at(0);
+    render_app(&app);
+    let (col, row) = button_center(&app, MouseTarget::QueueRow(9));
+    assert_eq!(app.queue_popup.cursor, 0);
+
+    assert!(
+        app.update(Msg::MouseClick {
+            col,
+            row,
+            multi: false,
+        })
+        .is_empty()
+    );
+    assert!(app.overlays.why_gem_video_id.is_none());
+
+    assert!(app.update(Msg::MouseDrag { col, row }).is_empty());
+    assert_eq!(
+        app.queue_popup.cursor, 0,
+        "the press that dismissed WhyGem must own its entire drag gesture"
+    );
+}

--- a/src/app/track_transition.rs
+++ b/src/app/track_transition.rs
@@ -8,6 +8,8 @@
 use super::*;
 use crate::queue::{QueueMutationPlan, QueueRemovalPlayback, QueueReplacementDraft};
 
+mod why_gem;
+
 #[derive(Clone, Copy)]
 enum TrackMove {
     Next { auto: bool },
@@ -49,17 +51,22 @@ struct TrackPostCommit {
     persist_playback_modes: bool,
     clear_heal_video_id: Option<String>,
     mode_switch: Option<super::mode_transition::ModeSwitchPlan>,
+    why_gem: Option<super::why_gem::WhyGemCommit>,
+    recommendation_queued: Option<why_gem::RecommendationQueuedCommit>,
 }
 
 /// Caller-owned reducer projections which become valid only with an accepted queue replacement.
 /// Keeping these effects in the track plan prevents a rejected load from changing screens,
 /// consuming a romanization request id, or persisting a queue mode mpv never received.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Default)]
 pub(in crate::app) struct QueueReplacementOptions {
     pub(in crate::app) player_mode: bool,
     pub(in crate::app) romanize_all: bool,
     pub(in crate::app) persist_playback_modes: bool,
     pub(in crate::app) force_autoplay_extend: bool,
+    /// `None` clears all provenance with the replacement. Recommendation-owned replacements
+    /// provide exact per-video models and install them only after player admission.
+    pub(in crate::app) why_gem: Option<Vec<super::why_gem::WhyGemPick>>,
 }
 
 #[derive(Clone)]
@@ -170,6 +177,14 @@ impl App {
 
     /// Release only the token-scoped Local intent/continuation owned by this rejected batch.
     pub(crate) fn reject_track_transition(&mut self, plan: &TrackTransitionPlan) {
+        if plan
+            .post_commit
+            .recommendation_queued
+            .as_ref()
+            .is_some_and(|commit| commit.streaming_refill)
+        {
+            self.cancel_pending_streaming_recommendation();
+        }
         let Some(mode_switch) = plan.post_commit.mode_switch.as_ref() else {
             return;
         };
@@ -373,24 +388,10 @@ impl App {
                 player_mode: options.player_mode,
                 romanize_songs,
                 persist_playback_modes: options.persist_playback_modes,
-                ..TrackPostCommit::default()
-            },
-        )
-    }
-
-    /// Load a caller-prepared queue mutation as one admission transaction. Play-now and idle
-    /// enqueue use this after inspecting their typed capacity outcome; screen selection and
-    /// caller-owned romanization requests remain deferred alongside the queue and load state.
-    pub(in crate::app) fn load_prepared_queue_mutation(
-        &mut self,
-        mutation: QueueMutationPlan,
-        romanize_songs: Vec<Song>,
-    ) -> Vec<Cmd> {
-        self.prepare_queue_mutation_track_transition(
-            mutation,
-            TrackPostCommit {
-                player_mode: true,
-                romanize_songs,
+                why_gem: Some(options.why_gem.map_or(
+                    super::why_gem::WhyGemCommit::Clear,
+                    super::why_gem::WhyGemCommit::Replace,
+                )),
                 ..TrackPostCommit::default()
             },
         )
@@ -409,6 +410,7 @@ impl App {
             mutation,
             TrackPostCommit {
                 mode_switch: Some(mode_switch),
+                why_gem: Some(super::why_gem::WhyGemCommit::Clear),
                 ..TrackPostCommit::default()
             },
         );
@@ -754,6 +756,9 @@ impl App {
                 effects.extend(self.maybe_autoplay_extend());
             }
         }
+
+        self.commit_why_gem_post_commit(&mut post_commit);
+        self.reconcile_why_gem();
 
         if post_commit.close_queue_popup {
             self.queue_popup.open = false;

--- a/src/app/track_transition/why_gem.rs
+++ b/src/app/track_transition/why_gem.rs
@@ -1,0 +1,80 @@
+//! Queue-admission projections for per-track recommendation provenance.
+
+use super::*;
+
+#[derive(Clone, Copy)]
+pub(super) struct RecommendationQueuedCommit {
+    pub(super) added: usize,
+    pub(super) streaming_refill: bool,
+}
+
+impl App {
+    /// Load a caller-prepared queue mutation as one admission transaction. Play-now and idle
+    /// enqueue use this after inspecting their typed capacity outcome; screen selection,
+    /// provenance, and caller-owned romanization remain deferred with the queue and player load.
+    pub(in crate::app) fn load_prepared_queue_mutation(
+        &mut self,
+        mutation: QueueMutationPlan,
+        romanize_songs: Vec<Song>,
+        accepted_manual_count: usize,
+    ) -> Vec<Cmd> {
+        let manual_video_ids = romanize_songs
+            .iter()
+            .take(accepted_manual_count)
+            .map(|song| song.video_id.clone())
+            .collect();
+        self.prepare_queue_mutation_track_transition(
+            mutation,
+            TrackPostCommit {
+                player_mode: true,
+                romanize_songs,
+                why_gem: Some(crate::app::why_gem::WhyGemCommit::Forget(manual_video_ids)),
+                ..TrackPostCommit::default()
+            },
+        )
+    }
+
+    /// Admission-atomic idle enqueue for autoplay and DJ Gem. A rejected player intent changes
+    /// neither queue/provenance nor the success toast and streaming circuit-breaker projection.
+    pub(in crate::app) fn load_prepared_recommendation_queue_mutation(
+        &mut self,
+        mutation: QueueMutationPlan,
+        romanize_songs: Vec<Song>,
+        why_gem: Vec<crate::app::why_gem::WhyGemPick>,
+        added: usize,
+        streaming_refill: bool,
+    ) -> Vec<Cmd> {
+        self.prepare_queue_mutation_track_transition(
+            mutation,
+            TrackPostCommit {
+                romanize_songs,
+                why_gem: Some(crate::app::why_gem::WhyGemCommit::Upsert(why_gem)),
+                recommendation_queued: Some(RecommendationQueuedCommit {
+                    added,
+                    streaming_refill,
+                }),
+                ..TrackPostCommit::default()
+            },
+        )
+    }
+
+    pub(super) fn commit_why_gem_post_commit(&mut self, post_commit: &mut TrackPostCommit) {
+        if let Some(commit) = post_commit.why_gem.take() {
+            match commit {
+                crate::app::why_gem::WhyGemCommit::Clear => self.clear_why_gem(),
+                crate::app::why_gem::WhyGemCommit::Forget(video_ids) => {
+                    self.forget_why_gem_ids(video_ids.iter().map(String::as_str));
+                }
+                crate::app::why_gem::WhyGemCommit::Replace(picks) => {
+                    self.replace_why_gem_picks(&picks);
+                }
+                crate::app::why_gem::WhyGemCommit::Upsert(picks) => {
+                    self.upsert_why_gem_picks(&picks);
+                }
+            }
+        }
+        if let Some(commit) = post_commit.recommendation_queued.take() {
+            self.commit_recommendation_queue_success(commit.added, commit.streaming_refill);
+        }
+    }
+}

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -439,6 +439,7 @@ pub enum Cmd {
     },
     /// Ask the anonymous API/search actor for related tracks to keep streaming going without DJ Gem.
     StreamingFallback {
+        request_id: u64,
         seed: String,
         seed_video_id: String,
         exclude_ids: Vec<String>,
@@ -448,6 +449,7 @@ pub enum Cmd {
     /// Ask the API actor to run a final metadata preflight on streaming picks before enqueueing.
     /// Only risky candidates trigger full yt-dlp extraction; clean picks pass through.
     StreamingPreflight {
+        request_id: u64,
         seed_video_id: String,
         picks: Vec<Song>,
         fallback: Vec<Song>,
@@ -457,6 +459,7 @@ pub enum Cmd {
     /// Hand a local candidate shortlist to the DJ Gem actor to rerank (ids only). The result
     /// returns as [`StreamingMsg::AiPicks`]; failure degrades to the stashed local pick.
     AiRerank {
+        request_id: u64,
         seed_video_id: String,
         prompt: String,
     },
@@ -650,6 +653,9 @@ pub enum MouseTarget {
     Onboarding(OnboardingAction),
     Global(Action),
     Player(Action),
+    /// Inert coverage for the open per-track WhyGem card; outside clicks close it while clicks
+    /// inside are consumed without reaching the covered queue/player surface.
+    WhyGemCard,
     /// A visible synced-lyric row. The owning track ID and original LRC index make stale frame
     /// targets fail closed instead of seeking a newly loaded track.
     LyricsLine {
@@ -778,6 +784,8 @@ pub enum MouseTarget {
     /// A row in the open queue window, by order position. Single-click selects; double-click
     /// jumps playback to it.
     QueueRow(usize),
+    /// The per-track WhyGem affordance on a queue-window row.
+    QueueWhyGem(usize),
     /// The `✗` delete button on a queue-window row, by order position.
     QueueDel(usize),
     /// The `✗` delete button on a Library list row, by row index in the current tab.
@@ -936,6 +944,7 @@ impl StreamNowPlaying {
 /// it (so a hallucinated id is dropped) — and `local_pick` is the guaranteed fallback ordering
 /// the engine produced, used to top up any slots the DJ Gem left empty.
 pub struct PendingRerank {
+    pub(crate) request_id: u64,
     pub(crate) seed_video_id: String,
     pub(crate) mode: StreamingMode,
     pub(crate) shortlist: Vec<Song>,
@@ -946,30 +955,6 @@ pub struct PendingRerank {
     /// Cache key for this rerank (hash of seed artist / mode / recent ids / candidate set), so the
     /// resolved ordering can be stored on return and replayed for a rapid identical refill.
     pub(crate) cache_key: u64,
-}
-
-/// The resolved, human-readable explanation of the last DJ Gem streaming rerank, shown by the "Why DJ Gem"
-/// overlay (the `w` key). Built when [`StreamingMsg::AiPicks`] resolves — the model's opaque cids are
-/// mapped back to real tracks (title + artist) while [`PendingRerank`] is still in hand — so the
-/// overlay can render it long after the pending rerank has been consumed.
-#[derive(Debug, Clone, Default)]
-pub struct StreamingAiExplain {
-    /// The model's self-reported confidence in [0,1], if any.
-    pub(crate) conf: Option<f32>,
-    /// The picks the model chose, in its best-first order (hallucinated cids already dropped).
-    pub(crate) picks: Vec<ExplainPick>,
-}
-
-/// One resolved pick in a [`StreamingAiExplain`]: the track it landed on plus the model's stated
-/// slot role and reason codes.
-#[derive(Debug, Clone)]
-pub(crate) struct ExplainPick {
-    pub(crate) title: String,
-    pub(crate) artist: String,
-    /// The model's slot role for this pick (core/bridge/adjacent/discovery/…), if it gave one.
-    pub(crate) role: Option<String>,
-    /// The model's reason codes (the evidence scores it leaned on, e.g. `tr`, `u`).
-    pub(crate) reasons: Vec<String>,
 }
 
 /// One ordered listening-session outcome (newest pushed to the back of

--- a/src/app/why_gem.rs
+++ b/src/app/why_gem.rs
@@ -1,0 +1,417 @@
+//! Session-only per-track WhyGem provenance for the native App owner.
+//!
+//! Producer paths normalize untrusted model metadata here, then commit it only after the
+//! corresponding queue mutation is accepted. Rendering and input use the narrow accessors below
+//! instead of reaching into the ledger directly.
+
+use super::*;
+use crate::remote::proto::WhyGemModel;
+
+pub(crate) const DJ_GEM_SLOT: &str = "dj_gem";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WhyGemPick {
+    pub(crate) video_id: String,
+    pub(crate) model: WhyGemModel,
+}
+
+impl WhyGemPick {
+    pub(crate) fn new(video_id: impl Into<String>, model: WhyGemModel) -> Self {
+        Self {
+            video_id: video_id.into(),
+            model,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PendingWhyGemBatch {
+    pub(crate) request_id: u64,
+    pub(crate) seed_video_id: String,
+    pub(crate) mode: StreamingMode,
+    pub(crate) detailed: Vec<WhyGemPick>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum WhyGemCommit {
+    Clear,
+    Forget(Vec<String>),
+    Replace(Vec<WhyGemPick>),
+    Upsert(Vec<WhyGemPick>),
+}
+
+pub(crate) fn streaming_origin_model(mode: StreamingMode) -> WhyGemModel {
+    WhyGemModel {
+        slot: match mode {
+            StreamingMode::Focused => "Focused",
+            StreamingMode::Balanced => "Balanced",
+            StreamingMode::Discovery => "Discovery",
+        }
+        .to_owned(),
+        reasons: Vec::new(),
+        confidence: None,
+    }
+}
+
+pub(crate) fn dj_gem_origin_model() -> WhyGemModel {
+    WhyGemModel {
+        slot: DJ_GEM_SLOT.to_owned(),
+        reasons: Vec::new(),
+        confidence: None,
+    }
+}
+
+pub(crate) fn model_from_ai_pick(pick: &AiPick, confidence: Option<f32>) -> WhyGemModel {
+    let slot = pick
+        .role
+        .as_deref()
+        .filter(|role| is_known_role(role))
+        .unwrap_or(DJ_GEM_SLOT)
+        .to_owned();
+    let mut reasons = Vec::with_capacity(pick.reasons.len().min(7));
+    for reason in &pick.reasons {
+        if is_known_reason(reason) && !reasons.contains(reason) {
+            reasons.push(reason.clone());
+        }
+    }
+    let confidence = confidence
+        .filter(|value| value.is_finite())
+        .and_then(|value| serde_json::Number::from_f64(f64::from(value.clamp(0.0, 1.0))));
+    WhyGemModel {
+        slot,
+        reasons,
+        confidence,
+    }
+}
+
+fn is_known_role(role: &str) -> bool {
+    matches!(
+        role,
+        "core" | "bridge" | "adjacent" | "discovery" | "stabilizer" | "recovery"
+    )
+}
+
+fn is_known_reason(reason: &str) -> bool {
+    matches!(reason, "co" | "tr" | "u" | "nov" | "cont" | "comp" | "m")
+}
+
+pub(crate) fn models_for_songs(
+    songs: &[Song],
+    detailed: &[WhyGemPick],
+    default: &WhyGemModel,
+) -> Vec<WhyGemPick> {
+    songs
+        .iter()
+        .map(|song| {
+            let model = detailed
+                .iter()
+                .rev()
+                .find(|pick| pick.video_id == song.video_id)
+                .map_or_else(|| default.clone(), |pick| pick.model.clone());
+            WhyGemPick::new(song.video_id.clone(), model)
+        })
+        .collect()
+}
+
+impl App {
+    pub(crate) fn why_gem_for(&self, video_id: &str) -> Option<&WhyGemModel> {
+        self.why_gem.get(video_id)
+    }
+
+    pub(crate) fn why_gem_target_song(&self) -> Option<(&Song, &WhyGemModel)> {
+        let video_id = self.overlays.why_gem_video_id.as_deref()?;
+        if self.overlays.why_gem_queue_revision != Some(self.queue.rev()) {
+            return None;
+        }
+        let queue_index = self.overlays.why_gem_queue_index?;
+        let song = self
+            .queue
+            .song_at_cursor(queue_index)
+            .filter(|song| song.video_id == video_id)?;
+        Some((song, self.why_gem.get(video_id)?))
+    }
+
+    pub(in crate::app) fn open_why_gem_at(&mut self, queue_index: usize) {
+        let Some(video_id) = self
+            .queue
+            .song_at_cursor(queue_index)
+            .map(|song| song.video_id.clone())
+        else {
+            self.status.kind = StatusKind::Info;
+            self.status.text = crate::i18n::why_gem::no_provenance().to_owned();
+            self.dirty = true;
+            return;
+        };
+        if self.why_gem.contains(&video_id) {
+            self.cancel_seekbar_scrub();
+            self.interaction.drag_selection = None;
+            self.interaction.drag_scrollbar = None;
+            self.interaction.ai_transcript_drag = None;
+            self.overlays.why_gem_video_id = Some(video_id);
+            self.overlays.why_gem_queue_index = Some(queue_index);
+            self.overlays.why_gem_queue_revision = Some(self.queue.rev());
+        } else {
+            self.status.kind = StatusKind::Info;
+            self.status.text = crate::i18n::why_gem::no_provenance().to_owned();
+        }
+        self.dirty = true;
+    }
+
+    pub(in crate::app) fn open_selected_why_gem(&mut self) {
+        let queue_index = if self.queue_popup.open {
+            Some(self.queue_popup.cursor)
+        } else if self.queue.current().is_some() {
+            Some(self.queue.cursor_pos())
+        } else {
+            None
+        };
+        if let Some(queue_index) = queue_index {
+            self.open_why_gem_at(queue_index);
+        } else {
+            self.status.kind = StatusKind::Info;
+            self.status.text = crate::i18n::why_gem::no_provenance().to_owned();
+            self.dirty = true;
+        }
+    }
+
+    pub(in crate::app) fn close_why_gem(&mut self) {
+        self.overlays.why_gem_queue_index = None;
+        self.overlays.why_gem_queue_revision = None;
+        if self.overlays.why_gem_video_id.take().is_some() {
+            self.dirty = true;
+        }
+    }
+
+    pub(in crate::app) fn upsert_why_gem_picks(&mut self, picks: &[WhyGemPick]) {
+        if self.why_gem.upsert_many(
+            picks
+                .iter()
+                .map(|pick| (pick.video_id.clone(), pick.model.clone())),
+        ) {
+            self.dirty = true;
+        }
+    }
+
+    pub(in crate::app) fn forget_why_gem_ids<'a>(
+        &mut self,
+        video_ids: impl IntoIterator<Item = &'a str>,
+    ) {
+        if self.why_gem.forget_many(video_ids) {
+            self.dirty = true;
+        }
+    }
+
+    pub(in crate::app) fn clear_why_gem(&mut self) {
+        if self.why_gem.clear() {
+            self.dirty = true;
+        }
+        self.close_why_gem();
+    }
+
+    pub(in crate::app) fn replace_why_gem_picks(&mut self, picks: &[WhyGemPick]) {
+        let live: Vec<(String, WhyGemModel)> = self
+            .queue
+            .ordered_iter()
+            .filter_map(|song| {
+                picks
+                    .iter()
+                    .rev()
+                    .find(|pick| pick.video_id == song.video_id)
+                    .map(|pick| (song.video_id.clone(), pick.model.clone()))
+            })
+            .collect();
+        if self.why_gem.replace(live) {
+            self.dirty = true;
+        }
+        self.close_why_gem();
+    }
+
+    pub(in crate::app) fn reconcile_why_gem(&mut self) {
+        let changed = self.why_gem.retain_video_ids(
+            self.queue.rev(),
+            self.queue.ordered_iter().map(|song| song.video_id.as_str()),
+        );
+        let target_is_live = self
+            .overlays
+            .why_gem_video_id
+            .as_deref()
+            .is_none_or(|video_id| {
+                self.overlays.why_gem_queue_revision == Some(self.queue.rev())
+                    && self.overlays.why_gem_queue_index.is_some_and(|index| {
+                        self.queue
+                            .song_at_cursor(index)
+                            .is_some_and(|song| song.video_id == video_id)
+                    })
+                    && self.why_gem.contains(video_id)
+            });
+        if !target_is_live {
+            self.overlays.why_gem_video_id = None;
+            self.overlays.why_gem_queue_index = None;
+            self.overlays.why_gem_queue_revision = None;
+        }
+        if changed || !target_is_live {
+            self.dirty = true;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_normalizes_unknown_codes_and_confidence() {
+        let pick = AiPick {
+            cid: "cid".to_owned(),
+            role: Some("raw\u{1b}".to_owned()),
+            reasons: vec!["tr".to_owned(), "raw".to_owned(), "tr".to_owned()],
+        };
+        let model = model_from_ai_pick(&pick, Some(1.7));
+        assert_eq!(model.slot, DJ_GEM_SLOT);
+        assert_eq!(model.reasons, ["tr"]);
+        assert_eq!(model.confidence.and_then(|value| value.as_f64()), Some(1.0));
+        assert!(
+            model_from_ai_pick(&pick, Some(f32::NAN))
+                .confidence
+                .is_none()
+        );
+        assert_eq!(
+            model_from_ai_pick(&pick, Some(-0.5))
+                .confidence
+                .and_then(|value| value.as_f64()),
+            Some(0.0)
+        );
+    }
+
+    #[test]
+    fn final_song_models_preserve_detail_and_fill_origin() {
+        let songs = vec![
+            Song::remote("a", "A", "Artist", "3:00"),
+            Song::remote("b", "B", "Artist", "3:00"),
+        ];
+        let detail = WhyGemPick::new(
+            "a",
+            WhyGemModel {
+                slot: "bridge".to_owned(),
+                reasons: vec!["tr".to_owned()],
+                confidence: None,
+            },
+        );
+        let origin = streaming_origin_model(StreamingMode::Balanced);
+        let models = models_for_songs(&songs, std::slice::from_ref(&detail), &origin);
+        assert_eq!(models[0], detail);
+        assert_eq!(models[1].model, origin);
+    }
+
+    #[test]
+    fn streaming_origin_slots_do_not_overlap_lowercase_model_roles() {
+        for (mode, slot) in [
+            (StreamingMode::Focused, "Focused"),
+            (StreamingMode::Balanced, "Balanced"),
+            (StreamingMode::Discovery, "Discovery"),
+        ] {
+            let model = streaming_origin_model(mode);
+            assert_eq!(model.slot, slot);
+            assert!(!is_known_role(&model.slot));
+        }
+    }
+
+    #[test]
+    fn queue_affordance_opens_the_exact_row_without_closing_queue() {
+        let mut app = App::new(50);
+        app.queue.set(
+            vec![
+                Song::remote("a", "A", "Artist", "3:00"),
+                Song::remote("b", "B", "Artist", "3:00"),
+            ],
+            0,
+        );
+        app.why_gem.upsert("b".to_owned(), dj_gem_origin_model());
+        app.open_queue_popup();
+
+        app.on_mouse_target(MouseTarget::QueueWhyGem(1));
+
+        assert_eq!(app.overlays.why_gem_video_id.as_deref(), Some("b"));
+        assert_eq!(app.overlays.why_gem_queue_index, Some(1));
+        assert_eq!(app.overlays.why_gem_queue_revision, Some(app.queue.rev()));
+        assert!(app.queue_popup.open);
+    }
+
+    #[test]
+    fn why_gem_mouse_modal_consumes_inside_and_outside_clicks() {
+        let mut app = App::new(50);
+        app.queue.set(
+            vec![
+                Song::remote("a", "A", "Artist", "3:00"),
+                Song::remote("b", "B", "Artist", "3:00"),
+            ],
+            0,
+        );
+        app.why_gem.upsert("b".to_owned(), dj_gem_origin_model());
+        app.open_queue_popup();
+        app.overlays.why_gem_video_id = Some("b".to_owned());
+        app.overlays.why_gem_queue_index = Some(1);
+        app.overlays.why_gem_queue_revision = Some(app.queue.rev());
+        app.register_mouse_button(Rect::new(0, 0, 1, 1), MouseTarget::QueueDel(0));
+        app.register_mouse_button(Rect::new(2, 2, 4, 3), MouseTarget::WhyGemCard);
+
+        app.on_mouse_click(3, 3, false);
+        assert_eq!(app.queue.len(), 2, "inside click is inert");
+        assert_eq!(app.overlays.why_gem_video_id.as_deref(), Some("b"));
+
+        app.on_mouse_click(0, 0, false);
+        assert_eq!(app.queue.len(), 2, "outside click never reaches QueueDel");
+        assert!(app.overlays.why_gem_video_id.is_none());
+        assert!(app.queue_popup.open, "the covered queue stays open");
+    }
+
+    #[test]
+    fn queue_revision_change_closes_duplicate_card_before_pruning_shared_provenance() {
+        let mut app = App::new(50);
+        app.queue.set(
+            vec![
+                Song::remote("dup", "First", "Artist", "3:00"),
+                Song::remote("dup", "Second", "Artist", "3:00"),
+            ],
+            0,
+        );
+        app.why_gem.upsert("dup".to_owned(), dj_gem_origin_model());
+        app.overlays.why_gem_video_id = Some("dup".to_owned());
+        app.overlays.why_gem_queue_index = Some(1);
+        app.overlays.why_gem_queue_revision = Some(app.queue.rev());
+
+        app.queue.remove_at(0);
+        app.reconcile_why_gem();
+        assert!(app.why_gem.contains("dup"));
+        assert!(app.overlays.why_gem_video_id.is_none());
+
+        app.queue.remove_at(0);
+        app.reconcile_why_gem();
+        assert!(!app.why_gem.contains("dup"));
+        assert!(app.overlays.why_gem_video_id.is_none());
+    }
+
+    #[test]
+    fn manual_enqueue_forgets_stale_origin_while_dj_enqueue_records_one() {
+        let mut app = App::new(50);
+        app.queue
+            .set(vec![Song::remote("seed", "Seed", "Artist", "3:00")], 0);
+        app.prefetch.loaded_video_id = Some("seed".to_owned());
+        app.why_gem.upsert("dup".to_owned(), dj_gem_origin_model());
+
+        app.enqueue(Song::remote("dup", "Manual", "Artist", "3:00"));
+        assert!(!app.why_gem.contains("dup"));
+
+        app.extend_queue_from_dj_gem(vec![Song::remote(
+            "recommended",
+            "Recommended",
+            "Artist",
+            "3:00",
+        )]);
+        assert_eq!(
+            app.why_gem_for("recommended")
+                .map(|model| model.slot.as_str()),
+            Some(DJ_GEM_SLOT)
+        );
+    }
+}

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -268,6 +268,7 @@ fn dispatch_engine_effects_inner(
         }
         match effect {
             engine::EngineEffect::StreamingFallback {
+                request_id,
                 seed,
                 seed_video_id,
                 exclude_ids,
@@ -276,6 +277,7 @@ fn dispatch_engine_effects_inner(
                 config,
             } => {
                 if let Err(error) = api.streaming(
+                    request_id,
                     seed,
                     seed_video_id.clone(),
                     exclude_ids,
@@ -286,6 +288,7 @@ fn dispatch_engine_effects_inner(
                     tracing::warn!(%error, "api command enqueue failed");
                     if !shutdown.is_triggered() {
                         terminal.push(DaemonEvent::Api(crate::api::ApiEvent::StreamingError {
+                            request_id,
                             seed_video_id,
                             error: error.to_string(),
                         }));
@@ -293,18 +296,25 @@ fn dispatch_engine_effects_inner(
                 }
             }
             engine::EngineEffect::StreamingPreflight {
+                request_id,
                 seed_video_id,
                 picks,
                 fallback,
                 mode,
                 config,
             } => {
-                if let Err(error) =
-                    api.streaming_preflight(seed_video_id.clone(), picks, fallback, mode, config)
-                {
+                if let Err(error) = api.streaming_preflight(
+                    request_id,
+                    seed_video_id.clone(),
+                    picks,
+                    fallback,
+                    mode,
+                    config,
+                ) {
                     tracing::warn!(%error, "api command enqueue failed");
                     if !shutdown.is_triggered() {
                         terminal.push(DaemonEvent::Api(crate::api::ApiEvent::StreamingError {
+                            request_id,
                             seed_video_id,
                             error: error.to_string(),
                         }));

--- a/src/daemon/engine.rs
+++ b/src/daemon/engine.rs
@@ -41,6 +41,10 @@ mod remote_dispatch;
 mod streaming;
 mod transport;
 
+use self::streaming::PendingStreamingRequest;
+#[cfg(test)]
+use self::streaming::StreamingRequestStage;
+
 #[path = "engine_session.rs"]
 mod engine_session;
 
@@ -84,6 +88,7 @@ pub(crate) struct EngineState {
 #[derive(Debug)]
 pub enum EngineEffect {
     StreamingFallback {
+        request_id: u64,
         seed: String,
         seed_video_id: String,
         exclude_ids: Vec<String>,
@@ -92,6 +97,7 @@ pub enum EngineEffect {
         config: SearchConfig,
     },
     StreamingPreflight {
+        request_id: u64,
         seed_video_id: String,
         picks: Vec<Song>,
         fallback: Vec<Song>,
@@ -153,7 +159,11 @@ pub struct DaemonEngine {
     #[cfg(test)]
     test_player_starts: VecDeque<PlayerRuntime>,
     streaming: bool,
+    /// Compatibility projection for status/tests. The owner correlation record below is the
+    /// source of truth; this bit is updated only through the streaming request helpers.
     streaming_pending: bool,
+    streaming_request_seq: u64,
+    pending_streaming_request: Option<PendingStreamingRequest>,
     last_extend: Option<Instant>,
     consecutive_streaming_failures: u8,
     last_error: Option<String>,
@@ -183,9 +193,8 @@ pub struct DaemonEngine {
     /// Per-session/page rows addressable by `play_tracks`/`enqueue_tracks`, hard-bounded by the
     /// remote session cap so reloads and reconnects cannot grow owner memory indefinitely.
     gui_search_index: GuiSearchIndex,
-    /// v1 why-gem provenance: pick origin per video id (bounded; see ai_context.rs).
-    why_gem: Vec<(String, crate::remote::proto::WhyGemModel)>,
-    why_gem_rev: u64,
+    /// Session-only WhyGem provenance shared with the TUI's lifecycle policy.
+    why_gem: crate::why_gem::WhyGemLedger<crate::remote::proto::WhyGemModel>,
     /// `accounts` topic revision + the transfer actor's live Spotify display name.
     accounts_rev: u64,
     spotify_user: Option<String>,
@@ -345,6 +354,8 @@ impl DaemonEngine {
             #[cfg(test)]
             test_player_starts: VecDeque::new(),
             streaming_pending: false,
+            streaming_request_seq: 0,
+            pending_streaming_request: None,
             last_extend: None,
             consecutive_streaming_failures: 0,
             last_error: None,
@@ -363,8 +374,7 @@ impl DaemonEngine {
             session_events: VecDeque::new(),
             media_art: None,
             gui_search_index: GuiSearchIndex::default(),
-            why_gem: Vec::new(),
-            why_gem_rev: 0,
+            why_gem: crate::why_gem::WhyGemLedger::default(),
             accounts_rev: 0,
             spotify_user: None,
             video_overlay: None,
@@ -388,6 +398,9 @@ impl DaemonEngine {
     /// Test-only mode seeding through the same persisted enum the daemon restores at startup.
     #[cfg(test)]
     pub(crate) fn restore_last_mode_for_test(&mut self, mode: LastMode) {
+        if self.last_mode != mode {
+            self.cancel_pending_streaming_request();
+        }
         self.last_mode = mode;
     }
 
@@ -584,14 +597,18 @@ impl DaemonEngine {
         if !self.queue.has_capacity_for(songs.len()) {
             return RemoteResponse::err("queue_full");
         }
+        let manual_ids: Vec<String> = songs.iter().map(|song| song.video_id.clone()).collect();
         let previous = self.queue.snapshot();
         let expected = songs.len();
         let added = self.queue.play_now_many(songs);
         debug_assert_eq!(added, expected, "queue capacity was preflighted");
-        self.load_current_or_restore_queue(previous)
-            .await
-            .map(|_| RemoteResponse::status(self.status()))
-            .unwrap_or_else(|e| RemoteResponse::err(e.reason()))
+        match self.load_current_or_restore_queue(previous).await {
+            Ok(()) => {
+                self.forget_why_gem_picks(manual_ids.iter().map(String::as_str));
+                RemoteResponse::status(self.status())
+            }
+            Err(error) => RemoteResponse::err(error.reason()),
+        }
     }
 
     async fn enqueue_tracks(
@@ -609,6 +626,7 @@ impl DaemonEngine {
         if !self.queue.has_capacity_for(songs.len()) {
             return RemoteResponse::err("queue_full");
         }
+        let manual_ids: Vec<String> = songs.iter().map(|song| song.video_id.clone()).collect();
         let previous = self.queue.snapshot();
         let old_len = self.queue.len();
         let was_idle = self.loaded_video_id.is_none();
@@ -622,12 +640,15 @@ impl DaemonEngine {
         if was_idle {
             self.queue
                 .goto(old_len.min(self.queue.len().saturating_sub(1)));
-            return self
-                .load_current_or_restore_queue(previous)
-                .await
-                .map(|_| RemoteResponse::status(self.status()))
-                .unwrap_or_else(|e| RemoteResponse::err(e.reason()));
+            return match self.load_current_or_restore_queue(previous).await {
+                Ok(()) => {
+                    self.forget_why_gem_picks(manual_ids.iter().map(String::as_str));
+                    RemoteResponse::status(self.status())
+                }
+                Err(error) => RemoteResponse::err(error.reason()),
+            };
         }
+        self.forget_why_gem_picks(manual_ids.iter().map(String::as_str));
         self.save_session();
         RemoteResponse::status(self.status())
     }
@@ -774,40 +795,9 @@ impl DaemonEngine {
             // Intercepted by the host loop (index + `search` topic push) before it
             // reaches the engine; defensive no-op if it ever lands here.
             ApiEvent::GuiSearchCompleted { .. } => Vec::new(),
-            ApiEvent::StreamingResults {
-                seed_video_id,
-                candidates,
-            } => {
-                self.streaming_pending = false;
-                if self.streaming_active() && self.queue.contains_video_id(&seed_video_id) {
-                    let picks = self.plan_local_streaming(&seed_video_id, candidates);
-                    self.extend_sanitized_streaming(&seed_video_id, picks, &[])
-                        .await
-                } else {
-                    Vec::new()
-                }
-            }
-            ApiEvent::StreamingPreflighted {
-                seed_video_id,
-                songs,
-            } => {
-                self.streaming_pending = false;
-                if self.streaming_active() && self.queue.contains_video_id(&seed_video_id) {
-                    self.extend_queue_from_streaming(songs).await
-                } else {
-                    Vec::new()
-                }
-            }
-            ApiEvent::StreamingError {
-                seed_video_id,
-                error,
-            } => {
-                self.streaming_pending = false;
-                if self.streaming_active() && self.queue.contains_video_id(&seed_video_id) {
-                    self.note_streaming_failure(format!("autoplay streaming failed: {error}"));
-                }
-                Vec::new()
-            }
+            event @ (ApiEvent::StreamingResults { .. }
+            | ApiEvent::StreamingPreflighted { .. }
+            | ApiEvent::StreamingError { .. }) => self.handle_streaming_api_event(event).await,
             // Playlist search/import is a TUI-only flow; the daemon never issues those
             // commands, so their answers are inert here.
             ApiEvent::ModeResolved { .. }
@@ -974,6 +964,8 @@ impl DaemonEngine {
     }
 
     fn restore_session_cache(&mut self, cache: SessionCache) {
+        self.cancel_pending_streaming_request();
+        self.clear_why_gem();
         self.last_mode = cache.last_mode;
         let active_queue = cache.active_queue().cloned();
         self.inactive_normal_queue = cache.normal_queue.map(Arc::new);
@@ -1120,14 +1112,18 @@ impl DaemonEngine {
             Ok(None) => return RemoteResponse::err("no_results"),
             Err(()) => return RemoteResponse::err("search_error"),
         };
+        let manual_id = song.video_id.clone();
         let previous = self.queue.snapshot();
         if !self.queue.play_now(song) {
             return RemoteResponse::err("queue_full");
         }
-        self.load_current_or_restore_queue(previous)
-            .await
-            .map(|_| RemoteResponse::status(self.status()))
-            .unwrap_or_else(|e| RemoteResponse::err(e.reason()))
+        match self.load_current_or_restore_queue(previous).await {
+            Ok(()) => {
+                self.forget_why_gem_picks([manual_id.as_str()]);
+                RemoteResponse::status(self.status())
+            }
+            Err(error) => RemoteResponse::err(error.reason()),
+        }
     }
 
     async fn search_and_enqueue(&mut self, query: String) -> RemoteResponse {
@@ -1139,6 +1135,7 @@ impl DaemonEngine {
             Ok(None) => return RemoteResponse::err("no_results"),
             Err(()) => return RemoteResponse::err("search_error"),
         };
+        let manual_id = song.video_id.clone();
         let previous = self.queue.snapshot();
         let old_len = self.queue.len();
         let was_idle = self.loaded_video_id.is_none();
@@ -1153,12 +1150,15 @@ impl DaemonEngine {
         if was_idle {
             self.queue
                 .goto(old_len.min(self.queue.len().saturating_sub(1)));
-            return self
-                .load_current_or_restore_queue(previous)
-                .await
-                .map(|_| RemoteResponse::status(self.status()))
-                .unwrap_or_else(|e| RemoteResponse::err(e.reason()));
+            return match self.load_current_or_restore_queue(previous).await {
+                Ok(()) => {
+                    self.forget_why_gem_picks([manual_id.as_str()]);
+                    RemoteResponse::status(self.status())
+                }
+                Err(error) => RemoteResponse::err(error.reason()),
+            };
         }
+        self.forget_why_gem_picks([manual_id.as_str()]);
         self.save_session();
         RemoteResponse::status(self.status())
     }
@@ -1273,7 +1273,7 @@ impl DaemonEngine {
         if self.streaming {
             self.consecutive_streaming_failures = 0;
         } else {
-            self.streaming_pending = false;
+            self.cancel_pending_streaming_request();
         }
         self.save_config("daemon autoplay streaming setting");
         let effects = if self.streaming {
@@ -1292,6 +1292,9 @@ impl DaemonEngine {
                 ToggleState::Off
             }),
             RemoteSettingChange::StreamingMode { value } => {
+                if self.config.streaming.mode != value {
+                    self.cancel_pending_streaming_request();
+                }
                 self.config.streaming.mode = value;
                 self.save_config("daemon streaming mode setting");
                 let effects = if self.streaming {
@@ -1303,7 +1306,11 @@ impl DaemonEngine {
             }
             RemoteSettingChange::StreamingSource { value } => {
                 let search = self.config.effective_search();
-                self.config.search.streaming_source = search.normalized_streaming_source(value);
+                let value = search.normalized_streaming_source(value);
+                if self.config.effective_search().streaming_source != value {
+                    self.cancel_pending_streaming_request();
+                }
+                self.config.search.streaming_source = value;
                 self.save_config("daemon streaming source setting");
                 let effects = if self.streaming {
                     self.force_autoplay_extend()
@@ -1570,6 +1577,8 @@ mod gui_search_tests;
 mod local_mode_tests;
 #[cfg(test)]
 mod persistence_gate_tests;
+#[cfg(test)]
+mod streaming_request_tests;
 #[cfg(test)]
 pub(in crate::daemon) mod tests;
 #[cfg(test)]

--- a/src/daemon/engine/ai_context.rs
+++ b/src/daemon/engine/ai_context.rs
@@ -47,8 +47,14 @@ impl DaemonEngine {
     }
 
     pub(in crate::daemon) async fn ai_play_tracks(&mut self, songs: Vec<Song>) {
-        self.record_why_gem_picks("DJ Gem", &songs);
-        let _ = self.gui_replace_queue(songs).await;
+        let video_ids: Vec<String> = songs.iter().map(|song| song.video_id.clone()).collect();
+        let response = self.gui_replace_queue(songs).await;
+        if response.ok {
+            self.record_why_gem_ids(
+                "DJ Gem",
+                video_ids.into_iter().take(crate::why_gem::WHY_GEM_MAX),
+            );
+        }
     }
 
     pub(in crate::daemon) async fn ai_enqueue(&mut self, songs: Vec<Song>) {
@@ -59,55 +65,70 @@ impl DaemonEngine {
     /// chat ("DJ Gem") or the autoplay streaming mode — with whatever the pick context
     /// carried. Reasons/confidence generation is deliberately out of scope; unknown
     /// tracks answer `fetch_why_gem` with no data (the GUI's null path).
+    #[cfg(test)]
     pub(in crate::daemon) fn record_why_gem_picks(&mut self, slot: &str, songs: &[Song]) {
-        for song in songs {
-            self.record_why_gem(
-                song.video_id.clone(),
-                crate::remote::proto::WhyGemModel {
-                    slot: slot.to_owned(),
-                    reasons: Vec::new(),
-                    confidence: None,
-                },
-            );
-        }
+        self.record_why_gem_ids(slot, songs.iter().map(|song| song.video_id.clone()));
     }
 
+    pub(in crate::daemon) fn record_why_gem_ids(
+        &mut self,
+        slot: &str,
+        video_ids: impl IntoIterator<Item = String>,
+    ) {
+        self.why_gem
+            .upsert_many(video_ids.into_iter().map(|video_id| {
+                (
+                    video_id,
+                    crate::remote::proto::WhyGemModel {
+                        slot: slot.to_owned(),
+                        reasons: Vec::new(),
+                        confidence: None,
+                    },
+                )
+            }));
+    }
+
+    #[cfg(test)]
     pub(in crate::daemon) fn record_why_gem(
         &mut self,
         video_id: String,
         model: crate::remote::proto::WhyGemModel,
     ) {
-        const WHY_GEM_MAX: usize = 999;
-        if let Some(entry) = self
-            .why_gem
-            .iter_mut()
-            .find(|(existing, _)| *existing == video_id)
-        {
-            if entry.1 == model {
-                return;
-            }
-            entry.1 = model;
-        } else {
-            if self.why_gem.len() >= WHY_GEM_MAX {
-                self.why_gem.remove(0);
-            }
-            self.why_gem.push((video_id, model));
-        }
-        self.why_gem_rev = self.why_gem_rev.wrapping_add(1);
+        self.why_gem.upsert(video_id, model);
     }
 
     pub fn why_gem_rev(&self) -> u64 {
-        self.why_gem_rev
+        self.why_gem.revision()
     }
 
     pub fn why_gem_ids(&self) -> Vec<String> {
-        self.why_gem.iter().map(|(id, _)| id.clone()).collect()
+        self.why_gem.ids()
+    }
+
+    /// Remove rows that no longer exist in the live queue before the retained provenance
+    /// snapshot is published. Duplicate queue occurrences intentionally keep one shared answer.
+    pub(in crate::daemon) fn reconcile_why_gem(&mut self) {
+        self.why_gem.retain_video_ids(
+            self.queue.rev(),
+            self.queue.ordered_iter().map(|song| song.video_id.as_str()),
+        );
+    }
+
+    pub(in crate::daemon) fn forget_why_gem_picks<'a>(
+        &mut self,
+        video_ids: impl IntoIterator<Item = &'a str>,
+    ) {
+        self.why_gem.forget_many(video_ids);
+    }
+
+    pub(in crate::daemon) fn clear_why_gem(&mut self) {
+        self.why_gem.clear();
     }
 
     pub(super) fn gui_fetch_why_gem(&self, video_id: &str) -> crate::remote::proto::RemoteResponse {
         use crate::remote::proto::{RemoteResponse, ResponseData};
         let mut response = RemoteResponse::ok("why gem".to_owned());
-        if let Some((_, model)) = self.why_gem.iter().find(|(id, _)| id == video_id) {
+        if let Some(model) = self.why_gem.get(video_id) {
             response.data = Some(ResponseData::WhyGem(model.clone()));
         }
         response

--- a/src/daemon/engine/gui_library.rs
+++ b/src/daemon/engine/gui_library.rs
@@ -346,10 +346,13 @@ impl DaemonEngine {
         }
         let previous = self.queue.snapshot();
         self.queue.set(songs, 0);
-        self.load_current_or_restore_queue(previous)
-            .await
-            .map(|_| RemoteResponse::status(self.status()))
-            .unwrap_or_else(|error| RemoteResponse::err(error.reason()))
+        match self.load_current_or_restore_queue(previous).await {
+            Ok(()) => {
+                self.clear_why_gem();
+                RemoteResponse::status(self.status())
+            }
+            Err(error) => RemoteResponse::err(error.reason()),
+        }
     }
 
     async fn gui_enqueue_songs(&mut self, songs: Vec<Song>) -> RemoteResponse {
@@ -359,6 +362,7 @@ impl DaemonEngine {
         if !self.queue.has_capacity_for(songs.len()) {
             return RemoteResponse::err("queue_full");
         }
+        let video_ids: Vec<String> = songs.iter().map(|song| song.video_id.clone()).collect();
         let previous = self.queue.snapshot();
         let old_len = self.queue.len();
         let was_idle = self.loaded_video_id.is_none();
@@ -372,12 +376,15 @@ impl DaemonEngine {
         if was_idle {
             self.queue
                 .goto(old_len.min(self.queue.len().saturating_sub(1)));
-            return self
-                .load_current_or_restore_queue(previous)
-                .await
-                .map(|_| RemoteResponse::status(self.status()))
-                .unwrap_or_else(|error| RemoteResponse::err(error.reason()));
+            return match self.load_current_or_restore_queue(previous).await {
+                Ok(()) => {
+                    self.forget_why_gem_picks(video_ids.iter().map(String::as_str));
+                    RemoteResponse::status(self.status())
+                }
+                Err(error) => RemoteResponse::err(error.reason()),
+            };
         }
+        self.forget_why_gem_picks(video_ids.iter().map(String::as_str));
         self.save_session();
         RemoteResponse::status(self.status())
     }
@@ -540,7 +547,7 @@ mod tests {
         engine.record_why_gem(
             "a".to_owned(),
             WhyGemModel {
-                slot: "balanced".to_owned(),
+                slot: "Balanced".to_owned(),
                 reasons: Vec::new(),
                 confidence: None,
             },
@@ -551,12 +558,177 @@ mod tests {
         let hit = engine.gui_fetch_why_gem("a");
         assert!(hit.ok);
         match hit.data {
-            Some(ResponseData::WhyGem(model)) => assert_eq!(model.slot, "balanced"),
+            Some(ResponseData::WhyGem(model)) => assert_eq!(model.slot, "Balanced"),
             other => panic!("expected why-gem data, got {other:?}"),
         }
         let miss = engine.gui_fetch_why_gem("zzz");
         assert!(miss.ok);
         assert!(miss.data.is_none(), "unknown track answers with no data");
+    }
+
+    #[test]
+    fn why_gem_reconcile_keeps_duplicate_video_until_its_last_queue_row_leaves() {
+        let mut engine = engine();
+        engine.queue.set(
+            vec![
+                song("a", "A1", "Alpha"),
+                song("a", "A2", "Alpha"),
+                song("b", "B", "Beta"),
+            ],
+            0,
+        );
+        engine.record_why_gem_picks(
+            "Balanced",
+            &[
+                song("a", "A", "Alpha"),
+                song("b", "B", "Beta"),
+                song("gone", "Gone", "Ghost"),
+            ],
+        );
+
+        engine.reconcile_why_gem();
+        assert_eq!(engine.why_gem_ids(), vec!["a", "b"]);
+
+        engine.queue.remove_at(0);
+        engine.reconcile_why_gem();
+        assert!(engine.why_gem_ids().contains(&"a".to_owned()));
+
+        engine.queue.remove_at(0);
+        engine.reconcile_why_gem();
+        assert_eq!(engine.why_gem_ids(), vec!["b"]);
+    }
+
+    #[tokio::test]
+    async fn manual_enqueue_of_the_same_video_forgets_stale_recommendation() {
+        let mut engine = engine();
+        engine.queue.set(vec![song("seed", "Seed", "Artist")], 0);
+        engine.loaded_video_id = Some("seed".to_owned());
+        engine.record_why_gem_picks("Balanced", &[song("dup", "Old", "Artist")]);
+
+        let response = engine
+            .gui_enqueue_songs(vec![song("dup", "Manual", "Artist")])
+            .await;
+
+        assert!(response.ok);
+        assert!(!engine.why_gem_ids().contains(&"dup".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn manual_queue_replacement_clears_only_after_player_admission() {
+        let mut accepted = engine();
+        accepted.queue.set(vec![song("old", "Old", "Artist")], 0);
+        accepted.loaded_video_id = Some("old".to_owned());
+        accepted.record_why_gem_picks("Balanced", &[song("old", "Old", "Artist")]);
+        let _player_rx = super::super::tests::install_accepting_player(&mut accepted);
+
+        let response = accepted
+            .gui_replace_queue(vec![song("new", "New", "Artist")])
+            .await;
+        assert!(response.ok);
+        assert!(accepted.why_gem_ids().is_empty());
+
+        let mut rejected = engine();
+        rejected.queue.set(vec![song("old", "Old", "Artist")], 0);
+        rejected.loaded_video_id = Some("old".to_owned());
+        rejected.record_why_gem_picks("Balanced", &[song("old", "Old", "Artist")]);
+        let player_rx = super::super::tests::install_accepting_player(&mut rejected);
+        drop(player_rx);
+
+        let response = rejected
+            .gui_replace_queue(vec![song("new", "New", "Artist")])
+            .await;
+        assert!(!response.ok);
+        assert_eq!(rejected.why_gem_ids(), vec!["old"]);
+        assert_eq!(
+            rejected.queue.current().map(|song| song.video_id.as_str()),
+            Some("old")
+        );
+    }
+
+    #[tokio::test]
+    async fn idle_recommendation_extension_loads_first_pick_before_recording_its_origin() {
+        use crate::remote::proto::ResponseData;
+
+        let mut engine = engine();
+        engine.config.streaming.mode = crate::streaming::StreamingMode::Discovery;
+        engine.consecutive_streaming_failures = 2;
+        let _player_rx = super::super::tests::install_accepting_player(&mut engine);
+
+        engine
+            .extend_queue_from_streaming(vec![song("first", "First", "Artist")])
+            .await;
+
+        assert_eq!(engine.queue.video_ids().collect::<Vec<_>>(), ["first"]);
+        assert_eq!(
+            engine.queue.current().map(|song| song.video_id.as_str()),
+            Some("first")
+        );
+        assert_eq!(engine.loaded_video_id.as_deref(), Some("first"));
+        assert_eq!(engine.consecutive_streaming_failures, 0);
+        match engine.gui_fetch_why_gem("first").data {
+            Some(ResponseData::WhyGem(model)) => assert_eq!(model.slot, "Discovery"),
+            other => panic!("expected why-gem data, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejected_idle_recommendation_restores_queue_ledger_counter_and_session_projection() {
+        let mut engine = engine();
+        engine
+            .queue
+            .set(vec![song("queued", "Queued", "Artist")], 0);
+        engine.record_why_gem_picks("Balanced", &[song("kept", "Kept", "Artist")]);
+        engine.consecutive_streaming_failures = 2;
+        let before_session = serde_json::to_value(engine.session_cache_snapshot()).unwrap();
+        let before_why_gem_rev = engine.why_gem_rev();
+        let before_why_gem_ids = engine.why_gem_ids();
+        let player_rx = super::super::tests::install_accepting_player(&mut engine);
+        drop(player_rx);
+
+        engine
+            .extend_queue_from_streaming(vec![song("rejected", "Rejected", "Artist")])
+            .await;
+
+        assert_eq!(engine.queue.video_ids().collect::<Vec<_>>(), ["queued"]);
+        assert_eq!(
+            engine.queue.current().map(|song| song.video_id.as_str()),
+            Some("queued")
+        );
+        assert_eq!(engine.loaded_video_id, None);
+        assert_eq!(engine.why_gem_rev(), before_why_gem_rev);
+        assert_eq!(engine.why_gem_ids(), before_why_gem_ids);
+        assert_eq!(engine.consecutive_streaming_failures, 2);
+        assert_eq!(
+            serde_json::to_value(engine.session_cache_snapshot()).unwrap(),
+            before_session
+        );
+        assert!(engine.library.history.is_empty());
+        assert!(engine.last_error.is_some());
+    }
+
+    #[tokio::test]
+    async fn recommendation_extension_records_only_the_capacity_accepted_prefix() {
+        let mut engine = engine();
+        engine.config.streaming.mode = crate::streaming::StreamingMode::Discovery;
+        let fill = (0..998)
+            .map(|index| song(&format!("fill-{index}"), "Fill", "Artist"))
+            .collect();
+        engine.queue.set(fill, 0);
+        engine.loaded_video_id = engine.queue.current().map(|song| song.video_id.clone());
+
+        engine
+            .extend_queue_from_streaming(vec![
+                song("accepted", "Accepted", "Artist"),
+                song("rejected", "Rejected", "Artist"),
+            ])
+            .await;
+
+        assert!(engine.why_gem_ids().contains(&"accepted".to_owned()));
+        assert!(!engine.why_gem_ids().contains(&"rejected".to_owned()));
+        let Some(ResponseData::WhyGem(model)) = engine.gui_fetch_why_gem("accepted").data else {
+            panic!("accepted recommendation should expose its why-gem origin");
+        };
+        assert_eq!(model.slot, "Discovery");
     }
 
     #[tokio::test]

--- a/src/daemon/engine/media_session.rs
+++ b/src/daemon/engine/media_session.rs
@@ -156,9 +156,12 @@ impl DaemonEngine {
                         });
                     let previous = self.queue.snapshot();
                     if self.queue.play_now(song) {
-                        if let Err(e) = self.load_current_or_restore_queue(previous).await {
-                            self.last_error = Some(e.to_string());
-                            self.stop_playback();
+                        match self.load_current_or_restore_queue(previous).await {
+                            Ok(()) => self.forget_why_gem_picks([id.as_str()]),
+                            Err(error) => {
+                                self.last_error = Some(error.to_string());
+                                self.stop_playback();
+                            }
                         }
                         effects.extend(self.maybe_autoplay_extend());
                     }

--- a/src/daemon/engine/remote_dispatch.rs
+++ b/src/daemon/engine/remote_dispatch.rs
@@ -213,6 +213,7 @@ impl DaemonEngine {
                 ) {
                     return (self.reject_player_command(error), false, effects);
                 }
+                self.cancel_pending_streaming_request();
                 self.config = defaults;
                 self.save_config("daemon settings reset");
                 RemoteResponse::ok("settings reset".to_string())

--- a/src/daemon/engine/streaming.rs
+++ b/src/daemon/engine/streaming.rs
@@ -6,7 +6,7 @@
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
-use crate::api::Song;
+use crate::api::{ApiEvent, Song};
 use crate::playback_policy::{
     AUTOPLAY_MAX_FAILURES, STREAMING_FALLBACK_COUNT, STREAMING_POOL_COUNT,
 };
@@ -15,7 +15,76 @@ use crate::streaming::{self, CandidateSource, Cooc, StationState, StreamingMode}
 
 use super::{DaemonEngine, DaemonOutcome, EngineEffect};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StreamingRequestStage {
+    Pool,
+    Preflight,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PendingStreamingRequest {
+    pub(super) request_id: u64,
+    seed_video_id: String,
+    mode: StreamingMode,
+    source: crate::search_source::SearchSource,
+    queue_rev: u64,
+    owner_mode: crate::session::LastMode,
+    pub(super) stage: StreamingRequestStage,
+}
+
 impl DaemonEngine {
+    pub(super) async fn handle_streaming_api_event(
+        &mut self,
+        event: ApiEvent,
+    ) -> Vec<EngineEffect> {
+        match event {
+            ApiEvent::StreamingResults {
+                request_id,
+                seed_video_id,
+                candidates,
+            } => {
+                let Some(pending) = self.take_streaming_request(
+                    request_id,
+                    &seed_video_id,
+                    StreamingRequestStage::Pool,
+                ) else {
+                    return Vec::new();
+                };
+                let picks = self.plan_local_streaming(&seed_video_id, candidates);
+                self.extend_sanitized_streaming(pending, picks, &[]).await
+            }
+            ApiEvent::StreamingPreflighted {
+                request_id,
+                seed_video_id,
+                songs,
+            } => {
+                let Some(pending) = self.take_streaming_request(
+                    request_id,
+                    &seed_video_id,
+                    StreamingRequestStage::Preflight,
+                ) else {
+                    return Vec::new();
+                };
+                let slot = Self::streaming_mode_slot(pending.mode);
+                self.extend_queue_from_picks(songs, slot).await
+            }
+            ApiEvent::StreamingError {
+                request_id,
+                seed_video_id,
+                error,
+            } => {
+                if self
+                    .take_streaming_request_for_error(request_id, &seed_video_id)
+                    .is_some()
+                {
+                    self.note_streaming_failure(format!("autoplay streaming failed: {error}"));
+                }
+                Vec::new()
+            }
+            _ => unreachable!("non-streaming API event reached streaming reducer"),
+        }
+    }
+
     /// Effective autoplay state. `streaming` remains the user's saved normal-mode preference;
     /// Local Deck (and the existing dedicated Radio boundary) suppresses network top-ups without
     /// rewriting it.
@@ -37,6 +106,7 @@ impl DaemonEngine {
     }
 
     fn autoplay_extend(&mut self, force: bool) -> Vec<EngineEffect> {
+        self.reconcile_pending_streaming_request();
         let Some(refill) = streaming::plan_autoplay_refill(
             self.streaming_active(),
             self.streaming_pending,
@@ -48,16 +118,119 @@ impl DaemonEngine {
             return Vec::new();
         };
         let exclude_ids = self.streaming_exclude_ids(&refill.seed_video_id);
+        let config = self.config.effective_search();
+        let request_id = self.begin_streaming_request(
+            refill.seed_video_id.clone(),
+            self.config.streaming.mode,
+            config.streaming_source,
+        );
         self.last_extend = Some(Instant::now());
-        self.streaming_pending = true;
         vec![EngineEffect::StreamingFallback {
+            request_id,
             seed: refill.seed,
             seed_video_id: refill.seed_video_id,
             exclude_ids,
             limit: STREAMING_POOL_COUNT,
             mode: self.config.streaming.mode,
-            config: self.config.effective_search(),
+            config,
         }]
+    }
+
+    fn begin_streaming_request(
+        &mut self,
+        seed_video_id: String,
+        mode: StreamingMode,
+        source: crate::search_source::SearchSource,
+    ) -> u64 {
+        self.streaming_request_seq = self.streaming_request_seq.saturating_add(1);
+        let request_id = self.streaming_request_seq;
+        self.pending_streaming_request = Some(PendingStreamingRequest {
+            request_id,
+            seed_video_id,
+            mode,
+            source,
+            queue_rev: self.queue.rev(),
+            owner_mode: self.last_mode,
+            stage: StreamingRequestStage::Pool,
+        });
+        self.streaming_pending = true;
+        request_id
+    }
+
+    pub(in crate::daemon) fn cancel_pending_streaming_request(&mut self) {
+        self.pending_streaming_request = None;
+        self.streaming_pending = false;
+    }
+
+    fn pending_streaming_request_is_current(&self, pending: &PendingStreamingRequest) -> bool {
+        self.streaming_active()
+            && self.queue.rev() == pending.queue_rev
+            && self.last_mode == pending.owner_mode
+            && self.config.streaming.mode == pending.mode
+            && self.config.effective_search().streaming_source == pending.source
+            && self.queue.contains_video_id(&pending.seed_video_id)
+    }
+
+    /// Owner-turn reconciliation makes queue/mode/session mutations cancel an in-flight result
+    /// even when the replacement queue happens to contain the same seed id.
+    pub(in crate::daemon) fn reconcile_pending_streaming_request(&mut self) {
+        let stale = self
+            .pending_streaming_request
+            .as_ref()
+            .is_some_and(|pending| !self.pending_streaming_request_is_current(pending));
+        if stale {
+            self.cancel_pending_streaming_request();
+        } else {
+            self.streaming_pending = self.pending_streaming_request.is_some();
+        }
+    }
+
+    pub(super) fn take_streaming_request(
+        &mut self,
+        request_id: u64,
+        seed_video_id: &str,
+        stage: StreamingRequestStage,
+    ) -> Option<PendingStreamingRequest> {
+        let pending = self.pending_streaming_request.as_ref()?;
+        if pending.request_id != request_id
+            || pending.seed_video_id != seed_video_id
+            || pending.stage != stage
+        {
+            return None;
+        }
+        if !self.pending_streaming_request_is_current(pending) {
+            self.cancel_pending_streaming_request();
+            return None;
+        }
+
+        let pending = self
+            .pending_streaming_request
+            .take()
+            .expect("streaming request was present");
+        self.streaming_pending = false;
+        Some(pending)
+    }
+
+    pub(super) fn take_streaming_request_for_error(
+        &mut self,
+        request_id: u64,
+        seed_video_id: &str,
+    ) -> Option<PendingStreamingRequest> {
+        let pending = self.pending_streaming_request.as_ref()?;
+        if pending.request_id != request_id || pending.seed_video_id != seed_video_id {
+            return None;
+        }
+        if !self.pending_streaming_request_is_current(pending) {
+            self.cancel_pending_streaming_request();
+            return None;
+        }
+
+        let pending = self
+            .pending_streaming_request
+            .take()
+            .expect("streaming request was present");
+        self.streaming_pending = false;
+        Some(pending)
     }
 
     pub(crate) fn streaming_exclude_ids(&self, seed_video_id: &str) -> Vec<String> {
@@ -93,77 +266,99 @@ impl DaemonEngine {
 
     pub(super) async fn extend_sanitized_streaming(
         &mut self,
-        seed_video_id: &str,
+        mut pending: PendingStreamingRequest,
         songs: Vec<Song>,
         fallback: &[Song],
     ) -> Vec<EngineEffect> {
-        let sanitized = streaming::sanitize_final_picks(
-            songs,
-            fallback,
-            self.config.streaming.mode,
-            &self.config.streaming,
-        );
+        let sanitized =
+            streaming::sanitize_final_picks(songs, fallback, pending.mode, &self.config.streaming);
         if !sanitized.is_empty()
             && streaming::final_preflight_needed(
                 &sanitized,
                 fallback,
-                self.config.streaming.mode,
+                pending.mode,
                 &self.config.streaming,
             )
         {
+            pending.stage = StreamingRequestStage::Preflight;
+            let request_id = pending.request_id;
+            let seed_video_id = pending.seed_video_id.clone();
+            let mode = pending.mode;
+            self.pending_streaming_request = Some(pending);
             self.streaming_pending = true;
             return vec![EngineEffect::StreamingPreflight {
-                seed_video_id: seed_video_id.to_owned(),
+                request_id,
+                seed_video_id,
                 picks: sanitized,
                 fallback: fallback.to_vec(),
-                mode: self.config.streaming.mode,
+                mode,
                 config: self.config.streaming.clone(),
             }];
         }
-        self.extend_queue_from_streaming(sanitized).await
+        let slot = Self::streaming_mode_slot(pending.mode);
+        self.extend_queue_from_picks(sanitized, slot).await
     }
 
+    #[cfg(test)]
     pub(super) async fn extend_queue_from_streaming(
         &mut self,
         songs: Vec<Song>,
     ) -> Vec<EngineEffect> {
-        let slot = self.streaming_mode_slot();
-        self.extend_queue_from_picks(songs, &slot).await
+        let slot = Self::streaming_mode_slot(self.config.streaming.mode);
+        self.extend_queue_from_picks(songs, slot).await
     }
 
-    /// Queue extension with why-gem pick provenance: one recording pass, labeled by the
-    /// caller's slot (autoplay = the streaming mode's wire name; the DJ Gem chat labels
-    /// its own enqueues). Recording candidates that dedup out is harmless — provenance
-    /// only lights the "why?" affordance on rows that actually exist.
+    /// Queue extension with WhyGem provenance. Queue capacity decides the accepted prefix;
+    /// rejected candidates never become fetchable explanations.
     pub(super) async fn extend_queue_from_picks(
         &mut self,
         songs: Vec<Song>,
         slot: &str,
     ) -> Vec<EngineEffect> {
-        self.record_why_gem_picks(slot, &songs);
+        let video_ids: Vec<String> = songs.iter().map(|song| song.video_id.clone()).collect();
+        let old_len = self.queue.len();
+        let was_idle = self.loaded_video_id.is_none();
+        let previous = was_idle.then(|| self.queue.snapshot());
         let added = self.queue.extend(songs);
         if added == 0 {
             self.note_streaming_failure("autoplay streaming found no new tracks".to_owned());
             return Vec::new();
         }
-        self.consecutive_streaming_failures = 0;
-        self.save_session();
-        if self.loaded_video_id.is_none() && self.queue.remaining() > 0 {
-            self.queue.next(false);
-            if let Err(e) = self.load_current().await {
-                self.last_error = Some(e.to_string());
-                self.stop_playback();
+
+        // An idle queue must admit the first newly appended track to the player before any
+        // recommendation provenance or success bookkeeping becomes observable. In particular,
+        // an empty queue already selects its first appended row; calling `next` would either skip
+        // that row or (for a single pick) fail to load anything at all.
+        if was_idle {
+            self.queue
+                .goto(old_len.min(self.queue.len().saturating_sub(1)));
+            if self
+                .load_current_or_restore_queue(
+                    previous.expect("idle streaming extension captured a queue snapshot"),
+                )
+                .await
+                .is_err()
+            {
+                return Vec::new();
             }
+        }
+
+        self.record_why_gem_ids(slot, video_ids.into_iter().take(added));
+        self.consecutive_streaming_failures = 0;
+        if !was_idle {
+            self.save_session();
         }
         Vec::new()
     }
 
-    /// The autoplay slot label for why-gem provenance: the streaming mode's wire name.
-    fn streaming_mode_slot(&self) -> String {
-        serde_json::to_value(self.config.streaming.mode)
-            .ok()
-            .and_then(|value| value.as_str().map(str::to_owned))
-            .unwrap_or_else(|| "autoplay".to_owned())
+    /// The local streaming origin shown by WhyGem. Gemini reason roles remain lower-case;
+    /// this source label intentionally follows the user-facing mode names.
+    pub(super) fn streaming_mode_slot(mode: StreamingMode) -> &'static str {
+        match mode {
+            StreamingMode::Focused => "Focused",
+            StreamingMode::Balanced => "Balanced",
+            StreamingMode::Discovery => "Discovery",
+        }
     }
 
     pub(super) fn note_streaming_failure(&mut self, status: String) {
@@ -173,7 +368,7 @@ impl DaemonEngine {
                 self.consecutive_streaming_failures.saturating_add(1);
             if self.consecutive_streaming_failures >= AUTOPLAY_MAX_FAILURES {
                 self.streaming = false;
-                self.streaming_pending = false;
+                self.cancel_pending_streaming_request();
                 self.config.autoplay_streaming = Some(false);
                 self.save_config("daemon streaming circuit-breaker");
             }

--- a/src/daemon/engine/streaming_request_tests.rs
+++ b/src/daemon/engine/streaming_request_tests.rs
@@ -1,0 +1,252 @@
+use super::*;
+
+fn song(id: &str) -> Song {
+    Song::remote(id, format!("title-{id}"), "artist", "3:00")
+}
+
+fn fallback_request_id(effects: &[EngineEffect]) -> u64 {
+    match effects {
+        [EngineEffect::StreamingFallback { request_id, .. }] => *request_id,
+        other => panic!("expected one streaming fallback, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn api_streaming_events_extend_clear_pending_and_trip_circuit_breaker() {
+    let mut engine = tests::engine_with_queue(&["seed"]);
+    engine.loaded_video_id = Some("seed".to_owned());
+    engine.streaming = true;
+    engine.consecutive_streaming_failures = 2;
+
+    let request_id = fallback_request_id(&engine.force_autoplay_extend());
+    engine
+        .pending_streaming_request
+        .as_mut()
+        .expect("request is pending")
+        .stage = StreamingRequestStage::Preflight;
+    let effects = engine
+        .handle_api_event(ApiEvent::StreamingPreflighted {
+            request_id,
+            seed_video_id: "seed".to_owned(),
+            songs: vec![song("fresh-a"), song("fresh-b")],
+        })
+        .await;
+    assert!(effects.is_empty());
+    assert!(!engine.streaming_pending);
+    assert_eq!(engine.consecutive_streaming_failures, 0);
+    assert!(engine.queue.contains_video_id("fresh-a"));
+
+    let request_id = fallback_request_id(&engine.force_autoplay_extend());
+    let effects = engine
+        .handle_api_event(ApiEvent::StreamingResults {
+            request_id,
+            seed_video_id: "not-in-queue".to_owned(),
+            candidates: vec![(song("ignored"), CandidateSource::YtdlpStreaming)],
+        })
+        .await;
+    assert!(effects.is_empty());
+    assert!(
+        engine.streaming_pending,
+        "wrong seed must not consume the request"
+    );
+    assert!(!engine.queue.contains_video_id("ignored"));
+    engine.cancel_pending_streaming_request();
+
+    for idx in 0..AUTOPLAY_MAX_FAILURES {
+        engine.streaming = true;
+        let request_id = fallback_request_id(&engine.force_autoplay_extend());
+        engine
+            .handle_api_event(ApiEvent::StreamingError {
+                request_id,
+                seed_video_id: "seed".to_owned(),
+                error: format!("failure-{idx}"),
+            })
+            .await;
+    }
+    assert!(!engine.streaming);
+    assert_eq!(engine.config.autoplay_streaming, Some(false));
+    assert!(
+        engine
+            .last_error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("autoplay streaming failed")
+    );
+
+    for inert in [
+        ApiEvent::TrackResolved {
+            seq: 1,
+            result: Ok(Vec::new()),
+        },
+        ApiEvent::SearchError {
+            request_id: 1,
+            source: crate::search_source::SearchSource::Youtube,
+            error: "offline".to_owned(),
+        },
+        ApiEvent::PlaylistTracksError {
+            title: "mix".to_owned(),
+            error: "private".to_owned(),
+        },
+    ] {
+        assert!(engine.handle_api_event(inert).await.is_empty());
+    }
+}
+
+#[tokio::test]
+async fn disable_reenable_same_seed_rejects_the_old_request_generation() {
+    let mut engine = tests::engine_with_queue(&["seed"]);
+    engine.loaded_video_id = Some("seed".to_owned());
+    engine.streaming = true;
+
+    let old_request_id = fallback_request_id(&engine.force_autoplay_extend());
+    let (_, off_effects) = engine.set_streaming(ToggleState::Off);
+    assert!(off_effects.is_empty());
+    assert!(!engine.streaming_pending);
+
+    let (_, on_effects) = engine.set_streaming(ToggleState::On);
+    let new_request_id = fallback_request_id(&on_effects);
+    assert!(new_request_id > old_request_id);
+
+    engine
+        .handle_api_event(ApiEvent::StreamingError {
+            request_id: old_request_id,
+            seed_video_id: "seed".to_owned(),
+            error: "old generation".to_owned(),
+        })
+        .await;
+    assert_eq!(
+        engine
+            .pending_streaming_request
+            .as_ref()
+            .map(|pending| pending.request_id),
+        Some(new_request_id)
+    );
+    assert_eq!(engine.consecutive_streaming_failures, 0);
+
+    engine
+        .handle_api_event(ApiEvent::StreamingError {
+            request_id: new_request_id,
+            seed_video_id: "seed".to_owned(),
+            error: "current generation".to_owned(),
+        })
+        .await;
+    assert!(!engine.streaming_pending);
+    assert_eq!(engine.consecutive_streaming_failures, 1);
+}
+
+#[tokio::test]
+async fn mode_change_rejects_old_results_instead_of_using_the_new_why_gem_source() {
+    use crate::remote::proto::ResponseData;
+
+    let mut engine = tests::engine_with_queue(&["seed"]);
+    engine.loaded_video_id = Some("seed".to_owned());
+    engine.streaming = true;
+    assert_eq!(engine.config.streaming.mode, StreamingMode::Balanced);
+    let old_request_id = fallback_request_id(&engine.force_autoplay_extend());
+
+    let (_, effects) = engine.set_setting(RemoteSettingChange::StreamingMode {
+        value: StreamingMode::Discovery,
+    });
+    let new_request_id = fallback_request_id(&effects);
+    engine
+        .handle_api_event(ApiEvent::StreamingResults {
+            request_id: old_request_id,
+            seed_video_id: "seed".to_owned(),
+            candidates: vec![(song("old-pick"), CandidateSource::YtdlpStreaming)],
+        })
+        .await;
+    assert!(!engine.queue.contains_video_id("old-pick"));
+    assert!(engine.gui_fetch_why_gem("old-pick").data.is_none());
+    assert_eq!(
+        engine
+            .pending_streaming_request
+            .as_ref()
+            .map(|pending| pending.request_id),
+        Some(new_request_id)
+    );
+
+    engine
+        .pending_streaming_request
+        .as_mut()
+        .expect("new mode request remains pending")
+        .stage = StreamingRequestStage::Preflight;
+    engine
+        .handle_api_event(ApiEvent::StreamingPreflighted {
+            request_id: new_request_id,
+            seed_video_id: "seed".to_owned(),
+            songs: vec![song("new-pick")],
+        })
+        .await;
+    let Some(ResponseData::WhyGem(model)) = engine.gui_fetch_why_gem("new-pick").data else {
+        panic!("new request should record WhyGem provenance");
+    };
+    assert_eq!(model.slot, "Discovery");
+}
+
+#[tokio::test]
+async fn admitted_same_seed_manual_replacement_cancels_the_old_queue_revision() {
+    let mut engine = tests::engine_with_queue(&["seed"]);
+    engine.loaded_video_id = Some("seed".to_owned());
+    engine.streaming = true;
+    let _player_rx = tests::install_accepting_player(&mut engine);
+    let old_request_id = fallback_request_id(&engine.force_autoplay_extend());
+    let old_queue_rev = engine.queue.rev();
+
+    let replacement = Song::remote("seed", "replacement", "manual artist", "4:00");
+    let response = engine.gui_replace_queue(vec![replacement]).await;
+    assert!(response.ok);
+    assert_ne!(engine.queue.rev(), old_queue_rev);
+    engine.reconcile_pending_streaming_request();
+    assert!(!engine.streaming_pending);
+
+    engine
+        .handle_api_event(ApiEvent::StreamingResults {
+            request_id: old_request_id,
+            seed_video_id: "seed".to_owned(),
+            candidates: vec![(song("stale-pick"), CandidateSource::YtdlpStreaming)],
+        })
+        .await;
+    assert!(!engine.queue.contains_video_id("stale-pick"));
+    assert_eq!(
+        engine.queue.current().map(|song| song.title.as_str()),
+        Some("replacement")
+    );
+}
+
+#[tokio::test]
+async fn duplicate_pool_result_during_preflight_does_not_consume_the_generation() {
+    let mut engine = tests::engine_with_queue(&["seed"]);
+    engine.loaded_video_id = Some("seed".to_owned());
+    engine.streaming = true;
+    let request_id = fallback_request_id(&engine.force_autoplay_extend());
+    engine
+        .pending_streaming_request
+        .as_mut()
+        .expect("request is pending")
+        .stage = StreamingRequestStage::Preflight;
+
+    let effects = engine
+        .handle_api_event(ApiEvent::StreamingResults {
+            request_id,
+            seed_video_id: "seed".to_owned(),
+            candidates: vec![(song("duplicate-pool"), CandidateSource::YtdlpStreaming)],
+        })
+        .await;
+    assert!(effects.is_empty());
+    assert!(matches!(
+        engine.pending_streaming_request.as_ref(),
+        Some(pending)
+            if pending.request_id == request_id
+                && pending.stage == StreamingRequestStage::Preflight
+    ));
+
+    engine
+        .handle_api_event(ApiEvent::StreamingPreflighted {
+            request_id,
+            seed_video_id: "seed".to_owned(),
+            songs: vec![song("preflight-pick")],
+        })
+        .await;
+    assert!(!engine.streaming_pending);
+    assert!(engine.queue.contains_video_id("preflight-pick"));
+}

--- a/src/daemon/engine/tests.rs
+++ b/src/daemon/engine/tests.rs
@@ -50,6 +50,8 @@ pub(in crate::daemon) fn engine_with_queue(ids: &[&str]) -> DaemonEngine {
         test_player_starts: VecDeque::new(),
         streaming: false,
         streaming_pending: false,
+        streaming_request_seq: 0,
+        pending_streaming_request: None,
         last_extend: None,
         consecutive_streaming_failures: 0,
         last_error: None,
@@ -68,8 +70,7 @@ pub(in crate::daemon) fn engine_with_queue(ids: &[&str]) -> DaemonEngine {
         session_events: VecDeque::new(),
         media_art: None,
         gui_search_index: GuiSearchIndex::default(),
-        why_gem: Vec::new(),
-        why_gem_rev: 0,
+        why_gem: crate::why_gem::WhyGemLedger::default(),
         accounts_rev: 0,
         spotify_user: None,
         video_overlay: None,
@@ -1121,85 +1122,6 @@ async fn media_commands_ignore_invalid_or_disabled_operations() {
     assert!(effects.is_empty());
     assert!(engine.loaded_video_id.is_none());
     assert_eq!(engine.transport_recovery, TransportRecoveryState::Shutdown);
-}
-
-#[tokio::test]
-async fn api_streaming_events_extend_clear_pending_and_trip_circuit_breaker() {
-    let mut engine = engine_with_queue(&["seed"]);
-    engine.loaded_video_id = Some("seed".to_owned());
-    engine.streaming = true;
-    engine.streaming_pending = true;
-    engine.consecutive_streaming_failures = 2;
-
-    let additions = vec![song("fresh-a"), song("fresh-b")];
-    let effects = engine
-        .handle_api_event(ApiEvent::StreamingPreflighted {
-            seed_video_id: "seed".to_owned(),
-            songs: additions,
-        })
-        .await;
-    assert!(effects.is_empty());
-    assert!(!engine.streaming_pending);
-    assert_eq!(engine.consecutive_streaming_failures, 0);
-    assert!(
-        engine
-            .queue
-            .ordered_iter()
-            .any(|song| song.video_id == "fresh-a")
-    );
-
-    engine.streaming_pending = true;
-    let effects = engine
-        .handle_api_event(ApiEvent::StreamingResults {
-            seed_video_id: "not-in-queue".to_owned(),
-            candidates: vec![(song("ignored"), CandidateSource::YtdlpStreaming)],
-        })
-        .await;
-    assert!(effects.is_empty());
-    assert!(!engine.streaming_pending);
-    assert!(
-        !engine
-            .queue
-            .ordered_iter()
-            .any(|song| song.video_id == "ignored")
-    );
-
-    for idx in 0..AUTOPLAY_MAX_FAILURES {
-        engine.streaming = true;
-        engine
-            .handle_api_event(ApiEvent::StreamingError {
-                seed_video_id: "seed".to_owned(),
-                error: format!("failure-{idx}"),
-            })
-            .await;
-    }
-    assert!(!engine.streaming);
-    assert_eq!(engine.config.autoplay_streaming, Some(false));
-    assert!(
-        engine
-            .last_error
-            .as_deref()
-            .unwrap_or_default()
-            .contains("autoplay streaming failed")
-    );
-
-    for inert in [
-        ApiEvent::TrackResolved {
-            seq: 1,
-            result: Ok(Vec::new()),
-        },
-        ApiEvent::SearchError {
-            request_id: 1,
-            source: crate::search_source::SearchSource::Youtube,
-            error: "offline".to_owned(),
-        },
-        ApiEvent::PlaylistTracksError {
-            title: "mix".to_owned(),
-            error: "private".to_owned(),
-        },
-    ] {
-        assert!(engine.handle_api_event(inert).await.is_empty());
-    }
 }
 
 #[test]

--- a/src/daemon/events.rs
+++ b/src/daemon/events.rs
@@ -139,13 +139,24 @@ impl DaemonEvent {
             | DaemonEvent::Api(crate::api::ApiEvent::SearchError { request_id, .. }) => {
                 Some(DaemonTelemetrySlot::StaleSearch(*request_id))
             }
-            DaemonEvent::Api(crate::api::ApiEvent::StreamingResults { seed_video_id, .. })
-            | DaemonEvent::Api(crate::api::ApiEvent::StreamingPreflighted {
-                seed_video_id, ..
+            DaemonEvent::Api(crate::api::ApiEvent::StreamingResults {
+                request_id,
+                seed_video_id,
+                ..
             })
-            | DaemonEvent::Api(crate::api::ApiEvent::StreamingError { seed_video_id, .. }) => {
-                Some(DaemonTelemetrySlot::StaleStreaming(seed_video_id.clone()))
-            }
+            | DaemonEvent::Api(crate::api::ApiEvent::StreamingPreflighted {
+                request_id,
+                seed_video_id,
+                ..
+            })
+            | DaemonEvent::Api(crate::api::ApiEvent::StreamingError {
+                request_id,
+                seed_video_id,
+                ..
+            }) => Some(DaemonTelemetrySlot::StaleStreaming(
+                *request_id,
+                seed_video_id.clone(),
+            )),
             _ => match self.policy() {
                 EventPolicy::CoalesceLatest { key, .. } => Some(DaemonTelemetrySlot::Static(key)),
                 _ => None,
@@ -162,7 +173,7 @@ pub(crate) enum DaemonTelemetrySlot {
     MediaArt(String),
     DownloadProgress(String),
     StaleSearch(u64),
-    StaleStreaming(String),
+    StaleStreaming(u64, String),
 }
 
 impl OwnerEvent for DaemonEvent {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -717,6 +717,10 @@ async fn run_owner_loop(
             engine.suppress_transport_recovery_for_shutdown();
             break;
         }
+        // Queue/session/settings mutations can invalidate an in-flight autoplay request even
+        // when the seed id still exists. Settle that owner generation before publishing this
+        // turn so a later pool/preflight result cannot mutate the replacement session.
+        engine.reconcile_pending_streaming_request();
         // Reconcile the persisted live setting on every owner turn so GUI/remote changes tear
         // down or create the platform generation before this turn's snapshot is published.
         let media_enabled = daemon_media_enabled(&engine, media_session_allowed);
@@ -783,6 +787,7 @@ async fn run_owner_loop(
             publisher.publish_library_invalidated();
             published_library_invalidations = library_invalidations;
         }
+        engine.reconcile_why_gem();
         let why_gem_rev = engine.why_gem_rev();
         if published_why_gem_rev != Some(why_gem_rev) {
             publisher.publish_why_gem(engine.why_gem_ids());

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -237,6 +237,7 @@ fn daemon_event_policy_covers_representative_events() {
     );
     assert_eq!(
         DaemonEvent::Api(crate::api::ApiEvent::StreamingResults {
+            request_id: 0,
             seed_video_id: "seed".to_owned(),
             candidates: Vec::new(),
         })
@@ -247,6 +248,7 @@ fn daemon_event_policy_covers_representative_events() {
     );
     assert_eq!(
         DaemonEvent::Api(crate::api::ApiEvent::StreamingPreflighted {
+            request_id: 1,
             seed_video_id: "seed".to_owned(),
             songs: Vec::new(),
         })
@@ -257,6 +259,7 @@ fn daemon_event_policy_covers_representative_events() {
     );
     assert_eq!(
         DaemonEvent::Api(crate::api::ApiEvent::StreamingError {
+            request_id: 0,
             seed_video_id: "seed".to_owned(),
             error: "bad".to_owned(),
         })
@@ -398,6 +401,7 @@ fn daemon_event_policy_covers_representative_events() {
     // Unlike the interactive owner, the daemon has no reducer-side stale slot for AI picks.
     assert_eq!(
         DaemonEvent::Ai(crate::ai::AiEvent::StreamingPicks {
+            request_id: 0,
             seed_video_id: "seed".to_owned(),
             picks: Vec::new(),
             conf: None,
@@ -607,6 +611,7 @@ async fn daemon_scrobble_health_and_stale_results_coalesce_when_owner_is_full() 
         emit_daemon_event(
             &tx,
             DaemonEvent::Api(crate::api::ApiEvent::StreamingError {
+                request_id: 0,
                 seed_video_id: "seed".to_owned(),
                 error: "old".to_owned(),
             })
@@ -620,6 +625,7 @@ async fn daemon_scrobble_health_and_stale_results_coalesce_when_owner_is_full() 
         emit_daemon_event(
             &tx,
             DaemonEvent::Api(crate::api::ApiEvent::StreamingError {
+                request_id: 0,
                 seed_video_id: "seed".to_owned(),
                 error: "new".to_owned(),
             })
@@ -633,6 +639,7 @@ async fn daemon_scrobble_health_and_stale_results_coalesce_when_owner_is_full() 
         emit_daemon_event(
             &tx,
             DaemonEvent::Api(crate::api::ApiEvent::StreamingError {
+                request_id: 0,
                 seed_video_id: "other".to_owned(),
                 error: "other".to_owned(),
             })
@@ -653,6 +660,7 @@ async fn daemon_scrobble_health_and_stale_results_coalesce_when_owner_is_full() 
         DaemonEvent::Api(crate::api::ApiEvent::StreamingError {
             seed_video_id,
             error,
+            ..
         }) if seed_video_id == "seed" && error == "new"
     )));
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -228,6 +228,121 @@ macro_rules! t {
     };
 }
 
+/// Localized copy for the per-track WhyGem card.
+///
+/// The wire model deliberately keeps compact, language-neutral slot/role/reason codes. Keeping
+/// their presentation here gives the TUI one trust boundary: known values become full localized
+/// copy, while unknown model output can be omitted instead of reaching the terminal verbatim.
+pub mod why_gem {
+    /// Card title and keymap action label.
+    pub fn title() -> &'static str {
+        crate::t!("Why this pick", "이 곡을 고른 이유", "この曲を選んだ理由")
+    }
+
+    /// Label before the recommendation source.
+    pub fn origin_label() -> &'static str {
+        crate::t!("Source", "선곡 출처", "選曲元")
+    }
+
+    /// Label before an optional DJ Gem role.
+    pub fn role_label() -> &'static str {
+        crate::t!("Role", "역할", "役割")
+    }
+
+    /// Label before an optional model confidence percentage.
+    pub fn confidence_label() -> &'static str {
+        crate::t!("Confidence", "확신도", "確信度")
+    }
+
+    /// Info toast shown when the contextual queue/current track has no recommendation provenance.
+    pub fn no_provenance() -> &'static str {
+        crate::t!(
+            "No recommendation reason is available for this track.",
+            "이 곡에는 추천 이유가 없습니다.",
+            "この曲にはおすすめ理由がありません。"
+        )
+    }
+
+    /// Human copy for a stable WhyGem source slot.
+    ///
+    /// `StreamingMode` currently serializes with title-case variant names, while older callers
+    /// and fixtures may use lowercase wire names. Both forms intentionally render identically.
+    /// An unknown slot is still recommendation provenance, but is not trusted as terminal copy;
+    /// it falls back to the generic DJ Gem source.
+    pub fn origin(slot: &str) -> &'static str {
+        match slot {
+            "Focused" | "focused" => {
+                crate::t!("Focused station", "집중 스테이션", "集中ステーション")
+            }
+            "Balanced" | "balanced" => {
+                crate::t!("Balanced station", "균형 스테이션", "バランスステーション")
+            }
+            "Discovery" | "discovery" => crate::t!(
+                "Discovery station",
+                "발견 스테이션",
+                "ディスカバリーステーション"
+            ),
+            "DJ Gem" | "dj_gem" => "DJ Gem",
+            _ => crate::t!("DJ Gem recommendation", "DJ Gem 추천", "DJ Gemのおすすめ"),
+        }
+    }
+
+    /// Localized model role, or `None` when a model returned an unknown value.
+    pub fn role(role: &str) -> Option<&'static str> {
+        Some(match role {
+            "core" => crate::t!("Core", "핵심", "中核"),
+            "bridge" => crate::t!("Bridge", "연결", "橋渡し"),
+            "adjacent" => crate::t!("Adjacent", "인접", "近接"),
+            "discovery" => crate::t!("Discovery", "발견", "発見"),
+            "stabilizer" => crate::t!("Stabilizer", "안정", "安定"),
+            "recovery" => crate::t!("Recovery", "회복", "回復"),
+            _ => return None,
+        })
+    }
+
+    /// Full localized sentence for one model evidence code.
+    pub fn reason(code: &str) -> Option<&'static str> {
+        Some(match code {
+            "co" => crate::t!(
+                "It often appears alongside what you have been listening to.",
+                "최근 들은 곡과 함께 자주 재생되는 곡이에요.",
+                "最近聴いた曲と一緒によく再生される曲です。"
+            ),
+            "tr" => crate::t!(
+                "It makes a smooth transition from the current track.",
+                "현재 곡에서 자연스럽게 이어지는 곡이에요.",
+                "現在の曲から自然につながる曲です。"
+            ),
+            "u" => crate::t!(
+                "It matches your listening preferences.",
+                "평소 감상 취향과 잘 맞는 곡이에요.",
+                "普段のリスニング傾向に合う曲です。"
+            ),
+            "nov" => crate::t!(
+                "It adds something new without straying too far.",
+                "취향에서 너무 벗어나지 않으면서 새로움을 더해요.",
+                "好みから離れすぎず、新鮮さを加える曲です。"
+            ),
+            "cont" => crate::t!(
+                "It continues the current source naturally.",
+                "현재 추천 흐름을 자연스럽게 이어 가는 곡이에요.",
+                "現在のおすすめの流れを自然に引き継ぐ曲です。"
+            ),
+            "comp" => crate::t!(
+                "You tend to listen through tracks like this.",
+                "비슷한 곡을 끝까지 듣는 경향이 있어요.",
+                "このような曲を最後まで聴く傾向があります。"
+            ),
+            "m" => crate::t!(
+                "It is a strongly verified official music release.",
+                "공식 음악 콘텐츠라는 근거가 충분한 곡이에요.",
+                "公式音楽コンテンツである根拠が十分な曲です。"
+            ),
+            _ => return None,
+        })
+    }
+}
+
 /// Serializes tests that explicitly select a language and installs a scoped per-thread value.
 ///
 /// Reducer tests that exercise config application can publish the configured language through
@@ -333,6 +448,28 @@ mod tests {
 
         set_language(Language::English);
         assert_eq!(t!("Settings", "설정", "設定"), "Settings");
+    }
+
+    #[test]
+    fn why_gem_catalog_localizes_known_codes_and_rejects_unknown_model_copy() {
+        let _guard = lock_for_test();
+
+        set_language(Language::Korean);
+        assert_eq!(why_gem::title(), "이 곡을 고른 이유");
+        assert_eq!(why_gem::origin("Balanced"), "균형 스테이션");
+        assert_eq!(why_gem::role("bridge"), Some("연결"));
+        assert_eq!(
+            why_gem::reason("tr"),
+            Some("현재 곡에서 자연스럽게 이어지는 곡이에요.")
+        );
+
+        set_language(Language::Japanese);
+        assert_eq!(why_gem::origin_label(), "選曲元");
+        assert_eq!(why_gem::confidence_label(), "確信度");
+        assert_eq!(why_gem::role("recovery"), Some("回復"));
+
+        assert_eq!(why_gem::role("model-invented-role"), None);
+        assert_eq!(why_gem::reason("model-invented-reason"), None);
     }
 
     #[test]

--- a/src/keymap/metadata.rs
+++ b/src/keymap/metadata.rs
@@ -640,9 +640,9 @@ const ACTION_META: &[(Action, &str, &str, &str, &str)] = &[
     (
         Action::WhyAi,
         "why_ai",
-        "Why these DJ Gem picks",
-        "DJ Gem 선곡 이유 보기",
-        "DJ Gemの選曲理由",
+        "Why this pick",
+        "이 곡을 고른 이유",
+        "この曲を選んだ理由",
     ),
     (
         Action::IdentifyNowPlaying,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub mod ui;
 pub mod update;
 pub mod util;
 pub mod video_overlay;
+pub mod why_gem;
 pub mod zoom;
 
 #[cfg(test)]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -218,10 +218,12 @@ impl From<RuntimeEvent> for Msg {
                 }
                 crate::ai::AiEvent::PlayPlaylist(key) => Msg::Ai(AiMsg::PlayPlaylist(key)),
                 crate::ai::AiEvent::StreamingPicks {
+                    request_id,
                     seed_video_id,
                     picks,
                     conf,
                 } => Msg::Streaming(StreamingMsg::AiPicks {
+                    request_id,
                     seed_video_id,
                     picks,
                     conf,
@@ -285,23 +287,29 @@ impl From<RuntimeEvent> for Msg {
                     Msg::PlaylistTracksError { title, error }
                 }
                 crate::api::ApiEvent::StreamingResults {
+                    request_id,
                     seed_video_id,
                     candidates,
                 } => Msg::Streaming(StreamingMsg::Results {
+                    request_id,
                     seed_video_id,
                     candidates,
                 }),
                 crate::api::ApiEvent::StreamingPreflighted {
+                    request_id,
                     seed_video_id,
                     songs,
                 } => Msg::Streaming(StreamingMsg::Preflighted {
+                    request_id,
                     seed_video_id,
                     songs,
                 }),
                 crate::api::ApiEvent::StreamingError {
+                    request_id,
                     seed_video_id,
                     error,
                 } => Msg::Streaming(StreamingMsg::Error {
+                    request_id,
                     seed_video_id,
                     error,
                 }),

--- a/src/runtime/delivery_reporting.rs
+++ b/src/runtime/delivery_reporting.rs
@@ -30,7 +30,10 @@ pub(super) enum ActorRejectionRecovery {
     Lyrics,
     Artwork,
     AiTurn,
-    AiRerank(String),
+    AiRerank {
+        request_id: u64,
+        seed_video_id: String,
+    },
     AiFeedback,
     TransferStart,
     TransferCancel,
@@ -45,9 +48,13 @@ pub(super) fn recover_actor_rejection(
         ActorRejectionRecovery::Lyrics => app.lyrics.loading = false,
         ActorRejectionRecovery::Artwork => app.art.loading = false,
         ActorRejectionRecovery::AiTurn => app.ai.thinking = false,
-        ActorRejectionRecovery::AiRerank(seed_video_id) => {
+        ActorRejectionRecovery::AiRerank {
+            request_id,
+            seed_video_id,
+        } => {
             app.ai.thinking = false;
             return Some(Msg::Streaming(StreamingMsg::AiPicks {
+                request_id,
                 seed_video_id,
                 picks: Vec::new(),
                 conf: None,

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -511,18 +511,22 @@ impl RuntimeHandles {
                 }
             }
             Cmd::AiRerank {
+                request_id,
                 seed_video_id,
                 prompt,
             } => {
                 let recovery_seed = seed_video_id.clone();
                 let result = self.ai_handle.as_ref().map_or_else(
                     || Err(crate::util::delivery::DeliveryError::Closed),
-                    |handle| handle.rerank(seed_video_id, prompt),
+                    |handle| handle.rerank(request_id, seed_video_id, prompt),
                 );
                 if !report_actor_delivery(app, "ai.rerank", result)
                     && let Some(msg) = recover_actor_rejection(
                         app,
-                        ActorRejectionRecovery::AiRerank(recovery_seed),
+                        ActorRejectionRecovery::AiRerank {
+                            request_id,
+                            seed_video_id: recovery_seed,
+                        },
                     )
                 {
                     self.reduce_owner_msg(app, msg);
@@ -562,6 +566,7 @@ impl RuntimeHandles {
                 }
             }
             Cmd::StreamingFallback {
+                request_id,
                 seed,
                 seed_video_id,
                 exclude_ids,
@@ -569,6 +574,7 @@ impl RuntimeHandles {
                 config,
             } => {
                 if let Err(error) = self.api_handle.streaming(
+                    request_id,
                     seed,
                     seed_video_id.clone(),
                     exclude_ids,
@@ -580,6 +586,7 @@ impl RuntimeHandles {
                     self.reduce_owner_msg(
                         app,
                         Msg::Streaming(StreamingMsg::Error {
+                            request_id,
                             seed_video_id,
                             error: error.to_string(),
                         }),
@@ -587,6 +594,7 @@ impl RuntimeHandles {
                 }
             }
             Cmd::StreamingPreflight {
+                request_id,
                 seed_video_id,
                 picks,
                 fallback,
@@ -594,6 +602,7 @@ impl RuntimeHandles {
                 config,
             } => {
                 if let Err(error) = self.api_handle.streaming_preflight(
+                    request_id,
                     seed_video_id.clone(),
                     picks,
                     fallback,
@@ -603,7 +612,8 @@ impl RuntimeHandles {
                     tracing::warn!(%error, "api command enqueue failed");
                     self.reduce_owner_msg(
                         app,
-                        Msg::Streaming(StreamingMsg::Error {
+                        Msg::Streaming(StreamingMsg::PreflightError {
+                            request_id,
                             seed_video_id,
                             error: error.to_string(),
                         }),

--- a/src/runtime/ingress.rs
+++ b/src/runtime/ingress.rs
@@ -17,7 +17,8 @@ pub(crate) enum RuntimeTelemetrySlot {
     StaleLyrics(String),
     StaleResolver(String),
     StaleSearch(u64),
-    StaleStreaming(String),
+    StaleStreamingRequest(u64, String),
+    StaleStreamingResolved(String),
     StaleTrackResolve(u64),
     TransferProgress(String),
     VideoPaused(u64),
@@ -64,9 +65,14 @@ impl RuntimeEvent {
             RuntimeEvent::App(msg) => {
                 app_stale_slot(msg).or_else(|| static_policy_slot(app_msg_policy(msg)))
             }
-            RuntimeEvent::Ai(crate::ai::AiEvent::StreamingPicks { seed_video_id, .. }) => {
-                Some(RuntimeTelemetrySlot::StaleStreaming(seed_video_id.clone()))
-            }
+            RuntimeEvent::Ai(crate::ai::AiEvent::StreamingPicks {
+                request_id,
+                seed_video_id,
+                ..
+            }) => Some(RuntimeTelemetrySlot::StaleStreamingRequest(
+                *request_id,
+                seed_video_id.clone(),
+            )),
             RuntimeEvent::Api(event) => api_stale_slot(event),
             RuntimeEvent::Artwork(crate::artwork::ArtworkEvent::Result { video_id, .. }) => {
                 Some(RuntimeTelemetrySlot::StaleArtwork(video_id.clone()))
@@ -126,11 +132,24 @@ fn api_stale_slot(event: &crate::api::ApiEvent) -> Option<RuntimeTelemetrySlot> 
         | crate::api::ApiEvent::SearchError { request_id, .. } => {
             Some(RuntimeTelemetrySlot::StaleSearch(*request_id))
         }
-        crate::api::ApiEvent::StreamingResults { seed_video_id, .. }
-        | crate::api::ApiEvent::StreamingPreflighted { seed_video_id, .. }
-        | crate::api::ApiEvent::StreamingError { seed_video_id, .. } => {
-            Some(RuntimeTelemetrySlot::StaleStreaming(seed_video_id.clone()))
+        crate::api::ApiEvent::StreamingResults {
+            request_id,
+            seed_video_id,
+            ..
         }
+        | crate::api::ApiEvent::StreamingPreflighted {
+            request_id,
+            seed_video_id,
+            ..
+        }
+        | crate::api::ApiEvent::StreamingError {
+            request_id,
+            seed_video_id,
+            ..
+        } => Some(RuntimeTelemetrySlot::StaleStreamingRequest(
+            *request_id,
+            seed_video_id.clone(),
+        )),
         _ => None,
     }
 }
@@ -149,16 +168,39 @@ fn app_stale_slot(msg: &Msg) -> Option<RuntimeTelemetrySlot> {
         Msg::Streaming(StreamingMsg::Resolved {
             self_heal: true, ..
         }) => None,
-        Msg::Streaming(streaming) => {
-            let seed_video_id = match streaming {
-                StreamingMsg::Resolved { video_id, .. } => video_id,
-                StreamingMsg::Results { seed_video_id, .. }
-                | StreamingMsg::Preflighted { seed_video_id, .. }
-                | StreamingMsg::Error { seed_video_id, .. }
-                | StreamingMsg::AiPicks { seed_video_id, .. } => seed_video_id,
-            };
-            Some(RuntimeTelemetrySlot::StaleStreaming(seed_video_id.clone()))
-        }
+        Msg::Streaming(StreamingMsg::Resolved { video_id, .. }) => Some(
+            RuntimeTelemetrySlot::StaleStreamingResolved(video_id.clone()),
+        ),
+        Msg::Streaming(
+            StreamingMsg::Results {
+                request_id,
+                seed_video_id,
+                ..
+            }
+            | StreamingMsg::Preflighted {
+                request_id,
+                seed_video_id,
+                ..
+            }
+            | StreamingMsg::PreflightError {
+                request_id,
+                seed_video_id,
+                ..
+            }
+            | StreamingMsg::Error {
+                request_id,
+                seed_video_id,
+                ..
+            }
+            | StreamingMsg::AiPicks {
+                request_id,
+                seed_video_id,
+                ..
+            },
+        ) => Some(RuntimeTelemetrySlot::StaleStreamingRequest(
+            *request_id,
+            seed_video_id.clone(),
+        )),
         Msg::TrackResolved { seq, .. } => Some(RuntimeTelemetrySlot::StaleTrackResolve(*seq)),
         _ => None,
     }

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -576,7 +576,10 @@ fn rejected_ai_rerank_schedules_empty_result_fallback() {
 
     let event = recover_actor_rejection(
         &mut app,
-        ActorRejectionRecovery::AiRerank("seed".to_owned()),
+        ActorRejectionRecovery::AiRerank {
+            request_id: 19,
+            seed_video_id: "seed".to_owned(),
+        },
     )
     .expect("rerank rejection must schedule the reducer's local fallback");
 
@@ -584,6 +587,7 @@ fn rejected_ai_rerank_schedules_empty_result_fallback() {
     assert!(matches!(
         event,
         Msg::Streaming(StreamingMsg::AiPicks {
+            request_id: 19,
             seed_video_id,
             picks,
             conf: None,
@@ -599,6 +603,7 @@ fn runtime_event_kind_and_telemetry_slots_are_stable() {
     );
     assert_eq!(
         RuntimeEvent::Api(crate::api::ApiEvent::StreamingError {
+            request_id: 23,
             seed_video_id: "seed".to_owned(),
             error: "e".to_owned(),
         })
@@ -779,6 +784,7 @@ fn app_message_policy_covers_backpressure_lanes() {
     );
     assert_eq!(
         app_msg_policy(&Msg::Streaming(StreamingMsg::Error {
+            request_id: 29,
             seed_video_id: "seed".to_owned(),
             error: "empty".to_owned(),
         })),
@@ -881,6 +887,7 @@ fn runtime_event_to_msg_preserves_ai_api_and_transport_payloads() {
     ));
 
     let msg = Msg::from(RuntimeEvent::Ai(crate::ai::AiEvent::StreamingPicks {
+        request_id: 31,
         seed_video_id: "seed".to_owned(),
         picks: vec![crate::ai::AiPick {
             cid: "c1".to_owned(),
@@ -892,6 +899,7 @@ fn runtime_event_to_msg_preserves_ai_api_and_transport_payloads() {
     assert!(matches!(
         msg,
         Msg::Streaming(StreamingMsg::AiPicks {
+            request_id: 31,
             seed_video_id,
             picks,
             conf: Some(conf),
@@ -1201,10 +1209,12 @@ fn runtime_event_to_msg_preserves_api_player_and_service_payloads() {
     ));
     assert!(matches!(
         Msg::from(RuntimeEvent::Api(crate::api::ApiEvent::StreamingResults {
+            request_id: 37,
             seed_video_id: "seed".to_owned(),
             candidates: vec![(song("cand1234567"), crate::streaming::CandidateSource::YtdlpStreaming)],
         })),
         Msg::Streaming(StreamingMsg::Results {
+            request_id: 37,
             seed_video_id,
             candidates,
         }) if seed_video_id == "seed"
@@ -1213,11 +1223,13 @@ fn runtime_event_to_msg_preserves_api_player_and_service_payloads() {
     ));
     assert!(matches!(
         Msg::from(RuntimeEvent::Api(crate::api::ApiEvent::StreamingPreflighted {
+            request_id: 77,
             seed_video_id: "seed".to_owned(),
             songs: vec![song("pre12345678")],
         })),
-        Msg::Streaming(StreamingMsg::Preflighted { seed_video_id, songs })
-            if seed_video_id == "seed" && songs[0].video_id == "pre12345678"
+        Msg::Streaming(StreamingMsg::Preflighted { request_id, seed_video_id, songs })
+            if request_id == 77 && seed_video_id == "seed"
+                && songs[0].video_id == "pre12345678"
     ));
 
     for (event, assert_msg) in [

--- a/src/runtime/tests/policy.rs
+++ b/src/runtime/tests/policy.rs
@@ -116,6 +116,7 @@ fn runtime_event_policy_covers_representative_events() {
     );
     assert_eq!(
         RuntimeEvent::Api(crate::api::ApiEvent::StreamingError {
+            request_id: 5,
             seed_video_id: "seed".to_owned(),
             error: "nope".to_owned(),
         })
@@ -183,6 +184,7 @@ fn runtime_event_policy_covers_leaf_event_classes() {
     );
     assert_policy(
         RuntimeEvent::Ai(crate::ai::AiEvent::StreamingPicks {
+            request_id: 7,
             seed_video_id: "seed".to_owned(),
             picks: Vec::new(),
             conf: None,

--- a/src/streaming/mod.rs
+++ b/src/streaming/mod.rs
@@ -265,17 +265,23 @@ pub fn merge_ai_picks_with_confidence(
     n: usize,
     conf: Option<f32>,
 ) -> Vec<Song> {
-    let ai_slots = match conf {
-        Some(c) if c < 0.45 => n.div_ceil(3),
-        Some(c) if c < 0.75 => n.div_ceil(2),
-        _ => n,
-    };
+    let ai_slots = ai_slots_for_confidence(n, conf);
     let ai_first = merge_ai_picks(ids, shortlist, local_pick, ai_slots);
     if ai_first.len() >= n {
         return ai_first;
     }
     let ai_ids: Vec<String> = ai_first.iter().map(|s| s.video_id.clone()).collect();
     merge_ai_picks(&ai_ids, shortlist, local_pick, n)
+}
+
+/// Number of final positions the model is allowed to own at a confidence level. Callers carrying
+/// per-pick provenance use this same boundary so local top-ups are never mislabeled as model picks.
+pub fn ai_slots_for_confidence(n: usize, conf: Option<f32>) -> usize {
+    match conf {
+        Some(c) if c < 0.45 => n.div_ceil(3),
+        Some(c) if c < 0.75 => n.div_ceil(2),
+        _ => n,
+    }
 }
 
 /// Last synchronous safety pass before streaming picks are appended to the queue. The scoring pass

--- a/src/ui/control_box.rs
+++ b/src/ui/control_box.rs
@@ -25,6 +25,8 @@ use beginner::StatusLabelTier;
 mod status_glyphs;
 mod status_line;
 use status_line::status_line_parts_with_labels_reusing;
+#[cfg(test)]
+mod why_gem_tests;
 
 /// Render the control block into four caller-provided single-height rows — the Player
 /// view's legacy top layout passes its own `rows[1]/[3]/[5]/[7]`, so the output is
@@ -341,6 +343,10 @@ fn fitted_status_line_parts(app: &App, width: u16, animated: bool) -> (u16, Stat
             if fits(&parts) {
                 return (buttons::text_width(gap), parts);
             }
+            parts = without_optional_why_gem(parts);
+            if fits(&parts) {
+                return (buttons::text_width(gap), parts);
+            }
         }
         (1, parts)
     } else {
@@ -357,9 +363,28 @@ fn fitted_status_line_parts(app: &App, width: u16, animated: bool) -> (u16, Stat
             if fits(&parts) {
                 return (buttons::text_width(gap), parts);
             }
+            parts = without_optional_why_gem(parts);
+            if fits(&parts) {
+                return (buttons::text_width(gap), parts);
+            }
         }
         (1, parts)
     }
+}
+
+/// The WhyGem chip is supplementary. On the final responsive tier it yields its own label and
+/// preceding gap before established transport controls are allowed to run off-screen.
+fn without_optional_why_gem(mut parts: StatusLineParts) -> StatusLineParts {
+    if let Some(index) = parts
+        .iter()
+        .position(|(target, _)| matches!(target, Some(MouseTarget::Global(Action::WhyAi))))
+    {
+        parts.remove(index);
+        if index > 0 && parts[index - 1].0.is_none() {
+            parts.remove(index - 1);
+        }
+    }
+    parts
 }
 
 /// Build the transport status-line as `(target, text)` segments from app state — split out

--- a/src/ui/control_box/status_line.rs
+++ b/src/ui/control_box/status_line.rs
@@ -37,6 +37,7 @@ pub(super) fn status_line_parts_with_labels_reusing(
     push_playback_state(&mut parts, app, labels, minimal, retro);
     push_queue_position(&mut parts, app, labels, gap, retro);
     push_rating(&mut parts, app, labels, gap, retro);
+    push_why_gem(&mut parts, app, labels, gap, retro);
     // Shuffle and repeat are both always shown as click toggles, and every state of each keeps
     // one display width, so the line's layout never shifts as they toggle or appear. Each
     // carries its media glyph — `<key>:🔀` shuffle, `<key>:🔁`/`<key>:🔂` repeat — or a padded cross when
@@ -68,6 +69,42 @@ pub(super) fn status_line_parts_with_labels_reusing(
     push_download_tag(&mut parts, app, gap, minimal);
 
     parts
+}
+
+/// Per-track provenance for the current queue item. The compact chip is deliberately ASCII:
+/// ambiguous-width symbols would move every click target that follows it on CJK terminals.
+fn push_why_gem(
+    parts: &mut StatusLineParts,
+    app: &App,
+    labels: StatusLabelTier,
+    gap: &'static str,
+    retro: bool,
+) {
+    let Some(song) = app.queue.current() else {
+        return;
+    };
+    if app.why_gem_for(&song.video_id).is_none() {
+        return;
+    }
+
+    parts.push((None, Cow::Borrowed(gap)));
+    let text = if labels.beginner() {
+        beginner_control_label(
+            app,
+            labels,
+            KeyContext::Global,
+            Action::WhyAi,
+            if retro {
+                "Why"
+            } else {
+                crate::i18n::why_gem::title()
+            },
+            None,
+        )
+    } else {
+        "WHY?".to_owned()
+    };
+    parts.push((Some(MouseTarget::Global(Action::WhyAi)), Cow::Owned(text)));
 }
 
 /// The playback state (`▸ playing` / `‖ paused`), shrunk to its one-cell glyph in the

--- a/src/ui/control_box/why_gem_tests.rs
+++ b/src/ui/control_box/why_gem_tests.rs
@@ -1,0 +1,40 @@
+use super::*;
+use std::borrow::Cow;
+
+use crate::api::Song;
+
+fn has_target(
+    parts: &[(Option<MouseTarget>, Cow<'static, str>)],
+    pred: impl Fn(&MouseTarget) -> bool,
+) -> bool {
+    parts
+        .iter()
+        .any(|(target, _)| target.as_ref().is_some_and(&pred))
+}
+
+#[test]
+fn status_line_shows_why_only_for_provenance_and_yields_it_when_narrow() {
+    let mut app = App::new(100);
+    app.queue.set(vec![Song::remote("a", "A", "x", "1:00")], 0);
+    assert!(!has_target(
+        &status_line_parts(&app, " ", false, false),
+        |target| { matches!(target, MouseTarget::Global(Action::WhyAi)) }
+    ));
+
+    app.why_gem.upsert(
+        "a".to_owned(),
+        crate::remote::proto::WhyGemModel {
+            slot: "Balanced".to_owned(),
+            reasons: Vec::new(),
+            confidence: None,
+        },
+    );
+    let (_, roomy) = fitted_status_line_parts(&app, 100, false);
+    assert!(has_target(&roomy, |target| {
+        matches!(target, MouseTarget::Global(Action::WhyAi))
+    }));
+    let (_, tiny) = fitted_status_line_parts(&app, 1, false);
+    assert!(!has_target(&tiny, |target| {
+        matches!(target, MouseTarget::Global(Action::WhyAi))
+    }));
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -92,10 +92,8 @@ pub fn render(frame: &mut Frame, app: &App) {
     if app.overlays.about_visible {
         views::about::render(frame, app, area);
     }
-    // The "Why DJ Gem" card explains the last DJ Gem streaming refill (`w`); also drawn on top.
-    if app.overlays.why_ai_visible {
-        views::why_ai::render(frame, app, area);
-    }
+    // The per-track WhyGem card is a modal over whichever surface selected its queue item.
+    views::why_ai::render(frame, app, area);
     // The "what's playing" identify card (radio): the result + favorite / ask-DJ Gem
     // actions. Below the mode confirmations so those stay on top.
     if app.overlays.now_playing_overlay.is_some() {

--- a/src/ui/views/mod.rs
+++ b/src/ui/views/mod.rs
@@ -16,6 +16,7 @@ pub mod onboarding;
 pub mod player;
 mod player_layout;
 mod player_lyrics;
+mod queue_actions;
 pub mod search;
 pub mod settings;
 pub mod why_ai;

--- a/src/ui/views/player.rs
+++ b/src/ui/views/player.rs
@@ -16,6 +16,7 @@ use crate::theme::ThemeRole as R;
 use crate::ui::buttons;
 
 use super::player_layout::calculate_player_filler_layout;
+use super::queue_actions;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let block = Block::default()
@@ -149,8 +150,6 @@ pub(in crate::ui) fn render_queue_popup(frame: &mut Frame, app: &App, area: Rect
     let sel_lo = app.queue_popup.cursor.min(app.queue_popup.anchor);
     let sel_hi = app.queue_popup.cursor.max(app.queue_popup.anchor);
 
-    const DEL_W: u16 = 2; // "✗ " click target on the right edge
-    let body_w = list.width.saturating_sub(DEL_W) as usize;
     for (vis, (i, song)) in app
         .queue
         .ordered_iter()
@@ -176,6 +175,8 @@ pub(in crate::ui) fn render_queue_popup(frame: &mut Frame, app: &App, area: Rect
         };
         let title = app.display_title(song);
         let artist = app.display_artist(song);
+        let actions_w = queue_actions::reserved_width(app, &song.video_id);
+        let body_w = list.width.saturating_sub(actions_w) as usize;
         let text = crate::ui::text::truncate_owned_to_width(
             format!("{marker}{:>3} {title} — {artist}", i + 1),
             body_w.saturating_sub(1),
@@ -204,29 +205,18 @@ pub(in crate::ui) fn render_queue_popup(frame: &mut Frame, app: &App, area: Rect
         };
         frame.render_widget(Paragraph::new(Line::from(text).style(base)), row);
 
-        // Trailing ✗ delete button, kept on the row's highlight when selected.
-        let del_x = row.x + row.width.saturating_sub(DEL_W);
-        let del_rect = Rect {
-            x: del_x,
-            y,
-            width: DEL_W,
-            height: 1,
-        };
-        let mut del_style = app.theme.style(R::Error);
-        if selected {
-            del_style = del_style.bg(app.theme.color(R::SelectionBg));
-        }
-        frame.render_widget(Paragraph::new(Line::from("✗").style(del_style)), del_rect);
-        app.register_mouse_button(del_rect, MouseTarget::QueueDel(i));
+        let actions_w = queue_actions::render(frame, app, row, i, &song.video_id, selected);
 
-        // The row body (everything left of the ✗) selects / jumps to the track.
+        // The row body (everything left of its trailing actions) selects / jumps to the track.
         let body_rect = Rect {
             x: row.x,
             y,
-            width: row.width.saturating_sub(DEL_W),
+            width: row.width.saturating_sub(actions_w),
             height: 1,
         };
-        app.register_mouse_button(body_rect, MouseTarget::QueueRow(i));
+        if !body_rect.is_empty() {
+            app.register_mouse_button(body_rect, MouseTarget::QueueRow(i));
+        }
     }
 
     // Scrollbar on the right border, tracking the viewport position; hidden when it all fits.

--- a/src/ui/views/queue_actions.rs
+++ b/src/ui/views/queue_actions.rs
@@ -1,0 +1,112 @@
+//! Trailing actions shared by every row in the player queue popup.
+//!
+//! Keeping the action geometry here leaves `player.rs` below its size ratchet and, more
+//! importantly, gives the row body one source of truth for the cells it must not claim.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::Line;
+use ratatui::widgets::Paragraph;
+
+use crate::app::{App, MouseTarget};
+use crate::theme::ThemeRole as R;
+
+const ACTION_WIDTH: u16 = 2;
+
+/// Width reserved at the right edge for the always-present delete action and, when the
+/// row has provenance, its WhyGem action.
+pub(super) fn reserved_width(app: &App, video_id: &str) -> u16 {
+    ACTION_WIDTH
+        + if app.why_gem_for(video_id).is_some() {
+            ACTION_WIDTH
+        } else {
+            0
+        }
+}
+
+/// Draw and register trailing row actions. Returns the same reserved width used by the
+/// caller to size the selectable row body.
+pub(super) fn render(
+    frame: &mut Frame,
+    app: &App,
+    row: Rect,
+    index: usize,
+    video_id: &str,
+    selected: bool,
+) -> u16 {
+    let reserved = reserved_width(app, video_id).min(row.width);
+    let selected_bg = selected.then(|| app.theme.color(R::SelectionBg));
+    let action_rect = |offset: u16| Rect {
+        x: row.right().saturating_sub(offset.min(row.width)),
+        y: row.y,
+        width: ACTION_WIDTH.min(row.width),
+        height: row.height.min(1),
+    };
+
+    // Delete owns the final two cells on every queue row.
+    let del_rect = action_rect(ACTION_WIDTH);
+    let del_style = selected_bg.map_or_else(
+        || app.theme.style(R::Error),
+        |bg| Style::default().fg(app.theme.color(R::Error)).bg(bg),
+    );
+    frame.render_widget(Paragraph::new(Line::from("✗").style(del_style)), del_rect);
+    if !del_rect.is_empty() {
+        app.register_mouse_button(del_rect, MouseTarget::QueueDel(index));
+    }
+
+    // Provenance is intentionally per video ID, so duplicate rows publish independent hit
+    // targets but open the same latest explanation.
+    if app.why_gem_for(video_id).is_some() && row.width >= ACTION_WIDTH.saturating_mul(2) {
+        let why_rect = action_rect(ACTION_WIDTH.saturating_mul(2));
+        let why_style = selected_bg.map_or_else(
+            || app.theme.style(R::Accent),
+            |bg| Style::default().fg(app.theme.color(R::Accent)).bg(bg),
+        );
+        frame.render_widget(Paragraph::new(Line::from("?").style(why_style)), why_rect);
+        app.register_mouse_button(why_rect, MouseTarget::QueueWhyGem(index));
+    }
+
+    reserved
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+    use crate::remote::proto::WhyGemModel;
+
+    #[test]
+    fn provenance_adds_a_separate_action_without_stealing_delete_cells() {
+        let mut app = App::new(50);
+        app.why_gem.upsert(
+            "track".to_owned(),
+            WhyGemModel {
+                slot: "Balanced".to_owned(),
+                reasons: Vec::new(),
+                confidence: None,
+            },
+        );
+        let backend = TestBackend::new(14, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render(frame, &app, Rect::new(2, 1, 10, 1), 3, "track", false);
+            })
+            .unwrap();
+
+        assert_eq!(reserved_width(&app, "track"), 4);
+        assert_eq!(app.hits.target_at(8, 1), Some(MouseTarget::QueueWhyGem(3)));
+        assert_eq!(app.hits.target_at(9, 1), Some(MouseTarget::QueueWhyGem(3)));
+        assert_eq!(app.hits.target_at(10, 1), Some(MouseTarget::QueueDel(3)));
+        assert_eq!(app.hits.target_at(11, 1), Some(MouseTarget::QueueDel(3)));
+    }
+
+    #[test]
+    fn manual_rows_keep_only_the_delete_action() {
+        let app = App::new(50);
+        assert_eq!(reserved_width(&app, "manual"), 2);
+    }
+}

--- a/src/ui/views/why_ai.rs
+++ b/src/ui/views/why_ai.rs
@@ -1,158 +1,381 @@
-//! The "Why DJ Gem" overlay: a small, centered card explaining the last autoplay-streaming refill that
-//! went through the Gemini reranker. For each pick it shows the slot role the model assigned
-//! (core / bridge / discovery / …), the track it landed on, and the evidence codes the model
-//! said it leaned on — so the DJ Gem's choices are inspectable rather than opaque. Opened with `w`
-//! ([`crate::keymap::Action::WhyAi`]); dismissed by `w` / Esc / Back. Styled with the same theme
-//! roles as the `?` cheat-sheet and About card so it matches whatever preset is active.
+//! The per-track WhyGem overlay. It explains the recommendation provenance of the queue row
+//! selected by the reducer; model-owned codes cross a localized allow-list before rendering.
 
 use ratatui::Frame;
-use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::layout::{Alignment, Rect};
 use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use unicode_width::UnicodeWidthStr;
 
 use crate::app::App;
+use crate::app::MouseTarget;
+use crate::i18n::{self, why_gem};
 use crate::keymap::{Action, KeyContext};
-use crate::t;
 use crate::theme::ThemeRole as R;
 use crate::ui::text::truncate_to_width;
 
-/// Render the "Why DJ Gem" card as a centered popup over `area`.
+const CARD_WIDTH: u16 = 68;
+
+/// Render the selected/current track's WhyGem card. Missing or stale targets fail closed.
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
-    let Some(explain) = app.streaming.last_explain.as_ref() else {
+    let Some((song, model)) = app.why_gem_target_song() else {
         return;
     };
+    if area.is_empty() {
+        return;
+    }
 
-    // One row per pick (role + track) plus a muted reasons row beneath it; clamp to the screen.
-    let body_rows = (explain.picks.len() as u16) * 2;
-    let h = (body_rows + 5).clamp(7, area.height);
-    let popup = centered_fixed(area, 72, h);
-    crate::ui::render_popup_background(frame, app, popup);
-
-    let title = match explain.conf {
-        Some(c) => format!(
-            " {} · {:.0}% ",
-            t!(
-                "Why these DJ Gem picks",
-                "DJ Gem 선곡 이유",
-                "DJ Gem選曲の理由"
-            ),
-            (c * 100.0).round()
-        ),
-        None => format!(
-            " {} ",
-            t!(
-                "Why these DJ Gem picks",
-                "DJ Gem 선곡 이유",
-                "DJ Gem選曲の理由"
-            )
-        ),
+    let popup_width = CARD_WIDTH.min(area.width);
+    let content_width = popup_width.saturating_sub(2).max(1);
+    let title = app.display_title(song);
+    let artist = app.display_artist(song);
+    let safe_title = truncate_to_width(title.as_ref(), usize::from(content_width));
+    let safe_artist = truncate_to_width(artist.as_ref(), usize::from(content_width));
+    let role = why_gem::role(&model.slot);
+    // Lowercase role slots are DJ Gem model output. Streaming origins use unambiguous
+    // title-case slots, so `discovery` can never masquerade as the Discovery station here.
+    let origin = if role.is_some() {
+        why_gem::origin("dj_gem")
+    } else {
+        why_gem::origin(&model.slot)
     };
+    let reasons = safe_reasons(&model.reasons);
+    let confidence = model
+        .confidence
+        .as_ref()
+        .and_then(serde_json::Number::as_f64)
+        .map(|value| value.clamp(0.0, 1.0));
+
+    let source_text = format!("{}: {}", why_gem::origin_label(), origin);
+    let mut body_rows = 2_u16.saturating_add(wrapped_rows(&source_text, content_width));
+    if let Some(role) = role {
+        let role_text = format!("{}: {role}", why_gem::role_label());
+        body_rows = body_rows.saturating_add(wrapped_rows(&role_text, content_width));
+    }
+    for reason in &reasons {
+        body_rows = body_rows.saturating_add(wrapped_rows(reason, content_width.saturating_sub(2)));
+    }
+    if confidence.is_some() {
+        let confidence_text = format!("{}: 100%", why_gem::confidence_label());
+        body_rows = body_rows.saturating_add(wrapped_rows(&confidence_text, content_width));
+    }
+    let popup_height = body_rows.saturating_add(3).min(area.height); // borders + close hint
+    let popup = centered_fixed(area, popup_width, popup_height);
+
+    crate::ui::render_popup_background(frame, app, popup);
     let block = Block::default()
-        .title(title)
+        .title(format!(" {} ", why_gem::title()))
         .borders(Borders::ALL)
         .border_style(crate::ui::popup_style(app, R::BorderPrimary))
         .style(crate::ui::popup_style(app, R::TextPrimary));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
-    let rows = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(inner);
-    draw_picks(frame, app, rows[0], explain);
+    let hint_height = inner.height.min(1);
+    let body = Rect {
+        x: inner.x,
+        y: inner.y,
+        width: inner.width,
+        height: inner.height.saturating_sub(hint_height),
+    };
+    let hint = Rect {
+        x: inner.x,
+        y: inner.bottom().saturating_sub(hint_height),
+        width: inner.width,
+        height: hint_height,
+    };
+    if !body.is_empty() {
+        draw_details(
+            frame,
+            app,
+            body,
+            &safe_title,
+            &safe_artist,
+            origin,
+            role,
+            &reasons,
+            confidence,
+        );
+    }
+    if !hint.is_empty() {
+        draw_close_hint(frame, app, hint);
+    }
 
-    // The close key respects rebinds (it's the chord bound to `WhyAi`, not a hardcoded `w`).
+    crate::ui::seal_popup_background(frame, app, popup);
+    crate::ui::mark_art_rows_for_popup(frame, app, popup);
+    // Published last, over the covered player/queue hit map, so clicks inside the modal are
+    // consumed while clicks outside can close it without activating anything underneath.
+    app.register_mouse_button(popup, MouseTarget::WhyGemCard);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_details(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    title: &str,
+    artist: &str,
+    origin: &str,
+    role: Option<&str>,
+    reasons: &[&str],
+    confidence: Option<f64>,
+) {
+    let heading = crate::ui::popup_style(app, R::HelpAction).add_modifier(Modifier::BOLD);
+    let label = crate::ui::popup_style(app, R::TextMuted);
+    let value = crate::ui::popup_style(app, R::TextPrimary);
+    let reason_style = crate::ui::popup_style(app, R::HelpAction);
+    let mut lines = Vec::with_capacity(5 + reasons.len());
+    lines.push(Line::from(Span::styled(title.to_owned(), heading)));
+    lines.push(Line::from(Span::styled(artist.to_owned(), label)));
+    lines.push(labelled_line(why_gem::origin_label(), origin, label, value));
+    if let Some(role) = role {
+        lines.push(labelled_line(why_gem::role_label(), role, label, value));
+    }
+    lines.extend(
+        reasons
+            .iter()
+            .map(|reason| Line::from(Span::styled(format!("- {reason}"), reason_style))),
+    );
+    if let Some(confidence) = confidence {
+        let percent = format!("{:.0}%", (confidence * 100.0).round());
+        lines.push(Line::from(vec![
+            Span::styled(format!("{}: ", why_gem::confidence_label()), label),
+            Span::styled(percent, value),
+        ]));
+    }
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+}
+
+fn labelled_line<'a>(
+    label: &'a str,
+    value: &'a str,
+    label_style: ratatui::style::Style,
+    value_style: ratatui::style::Style,
+) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(format!("{label}: "), label_style),
+        Span::styled(value, value_style),
+    ])
+}
+
+/// Bound and deduplicate the model list before allocating frame lines. Only the seven codes in
+/// the localization catalog can survive, and a short scan keeps corrupt remote data from making
+/// every render walk an arbitrarily large vector.
+fn safe_reasons(codes: &[String]) -> Vec<&'static str> {
+    let mut reasons = Vec::with_capacity(7);
+    for reason in codes
+        .iter()
+        .take(32)
+        .filter_map(|code| why_gem::reason(code))
+    {
+        if !reasons.contains(&reason) {
+            reasons.push(reason);
+        }
+        if reasons.len() == 7 {
+            break;
+        }
+    }
+    reasons
+}
+
+fn draw_close_hint(frame: &mut Frame, app: &App, area: Rect) {
     let close_key =
         app.keymap
             .label_for_display(KeyContext::Global, Action::WhyAi, app.retro_mode());
-    let hint = match crate::i18n::current() {
-        crate::i18n::Language::Korean => format!("{close_key} / Esc 닫기"),
-        crate::i18n::Language::Japanese => format!("{close_key} / Esc で閉じる"),
+    let text = match i18n::current() {
+        i18n::Language::Korean => format!("{close_key} / Esc 닫기"),
+        i18n::Language::Japanese => format!("{close_key} / Esc で閉じる"),
         _ => format!("{close_key} / Esc to close"),
     };
     frame.render_widget(
-        Paragraph::new(Line::from(hint))
+        Paragraph::new(text)
             .alignment(Alignment::Center)
             .style(crate::ui::popup_style(app, R::TextMuted)),
-        rows[1],
+        area,
     );
-    crate::ui::seal_popup_background(frame, app, popup);
-    crate::ui::mark_art_rows_for_popup(frame, app, popup);
 }
 
-/// Draw the numbered pick list: each pick is a role badge + track line, with a muted reason line
-/// beneath it.
-fn draw_picks(frame: &mut Frame, app: &App, area: Rect, explain: &crate::app::StreamingAiExplain) {
-    let width = area.width.saturating_sub(2) as usize;
-    let role_style = crate::ui::popup_style(app, R::Accent).add_modifier(Modifier::BOLD);
-    let track_style = crate::ui::popup_style(app, R::HelpAction);
-    let reason_style = crate::ui::popup_style(app, R::TextMuted);
-
-    let mut lines: Vec<Line> = Vec::with_capacity(explain.picks.len() * 2);
-    for (i, p) in explain.picks.iter().enumerate() {
-        let role = p.role.as_deref().map(role_label).unwrap_or("·");
-        let track = truncate_to_width(
-            &format!("{} — {}", p.title, p.artist),
-            width.saturating_sub(12),
-        );
-        lines.push(Line::from(vec![
-            Span::styled(format!("{:>2}. ", i + 1), reason_style),
-            Span::styled(format!("[{role}] "), role_style),
-            Span::styled(track, track_style),
-        ]));
-        let reasons = if p.reasons.is_empty() {
-            t!("(no reasons given)", "(이유 없음)", "(理由なし)").to_owned()
-        } else {
-            p.reasons
-                .iter()
-                .map(|c| reason_label(c))
-                .collect::<Vec<_>>()
-                .join(", ")
-        };
-        lines.push(Line::from(Span::styled(
-            format!(
-                "      {}",
-                truncate_to_width(&reasons, width.saturating_sub(6))
-            ),
-            reason_style,
-        )));
-    }
-    frame.render_widget(Paragraph::new(lines), area);
-}
-
-/// Human-readable slot-role label (the model returns terse codes).
-fn role_label(role: &str) -> &str {
-    match role {
-        "core" => t!("core", "핵심", "中核"),
-        "bridge" => t!("bridge", "연결", "連結"),
-        "adjacent" => t!("adjacent", "인접", "隣接"),
-        "discovery" => t!("discovery", "발견", "発見"),
-        "stabilizer" => t!("stabilizer", "안정", "安定"),
-        "recovery" => t!("recovery", "회복", "回復"),
-        other => other,
-    }
-}
-
-/// Human-readable evidence-code label (matches the score codes in the candidate pack).
-fn reason_label(code: &str) -> &str {
-    match code {
-        "co" => t!("co-occurrence", "동시청취", "同時聴取"),
-        "tr" => t!("transition", "전환", "遷移"),
-        "u" => t!("your affinity", "선호", "好み"),
-        "nov" => t!("novelty", "새로움", "新しさ"),
-        "cont" => t!("continuation", "연속성", "連続性"),
-        "comp" => t!("completion", "완청", "完聴"),
-        "m" => t!("official music", "공식음원", "公式音源"),
-        other => other,
-    }
+fn wrapped_rows(text: &str, width: u16) -> u16 {
+    let width = usize::from(width.max(1));
+    let cells = UnicodeWidthStr::width(text);
+    u16::try_from(cells.div_ceil(width).max(1)).unwrap_or(u16::MAX)
 }
 
 /// A `w`×`h` rect centered in `area`, clamped so it never exceeds the available space.
-fn centered_fixed(area: Rect, w: u16, h: u16) -> Rect {
-    let w = w.min(area.width);
-    let h = h.min(area.height);
+fn centered_fixed(area: Rect, width: u16, height: u16) -> Rect {
+    let width = width.min(area.width);
+    let height = height.min(area.height);
     Rect {
-        x: area.x + area.width.saturating_sub(w) / 2,
-        y: area.y + area.height.saturating_sub(h) / 2,
-        width: w,
-        height: h,
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+    use crate::api::Song;
+    use crate::remote::proto::WhyGemModel;
+
+    fn card_app(model: WhyGemModel) -> App {
+        let mut app = App::new(50);
+        app.queue.set(
+            vec![Song::remote("track", "Test Track", "Test Artist", "3:00")],
+            0,
+        );
+        app.why_gem.upsert("track".to_owned(), model);
+        app.overlays.why_gem_video_id = Some("track".to_owned());
+        app.overlays.why_gem_queue_index = Some(0);
+        app.overlays.why_gem_queue_revision = Some(app.queue.rev());
+        app
+    }
+
+    fn render_text(app: &App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app, frame.area()))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn wrapping_is_nonzero_and_saturating_for_tiny_widths() {
+        assert_eq!(wrapped_rows("", 0), 1);
+        assert_eq!(wrapped_rows("abcd", 0), 4);
+        assert_eq!(wrapped_rows("한글", 2), 2);
+    }
+
+    #[test]
+    fn centered_card_never_escapes_tiny_area() {
+        for area in [
+            Rect::new(0, 0, 0, 0),
+            Rect::new(4, 7, 1, 1),
+            Rect::new(u16::MAX - 2, u16::MAX - 2, 2, 2),
+        ] {
+            let card = centered_fixed(area, CARD_WIDTH, u16::MAX);
+            assert_eq!(card.intersection(area), card);
+        }
+    }
+
+    #[test]
+    fn reasons_drop_unknown_codes_and_duplicates() {
+        let _guard = crate::i18n::lock_for_test();
+        let codes = vec![
+            "tr".to_owned(),
+            "model-output".to_owned(),
+            "tr".to_owned(),
+            "u".to_owned(),
+        ];
+        let reasons = safe_reasons(&codes);
+        assert_eq!(reasons.len(), 2);
+        assert!(reasons[0].contains("transition"));
+        assert!(reasons[1].contains("preferences"));
+    }
+
+    #[test]
+    fn source_only_card_omits_confidence_and_reason_copy() {
+        let _guard = crate::i18n::lock_for_test();
+        let app = card_app(WhyGemModel {
+            slot: "Balanced".to_owned(),
+            reasons: Vec::new(),
+            confidence: None,
+        });
+        let text = render_text(&app, 80, 24);
+        assert!(text.contains("Test Track"));
+        assert!(text.contains("Balanced station"));
+        assert!(!text.contains("Confidence"));
+        assert!(!text.contains("- "));
+    }
+
+    #[test]
+    fn detailed_card_localizes_known_model_codes_and_clamps_confidence() {
+        let _guard = crate::i18n::lock_for_test();
+        let app = card_app(WhyGemModel {
+            slot: "bridge".to_owned(),
+            reasons: vec!["tr".to_owned(), "raw-control\u{1b}".to_owned()],
+            confidence: serde_json::Number::from_f64(1.4),
+        });
+        let text = render_text(&app, 80, 24);
+        assert!(text.contains("Bridge"));
+        assert!(text.contains("smooth transition"));
+        assert!(text.contains("100%"));
+        assert!(!text.contains("raw-control"));
+    }
+
+    #[test]
+    fn discovery_source_and_discovery_role_are_not_confused() {
+        let _guard = crate::i18n::lock_for_test();
+        let source = card_app(WhyGemModel {
+            slot: "Discovery".to_owned(),
+            reasons: Vec::new(),
+            confidence: None,
+        });
+        let source_text = render_text(&source, 80, 24);
+        assert!(source_text.contains("Source: Discovery station"));
+        assert!(!source_text.contains("Role: Discovery"));
+
+        let role = card_app(WhyGemModel {
+            slot: "discovery".to_owned(),
+            reasons: vec!["nov".to_owned()],
+            confidence: serde_json::Number::from_f64(0.8),
+        });
+        let role_text = render_text(&role, 80, 24);
+        assert!(role_text.contains("Source: DJ Gem"));
+        assert!(role_text.contains("Role: Discovery"));
+        assert!(!role_text.contains("Source: Discovery station"));
+    }
+
+    #[test]
+    fn duplicate_video_card_uses_the_selected_queue_occurrence_metadata() {
+        let _guard = crate::i18n::lock_for_test();
+        let mut app = App::new(50);
+        app.queue.set(
+            vec![
+                Song::remote("dup", "First Occurrence", "First Artist", "3:00"),
+                Song::remote("dup", "Second Occurrence", "Second Artist", "3:00"),
+            ],
+            0,
+        );
+        app.why_gem.upsert(
+            "dup".to_owned(),
+            WhyGemModel {
+                slot: "Balanced".to_owned(),
+                reasons: Vec::new(),
+                confidence: None,
+            },
+        );
+        app.overlays.why_gem_video_id = Some("dup".to_owned());
+        app.overlays.why_gem_queue_index = Some(1);
+        app.overlays.why_gem_queue_revision = Some(app.queue.rev());
+
+        let text = render_text(&app, 80, 24);
+        assert!(text.contains("Second Occurrence"));
+        assert!(text.contains("Second Artist"));
+        assert!(!text.contains("First Occurrence"));
+    }
+
+    #[test]
+    fn card_render_does_not_panic_on_tiny_surfaces() {
+        let app = card_app(WhyGemModel {
+            slot: "Balanced".to_owned(),
+            reasons: vec!["co".to_owned(), "tr".to_owned()],
+            confidence: None,
+        });
+        for (width, height) in [(1, 1), (2, 2), (12, 4), (34, 10)] {
+            let _ = render_text(&app, width, height);
+        }
     }
 }

--- a/src/why_gem.rs
+++ b/src/why_gem.rs
@@ -1,0 +1,319 @@
+//! Session-only provenance for recommendation-owned queue rows.
+//!
+//! Both playback owners use this ledger so a `video_id` has one current WhyGem answer,
+//! bounded independently from the queue implementation. The wire model remains owned by
+//! `remote::proto`; this module only owns lifecycle and revision semantics.
+
+use std::collections::HashSet;
+
+/// Keep the provenance store bounded to the same maximum cardinality as the play queue.
+pub const WHY_GEM_MAX: usize = 999;
+
+#[derive(Debug, Clone)]
+pub struct WhyGemLedger<T> {
+    entries: Vec<(String, T)>,
+    revision: u64,
+    reconciled_queue_revision: Option<u64>,
+}
+
+impl<T> Default for WhyGemLedger<T> {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            revision: 0,
+            reconciled_queue_revision: None,
+        }
+    }
+}
+
+impl<T> WhyGemLedger<T> {
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn contains(&self, video_id: &str) -> bool {
+        self.get(video_id).is_some()
+    }
+
+    pub fn get(&self, video_id: &str) -> Option<&T> {
+        self.entries
+            .iter()
+            .find_map(|(id, model)| (id == video_id).then_some(model))
+    }
+
+    pub fn ids(&self) -> Vec<String> {
+        self.entries.iter().map(|(id, _)| id.clone()).collect()
+    }
+
+    fn bump_revision(&mut self) {
+        // A session cannot realistically exhaust u64, but saturation keeps the advertised
+        // revision monotonic instead of allowing a wrap to look older to subscribers.
+        self.revision = self.revision.saturating_add(1);
+    }
+}
+
+impl<T: PartialEq> WhyGemLedger<T> {
+    /// Insert or replace the latest explanation for `video_id`.
+    ///
+    /// Existing keys retain their insertion position. New keys evict the oldest entry when
+    /// the fixed session cap is full. An identical value is an exact no-op, including revision.
+    pub fn upsert(&mut self, video_id: String, model: T) -> bool {
+        if !self.upsert_without_revision(video_id, model) {
+            return false;
+        }
+        self.bump_revision();
+        true
+    }
+
+    /// Apply one recommendation batch with one observable revision transition.
+    pub fn upsert_many<I>(&mut self, entries: I) -> bool
+    where
+        I: IntoIterator<Item = (String, T)>,
+        T: Clone,
+    {
+        // Replay the exact ordered batch against a bounded candidate. Comparing only its final
+        // state preserves cap/eviction semantics (including keys repeated around an eviction)
+        // while keeping a round trip back to the original ledger revision-neutral.
+        let mut candidate = self.clone();
+        for (video_id, model) in entries {
+            candidate.upsert_without_revision(video_id, model);
+        }
+        if candidate.entries == self.entries {
+            return false;
+        }
+        self.entries = candidate.entries;
+        self.reconciled_queue_revision = candidate.reconciled_queue_revision;
+        self.bump_revision();
+        true
+    }
+
+    /// Forget one video's recommendation origin. Duplicate queue rows intentionally share this
+    /// decision because the v1 contract is keyed by `video_id`, not queue occurrence.
+    pub fn forget(&mut self, video_id: &str) -> bool {
+        let Some(index) = self.entries.iter().position(|(id, _)| id == video_id) else {
+            return false;
+        };
+        self.entries.remove(index);
+        self.bump_revision();
+        true
+    }
+
+    /// Forget a batch of manual additions with one observable revision transition.
+    pub fn forget_many<I, S>(&mut self, video_ids: I) -> bool
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let forgotten: HashSet<String> = video_ids
+            .into_iter()
+            .map(|id| id.as_ref().to_owned())
+            .collect();
+        if forgotten.is_empty() {
+            return false;
+        }
+        let before = self.entries.len();
+        self.entries
+            .retain(|(video_id, _)| !forgotten.contains(video_id));
+        if self.entries.len() == before {
+            return false;
+        }
+        self.bump_revision();
+        true
+    }
+
+    pub fn clear(&mut self) -> bool {
+        if self.entries.is_empty() {
+            return false;
+        }
+        self.entries.clear();
+        self.bump_revision();
+        true
+    }
+
+    /// Replace the complete ledger, deduplicating by `video_id` with the last value winning.
+    pub fn replace<I>(&mut self, entries: I) -> bool
+    where
+        I: IntoIterator<Item = (String, T)>,
+    {
+        let mut replacement = Self::default();
+        for (video_id, model) in entries {
+            replacement.upsert_without_revision(video_id, model);
+        }
+        if self.entries == replacement.entries {
+            return false;
+        }
+        self.entries = replacement.entries;
+        self.reconciled_queue_revision = None;
+        self.bump_revision();
+        true
+    }
+
+    /// Drop explanations whose video is no longer represented anywhere in the live queue.
+    /// Repeated owner turns at the same queue revision are allocation-free no-ops.
+    pub fn retain_video_ids<'a, I>(&mut self, queue_revision: u64, video_ids: I) -> bool
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        if self.reconciled_queue_revision == Some(queue_revision) {
+            return false;
+        }
+        self.reconciled_queue_revision = Some(queue_revision);
+        if self.entries.is_empty() {
+            return false;
+        }
+        let live: HashSet<&str> = video_ids.into_iter().collect();
+        let before = self.entries.len();
+        self.entries
+            .retain(|(video_id, _)| live.contains(video_id.as_str()));
+        if self.entries.len() == before {
+            return false;
+        }
+        self.bump_revision();
+        true
+    }
+
+    fn upsert_without_revision(&mut self, video_id: String, model: T) -> bool {
+        if let Some((_, current)) = self.entries.iter_mut().find(|(id, _)| *id == video_id) {
+            if *current == model {
+                return false;
+            }
+            *current = model;
+            return true;
+        }
+        if self.entries.len() >= WHY_GEM_MAX {
+            self.entries.remove(0);
+        }
+        self.reconciled_queue_revision = None;
+        self.entries.push((video_id, model));
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_upsert_is_not_an_observable_mutation() {
+        let mut ledger = WhyGemLedger::default();
+        assert!(ledger.upsert("a".to_owned(), 1));
+        let revision = ledger.revision();
+        assert!(!ledger.upsert("a".to_owned(), 1));
+        assert_eq!(ledger.revision(), revision);
+
+        assert!(ledger.upsert("a".to_owned(), 2));
+        assert!(ledger.revision() > revision);
+        assert_eq!(ledger.get("a"), Some(&2));
+        assert_eq!(ledger.ids(), vec!["a"]);
+    }
+
+    #[test]
+    fn batches_bump_revision_once_and_last_duplicate_wins() {
+        let mut ledger = WhyGemLedger::default();
+        assert!(ledger.upsert_many([
+            ("a".to_owned(), 1),
+            ("b".to_owned(), 2),
+            ("a".to_owned(), 3),
+        ]));
+        assert_eq!(ledger.revision(), 1);
+        assert_eq!(ledger.ids(), vec!["a", "b"]);
+        assert_eq!(ledger.get("a"), Some(&3));
+    }
+
+    #[test]
+    fn ledger_evicts_the_oldest_entry_at_the_queue_cap() {
+        let mut ledger = WhyGemLedger::default();
+        ledger.upsert_many((0..WHY_GEM_MAX).map(|i| (format!("v{i}"), i)));
+        let revision = ledger.revision();
+        assert!(ledger.upsert("new".to_owned(), WHY_GEM_MAX));
+        assert_eq!(ledger.len(), WHY_GEM_MAX);
+        assert!(!ledger.contains("v0"));
+        assert!(ledger.contains("new"));
+        assert_eq!(ledger.revision(), revision + 1);
+    }
+
+    #[test]
+    fn retain_and_forget_only_bump_when_an_entry_disappears() {
+        let mut ledger = WhyGemLedger::default();
+        ledger.upsert_many([("a".to_owned(), 1), ("b".to_owned(), 2)]);
+        let revision = ledger.revision();
+
+        assert!(!ledger.retain_video_ids(1, ["a", "b", "manual"]));
+        assert!(!ledger.retain_video_ids(1, std::iter::empty()));
+        assert!(!ledger.forget("missing"));
+        assert_eq!(ledger.revision(), revision);
+
+        assert!(ledger.retain_video_ids(2, ["b"]));
+        assert_eq!(ledger.ids(), vec!["b"]);
+        assert!(ledger.forget_many(["b", "b"]));
+        assert!(ledger.is_empty());
+    }
+
+    #[test]
+    fn replace_is_atomic_and_deduplicates_with_the_latest_value() {
+        let mut ledger = WhyGemLedger::default();
+        ledger.upsert("old".to_owned(), 0);
+        let revision = ledger.revision();
+        assert!(ledger.replace([
+            ("a".to_owned(), 1),
+            ("a".to_owned(), 2),
+            ("b".to_owned(), 3),
+        ]));
+        assert_eq!(ledger.revision(), revision + 1);
+        assert_eq!(ledger.ids(), vec!["a", "b"]);
+        assert_eq!(ledger.get("a"), Some(&2));
+
+        let revision = ledger.revision();
+        assert!(!ledger.replace([("a".to_owned(), 2), ("b".to_owned(), 3)]));
+        assert_eq!(ledger.revision(), revision);
+    }
+
+    #[test]
+    fn batch_round_trip_is_not_an_observable_mutation() {
+        let mut ledger = WhyGemLedger::default();
+        ledger.upsert("a".to_owned(), 1);
+        let revision = ledger.revision();
+
+        assert!(!ledger.upsert_many([("a".to_owned(), 2), ("a".to_owned(), 1)]));
+        assert_eq!(ledger.get("a"), Some(&1));
+        assert_eq!(ledger.revision(), revision);
+    }
+
+    #[test]
+    fn repeated_key_around_cap_eviction_keeps_the_last_value() {
+        let mut ledger = WhyGemLedger::default();
+        ledger.upsert_many((0..WHY_GEM_MAX).map(|index| (format!("v{index}"), index)));
+
+        assert!(ledger.upsert_many([
+            ("v0".to_owned(), WHY_GEM_MAX + 1),
+            ("new".to_owned(), WHY_GEM_MAX + 2),
+            ("v0".to_owned(), WHY_GEM_MAX + 3),
+        ]));
+        assert_eq!(ledger.get("v0"), Some(&(WHY_GEM_MAX + 3)));
+        assert!(ledger.contains("new"));
+        assert!(!ledger.contains("v1"));
+        assert_eq!(ledger.len(), WHY_GEM_MAX);
+    }
+
+    #[test]
+    fn full_cap_rotation_back_to_the_original_is_revision_neutral() {
+        let mut ledger = WhyGemLedger::default();
+        ledger.upsert_many((0..WHY_GEM_MAX).map(|index| (format!("v{index}"), index)));
+        let revision = ledger.revision();
+        let original_ids = ledger.ids();
+        let batch = std::iter::once(("new".to_owned(), WHY_GEM_MAX))
+            .chain((0..WHY_GEM_MAX).map(|index| (format!("v{index}"), index)));
+
+        assert!(!ledger.upsert_many(batch));
+        assert_eq!(ledger.revision(), revision);
+        assert_eq!(ledger.ids(), original_ids);
+    }
+}


### PR DESCRIPTION
## Summary

- add a bounded, session-only per-video WhyGem provenance ledger shared by the App and daemon owners
- carry request generations through pool, AI rerank, metadata preflight, and admission so stale results cannot be attributed after context changes
- expose contextual w, WHY?, and queue ? actions with a localized modal card and mouse/tiny-terminal safety
- document the new keybinding and cover provenance lifetime, duplicate, admission, parity, and overlay behavior

## Validation

- canonical harness: all fmt, clippy, test, crossterm, and architecture gates passed
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace (library: 3701 passed, 1 ignored; all remaining workspace suites passed)
- GUI generated-type, file-size, and architecture checks passed
- isolated tmux verification at 80x24 and 30x30; w no-provenance notice and clean Ctrl+Q exit verified without playback

## Risk notes

- playback ownership remains dual-implemented in App and daemon; request-context and provenance lifecycle tests keep both paths in lockstep
- WhyGem data is deliberately session-only, capped at 999 video IDs, and committed only for the accepted queue prefix