### PR TITLE
Prepare 1.6.35 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "yututui"
-version = "1.6.34"
+version = "1.6.35"
 dependencies = [
  "anyhow",
  "base64",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "yututui-core"
-version = "1.6.34"
+version = "1.6.35"
 dependencies = [
  "serde",
  "ts-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui"
-version = "1.6.34"
+version = "1.6.35"
 edition = "2024"
 # Releases are repository-built binaries. The application depends on a private workspace core,
 # so make the existing non-crates.io distribution contract explicit and fail closed on publish.

--- a/crates/yututui-core/Cargo.toml
+++ b/crates/yututui-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui-core"
-version = "1.6.34"
+version = "1.6.35"
 edition = "2024"
 publish = false
 description = "Pure playback policies shared by yututui playback owners."

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           lib = pkgs.lib;
           yututui = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui";
-            version = "1.6.34"; # keep in sync with Cargo.toml
+            version = "1.6.35"; # keep in sync with Cargo.toml
 
             # Drop build artifacts and flake results from the copied source so the store path
             # stays small and rebuilds aren't invalidated by a local `target/`.
@@ -72,7 +72,7 @@
           # correct hash to paste here (docs/gui/04 §9 risk 2).
           guiDist = pkgs.buildNpmPackage {
             pname = "yututui-gui";
-            version = "1.6.34"; # private GUI package version; not part of the release surface
+            version = "1.6.35"; # private GUI package version; not part of the release surface
             src = ./gui;
             npmDepsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
             dontNpmInstall = true;
@@ -84,7 +84,7 @@
           };
           yututui-desktop = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui-desktop";
-            version = "1.6.34"; # keep the yututray binary version in sync with Cargo.toml
+            version = "1.6.35"; # keep the yututray binary version in sync with Cargo.toml
             src = desktopSrc;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = [ pkgs.makeWrapper pkgs.pkg-config ];


### PR DESCRIPTION
## Summary
- Bump workspace version 1.6.34 → 1.6.35 (`Cargo.toml`, `crates/yututui-core/Cargo.toml`, `Cargo.lock`, `flake.nix`) — same shape as the 1.6.33/1.6.34 prep commits.
- Includes everything merged to `main` since v1.6.34: artist search category + artist detail screen (#107), per-track why-gem recommendation provenance (#106), dependabot actions/checkout bump (#104).

## Release-artifact dry run
`build.yml` was dispatched (`workflow_dispatch`) on this branch to produce the full release artifact set. Publish jobs are tag-gated (`startsWith(github.ref, 'refs/tags/v')`) and do NOT run on dispatch — no homebrew/scoop/AUR side effects.

## Publish (human step)
After merge, the user tags `v1.6.35` on the merge commit (with the usual sanction granted) to trigger the actual publish. Agents do not create or push tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018q3QTSyBBcJhy54s6vJtLJ