### PR TITLE
feat(player): inherit volume in video overlay

### DIFF
--- a/src/app/video_transition.rs
+++ b/src/app/video_transition.rs
@@ -398,9 +398,13 @@ impl App {
             })
             .ok();
         let child = match spawner {
-            VideoSpawner::Real => {
-                spawn_video_overlay(&url, cookies.as_deref(), layout, ipc_path.as_deref())
-            }
+            VideoSpawner::Real => spawn_video_overlay(
+                &url,
+                cookies.as_deref(),
+                layout,
+                self.playback.volume,
+                ipc_path.as_deref(),
+            ),
             #[cfg(test)]
             VideoSpawner::Fake => spawn_fake_video_overlay_process()
                 .map_err(|error| tracing::warn!(%error, "fake video overlay failed to spawn"))

--- a/src/daemon/engine.rs
+++ b/src/daemon/engine.rs
@@ -536,6 +536,7 @@ impl DaemonEngine {
             &url,
             cookies.as_deref(),
             self.config.video_layout,
+            self.playback.volume,
             None,
         );
         let Some(overlay) = overlay else {

--- a/src/video_overlay.rs
+++ b/src/video_overlay.rs
@@ -2,16 +2,23 @@
 //! admission-atomic transition (`src/app/video_transition.rs`) and the daemon's
 //! `PlayVideo` remote command host both launch the same window.
 
+fn video_overlay_base_args(url: &str, volume_percent: i64) -> Vec<String> {
+    let volume_percent = volume_percent.clamp(0, crate::playback_policy::VOLUME_MAX);
+    vec![url.to_owned(), format!("--volume={volume_percent}")]
+}
+
 /// Spawn a borderless, always-on-top mpv overlay window for `url`, returning the child so the
 /// caller can track and later close it. Stdio is nulled so mpv can't touch the TUI's terminal.
 /// Cookies are forwarded to mpv's bundled yt-dlp (same option as the audio instance) when set;
 /// `--no-config` is intentionally omitted so the user's own mpv config applies to the video.
+/// `volume_percent` overrides only its startup volume with the owner's live music volume.
 /// With `ipc_path`, the window exposes a JSON IPC endpoint and gets `--keep-open=yes`, so a
 /// natural end pauses on the last frame (observable, and re-loadable) instead of exiting.
 pub fn spawn_video_overlay(
     url: &str,
     cookies: Option<&std::path::Path>,
     layout: crate::config::VideoOverlay,
+    volume_percent: i64,
     ipc_path: Option<&str>,
 ) -> Option<crate::util::process_tree::OwnedProcessTree> {
     if let Err(error) = crate::player::lifetime::ensure_media_start_allowed() {
@@ -22,7 +29,7 @@ pub fn spawn_video_overlay(
         tracing::warn!(%error, "refusing to spawn an unprotected video overlay");
         return None;
     }
-    let mut args = vec![url.to_owned()];
+    let mut args = video_overlay_base_args(url, volume_percent);
     // The audio instance already owns the OS media session; without this the
     // overlay mpv would register a second, duplicate entry (mpv >= 0.39 does so
     // by default even for a plain window). As a CLI option it wins over the
@@ -57,4 +64,19 @@ pub fn spawn_video_overlay(
         .map(crate::util::process_tree::OwnedProcessTree::new_guarded)
         .inspect_err(|error| tracing::warn!(%error, "protected video overlay spawn failed"))
         .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::video_overlay_base_args;
+
+    #[test]
+    fn base_args_inherit_live_volume_once_and_clamp() {
+        for (input, expected) in [(-1, 0), (0, 0), (37, 37), (100, 100), (101, 100)] {
+            let args = video_overlay_base_args("https://example.test/watch", input);
+            let expected = format!("--volume={expected}");
+
+            assert_eq!(args, ["https://example.test/watch".to_owned(), expected]);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- start each new mpv video overlay at the current live music-session volume
- apply the same behavior to the TUI and daemon/GUI playback owners
- clamp the startup volume to the supported 0–100 range and cover the argument construction with a regression test

## Why

The video overlay is a separate mpv process, so it previously started with its own configured or default volume instead of the volume the user was already listening at. Passing the live owner volume as a startup argument prevents an unexpected loud or quiet transition.

## User impact

Opening a video now preserves the current music volume. Muted music opens the video at volume 0. The inheritance is startup-only; an existing overlay keeps its own volume during subsequent in-window loads.

## Validation

- `nix develop --command cargo test video_overlay`
- `nix develop --command cargo test app::tests::video`
- `nix develop --command cargo test daemon::parity_tests`
- `nix develop --command /home/wmochi/.fable-harness/bin/run-gates .`