### PR TITLE
Prepare 1.6.35 release preflight

### DIFF
--- a/.github/workflows/release-preflight-1.6.35.yml
+++ b/.github/workflows/release-preflight-1.6.35.yml
@@ -1,24 +1,24 @@
-name: release preflight 1.6.34
+name: release preflight 1.6.35
 
 on:
   pull_request:
     branches: [main]
 
 concurrency:
-  group: release-preflight-1.6.34-${{ github.event.pull_request.number }}
+  group: release-preflight-1.6.35-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 env:
-  PREFLIGHT_VERSION: 1.6.34
+  PREFLIGHT_VERSION: 1.6.35
 
 permissions:
   contents: read
 
 jobs:
   verify-version:
-    name: Verify synchronized 1.6.34 source versions
+    name: Verify synchronized 1.6.35 source versions
     if: >-
-      github.head_ref == 'agent/aggregate-1.6.34-preflight' &&
+      github.head_ref == 'agent/aggregate-1.6.35-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +53,7 @@ jobs:
   release-build:
     name: Native release build and package
     if: >-
-      github.head_ref == 'agent/aggregate-1.6.34-preflight' &&
+      github.head_ref == 'agent/aggregate-1.6.35-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: verify-version
     uses: ./.github/workflows/native-release-build.yml
@@ -62,9 +62,9 @@ jobs:
       pull-requests: read
 
   aggregate:
-    name: Aggregate 1.6.34 preflight artifacts
+    name: Aggregate 1.6.35 preflight artifacts
     if: >-
-      github.head_ref == 'agent/aggregate-1.6.34-preflight' &&
+      github.head_ref == 'agent/aggregate-1.6.35-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: release-build
     runs-on: ubuntu-latest
@@ -146,7 +146,7 @@ jobs:
       - name: Upload complete preflight bundle
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: yututui-1.6.34-preflight
+          name: yututui-1.6.35-preflight
           if-no-files-found: error
           retention-days: 14
           path: |
@@ -158,10 +158,10 @@ jobs:
             checksums.txt
 
   preflight-result:
-    name: Release preflight 1.6.34 result
+    name: Release preflight 1.6.35 result
     if: >-
       always() &&
-      github.head_ref == 'agent/aggregate-1.6.34-preflight' &&
+      github.head_ref == 'agent/aggregate-1.6.35-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: [verify-version, release-build, aggregate]
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "yututui"
-version = "1.6.34"
+version = "1.6.35"
 dependencies = [
  "anyhow",
  "base64",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "yututui-core"
-version = "1.6.34"
+version = "1.6.35"
 dependencies = [
  "serde",
  "ts-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui"
-version = "1.6.34"
+version = "1.6.35"
 edition = "2024"
 # Releases are repository-built binaries. The application depends on a private workspace core,
 # so make the existing non-crates.io distribution contract explicit and fail closed on publish.

--- a/crates/yututui-core/Cargo.toml
+++ b/crates/yututui-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui-core"
-version = "1.6.34"
+version = "1.6.35"
 edition = "2024"
 publish = false
 description = "Pure playback policies shared by yututui playback owners."

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           lib = pkgs.lib;
           yututui = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui";
-            version = "1.6.34"; # keep in sync with Cargo.toml
+            version = "1.6.35"; # keep in sync with Cargo.toml
 
             # Drop build artifacts and flake results from the copied source so the store path
             # stays small and rebuilds aren't invalidated by a local `target/`.
@@ -72,7 +72,7 @@
           # correct hash to paste here (docs/gui/04 §9 risk 2).
           guiDist = pkgs.buildNpmPackage {
             pname = "yututui-gui";
-            version = "1.6.34"; # private GUI package version; not part of the release surface
+            version = "1.6.35"; # private GUI package version; not part of the release surface
             src = ./gui;
             npmDepsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
             dontNpmInstall = true;
@@ -84,7 +84,7 @@
           };
           yututui-desktop = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui-desktop";
-            version = "1.6.34"; # keep the yututray binary version in sync with Cargo.toml
+            version = "1.6.35"; # keep the yututray binary version in sync with Cargo.toml
             src = desktopSrc;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = [ pkgs.makeWrapper pkgs.pkg-config ];


### PR DESCRIPTION
## Summary
- Bump workspace version 1.6.34 → 1.6.35 in `Cargo.toml`, `crates/yututui-core/Cargo.toml`, `Cargo.lock`, and all three `flake.nix` versions — same file set as the 1.6.33/1.6.34 prep commits.
- Rename `release-preflight-1.6.34.yml` → `release-preflight-1.6.35.yml` (mechanical 1.6.34→1.6.35 substitution), scoped to this head branch per the cycle convention.
- Includes everything merged to `main` since v1.6.34: artist search category + artist detail screen (#107), per-track why-gem recommendation provenance (#106), dependabot actions/checkout bump (#104).

## Release-artifact preflight
The `release preflight 1.6.35` workflow on this PR verifies synchronized source versions, runs the reusable `native-release-build.yml` across all targets, verifies the full artifact set + checksums, and uploads the `yututui-1.6.35-preflight` bundle. Publish jobs in `build.yml` remain tag-gated and are untouched — no homebrew/scoop/AUR side effects from this PR.

## Verification
- Local canonical gates on the bumped tree: fmt / clippy / test (workspace + vendored crossterm) and all six arch checks — all PASS (run-gates log `yututui-20260720-232226`).

## Publish (human step)
After merge, tagging `v1.6.35` on the merge commit (with the usual user-granted sanction) triggers the actual publish. Agents do not create or push tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018q3QTSyBBcJhy54s6vJtLJ