### PR TITLE
feat(sync): add guided TUI sync workflows

### DIFF
--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -32,6 +32,7 @@ impl App {
             personal_export: PersonalDataExportState::default(),
             personal_state: PersonalStateRuntime {
                 ledger: personal_state,
+                sync_ui: SyncUiState::default(),
                 ..PersonalStateRuntime::default()
             },
             playback: Playback {

--- a/src/app/context_menu.rs
+++ b/src/app/context_menu.rs
@@ -216,7 +216,8 @@ impl App {
     /// Whether another modal owns input. The queue and search-filter popups are deliberately
     /// excluded: their semantic rows are valid context-menu targets.
     fn context_menu_blocked(&self) -> bool {
-        self.overlays.help_visible
+        self.personal_state.sync_ui.modal_open()
+            || self.overlays.help_visible
             || self.overlays.mouse_help_visible
             || self.overlays.about_visible
             || self.overlays.why_gem_video_id.is_some()

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -37,6 +37,11 @@ impl App {
         if self.tool_setup.is_some() {
             return self.on_key_tool_setup(k);
         }
+        // Sync setup and pairing are Settings-owned, top-level modals. They keep ownership even
+        // if the terminal shrinks to Mini or the underlying Settings screen is closed.
+        if self.personal_state.sync_ui.modal_open() {
+            return self.on_key_sync_wizard(k);
+        }
         // Beginner Mode's F6 focus bridge runs before ordinary surface routing, while every
         // established overlay keeps precedence. Unowned keys continue through unchanged.
         if !self.beginner_higher_overlay_open()
@@ -571,7 +576,8 @@ impl App {
     fn mini_mode_owns_modal(&self) -> bool {
         match self.mode {
             Mode::Settings => {
-                self.overlays.spotify_picker.is_some()
+                self.personal_state.sync_ui.modal_open()
+                    || self.overlays.spotify_picker.is_some()
                     || self.settings.as_ref().is_some_and(|s| {
                         s.spotify_import_mode_dropdown.is_some() || s.color_picker.is_some()
                     })
@@ -621,6 +627,12 @@ impl App {
     /// Whether a focused text field is currently capturing typed characters (so command
     /// keys and the `?` help shortcut must not fire — they'd be typed instead).
     pub(in crate::app) fn in_text_entry(&self) -> bool {
+        if matches!(
+            self.personal_state.sync_ui.wizard.as_ref(),
+            Some(SyncWizard::Setup { .. } | SyncWizard::Join { .. } | SyncWizard::Recovery(_))
+        ) {
+            return true;
+        }
         if self
             .overlays
             .audio_output_picker

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -173,8 +173,18 @@ mod settings_reducer;
 mod spotify_import_reducer;
 mod stream_metadata;
 mod streaming_reducer;
+mod sync_activation;
+mod sync_ui;
 pub(in crate::app) use clipboard::{copy_to_clipboard, spotify_auth_url_status};
 pub use streaming_reducer::StreamingMsg;
+pub use sync_activation::{SyncActivationCommit, SyncActivationPersisted};
+pub(crate) use sync_activation::{
+    SyncActivationCommitStage, SyncActivationKind, SyncActivationPersistOutcome,
+};
+pub(crate) use sync_ui::{
+    ConnectionField as SyncConnectionField, FormError as SyncFormError, SyncConnectionForm,
+    SyncJoinRequest, SyncRecoveryForm, SyncUiCommand, SyncUiEvent, SyncUiState, SyncWizard,
+};
 
 /// Autoplay/streaming and play-error breaker thresholds used by App reducers. Re-exported so
 /// this module's submodules keep resolving the names; refill admission itself lives in the

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -348,7 +348,7 @@ impl App {
         self.interaction.context_menu_press = false;
         self.interaction.drag_selection = None;
         self.interaction.drag_scrollbar = None;
-        if self.overlays.why_gem_video_id.is_some() {
+        if self.personal_state.sync_ui.modal_open() || self.overlays.why_gem_video_id.is_some() {
             self.cancel_seekbar_scrub();
             self.interaction.ai_transcript_drag = None;
             return Vec::new();

--- a/src/app/mouse/scrollbar.rs
+++ b/src/app/mouse/scrollbar.rs
@@ -173,6 +173,9 @@ impl App {
         if st.tab == SettingsTab::Keys {
             return None;
         }
+        if st.tab == SettingsTab::Sync {
+            return Some(self.sync_settings_model().rows.len());
+        }
         let fields = st.fields();
         // `st.sections()` (not `st.tab.sections()`) so the scroll length matches the
         // visibility-filtered field list in every mode.

--- a/src/app/mouse_routing.rs
+++ b/src/app/mouse_routing.rs
@@ -9,6 +9,19 @@ impl App {
         row: u16,
         multi: bool,
     ) -> Vec<Cmd> {
+        // The Sync wizard is rendered last and owns the whole screen while open. Only its
+        // explicit controls act; every other click is consumed to prevent click-through.
+        if self.personal_state.sync_ui.modal_open() {
+            return match self.mouse_target_at(col, row) {
+                Some(
+                    target @ (MouseTarget::SyncWizardField(_)
+                    | MouseTarget::SyncWizardPrimary
+                    | MouseTarget::SyncWizardSecondary
+                    | MouseTarget::SyncWizardReveal),
+                ) => self.on_sync_wizard_mouse_target(target),
+                _ => Vec::new(),
+            };
+        }
         if self.tool_setup.is_some() {
             return self
                 .mouse_target_at(col, row)
@@ -625,10 +638,34 @@ impl App {
                 Vec::new()
             }
             MouseTarget::SettingsTab(i) if self.mode == Mode::Settings => {
-                self.settings_select_tab(i);
-                Vec::new()
+                self.settings_select_tab(i)
             }
             MouseTarget::SettingsTab(_) => Vec::new(),
+            MouseTarget::SettingsSyncRow(index)
+                if self.mode == Mode::Settings
+                    && self
+                        .settings
+                        .as_ref()
+                        .is_some_and(|settings| settings.tab == SettingsTab::Sync)
+                    && index < self.sync_settings_model().rows.len() =>
+            {
+                self.personal_state.sync_ui.row = index;
+                self.dirty = true;
+                self.activate_sync_row()
+            }
+            MouseTarget::SettingsSyncRow(_) => Vec::new(),
+            target @ (MouseTarget::SyncWizardField(_)
+            | MouseTarget::SyncWizardPrimary
+            | MouseTarget::SyncWizardSecondary
+            | MouseTarget::SyncWizardReveal) => {
+                if self.personal_state.sync_ui.modal_open() {
+                    self.on_sync_wizard_mouse_target(target)
+                } else {
+                    // A stale hit map after the modal closes must fail closed instead of
+                    // reaching the Settings surface underneath it.
+                    Vec::new()
+                }
+            }
             MouseTarget::SettingsChange { row, delta } if self.mode == Mode::Settings => {
                 if self.settings_close_spotify_import_mode_dropdown() {
                     return Vec::new();

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -198,17 +198,24 @@ impl App {
     }
 
     /// Select a Settings tab by index into [`SettingsTab::ALL`] (from a tab click).
-    pub(in crate::app) fn settings_select_tab(&mut self, index: usize) {
+    pub(in crate::app) fn settings_select_tab(&mut self, index: usize) -> Vec<Cmd> {
+        let mut entered_sync = false;
         if let Some(st) = self.settings.as_mut()
             && let Some(&tab) = SettingsTab::ALL.get(index)
         {
             st.tab = tab;
+            entered_sync = tab == SettingsTab::Sync;
             st.row = 0;
             st.editing_text = false;
             st.capturing = None;
             // The new tab has a different row set; drop the old offset so it starts at the top.
             self.bridges.reset_settings_scroll();
             self.dirty = true;
+        }
+        if entered_sync {
+            self.request_sync_ui_refresh()
+        } else {
+            Vec::new()
         }
     }
 

--- a/src/app/onboarding.rs
+++ b/src/app/onboarding.rs
@@ -536,12 +536,10 @@ impl App {
             return Vec::new();
         };
         if !self.onboarding.settings_tab_visited {
-            self.settings_select_tab(SettingsTab::Playback.index());
-            return Vec::new();
+            return self.settings_select_tab(SettingsTab::Playback.index());
         }
         if tab != SettingsTab::General {
-            self.settings_select_tab(SettingsTab::General.index());
-            return Vec::new();
+            return self.settings_select_tab(SettingsTab::General.index());
         }
         let cmds = self.advance_beginner_step();
         self.focus_beginner_mode_setting();

--- a/src/app/personal_sync.rs
+++ b/src/app/personal_sync.rs
@@ -19,16 +19,36 @@ pub enum PersonalSyncAction {
 /// Debug is deliberately absent so retained outcome diagnostics cannot accidentally expand to
 /// transport internals.
 #[derive(Clone)]
-pub struct PersonalSyncReply(std::sync::Arc<std::sync::Mutex<Option<crate::remote::RemoteReply>>>);
+pub struct PersonalSyncReply(std::sync::Arc<PersonalSyncReplyInner>);
+
+struct PersonalSyncReplyInner {
+    remote: std::sync::Mutex<Option<crate::remote::RemoteReply>>,
+    tui_flow_id: Option<u64>,
+}
 
 impl PersonalSyncReply {
     pub(crate) fn new(reply: crate::remote::RemoteReply) -> Self {
-        Self(std::sync::Arc::new(std::sync::Mutex::new(Some(reply))))
+        Self(std::sync::Arc::new(PersonalSyncReplyInner {
+            remote: std::sync::Mutex::new(Some(reply)),
+            tui_flow_id: None,
+        }))
+    }
+
+    pub(crate) fn tui(flow_id: u64) -> Self {
+        Self(std::sync::Arc::new(PersonalSyncReplyInner {
+            remote: std::sync::Mutex::new(None),
+            tui_flow_id: Some(flow_id),
+        }))
+    }
+
+    pub(crate) fn tui_flow_id(&self) -> Option<u64> {
+        self.0.tui_flow_id
     }
 
     pub(crate) fn respond(&self, response: crate::remote::proto::RemoteResponse) {
         let mut reply = self
             .0
+            .remote
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if let Some(reply) = reply.take() {
@@ -96,12 +116,16 @@ pub(crate) struct PersonalStateRuntime {
     pub(crate) ledger: crate::personal_state::PersonalStateV2,
     pub(crate) device_id: Option<crate::personal_state::DeviceId>,
     pub(crate) sync: PersonalSyncState,
+    pub(crate) sync_ui: SyncUiState,
 }
 
 #[derive(Clone)]
-struct PersonalSyncShutdownContext {
-    observed_state: crate::personal_state::PersonalStateV2,
-    candidate: crate::sync::service::PreparedManualSync,
+enum PersonalSyncShutdownContext {
+    Manual {
+        observed_state: Box<crate::personal_state::PersonalStateV2>,
+        candidate: Box<crate::sync::service::PreparedManualSync>,
+    },
+    Activation(Box<SyncActivationCommit>),
 }
 
 impl App {
@@ -110,8 +134,26 @@ impl App {
         action: PersonalSyncAction,
         reply: crate::remote::RemoteReply,
     ) -> Vec<Cmd> {
-        let reply = PersonalSyncReply::new(reply);
+        self.start_personal_sync_with_reply(action, PersonalSyncReply::new(reply))
+    }
+
+    pub(in crate::app) fn start_personal_sync_for_tui(
+        &mut self,
+        action: PersonalSyncAction,
+        flow_id: u64,
+    ) -> Vec<Cmd> {
+        self.start_personal_sync_with_reply(action, PersonalSyncReply::tui(flow_id))
+    }
+
+    fn start_personal_sync_with_reply(
+        &mut self,
+        action: PersonalSyncAction,
+        reply: PersonalSyncReply,
+    ) -> Vec<Cmd> {
         if self.personal_state.sync.in_progress {
+            if let Some(flow_id) = reply.tui_flow_id() {
+                self.finish_tui_personal_sync_error(flow_id, SyncServiceError::LocalStateChanged);
+            }
             reply.respond(RemoteResponse::err_with_message(
                 "sync_busy",
                 "personal sync is already running".to_owned(),
@@ -119,6 +161,9 @@ impl App {
             return Vec::new();
         }
         if self.personal_state.device_id.is_none() {
+            if let Some(flow_id) = reply.tui_flow_id() {
+                self.finish_tui_personal_sync_error(flow_id, SyncServiceError::NotConfigured);
+            }
             reply.respond(sync_error_response(SyncServiceError::NotConfigured));
             return Vec::new();
         }
@@ -164,10 +209,11 @@ impl App {
                 ),
             Ok(candidate) => {
                 let summary = candidate.summary.clone();
-                self.personal_state.sync.shutdown_context = Some(PersonalSyncShutdownContext {
-                    observed_state: current_state.clone(),
-                    candidate: candidate.clone(),
-                });
+                self.personal_state.sync.shutdown_context =
+                    Some(PersonalSyncShutdownContext::Manual {
+                        observed_state: Box::new(current_state.clone()),
+                        candidate: Box::new(candidate.clone()),
+                    });
                 vec![Cmd::Persist(PersistCmd::PersonalSyncCommit(Box::new(
                     PersonalSyncCommit {
                         action: prepared.action,
@@ -264,9 +310,14 @@ impl App {
                 self.personal_state.sync.shutdown_context = None;
                 let message = sync_summary(&commit.action, &commit.summary);
                 commit.reply.respond(RemoteResponse::ok(message.clone()));
-                self.status.text = message;
-                self.status.kind = StatusKind::Info;
-                self.dirty = true;
+                if let Some(flow_id) = commit.reply.tui_flow_id() {
+                    self.finish_tui_personal_sync(flow_id, &commit.action, &commit.summary);
+                    return Vec::new();
+                } else {
+                    self.status.text = message;
+                    self.status.kind = StatusKind::Info;
+                    self.dirty = true;
+                }
                 Vec::new()
             }
         }
@@ -293,21 +344,52 @@ impl App {
         let current = self
             .reconcile_personal_state(&self.playlists)
             .map_err(SyncServiceError::from)?;
-        let local_device = self
-            .personal_state
-            .device_id
-            .as_ref()
-            .ok_or(SyncServiceError::NotConfigured)?;
-        crate::sync::service::PersonalSyncPersistence::shutdown(
-            context.observed_state.clone(),
-            current,
-            self.playlists.revision(),
-            context.candidate.clone(),
-            local_device,
-            personal_paths,
-            sync_paths,
-        )
+        match context {
+            PersonalSyncShutdownContext::Manual {
+                observed_state,
+                candidate,
+            } => {
+                let local_device = self
+                    .personal_state
+                    .device_id
+                    .as_ref()
+                    .ok_or(SyncServiceError::NotConfigured)?;
+                crate::sync::service::PersonalSyncPersistence::shutdown(
+                    observed_state.as_ref().clone(),
+                    current,
+                    self.playlists.revision(),
+                    candidate.as_ref().clone(),
+                    local_device,
+                    personal_paths,
+                    sync_paths,
+                )
+            }
+            PersonalSyncShutdownContext::Activation(commit) => commit.shutdown_persistence(
+                current,
+                self.playlists.revision(),
+                personal_paths,
+                sync_paths,
+            ),
+        }
         .map(Some)
+    }
+
+    pub(in crate::app) fn retain_sync_activation_shutdown_context(
+        &mut self,
+        commit: &SyncActivationCommit,
+    ) {
+        self.personal_state.sync.shutdown_context = Some(PersonalSyncShutdownContext::Activation(
+            Box::new(commit.clone()),
+        ));
+    }
+
+    pub(in crate::app) fn clear_sync_activation_shutdown_context(&mut self) {
+        if matches!(
+            self.personal_state.sync.shutdown_context,
+            Some(PersonalSyncShutdownContext::Activation(_))
+        ) {
+            self.personal_state.sync.shutdown_context = None;
+        }
     }
 
     fn retry_personal_sync(
@@ -333,10 +415,14 @@ impl App {
         self.personal_state.sync.in_progress = false;
         self.personal_state.sync.pending_reply = None;
         reply.respond(sync_error_response(error));
-        self.set_status_error(error.to_string());
+        if let Some(flow_id) = reply.tui_flow_id() {
+            self.finish_tui_personal_sync_error(flow_id, error);
+        } else {
+            self.set_status_error(error.to_string());
+        }
     }
 
-    fn install_personal_sync_runtime(
+    pub(in crate::app) fn install_personal_sync_runtime(
         &mut self,
         state: crate::personal_state::PersonalStateV2,
     ) -> Result<(), SyncServiceError> {

--- a/src/app/reducer.rs
+++ b/src/app/reducer.rs
@@ -37,6 +37,7 @@ impl App {
         // leftover `Info` color from a previous green toast.
         self.status.kind = StatusKind::Error;
         let mut cmds = self.dispatch(msg);
+        cmds.extend(self.start_pending_sync_ui_refresh());
         // A refill is scoped to the exact queue membership/order snapshot it started from.
         // Observe revisions after every owner reduction so an admitted manual replacement cannot
         // leave an old same-seed chain eligible merely because that video id is still present.
@@ -201,7 +202,7 @@ impl App {
         if self.expire_lyrics_delay_osd(Instant::now()) {
             self.dirty = true;
         }
-        Vec::new()
+        self.poll_sync_ui_if_due()
     }
 
     fn handle_player(&mut self, pm: PlayerMsg) -> Vec<Cmd> {
@@ -1008,6 +1009,19 @@ impl App {
         {
             return Vec::new();
         }
+        // The Settings-owned Sync wizard captures every pointer event. Ordinary clicks keep
+        // flowing through its hit-tested modal route. The paired double-click is consumed so the
+        // first press cannot both open and immediately confirm a destructive step.
+        if self.personal_state.sync_ui.modal_open() {
+            match &msg {
+                Msg::MouseDoubleClick { .. }
+                | Msg::MouseRightClick { .. }
+                | Msg::MouseRightDoubleClick { .. }
+                | Msg::MouseDrag { .. }
+                | Msg::MouseScroll { .. } => return Vec::new(),
+                _ => {}
+            }
+        }
         // A picker-opening/applying press owns its paired double-click. Check this before the
         // open-modal route: the second press of a swatch double-click arrives after the first has
         // opened the picker and must not be reinterpreted against the newly rendered popup.
@@ -1081,6 +1095,12 @@ impl App {
             }
             Msg::Data(DataMsg::PersonalSyncPersisted(persisted)) => {
                 return self.finish_personal_sync_persistence(*persisted);
+            }
+            Msg::Data(DataMsg::SyncActivationPersisted(persisted)) => {
+                return self.finish_sync_activation_persistence(*persisted);
+            }
+            Msg::Data(DataMsg::SyncUi(event)) => {
+                return self.finish_sync_ui_event(event);
             }
             Msg::Media(cmd) => return self.apply_media(cmd),
             Msg::MediaArtworkReady(ready) => {

--- a/src/app/settings_reducer.rs
+++ b/src/app/settings_reducer.rs
@@ -248,6 +248,10 @@ impl App {
             .settings
             .as_ref()
             .is_some_and(|s| s.tab == SettingsTab::Keys);
+        let on_sync_tab = self
+            .settings
+            .as_ref()
+            .is_some_and(|s| s.tab == SettingsTab::Sync);
         let on_mouse_binding = self.settings_current_mouse_binding().is_some();
         // A color row can now live anywhere (the Graphics tab), so the "reset color" key gates
         // on the focused field's type rather than a dedicated Colors tab.
@@ -271,12 +275,16 @@ impl App {
             // `q`/Esc commit the draft before leaving the screen. The action name stays
             // SettingsCancel for compatibility with existing keybinding ids.
             Some(Action::SettingsCancel | Action::Back) => self.close_settings(),
-            Some(Action::FocusNext) => {
-                self.settings_switch_tab(true);
+            Some(Action::FocusNext) => self.settings_switch_tab(true),
+            Some(Action::FocusPrev) => self.settings_switch_tab(false),
+            Some(Action::MoveUp) if on_sync_tab => {
+                self.personal_state.sync_ui.move_row(-1);
+                self.dirty = true;
                 Vec::new()
             }
-            Some(Action::FocusPrev) => {
-                self.settings_switch_tab(false);
+            Some(Action::MoveDown) if on_sync_tab => {
+                self.personal_state.sync_ui.move_row(1);
+                self.dirty = true;
                 Vec::new()
             }
             Some(Action::MoveUp) => {
@@ -297,6 +305,7 @@ impl App {
             }
             Some(Action::ChangeDecrease) if !on_keys_tab => self.settings_change(-1),
             Some(Action::ChangeIncrease) if !on_keys_tab => self.settings_change(1),
+            Some(Action::Confirm) if on_sync_tab => self.activate_sync_row(),
             Some(Action::Confirm) => {
                 if on_mouse_binding {
                     self.settings_change_mouse_binding(1);
@@ -481,9 +490,11 @@ impl App {
         }
     }
 
-    pub(in crate::app) fn settings_switch_tab(&mut self, forward: bool) {
+    pub(in crate::app) fn settings_switch_tab(&mut self, forward: bool) -> Vec<Cmd> {
+        let mut entered_sync = false;
         if let Some(st) = self.settings.as_mut() {
             st.tab = st.tab.stepped(forward);
+            entered_sync = st.tab == SettingsTab::Sync;
             st.row = 0;
             st.editing_text = false;
             st.capturing = None;
@@ -492,10 +503,20 @@ impl App {
             self.bridges.reset_settings_scroll();
             self.dirty = true;
         }
+        if entered_sync {
+            self.request_sync_ui_refresh()
+        } else {
+            Vec::new()
+        }
     }
 
     pub(in crate::app) fn settings_move_row(&mut self, delta: i32) {
         if let Some(st) = self.settings.as_mut() {
+            if st.tab == SettingsTab::Sync {
+                self.personal_state.sync_ui.move_row(delta);
+                self.dirty = true;
+                return;
+            }
             // The Keys tab is a list of remappable bindings rather than `Field`s.
             let n = match st.tab {
                 SettingsTab::Keys => {

--- a/src/app/sync_activation.rs
+++ b/src/app/sync_activation.rs
@@ -1,0 +1,415 @@
+//! Owner-lane completion for setup and device-pairing activation.
+//!
+//! Network workers only prepare transitions. This module sends the exact candidate through the
+//! PersonalState persistence lane, rebasing any local operations that race the durable commit.
+
+use super::sync_ui::localized_sync_error;
+use super::*;
+use crate::sync::service::{
+    PreparedPairingApproval, PreparedPairingJoinActivation, PreparedSetup, SyncServiceError,
+};
+
+const MAX_ACTIVATION_RETRIES: u8 = 3;
+
+fn activation_retry_limit_reached(
+    stage: &SyncActivationCommitStage,
+    attempt: u8,
+    count_initial_attempt: bool,
+) -> bool {
+    count_initial_attempt
+        && matches!(stage, SyncActivationCommitStage::Initial)
+        && attempt >= MAX_ACTIVATION_RETRIES
+}
+
+#[derive(Clone)]
+pub(crate) enum SyncActivationKind {
+    Setup(PreparedSetup),
+    PairJoin(PreparedPairingJoinActivation),
+    PairApprove {
+        prepared: PreparedPairingApproval,
+        network_observed_state: crate::personal_state::PersonalStateV2,
+    },
+}
+
+impl SyncActivationKind {
+    pub(crate) fn device_id(
+        &self,
+    ) -> Result<Option<crate::personal_state::DeviceId>, SyncServiceError> {
+        match self {
+            Self::Setup(prepared) => Ok(Some(prepared.device_id().clone())),
+            Self::PairJoin(prepared) => crate::personal_state::DeviceId::new(prepared.device_id())
+                .map(Some)
+                .map_err(|_| SyncServiceError::InvalidRemoteData),
+            Self::PairApprove { .. } => Ok(None),
+        }
+    }
+
+    pub(crate) fn target_state_for(
+        &self,
+        current: &crate::personal_state::PersonalStateV2,
+    ) -> Result<crate::personal_state::PersonalStateV2, SyncServiceError> {
+        match self {
+            Self::Setup(prepared) => prepared.target_state(current),
+            Self::PairJoin(prepared) => prepared.target_state_for(current),
+            Self::PairApprove {
+                prepared,
+                network_observed_state,
+            } => Ok(prepared
+                .retarget(network_observed_state, current)?
+                .candidate()
+                .state
+                .clone()),
+        }
+    }
+
+    /// Extend an activation which has already crossed its private/ledger commit boundary.
+    ///
+    /// A joining device is special: its first deletion-free import is now part of the
+    /// authenticated dataset, so every later local snapshot must extend that durable baseline
+    /// instead of rebuilding a replacement baseline from the original checkpoint.
+    fn target_state_after_commit(
+        &self,
+        durable: &crate::personal_state::PersonalStateV2,
+        current: &crate::personal_state::PersonalStateV2,
+    ) -> Result<crate::personal_state::PersonalStateV2, SyncServiceError> {
+        match self {
+            Self::PairJoin(prepared) => {
+                let device_id = crate::personal_state::DeviceId::new(prepared.device_id())
+                    .map_err(|_| SyncServiceError::InvalidRemoteData)?;
+                let mut candidate =
+                    crate::personal_state::plan_join_import(durable, current, &device_id)?
+                        .candidate;
+                if candidate != *current && candidate.revision <= current.revision {
+                    candidate.revision = current.revision.saturating_add(1);
+                    candidate.projection_fingerprint = None;
+                    candidate.normalize()?;
+                }
+                Ok(candidate)
+            }
+            Self::Setup(prepared) => {
+                let candidate = prepared.target_state(current)?;
+                crate::sync::service::verify_activation_extension(durable, &candidate)?;
+                Ok(candidate)
+            }
+            Self::PairApprove {
+                prepared,
+                network_observed_state,
+            } => {
+                let candidate = prepared
+                    .retarget(network_observed_state, current)?
+                    .candidate()
+                    .state
+                    .clone();
+                crate::sync::service::verify_activation_extension(durable, &candidate)?;
+                Ok(candidate)
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) enum SyncActivationCommitStage {
+    Initial,
+    Reconcile {
+        expected_state: Box<crate::personal_state::PersonalStateV2>,
+        candidate: Box<crate::personal_state::PersonalStateV2>,
+    },
+}
+
+#[derive(Clone)]
+pub struct SyncActivationCommit {
+    pub(crate) flow_id: u64,
+    pub(crate) attempt: u8,
+    pub(crate) kind: SyncActivationKind,
+    pub(crate) observed_local_state: crate::personal_state::PersonalStateV2,
+    pub(crate) playlist_revision: u64,
+    pub(crate) stage: SyncActivationCommitStage,
+}
+
+pub(crate) enum SyncActivationPersistOutcome {
+    Committed(Box<crate::personal_state::PersonalStateV2>),
+    Superseded,
+    Failed(SyncServiceError),
+}
+
+pub struct SyncActivationPersisted {
+    pub(crate) commit: Box<SyncActivationCommit>,
+    pub(crate) outcome: SyncActivationPersistOutcome,
+}
+
+impl App {
+    pub(in crate::app) fn start_sync_activation(
+        &mut self,
+        flow_id: u64,
+        kind: SyncActivationKind,
+    ) -> Vec<Cmd> {
+        if !self.personal_state.sync_ui.is_current(flow_id) {
+            return Vec::new();
+        }
+        if self.personal_state.sync.in_progress {
+            self.finish_sync_activation_error(flow_id, SyncServiceError::LocalStateChanged);
+            return Vec::new();
+        }
+        let current = match self.reconcile_personal_state(&self.playlists) {
+            Ok(state) => state,
+            Err(_) => {
+                self.finish_sync_activation_error(flow_id, SyncServiceError::Storage);
+                return Vec::new();
+            }
+        };
+        if let Err(error) = kind.target_state_for(&current) {
+            self.finish_sync_activation_error(flow_id, error);
+            return Vec::new();
+        }
+        self.personal_state.sync.in_progress = true;
+        self.dirty = true;
+        self.schedule_sync_activation_commit(Box::new(SyncActivationCommit {
+            flow_id,
+            attempt: 1,
+            kind,
+            observed_local_state: current,
+            playlist_revision: self.playlists.revision(),
+            stage: SyncActivationCommitStage::Initial,
+        }))
+    }
+
+    pub(in crate::app) fn finish_sync_activation_persistence(
+        &mut self,
+        persisted: SyncActivationPersisted,
+    ) -> Vec<Cmd> {
+        let SyncActivationPersisted {
+            mut commit,
+            outcome,
+        } = persisted;
+        if !self.personal_state.sync_ui.is_current(commit.flow_id)
+            || !self.personal_state.sync.in_progress
+        {
+            return Vec::new();
+        }
+        match outcome {
+            SyncActivationPersistOutcome::Failed(error) => {
+                self.finish_sync_activation_error(commit.flow_id, error);
+                Vec::new()
+            }
+            SyncActivationPersistOutcome::Superseded => {
+                if matches!(commit.stage, SyncActivationCommitStage::Initial) {
+                    return self.retry_sync_activation(commit, true);
+                }
+                let current = match self.reconcile_personal_state(&self.playlists) {
+                    Ok(state) => state,
+                    Err(_) => {
+                        self.finish_sync_activation_error(
+                            commit.flow_id,
+                            SyncServiceError::Storage,
+                        );
+                        return Vec::new();
+                    }
+                };
+                let SyncActivationCommitStage::Reconcile { expected_state, .. } = &commit.stage
+                else {
+                    unreachable!("initial activation was handled above");
+                };
+                let candidate = match commit
+                    .kind
+                    .target_state_after_commit(expected_state, &current)
+                {
+                    Ok(candidate) => candidate,
+                    Err(error) => {
+                        self.finish_sync_activation_error(commit.flow_id, error);
+                        return Vec::new();
+                    }
+                };
+                commit.observed_local_state = current;
+                commit.playlist_revision = self.playlists.revision();
+                commit.stage = SyncActivationCommitStage::Reconcile {
+                    expected_state: expected_state.clone(),
+                    candidate: Box::new(candidate),
+                };
+                self.retry_sync_activation(commit, false)
+            }
+            SyncActivationPersistOutcome::Committed(durable_state) => {
+                let current = match self.reconcile_personal_state(&self.playlists) {
+                    Ok(state) => state,
+                    Err(_) => {
+                        self.finish_sync_activation_error(
+                            commit.flow_id,
+                            SyncServiceError::Storage,
+                        );
+                        return Vec::new();
+                    }
+                };
+                if current != commit.observed_local_state {
+                    let candidate = match commit
+                        .kind
+                        .target_state_after_commit(&durable_state, &current)
+                    {
+                        Ok(candidate) => candidate,
+                        Err(error) => {
+                            self.finish_sync_activation_error(commit.flow_id, error);
+                            return Vec::new();
+                        }
+                    };
+                    commit.observed_local_state = current;
+                    commit.playlist_revision = self.playlists.revision();
+                    commit.stage = SyncActivationCommitStage::Reconcile {
+                        expected_state: durable_state,
+                        candidate: Box::new(candidate),
+                    };
+                    return self.retry_sync_activation(commit, false);
+                }
+                let device_id = match commit.kind.device_id() {
+                    Ok(device_id) => device_id,
+                    Err(error) => {
+                        self.finish_sync_activation_error(commit.flow_id, error);
+                        return Vec::new();
+                    }
+                };
+                if let Err(error) = self.install_personal_sync_runtime(*durable_state) {
+                    self.finish_sync_activation_error(commit.flow_id, error);
+                    return Vec::new();
+                }
+                if let Some(device_id) = device_id {
+                    self.personal_state.device_id = Some(device_id);
+                }
+                self.personal_state.sync.in_progress = false;
+                self.clear_sync_activation_shutdown_context();
+                self.personal_state.sync_ui.busy = None;
+                self.queue_sync_ui_refresh();
+                self.personal_state
+                    .sync_ui
+                    .finish_activation_success(&commit.kind);
+                self.dirty = true;
+                Vec::new()
+            }
+        }
+    }
+
+    fn retry_sync_activation(
+        &mut self,
+        mut commit: Box<SyncActivationCommit>,
+        count_initial_attempt: bool,
+    ) -> Vec<Cmd> {
+        if activation_retry_limit_reached(&commit.stage, commit.attempt, count_initial_attempt) {
+            self.finish_sync_activation_error(commit.flow_id, SyncServiceError::LocalStateChanged);
+            return Vec::new();
+        }
+        if count_initial_attempt && matches!(commit.stage, SyncActivationCommitStage::Initial) {
+            commit.attempt = commit.attempt.saturating_add(1);
+        }
+        if matches!(commit.stage, SyncActivationCommitStage::Initial) {
+            let current = match self.reconcile_personal_state(&self.playlists) {
+                Ok(state) => state,
+                Err(_) => {
+                    self.finish_sync_activation_error(commit.flow_id, SyncServiceError::Storage);
+                    return Vec::new();
+                }
+            };
+            commit.observed_local_state = current;
+            commit.playlist_revision = self.playlists.revision();
+        }
+        self.schedule_sync_activation_commit(commit)
+    }
+
+    fn schedule_sync_activation_commit(&mut self, commit: Box<SyncActivationCommit>) -> Vec<Cmd> {
+        self.retain_sync_activation_shutdown_context(&commit);
+        vec![Cmd::Persist(PersistCmd::SyncActivationCommit(commit))]
+    }
+
+    fn finish_sync_activation_error(&mut self, flow_id: u64, error: SyncServiceError) {
+        self.personal_state.sync.in_progress = false;
+        if self.personal_state.sync_ui.is_current(flow_id) {
+            self.personal_state.sync_ui.busy = None;
+            self.queue_sync_ui_refresh();
+            self.personal_state.sync_ui.wizard = Some(SyncWizard::Result {
+                success: false,
+                message: localized_sync_error(error),
+            });
+            self.dirty = true;
+        }
+    }
+}
+
+impl SyncActivationCommit {
+    pub(in crate::app) fn shutdown_persistence(
+        &self,
+        current: crate::personal_state::PersonalStateV2,
+        playlist_revision: u64,
+        personal_paths: crate::personal_state::PersonalStatePaths,
+        sync_paths: crate::sync::SyncPaths,
+    ) -> Result<crate::sync::service::PersonalSyncPersistence, SyncServiceError> {
+        let (durable_state, possible_reconcile_state) = match &self.stage {
+            SyncActivationCommitStage::Initial => (
+                self.kind.target_state_for(&self.observed_local_state)?,
+                None,
+            ),
+            SyncActivationCommitStage::Reconcile {
+                expected_state,
+                candidate,
+            } => (
+                expected_state.as_ref().clone(),
+                Some(candidate.as_ref().clone()),
+            ),
+        };
+        match &self.kind {
+            SyncActivationKind::Setup(prepared) => {
+                crate::sync::service::PersonalSyncPersistence::setup_activation_shutdown(
+                    current,
+                    playlist_revision,
+                    durable_state,
+                    possible_reconcile_state,
+                    prepared.clone(),
+                    personal_paths,
+                    sync_paths,
+                )
+            }
+            SyncActivationKind::PairJoin(prepared) => {
+                crate::sync::service::PersonalSyncPersistence::pairing_join_activation_shutdown(
+                    current,
+                    playlist_revision,
+                    durable_state,
+                    possible_reconcile_state,
+                    prepared.clone(),
+                    personal_paths,
+                    sync_paths,
+                )
+            }
+            SyncActivationKind::PairApprove {
+                prepared,
+                network_observed_state,
+            } => {
+                crate::sync::service::PersonalSyncPersistence::pairing_approval_activation_shutdown(
+                    network_observed_state.clone(),
+                    current,
+                    playlist_revision,
+                    durable_state,
+                    possible_reconcile_state,
+                    prepared.clone(),
+                    personal_paths,
+                    sync_paths,
+                )
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn committed_reconciliation_never_uses_the_initial_retry_limit() {
+        let state =
+            crate::personal_state::PersonalStateV2::empty("activation-retry".to_owned()).unwrap();
+        let stage = SyncActivationCommitStage::Reconcile {
+            expected_state: Box::new(state.clone()),
+            candidate: Box::new(state),
+        };
+
+        assert!(!activation_retry_limit_reached(&stage, u8::MAX, true));
+        assert!(activation_retry_limit_reached(
+            &SyncActivationCommitStage::Initial,
+            MAX_ACTIVATION_RETRIES,
+            true
+        ));
+    }
+}

--- a/src/app/sync_ui/event_reducer.rs
+++ b/src/app/sync_ui/event_reducer.rs
@@ -1,0 +1,505 @@
+use super::*;
+
+impl SyncUiState {
+    pub(crate) fn finish_activation_success(&mut self, kind: &super::super::SyncActivationKind) {
+        self.auto_poll_enabled = false;
+        let message = match kind {
+            super::super::SyncActivationKind::Setup(prepared) => match crate::i18n::current() {
+                crate::i18n::Language::Korean => {
+                    format!(
+                        "암호화 동기화를 설정했어요 (복구 확인값: {})",
+                        short_checksum(prepared.recovery_checksum())
+                    )
+                }
+                crate::i18n::Language::Japanese => {
+                    format!(
+                        "暗号化同期を設定しました（復旧チェック値: {}）",
+                        short_checksum(prepared.recovery_checksum())
+                    )
+                }
+                _ => format!(
+                    "Encrypted personal sync is ready (recovery check: {}).",
+                    short_checksum(prepared.recovery_checksum())
+                ),
+            },
+            super::super::SyncActivationKind::PairJoin(prepared) => {
+                let summary = prepared.summary();
+                match crate::i18n::current() {
+                    crate::i18n::Language::Korean => {
+                        format!(
+                            "기기를 연결했어요: {}개 변경 병합",
+                            summary.operations_added
+                        )
+                    }
+                    crate::i18n::Language::Japanese => {
+                        format!(
+                            "デバイスを接続しました: {}件を統合",
+                            summary.operations_added
+                        )
+                    }
+                    _ => format!(
+                        "Device connected: {} changes merged.",
+                        summary.operations_added
+                    ),
+                }
+            }
+            super::super::SyncActivationKind::PairApprove { prepared, .. } => {
+                match crate::i18n::current() {
+                    crate::i18n::Language::Korean => {
+                        format!("{} 기기를 승인했어요", prepared.target_device_name())
+                    }
+                    crate::i18n::Language::Japanese => {
+                        format!("{} を承認しました", prepared.target_device_name())
+                    }
+                    _ => format!("Approved {}.", prepared.target_device_name()),
+                }
+            }
+        };
+        self.wizard = Some(SyncWizard::Result {
+            success: true,
+            message,
+        });
+    }
+}
+
+impl super::super::App {
+    pub(in crate::app) fn reduce_sync_ui_event(
+        &mut self,
+        event: SyncUiEvent,
+    ) -> Vec<super::super::Cmd> {
+        let flow_id = sync_event_flow_id(&event);
+        if !self.personal_state.sync_ui.is_current(flow_id) {
+            return Vec::new();
+        }
+        match event {
+            SyncUiEvent::Refreshed {
+                request_id, result, ..
+            } => {
+                if self.personal_state.sync_ui.refresh_in_flight != Some(request_id) {
+                    return Vec::new();
+                }
+                self.personal_state.sync_ui.refresh_in_flight = None;
+                if self.personal_state.sync_ui.busy == Some(SyncBusy::Refresh) {
+                    self.personal_state.sync_ui.busy = None;
+                }
+                if request_id != self.personal_state.sync_ui.refresh_request_id {
+                    self.dirty = true;
+                    return Vec::new();
+                }
+                match *result {
+                    Ok(overview) => self.personal_state.sync_ui.set_overview(overview),
+                    Err(error) => {
+                        self.set_status_error(localized_sync_error(error));
+                    }
+                }
+                self.dirty = true;
+                Vec::new()
+            }
+            SyncUiEvent::RecoveryExported { result, .. } => {
+                self.personal_state.sync_ui.busy = None;
+                self.queue_sync_ui_refresh();
+                self.personal_state.sync_ui.wizard = Some(match *result {
+                    Ok(result) => SyncWizard::Result {
+                        success: true,
+                        message: match crate::i18n::current() {
+                            crate::i18n::Language::Korean => {
+                                format!(
+                                    "복구 키트를 확인하고 저장했어요 (확인값: {})",
+                                    short_checksum(&result.checksum)
+                                )
+                            }
+                            crate::i18n::Language::Japanese => {
+                                format!(
+                                    "復旧キットを確認して保存しました（チェック値: {}）",
+                                    short_checksum(&result.checksum)
+                                )
+                            }
+                            _ => format!(
+                                "Recovery kit verified and saved (check: {}).",
+                                short_checksum(&result.checksum)
+                            ),
+                        },
+                    },
+                    Err(error) => SyncWizard::Result {
+                        success: false,
+                        message: localized_sync_error(error),
+                    },
+                });
+                self.dirty = true;
+                Vec::new()
+            }
+            SyncUiEvent::SetupPrepared { result, .. } => match *result {
+                Ok(prepared) => {
+                    self.personal_state.sync_ui.busy = Some(SyncBusy::Setup);
+                    self.start_sync_activation(
+                        flow_id,
+                        super::super::SyncActivationKind::Setup(prepared),
+                    )
+                }
+                Err(error) => {
+                    self.sync_worker_failed(error);
+                    Vec::new()
+                }
+            },
+            SyncUiEvent::HostCreated { result, .. } => {
+                self.personal_state.sync_ui.busy = None;
+                match *result {
+                    Ok(host) => {
+                        let code = Zeroizing::new(host.code().to_owned());
+                        let expires_at_unix = host.expires_at_unix();
+                        self.personal_state.sync_ui.last_poll_unix =
+                            Some(crate::signals::unix_now());
+                        self.personal_state.sync_ui.auto_poll_enabled = true;
+                        self.personal_state.sync_ui.wizard = Some(SyncWizard::Host {
+                            code,
+                            expires_at_unix,
+                            host: Some(Box::new(host)),
+                            review: None,
+                        });
+                    }
+                    Err(error) => self.sync_worker_failed(error),
+                }
+                self.dirty = true;
+                Vec::new()
+            }
+            SyncUiEvent::HostPolled { host, result, .. } => {
+                self.personal_state.sync_ui.busy = None;
+                let (code, expires_at_unix) = take_host_display(&mut self.personal_state.sync_ui)
+                    .unwrap_or_else(|| {
+                        (
+                            Zeroizing::new(host.code().to_owned()),
+                            host.expires_at_unix(),
+                        )
+                    });
+                match *result {
+                    Ok(review) => {
+                        self.personal_state.sync_ui.last_poll_unix =
+                            Some(crate::signals::unix_now());
+                        self.personal_state.sync_ui.auto_poll_enabled = review.is_none();
+                        self.personal_state.sync_ui.wizard = Some(SyncWizard::Host {
+                            code,
+                            expires_at_unix,
+                            host: Some(host),
+                            review: review.map(Box::new),
+                        });
+                    }
+                    Err(error) => {
+                        self.personal_state.sync_ui.auto_poll_enabled = false;
+                        if host_error_can_retry(error) {
+                            self.personal_state.sync_ui.wizard = Some(SyncWizard::Host {
+                                code,
+                                expires_at_unix,
+                                host: Some(host),
+                                review: None,
+                            });
+                            self.sync_worker_error_status(error);
+                        } else {
+                            self.personal_state.sync_ui.wizard = Some(SyncWizard::Result {
+                                success: false,
+                                message: localized_sync_error(error),
+                            });
+                            self.queue_sync_ui_refresh();
+                            self.set_status_error(localized_sync_error(error));
+                        }
+                    }
+                }
+                self.dirty = true;
+                Vec::new()
+            }
+            SyncUiEvent::HostApprovalPrepared {
+                host,
+                observed_state,
+                result,
+                ..
+            } => match *result {
+                Ok(prepared) => {
+                    self.personal_state.sync_ui.busy = Some(SyncBusy::PairHostApprove);
+                    self.start_sync_activation(
+                        flow_id,
+                        super::super::SyncActivationKind::PairApprove {
+                            prepared,
+                            network_observed_state: *observed_state,
+                        },
+                    )
+                }
+                Err(error) => {
+                    let (code, expires_at_unix) =
+                        take_host_display(&mut self.personal_state.sync_ui).unwrap_or_else(|| {
+                            (
+                                Zeroizing::new(host.code().to_owned()),
+                                host.expires_at_unix(),
+                            )
+                        });
+                    self.personal_state.sync_ui.auto_poll_enabled = false;
+                    if host_error_can_retry(error) {
+                        self.personal_state.sync_ui.wizard = Some(SyncWizard::Host {
+                            code,
+                            expires_at_unix,
+                            host: Some(host),
+                            review: None,
+                        });
+                        self.sync_worker_error_status(error);
+                    } else {
+                        self.personal_state.sync_ui.wizard = Some(SyncWizard::Result {
+                            success: false,
+                            message: localized_sync_error(error),
+                        });
+                        self.queue_sync_ui_refresh();
+                        self.set_status_error(localized_sync_error(error));
+                    }
+                    Vec::new()
+                }
+            },
+            SyncUiEvent::HostCancelled { host, result, .. } => {
+                self.personal_state.sync_ui.busy = None;
+                self.personal_state.sync_ui.auto_poll_enabled = false;
+                self.personal_state.sync_ui.wizard = Some(match result {
+                    Ok(()) => {
+                        self.queue_sync_ui_refresh();
+                        SyncWizard::Result {
+                            success: true,
+                            message: crate::t!(
+                                "Device connection cancelled.",
+                                "기기 연결을 취소했어요.",
+                                "デバイス接続をキャンセルしました。"
+                            )
+                            .to_owned(),
+                        }
+                    }
+                    Err(error) => {
+                        self.set_status_error(localized_sync_error(error));
+                        SyncWizard::Host {
+                            code: Zeroizing::new(host.code().to_owned()),
+                            expires_at_unix: host.expires_at_unix(),
+                            host: Some(host),
+                            review: None,
+                        }
+                    }
+                });
+                Vec::new()
+            }
+            SyncUiEvent::JoinStarted { result, .. } => {
+                self.personal_state.sync_ui.busy = None;
+                match *result {
+                    Ok(waiting) => {
+                        self.personal_state.sync_ui.last_poll_unix = None;
+                        self.personal_state.sync_ui.auto_poll_enabled = true;
+                        self.personal_state.sync_ui.wizard =
+                            Some(SyncWizard::JoinWaiting(Box::new(waiting)));
+                        self.start_join_poll(flow_id)
+                    }
+                    Err(error) => {
+                        self.sync_worker_failed(error);
+                        Vec::new()
+                    }
+                }
+            }
+            SyncUiEvent::JoinPolled { result, .. } => {
+                self.personal_state.sync_ui.busy = None;
+                match *result {
+                    Ok(Some(preview)) => {
+                        self.personal_state.sync_ui.auto_poll_enabled = false;
+                        self.personal_state.sync_ui.wizard =
+                            Some(SyncWizard::JoinPreview(Box::new(preview)));
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        self.personal_state.sync_ui.auto_poll_enabled = false;
+                        self.sync_worker_failed(error);
+                    }
+                }
+                self.dirty = true;
+                Vec::new()
+            }
+            SyncUiEvent::JoinResumed { result, .. } => {
+                self.personal_state.sync_ui.busy = None;
+                match *result {
+                    Ok(preview) => {
+                        self.personal_state.sync_ui.auto_poll_enabled = false;
+                        self.personal_state.sync_ui.wizard =
+                            Some(SyncWizard::JoinPreview(Box::new(preview)));
+                    }
+                    Err(error) => self.sync_worker_failed(error),
+                }
+                self.dirty = true;
+                Vec::new()
+            }
+            SyncUiEvent::JoinDiscarded { result, .. } => {
+                self.personal_state.sync_ui.busy = None;
+                self.personal_state.sync_ui.auto_poll_enabled = false;
+                self.queue_sync_ui_refresh();
+                self.personal_state.sync_ui.wizard = Some(match result {
+                    Ok(()) => SyncWizard::Result {
+                        success: true,
+                        message: crate::t!(
+                            "The unfinished connection was discarded. Local listening data was not changed.",
+                            "완료되지 않은 연결을 버렸습니다. 이 기기의 감상 데이터는 변경되지 않았습니다.",
+                            "未完了の接続を破棄しました。ローカルの再生データは変更されていません。"
+                        )
+                        .to_owned(),
+                    },
+                    Err(error) => SyncWizard::Result {
+                        success: false,
+                        message: localized_discard_error(error),
+                    },
+                });
+                self.dirty = true;
+                Vec::new()
+            }
+            SyncUiEvent::JoinActivationPrepared { result, .. } => match *result {
+                Ok(prepared) => {
+                    self.personal_state.sync_ui.busy = Some(SyncBusy::PairJoinApply);
+                    self.start_sync_activation(
+                        flow_id,
+                        super::super::SyncActivationKind::PairJoin(prepared),
+                    )
+                }
+                Err(error) => {
+                    self.sync_worker_failed(error);
+                    Vec::new()
+                }
+            },
+        }
+    }
+
+    fn sync_worker_failed(&mut self, error: crate::sync::service::SyncServiceError) {
+        self.personal_state.sync_ui.busy = None;
+        self.personal_state.sync_ui.auto_poll_enabled = false;
+        self.queue_sync_ui_refresh();
+        self.personal_state.sync_ui.wizard = Some(SyncWizard::Result {
+            success: false,
+            message: localized_sync_error(error),
+        });
+        self.set_status_error(localized_sync_error(error));
+        self.dirty = true;
+    }
+
+    fn sync_worker_error_status(&mut self, error: crate::sync::service::SyncServiceError) {
+        self.personal_state.sync_ui.busy = None;
+        self.queue_sync_ui_refresh();
+        self.set_status_error(localized_sync_error(error));
+        self.dirty = true;
+    }
+
+    pub(in crate::app::sync_ui) fn start_join_poll(
+        &mut self,
+        flow_id: u64,
+    ) -> Vec<super::super::Cmd> {
+        self.personal_state.sync_ui.auto_poll_enabled = true;
+        self.personal_state.sync_ui.busy = Some(SyncBusy::PairJoinPoll);
+        self.personal_state.sync_ui.last_poll_unix = Some(crate::signals::unix_now());
+        vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
+            SyncUiCommand::JoinPoll {
+                flow_id,
+                state: Box::new(self.personal_state.ledger.clone()),
+            },
+        ))]
+    }
+
+    pub(in crate::app) fn poll_sync_ui_if_due(&mut self) -> Vec<super::super::Cmd> {
+        if self.personal_state.sync_ui.busy.is_some()
+            || !self.personal_state.sync_ui.auto_poll_enabled
+        {
+            return Vec::new();
+        }
+        let now = crate::signals::unix_now();
+        if self
+            .personal_state
+            .sync_ui
+            .last_poll_unix
+            .is_some_and(|last| now.saturating_sub(last) < 2)
+        {
+            return Vec::new();
+        }
+        match self.personal_state.sync_ui.wizard.take() {
+            Some(SyncWizard::JoinWaiting(waiting)) => {
+                self.personal_state.sync_ui.wizard = Some(SyncWizard::JoinWaiting(waiting));
+                self.start_join_poll(self.personal_state.sync_ui.flow_id)
+            }
+            Some(SyncWizard::Host {
+                code,
+                expires_at_unix,
+                host: Some(host),
+                review: None,
+            }) => {
+                self.personal_state.sync_ui.busy = Some(SyncBusy::PairHostPoll);
+                self.personal_state.sync_ui.last_poll_unix = Some(now);
+                self.personal_state.sync_ui.wizard = Some(SyncWizard::Host {
+                    code,
+                    expires_at_unix,
+                    host: None,
+                    review: None,
+                });
+                vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
+                    SyncUiCommand::HostPoll {
+                        flow_id: self.personal_state.sync_ui.flow_id,
+                        state: Box::new(self.personal_state.ledger.clone()),
+                        host,
+                    },
+                ))]
+            }
+            other => {
+                self.personal_state.sync_ui.wizard = other;
+                Vec::new()
+            }
+        }
+    }
+}
+fn sync_event_flow_id(event: &SyncUiEvent) -> u64 {
+    match event {
+        SyncUiEvent::Refreshed { flow_id, .. }
+        | SyncUiEvent::RecoveryExported { flow_id, .. }
+        | SyncUiEvent::SetupPrepared { flow_id, .. }
+        | SyncUiEvent::HostCreated { flow_id, .. }
+        | SyncUiEvent::HostPolled { flow_id, .. }
+        | SyncUiEvent::HostApprovalPrepared { flow_id, .. }
+        | SyncUiEvent::HostCancelled { flow_id, .. }
+        | SyncUiEvent::JoinStarted { flow_id, .. }
+        | SyncUiEvent::JoinPolled { flow_id, .. }
+        | SyncUiEvent::JoinResumed { flow_id, .. }
+        | SyncUiEvent::JoinDiscarded { flow_id, .. }
+        | SyncUiEvent::JoinActivationPrepared { flow_id, .. } => *flow_id,
+    }
+}
+
+fn short_checksum(checksum: &str) -> String {
+    checksum.chars().take(12).collect()
+}
+
+fn take_host_display(state: &mut SyncUiState) -> Option<(Zeroizing<String>, i64)> {
+    let SyncWizard::Host {
+        code,
+        expires_at_unix,
+        ..
+    } = state.wizard.take()?
+    else {
+        return None;
+    };
+    Some((code, expires_at_unix))
+}
+
+fn host_error_can_retry(error: crate::sync::service::SyncServiceError) -> bool {
+    use crate::sync::service::SyncServiceError as E;
+    matches!(
+        error,
+        E::PendingApproval
+            | E::Authentication
+            | E::Certificate
+            | E::Offline
+            | E::LocalStateChanged
+            | E::Storage
+    )
+}
+
+fn localized_discard_error(error: crate::sync::service::SyncServiceError) -> String {
+    use crate::sync::service::SyncServiceError as E;
+    match error {
+        E::AlreadyConfigured | E::LocalStateChanged => crate::t!(
+            "The connection changed and was kept. Continue it, or remove the device from an existing device if it was already approved.",
+            "연결 상태가 바뀌어 그대로 유지했습니다. 연결을 이어가거나, 이미 승인된 경우 기존 기기에서 해당 기기를 제거하세요.",
+            "接続状態が変わったため保持しました。接続を再開するか、承認済みの場合は既存のデバイスからこのデバイスを削除してください。"
+        )
+        .to_owned(),
+        _ => localized_sync_error(error),
+    }
+}

--- a/src/app/sync_ui/form.rs
+++ b/src/app/sync_ui/form.rs
@@ -1,0 +1,438 @@
+use age::secrecy::SecretString;
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::personal_state::DeviceRecord;
+use crate::sync::{MAX_CUSTOM_CA_PEM_BYTES, VaultCredential};
+use crate::util::text_edit::TextCursor;
+
+const MAX_ENDPOINT_CHARS: usize = 2_048;
+const MAX_USERNAME_CHARS: usize = 512;
+const MAX_SECRET_CHARS: usize = 8_192;
+const MAX_DEVICE_NAME_CHARS: usize = 128;
+const MAX_PAIRING_CODE_CHARS: usize = 128;
+const MAX_PATH_CHARS: usize = 4_096;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConnectionField {
+    Endpoint,
+    Username,
+    Secret,
+    DeviceName,
+    CustomCa,
+    RecoveryFile,
+    PairingCode,
+}
+
+impl ConnectionField {
+    pub(crate) fn is_secret(self) -> bool {
+        matches!(self, Self::Secret | Self::PairingCode)
+    }
+}
+
+/// Secret-bearing connection form. It is deliberately neither `Clone` nor `Debug`.
+pub(crate) struct SyncConnectionForm {
+    endpoint: String,
+    username: String,
+    secret: String,
+    device_name: String,
+    custom_ca: String,
+    recovery_file: String,
+    pairing_code: String,
+    pub(crate) field: usize,
+    pub(crate) cursor: TextCursor,
+    revealed_field: Option<ConnectionField>,
+}
+
+impl SyncConnectionForm {
+    pub(crate) fn setup() -> Self {
+        Self::new(false)
+    }
+
+    pub(crate) fn join() -> Self {
+        Self::new(true)
+    }
+
+    fn new(join: bool) -> Self {
+        let mut form = Self {
+            endpoint: String::new(),
+            username: String::new(),
+            secret: String::new(),
+            device_name: default_device_name(),
+            custom_ca: String::new(),
+            recovery_file: String::new(),
+            pairing_code: String::new(),
+            field: 0,
+            cursor: TextCursor::default(),
+            revealed_field: None,
+        };
+        if !join {
+            form.recovery_file = default_recovery_path();
+        }
+        form
+    }
+
+    pub(crate) fn fields(&self, join: bool) -> &'static [ConnectionField] {
+        if join {
+            &[
+                ConnectionField::Endpoint,
+                ConnectionField::Username,
+                ConnectionField::Secret,
+                ConnectionField::DeviceName,
+                ConnectionField::CustomCa,
+                ConnectionField::PairingCode,
+            ]
+        } else {
+            &[
+                ConnectionField::Endpoint,
+                ConnectionField::Username,
+                ConnectionField::Secret,
+                ConnectionField::DeviceName,
+                ConnectionField::CustomCa,
+                ConnectionField::RecoveryFile,
+            ]
+        }
+    }
+
+    pub(crate) fn current_field(&self, join: bool) -> ConnectionField {
+        let fields = self.fields(join);
+        fields[self.field.min(fields.len().saturating_sub(1))]
+    }
+
+    pub(crate) fn select_field(&mut self, join: bool, next: i32) {
+        let len = self.fields(join).len() as i32;
+        self.field = (self.field as i32 + next).clamp(0, len.saturating_sub(1)) as usize;
+        self.revealed_field = None;
+        self.cursor = TextCursor::at_end(self.current_value(join));
+    }
+
+    pub(crate) fn select_field_at(&mut self, join: bool, field: usize) {
+        if field >= self.fields(join).len() {
+            return;
+        }
+        self.field = field;
+        self.revealed_field = None;
+        self.cursor = TextCursor::at_end(self.current_value(join));
+    }
+
+    pub(crate) fn current_secret_is_revealed(&self, join: bool) -> bool {
+        self.revealed_field == Some(self.current_field(join))
+    }
+
+    pub(crate) fn toggle_current_secret(&mut self, join: bool) {
+        let field = self.current_field(join);
+        self.revealed_field = if field.is_secret() && self.revealed_field != Some(field) {
+            Some(field)
+        } else {
+            None
+        };
+    }
+
+    pub(crate) fn hide_secrets(&mut self) {
+        self.revealed_field = None;
+    }
+
+    pub(crate) fn current_value(&self, join: bool) -> &str {
+        self.value(self.current_field(join))
+    }
+
+    pub(crate) fn current_value_mut(&mut self, join: bool) -> &mut String {
+        self.value_mut(self.current_field(join))
+    }
+
+    pub(crate) fn display_value(&self, field: ConnectionField) -> String {
+        let value = self.value(field);
+        if field.is_secret() && self.revealed_field != Some(field) {
+            "•".repeat(value.chars().count().min(32))
+        } else {
+            value.to_owned()
+        }
+    }
+
+    pub(crate) fn max_chars(field: ConnectionField) -> usize {
+        match field {
+            ConnectionField::Endpoint => MAX_ENDPOINT_CHARS,
+            ConnectionField::Username => MAX_USERNAME_CHARS,
+            ConnectionField::Secret => MAX_SECRET_CHARS,
+            ConnectionField::DeviceName => MAX_DEVICE_NAME_CHARS,
+            ConnectionField::CustomCa | ConnectionField::RecoveryFile => MAX_PATH_CHARS,
+            ConnectionField::PairingCode => MAX_PAIRING_CODE_CHARS,
+        }
+    }
+
+    pub(crate) fn validate(&self, join: bool) -> Result<(), FormError> {
+        if self.endpoint.trim().is_empty() {
+            return Err(FormError::EndpointRequired);
+        }
+        if self.secret.is_empty() {
+            return Err(FormError::SecretRequired);
+        }
+        if !valid_device_name(&self.device_name) {
+            return Err(FormError::InvalidDeviceName);
+        }
+        if join && self.pairing_code.trim().is_empty() {
+            return Err(FormError::PairingCodeRequired);
+        }
+        if !join && self.recovery_file.trim().is_empty() {
+            return Err(FormError::RecoveryFileRequired);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn into_input(mut self, join: bool) -> Result<SyncConnectionInput, FormError> {
+        self.validate(join)?;
+        let credential = if self.username.trim().is_empty() {
+            VaultCredential::bearer_token(SecretString::from(std::mem::take(&mut self.secret)))
+        } else {
+            VaultCredential::password(
+                self.username.trim().to_owned(),
+                SecretString::from(std::mem::take(&mut self.secret)),
+            )
+        }
+        .map_err(|_| FormError::SecretRequired)?;
+        Ok(SyncConnectionInput {
+            endpoint: std::mem::take(&mut self.endpoint),
+            custom_ca_path: non_empty(std::mem::take(&mut self.custom_ca)),
+            device_name: std::mem::take(&mut self.device_name),
+            credential: Some(credential),
+            recovery_file: if join {
+                None
+            } else {
+                Some(std::path::PathBuf::from(std::mem::take(
+                    &mut self.recovery_file,
+                )))
+            },
+            pairing_code: if join {
+                Some(std::mem::take(&mut self.pairing_code))
+            } else {
+                None
+            },
+        })
+    }
+
+    fn value(&self, field: ConnectionField) -> &str {
+        match field {
+            ConnectionField::Endpoint => &self.endpoint,
+            ConnectionField::Username => &self.username,
+            ConnectionField::Secret => &self.secret,
+            ConnectionField::DeviceName => &self.device_name,
+            ConnectionField::CustomCa => &self.custom_ca,
+            ConnectionField::RecoveryFile => &self.recovery_file,
+            ConnectionField::PairingCode => &self.pairing_code,
+        }
+    }
+
+    fn value_mut(&mut self, field: ConnectionField) -> &mut String {
+        match field {
+            ConnectionField::Endpoint => &mut self.endpoint,
+            ConnectionField::Username => &mut self.username,
+            ConnectionField::Secret => &mut self.secret,
+            ConnectionField::DeviceName => &mut self.device_name,
+            ConnectionField::CustomCa => &mut self.custom_ca,
+            ConnectionField::RecoveryFile => &mut self.recovery_file,
+            ConnectionField::PairingCode => &mut self.pairing_code,
+        }
+    }
+}
+
+impl Drop for SyncConnectionForm {
+    fn drop(&mut self) {
+        self.endpoint.zeroize();
+        self.username.zeroize();
+        self.secret.zeroize();
+        self.device_name.zeroize();
+        self.custom_ca.zeroize();
+        self.recovery_file.zeroize();
+        self.pairing_code.zeroize();
+    }
+}
+
+/// One-shot worker input. Debug/Clone/serde are intentionally absent.
+pub struct SyncConnectionInput {
+    pub(crate) endpoint: String,
+    pub(crate) custom_ca_path: Option<std::path::PathBuf>,
+    pub(crate) device_name: String,
+    credential: Option<VaultCredential>,
+    pub(crate) recovery_file: Option<std::path::PathBuf>,
+    pub(crate) pairing_code: Option<String>,
+}
+
+impl SyncConnectionInput {
+    fn load_custom_ca(&self) -> Result<Option<Vec<u8>>, FormError> {
+        let Some(path) = self.custom_ca_path.as_deref() else {
+            return Ok(None);
+        };
+        crate::util::safe_fs::read_no_symlink_limited(path, MAX_CUSTOM_CA_PEM_BYTES as u64)
+            .map(Some)
+            .map_err(|_| FormError::CustomCa)
+    }
+
+    pub(crate) fn into_setup_request(
+        mut self,
+    ) -> Result<crate::sync::service::SetupRequest, FormError> {
+        let custom_ca_pem = self.load_custom_ca()?;
+        Ok(crate::sync::service::SetupRequest {
+            endpoint: std::mem::take(&mut self.endpoint),
+            custom_ca_pem,
+            device_name: std::mem::take(&mut self.device_name),
+            credential: self.credential.take().ok_or(FormError::SecretRequired)?,
+            recovery_file: self
+                .recovery_file
+                .take()
+                .ok_or(FormError::RecoveryFileRequired)?,
+        })
+    }
+
+    pub(crate) fn into_join_request(mut self) -> Result<SyncJoinRequest, FormError> {
+        let custom_ca_pem = self.load_custom_ca()?;
+        Ok(SyncJoinRequest {
+            endpoint: std::mem::take(&mut self.endpoint),
+            custom_ca_pem,
+            device_name: std::mem::take(&mut self.device_name),
+            credential: self.credential.take().ok_or(FormError::SecretRequired)?,
+            pairing_code: Zeroizing::new(
+                self.pairing_code
+                    .take()
+                    .ok_or(FormError::PairingCodeRequired)?,
+            ),
+        })
+    }
+}
+
+impl Drop for SyncConnectionInput {
+    fn drop(&mut self) {
+        self.endpoint.zeroize();
+        self.device_name.zeroize();
+        if let Some(code) = self.pairing_code.as_mut() {
+            code.zeroize();
+        }
+    }
+}
+
+/// Move-only join input used only inside the blocking worker.
+pub(crate) struct SyncJoinRequest {
+    pub(crate) endpoint: String,
+    pub(crate) custom_ca_pem: Option<Vec<u8>>,
+    pub(crate) device_name: String,
+    pub(crate) credential: VaultCredential,
+    pub(crate) pairing_code: Zeroizing<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FormError {
+    EndpointRequired,
+    SecretRequired,
+    InvalidDeviceName,
+    PairingCodeRequired,
+    RecoveryFileRequired,
+    CustomCa,
+}
+
+fn non_empty(value: String) -> Option<std::path::PathBuf> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(std::path::PathBuf::from(trimmed))
+    }
+}
+
+fn valid_device_name(value: &str) -> bool {
+    let value = value.trim();
+    !value.is_empty()
+        && value.chars().count() <= MAX_DEVICE_NAME_CHARS
+        && !value.chars().any(DeviceRecord::is_forbidden_name_char)
+}
+
+fn default_device_name() -> String {
+    std::env::var("HOSTNAME")
+        .or_else(|_| std::env::var("COMPUTERNAME"))
+        .ok()
+        .filter(|name| valid_device_name(name))
+        .unwrap_or_else(|| crate::t!("This device", "이 기기", "このデバイス").to_owned())
+}
+
+fn default_recovery_path() -> String {
+    directories::UserDirs::new()
+        .and_then(|dirs| dirs.download_dir().map(std::path::Path::to_path_buf))
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join("yututui-recovery-kit.json")
+        .display()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bidi_and_control_device_names_are_rejected() {
+        for character in [
+            '\u{061c}', '\u{200b}', '\u{200c}', '\u{200d}', '\u{200e}', '\u{200f}', '\u{202a}',
+            '\u{202b}', '\u{202c}', '\u{202d}', '\u{202e}', '\u{2066}', '\u{2067}', '\u{2068}',
+            '\u{2069}', '\u{feff}', '\0', '\n', '\u{007f}', '\u{0085}',
+        ] {
+            assert!(
+                !valid_device_name(&format!("safe{character}name")),
+                "U+{:04X} must be rejected",
+                u32::from(character)
+            );
+        }
+        assert!(valid_device_name("Living room 노트북"));
+    }
+
+    #[test]
+    fn dropped_form_zeroizes_secret_buffers() {
+        // The behavior is provided by zeroize's String implementation; this regression test also
+        // keeps the form non-Clone at the type boundary by exercising move-only conversion.
+        let mut form = SyncConnectionForm::join();
+        form.endpoint = "https://example.invalid/dav".to_owned();
+        form.secret = "sentinel-secret".to_owned();
+        form.device_name = "Laptop".to_owned();
+        form.pairing_code = "AAAA-BBBB".to_owned();
+        let input = form.into_input(true).unwrap();
+        assert!(input.recovery_file.is_none());
+    }
+
+    #[test]
+    fn revealing_one_secret_never_reveals_the_other() {
+        let mut form = SyncConnectionForm::join();
+        form.secret = "password-sentinel".to_owned();
+        form.pairing_code = "pairing-code-sentinel".to_owned();
+        form.field = 2;
+
+        form.toggle_current_secret(true);
+        assert_eq!(
+            form.display_value(ConnectionField::Secret),
+            "password-sentinel"
+        );
+        assert!(
+            !form
+                .display_value(ConnectionField::PairingCode)
+                .contains("sentinel")
+        );
+
+        form.select_field_at(true, 5);
+        assert!(
+            !form
+                .display_value(ConnectionField::Secret)
+                .contains("sentinel")
+        );
+        assert!(
+            !form
+                .display_value(ConnectionField::PairingCode)
+                .contains("sentinel")
+        );
+        form.toggle_current_secret(true);
+        assert_eq!(
+            form.display_value(ConnectionField::PairingCode),
+            "pairing-code-sentinel"
+        );
+
+        form.hide_secrets();
+        assert!(
+            !form
+                .display_value(ConnectionField::PairingCode)
+                .contains("sentinel")
+        );
+    }
+}

--- a/src/app/sync_ui/mod.rs
+++ b/src/app/sync_ui/mod.rs
@@ -1,0 +1,568 @@
+mod event_reducer;
+mod form;
+mod settings_reducer;
+mod wizard_reducer;
+
+use zeroize::Zeroizing;
+
+pub(crate) use form::{
+    ConnectionField, FormError, SyncConnectionForm, SyncConnectionInput, SyncJoinRequest,
+};
+
+use crate::sync::service::{
+    DeviceSummary, PairingHostInvite, PairingJoinPreview, PairingJoinWaiting, PairingReview,
+    PreparedPairingApproval, PreparedPairingJoinActivation, PreparedSetup, SyncLifecycleState,
+    SyncStatusReport,
+};
+use crate::sync::{SyncAuditEntry, SyncHealthState};
+
+/// Blocking sync-settings work. Secret-bearing variants intentionally implement neither
+/// `Debug` nor `Clone`; each is moved exactly once from the owner to a worker.
+pub enum SyncUiCommand {
+    Refresh {
+        flow_id: u64,
+        request_id: u64,
+        state: Box<crate::personal_state::PersonalStateV2>,
+        in_progress: bool,
+    },
+    RecoveryExport {
+        flow_id: u64,
+        state: Box<crate::personal_state::PersonalStateV2>,
+        source: std::path::PathBuf,
+        destination: std::path::PathBuf,
+    },
+    SetupPrepare {
+        flow_id: u64,
+        state: Box<crate::personal_state::PersonalStateV2>,
+        playlist_revision: u64,
+        input: SyncConnectionInput,
+    },
+    SetupResume {
+        flow_id: u64,
+        state: Box<crate::personal_state::PersonalStateV2>,
+        playlist_revision: u64,
+    },
+    HostCreate {
+        flow_id: u64,
+        state: Box<crate::personal_state::PersonalStateV2>,
+    },
+    HostPoll {
+        flow_id: u64,
+        state: Box<crate::personal_state::PersonalStateV2>,
+        host: Box<PairingHostInvite>,
+    },
+    HostApprove {
+        flow_id: u64,
+        state: Box<crate::personal_state::PersonalStateV2>,
+        host: Box<PairingHostInvite>,
+        review: Box<PairingReview>,
+    },
+    HostCancel {
+        flow_id: u64,
+        state: Box<crate::personal_state::PersonalStateV2>,
+        host: Box<PairingHostInvite>,
+    },
+    JoinStart {
+        flow_id: u64,
+        input: SyncConnectionInput,
+    },
+    JoinPoll {
+        flow_id: u64,
+        state: Box<crate::personal_state::PersonalStateV2>,
+    },
+    JoinResume {
+        flow_id: u64,
+        state: Box<crate::personal_state::PersonalStateV2>,
+    },
+    DiscardJoin {
+        flow_id: u64,
+    },
+    JoinPrepareActivation {
+        flow_id: u64,
+        state: Box<crate::personal_state::PersonalStateV2>,
+        preview: Box<PairingJoinPreview>,
+    },
+}
+
+impl SyncUiCommand {
+    pub(crate) fn flow_id(&self) -> u64 {
+        match self {
+            Self::Refresh { flow_id, .. }
+            | Self::RecoveryExport { flow_id, .. }
+            | Self::SetupPrepare { flow_id, .. }
+            | Self::SetupResume { flow_id, .. }
+            | Self::HostCreate { flow_id, .. }
+            | Self::HostPoll { flow_id, .. }
+            | Self::HostApprove { flow_id, .. }
+            | Self::HostCancel { flow_id, .. }
+            | Self::JoinStart { flow_id, .. }
+            | Self::JoinPoll { flow_id, .. }
+            | Self::JoinResume { flow_id, .. }
+            | Self::DiscardJoin { flow_id }
+            | Self::JoinPrepareActivation { flow_id, .. } => *flow_id,
+        }
+    }
+
+    pub(crate) fn is_read_only(&self) -> bool {
+        matches!(self, Self::Refresh { .. })
+    }
+}
+
+pub enum SyncUiEvent {
+    Refreshed {
+        flow_id: u64,
+        request_id: u64,
+        result:
+            Box<Result<crate::sync::service::SyncOverview, crate::sync::service::SyncServiceError>>,
+    },
+    RecoveryExported {
+        flow_id: u64,
+        result: Box<
+            Result<
+                crate::sync::service::RecoveryExportResult,
+                crate::sync::service::SyncServiceError,
+            >,
+        >,
+    },
+    SetupPrepared {
+        flow_id: u64,
+        result: Box<Result<PreparedSetup, crate::sync::service::SyncServiceError>>,
+    },
+    HostCreated {
+        flow_id: u64,
+        result: Box<Result<PairingHostInvite, crate::sync::service::SyncServiceError>>,
+    },
+    HostPolled {
+        flow_id: u64,
+        host: Box<PairingHostInvite>,
+        result: Box<Result<Option<PairingReview>, crate::sync::service::SyncServiceError>>,
+    },
+    HostApprovalPrepared {
+        flow_id: u64,
+        host: Box<PairingHostInvite>,
+        observed_state: Box<crate::personal_state::PersonalStateV2>,
+        result: Box<Result<PreparedPairingApproval, crate::sync::service::SyncServiceError>>,
+    },
+    HostCancelled {
+        flow_id: u64,
+        host: Box<PairingHostInvite>,
+        result: Result<(), crate::sync::service::SyncServiceError>,
+    },
+    JoinStarted {
+        flow_id: u64,
+        result: Box<Result<PairingJoinWaiting, crate::sync::service::SyncServiceError>>,
+    },
+    JoinPolled {
+        flow_id: u64,
+        result: Box<Result<Option<PairingJoinPreview>, crate::sync::service::SyncServiceError>>,
+    },
+    JoinResumed {
+        flow_id: u64,
+        result: Box<Result<PairingJoinPreview, crate::sync::service::SyncServiceError>>,
+    },
+    JoinDiscarded {
+        flow_id: u64,
+        result: Result<(), crate::sync::service::SyncServiceError>,
+    },
+    JoinActivationPrepared {
+        flow_id: u64,
+        result: Box<Result<PreparedPairingJoinActivation, crate::sync::service::SyncServiceError>>,
+    },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SyncPage {
+    Overview,
+    Devices,
+    Activity,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SyncBusy {
+    Refresh,
+    Setup,
+    SyncNow,
+    PairHostCreate,
+    PairHostPoll,
+    PairHostApprove,
+    PairHostCancel,
+    PairJoinStart,
+    PairJoinPoll,
+    PairJoinDiscard,
+    PairJoinApply,
+    Revoke,
+    RecoveryExport,
+}
+
+pub(crate) enum SyncWizard {
+    Setup {
+        form: SyncConnectionForm,
+        confirm: bool,
+    },
+    Join {
+        form: SyncConnectionForm,
+        confirm: bool,
+    },
+    Host {
+        code: Zeroizing<String>,
+        expires_at_unix: i64,
+        host: Option<Box<PairingHostInvite>>,
+        review: Option<Box<PairingReview>>,
+    },
+    JoinWaiting(Box<PairingJoinWaiting>),
+    JoinPreview(Box<PairingJoinPreview>),
+    DiscardJoinConfirm,
+    Revoke {
+        device_id: String,
+        device_name: String,
+    },
+    Recovery(SyncRecoveryForm),
+    Result {
+        success: bool,
+        message: String,
+    },
+}
+
+impl SyncWizard {
+    pub(crate) fn is_modal(&self) -> bool {
+        true
+    }
+}
+
+pub(crate) struct SyncRecoveryForm {
+    pub(crate) source: String,
+    pub(crate) destination: String,
+    pub(crate) field: usize,
+    pub(crate) cursor: crate::util::text_edit::TextCursor,
+    pub(crate) confirm: bool,
+}
+
+impl Drop for SyncRecoveryForm {
+    fn drop(&mut self) {
+        use zeroize::Zeroize;
+        self.source.zeroize();
+        self.destination.zeroize();
+    }
+}
+
+/// Interactive sync state owned by the primary App lane.
+///
+/// No `Debug` or `Clone`: wizard variants may own pairing material and private path/input values.
+pub(crate) struct SyncUiState {
+    pub(crate) flow_id: u64,
+    pub(crate) page: SyncPage,
+    pub(crate) row: usize,
+    pub(crate) status: SyncStatusReport,
+    pub(crate) lifecycle: SyncLifecycleState,
+    pub(crate) devices: Vec<DeviceSummary>,
+    pub(crate) audit: Vec<SyncAuditEntry>,
+    pub(crate) busy: Option<SyncBusy>,
+    pub(crate) wizard: Option<SyncWizard>,
+    pub(crate) last_poll_unix: Option<i64>,
+    pub(crate) auto_poll_enabled: bool,
+    pub(crate) refresh_request_id: u64,
+    pub(crate) refresh_in_flight: Option<u64>,
+    pub(crate) refresh_pending: bool,
+}
+
+impl Default for SyncUiState {
+    fn default() -> Self {
+        Self {
+            flow_id: 0,
+            page: SyncPage::Overview,
+            row: 0,
+            status: SyncStatusReport::default(),
+            lifecycle: SyncLifecycleState::Absent,
+            devices: Vec::new(),
+            audit: Vec::new(),
+            busy: None,
+            wizard: None,
+            last_poll_unix: None,
+            auto_poll_enabled: false,
+            refresh_request_id: 0,
+            refresh_in_flight: None,
+            refresh_pending: false,
+        }
+    }
+}
+
+impl SyncUiState {
+    pub(crate) fn next_flow(&mut self) -> u64 {
+        if matches!(self.busy, Some(SyncBusy::Refresh)) {
+            self.busy = None;
+        }
+        self.refresh_in_flight = None;
+        self.auto_poll_enabled = false;
+        self.flow_id = self.flow_id.wrapping_add(1).max(1);
+        self.flow_id
+    }
+
+    pub(crate) fn is_current(&self, flow_id: u64) -> bool {
+        self.flow_id == flow_id
+    }
+
+    pub(crate) fn configured(&self) -> bool {
+        self.lifecycle == SyncLifecycleState::Active && self.status.configured
+    }
+
+    pub(crate) fn syncing(&self) -> bool {
+        self.busy.is_some() || self.status.state == SyncHealthState::Syncing
+    }
+
+    pub(crate) fn modal_open(&self) -> bool {
+        self.wizard.as_ref().is_some_and(SyncWizard::is_modal)
+    }
+
+    pub(crate) fn set_overview(&mut self, overview: crate::sync::service::SyncOverview) {
+        self.status = overview.status;
+        self.lifecycle = overview.lifecycle;
+        self.devices = overview.devices;
+        self.audit = overview.audit;
+        self.row = self.row.min(self.row_count().saturating_sub(1));
+    }
+
+    pub(crate) fn row_count(&self) -> usize {
+        match self.page {
+            SyncPage::Overview if self.configured() => {
+                4 + usize::from(self.status.failure.is_some())
+            }
+            SyncPage::Overview => match self.lifecycle {
+                SyncLifecycleState::JoinWaiting => 3,
+                SyncLifecycleState::JoinReadyToMerge => 3,
+                SyncLifecycleState::SetupPending => 3,
+                SyncLifecycleState::NeedsCleanup => 5,
+                SyncLifecycleState::Absent
+                | SyncLifecycleState::Revoked
+                | SyncLifecycleState::Active => 2,
+            },
+            SyncPage::Devices => 3 + self.devices.len().max(1),
+            SyncPage::Activity => 1 + self.audit.len().clamp(1, 50),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn revocable_devices(&self) -> impl Iterator<Item = &DeviceSummary> {
+        let local = self.status.device_id.as_deref();
+        self.devices.iter().filter(move |device| {
+            device.active && device.keyed && Some(device.device_id.as_str()) != local
+        })
+    }
+
+    pub(crate) fn move_row(&mut self, delta: i32) {
+        let last = self.row_count().saturating_sub(1) as i32;
+        self.row = (self.row as i32 + delta).clamp(0, last.max(0)) as usize;
+    }
+}
+
+impl super::App {
+    pub(in crate::app) fn request_sync_ui_refresh(&mut self) -> Vec<super::Cmd> {
+        self.queue_sync_ui_refresh();
+        self.start_pending_sync_ui_refresh()
+    }
+
+    pub(crate) fn queue_sync_ui_refresh(&mut self) {
+        self.personal_state.sync_ui.refresh_request_id = self
+            .personal_state
+            .sync_ui
+            .refresh_request_id
+            .wrapping_add(1)
+            .max(1);
+        self.personal_state.sync_ui.refresh_pending = true;
+    }
+
+    pub(crate) fn start_pending_sync_ui_refresh(&mut self) -> Vec<super::Cmd> {
+        if !self.personal_state.sync_ui.refresh_pending
+            || self.personal_state.sync_ui.refresh_in_flight.is_some()
+            || self.personal_state.sync_ui.busy.is_some()
+        {
+            return Vec::new();
+        }
+        let flow_id = self.personal_state.sync_ui.flow_id.max(1);
+        if self.personal_state.sync_ui.flow_id == 0 {
+            self.personal_state.sync_ui.flow_id = flow_id;
+        }
+        let request_id = self.personal_state.sync_ui.refresh_request_id;
+        self.personal_state.sync_ui.refresh_pending = false;
+        self.personal_state.sync_ui.refresh_in_flight = Some(request_id);
+        self.personal_state.sync_ui.busy = Some(SyncBusy::Refresh);
+        vec![super::Cmd::Data(super::DataCmd::SyncUi(
+            SyncUiCommand::Refresh {
+                flow_id,
+                request_id,
+                state: Box::new(self.personal_state.ledger.clone()),
+                in_progress: self.personal_state.sync.in_progress,
+            },
+        ))]
+    }
+
+    pub(in crate::app) fn finish_sync_ui_event(&mut self, event: SyncUiEvent) -> Vec<super::Cmd> {
+        self.reduce_sync_ui_event(event)
+    }
+
+    pub(in crate::app) fn finish_tui_personal_sync(
+        &mut self,
+        flow_id: u64,
+        action: &super::PersonalSyncAction,
+        summary: &crate::sync::manual::ManualSyncSummary,
+    ) {
+        if !self.personal_state.sync_ui.is_current(flow_id) {
+            return;
+        }
+        self.personal_state.sync_ui.busy = None;
+        self.queue_sync_ui_refresh();
+        let message = if matches!(action, super::PersonalSyncAction::Revoke(_)) {
+            crate::t!(
+                "Device removed. Change the shared WebDAV password if it knew it.",
+                "기기를 삭제했어요. 해당 기기가 비밀번호를 알았다면 WebDAV 비밀번호를 바꾸세요.",
+                "デバイスを削除しました。パスワードを知られていた場合はWebDAVのパスワードを変更してください。"
+            )
+            .to_owned()
+        } else if summary.downloaded_operations == 0 && summary.uploaded_operations == 0 {
+            crate::t!(
+                "Personal state is up to date.",
+                "개인 상태가 최신이에요.",
+                "個人データは最新です。"
+            )
+            .to_owned()
+        } else {
+            match crate::i18n::current() {
+                crate::i18n::Language::Korean => format!(
+                    "동기화 완료: {}개 보냄, {}개 받음",
+                    summary.uploaded_operations, summary.downloaded_operations
+                ),
+                crate::i18n::Language::Japanese => format!(
+                    "同期完了: {}件送信、{}件受信",
+                    summary.uploaded_operations, summary.downloaded_operations
+                ),
+                _ => format!(
+                    "Sync complete: {} sent, {} received.",
+                    summary.uploaded_operations, summary.downloaded_operations
+                ),
+            }
+        };
+        self.status.text = message;
+        self.status.kind = super::StatusKind::Info;
+        self.dirty = true;
+    }
+
+    pub(in crate::app) fn finish_tui_personal_sync_error(
+        &mut self,
+        flow_id: u64,
+        error: crate::sync::service::SyncServiceError,
+    ) {
+        if !self.personal_state.sync_ui.is_current(flow_id) {
+            return;
+        }
+        self.personal_state.sync_ui.busy = None;
+        self.queue_sync_ui_refresh();
+        self.status.text = localized_sync_error(error);
+        self.status.kind = super::StatusKind::Error;
+        self.dirty = true;
+    }
+}
+
+pub(crate) fn localized_sync_error(error: crate::sync::service::SyncServiceError) -> String {
+    use crate::sync::service::SyncServiceError as Error;
+    match error {
+        Error::NotConfigured => crate::t!(
+            "Personal sync is not set up.",
+            "개인 동기화가 설정되지 않았어요.",
+            "個人同期は設定されていません。"
+        ),
+        Error::AlreadyConfigured => crate::t!(
+            "Personal sync is already set up.",
+            "개인 동기화가 이미 설정되어 있어요.",
+            "個人同期はすでに設定されています。"
+        ),
+        Error::PendingApproval => crate::t!(
+            "Waiting for device approval.",
+            "기기 승인을 기다리고 있어요.",
+            "デバイスの承認を待っています。"
+        ),
+        Error::Revoked => crate::t!(
+            "This device no longer has access.",
+            "이 기기는 더 이상 접근할 수 없어요.",
+            "このデバイスにはアクセス権がありません。"
+        ),
+        Error::MissingCredential | Error::Authentication => crate::t!(
+            "The password was not accepted.",
+            "비밀번호를 확인해 주세요.",
+            "パスワードを確認してください。"
+        ),
+        Error::UnsupportedServer => crate::t!(
+            "This server cannot store encrypted personal sync.",
+            "이 서버에서는 암호화된 개인 동기화를 사용할 수 없어요.",
+            "このサーバーでは暗号化された個人同期を利用できません。"
+        ),
+        Error::Certificate => crate::t!(
+            "The server certificate could not be verified.",
+            "서버 인증서를 확인할 수 없어요.",
+            "サーバー証明書を確認できません。"
+        ),
+        Error::Offline => crate::t!(
+            "Offline — try again when the server is reachable.",
+            "오프라인 — 서버에 연결되면 다시 시도하세요.",
+            "オフライン — サーバーに接続できたら再試行してください。"
+        ),
+        Error::InvalidRemoteData | Error::PairingRejected => crate::t!(
+            "The encrypted server data could not be verified.",
+            "서버의 암호화된 데이터를 확인할 수 없어요.",
+            "サーバーの暗号化データを確認できません。"
+        ),
+        Error::LocalStateChanged => crate::t!(
+            "Local changes arrived. Please review the updated result.",
+            "로컬 변경이 생겼어요. 갱신된 결과를 확인해 주세요.",
+            "ローカルで変更がありました。更新後の結果を確認してください。"
+        ),
+        Error::Storage | Error::RecoveryKitNotConfirmed => crate::t!(
+            "The change could not be saved safely.",
+            "변경 내용을 안전하게 저장하지 못했어요.",
+            "変更を安全に保存できませんでした。"
+        ),
+        Error::PairingExpired => crate::t!(
+            "The device connection code expired.",
+            "기기 연결 코드가 만료됐어요.",
+            "デバイス接続コードの有効期限が切れました。"
+        ),
+        Error::PairingNeedsCleanup => crate::t!(
+            "An unfinished device connection needs attention.",
+            "완료되지 않은 기기 연결을 정리해야 해요.",
+            "未完了のデバイス接続を整理する必要があります。"
+        ),
+    }
+    .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_device_is_never_a_revoke_row() {
+        let mut state = SyncUiState::default();
+        state.status.configured = true;
+        state.status.device_id = Some("this".to_owned());
+        state.lifecycle = SyncLifecycleState::Active;
+        state.devices = vec![
+            DeviceSummary {
+                device_id: "this".to_owned(),
+                name: "This device".to_owned(),
+                active: true,
+                keyed: true,
+            },
+            DeviceSummary {
+                device_id: "other".to_owned(),
+                name: "Other device".to_owned(),
+                active: true,
+                keyed: true,
+            },
+        ];
+        assert_eq!(
+            state
+                .revocable_devices()
+                .map(|device| device.device_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["other"]
+        );
+    }
+}

--- a/src/app/sync_ui/settings_reducer.rs
+++ b/src/app/sync_ui/settings_reducer.rs
@@ -1,0 +1,323 @@
+use super::*;
+use crate::settings::sync::{
+    SyncAuditRow, SyncDeviceRow, SyncDisplayPage, SyncNotice, SyncRow, SyncRowAction,
+    SyncSettingsModel,
+};
+
+impl super::super::App {
+    pub(crate) fn sync_settings_model(&self) -> SyncSettingsModel {
+        let busy = self.personal_state.sync_ui.syncing();
+        let selected = self.personal_state.sync_ui.row;
+        match self.personal_state.sync_ui.page {
+            SyncPage::Overview => {
+                let mut model = if self.personal_state.sync_ui.configured() {
+                    SyncSettingsModel::configured(
+                        self.personal_state.sync_ui.status.state,
+                        self.personal_state.sync_ui.status.failure,
+                    )
+                } else {
+                    overview_pending_model(&self.personal_state.sync_ui)
+                };
+                model.busy = busy;
+                model.selected = selected;
+                model
+            }
+            SyncPage::Devices => SyncSettingsModel {
+                page: SyncDisplayPage::Devices,
+                health: self.personal_state.sync_ui.status.state,
+                failure: self.personal_state.sync_ui.status.failure,
+                configured: self.personal_state.sync_ui.configured(),
+                busy,
+                selected,
+                rows: device_rows(&self.personal_state.sync_ui),
+            },
+            SyncPage::Activity => SyncSettingsModel {
+                page: SyncDisplayPage::Activity,
+                health: self.personal_state.sync_ui.status.state,
+                failure: self.personal_state.sync_ui.status.failure,
+                configured: self.personal_state.sync_ui.configured(),
+                busy,
+                selected,
+                rows: activity_rows(&self.personal_state.sync_ui),
+            },
+        }
+    }
+
+    pub(in crate::app) fn activate_sync_row(&mut self) -> Vec<super::super::Cmd> {
+        if self.personal_state.sync_ui.syncing() || self.personal_state.sync.in_progress {
+            return Vec::new();
+        }
+        let model = self.sync_settings_model();
+        let Some(row) = model.selected().and_then(|index| model.rows.get(index)) else {
+            return Vec::new();
+        };
+        match row {
+            SyncRow::Action(action) => self.activate_sync_action(*action),
+            SyncRow::Device(_) => self.open_selected_sync_device(),
+            SyncRow::Audit(_) | SyncRow::MergeSummary(_) | SyncRow::Notice(_) => Vec::new(),
+        }
+    }
+
+    fn activate_sync_action(&mut self, action: SyncRowAction) -> Vec<super::super::Cmd> {
+        match action {
+            SyncRowAction::Create => {
+                self.personal_state.sync_ui.next_flow();
+                self.personal_state.sync_ui.wizard = Some(SyncWizard::Setup {
+                    form: SyncConnectionForm::setup(),
+                    confirm: false,
+                });
+                self.dirty = true;
+                Vec::new()
+            }
+            SyncRowAction::Join => {
+                self.personal_state.sync_ui.next_flow();
+                self.personal_state.sync_ui.wizard = Some(SyncWizard::Join {
+                    form: SyncConnectionForm::join(),
+                    confirm: false,
+                });
+                self.dirty = true;
+                Vec::new()
+            }
+            SyncRowAction::SyncNow => self.start_sync_now_from_settings(),
+            SyncRowAction::Retry => self.retry_sync_lifecycle(),
+            SyncRowAction::ResumeConnection => self.resume_unfinished_connection(),
+            SyncRowAction::ReenterConnection => {
+                self.personal_state.sync_ui.next_flow();
+                self.personal_state.sync_ui.wizard = Some(SyncWizard::Join {
+                    form: SyncConnectionForm::join(),
+                    confirm: false,
+                });
+                self.dirty = true;
+                Vec::new()
+            }
+            SyncRowAction::DiscardConnection => {
+                self.personal_state.sync_ui.next_flow();
+                self.personal_state.sync_ui.wizard = Some(SyncWizard::DiscardJoinConfirm);
+                self.dirty = true;
+                Vec::new()
+            }
+            SyncRowAction::ReviewDevice => self.start_host_pairing(),
+            SyncRowAction::ReviewMerge => self.retry_sync_lifecycle(),
+            SyncRowAction::ViewMergeResult => {
+                self.open_sync_activity();
+                Vec::new()
+            }
+            SyncRowAction::AddDevice => self.start_host_pairing(),
+            SyncRowAction::Devices => {
+                self.personal_state.sync_ui.page = SyncPage::Devices;
+                self.personal_state.sync_ui.row = 0;
+                self.dirty = true;
+                Vec::new()
+            }
+            SyncRowAction::Recovery | SyncRowAction::SaveRecoveryKit => {
+                self.open_recovery_export();
+                Vec::new()
+            }
+            SyncRowAction::Activity => {
+                self.open_sync_activity();
+                Vec::new()
+            }
+            SyncRowAction::Back => {
+                self.personal_state.sync_ui.page = SyncPage::Overview;
+                self.personal_state.sync_ui.row = 0;
+                self.dirty = true;
+                Vec::new()
+            }
+            SyncRowAction::ApproveDevice
+            | SyncRowAction::RejectDevice
+            | SyncRowAction::ApplyMerge
+            | SyncRowAction::RemoveDevice
+            | SyncRowAction::ConfirmRemoveDevice => Vec::new(),
+        }
+    }
+
+    fn open_sync_activity(&mut self) {
+        self.personal_state.sync_ui.page = SyncPage::Activity;
+        self.personal_state.sync_ui.row = 0;
+        self.dirty = true;
+    }
+
+    fn start_sync_now_from_settings(&mut self) -> Vec<super::super::Cmd> {
+        let flow_id = self.personal_state.sync_ui.flow_id.max(1);
+        self.personal_state.sync_ui.flow_id = flow_id;
+        self.personal_state.sync_ui.busy = Some(SyncBusy::SyncNow);
+        self.start_personal_sync_for_tui(super::super::PersonalSyncAction::SyncNow, flow_id)
+    }
+
+    fn retry_sync_lifecycle(&mut self) -> Vec<super::super::Cmd> {
+        let flow_id = self.personal_state.sync_ui.flow_id.max(1);
+        self.personal_state.sync_ui.flow_id = flow_id;
+        match self.personal_state.sync_ui.lifecycle {
+            SyncLifecycleState::SetupPending => {
+                self.personal_state.sync_ui.busy = Some(SyncBusy::Setup);
+                vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
+                    SyncUiCommand::SetupResume {
+                        flow_id,
+                        state: Box::new(self.personal_state.ledger.clone()),
+                        playlist_revision: self.playlists.revision(),
+                    },
+                ))]
+            }
+            SyncLifecycleState::JoinWaiting | SyncLifecycleState::JoinReadyToMerge => {
+                self.start_join_poll(flow_id)
+            }
+            SyncLifecycleState::Active if self.personal_state.sync_ui.status.configured => {
+                self.start_sync_now_from_settings()
+            }
+            SyncLifecycleState::Absent
+            | SyncLifecycleState::Revoked
+            | SyncLifecycleState::NeedsCleanup
+            | SyncLifecycleState::Active => self.request_sync_ui_refresh(),
+        }
+    }
+
+    fn resume_unfinished_connection(&mut self) -> Vec<super::super::Cmd> {
+        let flow_id = self.personal_state.sync_ui.next_flow();
+        self.personal_state.sync_ui.busy = Some(SyncBusy::PairJoinPoll);
+        vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
+            SyncUiCommand::JoinResume {
+                flow_id,
+                state: Box::new(self.personal_state.ledger.clone()),
+            },
+        ))]
+    }
+
+    fn start_host_pairing(&mut self) -> Vec<super::super::Cmd> {
+        let flow_id = self.personal_state.sync_ui.next_flow();
+        self.personal_state.sync_ui.busy = Some(SyncBusy::PairHostCreate);
+        vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
+            SyncUiCommand::HostCreate {
+                flow_id,
+                state: Box::new(self.personal_state.ledger.clone()),
+            },
+        ))]
+    }
+
+    fn open_recovery_export(&mut self) {
+        self.personal_state.sync_ui.next_flow();
+        self.personal_state.sync_ui.wizard = Some(SyncWizard::Recovery(SyncRecoveryForm {
+            source: String::new(),
+            destination: directories::UserDirs::new()
+                .and_then(|dirs| dirs.download_dir().map(std::path::Path::to_path_buf))
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned(),
+            field: 0,
+            cursor: crate::util::text_edit::TextCursor::default(),
+            confirm: false,
+        }));
+        self.dirty = true;
+    }
+
+    fn open_selected_sync_device(&mut self) -> Vec<super::super::Cmd> {
+        if self.personal_state.sync_ui.page != SyncPage::Devices
+            || self.personal_state.sync_ui.row < 3
+        {
+            return Vec::new();
+        }
+        let index = self.personal_state.sync_ui.row - 3;
+        let Some(device) = self.personal_state.sync_ui.devices.get(index) else {
+            return Vec::new();
+        };
+        let local = self.personal_state.sync_ui.status.device_id.as_deref();
+        if !device.active || !device.keyed || Some(device.device_id.as_str()) == local {
+            return Vec::new();
+        }
+        self.personal_state.sync_ui.wizard = Some(SyncWizard::Revoke {
+            device_id: device.device_id.clone(),
+            device_name: device.name.clone(),
+        });
+        self.dirty = true;
+        Vec::new()
+    }
+}
+
+fn overview_pending_model(state: &SyncUiState) -> SyncSettingsModel {
+    let rows = match state.lifecycle {
+        SyncLifecycleState::Absent => vec![
+            SyncRow::Action(SyncRowAction::Create),
+            SyncRow::Action(SyncRowAction::Join),
+        ],
+        SyncLifecycleState::Revoked => vec![
+            SyncRow::Notice(SyncNotice::DeviceRevoked),
+            SyncRow::Action(SyncRowAction::Activity),
+        ],
+        SyncLifecycleState::SetupPending => vec![
+            SyncRow::Notice(SyncNotice::RecoveryKitRequired),
+            SyncRow::Action(SyncRowAction::Retry),
+            SyncRow::Action(SyncRowAction::Activity),
+        ],
+        SyncLifecycleState::JoinWaiting => vec![
+            SyncRow::Notice(SyncNotice::WaitingForDevice),
+            SyncRow::Action(SyncRowAction::Retry),
+            SyncRow::Action(SyncRowAction::Activity),
+        ],
+        SyncLifecycleState::JoinReadyToMerge => vec![
+            SyncRow::Notice(SyncNotice::FirstMergeKeepsEverything),
+            SyncRow::Action(SyncRowAction::ReviewMerge),
+            SyncRow::Action(SyncRowAction::Activity),
+        ],
+        SyncLifecycleState::NeedsCleanup => vec![
+            SyncRow::Notice(SyncNotice::NeedsCleanup),
+            SyncRow::Action(SyncRowAction::ResumeConnection),
+            SyncRow::Action(SyncRowAction::ReenterConnection),
+            SyncRow::Action(SyncRowAction::DiscardConnection),
+            SyncRow::Action(SyncRowAction::Activity),
+        ],
+        SyncLifecycleState::Active => vec![
+            SyncRow::Action(SyncRowAction::SyncNow),
+            SyncRow::Action(SyncRowAction::Activity),
+        ],
+    };
+    SyncSettingsModel {
+        page: SyncDisplayPage::Status,
+        health: state.status.state,
+        failure: (state.lifecycle != SyncLifecycleState::NeedsCleanup)
+            .then_some(state.status.failure)
+            .flatten(),
+        configured: false,
+        busy: state.syncing(),
+        selected: state.row,
+        rows,
+    }
+}
+
+fn device_rows(state: &SyncUiState) -> Vec<SyncRow> {
+    let mut rows = vec![
+        SyncRow::Action(SyncRowAction::Back),
+        SyncRow::Action(SyncRowAction::AddDevice),
+        SyncRow::Action(SyncRowAction::Recovery),
+    ];
+    if state.devices.is_empty() {
+        rows.push(SyncRow::Notice(SyncNotice::NoOtherDevices));
+        return rows;
+    }
+    let local = state.status.device_id.as_deref();
+    rows.extend(state.devices.iter().map(|device| {
+        SyncRow::Device(SyncDeviceRow::new(
+            &device.name,
+            &device.device_id,
+            Some(device.device_id.as_str()) == local,
+            device.active,
+        ))
+    }));
+    rows
+}
+
+fn activity_rows(state: &SyncUiState) -> Vec<SyncRow> {
+    let mut rows = vec![SyncRow::Action(SyncRowAction::Back)];
+    if state.audit.is_empty() {
+        rows.push(SyncRow::Notice(SyncNotice::NoActivity));
+    } else {
+        rows.extend(
+            state
+                .audit
+                .iter()
+                .rev()
+                .take(50)
+                .map(SyncAuditRow::from)
+                .map(SyncRow::Audit),
+        );
+    }
+    rows
+}

--- a/src/app/sync_ui/wizard_reducer.rs
+++ b/src/app/sync_ui/wizard_reducer.rs
@@ -1,0 +1,527 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::*;
+
+impl super::super::App {
+    pub(in crate::app) fn on_key_sync_wizard(&mut self, key: KeyEvent) -> Vec<super::super::Cmd> {
+        let is_typing_character = matches!(
+            self.personal_state.sync_ui.wizard.as_ref(),
+            Some(SyncWizard::Setup { confirm: false, .. })
+                | Some(SyncWizard::Join { confirm: false, .. })
+                | Some(SyncWizard::Recovery(SyncRecoveryForm {
+                    confirm: false,
+                    ..
+                }))
+        ) && matches!(key.code, KeyCode::Char(_))
+            && !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER);
+        if !is_typing_character
+            && matches!(
+                self.keymap.global_action(key.into()),
+                Some(crate::keymap::Action::Quit)
+            )
+        {
+            return self.quit_app();
+        }
+        let Some(wizard) = self.personal_state.sync_ui.wizard.take() else {
+            return Vec::new();
+        };
+        self.dirty = true;
+        match wizard {
+            SyncWizard::Setup { form, confirm } => {
+                self.key_connection_form(key, form, false, confirm)
+            }
+            SyncWizard::Join { form, confirm } => {
+                self.key_connection_form(key, form, true, confirm)
+            }
+            SyncWizard::Host {
+                code,
+                expires_at_unix,
+                host,
+                review,
+            } => self.key_host_wizard(key, code, expires_at_unix, host, review),
+            SyncWizard::JoinWaiting(waiting) => self.key_join_waiting(key, waiting),
+            SyncWizard::JoinPreview(preview) => self.key_join_preview(key, preview),
+            SyncWizard::DiscardJoinConfirm => self.key_discard_join_confirm(key),
+            SyncWizard::Revoke {
+                device_id,
+                device_name,
+            } => self.key_revoke(key, device_id, device_name),
+            SyncWizard::Recovery(form) => self.key_recovery(key, form),
+            SyncWizard::Result { success, message } => {
+                if matches!(key.code, KeyCode::Enter | KeyCode::Esc) {
+                    self.personal_state.sync_ui.wizard = None;
+                } else {
+                    self.personal_state.sync_ui.wizard =
+                        Some(SyncWizard::Result { success, message });
+                }
+                Vec::new()
+            }
+        }
+    }
+
+    pub(in crate::app) fn on_sync_wizard_mouse_target(
+        &mut self,
+        target: super::super::MouseTarget,
+    ) -> Vec<super::super::Cmd> {
+        match target {
+            super::super::MouseTarget::SyncWizardPrimary => {
+                self.on_key_sync_wizard(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            }
+            super::super::MouseTarget::SyncWizardSecondary => {
+                self.on_key_sync_wizard(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            }
+            super::super::MouseTarget::SyncWizardReveal => {
+                self.on_key_sync_wizard(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL))
+            }
+            super::super::MouseTarget::SyncWizardField(index) => {
+                match self.personal_state.sync_ui.wizard.as_mut() {
+                    Some(SyncWizard::Setup {
+                        form,
+                        confirm: false,
+                    }) if index < form.fields(false).len() => {
+                        form.select_field_at(false, index);
+                    }
+                    Some(SyncWizard::Join {
+                        form,
+                        confirm: false,
+                    }) if index < form.fields(true).len() => {
+                        form.select_field_at(true, index);
+                    }
+                    Some(SyncWizard::Recovery(form)) if !form.confirm && index < 2 => {
+                        form.field = index;
+                        let value = if index == 0 {
+                            &form.source
+                        } else {
+                            &form.destination
+                        };
+                        form.cursor = crate::util::text_edit::TextCursor::at_end(value);
+                    }
+                    _ => {}
+                }
+                self.dirty = true;
+                Vec::new()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn key_connection_form(
+        &mut self,
+        key: KeyEvent,
+        mut form: SyncConnectionForm,
+        join: bool,
+        mut confirm: bool,
+    ) -> Vec<super::super::Cmd> {
+        if self.personal_state.sync_ui.busy.is_some() {
+            self.personal_state.sync_ui.wizard = Some(if join {
+                SyncWizard::Join { form, confirm }
+            } else {
+                SyncWizard::Setup { form, confirm }
+            });
+            return Vec::new();
+        }
+        if key.code == KeyCode::Char('r') && key.modifiers == KeyModifiers::CONTROL {
+            form.toggle_current_secret(join);
+        } else if key.code == KeyCode::Esc {
+            if confirm {
+                confirm = false;
+            } else {
+                return Vec::new();
+            }
+        } else if key.code == KeyCode::Enter {
+            if !confirm {
+                match form.validate(join) {
+                    Ok(()) => {
+                        form.hide_secrets();
+                        confirm = true;
+                    }
+                    Err(error) => self.set_status_error(localized_form_error(error)),
+                }
+            } else {
+                return self.submit_connection_form(form, join);
+            }
+        } else if !confirm
+            && matches!(
+                key.code,
+                KeyCode::Up | KeyCode::Down | KeyCode::Tab | KeyCode::BackTab
+            )
+        {
+            let delta = if matches!(key.code, KeyCode::Up | KeyCode::BackTab)
+                || key.modifiers.contains(KeyModifiers::SHIFT)
+            {
+                -1
+            } else {
+                1
+            };
+            form.select_field(join, delta);
+        } else if !confirm {
+            edit_connection_form(self, &mut form, join, key);
+        }
+        self.personal_state.sync_ui.wizard = Some(if join {
+            SyncWizard::Join { form, confirm }
+        } else {
+            SyncWizard::Setup { form, confirm }
+        });
+        Vec::new()
+    }
+
+    fn submit_connection_form(
+        &mut self,
+        form: SyncConnectionForm,
+        join: bool,
+    ) -> Vec<super::super::Cmd> {
+        let input = match form.into_input(join) {
+            Ok(input) => input,
+            Err(error) => {
+                self.set_status_error(localized_form_error(error));
+                return Vec::new();
+            }
+        };
+        let flow_id = self.personal_state.sync_ui.flow_id.max(1);
+        self.personal_state.sync_ui.flow_id = flow_id;
+        if join {
+            self.personal_state.sync_ui.busy = Some(SyncBusy::PairJoinStart);
+            vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
+                SyncUiCommand::JoinStart { flow_id, input },
+            ))]
+        } else {
+            self.personal_state.sync_ui.busy = Some(SyncBusy::Setup);
+            vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
+                SyncUiCommand::SetupPrepare {
+                    flow_id,
+                    state: Box::new(self.personal_state.ledger.clone()),
+                    playlist_revision: self.playlists.revision(),
+                    input,
+                },
+            ))]
+        }
+    }
+
+    fn key_host_wizard(
+        &mut self,
+        key: KeyEvent,
+        code: Zeroizing<String>,
+        expires_at_unix: i64,
+        host: Option<Box<PairingHostInvite>>,
+        review: Option<Box<PairingReview>>,
+    ) -> Vec<super::super::Cmd> {
+        if self.personal_state.sync_ui.busy.is_some() {
+            self.personal_state.sync_ui.wizard = Some(SyncWizard::Host {
+                code,
+                expires_at_unix,
+                host,
+                review,
+            });
+            return Vec::new();
+        }
+        let flow_id = self.personal_state.sync_ui.flow_id;
+        match key.code {
+            KeyCode::Esc => {
+                let Some(host) = host else {
+                    return Vec::new();
+                };
+                self.personal_state.sync_ui.busy = Some(SyncBusy::PairHostCancel);
+                vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
+                    SyncUiCommand::HostCancel {
+                        flow_id,
+                        state: Box::new(self.personal_state.ledger.clone()),
+                        host,
+                    },
+                ))]
+            }
+            KeyCode::Enter => {
+                let Some(host) = host else {
+                    return Vec::new();
+                };
+                if let Some(review) = review {
+                    self.personal_state.sync_ui.busy = Some(SyncBusy::PairHostApprove);
+                    vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
+                        SyncUiCommand::HostApprove {
+                            flow_id,
+                            state: Box::new(self.personal_state.ledger.clone()),
+                            host,
+                            review,
+                        },
+                    ))]
+                } else {
+                    self.personal_state.sync_ui.auto_poll_enabled = true;
+                    self.personal_state.sync_ui.busy = Some(SyncBusy::PairHostPoll);
+                    self.personal_state.sync_ui.wizard = Some(SyncWizard::Host {
+                        code,
+                        expires_at_unix,
+                        host: None,
+                        review: None,
+                    });
+                    vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
+                        SyncUiCommand::HostPoll {
+                            flow_id,
+                            state: Box::new(self.personal_state.ledger.clone()),
+                            host,
+                        },
+                    ))]
+                }
+            }
+            _ => {
+                self.personal_state.sync_ui.wizard = Some(SyncWizard::Host {
+                    code,
+                    expires_at_unix,
+                    host,
+                    review,
+                });
+                Vec::new()
+            }
+        }
+    }
+
+    fn key_join_waiting(
+        &mut self,
+        key: KeyEvent,
+        waiting: Box<PairingJoinWaiting>,
+    ) -> Vec<super::super::Cmd> {
+        let flow_id = self.personal_state.sync_ui.flow_id;
+        if self.personal_state.sync_ui.busy.is_some() {
+            self.personal_state.sync_ui.wizard = Some(SyncWizard::JoinWaiting(waiting));
+            return Vec::new();
+        }
+        match key.code {
+            KeyCode::Enter => {
+                self.personal_state.sync_ui.wizard = Some(SyncWizard::JoinWaiting(waiting));
+                self.start_join_poll(flow_id)
+            }
+            KeyCode::Esc => {
+                self.personal_state.sync_ui.auto_poll_enabled = false;
+                self.status.text = crate::t!(
+                    "Device approval is still waiting. Return to Sync to continue later.",
+                    "기기 승인은 계속 대기 중이에요. 나중에 Sync에서 이어갈 수 있습니다.",
+                    "デバイス承認は待機中です。後で Sync から再開できます。"
+                )
+                .to_owned();
+                self.status.kind = super::super::StatusKind::Info;
+                self.queue_sync_ui_refresh();
+                Vec::new()
+            }
+            _ => {
+                self.personal_state.sync_ui.wizard = Some(SyncWizard::JoinWaiting(waiting));
+                Vec::new()
+            }
+        }
+    }
+
+    fn key_join_preview(
+        &mut self,
+        key: KeyEvent,
+        preview: Box<PairingJoinPreview>,
+    ) -> Vec<super::super::Cmd> {
+        match key.code {
+            KeyCode::Enter if self.personal_state.sync_ui.busy.is_none() => {
+                self.personal_state.sync_ui.busy = Some(SyncBusy::PairJoinApply);
+                vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
+                    SyncUiCommand::JoinPrepareActivation {
+                        flow_id: self.personal_state.sync_ui.flow_id,
+                        state: Box::new(self.personal_state.ledger.clone()),
+                        preview,
+                    },
+                ))]
+            }
+            KeyCode::Esc => {
+                self.personal_state.sync_ui.auto_poll_enabled = false;
+                self.status.text = crate::t!(
+                    "The approved merge is saved for later.",
+                    "승인된 병합을 나중에 이어갈 수 있도록 저장했어요.",
+                    "承認済みの統合を後で再開できるよう保存しました。"
+                )
+                .to_owned();
+                self.status.kind = super::super::StatusKind::Info;
+                self.queue_sync_ui_refresh();
+                Vec::new()
+            }
+            _ => {
+                self.personal_state.sync_ui.wizard = Some(SyncWizard::JoinPreview(preview));
+                Vec::new()
+            }
+        }
+    }
+
+    fn key_revoke(
+        &mut self,
+        key: KeyEvent,
+        device_id: String,
+        device_name: String,
+    ) -> Vec<super::super::Cmd> {
+        match key.code {
+            KeyCode::Enter if self.personal_state.sync_ui.busy.is_none() => {
+                let target = match crate::personal_state::DeviceId::new(device_id) {
+                    Ok(target) => target,
+                    Err(_) => {
+                        self.set_status_error(localized_sync_error(
+                            crate::sync::service::SyncServiceError::InvalidRemoteData,
+                        ));
+                        return Vec::new();
+                    }
+                };
+                let flow_id = self.personal_state.sync_ui.flow_id.max(1);
+                self.personal_state.sync_ui.busy = Some(SyncBusy::Revoke);
+                self.start_personal_sync_for_tui(
+                    super::super::PersonalSyncAction::Revoke(target),
+                    flow_id,
+                )
+            }
+            KeyCode::Esc => Vec::new(),
+            _ => {
+                self.personal_state.sync_ui.wizard = Some(SyncWizard::Revoke {
+                    device_id,
+                    device_name,
+                });
+                Vec::new()
+            }
+        }
+    }
+
+    fn key_discard_join_confirm(&mut self, key: KeyEvent) -> Vec<super::super::Cmd> {
+        if self.personal_state.sync_ui.busy.is_some() {
+            self.personal_state.sync_ui.wizard = Some(SyncWizard::DiscardJoinConfirm);
+            return Vec::new();
+        }
+        match key.code {
+            KeyCode::Enter => {
+                self.personal_state.sync_ui.busy = Some(SyncBusy::PairJoinDiscard);
+                vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
+                    SyncUiCommand::DiscardJoin {
+                        flow_id: self.personal_state.sync_ui.flow_id,
+                    },
+                ))]
+            }
+            KeyCode::Esc => Vec::new(),
+            _ => {
+                self.personal_state.sync_ui.wizard = Some(SyncWizard::DiscardJoinConfirm);
+                Vec::new()
+            }
+        }
+    }
+
+    fn key_recovery(
+        &mut self,
+        key: KeyEvent,
+        mut form: SyncRecoveryForm,
+    ) -> Vec<super::super::Cmd> {
+        if self.personal_state.sync_ui.busy.is_some() {
+            self.personal_state.sync_ui.wizard = Some(SyncWizard::Recovery(form));
+            return Vec::new();
+        }
+        match key.code {
+            KeyCode::Esc if form.confirm => form.confirm = false,
+            KeyCode::Esc => return Vec::new(),
+            KeyCode::Up | KeyCode::Down | KeyCode::Tab | KeyCode::BackTab if !form.confirm => {
+                form.field = usize::from(form.field == 0);
+                let value = if form.field == 0 {
+                    &form.source
+                } else {
+                    &form.destination
+                };
+                form.cursor = crate::util::text_edit::TextCursor::at_end(value);
+            }
+            KeyCode::Enter if !form.confirm => {
+                if form.source.trim().is_empty() || form.destination.trim().is_empty() {
+                    self.set_status_error(crate::t!(
+                        "Choose the recovery kit and destination folder.",
+                        "복구 키트와 저장할 폴더를 선택해 주세요.",
+                        "復旧キットと保存先フォルダーを選んでください。"
+                    ));
+                } else {
+                    form.confirm = true;
+                }
+            }
+            KeyCode::Enter => {
+                let flow_id = self.personal_state.sync_ui.flow_id;
+                let source = std::path::PathBuf::from(std::mem::take(&mut form.source));
+                let destination = std::path::PathBuf::from(std::mem::take(&mut form.destination));
+                self.personal_state.sync_ui.busy = Some(SyncBusy::RecoveryExport);
+                return vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
+                    SyncUiCommand::RecoveryExport {
+                        flow_id,
+                        state: Box::new(self.personal_state.ledger.clone()),
+                        source,
+                        destination,
+                    },
+                ))];
+            }
+            _ if !form.confirm => edit_recovery_form(self, &mut form, key),
+            _ => {}
+        }
+        self.personal_state.sync_ui.wizard = Some(SyncWizard::Recovery(form));
+        Vec::new()
+    }
+}
+
+fn edit_connection_form(
+    app: &super::super::App,
+    form: &mut SyncConnectionForm,
+    join: bool,
+    key: KeyEvent,
+) {
+    let field = form.current_field(join);
+    let mut cursor = form.cursor;
+    let value = form.current_value_mut(join);
+    if let Some(action) = app.keymap.text_edit_action(key.into()) {
+        let _ = super::super::apply_text_edit_action(action, &mut cursor, value);
+    } else if let KeyCode::Char(character) = key.code
+        && value.chars().count() < SyncConnectionForm::max_chars(field)
+    {
+        cursor.insert_char(value, character);
+    }
+    form.cursor = cursor;
+}
+
+fn edit_recovery_form(app: &super::super::App, form: &mut SyncRecoveryForm, key: KeyEvent) {
+    let mut cursor = form.cursor;
+    let value = if form.field == 0 {
+        &mut form.source
+    } else {
+        &mut form.destination
+    };
+    if let Some(action) = app.keymap.text_edit_action(key.into()) {
+        let _ = super::super::apply_text_edit_action(action, &mut cursor, value);
+    } else if let KeyCode::Char(character) = key.code
+        && value.chars().count() < 4_096
+    {
+        cursor.insert_char(value, character);
+    }
+    form.cursor = cursor;
+}
+
+fn localized_form_error(error: FormError) -> &'static str {
+    match error {
+        FormError::EndpointRequired => crate::t!(
+            "Enter the WebDAV address.",
+            "WebDAV 주소를 입력해 주세요.",
+            "WebDAVアドレスを入力してください。"
+        ),
+        FormError::SecretRequired => crate::t!(
+            "Enter the password or token.",
+            "비밀번호 또는 토큰을 입력해 주세요.",
+            "パスワードまたはトークンを入力してください。"
+        ),
+        FormError::InvalidDeviceName => crate::t!(
+            "Enter a short device name.",
+            "짧은 기기 이름을 입력해 주세요.",
+            "短いデバイス名を入力してください。"
+        ),
+        FormError::PairingCodeRequired => crate::t!(
+            "Enter the one-time connection code.",
+            "일회용 연결 코드를 입력해 주세요.",
+            "一回限りの接続コードを入力してください。"
+        ),
+        FormError::RecoveryFileRequired => crate::t!(
+            "Choose where to save the recovery kit.",
+            "복구 키트를 저장할 위치를 선택해 주세요.",
+            "復旧キットの保存先を選んでください。"
+        ),
+        FormError::CustomCa => crate::t!(
+            "The CA file could not be read safely.",
+            "CA 파일을 안전하게 읽을 수 없어요.",
+            "CAファイルを安全に読み込めませんでした。"
+        ),
+    }
+}

--- a/src/app/tests/downloads.rs
+++ b/src/app/tests/downloads.rs
@@ -1139,7 +1139,7 @@ fn settings_scroll_resets_on_tab_switch() {
     app.bridges.settings_keys_scroll[0].wheel(false, 4, 30);
     assert_eq!(app.bridges.settings_keys_scroll[0].resolve(0, 5, 30, 0), 4);
 
-    app.settings_switch_tab(true);
+    let _ = app.settings_switch_tab(true);
 
     assert_eq!(
         app.bridges.settings_scroll.resolve(0, 10, 50, 0),

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -69,6 +69,7 @@ mod settings_ui;
 mod source_recovery;
 mod startup_playback;
 mod streaming_extend;
+mod sync_settings;
 mod text_cursor_rendering;
 mod track_transitions;
 mod transport_recovery;

--- a/src/app/tests/settings_ui.rs
+++ b/src/app/tests/settings_ui.rs
@@ -47,6 +47,12 @@ fn settings_tab_cycles_through_all_tabs() {
     assert_eq!(app.settings.as_ref().unwrap().tab, SettingsTab::Ai);
     app.update(Msg::Key(key(KeyCode::Tab)));
     assert_eq!(app.settings.as_ref().unwrap().tab, SettingsTab::Accounts);
+    let cmds = app.update(Msg::Key(key(KeyCode::Tab)));
+    assert_eq!(app.settings.as_ref().unwrap().tab, SettingsTab::Sync);
+    assert!(cmds.iter().any(|cmd| matches!(
+        cmd,
+        Cmd::Data(DataCmd::SyncUi(SyncUiCommand::Refresh { .. }))
+    )));
     app.update(Msg::Key(key(KeyCode::Tab)));
     assert_eq!(app.settings.as_ref().unwrap().tab, SettingsTab::General); // wraps
 }

--- a/src/app/tests/sync_settings.rs
+++ b/src/app/tests/sync_settings.rs
@@ -1,0 +1,433 @@
+use super::*;
+
+#[test]
+fn keyboard_moves_and_activates_the_selected_sync_row() {
+    let mut app = App::new(100);
+    app.open_settings();
+    app.settings.as_mut().unwrap().tab = SettingsTab::Sync;
+
+    assert_eq!(app.personal_state.sync_ui.row, 0);
+    app.update(Msg::Key(key(KeyCode::Down)));
+    assert_eq!(app.personal_state.sync_ui.row, 1);
+
+    app.update(Msg::Key(key(KeyCode::Enter)));
+    assert!(
+        app.personal_state.sync_ui.modal_open(),
+        "Enter should activate the selected Join row"
+    );
+}
+
+#[test]
+fn clicking_the_sync_tab_requests_a_fresh_status_projection() {
+    let mut app = App::new(100);
+    app.open_settings();
+
+    let cmds = click_target(
+        &mut app,
+        MouseTarget::SettingsTab(SettingsTab::Sync.index()),
+    );
+    assert_eq!(app.settings.as_ref().unwrap().tab, SettingsTab::Sync);
+    assert!(cmds.iter().any(|cmd| matches!(
+        cmd,
+        Cmd::Data(DataCmd::SyncUi(SyncUiCommand::Refresh { .. }))
+    )));
+}
+
+#[test]
+fn sync_rows_have_dedicated_mouse_targets_and_activate_on_click() {
+    let mut app = App::new(100);
+    app.open_settings();
+    app.settings.as_mut().unwrap().tab = SettingsTab::Sync;
+
+    let _ = render_app_buffer(&app, 80, 24);
+    assert!(
+        app.hits
+            .regions()
+            .iter()
+            .any(|region| region.target == MouseTarget::SettingsSyncRow(1))
+    );
+
+    let cmds = click_target(&mut app, MouseTarget::SettingsSyncRow(1));
+    assert!(cmds.is_empty());
+    assert_eq!(app.personal_state.sync_ui.row, 1);
+    assert!(
+        app.personal_state.sync_ui.modal_open(),
+        "click should activate the selected Join row"
+    );
+}
+
+#[test]
+fn thirty_column_sync_layout_keeps_a_selectable_row_visible() {
+    let mut app = App::new(100);
+    app.config.retro_mode = true;
+    app.open_settings();
+    app.settings.as_mut().unwrap().tab = SettingsTab::Sync;
+
+    let buffer = render_app_buffer(&app, 30, 30);
+    assert!(
+        app.hits
+            .regions()
+            .iter()
+            .any(|region| region.target == MouseTarget::SettingsSyncRow(0)),
+        "the compact Settings layout should retain a keyboard-and-mouse selectable Sync row"
+    );
+    assert!(buffer_contains(&buffer, "Create"));
+}
+
+#[test]
+fn renderer_uses_the_live_sync_projection() {
+    let _guard = crate::i18n::lock_for_test();
+    crate::i18n::set_language(crate::i18n::Language::English);
+    let mut app = App::new(100);
+    app.config.retro_mode = true;
+    app.open_settings();
+    app.settings.as_mut().unwrap().tab = SettingsTab::Sync;
+    app.personal_state.sync_ui.lifecycle = crate::sync::service::SyncLifecycleState::Active;
+    app.personal_state.sync_ui.status.configured = true;
+    app.personal_state.sync_ui.status.state = crate::sync::SyncHealthState::UpToDate;
+
+    let buffer = render_app_buffer(&app, 80, 24);
+    assert!(buffer_contains(&buffer, "Sync now"));
+    assert!(!buffer_contains(&buffer, "Create encrypted sync"));
+}
+
+#[test]
+fn renderer_exposes_each_recoverable_unfinished_connection_action() {
+    let _guard = crate::i18n::lock_for_test();
+    crate::i18n::set_language(crate::i18n::Language::English);
+    let mut app = needs_cleanup_app();
+    app.config.retro_mode = true;
+    app.open_settings();
+    app.settings.as_mut().unwrap().tab = SettingsTab::Sync;
+
+    let buffer = render_app_buffer(&app, 100, 30);
+
+    assert!(buffer_contains(&buffer, "Continue saved connection"));
+    assert!(buffer_contains(&buffer, "Enter connection details again"));
+    assert!(buffer_contains(&buffer, "Discard unfinished connection"));
+}
+
+#[test]
+fn printable_quit_binding_is_text_inside_sync_connection_form() {
+    let mut app = App::new(100);
+    let mut bindings = std::collections::BTreeMap::new();
+    bindings.insert("global.quit".to_owned(), "q".to_owned());
+    app.keymap = crate::keymap::KeyMap::from_overrides(&bindings);
+    assert!(matches!(
+        app.keymap
+            .global_action(crate::keymap::Chord::from(key(KeyCode::Char('q')))),
+        Some(crate::keymap::Action::Quit)
+    ));
+    app.personal_state.sync_ui.wizard = Some(SyncWizard::Join {
+        form: SyncConnectionForm::join(),
+        confirm: false,
+    });
+
+    let commands = app.update(Msg::Key(key(KeyCode::Char('q'))));
+
+    assert!(commands.is_empty());
+    assert!(!app.should_quit);
+    let Some(SyncWizard::Join { form, .. }) = app.personal_state.sync_ui.wizard.as_ref() else {
+        panic!("join form should remain open");
+    };
+    assert_eq!(
+        form.display_value(SyncConnectionField::Endpoint),
+        "q",
+        "the printable global mapping belongs to the focused text field"
+    );
+}
+
+#[test]
+fn backtab_moves_to_the_previous_sync_connection_field() {
+    let mut app = App::new(100);
+    let mut form = SyncConnectionForm::join();
+    form.select_field(true, 1);
+    app.personal_state.sync_ui.wizard = Some(SyncWizard::Join {
+        form,
+        confirm: false,
+    });
+
+    app.update(Msg::Key(key(KeyCode::BackTab)));
+
+    let Some(SyncWizard::Join { form, .. }) = app.personal_state.sync_ui.wizard.as_ref() else {
+        panic!("join form should remain open");
+    };
+    assert!(matches!(
+        form.current_field(true),
+        SyncConnectionField::Endpoint
+    ));
+}
+
+#[test]
+fn revealed_sync_secret_updates_the_keyboard_hint() {
+    let _guard = crate::i18n::lock_for_test();
+    crate::i18n::set_language(crate::i18n::Language::English);
+    let mut app = App::new(100);
+    let mut form = SyncConnectionForm::join();
+    form.select_field(true, 2);
+    app.personal_state.sync_ui.wizard = Some(SyncWizard::Join {
+        form,
+        confirm: false,
+    });
+    for ch in "z9Q".chars() {
+        app.update(Msg::Key(key(KeyCode::Char(ch))));
+    }
+    app.update(Msg::Key(ctrl(KeyCode::Char('r'))));
+
+    let buffer = render_app_buffer(&app, 80, 24);
+
+    assert!(buffer_contains(&buffer, "z9Q"));
+    assert!(buffer_contains(&buffer, "Ctrl+R hide"));
+}
+
+#[test]
+fn paired_double_click_cannot_advance_a_sync_wizard_twice() {
+    let mut app = App::new(100);
+    app.personal_state.sync_ui.wizard = Some(SyncWizard::Join {
+        form: SyncConnectionForm::join(),
+        confirm: false,
+    });
+
+    let commands = app.update(Msg::MouseDoubleClick { col: 10, row: 10 });
+
+    assert!(commands.is_empty());
+    assert!(matches!(
+        app.personal_state.sync_ui.wizard,
+        Some(SyncWizard::Join { confirm: false, .. })
+    ));
+}
+
+fn sync_overview(state: crate::sync::SyncHealthState) -> crate::sync::service::SyncOverview {
+    crate::sync::service::SyncOverview {
+        status: crate::sync::service::SyncStatusReport {
+            state,
+            label: state.label().to_owned(),
+            ..Default::default()
+        },
+        lifecycle: crate::sync::service::SyncLifecycleState::Absent,
+        devices: Vec::new(),
+        audit: Vec::new(),
+    }
+}
+
+#[test]
+fn refresh_is_single_flight_and_only_the_latest_request_applies() {
+    let mut app = App::new(100);
+    let first = app.request_sync_ui_refresh();
+    let [
+        Cmd::Data(DataCmd::SyncUi(SyncUiCommand::Refresh {
+            flow_id,
+            request_id: first_request,
+            ..
+        })),
+    ] = first.as_slice()
+    else {
+        panic!("first refresh should start");
+    };
+    app.queue_sync_ui_refresh();
+    let latest_request = app.personal_state.sync_ui.refresh_request_id;
+    assert_ne!(*first_request, latest_request);
+
+    let follow_up = app.update(Msg::Data(DataMsg::SyncUi(SyncUiEvent::Refreshed {
+        flow_id: *flow_id,
+        request_id: *first_request,
+        result: Box::new(Ok(sync_overview(
+            crate::sync::SyncHealthState::NeedsAttention,
+        ))),
+    })));
+
+    assert_eq!(
+        app.personal_state.sync_ui.status.state,
+        crate::sync::SyncHealthState::Off
+    );
+    assert!(matches!(
+        follow_up.as_slice(),
+        [Cmd::Data(DataCmd::SyncUi(SyncUiCommand::Refresh {
+            request_id,
+            ..
+        }))] if *request_id == latest_request
+    ));
+
+    let duplicate = app.update(Msg::Data(DataMsg::SyncUi(SyncUiEvent::Refreshed {
+        flow_id: *flow_id,
+        request_id: *first_request,
+        result: Box::new(Ok(sync_overview(
+            crate::sync::SyncHealthState::NeedsAttention,
+        ))),
+    })));
+    assert!(duplicate.is_empty());
+    assert!(matches!(
+        app.personal_state.sync_ui.busy,
+        Some(crate::app::sync_ui::SyncBusy::Refresh)
+    ));
+
+    app.update(Msg::Data(DataMsg::SyncUi(SyncUiEvent::Refreshed {
+        flow_id: *flow_id,
+        request_id: latest_request,
+        result: Box::new(Ok(sync_overview(crate::sync::SyncHealthState::UpToDate))),
+    })));
+    assert_eq!(
+        app.personal_state.sync_ui.status.state,
+        crate::sync::SyncHealthState::UpToDate
+    );
+    assert!(app.personal_state.sync_ui.busy.is_none());
+}
+
+#[test]
+fn terminal_sync_worker_error_queues_a_fresh_overview() {
+    let mut app = App::new(100);
+    app.personal_state.sync_ui.flow_id = 7;
+    app.personal_state.sync_ui.busy = Some(crate::app::sync_ui::SyncBusy::RecoveryExport);
+
+    let commands = app.update(Msg::Data(DataMsg::SyncUi(SyncUiEvent::RecoveryExported {
+        flow_id: 7,
+        result: Box::new(Err(crate::sync::service::SyncServiceError::Storage)),
+    })));
+
+    assert!(matches!(
+        commands.as_slice(),
+        [Cmd::Data(DataCmd::SyncUi(SyncUiCommand::Refresh { .. }))]
+    ));
+    assert!(matches!(
+        app.personal_state.sync_ui.wizard,
+        Some(SyncWizard::Result { success: false, .. })
+    ));
+}
+
+#[test]
+fn sync_rows_are_inert_while_status_reports_syncing() {
+    let mut app = App::new(100);
+    app.personal_state.sync_ui.lifecycle = crate::sync::service::SyncLifecycleState::Active;
+    app.personal_state.sync_ui.status.configured = true;
+    app.personal_state.sync_ui.status.state = crate::sync::SyncHealthState::Syncing;
+    app.personal_state.sync_ui.row = 0;
+
+    assert!(app.activate_sync_row().is_empty());
+    assert!(app.personal_state.sync_ui.wizard.is_none());
+}
+
+fn needs_cleanup_app() -> App {
+    let mut app = App::new(100);
+    app.personal_state.sync_ui.lifecycle = crate::sync::service::SyncLifecycleState::NeedsCleanup;
+    app.personal_state.sync_ui.status.state = crate::sync::SyncHealthState::NeedsAttention;
+    app.personal_state.sync_ui.status.failure = Some(crate::sync::SyncFailureKind::Storage);
+    app
+}
+
+#[test]
+fn needs_cleanup_offers_resume_reentry_discard_and_activity() {
+    let app = needs_cleanup_app();
+    let model = app.sync_settings_model();
+
+    assert_eq!(model.failure, None);
+    assert_eq!(
+        model.rows,
+        vec![
+            crate::settings::sync::SyncRow::Notice(crate::settings::sync::SyncNotice::NeedsCleanup),
+            crate::settings::sync::SyncRow::Action(
+                crate::settings::sync::SyncRowAction::ResumeConnection
+            ),
+            crate::settings::sync::SyncRow::Action(
+                crate::settings::sync::SyncRowAction::ReenterConnection
+            ),
+            crate::settings::sync::SyncRow::Action(
+                crate::settings::sync::SyncRowAction::DiscardConnection
+            ),
+            crate::settings::sync::SyncRow::Action(crate::settings::sync::SyncRowAction::Activity),
+        ]
+    );
+    assert_eq!(app.personal_state.sync_ui.row_count(), 5);
+}
+
+#[test]
+fn needs_cleanup_resume_is_a_move_only_worker_request() {
+    let mut app = needs_cleanup_app();
+    app.personal_state.sync_ui.row = 1;
+
+    let commands = app.activate_sync_row();
+
+    assert!(matches!(
+        commands.as_slice(),
+        [Cmd::Data(DataCmd::SyncUi(SyncUiCommand::JoinResume {
+            flow_id,
+            ..
+        }))] if *flow_id == app.personal_state.sync_ui.flow_id
+    ));
+    assert!(matches!(
+        app.personal_state.sync_ui.busy,
+        Some(crate::app::sync_ui::SyncBusy::PairJoinPoll)
+    ));
+}
+
+#[test]
+fn needs_cleanup_can_reenter_the_same_connection_details() {
+    let mut app = needs_cleanup_app();
+    app.personal_state.sync_ui.row = 2;
+
+    assert!(app.activate_sync_row().is_empty());
+
+    assert!(matches!(
+        app.personal_state.sync_ui.wizard,
+        Some(SyncWizard::Join { confirm: false, .. })
+    ));
+}
+
+#[test]
+fn unfinished_connection_discard_requires_a_separate_confirmation() {
+    let mut app = needs_cleanup_app();
+    app.personal_state.sync_ui.row = 3;
+
+    assert!(app.activate_sync_row().is_empty());
+    assert!(matches!(
+        app.personal_state.sync_ui.wizard,
+        Some(SyncWizard::DiscardJoinConfirm)
+    ));
+
+    let commands = app.update(Msg::Key(key(KeyCode::Enter)));
+    assert!(matches!(
+        commands.as_slice(),
+        [Cmd::Data(DataCmd::SyncUi(SyncUiCommand::DiscardJoin {
+            flow_id
+        }))] if *flow_id == app.personal_state.sync_ui.flow_id
+    ));
+    assert!(matches!(
+        app.personal_state.sync_ui.busy,
+        Some(crate::app::sync_ui::SyncBusy::PairJoinDiscard)
+    ));
+}
+
+#[test]
+fn cancelling_discard_confirmation_preserves_the_unfinished_connection() {
+    let mut app = needs_cleanup_app();
+    app.personal_state.sync_ui.wizard = Some(SyncWizard::DiscardJoinConfirm);
+
+    assert!(app.update(Msg::Key(key(KeyCode::Esc))).is_empty());
+    assert!(app.personal_state.sync_ui.wizard.is_none());
+    assert!(app.personal_state.sync_ui.busy.is_none());
+}
+
+#[test]
+fn discarded_connection_reports_local_data_was_preserved_and_refreshes() {
+    let _guard = crate::i18n::lock_for_test();
+    crate::i18n::set_language(crate::i18n::Language::English);
+    let mut app = needs_cleanup_app();
+    app.personal_state.sync_ui.flow_id = 9;
+    app.personal_state.sync_ui.busy = Some(crate::app::sync_ui::SyncBusy::PairJoinDiscard);
+
+    let commands = app.update(Msg::Data(DataMsg::SyncUi(SyncUiEvent::JoinDiscarded {
+        flow_id: 9,
+        result: Ok(()),
+    })));
+
+    assert!(matches!(
+        commands.as_slice(),
+        [Cmd::Data(DataCmd::SyncUi(SyncUiCommand::Refresh { .. }))]
+    ));
+    assert!(matches!(
+        app.personal_state.sync_ui.wizard,
+        Some(SyncWizard::Result {
+            success: true,
+            ref message,
+        }) if message.contains("Local listening data was not changed")
+    ));
+}

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -6,6 +6,10 @@
 
 use super::*;
 
+#[path = "types/scroll_surface.rs"]
+mod scroll_surface;
+pub use scroll_surface::ScrollSurface;
+
 /// Pending owner-mediated transfer commit. The candidate is intentionally not installed into
 /// live App state until this exact persistence generation is confirmed.
 pub struct TransferPlaylistCommit {
@@ -277,6 +281,8 @@ pub enum DataMsg {
     PersonalSyncPrepared(Box<PersonalSyncPrepared>),
     /// Exact persistence-actor result for a detached WebDAV candidate or its local rebase.
     PersonalSyncPersisted(Box<PersonalSyncPersisted>),
+    SyncActivationPersisted(Box<SyncActivationPersisted>),
+    SyncUi(SyncUiEvent),
 }
 
 /// Events produced by the portable personal-data export worker.
@@ -323,6 +329,7 @@ pub enum DataCmd {
         personal_state: Box<crate::personal_state::PersonalStateV2>,
         reply: PersonalSyncReply,
     },
+    SyncUi(SyncUiCommand),
 }
 
 /// Effects in the portable personal-data export domain.
@@ -488,6 +495,7 @@ pub enum PersistCmd {
     TransferPlaylistCommit(Box<TransferPlaylistCommit>),
     /// Install one WebDAV candidate through the PersonalState persistence ordering lane.
     PersonalSyncCommit(Box<PersonalSyncCommit>),
+    SyncActivationCommit(Box<SyncActivationCommit>),
 }
 
 /// Blocking Local Deck work requested by the reducer.
@@ -722,6 +730,17 @@ pub enum MouseTarget {
     MouseHelp,
     /// A Settings tab header, by index into [`SettingsTab::ALL`].
     SettingsTab(usize),
+    /// An action or detail row in the privacy-safe Sync settings projection. Clicking selects
+    /// the row and delegates to the same action path as Enter; informational rows safely no-op.
+    SettingsSyncRow(usize),
+    /// A field in the move-only Sync setup/join/recovery wizard.
+    SyncWizardField(usize),
+    /// The wizard's affirmative action (continue, approve, merge, remove, or finish).
+    SyncWizardPrimary,
+    /// The wizard's non-affirmative action (back, cancel, or reject).
+    SyncWizardSecondary,
+    /// Reveal or mask the currently focused secret field. The target carries no secret value.
+    SyncWizardReveal,
     /// A clickable value control on a Settings field row — the checkbox of a toggle or the
     /// `<` / `>` arrow of a Select/Slider. Carries the field-row index and the nudge direction,
     /// so a click is the mouse equivalent of ←/→ on that row.
@@ -864,27 +883,6 @@ pub enum MouseTarget {
 pub struct MouseButtonRegion {
     pub rect: Rect,
     pub target: MouseTarget,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ScrollSurface {
-    Library,
-    Search,
-    LocalFind,
-    /// The search results-filter popup's list.
-    SearchFilter,
-    /// The artist detail screen's top-songs list.
-    ArtistSongs,
-    /// The artist detail screen's albums/singles list.
-    ArtistAlbums,
-    AiTranscript,
-    AiSuggestions,
-    Settings,
-    Queue,
-    /// The radio "now playing" (지듣노) card's title line — marquee-only, no scrollbar.
-    NowPlaying,
-    /// The player/mini/docked title row — marquee-only, no scrollbar.
-    PlayerTitle,
 }
 
 /// Who authored a line in the DJ Gem chat transcript.

--- a/src/app/types/scroll_surface.rs
+++ b/src/app/types/scroll_surface.rs
@@ -1,0 +1,22 @@
+//! Semantic owners of rendered scroll tracks.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollSurface {
+    Library,
+    Search,
+    LocalFind,
+    /// The search results-filter popup's list.
+    SearchFilter,
+    /// The artist detail screen's top-songs list.
+    ArtistSongs,
+    /// The artist detail screen's albums/singles list.
+    ArtistAlbums,
+    AiTranscript,
+    AiSuggestions,
+    Settings,
+    Queue,
+    /// The radio "now playing" (지듣노) card's title line — marquee-only, no scrollbar.
+    NowPlaying,
+    /// The player/mini/docked title row — marquee-only, no scrollbar.
+    PlayerTitle,
+}

--- a/src/daemon/engine.rs
+++ b/src/daemon/engine.rs
@@ -899,9 +899,7 @@ impl DaemonEngine {
                         mime: None,
                     })
             }),
-            personal_sync: Some(crate::sync::service::read_current_status(
-                self.personal_sync_in_progress,
-            )),
+            personal_sync: Some(self.personal_sync_status()),
         }
     }
 

--- a/src/daemon/engine/personal_sync.rs
+++ b/src/daemon/engine/personal_sync.rs
@@ -15,6 +15,16 @@ impl DaemonEngine {
         self.personal_sync_in_progress = in_progress;
     }
 
+    pub(in crate::daemon) fn personal_sync_status(&self) -> crate::sync::service::SyncStatusReport {
+        match self.personal_state_paths() {
+            Ok(paths) => crate::sync::service::read_current_status_at(
+                &crate::sync::SyncPaths::for_data_root(paths.data_root),
+                self.personal_sync_in_progress,
+            ),
+            Err(_) => crate::sync::service::read_current_status(self.personal_sync_in_progress),
+        }
+    }
+
     pub(in crate::daemon) fn personal_sync_source(
         &mut self,
     ) -> Result<

--- a/src/personal_state/model.rs
+++ b/src/personal_state/model.rs
@@ -350,6 +350,16 @@ pub struct DeviceRecord {
     pub public_identity: Option<DevicePublicIdentity>,
 }
 
+impl DeviceRecord {
+    /// Characters that are unsafe in portable device names and their one-line projections.
+    ///
+    /// Keep this policy here so the ledger validator, setup form, and redacted Settings model
+    /// cannot disagree about invisible or bidirectional formatting characters.
+    pub(crate) fn is_forbidden_name_char(character: char) -> bool {
+        forbidden_char(character)
+    }
+}
+
 pub type DeviceRegistry = BTreeMap<DeviceId, DeviceRecord>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -896,7 +906,8 @@ fn forbidden_char(character: char) -> bool {
     character.is_control()
         || matches!(
             character,
-            '\u{200b}'
+            '\u{061c}'
+                | '\u{200b}'
                 | '\u{200c}'
                 | '\u{200d}'
                 | '\u{200e}'
@@ -905,4 +916,31 @@ fn forbidden_char(character: char) -> bool {
                 | '\u{2066}'..='\u{2069}'
                 | '\u{feff}'
         )
+}
+
+#[cfg(test)]
+mod forbidden_character_tests {
+    use super::{DeviceRecord, validate_text};
+
+    #[test]
+    fn device_names_reject_every_forbidden_format_character_and_controls() {
+        for character in [
+            '\u{061c}', '\u{200b}', '\u{200c}', '\u{200d}', '\u{200e}', '\u{200f}', '\u{202a}',
+            '\u{202b}', '\u{202c}', '\u{202d}', '\u{202e}', '\u{2066}', '\u{2067}', '\u{2068}',
+            '\u{2069}', '\u{feff}', '\0', '\n', '\u{007f}', '\u{0085}',
+        ] {
+            assert!(
+                DeviceRecord::is_forbidden_name_char(character),
+                "U+{:04X} must be forbidden",
+                u32::from(character)
+            );
+            assert!(
+                validate_text("device name", &format!("safe{character}name")).is_err(),
+                "U+{:04X} must fail portable text validation",
+                u32::from(character)
+            );
+        }
+        assert!(!DeviceRecord::is_forbidden_name_char('한'));
+        assert!(validate_text("device name", "Living room 노트북").is_ok());
+    }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -30,6 +30,8 @@ mod personal_sync_commit;
 pub(crate) mod player_delivery;
 mod read_only;
 mod recorder_recovery;
+mod sync_activation_commit;
+mod sync_ui_worker;
 mod task_set;
 mod transfer_commit;
 

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -162,11 +162,24 @@ impl RuntimeHandles {
             Cmd::Persist(PersistCmd::PersonalSyncCommit(commit)) => {
                 self.dispatch_personal_sync_commit(app, commit);
             }
+            Cmd::Persist(PersistCmd::SyncActivationCommit(commit)) => {
+                self.dispatch_sync_activation_commit(app, commit);
+            }
             Cmd::Persist(p) => {
                 let result = persist_delivery::admit(&self.persist, app, p);
                 report_actor_delivery(app, "persistence", result);
             }
             Cmd::Data(cmd) => match cmd {
+                DataCmd::SyncUi(command) => {
+                    let emitter = self.background_tasks.emitter(self.worker_tx.clone());
+                    self.background_tasks
+                        .spawn_blocking("sync_settings", move || {
+                            let event = super::sync_ui_worker::run(command);
+                            emitter.emit_terminal_blocking(RuntimeEvent::App(Msg::Data(
+                                crate::app::DataMsg::SyncUi(event),
+                            )));
+                        });
+                }
                 DataCmd::PersonalSync {
                     action,
                     attempt,

--- a/src/runtime/persist_delivery.rs
+++ b/src/runtime/persist_delivery.rs
@@ -20,6 +20,9 @@ pub(super) fn admit(handle: &PersistHandle, app: &mut App, command: PersistCmd) 
         PersistCmd::PersonalSyncCommit(_) => {
             unreachable!("targeted sync persistence is dispatched before snapshot markers")
         }
+        PersistCmd::SyncActivationCommit(_) => {
+            unreachable!("targeted sync activation is dispatched before snapshot markers")
+        }
     }
 }
 

--- a/src/runtime/read_only.rs
+++ b/src/runtime/read_only.rs
@@ -30,6 +30,7 @@ pub(super) fn durable_mutation_component(cmd: &Cmd) -> Option<&'static str> {
         Cmd::Scrobble(_) => Some("scrobble state"),
         Cmd::Transfer(_) => Some("transfer state"),
         Cmd::Data(DataCmd::PersonalSync { .. }) => Some("personal sync"),
+        Cmd::Data(DataCmd::SyncUi(command)) if !command.is_read_only() => Some("personal sync"),
         Cmd::PlayerControl(_)
         | Cmd::VideoConnect { .. }
         | Cmd::VideoLoad(_)
@@ -37,7 +38,9 @@ pub(super) fn durable_mutation_component(cmd: &Cmd) -> Option<&'static str> {
         | Cmd::VideoToggleFullscreen
         | Cmd::VideoToggleMute
         | Cmd::Search(_)
-        | Cmd::Data(DataCmd::ScanDownloads(_) | DataCmd::PersonalDataExport(_))
+        | Cmd::Data(
+            DataCmd::ScanDownloads(_) | DataCmd::PersonalDataExport(_) | DataCmd::SyncUi(_),
+        )
         | Cmd::Download(DownloadCmd::Scan(_))
         | Cmd::FetchLyrics(_)
         | Cmd::Resolve { .. }
@@ -107,6 +110,14 @@ pub(super) fn reject_mutation(app: &mut App, cmd: &Cmd, component: &str, reason:
                 ));
             Vec::new()
         }
+        Cmd::Persist(crate::app::PersistCmd::SyncActivationCommit(commit)) => {
+            app.personal_state.sync.in_progress = false;
+            if app.personal_state.sync_ui.is_current(commit.flow_id) {
+                app.personal_state.sync_ui.busy = None;
+                app.queue_sync_ui_refresh();
+            }
+            app.start_pending_sync_ui_refresh()
+        }
         Cmd::Data(DataCmd::PersonalSync { reply, .. }) => {
             app.personal_state.sync.in_progress = false;
             app.personal_state.sync.pending_reply = None;
@@ -115,6 +126,13 @@ pub(super) fn reject_mutation(app: &mut App, cmd: &Cmd, component: &str, reason:
                 "the read-only secondary cannot change personal sync state".to_owned(),
             ));
             Vec::new()
+        }
+        Cmd::Data(DataCmd::SyncUi(command)) => {
+            if app.personal_state.sync_ui.is_current(command.flow_id()) {
+                app.personal_state.sync_ui.busy = None;
+                app.queue_sync_ui_refresh();
+            }
+            app.start_pending_sync_ui_refresh()
         }
         _ => Vec::new(),
     };

--- a/src/runtime/sync_activation_commit.rs
+++ b/src/runtime/sync_activation_commit.rs
@@ -1,0 +1,160 @@
+//! Exact persistence confirmation for setup and pairing activation.
+
+use std::time::Duration;
+
+use super::task_set::RuntimeTaskEmitter;
+use super::{RuntimeEvent, RuntimeHandles};
+use crate::app::{
+    Msg, SyncActivationCommit, SyncActivationCommitStage, SyncActivationPersistOutcome,
+    SyncActivationPersisted,
+};
+use crate::persist::{Snapshot, TargetFlushOutcome};
+use crate::sync::service::{PersonalSyncPersistence, SyncServiceError};
+
+const TARGET_FLUSH_BUDGET: Duration = Duration::from_secs(5);
+const UNCONFIRMED_RETRY_DELAY: Duration = Duration::from_millis(100);
+
+impl RuntimeHandles {
+    pub(super) fn dispatch_sync_activation_commit(
+        &mut self,
+        app: &mut crate::app::App,
+        commit: Box<SyncActivationCommit>,
+    ) {
+        let persist = self.persist.clone();
+        let emitter = self.background_tasks.emitter(self.worker_tx.clone());
+        let rejected = commit.clone();
+        let admitted = self.background_tasks.spawn_cancellable(
+            "sync_activation_commit",
+            persist_sync_activation(persist, emitter, commit),
+        );
+        if !admitted {
+            self.reduce_owner_msg(
+                app,
+                Msg::Data(crate::app::DataMsg::SyncActivationPersisted(Box::new(
+                    SyncActivationPersisted {
+                        commit: rejected,
+                        outcome: SyncActivationPersistOutcome::Failed(SyncServiceError::Storage),
+                    },
+                ))),
+            );
+        }
+    }
+}
+
+async fn persist_sync_activation(
+    persist: crate::persist::PersistHandle,
+    emitter: RuntimeTaskEmitter,
+    commit: Box<SyncActivationCommit>,
+) {
+    let writer = match prepare_writer(&commit) {
+        Ok(writer) => writer,
+        Err(error) => {
+            emit_completion(
+                &emitter,
+                commit,
+                SyncActivationPersistOutcome::Failed(error),
+            )
+            .await;
+            return;
+        }
+    };
+    let target_state = writer.state().clone();
+    let target = match persist.save_tracked(Snapshot::PersonalSync(writer.clone())) {
+        Ok(target) => target,
+        Err(_) => {
+            emit_completion(
+                &emitter,
+                commit,
+                SyncActivationPersistOutcome::Failed(SyncServiceError::Storage),
+            )
+            .await;
+            return;
+        }
+    };
+
+    let outcome = loop {
+        let flush = persist.flush_target(target, TARGET_FLUSH_BUDGET).await;
+        if writer.committed() {
+            break SyncActivationPersistOutcome::Committed(Box::new(target_state));
+        }
+        match flush {
+            TargetFlushOutcome::Superseded => {
+                break SyncActivationPersistOutcome::Superseded;
+            }
+            TargetFlushOutcome::CommittedExact => {
+                break SyncActivationPersistOutcome::Failed(SyncServiceError::Storage);
+            }
+            TargetFlushOutcome::Unconfirmed => {
+                tokio::time::sleep(UNCONFIRMED_RETRY_DELAY).await;
+            }
+        }
+    };
+    emit_completion(&emitter, commit, outcome).await;
+}
+
+fn prepare_writer(
+    commit: &SyncActivationCommit,
+) -> Result<PersonalSyncPersistence, SyncServiceError> {
+    let personal_paths =
+        crate::personal_state::PersonalStatePaths::current().map_err(SyncServiceError::from)?;
+    let sync_paths = crate::sync::SyncPaths::current().map_err(SyncServiceError::from)?;
+    match &commit.stage {
+        SyncActivationCommitStage::Reconcile {
+            expected_state,
+            candidate,
+        } => PersonalSyncPersistence::reconcile(
+            expected_state.as_ref().clone(),
+            commit.observed_local_state.clone(),
+            candidate.as_ref().clone(),
+            commit.playlist_revision,
+            personal_paths,
+            sync_paths,
+        ),
+        SyncActivationCommitStage::Initial => match &commit.kind {
+            crate::app::SyncActivationKind::Setup(prepared) => {
+                PersonalSyncPersistence::setup_activation(
+                    commit.observed_local_state.clone(),
+                    commit.playlist_revision,
+                    prepared.clone(),
+                    personal_paths,
+                    sync_paths,
+                )
+            }
+            crate::app::SyncActivationKind::PairJoin(prepared) => {
+                PersonalSyncPersistence::pairing_join_activation(
+                    commit.observed_local_state.clone(),
+                    commit.playlist_revision,
+                    prepared.clone(),
+                    personal_paths,
+                    sync_paths,
+                )
+            }
+            crate::app::SyncActivationKind::PairApprove {
+                prepared,
+                network_observed_state,
+            } => PersonalSyncPersistence::pairing_approval_activation(
+                network_observed_state.clone(),
+                commit.observed_local_state.clone(),
+                commit.playlist_revision,
+                prepared.clone(),
+                personal_paths,
+                sync_paths,
+            ),
+        },
+    }
+}
+
+async fn emit_completion(
+    emitter: &RuntimeTaskEmitter,
+    commit: Box<SyncActivationCommit>,
+    outcome: SyncActivationPersistOutcome,
+) {
+    emitter
+        .emit_terminal(RuntimeEvent::App(Msg::Data(
+            crate::app::DataMsg::SyncActivationPersisted(Box::new(SyncActivationPersisted {
+                commit,
+                outcome,
+            })),
+        )))
+        .await;
+}

--- a/src/runtime/sync_ui_worker.rs
+++ b/src/runtime/sync_ui_worker.rs
@@ -1,0 +1,295 @@
+//! Bounded blocking operations for the Settings Sync wizard.
+
+use crate::app::{SyncFormError, SyncUiCommand, SyncUiEvent};
+use crate::sync::service::SyncServiceError;
+
+pub(super) fn run(command: SyncUiCommand) -> SyncUiEvent {
+    match command {
+        SyncUiCommand::Refresh {
+            flow_id,
+            request_id,
+            state,
+            in_progress,
+        } => {
+            let result = sync_paths().and_then(|paths| {
+                let read_only = crate::persist::persistence_access().is_read_only();
+                let state = if read_only {
+                    let personal_paths = crate::personal_state::PersonalStatePaths::current()
+                        .map_err(SyncServiceError::from)?;
+                    crate::sync::service::load_personal_state_read_only(&personal_paths)?
+                        .unwrap_or(*state)
+                } else {
+                    *state
+                };
+                crate::sync::service::read_overview(
+                    &paths,
+                    &state,
+                    in_progress,
+                    crate::signals::unix_now(),
+                )
+            });
+            SyncUiEvent::Refreshed {
+                flow_id,
+                request_id,
+                result: Box::new(result),
+            }
+        }
+        SyncUiCommand::RecoveryExport {
+            flow_id,
+            state,
+            source,
+            destination,
+        } => {
+            let result = sync_paths().and_then(|paths| {
+                crate::sync::service::export_recovery_kit(&state, &paths, &source, &destination)
+            });
+            SyncUiEvent::RecoveryExported {
+                flow_id,
+                result: Box::new(result),
+            }
+        }
+        SyncUiCommand::SetupPrepare {
+            flow_id,
+            state,
+            playlist_revision,
+            input,
+        } => {
+            let result = input
+                .into_setup_request()
+                .map_err(map_form_error)
+                .and_then(|request| {
+                    sync_paths().and_then(|paths| {
+                        crate::sync::service::prepare_setup(
+                            &state,
+                            playlist_revision,
+                            &paths,
+                            request,
+                        )
+                    })
+                });
+            SyncUiEvent::SetupPrepared {
+                flow_id,
+                result: Box::new(result),
+            }
+        }
+        SyncUiCommand::SetupResume {
+            flow_id,
+            state,
+            playlist_revision,
+        } => {
+            let result = sync_paths().and_then(|paths| {
+                crate::sync::service::resume_prepared_setup(&state, playlist_revision, &paths)
+            });
+            SyncUiEvent::SetupPrepared {
+                flow_id,
+                result: Box::new(result),
+            }
+        }
+        SyncUiCommand::HostCreate { flow_id, state } => {
+            let result = sync_paths().and_then(|paths| {
+                crate::sync::service::create_pairing_invite(
+                    &state,
+                    &paths,
+                    crate::signals::unix_now(),
+                )
+            });
+            SyncUiEvent::HostCreated {
+                flow_id,
+                result: Box::new(result),
+            }
+        }
+        SyncUiCommand::HostPoll {
+            flow_id,
+            state,
+            mut host,
+        } => {
+            let result = sync_paths().and_then(|paths| {
+                crate::sync::service::poll_pairing_request(
+                    &state,
+                    &paths,
+                    &mut host,
+                    crate::signals::unix_now(),
+                )
+            });
+            SyncUiEvent::HostPolled {
+                flow_id,
+                host,
+                result: Box::new(result),
+            }
+        }
+        SyncUiCommand::HostApprove {
+            flow_id,
+            state,
+            mut host,
+            review,
+        } => {
+            let observed_state = state.clone();
+            let result = sync_paths().and_then(|paths| {
+                crate::sync::service::prepare_pairing_approval(
+                    &state,
+                    &paths,
+                    &mut host,
+                    *review,
+                    crate::signals::unix_now(),
+                )
+            });
+            SyncUiEvent::HostApprovalPrepared {
+                flow_id,
+                host,
+                observed_state,
+                result: Box::new(result),
+            }
+        }
+        SyncUiCommand::HostCancel {
+            flow_id,
+            state,
+            host,
+        } => {
+            let result = sync_paths().and_then(|paths| {
+                crate::sync::service::cancel_pairing_invite(&state, &paths, &host)
+            });
+            SyncUiEvent::HostCancelled {
+                flow_id,
+                host,
+                result,
+            }
+        }
+        SyncUiCommand::JoinStart { flow_id, input } => {
+            let result = input.into_join_request().map_err(map_form_error).and_then(
+                |input: crate::app::SyncJoinRequest| {
+                    sync_paths().and_then(|paths| {
+                        crate::sync::service::start_pairing_join(
+                            &paths,
+                            input.endpoint,
+                            input.custom_ca_pem,
+                            input.credential,
+                            input.pairing_code.as_str(),
+                            input.device_name,
+                            crate::signals::unix_now(),
+                        )
+                    })
+                },
+            );
+            SyncUiEvent::JoinStarted {
+                flow_id,
+                result: Box::new(result),
+            }
+        }
+        SyncUiCommand::JoinPoll { flow_id, state } => {
+            let result = sync_paths().and_then(|paths| {
+                crate::sync::service::poll_pairing_join(&state, &paths, crate::signals::unix_now())
+            });
+            SyncUiEvent::JoinPolled {
+                flow_id,
+                result: Box::new(result),
+            }
+        }
+        SyncUiCommand::JoinResume { flow_id, state } => {
+            let result = sync_paths()
+                .and_then(|paths| crate::sync::service::resume_pairing_join(&state, &paths));
+            SyncUiEvent::JoinResumed {
+                flow_id,
+                result: Box::new(result),
+            }
+        }
+        SyncUiCommand::DiscardJoin { flow_id } => {
+            let result = sync_paths().and_then(|paths| discard_unfinished_join_at(&paths));
+            SyncUiEvent::JoinDiscarded { flow_id, result }
+        }
+        SyncUiCommand::JoinPrepareActivation {
+            flow_id,
+            state,
+            preview,
+        } => {
+            let result = sync_paths().and_then(|paths| {
+                crate::sync::service::prepare_pairing_join_activation(&state, &paths, *preview)
+            });
+            SyncUiEvent::JoinActivationPrepared {
+                flow_id,
+                result: Box::new(result),
+            }
+        }
+    }
+}
+
+fn sync_paths() -> Result<crate::sync::SyncPaths, SyncServiceError> {
+    crate::sync::SyncPaths::current().map_err(SyncServiceError::from)
+}
+
+fn discard_unfinished_join_at(paths: &crate::sync::SyncPaths) -> Result<(), SyncServiceError> {
+    if crate::sync::service::read_lifecycle(paths)?
+        != crate::sync::service::SyncLifecycleState::NeedsCleanup
+    {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
+    crate::sync::service::cancel_pairing_join(paths)
+}
+
+fn map_form_error(error: SyncFormError) -> SyncServiceError {
+    match error {
+        SyncFormError::CustomCa => SyncServiceError::Certificate,
+        SyncFormError::EndpointRequired
+        | SyncFormError::SecretRequired
+        | SyncFormError::InvalidDeviceName
+        | SyncFormError::PairingCodeRequired
+        | SyncFormError::RecoveryFileRequired => SyncServiceError::InvalidRemoteData,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TempRoot(std::path::PathBuf);
+
+    impl TempRoot {
+        fn new() -> Self {
+            static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            let sequence = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let root = std::env::temp_dir().join(format!(
+                "yututui-sync-ui-worker-{}-{sequence}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&root).unwrap();
+            Self(root)
+        }
+    }
+
+    impl Drop for TempRoot {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn discard_scope_guard_rejects_a_non_cleanup_lifecycle() {
+        let root = TempRoot::new();
+        let paths = crate::sync::SyncPaths::for_data_root(root.0.clone());
+
+        assert_eq!(
+            discard_unfinished_join_at(&paths),
+            Err(SyncServiceError::LocalStateChanged)
+        );
+    }
+
+    #[test]
+    fn discard_keeps_unverifiable_cleanup_artifacts() {
+        let root = TempRoot::new();
+        let paths = crate::sync::SyncPaths::for_data_root(root.0.clone());
+        std::fs::create_dir_all(paths.root()).unwrap();
+        std::fs::write(paths.profile(), b"not an authenticated profile").unwrap();
+
+        assert_eq!(
+            crate::sync::service::read_lifecycle(&paths).unwrap(),
+            crate::sync::service::SyncLifecycleState::NeedsCleanup
+        );
+        assert_eq!(
+            discard_unfinished_join_at(&paths),
+            Err(SyncServiceError::InvalidRemoteData)
+        );
+        assert!(
+            paths.profile().exists(),
+            "unverifiable artifacts must not be deleted"
+        );
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -30,6 +30,7 @@ mod color_picker;
 mod display;
 mod field_meta;
 pub(crate) mod gui_mutation;
+pub mod sync;
 pub use actions::{FieldKind, PersonalDataExportStatus};
 pub use color_picker::{
     COLOR_PICKER_CHOICE_COUNT, ColorPickerChoice, ColorPickerSelection, ColorPickerState,
@@ -64,16 +65,19 @@ pub enum SettingsTab {
     /// External accounts: Last.fm / ListenBrainz scrobbling (and later Spotify), as
     /// per-service sub-categories.
     Accounts,
+    /// Encrypted personal-state sync. This tab has its own render/navigation path.
+    Sync,
 }
 
 impl SettingsTab {
-    pub const ALL: [SettingsTab; 6] = [
+    pub const ALL: [SettingsTab; 7] = [
         SettingsTab::General,
         SettingsTab::Playback,
         SettingsTab::Keys,
         SettingsTab::Graphics,
         SettingsTab::Ai,
         SettingsTab::Accounts,
+        SettingsTab::Sync,
     ];
 
     pub fn label(self) -> &'static str {
@@ -84,6 +88,7 @@ impl SettingsTab {
             SettingsTab::Graphics => t!("Graphics", "그래픽", "グラフィック"),
             SettingsTab::Ai => t!("DJ Gem", "DJ Gem", "DJ Gem"),
             SettingsTab::Accounts => t!("Accounts", "계정", "アカウント"),
+            SettingsTab::Sync => t!("Sync", "동기화", "同期"),
         }
     }
 
@@ -238,7 +243,7 @@ impl SettingsTab {
             ],
             // The Keys tab is a list of remappable bindings, not `Field`s; it has its own
             // navigation and rendering paths (see `crate::keymap::editable_entries`).
-            SettingsTab::Keys => Vec::new(),
+            SettingsTab::Keys | SettingsTab::Sync => Vec::new(),
         }
     }
 
@@ -251,7 +256,7 @@ impl SettingsTab {
             SettingsTab::Graphics => graphics_sections(),
             SettingsTab::Accounts => accounts_sections(),
             SettingsTab::Ai => ai_sections(),
-            SettingsTab::General | SettingsTab::Keys => Vec::new(),
+            SettingsTab::General | SettingsTab::Keys | SettingsTab::Sync => Vec::new(),
         }
     }
 }
@@ -1022,15 +1027,16 @@ impl SettingsState {
             | SettingsTab::Keys
             | SettingsTab::Graphics
             | SettingsTab::Ai
-            | SettingsTab::Accounts => {}
+            | SettingsTab::Accounts
+            | SettingsTab::Sync => {}
         }
         sections
     }
 
-    /// The field the cursor is on, or `None` when the tab has no `Field`s (the Keys tab, which
-    /// edits bindings instead). `saturating_sub` matches the view's row clamp; `get` keeps this
-    /// panic-free even for an empty tab, so callers reached on any tab (e.g. the per-keystroke
-    /// "is this a color row?" check) stay sound.
+    /// The field the cursor is on, or `None` when the tab has no `Field`s (Keys and Sync use
+    /// dedicated presentation paths). `saturating_sub` matches the view's row clamp; `get`
+    /// keeps this panic-free even for an empty tab, so callers reached on any tab (e.g. the
+    /// per-keystroke "is this a color row?" check) stay sound.
     pub fn current_field(&self) -> Option<Field> {
         let fields = self.fields();
         fields

--- a/src/settings/sync.rs
+++ b/src/settings/sync.rs
@@ -1,0 +1,606 @@
+//! Privacy-safe presentation state for the Sync settings tab.
+//!
+//! This module deliberately has no endpoint, credential, recovery identity, pairing secret, or
+//! filesystem-path field. Network workers keep those values in their short-lived request state
+//! and project only these typed summaries into the renderer.
+
+use crate::personal_state::DeviceRecord;
+use crate::sync::{
+    SyncAuditAction, SyncAuditEntry, SyncAuditOutcome, SyncFailureKind, SyncHealthState,
+};
+use crate::t;
+
+/// The Sync tab's current screen.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SyncDisplayPage {
+    #[default]
+    Status,
+    Create,
+    Join,
+    PairDevice,
+    MergePreview,
+    Devices,
+    Recovery,
+    Activity,
+    RevokeDevice,
+}
+
+impl SyncDisplayPage {
+    pub fn title(self) -> &'static str {
+        match self {
+            Self::Status => t!("Personal sync", "개인 동기화", "個人データ同期"),
+            Self::Create => t!(
+                "Set up personal sync",
+                "개인 동기화 설정",
+                "個人データ同期を設定"
+            ),
+            Self::Join => t!(
+                "Join personal sync",
+                "개인 동기화에 연결",
+                "個人データ同期に参加"
+            ),
+            Self::PairDevice => t!("Add a device", "기기 추가", "デバイスを追加"),
+            Self::MergePreview => t!("Review changes", "변경 사항 확인", "変更内容を確認"),
+            Self::Devices => t!("Devices", "기기", "デバイス"),
+            Self::Recovery => t!("Recovery", "복구", "復旧"),
+            Self::Activity => t!("Sync activity", "동기화 활동", "同期アクティビティ"),
+            Self::RevokeDevice => t!("Remove device", "기기 제거", "デバイスを削除"),
+        }
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::Status => t!(
+                "Your listening data stays available on this device.",
+                "감상 데이터는 이 기기에서 계속 사용할 수 있습니다.",
+                "再生データはこのデバイスでいつでも利用できます。"
+            ),
+            Self::Create => t!(
+                "Save a recovery kit before connecting another device.",
+                "다른 기기를 연결하기 전에 복구 키트를 저장하세요.",
+                "別のデバイスを接続する前に復旧キットを保存します。"
+            ),
+            Self::Join => t!(
+                "Enter the connection details and one-time code from an approved device.",
+                "연결 정보와 승인된 기기의 일회용 코드를 입력하세요.",
+                "接続情報と承認済みデバイスの一回限りのコードを入力します。"
+            ),
+            Self::PairDevice => t!(
+                "The code expires after 10 minutes. Review the device before approving it.",
+                "코드는 10분 후 만료됩니다. 승인 전에 기기를 확인하세요.",
+                "コードは10分後に期限切れになります。承認前にデバイスを確認してください。"
+            ),
+            Self::MergePreview => t!(
+                "The first merge keeps both sides. Nothing is deleted.",
+                "첫 병합은 양쪽 데이터를 모두 유지하며 삭제하지 않습니다.",
+                "最初の統合では両方のデータを残し、削除しません。"
+            ),
+            Self::Devices => t!(
+                "Only remove a device you no longer trust or use.",
+                "더 이상 신뢰하거나 사용하지 않는 기기만 제거하세요.",
+                "信頼しない、または使わなくなったデバイスだけを削除してください。"
+            ),
+            Self::Recovery => t!(
+                "Keep the recovery kit separate from your sync password.",
+                "복구 키트는 동기화 비밀번호와 별도로 보관하세요.",
+                "復旧キットは同期パスワードとは別に保管してください。"
+            ),
+            Self::Activity => t!(
+                "Recent results are shown without passwords, addresses, or file locations.",
+                "최근 결과에는 비밀번호, 주소, 파일 위치가 표시되지 않습니다.",
+                "最近の結果にはパスワード、アドレス、ファイルの場所は表示されません。"
+            ),
+            Self::RevokeDevice => t!(
+                "Removed devices cannot receive future changes.",
+                "제거된 기기는 이후 변경 사항을 받을 수 없습니다.",
+                "削除したデバイスは今後の変更を受け取れません。"
+            ),
+        }
+    }
+}
+
+/// Stable actions a Sync row can invoke. Secret-bearing form values live outside this model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncRowAction {
+    Create,
+    Join,
+    SyncNow,
+    Retry,
+    ResumeConnection,
+    ReenterConnection,
+    DiscardConnection,
+    ReviewDevice,
+    ReviewMerge,
+    ViewMergeResult,
+    AddDevice,
+    Devices,
+    Recovery,
+    Activity,
+    SaveRecoveryKit,
+    ApproveDevice,
+    RejectDevice,
+    ApplyMerge,
+    RemoveDevice,
+    ConfirmRemoveDevice,
+    Back,
+}
+
+impl SyncRowAction {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Create => t!(
+                "Create encrypted sync",
+                "암호화 동기화 만들기",
+                "暗号化同期を作成"
+            ),
+            Self::Join => t!(
+                "Join existing sync",
+                "기존 동기화에 연결",
+                "既存の同期に参加"
+            ),
+            Self::SyncNow => t!("Sync now", "지금 동기화", "今すぐ同期"),
+            Self::Retry => t!("Retry", "다시 시도", "再試行"),
+            Self::ResumeConnection => t!(
+                "Continue saved connection",
+                "저장된 연결 이어가기",
+                "保存した接続を再開"
+            ),
+            Self::ReenterConnection => t!(
+                "Enter connection details again",
+                "연결 정보 다시 입력",
+                "接続情報を再入力"
+            ),
+            Self::DiscardConnection => t!(
+                "Discard unfinished connection",
+                "완료되지 않은 연결 버리기",
+                "未完了の接続を破棄"
+            ),
+            Self::ReviewDevice => t!("Review device", "기기 확인", "デバイスを確認"),
+            Self::ReviewMerge => t!("Review changes", "변경 사항 확인", "変更内容を確認"),
+            Self::ViewMergeResult => {
+                t!("View merge result", "병합 결과 보기", "統合結果を表示")
+            }
+            Self::AddDevice => t!("Add device", "기기 추가", "デバイスを追加"),
+            Self::Devices => t!("Devices & recovery", "기기 및 복구", "デバイスと復旧"),
+            Self::Recovery => t!("Recovery", "복구", "復旧"),
+            Self::Activity => t!("View sync activity", "동기화 활동 보기", "同期履歴を表示"),
+            Self::SaveRecoveryKit => {
+                t!("Save recovery kit", "복구 키트 저장", "復旧キットを保存")
+            }
+            Self::ApproveDevice => t!("Approve device", "기기 승인", "デバイスを承認"),
+            Self::RejectDevice => t!("Reject device", "기기 거절", "デバイスを拒否"),
+            Self::ApplyMerge => t!("Merge these changes", "변경 사항 병합", "この変更を統合"),
+            Self::RemoveDevice => t!("Remove device", "기기 제거", "デバイスを削除"),
+            Self::ConfirmRemoveDevice => {
+                t!("Remove this device", "이 기기 제거", "このデバイスを削除")
+            }
+            Self::Back => t!("Back", "뒤로", "戻る"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncNotice {
+    RecoveryKitRequired,
+    WaitingForDevice,
+    FirstMergeKeepsEverything,
+    NeedsCleanup,
+    DeviceRevoked,
+    RecoveryKitSaved,
+    NoOtherDevices,
+    NoActivity,
+}
+
+impl SyncNotice {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::RecoveryKitRequired => t!(
+                "Save and confirm your recovery kit to finish setup.",
+                "설정을 마치려면 복구 키트를 저장하고 확인하세요.",
+                "設定を完了するには復旧キットを保存して確認してください。"
+            ),
+            Self::WaitingForDevice => t!(
+                "Waiting for the other device…",
+                "다른 기기를 기다리는 중…",
+                "もう一方のデバイスを待っています…"
+            ),
+            Self::FirstMergeKeepsEverything => t!(
+                "Both sides will be kept. Nothing will be deleted.",
+                "양쪽 데이터를 모두 유지하며 삭제하지 않습니다.",
+                "両方のデータを残し、削除しません。"
+            ),
+            Self::NeedsCleanup => t!(
+                "A connection did not finish. Local listening data is safe. Try the saved connection or enter the same details again.",
+                "연결이 완료되지 않았습니다. 이 기기의 감상 데이터는 안전합니다. 저장된 연결을 이어가거나 같은 정보를 다시 입력하세요.",
+                "接続が完了しませんでした。ローカルの再生データは安全です。保存した接続を再開するか、同じ情報を再入力してください。"
+            ),
+            Self::DeviceRevoked => t!(
+                "This device was removed from sync. Its local listening data was not deleted.",
+                "이 기기는 동기화에서 제거되었습니다. 로컬 감상 데이터는 삭제되지 않았습니다.",
+                "このデバイスは同期から削除されました。ローカルの再生データは削除されていません。"
+            ),
+            Self::RecoveryKitSaved => {
+                t!(
+                    "Recovery kit saved",
+                    "복구 키트 저장됨",
+                    "復旧キットを保存しました"
+                )
+            }
+            Self::NoOtherDevices => t!(
+                "No other connected devices",
+                "연결된 다른 기기 없음",
+                "ほかに接続済みのデバイスはありません"
+            ),
+            Self::NoActivity => t!(
+                "No sync activity yet",
+                "아직 동기화 활동 없음",
+                "同期履歴はまだありません"
+            ),
+        }
+    }
+}
+
+/// A single device projected for display. Values are normalized to bounded, single-line text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncDeviceRow {
+    name: String,
+    fingerprint: String,
+    pub current: bool,
+    pub active: bool,
+}
+
+impl SyncDeviceRow {
+    pub fn new(name: &str, fingerprint: &str, current: bool, active: bool) -> Self {
+        Self {
+            name: safe_one_line(
+                name,
+                80,
+                t!("Unnamed device", "이름 없는 기기", "名前のないデバイス"),
+            ),
+            fingerprint: safe_one_line(fingerprint, 96, "—"),
+            current,
+            active,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+}
+
+/// A redacted activity row. Counts and typed outcomes are safe to retain in Settings state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncAuditRow {
+    pub at_unix: i64,
+    pub action: SyncAuditAction,
+    pub outcome: SyncAuditOutcome,
+    pub failure: Option<SyncFailureKind>,
+    pub local_changes: usize,
+    pub remote_changes: usize,
+}
+
+impl From<&SyncAuditEntry> for SyncAuditRow {
+    fn from(entry: &SyncAuditEntry) -> Self {
+        Self {
+            at_unix: entry.at_unix,
+            action: entry.action,
+            outcome: entry.outcome,
+            failure: entry.failure,
+            local_changes: entry.local_operations,
+            remote_changes: entry.remote_operations,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SyncMergeSummary {
+    pub local_changes: usize,
+    pub remote_changes: usize,
+    pub duplicates_skipped: usize,
+}
+
+/// A presentation row. It contains no arbitrary endpoint, path, credential, or error string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyncRow {
+    Action(SyncRowAction),
+    Device(SyncDeviceRow),
+    Audit(SyncAuditRow),
+    MergeSummary(SyncMergeSummary),
+    Notice(SyncNotice),
+}
+
+/// Cloneable, redacted snapshot consumed by the Sync settings renderer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncSettingsModel {
+    pub page: SyncDisplayPage,
+    pub health: SyncHealthState,
+    pub failure: Option<SyncFailureKind>,
+    pub configured: bool,
+    pub busy: bool,
+    pub selected: usize,
+    pub rows: Vec<SyncRow>,
+}
+
+impl Default for SyncSettingsModel {
+    fn default() -> Self {
+        Self::off()
+    }
+}
+
+impl SyncSettingsModel {
+    pub fn off() -> Self {
+        Self {
+            page: SyncDisplayPage::Status,
+            health: SyncHealthState::Off,
+            failure: None,
+            configured: false,
+            busy: false,
+            selected: 0,
+            rows: vec![
+                SyncRow::Action(SyncRowAction::Create),
+                SyncRow::Action(SyncRowAction::Join),
+            ],
+        }
+    }
+
+    pub fn configured(health: SyncHealthState, failure: Option<SyncFailureKind>) -> Self {
+        let mut rows = Vec::new();
+        if let Some(failure) = failure {
+            rows.push(SyncRow::Action(failure_action(failure)));
+        }
+        rows.extend([
+            SyncRow::Action(SyncRowAction::SyncNow),
+            SyncRow::Action(SyncRowAction::AddDevice),
+            SyncRow::Action(SyncRowAction::Devices),
+            SyncRow::Action(SyncRowAction::Activity),
+        ]);
+        Self {
+            page: SyncDisplayPage::Status,
+            health,
+            failure,
+            configured: true,
+            busy: health == SyncHealthState::Syncing,
+            selected: 0,
+            rows,
+        }
+    }
+
+    pub fn selected(&self) -> Option<usize> {
+        (!self.rows.is_empty()).then(|| self.selected.min(self.rows.len() - 1))
+    }
+}
+
+fn failure_action(failure: SyncFailureKind) -> SyncRowAction {
+    match failure {
+        SyncFailureKind::RemoteChanged => SyncRowAction::ViewMergeResult,
+        SyncFailureKind::DeviceApproval => SyncRowAction::ReviewDevice,
+        SyncFailureKind::InvalidRemoteData | SyncFailureKind::Storage => SyncRowAction::Activity,
+        SyncFailureKind::Authentication
+        | SyncFailureKind::Certificate
+        | SyncFailureKind::Offline
+        | SyncFailureKind::LocalStateChanged => SyncRowAction::Retry,
+    }
+}
+
+pub fn health_label(state: SyncHealthState) -> &'static str {
+    match state {
+        SyncHealthState::Off => t!("Off", "꺼짐", "オフ"),
+        SyncHealthState::UpToDate => t!("Up to date", "최신 상태", "最新"),
+        SyncHealthState::Syncing => t!("Syncing", "동기화 중", "同期中"),
+        SyncHealthState::OfflineWillRetry => t!(
+            "Offline — will retry",
+            "오프라인 — 다시 시도함",
+            "オフライン — 再試行します"
+        ),
+        SyncHealthState::NeedsAttention => t!("Needs attention", "확인 필요", "確認が必要"),
+    }
+}
+
+pub fn failure_label(failure: SyncFailureKind) -> &'static str {
+    match failure {
+        SyncFailureKind::Authentication => t!(
+            "The password needs updating",
+            "비밀번호를 업데이트해야 합니다",
+            "パスワードの更新が必要です"
+        ),
+        SyncFailureKind::Certificate => t!(
+            "The certificate needs attention",
+            "인증서를 확인해야 합니다",
+            "証明書の確認が必要です"
+        ),
+        SyncFailureKind::Offline => t!(
+            "Sync storage cannot be reached",
+            "동기화 저장소에 연결할 수 없습니다",
+            "同期ストレージに接続できません"
+        ),
+        SyncFailureKind::RemoteChanged => t!(
+            "New changes were found",
+            "새 변경 사항을 찾았습니다",
+            "新しい変更が見つかりました"
+        ),
+        SyncFailureKind::DeviceApproval => t!(
+            "A device is waiting for approval",
+            "승인을 기다리는 기기가 있습니다",
+            "承認待ちのデバイスがあります"
+        ),
+        SyncFailureKind::InvalidRemoteData => t!(
+            "Sync data needs review",
+            "동기화 데이터를 확인해야 합니다",
+            "同期データの確認が必要です"
+        ),
+        SyncFailureKind::LocalStateChanged => t!(
+            "Local changes arrived during sync",
+            "동기화 중 로컬 변경 사항이 생겼습니다",
+            "同期中にこのデバイスのデータが変更されました"
+        ),
+        SyncFailureKind::Storage => t!(
+            "Sync files need review",
+            "동기화 파일을 확인해야 합니다",
+            "同期ファイルの確認が必要です"
+        ),
+    }
+}
+
+pub fn failure_recovery_label(failure: SyncFailureKind) -> &'static str {
+    match failure {
+        SyncFailureKind::Authentication
+        | SyncFailureKind::Certificate
+        | SyncFailureKind::Offline
+        | SyncFailureKind::LocalStateChanged => {
+            t!("Retry", "다시 시도", "再試行")
+        }
+        SyncFailureKind::RemoteChanged => {
+            t!("View merge result", "병합 결과 보기", "統合結果を表示")
+        }
+        SyncFailureKind::DeviceApproval => {
+            t!("Review device", "기기 확인", "デバイスを確認")
+        }
+        SyncFailureKind::InvalidRemoteData | SyncFailureKind::Storage => {
+            t!("Review sync activity", "동기화 활동 확인", "同期履歴を確認")
+        }
+    }
+}
+
+pub fn audit_action_label(action: SyncAuditAction) -> &'static str {
+    match action {
+        SyncAuditAction::Setup => t!(
+            "Personal sync was set up",
+            "개인 동기화를 설정했습니다",
+            "個人データ同期を設定しました"
+        ),
+        SyncAuditAction::ManualSync => t!(
+            "Personal data was synced",
+            "개인 데이터를 동기화했습니다",
+            "個人データを同期しました"
+        ),
+        SyncAuditAction::PairCreate => t!(
+            "A device connection was started",
+            "기기 연결을 시작했습니다",
+            "デバイス接続を開始しました"
+        ),
+        SyncAuditAction::PairJoin => t!(
+            "This device joined personal sync",
+            "이 기기를 개인 동기화에 연결했습니다",
+            "このデバイスが個人データ同期に参加しました"
+        ),
+        SyncAuditAction::RevokeDevice => t!(
+            "A device was removed",
+            "기기를 제거했습니다",
+            "デバイスを削除しました"
+        ),
+        SyncAuditAction::RecoveryExport => t!(
+            "A recovery kit was saved",
+            "복구 키트를 저장했습니다",
+            "復旧キットを保存しました"
+        ),
+    }
+}
+
+pub fn audit_outcome_label(outcome: SyncAuditOutcome) -> &'static str {
+    match outcome {
+        SyncAuditOutcome::Succeeded => t!("Completed", "완료", "完了"),
+        SyncAuditOutcome::NoChanges => t!("No changes", "변경 없음", "変更なし"),
+        SyncAuditOutcome::Failed => t!("Needs attention", "확인 필요", "確認が必要"),
+    }
+}
+
+fn safe_one_line(value: &str, max_chars: usize, fallback: &'static str) -> String {
+    let value: String = value
+        .chars()
+        .filter(|character| !DeviceRecord::is_forbidden_name_char(*character))
+        .take(max_chars)
+        .collect();
+    let value = value.trim();
+    if value.is_empty() {
+        fallback.to_owned()
+    } else {
+        value.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::i18n::Language;
+
+    #[test]
+    fn labels_are_localized_for_all_public_sync_states() {
+        let _guard = crate::i18n::lock_for_test();
+        for language in [Language::English, Language::Korean, Language::Japanese] {
+            crate::i18n::set_language(language);
+            for state in [
+                SyncHealthState::Off,
+                SyncHealthState::UpToDate,
+                SyncHealthState::Syncing,
+                SyncHealthState::OfflineWillRetry,
+                SyncHealthState::NeedsAttention,
+            ] {
+                assert!(!health_label(state).is_empty());
+            }
+            for failure in [
+                SyncFailureKind::Authentication,
+                SyncFailureKind::Certificate,
+                SyncFailureKind::Offline,
+                SyncFailureKind::RemoteChanged,
+                SyncFailureKind::DeviceApproval,
+                SyncFailureKind::InvalidRemoteData,
+                SyncFailureKind::LocalStateChanged,
+                SyncFailureKind::Storage,
+            ] {
+                assert!(!failure_label(failure).is_empty());
+                assert!(!failure_recovery_label(failure).is_empty());
+            }
+            for action in [
+                SyncRowAction::ResumeConnection,
+                SyncRowAction::ReenterConnection,
+                SyncRowAction::DiscardConnection,
+            ] {
+                assert!(!action.label().is_empty());
+            }
+            assert!(!SyncNotice::NeedsCleanup.label().is_empty());
+        }
+    }
+
+    #[test]
+    fn device_rows_are_bounded_single_line_display_values() {
+        let row = SyncDeviceRow::new(" living\nroom\u{7} ", &"a".repeat(120), false, true);
+        assert_eq!(row.name(), "livingroom");
+        assert_eq!(row.fingerprint().chars().count(), 96);
+        assert!(!row.name().chars().any(char::is_control));
+    }
+
+    #[test]
+    fn device_rows_remove_every_forbidden_format_character_and_controls() {
+        for character in [
+            '\u{061c}', '\u{200b}', '\u{200c}', '\u{200d}', '\u{200e}', '\u{200f}', '\u{202a}',
+            '\u{202b}', '\u{202c}', '\u{202d}', '\u{202e}', '\u{2066}', '\u{2067}', '\u{2068}',
+            '\u{2069}', '\u{feff}', '\0', '\n', '\u{007f}', '\u{0085}',
+        ] {
+            let row =
+                SyncDeviceRow::new(&format!("safe{character}name"), "fingerprint", false, true);
+            assert_eq!(
+                row.name(),
+                "safename",
+                "U+{:04X} must be removed",
+                u32::from(character)
+            );
+        }
+    }
+
+    #[test]
+    fn default_model_contains_no_free_form_values() {
+        let model = SyncSettingsModel::default();
+        assert_eq!(model.health, SyncHealthState::Off);
+        assert!(
+            model
+                .rows
+                .iter()
+                .all(|row| matches!(row, SyncRow::Action(_)))
+        );
+        assert_eq!(model.selected(), Some(0));
+    }
+}

--- a/src/settings/tests.rs
+++ b/src/settings/tests.rs
@@ -120,8 +120,9 @@ fn tabs_step_and_wrap() {
     assert_eq!(SettingsTab::Keys.stepped(true), SettingsTab::Graphics);
     assert_eq!(SettingsTab::Graphics.stepped(true), SettingsTab::Ai);
     assert_eq!(SettingsTab::Ai.stepped(true), SettingsTab::Accounts);
-    assert_eq!(SettingsTab::Accounts.stepped(true), SettingsTab::General); // wraps
-    assert_eq!(SettingsTab::General.stepped(false), SettingsTab::Accounts); // wraps back
+    assert_eq!(SettingsTab::Accounts.stepped(true), SettingsTab::Sync);
+    assert_eq!(SettingsTab::Sync.stepped(true), SettingsTab::General); // wraps
+    assert_eq!(SettingsTab::General.stepped(false), SettingsTab::Sync); // wraps back
 }
 
 #[test]

--- a/src/sync/membership.rs
+++ b/src/sync/membership.rs
@@ -556,7 +556,10 @@ fn validate_device(device: &DeviceRecord) -> Result<(), VaultError> {
     if device.revoked
         || super::crypto::validate_device_id(device.device_id.as_str()).is_err()
         || device.name.chars().count() > 1_024
-        || device.name.chars().any(char::is_control)
+        || device
+            .name
+            .chars()
+            .any(DeviceRecord::is_forbidden_name_char)
     {
         return Err(VaultError::InvalidDeviceIdentity);
     }
@@ -597,4 +600,35 @@ fn ensure_unique_device_identity(
 
 fn validate_dataset_id(dataset_id: &str) -> Result<(), VaultError> {
     super::crypto::validate_dataset_id(dataset_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::crypto::DeviceSecretMaterial;
+
+    #[test]
+    fn remote_membership_device_names_reject_invisible_and_bidi_controls() {
+        let secrets = DeviceSecretMaterial::generate_for("membership-name-validation").unwrap();
+
+        for character in [
+            '\u{061c}', '\u{200b}', '\u{200c}', '\u{200d}', '\u{200e}', '\u{200f}', '\u{202a}',
+            '\u{202b}', '\u{202c}', '\u{202d}', '\u{202e}', '\u{2066}', '\u{2067}', '\u{2068}',
+            '\u{2069}', '\u{feff}',
+        ] {
+            let device = DeviceRecord {
+                device_id: DeviceId::new(secrets.device_id()).unwrap(),
+                name: format!("remote{character}device"),
+                revoked: false,
+                public_identity: Some(secrets.public_identity()),
+            };
+
+            assert_eq!(
+                validate_device(&device),
+                Err(VaultError::InvalidDeviceIdentity),
+                "U+{:04X} must be rejected at membership ingress",
+                u32::from(character)
+            );
+        }
+    }
 }

--- a/src/sync/pairing.rs
+++ b/src/sync/pairing.rs
@@ -746,7 +746,10 @@ fn validate_request_proof(
 fn validate_device(device: &DeviceRecord) -> Result<(), VaultError> {
     if device.revoked
         || device.name.chars().count() > 1_024
-        || device.name.chars().any(char::is_control)
+        || device
+            .name
+            .chars()
+            .any(DeviceRecord::is_forbidden_name_char)
         || super::crypto::validate_device_id(device.device_id.as_str()).is_err()
     {
         return Err(VaultError::InvalidDeviceIdentity);
@@ -818,4 +821,34 @@ fn device_add_position(
             }
             _ => None,
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_pairing_device_names_reject_invisible_and_bidi_controls() {
+        let secrets = DeviceSecretMaterial::generate_for("pairing-name-validation").unwrap();
+
+        for character in [
+            '\u{061c}', '\u{200b}', '\u{200c}', '\u{200d}', '\u{200e}', '\u{200f}', '\u{202a}',
+            '\u{202b}', '\u{202c}', '\u{202d}', '\u{202e}', '\u{2066}', '\u{2067}', '\u{2068}',
+            '\u{2069}', '\u{feff}',
+        ] {
+            let device = DeviceRecord {
+                device_id: DeviceId::new(secrets.device_id()).unwrap(),
+                name: format!("remote{character}device"),
+                revoked: false,
+                public_identity: Some(secrets.public_identity()),
+            };
+
+            assert_eq!(
+                validate_device(&device),
+                Err(VaultError::InvalidDeviceIdentity),
+                "U+{:04X} must be rejected at pairing ingress",
+                u32::from(character)
+            );
+        }
+    }
 }

--- a/src/sync/private_store.rs
+++ b/src/sync/private_store.rs
@@ -4,6 +4,7 @@
 //! store is exported or synchronized, and the offline recovery identity is never accepted by its
 //! API or represented by its on-disk schema.
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 
@@ -12,7 +13,8 @@ use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::personal_state::{
-    DeviceId, DevicePublicIdentity, PersonalStateV2, validate_join_import_extension,
+    DeviceId, DevicePublicIdentity, Operation, OperationEnvelope, OperationOrigin, PersonalStateV2,
+    validate_join_import_extension,
 };
 use crate::util::safe_fs::{
     AdvisoryFileLock, read_owner_only_limited, remove_owner_only_file_durable, sync_parent_dir,
@@ -28,7 +30,9 @@ use super::error::VaultError;
 use super::membership::MembershipAnchor;
 use super::pairing::ApprovedPairing;
 
+mod credential;
 mod transition;
+pub use credential::{VaultCredential, VaultCredentialKind};
 
 const PRIVATE_STORE_KIND: &str = "yututui_vault_private_store";
 const PRIVATE_STORE_SCHEMA_VERSION: u32 = 1;
@@ -58,13 +62,6 @@ pub enum EnrollmentState {
     Revoked,
 }
 
-/// Authentication form used by the state-vault WebDAV endpoint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum VaultCredentialKind {
-    Password,
-    BearerToken,
-}
-
 /// Restart-safe context for one joining device's encrypted approval.
 ///
 /// It contains neither the one-time pairing code nor any WebDAV credential, and intentionally
@@ -89,50 +86,6 @@ impl Drop for PendingPairing {
     fn drop(&mut self) {
         self.invite_id.zeroize();
         self.request_nonce.zeroize();
-    }
-}
-
-/// A WebDAV credential whose secret values have no `Debug`, `Clone`, or serde implementation.
-pub struct VaultCredential {
-    kind: VaultCredentialKind,
-    username: Option<SecretString>,
-    secret: SecretString,
-}
-
-impl VaultCredential {
-    pub fn password(
-        username: impl Into<String>,
-        password: SecretString,
-    ) -> Result<Self, VaultError> {
-        let username = username.into();
-        validate_credential_part(&username, MAX_USERNAME_BYTES, false)?;
-        validate_credential_part(password.expose_secret(), MAX_CREDENTIAL_BYTES, true)?;
-        Ok(Self {
-            kind: VaultCredentialKind::Password,
-            username: Some(SecretString::from(username)),
-            secret: password,
-        })
-    }
-
-    pub fn bearer_token(token: SecretString) -> Result<Self, VaultError> {
-        validate_credential_part(token.expose_secret(), MAX_CREDENTIAL_BYTES, true)?;
-        Ok(Self {
-            kind: VaultCredentialKind::BearerToken,
-            username: None,
-            secret: token,
-        })
-    }
-
-    pub fn kind(&self) -> VaultCredentialKind {
-        self.kind
-    }
-
-    pub fn username(&self) -> Option<&SecretString> {
-        self.username.as_ref()
-    }
-
-    pub fn secret(&self) -> &SecretString {
-        &self.secret
     }
 }
 
@@ -448,6 +401,52 @@ impl PrivateStoreSnapshot {
         Ok(())
     }
 
+    /// Activate the first device after committing its signed bootstrap plus local in-flight work.
+    ///
+    /// The retained rollback anchor is always the exact signed bootstrap checkpoint. The
+    /// committed ledger may only append a contiguous sequence of ordinary local operations by
+    /// this device; membership, authenticated operations, metadata, compaction state, and causal
+    /// coverage from every other device remain immutable.
+    pub fn mark_active_after_setup(
+        &mut self,
+        bootstrap_checkpoint: &SignedCheckpoint,
+        committed_candidate: &PersonalStateV2,
+    ) -> Result<(), VaultError> {
+        if self.enrollment != EnrollmentState::PendingLedgerCommit
+            || self.trust_anchors.is_none()
+            || self.setup_recovery_checksum.is_none()
+            || self.pending_pairing.is_some()
+        {
+            return Err(VaultError::InvalidPrivateStore);
+        }
+        let trust_anchors = self
+            .trust_anchors
+            .as_ref()
+            .ok_or(VaultError::InvalidPrivateStore)?;
+        let (dataset_id, bootstrap_anchor) =
+            verified_pending_ledger(&self.device, trust_anchors, bootstrap_checkpoint)?;
+        let local_device_id =
+            DeviceId::new(self.device.device_id()).map_err(|_| VaultError::InvalidPrivateStore)?;
+        if dataset_id != self.dataset_id
+            || self.pending_ledger_anchor.as_ref() != Some(&bootstrap_anchor)
+            || validate_setup_activation_extension(
+                &bootstrap_checkpoint.payload.state,
+                committed_candidate,
+                &local_device_id,
+            )
+            .is_err()
+        {
+            return Err(VaultError::InvalidPrivateStore);
+        }
+
+        self.checkpoint_anchor = Some(bootstrap_anchor.checkpoint);
+        self.pending_ledger_anchor = None;
+        self.pending_pairing = None;
+        self.setup_recovery_checksum = None;
+        self.enrollment = EnrollmentState::Active;
+        Ok(())
+    }
+
     /// Activate a newly approved device after committing its deletion-free local merge.
     ///
     /// The signed approval checkpoint remains the retained rollback anchor. The committed ledger
@@ -534,6 +533,89 @@ impl PrivateStoreSnapshot {
     pub fn clear_credential(&mut self) {
         self.credential = None;
     }
+}
+
+fn validate_setup_activation_extension(
+    authenticated: &PersonalStateV2,
+    candidate: &PersonalStateV2,
+    local_device_id: &DeviceId,
+) -> Result<(), VaultError> {
+    authenticated
+        .validate()
+        .map_err(|_| VaultError::InvalidPrivateStore)?;
+    candidate
+        .validate()
+        .map_err(|_| VaultError::InvalidPrivateStore)?;
+    if authenticated.dataset_id != candidate.dataset_id
+        || authenticated.device_registry != candidate.device_registry
+        || authenticated.compaction_checkpoint != candidate.compaction_checkpoint
+        || authenticated.metadata != candidate.metadata
+        || candidate.revision < authenticated.revision
+    {
+        return Err(VaultError::InvalidPrivateStore);
+    }
+
+    let authenticated_by_id: BTreeMap<&str, &OperationEnvelope> = authenticated
+        .operations
+        .iter()
+        .map(|operation| (operation.operation_id.as_str(), operation))
+        .collect();
+    if authenticated.operations.iter().any(|operation| {
+        candidate
+            .operations
+            .iter()
+            .find(|candidate| candidate.operation_id == operation.operation_id)
+            != Some(operation)
+    }) {
+        return Err(VaultError::InvalidPrivateStore);
+    }
+
+    let mut additions = candidate
+        .operations
+        .iter()
+        .filter(|operation| !authenticated_by_id.contains_key(operation.operation_id.as_str()))
+        .collect::<Vec<_>>();
+    if candidate.operations.len() != authenticated.operations.len() + additions.len() {
+        return Err(VaultError::InvalidPrivateStore);
+    }
+    if additions.is_empty() {
+        return if candidate == authenticated {
+            Ok(())
+        } else {
+            Err(VaultError::InvalidPrivateStore)
+        };
+    }
+
+    additions.sort_by(|left, right| {
+        left.stamp
+            .dot
+            .cmp(&right.stamp.dot)
+            .then(left.operation_id.cmp(&right.operation_id))
+    });
+    let mut expected_vector = authenticated.version_vector.clone();
+    for addition in additions {
+        let expected_sequence = expected_vector
+            .observed(local_device_id)
+            .checked_add(1)
+            .ok_or(VaultError::InvalidPrivateStore)?;
+        if addition.origin != OperationOrigin::Local
+            || addition.stamp.dot.device_id != *local_device_id
+            || addition.stamp.dot.sequence != expected_sequence
+            || addition.stamp.observed != expected_vector
+            || addition.operation_id != format!("{}:{expected_sequence}", local_device_id.as_str())
+            || matches!(
+                addition.operation,
+                Operation::AddDevice { .. } | Operation::RevokeDevice { .. }
+            )
+        {
+            return Err(VaultError::InvalidPrivateStore);
+        }
+        expected_vector.observe(&addition.stamp.dot);
+    }
+    if candidate.version_vector != expected_vector {
+        return Err(VaultError::InvalidPrivateStore);
+    }
+    Ok(())
 }
 
 /// A durable, compare-and-swap owner of one private sync store file.
@@ -812,17 +894,16 @@ impl DiskPrivateStore {
                 None => (None, None, None),
             };
         let credential = snapshot.credential.as_ref().map(|credential| {
-            let kind = match credential.kind {
+            let kind = match credential.kind() {
                 VaultCredentialKind::Password => DiskVaultCredentialKind::Password,
                 VaultCredentialKind::BearerToken => DiskVaultCredentialKind::BearerToken,
             };
             DiskVaultCredential {
                 kind,
                 username: credential
-                    .username
-                    .as_ref()
+                    .username()
                     .map(|username| username.expose_secret().to_owned()),
-                secret: credential.secret.expose_secret().to_owned(),
+                secret: credential.secret().expose_secret().to_owned(),
             }
         });
         let pending_pairing = snapshot

--- a/src/sync/private_store/credential.rs
+++ b/src/sync/private_store/credential.rs
@@ -1,0 +1,56 @@
+//! Move-only WebDAV credentials owned by the local private store.
+
+use age::secrecy::{ExposeSecret, SecretString};
+
+use super::{MAX_CREDENTIAL_BYTES, MAX_USERNAME_BYTES, VaultError, validate_credential_part};
+
+/// Authentication form used by the state-vault WebDAV endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VaultCredentialKind {
+    Password,
+    BearerToken,
+}
+
+/// A WebDAV credential whose secret values have no `Debug`, `Clone`, or serde implementation.
+pub struct VaultCredential {
+    kind: VaultCredentialKind,
+    username: Option<SecretString>,
+    secret: SecretString,
+}
+
+impl VaultCredential {
+    pub fn password(
+        username: impl Into<String>,
+        password: SecretString,
+    ) -> Result<Self, VaultError> {
+        let username = username.into();
+        validate_credential_part(&username, MAX_USERNAME_BYTES, false)?;
+        validate_credential_part(password.expose_secret(), MAX_CREDENTIAL_BYTES, true)?;
+        Ok(Self {
+            kind: VaultCredentialKind::Password,
+            username: Some(SecretString::from(username)),
+            secret: password,
+        })
+    }
+
+    pub fn bearer_token(token: SecretString) -> Result<Self, VaultError> {
+        validate_credential_part(token.expose_secret(), MAX_CREDENTIAL_BYTES, true)?;
+        Ok(Self {
+            kind: VaultCredentialKind::BearerToken,
+            username: None,
+            secret: token,
+        })
+    }
+
+    pub fn kind(&self) -> VaultCredentialKind {
+        self.kind
+    }
+
+    pub fn username(&self) -> Option<&SecretString> {
+        self.username.as_ref()
+    }
+
+    pub fn secret(&self) -> &SecretString {
+        &self.secret
+    }
+}

--- a/src/sync/private_store/tests.rs
+++ b/src/sync/private_store/tests.rs
@@ -4,7 +4,7 @@ use age::secrecy::{ExposeSecret, SecretString};
 
 use crate::personal_state::{
     CausalStamp, DeviceRecord, Dot, Operation, OperationEnvelope, OperationOrigin, VersionVector,
-    legacy_state, plan_join_import,
+    append_operation_as, legacy_state, plan_join_import,
 };
 use crate::sync::{
     CheckpointAnchor, MembershipAnchor, MembershipChain, RecoveryKit, SignedCheckpoint,
@@ -212,6 +212,108 @@ fn pending_setup_recovery_confirmation_is_signed_and_cleared_on_activation() {
             .expect("reload active setup")
             .setup_recovery_checksum(),
         None
+    );
+}
+
+#[test]
+fn setup_activation_accepts_a_contiguous_local_non_membership_suffix() {
+    let mut fixture = pending_ledger_fixture();
+    fixture
+        .snapshot
+        .confirm_setup_recovery("e".repeat(SHA256_HEX_BYTES))
+        .expect("confirm setup recovery");
+    let device_id = DeviceId::new(fixture.snapshot.device_id()).expect("device id");
+    let first = append_operation_as(
+        &fixture.state,
+        &device_id,
+        Operation::SetAvoidArtist {
+            artist_key: "first-local".to_owned(),
+            avoid: true,
+        },
+        10,
+    )
+    .expect("first local operation");
+    let candidate = append_operation_as(
+        &first,
+        &device_id,
+        Operation::SetAvoidArtist {
+            artist_key: "second-local".to_owned(),
+            avoid: true,
+        },
+        11,
+    )
+    .expect("second local operation");
+    let expected_hash = fixture.checkpoint.hash().expect("checkpoint hash");
+
+    fixture
+        .snapshot
+        .mark_active_after_setup(&fixture.checkpoint, &candidate)
+        .expect("activate setup extension");
+    assert_eq!(fixture.snapshot.enrollment(), EnrollmentState::Active);
+    assert_eq!(
+        fixture.snapshot.checkpoint_hash(),
+        Some(expected_hash.as_str())
+    );
+}
+
+#[test]
+fn setup_activation_rejects_foreign_membership_and_tampered_operations() {
+    let fixture = pending_ledger_fixture();
+    let device_id = DeviceId::new(fixture.snapshot.device_id()).expect("device id");
+    let local = append_operation_as(
+        &fixture.state,
+        &device_id,
+        Operation::SetAvoidArtist {
+            artist_key: "local".to_owned(),
+            avoid: true,
+        },
+        10,
+    )
+    .expect("local operation");
+
+    let mut foreign = local.clone();
+    foreign
+        .operations
+        .iter_mut()
+        .find(|operation| matches!(operation.operation, Operation::SetAvoidArtist { .. }))
+        .expect("local addition")
+        .origin = OperationOrigin::WebDav;
+    assert_setup_activation_rejected(fixture, foreign);
+
+    let fixture = pending_ledger_fixture();
+    let device_id = DeviceId::new(fixture.snapshot.device_id()).expect("device id");
+    let membership = append_operation_as(
+        &fixture.state,
+        &device_id,
+        Operation::RevokeDevice {
+            device_id: device_id.clone(),
+        },
+        10,
+    )
+    .expect("membership operation");
+    assert_setup_activation_rejected(fixture, membership);
+
+    let fixture = pending_ledger_fixture();
+    let mut tampered = fixture.state.clone();
+    tampered.operations[0].stamp.recorded_at_unix += 1;
+    tampered.normalize().expect("structurally valid tamper");
+    assert_setup_activation_rejected(fixture, tampered);
+}
+
+fn assert_setup_activation_rejected(mut fixture: PendingLedgerFixture, candidate: PersonalStateV2) {
+    fixture
+        .snapshot
+        .confirm_setup_recovery("e".repeat(SHA256_HEX_BYTES))
+        .expect("confirm setup recovery");
+    assert_eq!(
+        fixture
+            .snapshot
+            .mark_active_after_setup(&fixture.checkpoint, &candidate),
+        Err(VaultError::InvalidPrivateStore)
+    );
+    assert_eq!(
+        fixture.snapshot.enrollment(),
+        EnrollmentState::PendingLedgerCommit
     );
 }
 

--- a/src/sync/service/mod.rs
+++ b/src/sync/service/mod.rs
@@ -7,6 +7,7 @@ mod devices;
 mod manual;
 mod pairing;
 mod persistence;
+mod recovery_export;
 mod setup;
 mod status;
 mod transition;
@@ -22,16 +23,25 @@ pub use manual::{
     prepare_manual_sync, prepare_manual_sync_with_transport, sync_now,
 };
 pub use pairing::{
-    PairingHostInvite, PairingJoinPreview, PairingReview, apply_pairing_join,
-    approve_pairing_request, begin_pairing_join, cancel_pairing_join, create_pairing_invite,
-    defer_pairing_join, poll_pairing_request, resume_pairing_join,
+    PairingHostInvite, PairingJoinPreview, PairingJoinWaiting, PairingReview,
+    PreparedPairingApproval, PreparedPairingJoinActivation, apply_pairing_join,
+    apply_prepared_pairing_approval, apply_prepared_pairing_join, approve_pairing_request,
+    begin_pairing_join, cancel_pairing_invite, cancel_pairing_join, create_pairing_invite,
+    defer_pairing_join, finalize_prepared_pairing_approval, poll_pairing_join,
+    poll_pairing_request, prepare_pairing_approval, prepare_pairing_join_activation,
+    resume_pairing_join, start_pairing_join,
 };
-pub(crate) use persistence::rebase_local_operations;
 pub use persistence::{PersonalSyncApplyKind, PersonalSyncPersistence};
-pub use setup::{SetupRequest, SetupResult, setup};
+pub(crate) use persistence::{rebase_local_operations, verify_activation_extension};
+pub use recovery_export::{RecoveryExportResult, export_recovery_kit};
+pub use setup::{
+    PreparedSetup, SetupRequest, SetupResult, apply_prepared_setup, prepare_setup,
+    resume_prepared_setup, setup,
+};
 pub use status::{
-    LocalSyncSnapshot, SyncStatusReport, load_local_snapshot, load_personal_state_read_only,
-    read_audit, read_current_status, read_devices, read_status,
+    LocalSyncSnapshot, SyncLifecycleState, SyncOverview, SyncStatusReport, load_local_snapshot,
+    load_personal_state_read_only, read_audit, read_current_status, read_current_status_at,
+    read_devices, read_lifecycle, read_overview, read_status,
 };
 pub(crate) use transition::recover_pending_anchor_transition;
 

--- a/src/sync/service/pairing.rs
+++ b/src/sync/service/pairing.rs
@@ -1,6 +1,10 @@
 mod durable;
 #[path = "pairing/join_durable.rs"]
 mod join_durable;
+#[path = "pairing/lifecycle.rs"]
+mod lifecycle;
+#[path = "pairing/storage.rs"]
+mod storage;
 
 use std::thread;
 use std::time::Duration;
@@ -8,27 +12,35 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 use crate::personal_state::{
-    DeviceId, ImportSummary, Operation, PersonalStateCommit, PersonalStateV2, append_operation_as,
+    DeviceId, DeviceRecord, Operation, PersonalStateCommit, PersonalStateV2, append_operation_as,
     plan_join_import,
 };
 
 use super::super::manual::{ManualSyncEngine, ManualSyncInput};
 use super::super::{
     DeviceSecretMaterial, EncryptedObject, EnrollmentState, MAX_VAULT_PAYLOAD_BYTES,
-    MembershipAction, ObjectCondition, ObjectKey, PairingCode, PairingInvite,
-    PairingRequestPayload, PrivateStore, PrivateStoreSnapshot, SealedPairingApproval,
-    SealedPairingRequest, SyncAuditAction, SyncAuditEntry, SyncAuditOutcome, SyncAuditStore,
-    SyncHealthStore, SyncPaths, VaultCredential, VaultError, VaultTransport, WebDavProfile,
-    WebDavProfileStore,
+    MembershipAction, PairingCode, PairingInvite, PairingRequestPayload, PrivateStore,
+    PrivateStoreSnapshot, SealedPairingApproval, SealedPairingRequest, SyncAuditAction,
+    SyncAuditEntry, SyncAuditOutcome, SyncAuditStore, SyncHealthStore, SyncPaths, VaultCredential,
+    VaultError, VaultTransport, WebDavProfile, WebDavProfileStore,
 };
 use super::manual::{
     PreparedManualSync, load_remote_membership, membership_anchor, membership_prefix_for_registry,
-    prepare_manual_sync_with_transport, validate_active_context,
+    prepare_manual_sync_with_transport, validate_active_context, validate_active_private,
 };
 use super::transition::{AnchorActivationKind, commit_with_anchor_transition};
 use super::{SyncServiceError, apply_manual_sync, open_saved_webdav_transport};
 use durable::{HostPairingSnapshot, HostPairingStore};
 use join_durable::{JoinPairingSnapshot, JoinPairingStore};
+pub use lifecycle::{
+    PairingJoinPreview, PairingJoinWaiting, PreparedPairingApproval, PreparedPairingJoinActivation,
+};
+#[cfg(test)]
+use storage::fetch_join_checkpoint;
+use storage::{
+    checkpoint_key, dataset_pairing_key, global_pairing_key, load_or_fetch_join_checkpoint,
+    persist_join_checkpoint, put_immutable_or_verify, regular_file_exists, validate_locator,
+};
 
 const LOCATOR_KIND: &str = "yututui_pairing_locator";
 const PAIRING_POLL_INTERVAL: Duration = Duration::from_secs(1);
@@ -73,13 +85,21 @@ pub struct PairingReview {
     payload: PairingRequestPayload,
 }
 
-pub struct PairingJoinPreview {
-    pub summary: ImportSummary,
-    pub device_id: String,
-    candidate: PersonalStateV2,
-    checkpoint: super::super::SignedCheckpoint,
-    expected_local_revision: u64,
-    expected_private_revision: u64,
+pub(super) fn host_pairing_needs_review(
+    current_state: &PersonalStateV2,
+    paths: &SyncPaths,
+) -> Result<bool, SyncServiceError> {
+    let private = PrivateStore::new(paths.private_store())?.load()?;
+    validate_active_private(current_state, &private)?;
+    let Some(durable) = HostPairingStore::new(paths).load(private.device())? else {
+        return Ok(false);
+    };
+    if durable.dataset_id() != current_state.dataset_id
+        || durable.host_device_id() != private.device_id()
+    {
+        return Err(SyncServiceError::InvalidRemoteData);
+    }
+    Ok(durable.has_bound_request() || durable.has_handoff())
 }
 
 pub fn create_pairing_invite(
@@ -95,6 +115,17 @@ pub fn create_pairing_invite(
         .credential()
         .ok_or(SyncServiceError::MissingCredential)?;
     let transport = open_saved_webdav_transport(&profile, credential)?;
+    create_pairing_invite_with_transport(current_state, paths, now_unix, &private, &transport)
+}
+
+fn create_pairing_invite_with_transport<T: VaultTransport + ?Sized>(
+    current_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    now_unix: i64,
+    private: &PrivateStoreSnapshot,
+    transport: &T,
+) -> Result<PairingHostInvite, SyncServiceError> {
+    validate_active_private(current_state, private)?;
     let host_store = HostPairingStore::new(paths);
     if let Some(durable) = host_store.load(private.device())? {
         if durable.dataset_id() != current_state.dataset_id
@@ -111,7 +142,7 @@ pub fn create_pairing_invite(
             let invite = durable.invite()?;
             let locator = host_store.locator(&durable)?;
             put_immutable_or_verify(
-                &transport,
+                transport,
                 &global_pairing_key(invite.invite_id(), "locator.age")?,
                 &locator,
             )?;
@@ -122,8 +153,8 @@ pub fn create_pairing_invite(
             });
         }
     }
-    let anchor = membership_anchor(&private)?;
-    let remote = load_remote_membership(current_state, &private, &anchor, &transport)?;
+    let anchor = membership_anchor(private)?;
+    let remote = load_remote_membership(current_state, private, &anchor, transport)?;
     let local = membership_prefix_for_registry(&remote, &anchor, &current_state.device_registry)?;
     let verified = local.verify(&anchor)?;
     let invite = PairingInvite::create(
@@ -148,7 +179,7 @@ pub fn create_pairing_invite(
         &encrypted,
     )?;
     put_immutable_or_verify(
-        &transport,
+        transport,
         &global_pairing_key(invite.invite_id(), "locator.age")?,
         &encrypted,
     )?;
@@ -157,6 +188,57 @@ pub fn create_pairing_invite(
         durable,
         resumed: false,
     })
+}
+
+/// Cancel an uncommitted host invitation, including a request that the user rejected.
+///
+/// Immutable remote request objects are harmless without a signed handoff and expire naturally.
+/// Once a handoff exists, cancellation is refused because the joining device may already be an
+/// active remote member; the prepared approval must instead be installed and finalized.
+pub fn cancel_pairing_invite(
+    current_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    host: &PairingHostInvite,
+) -> Result<(), SyncServiceError> {
+    let private = PrivateStore::new(paths.private_store())?.load()?;
+    let profile = WebDavProfileStore::new(paths.profile())?.load(private.device())?;
+    let credential = private
+        .credential()
+        .ok_or(SyncServiceError::MissingCredential)?;
+    let transport = open_saved_webdav_transport(&profile, credential)?;
+    cancel_pairing_invite_with_transport(current_state, paths, host, &private, &transport)
+}
+
+fn cancel_pairing_invite_with_transport<T: VaultTransport + ?Sized>(
+    current_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    host: &PairingHostInvite,
+    private: &PrivateStoreSnapshot,
+    transport: &T,
+) -> Result<(), SyncServiceError> {
+    validate_host_identity(current_state, paths, private, host)?;
+    if host.durable.has_handoff() {
+        return Err(SyncServiceError::AlreadyConfigured);
+    }
+    if let Some(request_device_id) = host.durable.request_device_id() {
+        // A lost response may leave the remote AddDevice/checkpoint committed before the local
+        // handoff journal is written. Re-read authenticated membership before deleting the only
+        // recovery context; an active target must resume/finalize instead of becoming an orphan.
+        let anchor = membership_anchor(private)?;
+        let membership = load_remote_membership(current_state, private, &anchor, transport)?;
+        let verified = membership.verify(&anchor)?;
+        let request_device_id =
+            DeviceId::new(request_device_id).map_err(|_| SyncServiceError::InvalidRemoteData)?;
+        if verified
+            .devices
+            .get(&request_device_id)
+            .is_some_and(|device| !device.revoked)
+        {
+            return Err(SyncServiceError::AlreadyConfigured);
+        }
+    }
+    HostPairingStore::new(paths).remove()?;
+    Ok(())
 }
 
 pub fn poll_pairing_request(
@@ -173,6 +255,19 @@ pub fn poll_pairing_request(
         .credential()
         .ok_or(SyncServiceError::MissingCredential)?;
     let transport = open_saved_webdav_transport(&profile, credential)?;
+    poll_pairing_request_with_transport(current_state, paths, host, now_unix, &private, &transport)
+}
+
+fn poll_pairing_request_with_transport<T: VaultTransport + ?Sized>(
+    current_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    host: &mut PairingHostInvite,
+    now_unix: i64,
+    private: &PrivateStoreSnapshot,
+    transport: &T,
+) -> Result<Option<PairingReview>, SyncServiceError> {
+    validate_host_identity(current_state, paths, private, host)?;
+    validate_active_private(current_state, private)?;
     let host_store = HostPairingStore::new(paths);
     let key = dataset_pairing_key(
         &current_state.dataset_id,
@@ -218,8 +313,18 @@ pub fn poll_pairing_request(
         )?;
         payload
     };
-    let identity = payload
-        .device
+    let fingerprint = pairing_fingerprint(&payload.device)?;
+    Ok(Some(PairingReview {
+        device_id: payload.device.device_id.as_str().to_owned(),
+        device_name: payload.device.name.clone(),
+        fingerprint,
+        sealed,
+        payload,
+    }))
+}
+
+fn pairing_fingerprint(device: &DeviceRecord) -> Result<String, SyncServiceError> {
+    let identity = device
         .public_identity
         .as_ref()
         .ok_or(SyncServiceError::InvalidRemoteData)?;
@@ -230,13 +335,7 @@ pub fn poll_pairing_request(
             identity.ed25519_verifying_key.as_bytes(),
         ],
     );
-    Ok(Some(PairingReview {
-        device_id: payload.device.device_id.as_str().to_owned(),
-        device_name: payload.device.name.clone(),
-        fingerprint: fingerprint[..16].to_owned(),
-        sealed,
-        payload,
-    }))
+    Ok(fingerprint[..16].to_owned())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -247,49 +346,95 @@ pub fn approve_pairing_request(
     paths: &SyncPaths,
     host: &mut PairingHostInvite,
     review: PairingReview,
-    _now_unix: i64,
+    now_unix: i64,
 ) -> Result<PersonalStateV2, SyncServiceError> {
+    let prepared = prepare_pairing_approval(current_state, paths, host, review, now_unix)?;
+    apply_prepared_pairing_approval(
+        current_state,
+        playlist_revision,
+        personal_paths,
+        paths,
+        prepared,
+    )
+}
+
+/// Publish an authenticated approval handoff without installing its local ledger candidate.
+///
+/// This is the network-worker half of host approval. The caller must route the returned candidate
+/// through the primary persistence owner, then call [`finalize_prepared_pairing_approval`].
+pub fn prepare_pairing_approval(
+    current_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    host: &mut PairingHostInvite,
+    review: PairingReview,
+    now_unix: i64,
+) -> Result<PreparedPairingApproval, SyncServiceError> {
     let private_store = PrivateStore::new(paths.private_store())?;
     let private = private_store.load()?;
     validate_host_identity(current_state, paths, &private, host)?;
     let profile = WebDavProfileStore::new(paths.profile())?.load(private.device())?;
     validate_active_context(current_state, &private, &profile)?;
+    let credential = private
+        .credential()
+        .ok_or(SyncServiceError::MissingCredential)?;
+    let transport = open_saved_webdav_transport(&profile, credential)?;
+    prepare_pairing_approval_with_transport(
+        current_state,
+        paths,
+        host,
+        review,
+        now_unix,
+        &private,
+        &transport,
+    )
+}
+
+fn prepare_pairing_approval_with_transport<T: VaultTransport + ?Sized>(
+    current_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    host: &mut PairingHostInvite,
+    review: PairingReview,
+    now_unix: i64,
+    private: &PrivateStoreSnapshot,
+    transport: &T,
+) -> Result<PreparedPairingApproval, SyncServiceError> {
+    validate_host_identity(current_state, paths, private, host)?;
+    validate_active_private(current_state, private)?;
     let authenticated_request = host.invite.review_bound_request(&review.sealed)?;
     if authenticated_request != review.payload {
         return Err(SyncServiceError::PairingRejected);
     }
+    let target_device = authenticated_request.device;
+    let target_device_name = target_device.name.clone();
+    let target_fingerprint = pairing_fingerprint(&target_device)?;
     let host_store = HostPairingStore::new(paths);
     host_store.bind_request(
         private.device(),
         &mut host.durable,
         &review.sealed.encrypted,
-        &review.payload.device.device_id,
+        &target_device.device_id,
     )?;
-    let credential = private
-        .credential()
-        .ok_or(SyncServiceError::MissingCredential)?;
-    let transport = open_saved_webdav_transport(&profile, credential)?;
-    let anchor = membership_anchor(&private)?;
-    let mut prepared = prepare_manual_sync_with_transport(current_state, &private, &transport)?;
-    if !pairing_device_is_active(&prepared, &review.payload.device) && !host.durable.has_handoff() {
-        if crate::signals::unix_now() > host.expires_at_unix() {
+    let anchor = membership_anchor(private)?;
+    let mut prepared = prepare_manual_sync_with_transport(current_state, private, transport)?;
+    if !pairing_device_is_active(&prepared, &target_device) && !host.durable.has_handoff() {
+        if now_unix > host.expires_at_unix() {
             host_store.remove()?;
             return Err(SyncServiceError::PairingExpired);
         }
         prepared = match commit_pairing_membership(
             current_state,
-            &private,
+            private,
             &anchor,
-            &transport,
+            transport,
             prepared,
-            &review.payload.device,
+            &target_device,
             host.expires_at_unix(),
         ) {
             Ok(prepared) => prepared,
             Err(SyncServiceError::PairingExpired) => {
                 let detected =
-                    prepare_manual_sync_with_transport(current_state, &private, &transport)?;
-                if !pairing_device_is_active(&detected, &review.payload.device) {
+                    prepare_manual_sync_with_transport(current_state, private, transport)?;
+                if !pairing_device_is_active(&detected, &target_device) {
                     host_store.remove()?;
                     return Err(SyncServiceError::PairingExpired);
                 }
@@ -298,13 +443,19 @@ pub fn approve_pairing_request(
             Err(error) => return Err(error),
         };
     }
-    if !pairing_device_is_active(&prepared, &review.payload.device) {
+    if !pairing_device_is_active(&prepared, &target_device) {
         return Err(SyncServiceError::InvalidRemoteData);
     }
 
     if !host.durable.has_handoff() {
         let (encrypted_checkpoint, checkpoint_hash, membership_head_hash) =
-            load_prepared_checkpoint(current_state, &anchor, &transport, &prepared)?;
+            load_prepared_checkpoint(
+                current_state,
+                &anchor,
+                transport,
+                private.device(),
+                &prepared,
+            )?;
         let approval = host.invite.approve_committed(
             &review.sealed,
             prepared.membership.clone(),
@@ -324,32 +475,80 @@ pub fn approve_pairing_request(
     publish_pairing_handoff(
         current_state,
         host.invite.invite_id(),
-        &transport,
+        transport,
         &handoff.checkpoint,
         &handoff.approval,
     )?;
+    Ok(PreparedPairingApproval {
+        candidate: prepared,
+        target_device,
+        target_device_name,
+        target_fingerprint,
+        invite_id: host.invite.invite_id().to_owned(),
+    })
+}
 
-    let summary = prepared.summary.clone();
-    // Publish the complete, authenticated join handoff before installing the owner's local
-    // projection. If the local commit then fails, both devices can recover from the already
-    // published checkpoint; the reverse order could strand an added device with no approval.
+/// Install a prepared host approval through the same exact manual-sync transaction as the CLI.
+pub fn apply_prepared_pairing_approval(
+    current_state: &PersonalStateV2,
+    playlist_revision: u64,
+    personal_paths: &crate::personal_state::PersonalStatePaths,
+    paths: &SyncPaths,
+    prepared: PreparedPairingApproval,
+) -> Result<PersonalStateV2, SyncServiceError> {
     let installed = apply_manual_sync(
         current_state,
         playlist_revision,
-        prepared,
+        prepared.candidate.clone(),
         personal_paths,
         paths,
     )?;
+    finalize_prepared_pairing_approval(&installed, paths, &prepared)?;
+    Ok(installed)
+}
+
+/// Remove the durable host invite only after its exact target is present in the installed ledger.
+///
+/// This step is idempotent so a persistence acknowledgement lost after the ledger transaction can
+/// be retried without regenerating or republishing any secret-bearing pairing object.
+pub fn finalize_prepared_pairing_approval(
+    installed_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    prepared: &PreparedPairingApproval,
+) -> Result<(), SyncServiceError> {
+    let private = PrivateStore::new(paths.private_store())?.load()?;
+    validate_active_private(installed_state, &private)?;
+    if installed_state.dataset_id != prepared.candidate.state.dataset_id
+        || prepared.candidate.local_device_id.as_str() != private.device_id()
+        || installed_state
+            .device_registry
+            .get(&prepared.target_device.device_id)
+            != Some(&prepared.target_device)
+    {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
+    let host_store = HostPairingStore::new(paths);
+    let Some(durable) = host_store.load(private.device())? else {
+        return Ok(());
+    };
+    if durable.dataset_id() != installed_state.dataset_id
+        || durable.host_device_id() != private.device_id()
+        || durable.invite_id() != prepared.invite_id
+        || durable.request_device_id() != Some(prepared.target_device.device_id.as_str())
+        || !durable.has_handoff()
+    {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
+    host_store.remove()?;
     let _ = record_pairing_audit(
         paths,
         crate::signals::unix_now(),
         SyncAuditAction::PairCreate,
-        Some(review.device_id),
-        summary.uploaded_operations,
-        summary.downloaded_operations,
+        Some(prepared.target_device.device_id.as_str().to_owned()),
+        prepared.candidate.summary.uploaded_operations,
+        prepared.candidate.summary.downloaded_operations,
     );
-    host_store.remove()?;
-    Ok(installed)
+    Ok(())
 }
 
 fn pairing_device_is_active(
@@ -428,6 +627,7 @@ fn load_prepared_checkpoint<T: VaultTransport + ?Sized>(
     current_state: &PersonalStateV2,
     anchor: &super::super::MembershipAnchor,
     transport: &T,
+    device: &DeviceSecretMaterial,
     prepared: &PreparedManualSync,
 ) -> Result<(EncryptedObject, String, String), SyncServiceError> {
     let checkpoint_hash = prepared
@@ -436,7 +636,7 @@ fn load_prepared_checkpoint<T: VaultTransport + ?Sized>(
         .clone()
         .ok_or(SyncServiceError::InvalidRemoteData)?;
     let verified_membership = prepared.membership.verify(anchor)?;
-    let checkpoint_key = super::super::manual::checkpoint_key(
+    let checkpoint_key = checkpoint_key(
         &current_state.dataset_id,
         verified_membership.epoch,
         &checkpoint_hash,
@@ -444,8 +644,19 @@ fn load_prepared_checkpoint<T: VaultTransport + ?Sized>(
     let (encrypted_checkpoint, _) = transport
         .get(&checkpoint_key, MAX_VAULT_PAYLOAD_BYTES)?
         .ok_or(SyncServiceError::InvalidRemoteData)?;
+    let checkpoint =
+        super::super::SignedCheckpoint::decrypt_for_device(&encrypted_checkpoint, device, anchor)?;
+    if checkpoint.hash()? != checkpoint_hash
+        || checkpoint.payload.checkpoint_sequence != prepared.checkpoint_anchor.checkpoint_sequence
+        || checkpoint.payload.membership != prepared.membership
+        || checkpoint.payload.state != prepared.state
+    {
+        return Err(SyncServiceError::InvalidRemoteData);
+    }
     Ok((
-        encrypted_checkpoint,
+        // A complete age decrypt, membership/signature validation, and exact signed payload/hash
+        // comparison above make this readback safe to stage and publish to the joining device.
+        encrypted_checkpoint.authenticated_after_verification(),
         checkpoint_hash,
         verified_membership.head_hash,
     ))
@@ -493,8 +704,7 @@ fn merge_sync_summary(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn begin_pairing_join(
-    current_state: &PersonalStateV2,
+pub fn start_pairing_join(
     paths: &SyncPaths,
     endpoint: String,
     custom_ca_pem: Option<Vec<u8>>,
@@ -502,13 +712,36 @@ pub fn begin_pairing_join(
     code: &str,
     device_name: String,
     now_unix: i64,
-) -> Result<PairingJoinPreview, SyncServiceError> {
+) -> Result<PairingJoinWaiting, SyncServiceError> {
+    let transport =
+        super::setup::checked_webdav_transport(&endpoint, custom_ca_pem.as_deref(), &credential)?;
+    start_pairing_join_with_transport(
+        paths,
+        endpoint,
+        custom_ca_pem,
+        credential,
+        code,
+        device_name,
+        now_unix,
+        &transport,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn start_pairing_join_with_transport<T: VaultTransport + ?Sized>(
+    paths: &SyncPaths,
+    endpoint: String,
+    custom_ca_pem: Option<Vec<u8>>,
+    credential: VaultCredential,
+    code: &str,
+    device_name: String,
+    now_unix: i64,
+    transport: &T,
+) -> Result<PairingJoinWaiting, SyncServiceError> {
     let code = PairingCode::parse(code)?;
     let invite_id = PairingInvite::invite_id_for_code(&code)?;
-    let probe =
-        super::setup::checked_webdav_transport(&endpoint, custom_ca_pem.as_deref(), &credential)?;
     let locator_key = global_pairing_key(&invite_id, "locator.age")?;
-    let (encrypted_locator, _) = probe
+    let (encrypted_locator, _) = transport
         .get(&locator_key, MAX_VAULT_PAYLOAD_BYTES)?
         .ok_or(SyncServiceError::PairingRejected)?;
     let locator: PairingLocator =
@@ -540,7 +773,7 @@ pub fn begin_pairing_join(
             let request = join_store.request(&journal)?;
             let request_key =
                 dataset_pairing_key(journal.dataset_id(), journal.invite_id(), "request.age")?;
-            if let Some((remote, _)) = probe.get(&request_key, MAX_VAULT_PAYLOAD_BYTES)?
+            if let Some((remote, _)) = transport.get(&request_key, MAX_VAULT_PAYLOAD_BYTES)?
                 && remote.as_bytes() != request.as_bytes()
             {
                 return Err(SyncServiceError::InvalidRemoteData);
@@ -552,14 +785,17 @@ pub fn begin_pairing_join(
         }
         // A request without its signed journal, private keys, or profile cannot recover or
         // authorize anything. Discarding this local ciphertext does not change remote state.
-        crate::util::safe_fs::remove_owner_only_file_durable(paths.pending_join_request())
-            .map_err(|_| SyncServiceError::Storage)?;
-        crate::util::safe_fs::remove_owner_only_file_durable(paths.pending_join_checkpoint())
-            .map_err(|_| SyncServiceError::Storage)?;
+        for path in [
+            paths.pending_join_request(),
+            paths.pending_join_checkpoint(),
+        ] {
+            if regular_file_exists(path)? {
+                crate::util::safe_fs::remove_owner_only_file_durable(path)
+                    .map_err(|_| SyncServiceError::Storage)?;
+            }
+        }
     }
-    drop(probe);
-
-    let (mut private, profile, sealed_request, request_nonce, device_id) = if existing_private {
+    let (sealed_request, device_id) = if existing_private {
         let private = private_store.load()?;
         let expected_profile = WebDavProfile::with_custom_ca(
             locator.dataset_id.clone(),
@@ -614,16 +850,10 @@ pub fn begin_pairing_join(
             private.device(),
             now_unix,
         )?;
-        let profile = load_or_create_join_profile(
-            &profile_store,
-            existing_profile,
-            &private,
-            expected_profile,
-        )?;
-        let request_nonce = pending.request_nonce().to_owned();
+        load_or_create_join_profile(&profile_store, existing_profile, &private, expected_profile)?;
         let device_id =
             DeviceId::new(private.device_id()).map_err(|_| SyncServiceError::PairingRejected)?;
-        (private, profile, sealed_request, request_nonce, device_id)
+        (sealed_request, device_id)
     } else {
         let device_id = DeviceId::new(format!(
             "dev-{}",
@@ -662,77 +892,74 @@ pub fn begin_pairing_join(
             // can reconstruct the missing profile without minting a second device identity.
             return Err(error.into());
         }
-        (private, profile, sealed_request, request_nonce, device_id)
+        (sealed_request, device_id)
     };
-    let credential = private
-        .credential()
-        .ok_or(SyncServiceError::MissingCredential)?;
-    let transport = open_saved_webdav_transport(&profile, credential)?;
-    (|| {
-        let request_key = dataset_pairing_key(
-            &locator.dataset_id,
-            &sealed_request.invite_id,
-            "request.age",
-        )?;
-        put_immutable_or_verify(&transport, &request_key, &sealed_request.encrypted)?;
+    let request_key = dataset_pairing_key(
+        &locator.dataset_id,
+        &sealed_request.invite_id,
+        "request.age",
+    )?;
+    put_immutable_or_verify(transport, &request_key, &sealed_request.encrypted)?;
+    Ok(PairingJoinWaiting {
+        device_id: device_id.as_str().to_owned(),
+        expires_at_unix: locator.expires_at_unix,
+        resumed: existing_private,
+    })
+}
 
-        let wait_until = locator
-            .expires_at_unix
-            .min(now_unix.saturating_add(MAX_PAIRING_WAIT_SECONDS));
-        let approval_key = dataset_pairing_key(
-            &locator.dataset_id,
-            &sealed_request.invite_id,
-            "approval.age",
-        )?;
-        let encrypted_approval = poll_until_present(&transport, &approval_key, wait_until)?;
-        let checkpoint_key = dataset_pairing_key(
-            &locator.dataset_id,
-            &sealed_request.invite_id,
-            "checkpoint.age",
-        )?;
-        let encrypted_checkpoint = poll_until_present(&transport, &checkpoint_key, wait_until)?;
-        let sealed_approval = SealedPairingApproval {
-            invite_id: sealed_request.invite_id,
-            encrypted: encrypted_approval,
-        };
-        let approved = super::super::ApprovedPairing::open(
-            &code,
-            &sealed_approval,
-            &request_nonce,
-            private.device(),
-            &encrypted_checkpoint,
-            crate::signals::unix_now(),
-        )?;
-        match private.enrollment() {
-            EnrollmentState::PendingApproval => {
-                private.approve(&approved)?;
-                private_store.save(&mut private)?;
-            }
-            EnrollmentState::PendingLedgerCommit => {
-                private.validate_approved_pairing(&approved)?;
-            }
-            EnrollmentState::Active | EnrollmentState::Revoked => {
-                return Err(SyncServiceError::AlreadyConfigured);
+/// Preserve the CLI's blocking behavior on top of the one-shot lifecycle API.
+#[allow(clippy::too_many_arguments)]
+pub fn begin_pairing_join(
+    current_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    endpoint: String,
+    custom_ca_pem: Option<Vec<u8>>,
+    credential: VaultCredential,
+    code: &str,
+    device_name: String,
+    now_unix: i64,
+) -> Result<PairingJoinPreview, SyncServiceError> {
+    let _waiting = start_pairing_join(
+        paths,
+        endpoint,
+        custom_ca_pem,
+        credential,
+        code,
+        device_name,
+        now_unix,
+    )?;
+    loop {
+        if let Some(preview) = poll_pairing_join(current_state, paths, crate::signals::unix_now())?
+        {
+            return Ok(preview);
+        }
+        thread::sleep(PAIRING_POLL_INTERVAL);
+    }
+}
+
+/// Perform one bounded read of the approval lifecycle.
+///
+/// `Ok(None)` means the host has not completed approval yet. No sleep or retry occurs here.
+pub fn poll_pairing_join(
+    current_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    now_unix: i64,
+) -> Result<Option<PairingJoinPreview>, SyncServiceError> {
+    match resume_pairing_join(current_state, paths) {
+        Ok(preview) => Ok(Some(preview)),
+        Err(SyncServiceError::PendingApproval) => {
+            let expires_at_unix = JoinPairingStore::new(paths)
+                .load_authenticated()?
+                .map(|(journal, _)| journal.expires_at_unix())
+                .ok_or(SyncServiceError::PairingNeedsCleanup)?;
+            if now_unix > expires_at_unix {
+                Err(SyncServiceError::PairingExpired)
+            } else {
+                Ok(None)
             }
         }
-        // Trust anchors must become durable before the code-independent checkpoint artifact.
-        // If the following write is interrupted, `resume_pairing_join` authenticates and restores
-        // the exact immutable checkpoint from WebDAV using those anchors and the retained invite.
-        persist_join_checkpoint(paths, approved.encrypted_checkpoint())?;
-        let plan = plan_join_import(
-            &approved.signed_checkpoint().payload.state,
-            current_state,
-            &device_id,
-        )?;
-        Ok(PairingJoinPreview {
-            summary: plan.summary,
-            device_id: device_id.as_str().to_owned(),
-            candidate: plan.candidate,
-            checkpoint: approved.signed_checkpoint().clone(),
-            expected_local_revision: current_state.revision,
-            expected_private_revision: private.revision(),
-        })
-    })()
+        Err(error) => Err(error),
+    }
 }
 
 fn load_or_create_join_profile(
@@ -960,18 +1187,78 @@ pub fn apply_pairing_join(
     paths: &SyncPaths,
     preview: PairingJoinPreview,
 ) -> Result<PersonalStateV2, SyncServiceError> {
+    let prepared = prepare_pairing_join_activation(current_state, paths, preview)?;
+    apply_prepared_pairing_join(
+        current_state,
+        playlist_revision,
+        personal_paths,
+        paths,
+        prepared,
+    )
+}
+
+/// Validate and detach a join activation without writing the ledger or private store.
+pub fn prepare_pairing_join_activation(
+    current_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    preview: PairingJoinPreview,
+) -> Result<PreparedPairingJoinActivation, SyncServiceError> {
+    validate_pairing_join_preview(current_state, paths, &preview)?;
+    Ok(preview.into_activation())
+}
+
+/// Apply a clone-safe join activation on the persistence-owner lane.
+pub fn apply_prepared_pairing_join(
+    current_state: &PersonalStateV2,
+    playlist_revision: u64,
+    personal_paths: &crate::personal_state::PersonalStatePaths,
+    paths: &SyncPaths,
+    prepared: PreparedPairingJoinActivation,
+) -> Result<PersonalStateV2, SyncServiceError> {
+    let preview = prepared.preview;
+    validate_pairing_join_preview(current_state, paths, &preview)?;
+    apply_pairing_join_exact(
+        current_state,
+        playlist_revision,
+        personal_paths,
+        paths,
+        preview,
+    )
+}
+
+fn validate_pairing_join_preview(
+    current_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    preview: &PairingJoinPreview,
+) -> Result<(), SyncServiceError> {
     if current_state.revision != preview.expected_local_revision {
         return Err(SyncServiceError::LocalStateChanged);
     }
-    let private_store = PrivateStore::new(paths.private_store())?;
-    let mut private = private_store.load()?;
+    let private = PrivateStore::new(paths.private_store())?.load()?;
     if private.revision() != preview.expected_private_revision
         || private.enrollment() != EnrollmentState::PendingLedgerCommit
         || private.device_id() != preview.device_id
     {
         return Err(SyncServiceError::LocalStateChanged);
     }
-    let commit = PersonalStateCommit::prepare_for_runtime(preview.candidate, playlist_revision)?;
+    if preview.candidate.dataset_id != private.dataset_id()
+        || preview.checkpoint.payload.dataset_id != private.dataset_id()
+    {
+        return Err(SyncServiceError::InvalidRemoteData);
+    }
+    Ok(())
+}
+
+fn apply_pairing_join_exact(
+    current_state: &PersonalStateV2,
+    playlist_revision: u64,
+    personal_paths: &crate::personal_state::PersonalStatePaths,
+    paths: &SyncPaths,
+    preview: PairingJoinPreview,
+) -> Result<PersonalStateV2, SyncServiceError> {
+    let private_store = PrivateStore::new(paths.private_store())?;
+    let mut private = private_store.load()?;
+    let commit = prepare_pairing_join_commit(current_state, playlist_revision, preview.candidate)?;
     private.mark_active_after_join(&preview.checkpoint, commit.state())?;
     let checkpoint_sequence = preview.checkpoint.payload.checkpoint_sequence;
     let checkpoint_hash = preview.checkpoint.hash()?;
@@ -986,9 +1273,6 @@ pub fn apply_pairing_join(
         &checkpoint_hash,
         playlist_revision,
     )?;
-    let _ = crate::util::safe_fs::remove_owner_only_file_durable(paths.pending_join_checkpoint());
-    let _ = JoinPairingStore::new(paths).remove_state();
-    let _ = crate::util::safe_fs::remove_owner_only_file_durable(paths.pending_join_request());
     let _ = record_pairing_audit(
         paths,
         crate::signals::unix_now(),
@@ -998,6 +1282,24 @@ pub fn apply_pairing_join(
         0,
     );
     Ok(installed)
+}
+
+pub(super) fn prepare_pairing_join_commit(
+    current_state: &PersonalStateV2,
+    playlist_revision: u64,
+    mut candidate: PersonalStateV2,
+) -> Result<PersonalStateCommit, SyncServiceError> {
+    // Joining replaces the fresh device's local dataset with the authenticated remote dataset.
+    // PersonalState transactions are still ordered by one local revision counter, so the first
+    // remote candidate must be strictly newer than whichever local ledger is currently visible.
+    candidate.revision = candidate
+        .revision
+        .max(current_state.revision.saturating_add(1));
+    let commit = PersonalStateCommit::prepare_for_runtime(candidate, playlist_revision)?;
+    if commit.state().revision <= current_state.revision {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
+    Ok(commit)
 }
 
 /// Leave an authenticated join staged for a later code-independent `--resume`.
@@ -1117,157 +1419,6 @@ fn validate_host_identity(
         return Err(SyncServiceError::LocalStateChanged);
     }
     Ok(())
-}
-
-fn validate_locator(
-    locator: &PairingLocator,
-    invite_id: &str,
-    now_unix: i64,
-) -> Result<(), SyncServiceError> {
-    if locator.kind != LOCATOR_KIND
-        || locator.schema_version != super::super::VAULT_SCHEMA_VERSION
-        || locator.invite_id != invite_id
-        || locator.expires_at_unix > now_unix.saturating_add(MAX_PAIRING_WAIT_SECONDS)
-        || crate::personal_state::PersonalStateV2::empty(locator.dataset_id.clone()).is_err()
-    {
-        return Err(SyncServiceError::PairingRejected);
-    }
-    if locator.expires_at_unix < now_unix {
-        return Err(SyncServiceError::PairingExpired);
-    }
-    Ok(())
-}
-
-fn poll_until_present<T: VaultTransport + ?Sized>(
-    transport: &T,
-    key: &ObjectKey,
-    wait_until_unix: i64,
-) -> Result<EncryptedObject, SyncServiceError> {
-    loop {
-        if let Some((object, _)) = transport.get(key, MAX_VAULT_PAYLOAD_BYTES)? {
-            return Ok(object);
-        }
-        if crate::signals::unix_now() > wait_until_unix {
-            return Err(SyncServiceError::PairingExpired);
-        }
-        thread::sleep(PAIRING_POLL_INTERVAL);
-    }
-}
-
-fn put_immutable_or_verify<T: VaultTransport + ?Sized>(
-    transport: &T,
-    key: &ObjectKey,
-    object: &EncryptedObject,
-) -> Result<(), SyncServiceError> {
-    match transport.put(key, object, ObjectCondition::CreateOnly) {
-        Ok(_) => Ok(()),
-        Err(VaultError::PreconditionFailed) => {
-            let (existing, _) = transport
-                .get(key, MAX_VAULT_PAYLOAD_BYTES)?
-                .ok_or(SyncServiceError::InvalidRemoteData)?;
-            if existing.as_bytes() == object.as_bytes() {
-                Ok(())
-            } else {
-                Err(SyncServiceError::InvalidRemoteData)
-            }
-        }
-        Err(error) => match transport.get(key, MAX_VAULT_PAYLOAD_BYTES) {
-            Ok(Some((existing, _))) if existing.as_bytes() == object.as_bytes() => Ok(()),
-            Ok(Some(_)) => Err(SyncServiceError::InvalidRemoteData),
-            Ok(None) | Err(_) => Err(error.into()),
-        },
-    }
-}
-
-fn global_pairing_key(invite_id: &str, file: &str) -> Result<ObjectKey, SyncServiceError> {
-    pairing_key(None, invite_id, file)
-}
-
-fn dataset_pairing_key(
-    dataset_id: &str,
-    invite_id: &str,
-    file: &str,
-) -> Result<ObjectKey, SyncServiceError> {
-    pairing_key(Some(dataset_id), invite_id, file)
-}
-
-fn pairing_key(
-    dataset_id: Option<&str>,
-    invite_id: &str,
-    file: &str,
-) -> Result<ObjectKey, SyncServiceError> {
-    let key = match dataset_id {
-        Some(dataset_id) => {
-            format!("yututui/v2/{dataset_id}/pairing/{invite_id}/{file}")
-        }
-        None => format!("yututui/v2/pairing/{invite_id}/{file}"),
-    };
-    ObjectKey::new(key).map_err(Into::into)
-}
-
-fn regular_file_exists(path: &std::path::Path) -> Result<bool, SyncServiceError> {
-    match std::fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => Ok(true),
-        Ok(_) => Err(SyncServiceError::Storage),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
-        Err(_) => Err(SyncServiceError::Storage),
-    }
-}
-
-fn persist_join_checkpoint(
-    paths: &SyncPaths,
-    checkpoint: &EncryptedObject,
-) -> Result<(), SyncServiceError> {
-    if regular_file_exists(paths.pending_join_checkpoint())? {
-        let current = read_join_checkpoint(paths)?;
-        if current.as_bytes() == checkpoint.as_bytes() {
-            return Ok(());
-        }
-        return Err(SyncServiceError::InvalidRemoteData);
-    }
-    crate::util::safe_fs::write_owner_only_atomic(
-        paths.pending_join_checkpoint(),
-        checkpoint.as_bytes(),
-    )
-    .map_err(|_| SyncServiceError::Storage)
-}
-
-fn read_join_checkpoint(paths: &SyncPaths) -> Result<EncryptedObject, SyncServiceError> {
-    let bytes = crate::util::safe_fs::read_owner_only_limited(
-        paths.pending_join_checkpoint(),
-        super::super::crypto::MAX_ENCRYPTED_OBJECT_BYTES as u64,
-    )
-    .map_err(|_| SyncServiceError::Storage)?;
-    EncryptedObject::from_bytes(bytes).map_err(Into::into)
-}
-
-fn load_or_fetch_join_checkpoint(
-    paths: &SyncPaths,
-    private: &PrivateStoreSnapshot,
-    profile: &WebDavProfile,
-    invite_id: &str,
-) -> Result<(EncryptedObject, bool), SyncServiceError> {
-    if regular_file_exists(paths.pending_join_checkpoint())? {
-        return read_join_checkpoint(paths).map(|checkpoint| (checkpoint, false));
-    }
-    let credential = private
-        .credential()
-        .ok_or(SyncServiceError::MissingCredential)?;
-    let transport = open_saved_webdav_transport(profile, credential)?;
-    fetch_join_checkpoint(&transport, private.dataset_id(), invite_id)
-        .map(|checkpoint| (checkpoint, true))
-}
-
-fn fetch_join_checkpoint<T: VaultTransport + ?Sized>(
-    transport: &T,
-    dataset_id: &str,
-    invite_id: &str,
-) -> Result<EncryptedObject, SyncServiceError> {
-    let key = dataset_pairing_key(dataset_id, invite_id, "checkpoint.age")?;
-    transport
-        .get(&key, MAX_VAULT_PAYLOAD_BYTES)?
-        .map(|(checkpoint, _)| checkpoint)
-        .ok_or(SyncServiceError::PendingApproval)
 }
 
 fn record_pairing_audit(

--- a/src/sync/service/pairing/durable.rs
+++ b/src/sync/service/pairing/durable.rs
@@ -140,7 +140,10 @@ impl<'a> HostPairingStore<'a> {
         if ciphertext_hash(LOCATOR_HASH_DOMAIN, &locator) != snapshot.locator_ciphertext_hash {
             return Err(VaultError::InvalidPrivateStore);
         }
-        Ok(locator)
+        // `snapshot` was authenticated with the host signing key when it was loaded. Restoring
+        // the exact ciphertext bound by that signed hash is therefore equivalent to restoring a
+        // locally produced object after a crash before the first remote PUT.
+        Ok(locator.authenticated_after_verification())
     }
 
     pub fn bind_request(
@@ -262,8 +265,11 @@ impl<'a> HostPairingStore<'a> {
             return Err(VaultError::InvalidPrivateStore);
         }
         Ok(DurableHandoff {
-            checkpoint,
-            approval,
+            // The owner-signed journal binds both exact ciphertext hashes. Only after that
+            // signature and the hashes above have been verified may restart-restored bytes regain
+            // locally-produced provenance and cross the vault transport's upload boundary.
+            checkpoint: checkpoint.authenticated_after_verification(),
+            approval: approval.authenticated_after_verification(),
         })
     }
 
@@ -345,6 +351,14 @@ impl HostPairingSnapshot {
 
     pub fn host_device_id(&self) -> &str {
         &self.host_device_id
+    }
+
+    pub fn invite_id(&self) -> &str {
+        &self.invite_id
+    }
+
+    pub fn request_device_id(&self) -> Option<&str> {
+        self.request_device_id.as_deref()
     }
 
     pub fn same_durable_record(&self, other: &Self) -> bool {

--- a/src/sync/service/pairing/durable/tests.rs
+++ b/src/sync/service/pairing/durable/tests.rs
@@ -57,6 +57,12 @@ fn exact_pairing_artifacts_survive_every_host_restart_boundary() {
         .expect("durably bind request");
     let restarted = store.load(&host).unwrap().expect("reload request");
     assert!(restarted.has_bound_request());
+    assert!(
+        store
+            .locator(&restarted)
+            .expect("reload signed locator")
+            .is_locally_produced()
+    );
     assert!(store.request_matches(&restarted, &request.encrypted, &joining_id));
     assert_eq!(
         store.request(&restarted).unwrap().as_bytes(),
@@ -83,6 +89,8 @@ fn exact_pairing_artifacts_survive_every_host_restart_boundary() {
     let handoff = store.load_handoff(&restarted).unwrap();
     assert_eq!(handoff.checkpoint.as_bytes(), checkpoint.as_bytes());
     assert_eq!(handoff.approval.as_bytes(), approval.as_bytes());
+    assert!(handoff.checkpoint.is_locally_produced());
+    assert!(handoff.approval.is_locally_produced());
 }
 
 #[test]

--- a/src/sync/service/pairing/lifecycle.rs
+++ b/src/sync/service/pairing/lifecycle.rs
@@ -1,0 +1,185 @@
+use crate::personal_state::{DeviceId, DeviceRecord, ImportSummary, PersonalStateV2};
+
+use super::super::manual::PreparedManualSync;
+use super::super::{SyncServiceError, rebase_local_operations};
+
+/// Redacted state returned after a join request is durably published.
+///
+/// It contains no endpoint, credential, pairing code, request nonce, or private key and is safe to
+/// retain in UI state while one-shot polling is scheduled.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PairingJoinWaiting {
+    pub device_id: String,
+    pub expires_at_unix: i64,
+    pub resumed: bool,
+}
+
+/// A remote pairing handoff prepared by a network worker but not installed in the local ledger.
+///
+/// Debug and serde are intentionally absent so future changes cannot accidentally make this a
+/// retained diagnostic payload. The contained manual-sync candidate is already redacted.
+#[derive(Clone)]
+pub struct PreparedPairingApproval {
+    pub(super) candidate: PreparedManualSync,
+    pub(super) target_device: DeviceRecord,
+    pub(super) target_device_name: String,
+    pub(super) target_fingerprint: String,
+    pub(super) invite_id: String,
+}
+
+impl PreparedPairingApproval {
+    pub fn candidate(&self) -> &PreparedManualSync {
+        &self.candidate
+    }
+
+    pub fn into_candidate(self) -> PreparedManualSync {
+        self.candidate
+    }
+
+    pub fn target_device_id(&self) -> &DeviceId {
+        &self.target_device.device_id
+    }
+
+    pub fn target_device_name(&self) -> &str {
+        &self.target_device_name
+    }
+
+    pub fn target_fingerprint(&self) -> &str {
+        &self.target_fingerprint
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_persistence_test(
+        candidate: PreparedManualSync,
+        target_device: DeviceRecord,
+    ) -> Self {
+        Self {
+            target_device_name: target_device.name.clone(),
+            target_fingerprint: "test-fingerprint".to_owned(),
+            invite_id: "test-invite".to_owned(),
+            candidate,
+            target_device,
+        }
+    }
+
+    /// Rebase a detached host approval over local operations recorded while it was in flight.
+    ///
+    /// The authenticated membership/checkpoint result and private-store revision stay unchanged.
+    /// Only the observed local suffix is re-authored after that result, and the candidate is bound
+    /// to the latest owner revision.
+    pub fn retarget(
+        &self,
+        observed: &PersonalStateV2,
+        current: &PersonalStateV2,
+    ) -> Result<Self, SyncServiceError> {
+        if self.candidate.expected_local_revision != observed.revision {
+            return Err(SyncServiceError::LocalStateChanged);
+        }
+        let mut candidate = self.candidate.clone();
+        candidate.state = rebase_local_operations(
+            &candidate.state,
+            observed,
+            current,
+            &candidate.local_device_id,
+        )?;
+        candidate.expected_local_revision = current.revision;
+        Ok(Self {
+            candidate,
+            target_device: self.target_device.clone(),
+            target_device_name: self.target_device_name.clone(),
+            target_fingerprint: self.target_fingerprint.clone(),
+            invite_id: self.invite_id.clone(),
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct PairingJoinPreview {
+    pub summary: ImportSummary,
+    pub device_id: String,
+    pub(super) candidate: PersonalStateV2,
+    pub(super) checkpoint: super::super::super::SignedCheckpoint,
+    pub(super) expected_local_revision: u64,
+    pub(super) expected_private_revision: u64,
+}
+
+impl PairingJoinPreview {
+    pub fn target_state(&self) -> &PersonalStateV2 {
+        &self.candidate
+    }
+
+    pub fn expected_local_revision(&self) -> u64 {
+        self.expected_local_revision
+    }
+
+    pub fn expected_private_revision(&self) -> u64 {
+        self.expected_private_revision
+    }
+
+    pub fn into_activation(self) -> PreparedPairingJoinActivation {
+        PreparedPairingJoinActivation { preview: self }
+    }
+}
+
+/// Clone-safe, secret-free payload for applying a join on the persistence-owner lane.
+///
+/// The exact private-store revision and signed checkpoint stay bound to the preview, so a worker
+/// cannot turn this into an unguarded ledger write.
+#[derive(Clone)]
+pub struct PreparedPairingJoinActivation {
+    pub(super) preview: PairingJoinPreview,
+}
+
+impl PreparedPairingJoinActivation {
+    pub fn target_state(&self) -> &PersonalStateV2 {
+        self.preview.target_state()
+    }
+
+    pub fn expected_local_revision(&self) -> u64 {
+        self.preview.expected_local_revision
+    }
+
+    pub fn expected_private_revision(&self) -> u64 {
+        self.preview.expected_private_revision
+    }
+
+    pub fn device_id(&self) -> &str {
+        &self.preview.device_id
+    }
+
+    pub fn summary(&self) -> &ImportSummary {
+        &self.preview.summary
+    }
+
+    /// Recompute the deletion-free join target against the latest local owner state.
+    ///
+    /// This performs no file or network I/O. The authenticated checkpoint and the pending private
+    /// revision remain fixed; only the portable local contribution and expected local revision
+    /// are refreshed.
+    pub fn retarget(&self, current: &PersonalStateV2) -> Result<Self, SyncServiceError> {
+        let device_id = DeviceId::new(self.preview.device_id.clone())
+            .map_err(|_| SyncServiceError::InvalidRemoteData)?;
+        let plan = crate::personal_state::plan_join_import(
+            &self.preview.checkpoint.payload.state,
+            current,
+            &device_id,
+        )?;
+        Ok(Self {
+            preview: PairingJoinPreview {
+                summary: plan.summary,
+                device_id: self.preview.device_id.clone(),
+                candidate: plan.candidate,
+                checkpoint: self.preview.checkpoint.clone(),
+                expected_local_revision: current.revision,
+                expected_private_revision: self.preview.expected_private_revision,
+            },
+        })
+    }
+
+    pub fn target_state_for(
+        &self,
+        current: &PersonalStateV2,
+    ) -> Result<PersonalStateV2, SyncServiceError> {
+        Ok(self.retarget(current)?.preview.candidate)
+    }
+}

--- a/src/sync/service/pairing/storage.rs
+++ b/src/sync/service/pairing/storage.rs
@@ -1,0 +1,152 @@
+use super::{
+    EncryptedObject, LOCATOR_KIND, MAX_PAIRING_WAIT_SECONDS, MAX_VAULT_PAYLOAD_BYTES,
+    PairingLocator, PrivateStoreSnapshot, SyncPaths, SyncServiceError, VaultError, VaultTransport,
+    WebDavProfile, open_saved_webdav_transport,
+};
+use crate::sync::{ObjectCondition, ObjectKey};
+
+pub(super) fn validate_locator(
+    locator: &PairingLocator,
+    invite_id: &str,
+    now_unix: i64,
+) -> Result<(), SyncServiceError> {
+    if locator.kind != LOCATOR_KIND
+        || locator.schema_version != crate::sync::VAULT_SCHEMA_VERSION
+        || locator.invite_id != invite_id
+        || locator.expires_at_unix > now_unix.saturating_add(MAX_PAIRING_WAIT_SECONDS)
+        || crate::personal_state::PersonalStateV2::empty(locator.dataset_id.clone()).is_err()
+    {
+        return Err(SyncServiceError::PairingRejected);
+    }
+    if locator.expires_at_unix < now_unix {
+        return Err(SyncServiceError::PairingExpired);
+    }
+    Ok(())
+}
+
+pub(super) fn put_immutable_or_verify<T: VaultTransport + ?Sized>(
+    transport: &T,
+    key: &ObjectKey,
+    object: &EncryptedObject,
+) -> Result<(), SyncServiceError> {
+    match transport.put(key, object, ObjectCondition::CreateOnly) {
+        Ok(_) => Ok(()),
+        Err(VaultError::PreconditionFailed) => {
+            let (existing, _) = transport
+                .get(key, MAX_VAULT_PAYLOAD_BYTES)?
+                .ok_or(SyncServiceError::InvalidRemoteData)?;
+            if existing.as_bytes() == object.as_bytes() {
+                Ok(())
+            } else {
+                Err(SyncServiceError::InvalidRemoteData)
+            }
+        }
+        Err(error) => match transport.get(key, MAX_VAULT_PAYLOAD_BYTES) {
+            Ok(Some((existing, _))) if existing.as_bytes() == object.as_bytes() => Ok(()),
+            Ok(Some(_)) => Err(SyncServiceError::InvalidRemoteData),
+            Ok(None) | Err(_) => Err(error.into()),
+        },
+    }
+}
+
+pub(super) fn global_pairing_key(
+    invite_id: &str,
+    file: &str,
+) -> Result<ObjectKey, SyncServiceError> {
+    pairing_key(None, invite_id, file)
+}
+
+pub(super) fn dataset_pairing_key(
+    dataset_id: &str,
+    invite_id: &str,
+    file: &str,
+) -> Result<ObjectKey, SyncServiceError> {
+    pairing_key(Some(dataset_id), invite_id, file)
+}
+
+pub(super) fn checkpoint_key(
+    dataset_id: &str,
+    epoch: u64,
+    checkpoint_hash: &str,
+) -> Result<ObjectKey, SyncServiceError> {
+    crate::sync::manual::checkpoint_key(dataset_id, epoch, checkpoint_hash).map_err(Into::into)
+}
+
+fn pairing_key(
+    dataset_id: Option<&str>,
+    invite_id: &str,
+    file: &str,
+) -> Result<ObjectKey, SyncServiceError> {
+    let key = match dataset_id {
+        Some(dataset_id) => {
+            format!("yututui/v2/{dataset_id}/pairing/{invite_id}/{file}")
+        }
+        None => format!("yututui/v2/pairing/{invite_id}/{file}"),
+    };
+    ObjectKey::new(key).map_err(Into::into)
+}
+
+pub(super) fn regular_file_exists(path: &std::path::Path) -> Result<bool, SyncServiceError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => Ok(true),
+        Ok(_) => Err(SyncServiceError::Storage),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(_) => Err(SyncServiceError::Storage),
+    }
+}
+
+pub(super) fn persist_join_checkpoint(
+    paths: &SyncPaths,
+    checkpoint: &EncryptedObject,
+) -> Result<(), SyncServiceError> {
+    if regular_file_exists(paths.pending_join_checkpoint())? {
+        let current = read_join_checkpoint(paths)?;
+        if current.as_bytes() == checkpoint.as_bytes() {
+            return Ok(());
+        }
+        return Err(SyncServiceError::InvalidRemoteData);
+    }
+    crate::util::safe_fs::write_owner_only_atomic(
+        paths.pending_join_checkpoint(),
+        checkpoint.as_bytes(),
+    )
+    .map_err(|_| SyncServiceError::Storage)
+}
+
+fn read_join_checkpoint(paths: &SyncPaths) -> Result<EncryptedObject, SyncServiceError> {
+    let bytes = crate::util::safe_fs::read_owner_only_limited(
+        paths.pending_join_checkpoint(),
+        crate::sync::crypto::MAX_ENCRYPTED_OBJECT_BYTES as u64,
+    )
+    .map_err(|_| SyncServiceError::Storage)?;
+    EncryptedObject::from_bytes(bytes).map_err(Into::into)
+}
+
+pub(super) fn load_or_fetch_join_checkpoint(
+    paths: &SyncPaths,
+    private: &PrivateStoreSnapshot,
+    profile: &WebDavProfile,
+    invite_id: &str,
+) -> Result<(EncryptedObject, bool), SyncServiceError> {
+    if regular_file_exists(paths.pending_join_checkpoint())? {
+        return read_join_checkpoint(paths).map(|checkpoint| (checkpoint, false));
+    }
+    let credential = private
+        .credential()
+        .ok_or(SyncServiceError::MissingCredential)?;
+    let transport = open_saved_webdav_transport(profile, credential)?;
+    fetch_join_checkpoint(&transport, private.dataset_id(), invite_id)
+        .map(|checkpoint| (checkpoint, true))
+}
+
+pub(super) fn fetch_join_checkpoint<T: VaultTransport + ?Sized>(
+    transport: &T,
+    dataset_id: &str,
+    invite_id: &str,
+) -> Result<EncryptedObject, SyncServiceError> {
+    let key = dataset_pairing_key(dataset_id, invite_id, "checkpoint.age")?;
+    transport
+        .get(&key, MAX_VAULT_PAYLOAD_BYTES)?
+        .map(|(checkpoint, _)| checkpoint)
+        .ok_or(SyncServiceError::PendingApproval)
+}

--- a/src/sync/service/pairing/tests.rs
+++ b/src/sync/service/pairing/tests.rs
@@ -4,7 +4,8 @@ use age::secrecy::SecretString;
 
 use crate::personal_state::{
     CausalStamp, DeviceId, DeviceRecord, Dot, Operation, OperationEnvelope, OperationOrigin,
-    PersonalStateV2, VersionVector, append_operation_as,
+    PersonalStateCommit, PersonalStatePaths, PersonalStateV2, VersionVector, append_operation_as,
+    load_ledger,
 };
 use crate::sync::{
     CheckpointAnchor, DeviceSecretMaterial, FileVaultTransport, MembershipAction, MembershipAnchor,
@@ -50,6 +51,101 @@ struct JoinFixture {
     expires_at_unix: i64,
     invite_id: String,
     _root: TempRoot,
+}
+
+struct HostFixture {
+    paths: SyncPaths,
+    personal_paths: PersonalStatePaths,
+    state: PersonalStateV2,
+    private: PrivateStoreSnapshot,
+    remote: FileVaultTransport,
+    _root: TempRoot,
+}
+
+fn host_fixture() -> HostFixture {
+    let root = TempRoot::new();
+    let paths = SyncPaths::for_data_root(root.0.clone());
+    let personal_paths = PersonalStatePaths::for_data_root(root.0.clone());
+    let recovery = RecoveryKit::generate("dataset-host", None).unwrap();
+    let host = DeviceSecretMaterial::generate_for("device-host").unwrap();
+    let host_record = device_record(&host, "Host");
+    let state = initial_state("dataset-host", &host_record);
+    let membership_root = SignedMembershipRoot::create(
+        state.dataset_id.clone(),
+        recovery.recovery_recipient(),
+        &recovery.signing_key().unwrap(),
+        host_record.clone(),
+    )
+    .unwrap();
+    let root_hash = membership_root.hash().unwrap();
+    let anchor = MembershipAnchor::RootHash(root_hash.clone());
+    let membership = MembershipChain::new(membership_root);
+    let checkpoint = SignedCheckpoint::create(
+        membership.clone(),
+        &anchor,
+        host_record.device_id,
+        host.signing_key(),
+        &CheckpointAnchor::default(),
+        state.clone(),
+    )
+    .unwrap();
+    let mut private = PrivateStoreSnapshot::pending_ledger_commit(
+        host,
+        recovery.recovery_recipient(),
+        recovery.recovery_verifying_key().unwrap(),
+        root_hash,
+        &checkpoint,
+    )
+    .unwrap();
+    private.set_credential(test_credential());
+    private.mark_active(&checkpoint, &state).unwrap();
+    PrivateStore::new(paths.private_store())
+        .unwrap()
+        .create(&mut private)
+        .unwrap();
+    let mut profile =
+        WebDavProfile::new(&state.dataset_id, private.device(), "https://example.test").unwrap();
+    WebDavProfileStore::new(paths.profile())
+        .unwrap()
+        .create(&mut profile, private.device())
+        .unwrap();
+    let installed = PersonalStateCommit::prepare_for_runtime(state, 0)
+        .unwrap()
+        .commit(&personal_paths)
+        .unwrap();
+    let remote = FileVaultTransport::create(root.0.join("remote")).unwrap();
+    let empty_anchor = CheckpointAnchor::default();
+    let input = ManualSyncInput {
+        local_state: &installed,
+        membership: &membership,
+        membership_anchor: &anchor,
+        device: private.device(),
+        checkpoint_anchor: &empty_anchor,
+        bootstrap_checkpoint: Some(&checkpoint),
+        expected_local_revision: installed.revision,
+    };
+    let bootstrapped = ManualSyncEngine::new(&remote)
+        .synchronize(&input, &|expected| {
+            if expected == installed.revision {
+                Ok(())
+            } else {
+                Err(VaultError::RevisionConflict)
+            }
+        })
+        .unwrap();
+    assert_eq!(bootstrapped.state, installed);
+    HostFixture {
+        paths,
+        personal_paths,
+        state: installed,
+        private,
+        remote,
+        _root: root,
+    }
+}
+
+fn test_credential() -> VaultCredential {
+    VaultCredential::bearer_token(SecretString::from("test-token".to_owned())).unwrap()
 }
 
 fn join_fixture() -> JoinFixture {
@@ -247,6 +343,671 @@ fn put_pairing_handoff(remote: &FileVaultTransport, fixture: &JoinFixture) {
             .put(&key, object, ObjectCondition::CreateOnly)
             .unwrap();
     }
+}
+
+fn start_join_for_host(
+    fixture: &HostFixture,
+    host: &PairingHostInvite,
+    name: &str,
+    now_unix: i64,
+) -> (SyncPaths, PairingJoinWaiting) {
+    let join_root = fixture._root.0.join(name);
+    crate::util::safe_fs::ensure_private_dir(&join_root).unwrap();
+    let join_paths = SyncPaths::for_data_root(join_root);
+    let waiting = start_pairing_join_with_transport(
+        &join_paths,
+        "https://example.test".to_owned(),
+        None,
+        test_credential(),
+        host.code(),
+        "Joining device".to_owned(),
+        now_unix,
+        &fixture.remote,
+    )
+    .unwrap();
+    (join_paths, waiting)
+}
+
+fn prepare_host_approval(
+    fixture: &HostFixture,
+    host: &mut PairingHostInvite,
+    join_name: &str,
+    now_unix: i64,
+) -> PreparedPairingApproval {
+    let _ = start_join_for_host(fixture, host, join_name, now_unix);
+    let review = poll_pairing_request_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        host,
+        now_unix + 1,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap()
+    .unwrap();
+    prepare_pairing_approval_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        host,
+        review,
+        now_unix + 2,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap()
+}
+
+fn poll_pending_pairing_join_once_with_transport<T: VaultTransport + ?Sized>(
+    current_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    private_store: &PrivateStore,
+    private: &mut PrivateStoreSnapshot,
+    journal: &JoinPairingSnapshot,
+    transport: &T,
+    now_unix: i64,
+) -> Result<Option<PairingJoinPreview>, SyncServiceError> {
+    match resume_pending_approval_with_transport(
+        current_state,
+        paths,
+        private_store,
+        private,
+        journal,
+        transport,
+        now_unix,
+    ) {
+        Ok(preview) => Ok(Some(preview)),
+        Err(SyncServiceError::PendingApproval) if now_unix > journal.expires_at_unix() => {
+            Err(SyncServiceError::PairingExpired)
+        }
+        Err(SyncServiceError::PendingApproval) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+#[test]
+fn start_and_one_shot_poll_wait_then_return_approved_preview() {
+    let fixture = host_fixture();
+    let now = crate::signals::unix_now();
+    let mut host = create_pairing_invite_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        now,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap();
+    let (join_paths, waiting) = start_join_for_host(&fixture, &host, "join-one-shot", now + 1);
+    assert!(!waiting.resumed);
+    assert!(waiting.expires_at_unix > now);
+
+    let review = poll_pairing_request_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        &mut host,
+        now + 2,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(review.device_id, waiting.device_id);
+
+    let private_store = PrivateStore::new(join_paths.private_store()).unwrap();
+    let mut joining_private = private_store.load().unwrap();
+    let journal = JoinPairingStore::new(&join_paths)
+        .load(joining_private.device())
+        .unwrap()
+        .unwrap();
+    let local = PersonalStateV2::empty("dataset-local".to_owned()).unwrap();
+    assert!(
+        poll_pending_pairing_join_once_with_transport(
+            &local,
+            &join_paths,
+            &private_store,
+            &mut joining_private,
+            &journal,
+            &fixture.remote,
+            now + 3,
+        )
+        .unwrap()
+        .is_none()
+    );
+    assert_eq!(
+        private_store.load().unwrap().enrollment(),
+        EnrollmentState::PendingApproval
+    );
+
+    let prepared = prepare_pairing_approval_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        &mut host,
+        review,
+        now + 4,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap();
+    let preview = poll_pending_pairing_join_once_with_transport(
+        &local,
+        &join_paths,
+        &private_store,
+        &mut joining_private,
+        &journal,
+        &fixture.remote,
+        now + 5,
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(preview.device_id, waiting.device_id);
+    assert_eq!(
+        preview.target_state().device_registry,
+        prepared.candidate().state.device_registry
+    );
+    assert_eq!(
+        private_store.load().unwrap().enrollment(),
+        EnrollmentState::PendingLedgerCommit
+    );
+}
+
+#[test]
+fn prepared_host_approval_does_not_install_ledger_until_apply() {
+    fn assert_clone_send_sync<T: Clone + Send + Sync>(_: &T) {}
+
+    let fixture = host_fixture();
+    let now = crate::signals::unix_now();
+    let mut host = create_pairing_invite_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        now,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap();
+    let before = load_ledger(&fixture.personal_paths).unwrap().unwrap();
+    let prepared = prepare_host_approval(&fixture, &mut host, "join-prepare", now + 1);
+    assert!(host_pairing_needs_review(&fixture.state, &fixture.paths).unwrap());
+    assert_clone_send_sync(&prepared);
+    assert_eq!(
+        load_ledger(&fixture.personal_paths).unwrap().unwrap(),
+        before
+    );
+    assert!(
+        !before
+            .device_registry
+            .contains_key(prepared.target_device_id())
+    );
+    assert!(
+        prepared
+            .candidate()
+            .state
+            .device_registry
+            .contains_key(prepared.target_device_id())
+    );
+    assert_eq!(
+        prepared.clone().into_candidate().state,
+        prepared.candidate().state
+    );
+
+    let installed = apply_prepared_pairing_approval(
+        &before,
+        0,
+        &fixture.personal_paths,
+        &fixture.paths,
+        prepared.clone(),
+    )
+    .unwrap();
+    assert!(
+        installed
+            .device_registry
+            .contains_key(prepared.target_device_id())
+    );
+    assert_eq!(
+        load_ledger(&fixture.personal_paths).unwrap().unwrap(),
+        installed
+    );
+    assert!(!fixture.paths.pairing_host_state().exists());
+    assert!(!host_pairing_needs_review(&installed, &fixture.paths).unwrap());
+    finalize_prepared_pairing_approval(&installed, &fixture.paths, &prepared).unwrap();
+}
+
+#[test]
+fn host_rejects_a_valid_but_substituted_checkpoint_readback() {
+    let fixture = host_fixture();
+    let now = crate::signals::unix_now();
+    let mut host = create_pairing_invite_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        now,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap();
+    let _ = start_join_for_host(&fixture, &host, "join-substituted-checkpoint", now + 1);
+    let review = poll_pairing_request_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        &mut host,
+        now + 2,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap()
+    .unwrap();
+    let target_device = review.payload.device.clone();
+    let anchor = membership_anchor(&fixture.private).unwrap();
+    let base =
+        prepare_manual_sync_with_transport(&fixture.state, &fixture.private, &fixture.remote)
+            .unwrap();
+    let prepared = commit_pairing_membership(
+        &fixture.state,
+        &fixture.private,
+        &anchor,
+        &fixture.remote,
+        base,
+        &target_device,
+        host.expires_at_unix(),
+    )
+    .unwrap();
+
+    let host_id = DeviceId::new(fixture.private.device_id()).unwrap();
+    let alternate_state = append_operation_as(
+        &prepared.state,
+        &host_id,
+        Operation::SetAvoidArtist {
+            artist_key: "substituted-checkpoint".to_owned(),
+            avoid: true,
+        },
+        now + 3,
+    )
+    .unwrap();
+    let previous_anchor = super::super::manual::checkpoint_anchor(&fixture.private).unwrap();
+    let alternate = SignedCheckpoint::create(
+        prepared.membership.clone(),
+        &anchor,
+        host_id,
+        fixture.private.device().signing_key(),
+        &previous_anchor,
+        alternate_state,
+    )
+    .unwrap();
+    let expected_hash = prepared
+        .checkpoint_anchor
+        .checkpoint_hash
+        .as_deref()
+        .unwrap();
+    assert_ne!(alternate.hash().unwrap(), expected_hash);
+    let alternate = alternate.encrypt(&anchor).unwrap();
+    let key = checkpoint_key(
+        &fixture.state.dataset_id,
+        prepared.membership.verify(&anchor).unwrap().epoch,
+        expected_hash,
+    )
+    .unwrap();
+    let (_, metadata) = fixture
+        .remote
+        .get(&key, MAX_VAULT_PAYLOAD_BYTES)
+        .unwrap()
+        .unwrap();
+    fixture
+        .remote
+        .put(
+            &key,
+            &alternate,
+            crate::sync::ObjectCondition::Match(metadata.etag),
+        )
+        .unwrap();
+
+    assert_eq!(
+        load_prepared_checkpoint(
+            &fixture.state,
+            &anchor,
+            &fixture.remote,
+            fixture.private.device(),
+            &prepared,
+        ),
+        Err(SyncServiceError::InvalidRemoteData)
+    );
+}
+
+#[test]
+fn pairing_approval_persistence_rebases_and_finalizes_idempotently() {
+    let fixture = host_fixture();
+    let now = crate::signals::unix_now();
+    let mut host = create_pairing_invite_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        now,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap();
+    let prepared = prepare_host_approval(&fixture, &mut host, "join-rebase", now + 1);
+    let host_device = DeviceId::new(fixture.private.device_id()).unwrap();
+    let local = append_operation_as(
+        &fixture.state,
+        &host_device,
+        Operation::SetAvoidArtist {
+            artist_key: "approval-in-flight-artist".to_owned(),
+            avoid: true,
+        },
+        now + 3,
+    )
+    .unwrap();
+    let local = PersonalStateCommit::prepare_for_runtime(local, 0)
+        .unwrap()
+        .commit(&fixture.personal_paths)
+        .unwrap();
+    let retargeted = prepared.retarget(&fixture.state, &local).unwrap();
+    assert_eq!(
+        retargeted.candidate().expected_local_revision,
+        local.revision
+    );
+    assert!(
+        retargeted
+            .candidate()
+            .state
+            .operations
+            .iter()
+            .any(|operation| matches!(
+                operation.operation,
+                Operation::SetAvoidArtist {
+                    ref artist_key,
+                    avoid: true
+                } if artist_key == "approval-in-flight-artist"
+            ))
+    );
+
+    let writer = crate::sync::service::PersonalSyncPersistence::pairing_approval_activation(
+        fixture.state.clone(),
+        local.clone(),
+        0,
+        prepared.clone(),
+        fixture.personal_paths.clone(),
+        SyncPaths::for_data_root(fixture._root.0.clone()),
+    )
+    .unwrap();
+    let target = writer.state().clone();
+    writer.write().unwrap();
+    assert!(writer.committed());
+    assert_eq!(
+        load_ledger(&fixture.personal_paths).unwrap(),
+        Some(target.clone())
+    );
+    assert!(!fixture.paths.pairing_host_state().exists());
+
+    let retry = crate::sync::service::PersonalSyncPersistence::pairing_approval_activation(
+        fixture.state.clone(),
+        local,
+        0,
+        prepared,
+        fixture.personal_paths.clone(),
+        SyncPaths::for_data_root(fixture._root.0.clone()),
+    )
+    .unwrap();
+    assert_eq!(retry.state(), &target);
+    retry.write().unwrap();
+    assert!(retry.committed());
+    assert!(!fixture.paths.pairing_host_state().exists());
+}
+
+#[test]
+fn pairing_join_activation_retargets_and_retries_the_exact_target() {
+    let fixture = join_fixture();
+    let personal_paths = PersonalStatePaths::for_data_root(fixture._root.0.clone());
+    let local_device = DeviceSecretMaterial::generate_for("pre-join-local-device").unwrap();
+    let local_record = device_record(&local_device, "Local before join");
+    let observed =
+        PersonalStateCommit::prepare_for_runtime(initial_state("dataset-local", &local_record), 0)
+            .unwrap()
+            .state()
+            .clone();
+    let joining_device = DeviceId::new(fixture.private.device_id()).unwrap();
+    let initial_plan = crate::personal_state::plan_join_import(
+        &fixture.checkpoint.payload.state,
+        &observed,
+        &joining_device,
+    )
+    .unwrap();
+    let activation = PairingJoinPreview {
+        summary: initial_plan.summary,
+        device_id: joining_device.as_str().to_owned(),
+        candidate: initial_plan.candidate,
+        checkpoint: fixture.checkpoint.clone(),
+        expected_local_revision: observed.revision,
+        expected_private_revision: fixture.private.revision(),
+    }
+    .into_activation();
+
+    let latest = append_operation_as(
+        &observed,
+        &local_record.device_id,
+        Operation::SetAvoidArtist {
+            artist_key: "join-in-flight-artist".to_owned(),
+            avoid: true,
+        },
+        2_000,
+    )
+    .unwrap();
+    let latest = PersonalStateCommit::prepare_for_runtime(latest, 0)
+        .unwrap()
+        .commit(&personal_paths)
+        .unwrap();
+    let retargeted = activation.retarget(&latest).unwrap();
+    assert_eq!(retargeted.expected_local_revision(), latest.revision);
+    assert_eq!(
+        activation.target_state_for(&latest).unwrap(),
+        retargeted.target_state().clone()
+    );
+
+    let writer = crate::sync::service::PersonalSyncPersistence::pairing_join_activation(
+        latest.clone(),
+        0,
+        activation.clone(),
+        personal_paths.clone(),
+        SyncPaths::for_data_root(fixture._root.0.clone()),
+    )
+    .unwrap();
+    let target = writer.state().clone();
+    assert!(
+        target
+            .operations
+            .iter()
+            .any(|operation| matches!(operation.operation, Operation::LegacyBaseline { .. }))
+    );
+    writer.write().unwrap();
+    assert!(writer.committed());
+    assert_eq!(load_ledger(&personal_paths).unwrap(), Some(target.clone()));
+    assert_eq!(
+        PrivateStore::new(fixture.paths.private_store())
+            .unwrap()
+            .load()
+            .unwrap()
+            .enrollment(),
+        EnrollmentState::Active
+    );
+
+    let retry = crate::sync::service::PersonalSyncPersistence::pairing_join_activation(
+        latest,
+        0,
+        activation,
+        personal_paths.clone(),
+        SyncPaths::for_data_root(fixture._root.0.clone()),
+    )
+    .unwrap();
+    assert_eq!(retry.state(), &target);
+    retry.write().unwrap();
+    assert!(retry.committed());
+}
+
+#[test]
+fn cancelling_host_invite_invalidates_bound_request_and_rotates_code() {
+    let fixture = host_fixture();
+    let now = crate::signals::unix_now();
+    let mut host = create_pairing_invite_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        now,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap();
+    let old_code = host.code().to_owned();
+    let old_invite_id = host.invite.invite_id().to_owned();
+    let _ = start_join_for_host(&fixture, &host, "join-cancel", now + 1);
+    assert!(
+        poll_pairing_request_with_transport(
+            &fixture.state,
+            &fixture.paths,
+            &mut host,
+            now + 2,
+            &fixture.private,
+            &fixture.remote,
+        )
+        .unwrap()
+        .is_some()
+    );
+
+    cancel_pairing_invite_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        &host,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap();
+    for path in [
+        fixture.paths.pairing_host_state(),
+        fixture.paths.pairing_host_locator(),
+        fixture.paths.pairing_host_request(),
+    ] {
+        assert!(!path.exists());
+    }
+    assert!(matches!(
+        poll_pairing_request_with_transport(
+            &fixture.state,
+            &fixture.paths,
+            &mut host,
+            now + 3,
+            &fixture.private,
+            &fixture.remote,
+        ),
+        Err(SyncServiceError::LocalStateChanged)
+    ));
+    let old_request_key =
+        dataset_pairing_key(&fixture.state.dataset_id, &old_invite_id, "request.age").unwrap();
+    assert!(
+        fixture
+            .remote
+            .get(&old_request_key, MAX_VAULT_PAYLOAD_BYTES)
+            .unwrap()
+            .is_some()
+    );
+
+    let replacement = create_pairing_invite_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        now + 4,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap();
+    assert_ne!(replacement.code(), old_code);
+    assert_ne!(replacement.invite.invite_id(), old_invite_id);
+}
+
+#[test]
+fn cancelling_host_invite_is_rejected_after_handoff_exists() {
+    let fixture = host_fixture();
+    let now = crate::signals::unix_now();
+    let mut host = create_pairing_invite_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        now,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap();
+    let prepared = prepare_host_approval(&fixture, &mut host, "join-handoff", now + 1);
+    assert!(
+        prepared
+            .candidate()
+            .state
+            .device_registry
+            .contains_key(prepared.target_device_id())
+    );
+    assert_eq!(
+        cancel_pairing_invite_with_transport(
+            &fixture.state,
+            &fixture.paths,
+            &host,
+            &fixture.private,
+            &fixture.remote,
+        ),
+        Err(SyncServiceError::AlreadyConfigured)
+    );
+    assert!(fixture.paths.pairing_host_state().is_file());
+    assert!(fixture.paths.pairing_host_approval().is_file());
+}
+
+#[test]
+fn cancelling_host_invite_is_rejected_after_remote_commit_before_handoff() {
+    let fixture = host_fixture();
+    let now = crate::signals::unix_now();
+    let mut host = create_pairing_invite_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        now,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap();
+    let _ = start_join_for_host(&fixture, &host, "join-commit-before-handoff", now + 1);
+    let review = poll_pairing_request_with_transport(
+        &fixture.state,
+        &fixture.paths,
+        &mut host,
+        now + 2,
+        &fixture.private,
+        &fixture.remote,
+    )
+    .unwrap()
+    .unwrap();
+    HostPairingStore::new(&fixture.paths)
+        .bind_request(
+            fixture.private.device(),
+            &mut host.durable,
+            &review.sealed.encrypted,
+            &review.payload.device.device_id,
+        )
+        .unwrap();
+    let anchor = membership_anchor(&fixture.private).unwrap();
+    let base =
+        prepare_manual_sync_with_transport(&fixture.state, &fixture.private, &fixture.remote)
+            .unwrap();
+    commit_pairing_membership(
+        &fixture.state,
+        &fixture.private,
+        &anchor,
+        &fixture.remote,
+        base,
+        &review.payload.device,
+        host.expires_at_unix(),
+    )
+    .unwrap();
+    assert!(host.durable.has_bound_request());
+    assert!(!host.durable.has_handoff());
+
+    assert_eq!(
+        cancel_pairing_invite_with_transport(
+            &fixture.state,
+            &fixture.paths,
+            &host,
+            &fixture.private,
+            &fixture.remote,
+        ),
+        Err(SyncServiceError::AlreadyConfigured)
+    );
+    assert!(fixture.paths.pairing_host_state().is_file());
 }
 
 #[test]

--- a/src/sync/service/persistence.rs
+++ b/src/sync/service/persistence.rs
@@ -4,13 +4,19 @@
 //! candidate locally. It is retry-safe because the target ledger and private checkpoint anchor
 //! are both checked before a repeated write is accepted as complete.
 
+#[path = "persistence/activation.rs"]
+mod activation;
+#[cfg(test)]
+#[path = "persistence/tests.rs"]
+mod activation_tests;
+
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::personal_state::{
-    DeviceId, OperationEnvelope, PersonalStateCommit, PersonalStatePaths, PersonalStateV2,
-    append_operation_as, load_ledger,
+    DeviceId, Operation, OperationEnvelope, OperationOrigin, PersonalStateCommit,
+    PersonalStatePaths, PersonalStateV2, append_operation_as, load_ledger,
 };
 
 use super::super::{EnrollmentState, PrivateStore, SyncPaths};
@@ -18,12 +24,16 @@ use super::devices::record_revoke_success;
 use super::manual::{
     PreparedManualSync, record_sync_failure, record_sync_started, record_sync_success,
 };
-use super::{SyncServiceError, apply_manual_sync, recover_pending_anchor_transition};
+use super::{
+    PreparedPairingApproval, PreparedPairingJoinActivation, PreparedSetup, SyncServiceError,
+    apply_manual_sync, recover_pending_anchor_transition,
+};
 
 #[derive(Clone)]
 pub enum PersonalSyncApplyKind {
     SyncNow,
     Revoke(DeviceId),
+    PairApprove(Box<PreparedPairingApproval>),
 }
 
 /// A clone-cheap, panic-frontier-safe personal-sync write owned by the persistence actor.
@@ -42,20 +52,30 @@ enum PersonalSyncWrite {
     Initial {
         current_state: PersonalStateV2,
         playlist_revision: u64,
-        candidate: PreparedManualSync,
+        candidate: Box<PreparedManualSync>,
         action: PersonalSyncApplyKind,
     },
     Reconcile {
-        expected_state: PersonalStateV2,
-        alternate_expected_state: PersonalStateV2,
+        accepted_states: Vec<PersonalStateV2>,
         commit: Box<PersonalStateCommit>,
+    },
+    Setup {
+        current_state: PersonalStateV2,
+        playlist_revision: u64,
+        prepared: Box<PreparedSetup>,
+    },
+    PairJoin {
+        current_state: PersonalStateV2,
+        playlist_revision: u64,
+        prepared: Box<PreparedPairingJoinActivation>,
     },
     Shutdown {
         current_state: PersonalStateV2,
         accepted_states: Vec<PersonalStateV2>,
         playlist_revision: u64,
-        candidate: PreparedManualSync,
+        candidate: Box<PreparedManualSync>,
         commit: Box<PersonalStateCommit>,
+        pairing_approval: Option<Box<PreparedPairingApproval>>,
     },
 }
 
@@ -71,6 +91,11 @@ impl PersonalSyncPersistence {
     ) -> Result<Self, SyncServiceError> {
         if candidate.expected_local_revision != current_state.revision {
             return Err(SyncServiceError::LocalStateChanged);
+        }
+        if let PersonalSyncApplyKind::PairApprove(prepared) = &action
+            && !same_manual_sync_candidate(&candidate, prepared.candidate())
+        {
+            return Err(SyncServiceError::InvalidRemoteData);
         }
         let prepared_current =
             PersonalStateCommit::prepare_for_runtime(current_state.clone(), playlist_revision)?;
@@ -88,8 +113,55 @@ impl PersonalSyncPersistence {
             write: PersonalSyncWrite::Initial {
                 current_state,
                 playlist_revision,
-                candidate,
+                candidate: Box::new(candidate),
                 action,
+            },
+            target_state,
+            personal_paths,
+            sync_paths,
+            committed: AtomicBool::new(false),
+        })))
+    }
+
+    /// Validate and own a host approval whose in-flight local suffix was deterministically
+    /// re-authored after the authenticated remote checkpoint.
+    ///
+    /// Unlike an ordinary manual-sync candidate, the target cannot be a byte-for-byte extension
+    /// of `current_state`: local operations which raced the remote membership write may need fresh
+    /// dots. Recompute that target here from the sealed approval plus both owner snapshots, then
+    /// require it to retain the exact network-observed prefix before admitting the writer.
+    #[allow(clippy::too_many_arguments)]
+    pub fn pairing_approval_activation(
+        observed_state: PersonalStateV2,
+        current_state: PersonalStateV2,
+        playlist_revision: u64,
+        prepared: PreparedPairingApproval,
+        personal_paths: PersonalStatePaths,
+        sync_paths: SyncPaths,
+    ) -> Result<Self, SyncServiceError> {
+        let prepared = prepared.retarget(&observed_state, &current_state)?;
+        let mut candidate = prepared.candidate().clone();
+        if candidate.expected_local_revision != current_state.revision {
+            return Err(SyncServiceError::LocalStateChanged);
+        }
+        let prepared_current =
+            PersonalStateCommit::prepare_for_runtime(current_state.clone(), playlist_revision)?;
+        if prepared_current.state() != &current_state {
+            return Err(SyncServiceError::LocalStateChanged);
+        }
+        let target =
+            PersonalStateCommit::prepare_for_runtime(candidate.state.clone(), playlist_revision)?;
+        candidate.state = target.state().clone();
+        if !verified_state_extension(&observed_state, &candidate.state)? {
+            return Err(SyncServiceError::InvalidRemoteData);
+        }
+        let target_state = candidate.state.clone();
+        Ok(Self(Arc::new(PersonalSyncPersistenceInner {
+            write: PersonalSyncWrite::Initial {
+                current_state,
+                playlist_revision,
+                candidate: Box::new(candidate),
+                action: PersonalSyncApplyKind::PairApprove(Box::new(prepared)),
             },
             target_state,
             personal_paths,
@@ -107,12 +179,31 @@ impl PersonalSyncPersistence {
         personal_paths: PersonalStatePaths,
         sync_paths: SyncPaths,
     ) -> Result<Self, SyncServiceError> {
+        Self::reconcile_accepted(
+            vec![expected_state, alternate_expected_state],
+            candidate,
+            playlist_revision,
+            personal_paths,
+            sync_paths,
+        )
+    }
+
+    fn reconcile_accepted(
+        mut accepted_states: Vec<PersonalStateV2>,
+        candidate: PersonalStateV2,
+        playlist_revision: u64,
+        personal_paths: PersonalStatePaths,
+        sync_paths: SyncPaths,
+    ) -> Result<Self, SyncServiceError> {
+        if accepted_states.is_empty() {
+            return Err(SyncServiceError::LocalStateChanged);
+        }
+        accepted_states.dedup();
         let commit = PersonalStateCommit::prepare_for_runtime(candidate, playlist_revision)?;
         let target_state = commit.state().clone();
         Ok(Self(Arc::new(PersonalSyncPersistenceInner {
             write: PersonalSyncWrite::Reconcile {
-                expected_state,
-                alternate_expected_state,
+                accepted_states,
                 commit: Box::new(commit),
             },
             target_state,
@@ -131,8 +222,66 @@ impl PersonalSyncPersistence {
         observed_state: PersonalStateV2,
         current_state: PersonalStateV2,
         playlist_revision: u64,
+        candidate: PreparedManualSync,
+        local_device: &DeviceId,
+        personal_paths: PersonalStatePaths,
+        sync_paths: SyncPaths,
+    ) -> Result<Self, SyncServiceError> {
+        Self::shutdown_with_context(
+            observed_state,
+            current_state,
+            playlist_revision,
+            candidate,
+            local_device,
+            Vec::new(),
+            None,
+            personal_paths,
+            sync_paths,
+        )
+    }
+
+    /// Preserve a host pairing approval when its activation completion is retired at shutdown.
+    ///
+    /// The initial activation target and the last reconcile target are accepted in addition to the
+    /// ordinary manual-sync race states. This covers a reconcile writer which became durable just
+    /// before owner ingress closed, while still applying the original checkpoint transition when
+    /// it did not.
+    #[allow(clippy::too_many_arguments)]
+    pub fn pairing_approval_activation_shutdown(
+        observed_state: PersonalStateV2,
+        current_state: PersonalStateV2,
+        playlist_revision: u64,
+        committed_activation_state: PersonalStateV2,
+        possible_reconcile_state: Option<PersonalStateV2>,
+        prepared: PreparedPairingApproval,
+        personal_paths: PersonalStatePaths,
+        sync_paths: SyncPaths,
+    ) -> Result<Self, SyncServiceError> {
+        let mut accepted_states = vec![committed_activation_state];
+        accepted_states.extend(possible_reconcile_state);
+        let local_device = prepared.candidate().local_device_id.clone();
+        Self::shutdown_with_context(
+            observed_state,
+            current_state,
+            playlist_revision,
+            prepared.candidate().clone(),
+            &local_device,
+            accepted_states,
+            Some(prepared),
+            personal_paths,
+            sync_paths,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn shutdown_with_context(
+        observed_state: PersonalStateV2,
+        current_state: PersonalStateV2,
+        playlist_revision: u64,
         mut candidate: PreparedManualSync,
         local_device: &DeviceId,
+        additional_accepted_states: Vec<PersonalStateV2>,
+        pairing_approval: Option<PreparedPairingApproval>,
         personal_paths: PersonalStatePaths,
         sync_paths: SyncPaths,
     ) -> Result<Self, SyncServiceError> {
@@ -168,6 +317,7 @@ impl PersonalSyncPersistence {
             prepared_current.clone(),
             candidate.state.clone(),
         ];
+        accepted_states.extend(additional_accepted_states);
         accepted_states.dedup();
 
         Ok(Self(Arc::new(PersonalSyncPersistenceInner {
@@ -175,8 +325,9 @@ impl PersonalSyncPersistence {
                 current_state: prepared_current,
                 accepted_states,
                 playlist_revision,
-                candidate,
+                candidate: Box::new(candidate),
                 commit: Box::new(commit),
+                pairing_approval: pairing_approval.map(Box::new),
             },
             target_state,
             personal_paths,
@@ -206,23 +357,43 @@ impl PersonalSyncPersistence {
                 action,
             } => self.write_initial(current_state, *playlist_revision, candidate, action)?,
             PersonalSyncWrite::Reconcile {
-                expected_state,
-                alternate_expected_state,
+                accepted_states,
                 commit,
-            } => self.write_reconciliation(expected_state, alternate_expected_state, commit)?,
+            } => self.write_reconciliation(accepted_states, commit)?,
+            PersonalSyncWrite::Setup {
+                current_state,
+                playlist_revision,
+                prepared,
+            } => self.write_setup(current_state, *playlist_revision, prepared)?,
+            PersonalSyncWrite::PairJoin {
+                current_state,
+                playlist_revision,
+                prepared,
+            } => self.write_pair_join(current_state, *playlist_revision, prepared)?,
             PersonalSyncWrite::Shutdown {
                 current_state,
                 accepted_states,
                 playlist_revision,
                 candidate,
                 commit,
-            } => self.write_shutdown(
-                current_state,
-                accepted_states,
-                *playlist_revision,
-                candidate,
-                commit,
-            )?,
+                pairing_approval,
+            } => {
+                let installed = self.write_shutdown(
+                    current_state,
+                    accepted_states,
+                    *playlist_revision,
+                    candidate,
+                    commit,
+                )?;
+                if let Some(prepared) = pairing_approval {
+                    super::finalize_prepared_pairing_approval(
+                        &installed,
+                        &self.0.sync_paths,
+                        prepared,
+                    )?;
+                }
+                installed
+            }
         };
         if installed != self.0.target_state {
             return Err(SyncServiceError::LocalStateChanged);
@@ -259,6 +430,13 @@ impl PersonalSyncPersistence {
             return Err(SyncServiceError::LocalStateChanged);
         }
         if self.initial_target_is_already_durable(candidate)? {
+            if let PersonalSyncApplyKind::PairApprove(prepared) = action {
+                super::finalize_prepared_pairing_approval(
+                    &self.0.target_state,
+                    &self.0.sync_paths,
+                    prepared,
+                )?;
+            }
             return Ok(self.0.target_state.clone());
         }
 
@@ -267,13 +445,21 @@ impl PersonalSyncPersistence {
         let result = (|| {
             self.ensure_current_state_durable(current_state, playlist_revision)?;
             after_current_durable()?;
-            apply_manual_sync(
+            let installed = apply_manual_sync(
                 current_state,
                 playlist_revision,
                 candidate.clone(),
                 &self.0.personal_paths,
                 &self.0.sync_paths,
-            )
+            )?;
+            if let PersonalSyncApplyKind::PairApprove(prepared) = action {
+                super::finalize_prepared_pairing_approval(
+                    &installed,
+                    &self.0.sync_paths,
+                    prepared,
+                )?;
+            }
+            Ok(installed)
         })();
         match &result {
             Ok(_) => match action {
@@ -288,6 +474,7 @@ impl PersonalSyncPersistence {
                         &candidate.summary,
                     );
                 }
+                PersonalSyncApplyKind::PairApprove(_) => {}
             },
             Err(error) => {
                 let _ = record_sync_failure(&self.0.sync_paths, now, *error);
@@ -338,8 +525,7 @@ impl PersonalSyncPersistence {
 
     fn write_reconciliation(
         &self,
-        expected_state: &PersonalStateV2,
-        alternate_expected_state: &PersonalStateV2,
+        accepted_states: &[PersonalStateV2],
         commit: &PersonalStateCommit,
     ) -> Result<PersonalStateV2, SyncServiceError> {
         let _ = recover_pending_anchor_transition(&self.0.personal_paths, &self.0.sync_paths)?;
@@ -348,7 +534,7 @@ impl PersonalSyncPersistence {
         if installed == self.0.target_state {
             return Ok(installed);
         }
-        if !reconciliation_base_matches(&installed, expected_state, alternate_expected_state) {
+        if !accepted_states.iter().any(|state| state == &installed) {
             return Err(SyncServiceError::LocalStateChanged);
         }
         let installed = commit.commit(&self.0.personal_paths)?;
@@ -448,6 +634,16 @@ impl PersonalSyncPersistence {
     }
 }
 
+fn same_manual_sync_candidate(left: &PreparedManualSync, right: &PreparedManualSync) -> bool {
+    left.state == right.state
+        && left.membership == right.membership
+        && left.checkpoint_anchor == right.checkpoint_anchor
+        && left.expected_local_revision == right.expected_local_revision
+        && left.expected_private_revision == right.expected_private_revision
+        && left.local_device_id == right.local_device_id
+        && left.summary == right.summary
+}
+
 fn roll_forward_verified_extension(
     installed: PersonalStateV2,
     current: &PersonalStateV2,
@@ -467,6 +663,17 @@ fn roll_forward_verified_extension(
     let installed = commit.commit(personal_paths)?;
     if installed == *current {
         Ok(installed)
+    } else {
+        Err(SyncServiceError::LocalStateChanged)
+    }
+}
+
+pub(crate) fn verify_activation_extension(
+    base: &PersonalStateV2,
+    extension: &PersonalStateV2,
+) -> Result<(), SyncServiceError> {
+    if verified_state_extension(base, extension)? {
+        Ok(())
     } else {
         Err(SyncServiceError::LocalStateChanged)
     }
@@ -505,14 +712,6 @@ fn verified_state_extension(
             .copied()
             == Some(operation)
     }))
-}
-
-fn reconciliation_base_matches(
-    installed: &PersonalStateV2,
-    durable_sync_state: &PersonalStateV2,
-    observed_local_state: &PersonalStateV2,
-) -> bool {
-    installed == durable_sync_state || installed == observed_local_state
 }
 
 fn shutdown_anchor_matches(
@@ -576,6 +775,17 @@ pub(crate) fn rebase_local_operations(
         .iter()
         .map(|operation| (operation.operation_id.as_str(), operation))
         .collect();
+    if observed_by_id
+        .iter()
+        .any(|(id, operation)| durable_by_id.get(id).copied() != Some(*operation))
+        || observed
+            .version_vector
+            .0
+            .iter()
+            .any(|(device, sequence)| durable.version_vector.observed(device) < *sequence)
+    {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
     let mut additions: Vec<&OperationEnvelope> = current
         .operations
         .iter()
@@ -587,6 +797,30 @@ pub(crate) fn rebase_local_operations(
             .cmp(&right.stamp.dot)
             .then(left.operation_id.cmp(&right.operation_id))
     });
+
+    let mut expected_vector = observed.version_vector.clone();
+    for addition in &additions {
+        let expected_sequence = expected_vector
+            .observed(local_device)
+            .checked_add(1)
+            .ok_or(SyncServiceError::LocalStateChanged)?;
+        if addition.origin != OperationOrigin::Local
+            || addition.stamp.dot.device_id != *local_device
+            || addition.stamp.dot.sequence != expected_sequence
+            || addition.stamp.observed != expected_vector
+            || addition.operation_id != format!("{}:{expected_sequence}", local_device.as_str())
+            || matches!(
+                addition.operation,
+                Operation::AddDevice { .. } | Operation::RevokeDevice { .. }
+            )
+        {
+            return Err(SyncServiceError::LocalStateChanged);
+        }
+        expected_vector.observe(&addition.stamp.dot);
+    }
+    if current.version_vector != expected_vector {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
 
     let mut rebased = durable.clone();
     let mut appended = false;
@@ -627,14 +861,14 @@ mod tests {
 
     static NEXT_ROOT: AtomicU64 = AtomicU64::new(0);
 
-    struct ShutdownFixture {
-        root: std::path::PathBuf,
-        personal_paths: PersonalStatePaths,
-        initial: PersonalStateV2,
-        local: PersonalStateV2,
-        candidate: PreparedManualSync,
-        device_id: DeviceId,
-        checkpoint_sequence: u64,
+    pub(super) struct ShutdownFixture {
+        pub(super) root: std::path::PathBuf,
+        pub(super) personal_paths: PersonalStatePaths,
+        pub(super) initial: PersonalStateV2,
+        pub(super) local: PersonalStateV2,
+        pub(super) candidate: PreparedManualSync,
+        pub(super) device_id: DeviceId,
+        pub(super) checkpoint_sequence: u64,
     }
 
     impl Drop for ShutdownFixture {
@@ -643,7 +877,7 @@ mod tests {
         }
     }
 
-    fn shutdown_fixture() -> ShutdownFixture {
+    pub(super) fn shutdown_fixture() -> ShutdownFixture {
         let sequence = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
         let root = std::env::temp_dir().join(format!(
             "yututui-sync-shutdown-{}-{sequence}",
@@ -819,9 +1053,10 @@ mod tests {
         let unrelated =
             PersonalStateV2::empty("persistence-unrelated".to_owned()).expect("other state");
 
-        assert!(reconciliation_base_matches(&durable, &durable, &local));
-        assert!(reconciliation_base_matches(&local, &durable, &local));
-        assert!(!reconciliation_base_matches(&unrelated, &durable, &local));
+        let accepted = [durable.clone(), local.clone()];
+        assert!(accepted.contains(&durable));
+        assert!(accepted.contains(&local));
+        assert!(!accepted.contains(&unrelated));
     }
 
     #[test]

--- a/src/sync/service/persistence/activation.rs
+++ b/src/sync/service/persistence/activation.rs
@@ -1,0 +1,315 @@
+//! Persistence-owner writers for setup and pairing-join activation.
+//!
+//! Network workers may prepare either transition, but the ledger and private enrollment anchor
+//! become active only from the PersonalState persistence lane.
+
+use super::*;
+
+impl PersonalSyncPersistence {
+    pub fn setup_activation(
+        current_state: PersonalStateV2,
+        playlist_revision: u64,
+        prepared: PreparedSetup,
+        personal_paths: PersonalStatePaths,
+        sync_paths: SyncPaths,
+    ) -> Result<Self, SyncServiceError> {
+        let current =
+            PersonalStateCommit::prepare_for_runtime(current_state.clone(), playlist_revision)?;
+        if current.state() != &current_state {
+            return Err(SyncServiceError::LocalStateChanged);
+        }
+        let target_state = prepared.target_state(&current_state)?;
+        let target =
+            PersonalStateCommit::prepare_for_runtime(target_state.clone(), playlist_revision)?;
+        if target.state() != &target_state {
+            return Err(SyncServiceError::LocalStateChanged);
+        }
+        Ok(Self(Arc::new(PersonalSyncPersistenceInner {
+            write: PersonalSyncWrite::Setup {
+                current_state,
+                playlist_revision,
+                prepared: Box::new(prepared),
+            },
+            target_state,
+            personal_paths,
+            sync_paths,
+            committed: AtomicBool::new(false),
+        })))
+    }
+
+    pub fn pairing_join_activation(
+        current_state: PersonalStateV2,
+        playlist_revision: u64,
+        prepared: PreparedPairingJoinActivation,
+        personal_paths: PersonalStatePaths,
+        sync_paths: SyncPaths,
+    ) -> Result<Self, SyncServiceError> {
+        let prepared = prepared.retarget(&current_state)?;
+        let current =
+            PersonalStateCommit::prepare_for_runtime(current_state.clone(), playlist_revision)?;
+        if current.state() != &current_state {
+            return Err(SyncServiceError::LocalStateChanged);
+        }
+        let target = super::super::pairing::prepare_pairing_join_commit(
+            &current_state,
+            playlist_revision,
+            prepared.target_state().clone(),
+        )?;
+        let target_state = target.state().clone();
+        Ok(Self(Arc::new(PersonalSyncPersistenceInner {
+            write: PersonalSyncWrite::PairJoin {
+                current_state,
+                playlist_revision,
+                prepared: Box::new(prepared),
+            },
+            target_state,
+            personal_paths,
+            sync_paths,
+            committed: AtomicBool::new(false),
+        })))
+    }
+
+    /// Build the final setup writer after the owner has stopped accepting activation completions.
+    ///
+    /// Background activation work is joined before this constructor is called. The private store
+    /// therefore tells us whether the initial cross-store transition committed: a pending setup is
+    /// activated against the latest local state, while an active setup only needs a ledger
+    /// reconciliation which retains every possible superseding snapshot.
+    #[allow(clippy::too_many_arguments)]
+    pub fn setup_activation_shutdown(
+        current_state: PersonalStateV2,
+        playlist_revision: u64,
+        committed_activation_state: PersonalStateV2,
+        possible_reconcile_state: Option<PersonalStateV2>,
+        prepared: PreparedSetup,
+        personal_paths: PersonalStatePaths,
+        sync_paths: SyncPaths,
+    ) -> Result<Self, SyncServiceError> {
+        let _ = recover_pending_anchor_transition(&personal_paths, &sync_paths)?;
+        let installed = load_ledger(&personal_paths)?.ok_or(SyncServiceError::LocalStateChanged)?;
+        let private = PrivateStore::new(sync_paths.private_store())?.load()?;
+        match private.enrollment() {
+            EnrollmentState::PendingLedgerCommit
+                if private.revision() == prepared.expected_private_revision()
+                    && private.device_id() == prepared.device_id().as_str() =>
+            {
+                Self::setup_activation(
+                    current_state,
+                    playlist_revision,
+                    prepared,
+                    personal_paths,
+                    sync_paths,
+                )
+            }
+            EnrollmentState::Active
+                if active_private_matches(
+                    &private,
+                    &committed_activation_state,
+                    prepared.device_id().as_str(),
+                ) =>
+            {
+                let candidate = prepared.target_state(&current_state)?;
+                verify_activation_extension(&committed_activation_state, &candidate)?;
+                if let Some(possible) = possible_reconcile_state.as_ref()
+                    && installed == *possible
+                {
+                    verify_activation_extension(possible, &candidate)?;
+                }
+                let accepted_states = shutdown_accepted_states(
+                    installed,
+                    current_state,
+                    committed_activation_state,
+                    possible_reconcile_state,
+                );
+                Self::reconcile_accepted(
+                    accepted_states,
+                    candidate,
+                    playlist_revision,
+                    personal_paths,
+                    sync_paths,
+                )
+            }
+            _ => Err(SyncServiceError::LocalStateChanged),
+        }
+    }
+
+    /// Build the final pairing-join writer after activation completion delivery was retired.
+    ///
+    /// Once the private store is active, the already imported baseline is immutable. Replanning
+    /// from that durable state appends a new deterministic baseline for later local changes rather
+    /// than replacing the first import operation.
+    #[allow(clippy::too_many_arguments)]
+    pub fn pairing_join_activation_shutdown(
+        current_state: PersonalStateV2,
+        playlist_revision: u64,
+        committed_activation_state: PersonalStateV2,
+        possible_reconcile_state: Option<PersonalStateV2>,
+        prepared: PreparedPairingJoinActivation,
+        personal_paths: PersonalStatePaths,
+        sync_paths: SyncPaths,
+    ) -> Result<Self, SyncServiceError> {
+        let _ = recover_pending_anchor_transition(&personal_paths, &sync_paths)?;
+        let installed = load_ledger(&personal_paths)?.ok_or(SyncServiceError::LocalStateChanged)?;
+        let private = PrivateStore::new(sync_paths.private_store())?.load()?;
+        match private.enrollment() {
+            EnrollmentState::PendingLedgerCommit
+                if private.revision() == prepared.expected_private_revision()
+                    && private.device_id() == prepared.device_id() =>
+            {
+                Self::pairing_join_activation(
+                    current_state,
+                    playlist_revision,
+                    prepared,
+                    personal_paths,
+                    sync_paths,
+                )
+            }
+            EnrollmentState::Active
+                if active_private_matches(
+                    &private,
+                    &committed_activation_state,
+                    prepared.device_id(),
+                ) =>
+            {
+                let durable = if possible_reconcile_state
+                    .as_ref()
+                    .is_some_and(|candidate| candidate == &installed)
+                    || (installed.dataset_id == committed_activation_state.dataset_id
+                        && verified_state_extension(&committed_activation_state, &installed)?)
+                {
+                    installed.clone()
+                } else {
+                    committed_activation_state.clone()
+                };
+                let device_id = DeviceId::new(prepared.device_id())
+                    .map_err(|_| SyncServiceError::InvalidRemoteData)?;
+                let planned =
+                    crate::personal_state::plan_join_import(&durable, &current_state, &device_id)?;
+                let candidate = super::super::pairing::prepare_pairing_join_commit(
+                    &current_state,
+                    playlist_revision,
+                    planned.candidate,
+                )?
+                .state()
+                .clone();
+                verify_activation_extension(&durable, &candidate)?;
+                let accepted_states = shutdown_accepted_states(
+                    installed,
+                    current_state,
+                    committed_activation_state,
+                    possible_reconcile_state,
+                );
+                Self::reconcile_accepted(
+                    accepted_states,
+                    candidate,
+                    playlist_revision,
+                    personal_paths,
+                    sync_paths,
+                )
+            }
+            _ => Err(SyncServiceError::LocalStateChanged),
+        }
+    }
+
+    pub(super) fn write_setup(
+        &self,
+        current_state: &PersonalStateV2,
+        playlist_revision: u64,
+        prepared: &PreparedSetup,
+    ) -> Result<PersonalStateV2, SyncServiceError> {
+        let recovered =
+            recover_pending_anchor_transition(&self.0.personal_paths, &self.0.sync_paths)?;
+        if recovered.as_ref() == Some(&self.0.target_state)
+            || self.activation_target_is_already_durable(prepared.device_id().as_str())?
+        {
+            return Ok(self.0.target_state.clone());
+        }
+        if recovered.is_some_and(|installed| installed != *current_state) {
+            return Err(SyncServiceError::LocalStateChanged);
+        }
+        self.ensure_current_state_durable(current_state, playlist_revision)?;
+        super::super::apply_prepared_setup(
+            current_state,
+            playlist_revision,
+            &self.0.personal_paths,
+            &self.0.sync_paths,
+            prepared.clone(),
+        )
+        .map(|result| result.state)
+    }
+
+    pub(super) fn write_pair_join(
+        &self,
+        current_state: &PersonalStateV2,
+        playlist_revision: u64,
+        prepared: &PreparedPairingJoinActivation,
+    ) -> Result<PersonalStateV2, SyncServiceError> {
+        let recovered =
+            recover_pending_anchor_transition(&self.0.personal_paths, &self.0.sync_paths)?;
+        if recovered.as_ref() == Some(&self.0.target_state)
+            || self.activation_target_is_already_durable(prepared.device_id())?
+        {
+            return Ok(self.0.target_state.clone());
+        }
+        if recovered.is_some_and(|installed| installed != *current_state) {
+            return Err(SyncServiceError::LocalStateChanged);
+        }
+        self.ensure_current_state_durable(current_state, playlist_revision)?;
+        super::super::apply_prepared_pairing_join(
+            current_state,
+            playlist_revision,
+            &self.0.personal_paths,
+            &self.0.sync_paths,
+            prepared.clone(),
+        )
+    }
+
+    fn activation_target_is_already_durable(
+        &self,
+        device_id: &str,
+    ) -> Result<bool, SyncServiceError> {
+        if load_ledger(&self.0.personal_paths)?.as_ref() != Some(&self.0.target_state) {
+            return Ok(false);
+        }
+        let private = PrivateStore::new(self.0.sync_paths.private_store())?.load()?;
+        let device = self
+            .0
+            .target_state
+            .device_registry
+            .values()
+            .find(|device| device.device_id.as_str() == device_id);
+        Ok(private.enrollment() == EnrollmentState::Active
+            && private.dataset_id() == self.0.target_state.dataset_id
+            && private.device_id() == device_id
+            && device.is_some_and(|record| {
+                !record.revoked && private.device().matches_personal_record(record)
+            }))
+    }
+}
+
+fn active_private_matches(
+    private: &crate::sync::PrivateStoreSnapshot,
+    state: &PersonalStateV2,
+    device_id: &str,
+) -> bool {
+    private.dataset_id() == state.dataset_id
+        && private.device_id() == device_id
+        && state
+            .device_registry
+            .values()
+            .find(|device| device.device_id.as_str() == device_id)
+            .is_some_and(|record| {
+                !record.revoked && private.device().matches_personal_record(record)
+            })
+}
+
+fn shutdown_accepted_states(
+    installed: PersonalStateV2,
+    current: PersonalStateV2,
+    committed: PersonalStateV2,
+    possible_reconcile: Option<PersonalStateV2>,
+) -> Vec<PersonalStateV2> {
+    let mut states = vec![installed, current, committed];
+    states.extend(possible_reconcile);
+    states
+}

--- a/src/sync/service/persistence/tests.rs
+++ b/src/sync/service/persistence/tests.rs
@@ -1,0 +1,188 @@
+use super::tests::shutdown_fixture;
+use super::*;
+
+#[test]
+fn pairing_join_retargets_three_times_from_the_durable_import_baseline() {
+    let fixture = shutdown_fixture();
+    let baseline_count = |state: &PersonalStateV2| {
+        state
+            .operations
+            .iter()
+            .filter(|operation| matches!(operation.operation, Operation::LegacyBaseline { .. }))
+            .count()
+    };
+
+    let first = crate::personal_state::plan_join_import(
+        &fixture.candidate.state,
+        &fixture.local,
+        &fixture.device_id,
+    )
+    .unwrap()
+    .candidate;
+    assert_eq!(
+        baseline_count(&first),
+        baseline_count(&fixture.candidate.state) + 1
+    );
+
+    let second_local = append_operation_as(
+        &fixture.local,
+        &fixture.device_id,
+        Operation::SetAvoidArtist {
+            artist_key: "join-second-retarget".to_owned(),
+            avoid: true,
+        },
+        6,
+    )
+    .unwrap();
+    let second = crate::personal_state::plan_join_import(&first, &second_local, &fixture.device_id)
+        .unwrap()
+        .candidate;
+    verify_activation_extension(&first, &second).unwrap();
+    assert_eq!(baseline_count(&second), baseline_count(&first) + 1);
+
+    let third_local = append_operation_as(
+        &second_local,
+        &fixture.device_id,
+        Operation::SetAvoidArtist {
+            artist_key: "join-third-retarget".to_owned(),
+            avoid: true,
+        },
+        7,
+    )
+    .unwrap();
+    let third = crate::personal_state::plan_join_import(&second, &third_local, &fixture.device_id)
+        .unwrap()
+        .candidate;
+    verify_activation_extension(&second, &third).unwrap();
+    assert_eq!(baseline_count(&third), baseline_count(&second) + 1);
+}
+
+#[test]
+fn pairing_approval_shutdown_extends_the_second_reconcile_boundary() {
+    let fixture = shutdown_fixture();
+    let sync_paths = SyncPaths::for_data_root(fixture.root.clone());
+    let target_device = fixture
+        .initial
+        .device_registry
+        .get(&fixture.device_id)
+        .unwrap()
+        .clone();
+    let prepared =
+        PreparedPairingApproval::for_persistence_test(fixture.candidate.clone(), target_device);
+
+    let initial_writer = PersonalSyncPersistence::initial(
+        fixture.initial.clone(),
+        7,
+        prepared.candidate().clone(),
+        PersonalSyncApplyKind::PairApprove(Box::new(prepared.clone())),
+        fixture.personal_paths.clone(),
+        SyncPaths::for_data_root(fixture.root.clone()),
+    )
+    .unwrap();
+    initial_writer.write().unwrap();
+    let durable = initial_writer.state().clone();
+
+    let first_local = PersonalStateCommit::prepare_for_runtime(fixture.local.clone(), 7)
+        .unwrap()
+        .state()
+        .clone();
+    let first_retarget = prepared.retarget(&fixture.initial, &first_local).unwrap();
+    let first_writer = PersonalSyncPersistence::reconcile(
+        durable.clone(),
+        first_local.clone(),
+        first_retarget.candidate().state.clone(),
+        7,
+        fixture.personal_paths.clone(),
+        SyncPaths::for_data_root(fixture.root.clone()),
+    )
+    .unwrap();
+
+    let second_local = append_operation_as(
+        &first_local,
+        &fixture.device_id,
+        Operation::SetAvoidArtist {
+            artist_key: "approval-second-retarget".to_owned(),
+            avoid: true,
+        },
+        8,
+    )
+    .unwrap();
+    let second_local = PersonalStateCommit::prepare_for_runtime(second_local, 7)
+        .unwrap()
+        .state()
+        .clone();
+    let second_retarget = prepared.retarget(&fixture.initial, &second_local).unwrap();
+    let second_writer = PersonalSyncPersistence::reconcile(
+        durable.clone(),
+        second_local.clone(),
+        second_retarget.candidate().state.clone(),
+        7,
+        fixture.personal_paths.clone(),
+        SyncPaths::for_data_root(fixture.root.clone()),
+    )
+    .unwrap();
+    assert!(
+        verified_state_extension(first_writer.state(), second_writer.state()).unwrap(),
+        "the second retry must preserve the first retry target"
+    );
+    second_writer.write().unwrap();
+    assert!(second_writer.committed());
+
+    let third_local = append_operation_as(
+        &second_local,
+        &fixture.device_id,
+        Operation::SetAvoidArtist {
+            artist_key: "approval-shutdown-retarget".to_owned(),
+            avoid: true,
+        },
+        9,
+    )
+    .unwrap();
+    let third_local = PersonalStateCommit::prepare_for_runtime(third_local, 7)
+        .unwrap()
+        .state()
+        .clone();
+    let shutdown_writer = PersonalSyncPersistence::pairing_approval_activation_shutdown(
+        fixture.initial.clone(),
+        third_local,
+        7,
+        durable,
+        Some(second_writer.state().clone()),
+        prepared,
+        fixture.personal_paths.clone(),
+        SyncPaths::for_data_root(fixture.root.clone()),
+    )
+    .unwrap();
+    assert!(
+        verified_state_extension(second_writer.state(), shutdown_writer.state()).unwrap(),
+        "shutdown must extend a reconcile target committed just before ingress closes"
+    );
+
+    shutdown_writer.write().unwrap();
+
+    assert!(shutdown_writer.committed());
+    let installed = load_ledger(&fixture.personal_paths).unwrap().unwrap();
+    assert_eq!(&installed, shutdown_writer.state());
+    for artist_key in [
+        "local-artist",
+        "approval-second-retarget",
+        "approval-shutdown-retarget",
+    ] {
+        assert!(installed.operations.iter().any(|operation| matches!(
+            operation.operation,
+            Operation::SetAvoidArtist {
+                artist_key: ref candidate,
+                avoid: true
+            } if candidate == artist_key
+        )));
+    }
+    let private = PrivateStore::new(sync_paths.private_store())
+        .unwrap()
+        .load()
+        .unwrap();
+    assert_eq!(
+        private.checkpoint_sequence(),
+        Some(fixture.checkpoint_sequence + 1)
+    );
+    assert_eq!(private.checkpoint_hash(), Some("b".repeat(64).as_str()));
+}

--- a/src/sync/service/recovery_export.rs
+++ b/src/sync/service/recovery_export.rs
@@ -1,0 +1,112 @@
+use std::path::{Path, PathBuf};
+
+use zeroize::Zeroizing;
+
+use crate::personal_state::PersonalStateV2;
+
+use super::super::{
+    PrivateStore, RecoveryKit, SyncAuditAction, SyncAuditEntry, SyncAuditOutcome, SyncAuditStore,
+    SyncPaths,
+};
+use super::SyncServiceError;
+
+const RECOVERY_KIT_MAX_BYTES: u64 = 64 * 1024;
+const RECOVERY_NAME: &str = "yututui-recovery-kit.json";
+const RECOVERY_COPY_LIMIT: usize = 10_000;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct RecoveryExportResult {
+    pub checksum: String,
+}
+
+/// Verify an existing recovery kit and make a no-overwrite owner-only copy.
+///
+/// Paths never enter the return value, audit entry, or error. The caller may retain its own
+/// transient field while the wizard is open, but status/toast layers only need the checksum.
+pub fn export_recovery_kit(
+    state: &PersonalStateV2,
+    paths: &SyncPaths,
+    source: &Path,
+    destination_directory: &Path,
+) -> Result<RecoveryExportResult, SyncServiceError> {
+    let source_bytes = Zeroizing::new(
+        crate::util::safe_fs::read_no_symlink_limited(source, RECOVERY_KIT_MAX_BYTES)
+            .map_err(|_| SyncServiceError::Storage)?,
+    );
+    if source_bytes.is_empty() {
+        return Err(SyncServiceError::InvalidRemoteData);
+    }
+    let kit =
+        RecoveryKit::from_json(&source_bytes).map_err(|_| SyncServiceError::InvalidRemoteData)?;
+    if kit.dataset_id() != state.dataset_id {
+        return Err(SyncServiceError::InvalidRemoteData);
+    }
+
+    let private = PrivateStore::new(paths.private_store())?.load()?;
+    let recovery_verifying_key = kit
+        .recovery_verifying_key()
+        .map_err(|_| SyncServiceError::InvalidRemoteData)?;
+    if private.dataset_id() != state.dataset_id
+        || private.recovery_recipient() != Some(kit.recovery_recipient().as_str())
+        || private.recovery_verifying_key() != Some(recovery_verifying_key.as_str())
+    {
+        return Err(SyncServiceError::InvalidRemoteData);
+    }
+
+    let destination = unused_recovery_path(destination_directory)?;
+    let checksum = kit
+        .export_confirmed(&destination)
+        .map_err(|_| SyncServiceError::Storage)?;
+    let now = crate::signals::unix_now();
+    if let Ok(entry) = SyncAuditEntry::new(
+        now,
+        SyncAuditAction::RecoveryExport,
+        SyncAuditOutcome::Succeeded,
+    ) {
+        let _ = SyncAuditStore::new(paths.audit()).and_then(|store| store.append(now, entry));
+    }
+    Ok(RecoveryExportResult { checksum })
+}
+
+fn unused_recovery_path(directory: &Path) -> Result<PathBuf, SyncServiceError> {
+    let metadata = std::fs::symlink_metadata(directory).map_err(|_| SyncServiceError::Storage)?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(SyncServiceError::Storage);
+    }
+    let directory = std::fs::canonicalize(directory).map_err(|_| SyncServiceError::Storage)?;
+    for index in 0..RECOVERY_COPY_LIMIT {
+        let name = if index == 0 {
+            RECOVERY_NAME.to_owned()
+        } else {
+            format!("yututui-recovery-kit-{index}.json")
+        };
+        let candidate = directory.join(name);
+        match std::fs::symlink_metadata(&candidate) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(candidate),
+            Ok(_) => {}
+            Err(_) => return Err(SyncServiceError::Storage),
+        }
+    }
+    Err(SyncServiceError::Storage)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn destination_names_are_bounded_and_never_overwrite() {
+        let root = std::env::temp_dir().join(format!(
+            "yututui-recovery-export-name-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let first = unused_recovery_path(&root).unwrap();
+        assert_eq!(first.file_name().unwrap(), RECOVERY_NAME);
+        std::fs::write(&first, b"occupied").unwrap();
+        let second = unused_recovery_path(&root).unwrap();
+        assert_eq!(second.file_name().unwrap(), "yututui-recovery-kit-1.json");
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/sync/service/setup.rs
+++ b/src/sync/service/setup.rs
@@ -1,10 +1,12 @@
+use std::collections::BTreeMap;
 use std::io;
 use std::path::PathBuf;
 
 use crate::personal_state::{
-    DeviceId, DeviceRecord, Operation, OperationOrigin, PersonalStateCommit, PersonalStateV2,
-    append_operation_as,
+    DeviceId, DeviceRecord, Operation, OperationEnvelope, OperationOrigin, PersonalStateCommit,
+    PersonalStateV2, append_operation_as, load_ledger,
 };
+use crate::util::safe_fs::remove_owner_only_file_durable;
 
 use super::super::manual::{
     ManualSyncEngine, ManualSyncInput, ManualSyncSummary, SignedVaultManifest, manifest_key,
@@ -17,7 +19,7 @@ use super::super::{
     WebDavProfileStore, decrypt_json_with_identity,
 };
 use super::transition::{AnchorActivationKind, commit_with_anchor_transition};
-use super::{SyncServiceError, map_webdav_error};
+use super::{SyncServiceError, map_webdav_error, open_saved_webdav_transport};
 
 /// Secret-bearing setup input. It intentionally implements neither `Debug` nor `Clone`.
 pub struct SetupRequest {
@@ -36,9 +38,79 @@ pub struct SetupResult {
     pub resumed: bool,
 }
 
-struct PreparedSetup {
+/// Redacted result of completing the remote setup handshake.
+///
+/// The WebDAV endpoint, credential, private device keys, and recovery-kit path remain only in
+/// their owner-only stores. This value is therefore safe to clone across the detached worker and
+/// primary-owner boundary, but intentionally has no `Debug` implementation.
+#[derive(Clone)]
+pub struct PreparedSetup {
+    observed_state: PersonalStateV2,
+    checkpoint: SignedCheckpoint,
+    expected_private_revision: u64,
+    device_id: DeviceId,
+    recovery_checksum: String,
+    summary: ManualSyncSummary,
+    resumed: bool,
+}
+
+impl PreparedSetup {
+    /// The exact local revision observed before the network handshake began.
+    pub fn expected_local_revision(&self) -> u64 {
+        self.observed_state.revision
+    }
+
+    /// The pending private-store revision that must still be visible at activation.
+    pub fn expected_private_revision(&self) -> u64 {
+        self.expected_private_revision
+    }
+
+    pub fn device_id(&self) -> &DeviceId {
+        &self.device_id
+    }
+
+    pub fn recovery_checksum(&self) -> &str {
+        &self.recovery_checksum
+    }
+
+    pub fn summary(&self) -> &ManualSyncSummary {
+        &self.summary
+    }
+
+    pub fn resumed(&self) -> bool {
+        self.resumed
+    }
+
+    /// Compute the exact owner candidate without performing any file or network I/O.
+    ///
+    /// Local personal-state operations recorded while setup was in flight are re-authored after
+    /// the signed bootstrap checkpoint. Only the contiguous, local, non-membership suffix owned
+    /// by this device is accepted.
+    pub fn target_state(
+        &self,
+        current_state: &PersonalStateV2,
+    ) -> Result<PersonalStateV2, SyncServiceError> {
+        let additions =
+            validate_observed_local_suffix(&self.observed_state, current_state, &self.device_id)?;
+        let mut target = self.checkpoint.payload.state.clone();
+        for addition in additions {
+            target = append_operation_as(
+                &target,
+                &self.device_id,
+                addition.operation.clone(),
+                addition.stamp.recorded_at_unix,
+            )?;
+        }
+        if target != self.checkpoint.payload.state {
+            target.revision = target.revision.max(current_state.revision);
+            target.projection_fingerprint = None;
+        }
+        Ok(PersonalStateCommit::prepare(target)?.state().clone())
+    }
+}
+
+struct InitialSetup {
     expected_state: PersonalStateV2,
-    playlist_revision: u64,
     commit: PersonalStateCommit,
     private: PrivateStoreSnapshot,
     profile: WebDavProfile,
@@ -46,6 +118,7 @@ struct PreparedSetup {
     membership_anchor: MembershipAnchor,
     checkpoint: SignedCheckpoint,
     device_id: DeviceId,
+    recovery_file: PathBuf,
 }
 
 struct PendingSetup {
@@ -54,7 +127,6 @@ struct PendingSetup {
 }
 
 struct ResumableRemoteSetup {
-    commit: PersonalStateCommit,
     checkpoint: SignedCheckpoint,
     summary: ManualSyncSummary,
 }
@@ -66,6 +138,26 @@ pub fn setup(
     sync_paths: &SyncPaths,
     request: SetupRequest,
 ) -> Result<SetupResult, SyncServiceError> {
+    let prepared = prepare_setup(current_state, playlist_revision, sync_paths, request)?;
+    apply_prepared_setup(
+        current_state,
+        playlist_revision,
+        personal_paths,
+        sync_paths,
+        prepared,
+    )
+}
+
+/// Complete capability testing and the encrypted remote bootstrap without installing a ledger.
+///
+/// This is intended for a detached network worker. It durably retains the pending private keys,
+/// credential, profile, and confirmed recovery marker so an ambiguous response can be resumed.
+pub fn prepare_setup(
+    current_state: &PersonalStateV2,
+    playlist_revision: u64,
+    sync_paths: &SyncPaths,
+    request: SetupRequest,
+) -> Result<PreparedSetup, SyncServiceError> {
     if let Some(mut pending) = load_pending_setup(
         sync_paths,
         &request.endpoint,
@@ -93,14 +185,8 @@ pub fn setup(
             load_resumable_remote_setup(current_state, playlist_revision, &pending, &transport)?
         {
             pending.private.set_credential(request.credential);
-            return finish_resumed_setup(
-                current_state,
-                playlist_revision,
-                personal_paths,
-                sync_paths,
-                pending,
-                remote,
-            );
+            PrivateStore::new(sync_paths.private_store())?.save(&mut pending.private)?;
+            return prepared_resumed_setup(current_state, pending, remote);
         }
 
         cleanup_pending_setup(
@@ -115,8 +201,39 @@ pub fn setup(
         request.custom_ca_pem.as_deref(),
         &request.credential,
     )?;
-    let prepared = prepare(current_state, playlist_revision, request, sync_paths)?;
-    setup_with_transport(prepared, personal_paths, sync_paths, &transport)
+    let initial = prepare_initial(current_state, playlist_revision, request, sync_paths)?;
+    prepare_setup_with_transport(initial, sync_paths, &transport)
+}
+
+/// Resume an already-published setup using only owner-only durable state.
+///
+/// No form values or recovery path are required after a close or crash. The stored credential is
+/// used only to authenticate and revalidate the exact encrypted bootstrap selected by the remote
+/// manifest.
+pub fn resume_prepared_setup(
+    current_state: &PersonalStateV2,
+    playlist_revision: u64,
+    sync_paths: &SyncPaths,
+) -> Result<PreparedSetup, SyncServiceError> {
+    let pending = load_saved_pending_setup(sync_paths)?;
+    let credential = pending
+        .private
+        .credential()
+        .ok_or(SyncServiceError::MissingCredential)?;
+    let transport = open_saved_webdav_transport(&pending.profile, credential)?;
+    prepared_saved_setup_with_transport(current_state, playlist_revision, pending, &transport)
+}
+
+fn prepared_saved_setup_with_transport<T: VaultTransport + ?Sized>(
+    current_state: &PersonalStateV2,
+    playlist_revision: u64,
+    pending: PendingSetup,
+    transport: &T,
+) -> Result<PreparedSetup, SyncServiceError> {
+    let remote =
+        load_resumable_remote_setup(current_state, playlist_revision, &pending, transport)?
+            .ok_or(SyncServiceError::InvalidRemoteData)?;
+    prepared_resumed_setup(current_state, pending, remote)
 }
 
 pub(super) fn checked_webdav_transport(
@@ -140,12 +257,12 @@ pub(super) fn checked_webdav_transport(
     Ok(transport)
 }
 
-fn prepare(
+fn prepare_initial(
     current_state: &PersonalStateV2,
     playlist_revision: u64,
     request: SetupRequest,
     sync_paths: &SyncPaths,
-) -> Result<PreparedSetup, SyncServiceError> {
+) -> Result<InitialSetup, SyncServiceError> {
     ensure_setup_absent(sync_paths)?;
     let local = unkeyed_local_device(current_state)?;
     let device = DeviceSecretMaterial::generate_for(local.device_id.as_str())?;
@@ -205,9 +322,8 @@ fn prepare(
         &request.endpoint,
         request.custom_ca_pem.as_deref(),
     )?;
-    Ok(PreparedSetup {
+    Ok(InitialSetup {
         expected_state: current_state.clone(),
-        playlist_revision,
         commit,
         private,
         profile,
@@ -215,47 +331,41 @@ fn prepare(
         membership_anchor,
         checkpoint,
         device_id: local.device_id.clone(),
+        recovery_file: request.recovery_file,
     })
 }
 
-fn setup_with_transport<T: VaultTransport + ?Sized>(
-    prepared: PreparedSetup,
-    personal_paths: &crate::personal_state::PersonalStatePaths,
+fn prepare_setup_with_transport<T: VaultTransport + ?Sized>(
+    mut initial: InitialSetup,
     sync_paths: &SyncPaths,
     transport: &T,
-) -> Result<SetupResult, SyncServiceError> {
-    setup_with_transport_using(prepared, personal_paths, sync_paths, transport, || Ok(()))
-}
-
-fn setup_with_transport_using<T: VaultTransport + ?Sized>(
-    mut prepared: PreparedSetup,
-    personal_paths: &crate::personal_state::PersonalStatePaths,
-    sync_paths: &SyncPaths,
-    transport: &T,
-    before_local_commit: impl FnOnce() -> Result<(), SyncServiceError>,
-) -> Result<SetupResult, SyncServiceError> {
+) -> Result<PreparedSetup, SyncServiceError> {
     let private_store = PrivateStore::new(sync_paths.private_store())?;
     let profile_store = WebDavProfileStore::new(sync_paths.profile())?;
-    private_store.create(&mut prepared.private)?;
-    if let Err(error) = profile_store.create(&mut prepared.profile, prepared.private.device()) {
+    if let Err(error) = private_store.create(&mut initial.private) {
+        remove_new_recovery_file(&initial.recovery_file)?;
+        return Err(error.into());
+    }
+    if let Err(error) = profile_store.create(&mut initial.profile, initial.private.device()) {
         private_store
-            .remove(prepared.private.revision())
+            .remove(initial.private.revision())
             .map_err(|_| SyncServiceError::Storage)?;
+        remove_new_recovery_file(&initial.recovery_file)?;
         return Err(error.into());
     }
 
     let checkpoint_anchor = CheckpointAnchor::default();
     let input = ManualSyncInput {
-        local_state: prepared.commit.state(),
-        membership: &prepared.membership,
-        membership_anchor: &prepared.membership_anchor,
-        device: prepared.private.device(),
+        local_state: initial.commit.state(),
+        membership: &initial.membership,
+        membership_anchor: &initial.membership_anchor,
+        device: initial.private.device(),
         checkpoint_anchor: &checkpoint_anchor,
-        bootstrap_checkpoint: Some(&prepared.checkpoint),
-        expected_local_revision: prepared.commit.state().revision,
+        bootstrap_checkpoint: Some(&initial.checkpoint),
+        expected_local_revision: initial.commit.state().revision,
     };
     let candidate = match ManualSyncEngine::new(transport).synchronize(&input, &|expected| {
-        if expected == prepared.commit.state().revision {
+        if expected == initial.commit.state().revision {
             Ok(())
         } else {
             Err(super::super::VaultError::RevisionConflict)
@@ -265,68 +375,104 @@ fn setup_with_transport_using<T: VaultTransport + ?Sized>(
         Err(error) => {
             // Once the manifest may be visible, local keys and the confirmed recovery marker are
             // the only safe way to finish the exact bootstrap. A conclusive missing read means no
-            // usable vault was published, so credentials/profile can be removed immediately.
+            // usable vault was published, so all newly created local setup artifacts can be
+            // removed immediately. An unavailable or ambiguous read deliberately retains them.
             if transport
                 .get(
-                    &manifest_key(&prepared.commit.state().dataset_id)?,
+                    &manifest_key(&initial.commit.state().dataset_id)?,
                     MAX_VAULT_PAYLOAD_BYTES,
                 )
                 .is_ok_and(|remote| remote.is_none())
             {
-                cleanup_pending_setup(&private_store, &prepared.private, &profile_store)?;
+                cleanup_pending_setup(&private_store, &initial.private, &profile_store)?;
+                remove_new_recovery_file(&initial.recovery_file)?;
             }
             return Err(error.into());
         }
     };
-    if candidate.state != *prepared.commit.state()
-        || candidate.membership != prepared.membership
+    if candidate.state != *initial.commit.state()
+        || candidate.membership != initial.membership
         || candidate.checkpoint_anchor.checkpoint_sequence
-            != prepared.checkpoint.payload.checkpoint_sequence
+            != initial.checkpoint.payload.checkpoint_sequence
         || candidate.checkpoint_anchor.checkpoint_hash.as_deref()
-            != Some(prepared.checkpoint.hash()?.as_str())
+            != Some(initial.checkpoint.hash()?.as_str())
     {
         return Err(SyncServiceError::InvalidRemoteData);
     }
 
-    before_local_commit()?;
-    let checkpoint_hash = prepared.checkpoint.hash()?;
-    let recovery_checksum = prepared
+    let recovery_checksum = initial
         .private
         .setup_recovery_checksum()
         .ok_or(SyncServiceError::RecoveryKitNotConfirmed)?
         .to_owned();
-    prepared
-        .private
-        .mark_active(&prepared.checkpoint, prepared.commit.state())?;
-    let installed = commit_with_anchor_transition(
-        &prepared.expected_state,
-        &prepared.commit,
-        personal_paths,
-        sync_paths,
-        &mut prepared.private,
-        AnchorActivationKind::Setup,
-        prepared.checkpoint.payload.checkpoint_sequence,
-        &checkpoint_hash,
-        prepared.playlist_revision,
-    )?;
-    let _ = record_setup_success(sync_paths, candidate.summary.remote_writes);
-    Ok(SetupResult {
-        state: installed,
-        device_id: prepared.device_id,
+    Ok(PreparedSetup {
+        observed_state: initial.expected_state,
+        checkpoint: initial.checkpoint,
+        expected_private_revision: initial.private.revision(),
+        device_id: initial.device_id,
         recovery_checksum,
         summary: candidate.summary,
         resumed: false,
     })
 }
 
-fn finish_resumed_setup(
+/// Install one previously prepared setup through the owner-only cross-store transaction.
+///
+/// The caller-provided current state must still be the exact durable ledger. A stale detached
+/// result is never allowed to overwrite a newer owner state.
+pub fn apply_prepared_setup(
     current_state: &PersonalStateV2,
     playlist_revision: u64,
     personal_paths: &crate::personal_state::PersonalStatePaths,
     sync_paths: &SyncPaths,
-    mut pending: PendingSetup,
-    remote: ResumableRemoteSetup,
+    prepared: PreparedSetup,
 ) -> Result<SetupResult, SyncServiceError> {
+    if load_ledger(personal_paths)?.as_ref() != Some(current_state) {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
+    let target = prepared.target_state(current_state)?;
+    let commit = PersonalStateCommit::prepare_for_runtime(target.clone(), playlist_revision)?;
+    if commit.state() != &target {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
+
+    let mut private = PrivateStore::new(sync_paths.private_store())?.load()?;
+    if private.revision() != prepared.expected_private_revision
+        || private.enrollment() != EnrollmentState::PendingLedgerCommit
+        || private.dataset_id() != target.dataset_id
+        || private.device_id() != prepared.device_id.as_str()
+        || private.setup_recovery_checksum() != Some(prepared.recovery_checksum.as_str())
+    {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
+    let checkpoint_hash = prepared.checkpoint.hash()?;
+    private.mark_active_after_setup(&prepared.checkpoint, commit.state())?;
+    let installed = commit_with_anchor_transition(
+        current_state,
+        &commit,
+        personal_paths,
+        sync_paths,
+        &mut private,
+        AnchorActivationKind::Setup,
+        prepared.checkpoint.payload.checkpoint_sequence,
+        &checkpoint_hash,
+        playlist_revision,
+    )?;
+    let _ = record_setup_success(sync_paths, prepared.summary.remote_writes);
+    Ok(SetupResult {
+        state: installed,
+        device_id: prepared.device_id,
+        recovery_checksum: prepared.recovery_checksum,
+        summary: prepared.summary,
+        resumed: prepared.resumed,
+    })
+}
+
+fn prepared_resumed_setup(
+    current_state: &PersonalStateV2,
+    pending: PendingSetup,
+    remote: ResumableRemoteSetup,
+) -> Result<PreparedSetup, SyncServiceError> {
     let recovery_checksum = pending
         .private
         .setup_recovery_checksum()
@@ -334,29 +480,19 @@ fn finish_resumed_setup(
         .to_owned();
     let device_id = DeviceId::new(pending.private.device_id())
         .map_err(|_| SyncServiceError::InvalidRemoteData)?;
-    let checkpoint_hash = remote.checkpoint.hash()?;
-    pending
-        .private
-        .mark_active(&remote.checkpoint, remote.commit.state())?;
-    let installed = commit_with_anchor_transition(
-        current_state,
-        &remote.commit,
-        personal_paths,
-        sync_paths,
-        &mut pending.private,
-        AnchorActivationKind::Setup,
-        remote.checkpoint.payload.checkpoint_sequence,
-        &checkpoint_hash,
-        playlist_revision,
-    )?;
-    let _ = record_setup_success(sync_paths, 0);
-    Ok(SetupResult {
-        state: installed,
+    Ok(PreparedSetup {
+        observed_state: current_state.clone(),
+        checkpoint: remote.checkpoint,
+        expected_private_revision: pending.private.revision(),
         device_id,
         recovery_checksum,
         summary: remote.summary,
         resumed: true,
     })
+}
+
+fn remove_new_recovery_file(path: &std::path::Path) -> Result<(), SyncServiceError> {
+    remove_owner_only_file_durable(path).map_err(|_| SyncServiceError::Storage)
 }
 
 fn load_resumable_remote_setup<T: VaultTransport + ?Sized>(
@@ -435,14 +571,13 @@ fn load_resumable_remote_setup<T: VaultTransport + ?Sized>(
     {
         return Err(SyncServiceError::InvalidRemoteData);
     }
-    let commit = validate_setup_extension(
+    let _ = validate_setup_extension(
         current_state,
         playlist_revision,
         pending.private.device(),
         &checkpoint.payload.state,
     )?;
     Ok(Some(ResumableRemoteSetup {
-        commit,
         checkpoint,
         summary: ManualSyncSummary {
             attempts: 1,
@@ -500,6 +635,88 @@ fn validate_setup_extension(
         return Err(SyncServiceError::InvalidRemoteData);
     }
     Ok(commit)
+}
+
+fn validate_observed_local_suffix<'a>(
+    observed: &PersonalStateV2,
+    current: &'a PersonalStateV2,
+    local_device: &DeviceId,
+) -> Result<Vec<&'a OperationEnvelope>, SyncServiceError> {
+    observed.validate()?;
+    current.validate()?;
+    if PersonalStateCommit::prepare(observed.clone())?.state() != observed
+        || PersonalStateCommit::prepare(current.clone())?.state() != current
+        || observed.dataset_id != current.dataset_id
+        || observed.device_registry != current.device_registry
+        || observed.compaction_checkpoint != current.compaction_checkpoint
+        || observed.metadata != current.metadata
+        || current.revision < observed.revision
+    {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
+
+    let current_by_id: BTreeMap<&str, &OperationEnvelope> = current
+        .operations
+        .iter()
+        .map(|operation| (operation.operation_id.as_str(), operation))
+        .collect();
+    if observed.operations.iter().any(|operation| {
+        current_by_id.get(operation.operation_id.as_str()).copied() != Some(operation)
+    }) {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
+
+    let observed_by_id: BTreeMap<&str, &OperationEnvelope> = observed
+        .operations
+        .iter()
+        .map(|operation| (operation.operation_id.as_str(), operation))
+        .collect();
+    let mut additions = current
+        .operations
+        .iter()
+        .filter(|operation| !observed_by_id.contains_key(operation.operation_id.as_str()))
+        .collect::<Vec<_>>();
+    if current.operations.len() != observed.operations.len() + additions.len() {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
+    if additions.is_empty() {
+        return if current == observed {
+            Ok(additions)
+        } else {
+            Err(SyncServiceError::LocalStateChanged)
+        };
+    }
+
+    additions.sort_by(|left, right| {
+        left.stamp
+            .dot
+            .cmp(&right.stamp.dot)
+            .then(left.operation_id.cmp(&right.operation_id))
+    });
+    let mut expected_vector = observed.version_vector.clone();
+    for addition in &additions {
+        let expected_sequence = expected_vector
+            .observed(local_device)
+            .checked_add(1)
+            .ok_or(SyncServiceError::LocalStateChanged)?;
+        if addition.origin != OperationOrigin::Local
+            || addition.stamp.dot.device_id != *local_device
+            || addition.stamp.dot.sequence != expected_sequence
+            || addition.stamp.observed != expected_vector
+            || addition.operation_id != format!("{}:{expected_sequence}", local_device.as_str())
+            || matches!(
+                addition.operation,
+                Operation::AddDevice { .. } | Operation::RevokeDevice { .. }
+            )
+        {
+            return Err(SyncServiceError::LocalStateChanged);
+        }
+        expected_vector.observe(&addition.stamp.dot);
+    }
+    if current.version_vector != expected_vector {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
+    Ok(additions)
 }
 
 fn unkeyed_local_device(state: &PersonalStateV2) -> Result<&DeviceRecord, SyncServiceError> {
@@ -567,6 +784,28 @@ fn load_pending_setup(
         return Err(SyncServiceError::InvalidRemoteData);
     }
     Ok(Some(PendingSetup { private, profile }))
+}
+
+fn load_saved_pending_setup(paths: &SyncPaths) -> Result<PendingSetup, SyncServiceError> {
+    if !regular_file_exists(paths.private_store())? || !regular_file_exists(paths.profile())? {
+        return Err(SyncServiceError::NotConfigured);
+    }
+    let private = PrivateStore::new(paths.private_store())?
+        .load()
+        .map_err(|_| SyncServiceError::InvalidRemoteData)?;
+    if private.enrollment() != EnrollmentState::PendingLedgerCommit
+        || private.setup_recovery_checksum().is_none()
+        || private.pending_pairing()?.is_some()
+    {
+        return Err(SyncServiceError::AlreadyConfigured);
+    }
+    let profile = WebDavProfileStore::new(paths.profile())?
+        .load(private.device())
+        .map_err(|_| SyncServiceError::InvalidRemoteData)?;
+    if profile.dataset_id() != private.dataset_id() || profile.device_id() != private.device_id() {
+        return Err(SyncServiceError::InvalidRemoteData);
+    }
+    Ok(PendingSetup { private, profile })
 }
 
 fn cleanup_pending_setup(

--- a/src/sync/service/setup/tests.rs
+++ b/src/sync/service/setup/tests.rs
@@ -2,7 +2,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use age::secrecy::SecretString;
 
-use crate::personal_state::{PersonalStateCommit, PersonalStatePaths, legacy_state, load_ledger};
+use crate::personal_state::{
+    CausalStamp, Dot, Operation, OperationEnvelope, OperationOrigin, PersonalStateCommit,
+    PersonalStatePaths, legacy_state, load_ledger,
+};
 use crate::sync::{
     EncryptedObject, EnrollmentState, FileVaultTransport, ObjectCondition, ObjectKey,
     ObjectMetadata, ObjectWriteResult, PrivateStore, SyncPaths, VaultCredential, VaultError,
@@ -80,29 +83,22 @@ fn setup_resumes_after_remote_bootstrap_and_pre_marker_local_failure() {
     let transport =
         FileVaultTransport::create(fixture.root.0.join("remote")).expect("file vault transport");
     let recovery_file = fixture.root.0.join("recovery.json");
-    let prepared = prepare(
+    let initial = prepare_initial(
         &fixture.state,
         0,
         request(recovery_file.clone()),
         &fixture.sync_paths,
     )
     .expect("prepare setup");
-    let checksum = prepared
+    let checksum = initial
         .private
         .setup_recovery_checksum()
         .expect("recovery marker")
         .to_owned();
 
-    let error = setup_with_transport_using(
-        prepared,
-        &fixture.personal_paths,
-        &fixture.sync_paths,
-        &transport,
-        || Err(SyncServiceError::Storage),
-    )
-    .err()
-    .expect("injected local failure");
-    assert_eq!(error, SyncServiceError::Storage);
+    let prepared = prepare_setup_with_transport(initial, &fixture.sync_paths, &transport)
+        .expect("remote setup");
+    assert_eq!(prepared.recovery_checksum(), checksum);
     assert!(recovery_file.is_file());
     assert_eq!(
         load_ledger(&fixture.personal_paths)
@@ -119,26 +115,17 @@ fn setup_resumes_after_remote_bootstrap_and_pre_marker_local_failure() {
     assert!(!fixture.sync_paths.health().exists());
     assert!(!fixture.sync_paths.audit().exists());
 
-    let mut pending =
-        load_pending_setup(&fixture.sync_paths, "https://dav.example.test/state", None)
-            .expect("load pending setup")
-            .expect("pending setup");
-    let remote = load_resumable_remote_setup(&fixture.state, 0, &pending, &transport)
-        .expect("validate remote setup")
-        .expect("published remote setup");
-    pending.private.set_credential(
-        VaultCredential::bearer_token(SecretString::from("replacement-token"))
-            .expect("replacement credential"),
-    );
-    let result = finish_resumed_setup(
+    let pending = load_saved_pending_setup(&fixture.sync_paths).expect("load saved pending setup");
+    let prepared = prepared_saved_setup_with_transport(&fixture.state, 0, pending, &transport)
+        .expect("prepare resumed setup");
+    let result = apply_prepared_setup(
         &fixture.state,
         0,
         &fixture.personal_paths,
         &fixture.sync_paths,
-        pending,
-        remote,
+        prepared,
     )
-    .expect("resume setup");
+    .expect("apply resumed setup");
 
     assert!(result.resumed);
     assert_eq!(result.recovery_checksum, checksum);
@@ -164,25 +151,18 @@ fn confirmed_missing_manifest_cleans_credentials_and_profile_after_bootstrap_fai
         FileVaultTransport::create(fixture.root.0.join("remote")).expect("file vault transport");
     let failing = RejectWrites(&transport);
     let recovery_file = fixture.root.0.join("recovery.json");
-    let prepared = prepare(
+    let initial = prepare_initial(
         &fixture.state,
         0,
-        request(recovery_file),
+        request(recovery_file.clone()),
         &fixture.sync_paths,
     )
     .expect("prepare setup");
 
-    assert!(
-        setup_with_transport(
-            prepared,
-            &fixture.personal_paths,
-            &fixture.sync_paths,
-            &failing,
-        )
-        .is_err()
-    );
+    assert!(prepare_setup_with_transport(initial, &fixture.sync_paths, &failing).is_err());
     assert!(!fixture.sync_paths.private_store().exists());
     assert!(!fixture.sync_paths.profile().exists());
+    assert!(!recovery_file.exists());
     assert!(!fixture.sync_paths.health().exists());
     assert!(!fixture.sync_paths.audit().exists());
 }
@@ -190,7 +170,7 @@ fn confirmed_missing_manifest_cleans_credentials_and_profile_after_bootstrap_fai
 #[test]
 fn pending_setup_rejects_a_different_endpoint_without_changing_local_state() {
     let fixture = fixture();
-    let prepared = prepare(
+    let prepared = prepare_initial(
         &fixture.state,
         0,
         request(fixture.root.0.join("recovery.json")),
@@ -229,6 +209,237 @@ fn pending_setup_rejects_a_different_endpoint_without_changing_local_state() {
     );
 }
 
+#[test]
+fn detached_setup_prepares_without_installing_and_applies_the_exact_target() {
+    let fixture = fixture();
+    let transport =
+        FileVaultTransport::create(fixture.root.0.join("remote")).expect("file vault transport");
+    let initial = prepare_initial(
+        &fixture.state,
+        0,
+        request(fixture.root.0.join("recovery.json")),
+        &fixture.sync_paths,
+    )
+    .expect("initial setup");
+    let prepared = prepare_setup_with_transport(initial, &fixture.sync_paths, &transport)
+        .expect("remote bootstrap");
+    let target = prepared.target_state(&fixture.state).expect("exact target");
+    assert_eq!(target, prepared.checkpoint.payload.state);
+    assert_eq!(
+        load_ledger(&fixture.personal_paths)
+            .expect("load ledger")
+            .expect("ledger"),
+        fixture.state
+    );
+    assert_eq!(
+        PrivateStore::new(fixture.sync_paths.private_store())
+            .expect("private store")
+            .load()
+            .expect("pending private")
+            .enrollment(),
+        EnrollmentState::PendingLedgerCommit
+    );
+
+    let result = apply_prepared_setup(
+        &fixture.state,
+        0,
+        &fixture.personal_paths,
+        &fixture.sync_paths,
+        prepared,
+    )
+    .expect("apply setup");
+    assert_eq!(result.state, target);
+    assert_eq!(
+        PrivateStore::new(fixture.sync_paths.private_store())
+            .expect("private store")
+            .load()
+            .expect("active private")
+            .enrollment(),
+        EnrollmentState::Active
+    );
+}
+
+#[test]
+fn detached_setup_rebases_a_contiguous_local_suffix_after_the_bootstrap() {
+    let fixture = fixture();
+    let transport =
+        FileVaultTransport::create(fixture.root.0.join("remote")).expect("file vault transport");
+    let initial = prepare_initial(
+        &fixture.state,
+        0,
+        request(fixture.root.0.join("recovery.json")),
+        &fixture.sync_paths,
+    )
+    .expect("initial setup");
+    let prepared = prepare_setup_with_transport(initial, &fixture.sync_paths, &transport)
+        .expect("remote bootstrap");
+    let local = append_unkeyed_local_operation(
+        &fixture.state,
+        Operation::SetAvoidArtist {
+            artist_key: "in-flight-artist".to_owned(),
+            avoid: true,
+        },
+    );
+    let local = PersonalStateCommit::prepare_for_runtime(local, 0)
+        .expect("prepare local suffix")
+        .commit(&fixture.personal_paths)
+        .expect("commit local suffix");
+
+    let target = prepared.target_state(&local).expect("rebased target");
+    let bootstrap_sequence = prepared
+        .checkpoint
+        .payload
+        .state
+        .version_vector
+        .observed(prepared.device_id());
+    let rebased = target
+        .operations
+        .iter()
+        .find(|operation| {
+            matches!(
+                operation.operation,
+                Operation::SetAvoidArtist {
+                    ref artist_key,
+                    avoid: true
+                } if artist_key == "in-flight-artist"
+            )
+        })
+        .expect("rebased local operation");
+    assert_eq!(rebased.origin, OperationOrigin::Local);
+    assert_eq!(rebased.stamp.dot.device_id, *prepared.device_id());
+    assert_eq!(rebased.stamp.dot.sequence, bootstrap_sequence + 1);
+    assert_eq!(
+        rebased.stamp.observed,
+        prepared.checkpoint.payload.state.version_vector
+    );
+
+    let result = apply_prepared_setup(
+        &local,
+        0,
+        &fixture.personal_paths,
+        &fixture.sync_paths,
+        prepared,
+    )
+    .expect("apply rebased setup");
+    assert_eq!(result.state, target);
+}
+
+#[test]
+fn setup_activation_persistence_retries_the_exact_target_idempotently() {
+    let fixture = fixture();
+    let transport =
+        FileVaultTransport::create(fixture.root.0.join("remote")).expect("file vault transport");
+    let initial = prepare_initial(
+        &fixture.state,
+        0,
+        request(fixture.root.0.join("recovery.json")),
+        &fixture.sync_paths,
+    )
+    .expect("initial setup");
+    let prepared = prepare_setup_with_transport(initial, &fixture.sync_paths, &transport)
+        .expect("remote bootstrap");
+    let local = append_unkeyed_local_operation(
+        &fixture.state,
+        Operation::SetAvoidArtist {
+            artist_key: "activation-retry-artist".to_owned(),
+            avoid: true,
+        },
+    );
+    let local = PersonalStateCommit::prepare_for_runtime(local, 0)
+        .expect("prepare local suffix")
+        .commit(&fixture.personal_paths)
+        .expect("commit local suffix");
+
+    let writer = crate::sync::service::PersonalSyncPersistence::setup_activation(
+        local.clone(),
+        0,
+        prepared.clone(),
+        fixture.personal_paths.clone(),
+        SyncPaths::for_data_root(fixture.root.0.clone()),
+    )
+    .expect("prepare owner activation");
+    let target = writer.state().clone();
+    writer.write().expect("first activation write");
+    assert!(writer.committed());
+    assert_eq!(
+        load_ledger(&fixture.personal_paths).expect("load activated ledger"),
+        Some(target.clone())
+    );
+
+    let retry = crate::sync::service::PersonalSyncPersistence::setup_activation(
+        local,
+        0,
+        prepared,
+        fixture.personal_paths.clone(),
+        SyncPaths::for_data_root(fixture.root.0.clone()),
+    )
+    .expect("recreate unacknowledged activation");
+    assert_eq!(retry.state(), &target);
+    retry.write().expect("idempotent activation retry");
+    assert!(retry.committed());
+    assert_eq!(
+        PrivateStore::new(fixture.sync_paths.private_store())
+            .expect("private store")
+            .load()
+            .expect("active private")
+            .enrollment(),
+        EnrollmentState::Active
+    );
+}
+
+#[test]
+fn ambiguous_bootstrap_failure_retains_pending_keys_and_new_recovery_file() {
+    let fixture = fixture();
+    let recovery_file = fixture.root.0.join("recovery.json");
+    let initial = prepare_initial(
+        &fixture.state,
+        0,
+        request(recovery_file.clone()),
+        &fixture.sync_paths,
+    )
+    .expect("initial setup");
+
+    assert!(
+        prepare_setup_with_transport(initial, &fixture.sync_paths, &UnavailableTransport).is_err()
+    );
+    assert!(fixture.sync_paths.private_store().exists());
+    assert!(fixture.sync_paths.profile().exists());
+    assert!(recovery_file.exists());
+}
+
+fn append_unkeyed_local_operation(
+    state: &PersonalStateV2,
+    operation: Operation,
+) -> PersonalStateV2 {
+    let device_id = state
+        .device_registry
+        .values()
+        .find(|device| !device.revoked && device.device_id.as_str() != "legacy")
+        .expect("local device")
+        .device_id
+        .clone();
+    let sequence = state.version_vector.observed(&device_id) + 1;
+    let dot = Dot {
+        device_id: device_id.clone(),
+        sequence,
+    };
+    let mut candidate = state.clone();
+    candidate.operations.push(OperationEnvelope {
+        operation_id: format!("{}:{sequence}", device_id.as_str()),
+        stamp: CausalStamp {
+            dot: dot.clone(),
+            observed: state.version_vector.clone(),
+            recorded_at_unix: 123,
+        },
+        origin: OperationOrigin::Local,
+        operation,
+    });
+    candidate.version_vector.observe(&dot);
+    candidate.projection_fingerprint = None;
+    candidate.normalize().expect("normalize local suffix");
+    candidate
+}
+
 struct RejectWrites<'a>(&'a FileVaultTransport);
 
 impl VaultTransport for RejectWrites<'_> {
@@ -255,5 +466,34 @@ impl VaultTransport for RejectWrites<'_> {
         max_resources: usize,
     ) -> Result<Vec<ObjectMetadata>, VaultError> {
         self.0.list(prefix, max_resources)
+    }
+}
+
+struct UnavailableTransport;
+
+impl VaultTransport for UnavailableTransport {
+    fn get(
+        &self,
+        _key: &ObjectKey,
+        _max_bytes: usize,
+    ) -> Result<Option<(EncryptedObject, ObjectMetadata)>, VaultError> {
+        Err(VaultError::StorageFailed)
+    }
+
+    fn put(
+        &self,
+        _key: &ObjectKey,
+        _object: &EncryptedObject,
+        _condition: ObjectCondition,
+    ) -> Result<ObjectWriteResult, VaultError> {
+        Err(VaultError::StorageFailed)
+    }
+
+    fn list(
+        &self,
+        _prefix: &ObjectKey,
+        _max_resources: usize,
+    ) -> Result<Vec<ObjectMetadata>, VaultError> {
+        Err(VaultError::StorageFailed)
     }
 }

--- a/src/sync/service/status.rs
+++ b/src/sync/service/status.rs
@@ -8,6 +8,30 @@ use super::super::{
 };
 use super::{DeviceSummary, SyncServiceError};
 
+/// Sanitized setup/device-connection phase used by interactive clients.
+///
+/// This projection deliberately excludes endpoints, paths, pairing codes, credentials, and key
+/// material. It is safe to retain in a TUI model or expose through an additive status snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncLifecycleState {
+    Absent,
+    SetupPending,
+    Active,
+    JoinWaiting,
+    JoinReadyToMerge,
+    Revoked,
+    NeedsCleanup,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncOverview {
+    pub status: SyncStatusReport,
+    pub lifecycle: SyncLifecycleState,
+    pub devices: Vec<DeviceSummary>,
+    pub audit: Vec<SyncAuditEntry>,
+}
+
 pub struct LocalSyncSnapshot {
     pub state: PersonalStateV2,
     pub playlist_revision: u64,
@@ -85,32 +109,136 @@ pub fn read_status(paths: &SyncPaths) -> Result<SyncStatusReport, SyncServiceErr
     ))
 }
 
+pub fn read_lifecycle(paths: &SyncPaths) -> Result<SyncLifecycleState, SyncServiceError> {
+    let private_exists = regular_file_exists(paths.private_store())?;
+    let profile_exists = regular_file_exists(paths.profile())?;
+    if !private_exists {
+        return Ok(if profile_exists {
+            SyncLifecycleState::NeedsCleanup
+        } else {
+            SyncLifecycleState::Absent
+        });
+    }
+
+    let private = PrivateStore::new(paths.private_store())?.load()?;
+    if !profile_exists {
+        return Ok(SyncLifecycleState::NeedsCleanup);
+    }
+    let profile = WebDavProfileStore::new(paths.profile())
+        .and_then(|store| store.load(private.device()))
+        .map_err(|_| SyncServiceError::InvalidRemoteData)?;
+    if profile.dataset_id() != private.dataset_id() || profile.device_id() != private.device_id() {
+        return Ok(SyncLifecycleState::NeedsCleanup);
+    }
+
+    Ok(match private.enrollment() {
+        EnrollmentState::Active => SyncLifecycleState::Active,
+        EnrollmentState::Revoked => SyncLifecycleState::Revoked,
+        EnrollmentState::PendingApproval => SyncLifecycleState::JoinWaiting,
+        EnrollmentState::PendingLedgerCommit if private.setup_recovery_checksum().is_some() => {
+            SyncLifecycleState::SetupPending
+        }
+        EnrollmentState::PendingLedgerCommit
+            if regular_file_exists(paths.pending_join_checkpoint())? =>
+        {
+            SyncLifecycleState::JoinReadyToMerge
+        }
+        EnrollmentState::PendingLedgerCommit => SyncLifecycleState::NeedsCleanup,
+    })
+}
+
+pub fn read_overview(
+    paths: &SyncPaths,
+    state: &PersonalStateV2,
+    in_progress: bool,
+    now_unix: i64,
+) -> Result<SyncOverview, SyncServiceError> {
+    // Read the durable lifecycle first. Incomplete local artifacts intentionally fail
+    // `read_status`, but the interactive surface still needs a bounded, actionable projection
+    // from which the user can recover. A revoked device likewise keeps the health written while
+    // it was active; loading that non-Off health as "not configured" would reject the otherwise
+    // valid revoked lifecycle.
+    let lifecycle = read_lifecycle(paths)?;
+    let status = match lifecycle {
+        // Cleanup is an authoritative local-storage problem, not a live network operation. Do
+        // not let an obsolete in-progress flag hide its one human-readable recovery action.
+        SyncLifecycleState::NeedsCleanup => needs_cleanup_status(),
+        SyncLifecycleState::Revoked => SyncStatusReport::default(),
+        _ => {
+            let mut status = read_status(paths)?;
+            if lifecycle == SyncLifecycleState::Active
+                && super::pairing::host_pairing_needs_review(state, paths)?
+            {
+                let failure = SyncFailureKind::DeviceApproval;
+                status.state = SyncHealthState::NeedsAttention;
+                status.label = SyncHealthState::NeedsAttention.label().to_owned();
+                status.failure = Some(failure);
+                status.recovery_action = Some(failure.recovery_action().to_owned());
+            }
+            apply_live_progress(&mut status, in_progress);
+            status
+        }
+    };
+    Ok(SyncOverview {
+        status,
+        lifecycle,
+        devices: read_devices(state),
+        audit: read_audit(paths, now_unix)?,
+    })
+}
+
+fn needs_cleanup_status() -> SyncStatusReport {
+    let state = SyncHealthState::NeedsAttention;
+    let failure = SyncFailureKind::Storage;
+    SyncStatusReport {
+        state,
+        label: state.label().to_owned(),
+        configured: true,
+        failure: Some(failure),
+        recovery_action: Some(failure.recovery_action().to_owned()),
+        ..SyncStatusReport::default()
+    }
+}
+
 /// Build the privacy-safe status projection embedded in owner status snapshots.
 ///
 /// Errors become one of the same five public states; endpoint, path, credential, and upstream
 /// error details never enter the local IPC protocol.
 pub fn read_current_status(in_progress: bool) -> SyncStatusReport {
-    let mut report = match SyncPaths::current()
-        .map_err(SyncServiceError::from)
-        .and_then(|paths| read_status(&paths))
-    {
+    match SyncPaths::current() {
+        Ok(paths) => read_current_status_at(&paths, in_progress),
+        Err(error) => status_from_error(error.into(), in_progress),
+    }
+}
+
+/// Build the owner status projection from an explicitly bound data root.
+///
+/// Daemon owners use this entry point so a status read observes the same store set as their
+/// personal-state coordinator instead of whichever process-global data directory is visible at
+/// the instant the snapshot is built.
+pub fn read_current_status_at(paths: &SyncPaths, in_progress: bool) -> SyncStatusReport {
+    let mut report = match read_status(paths) {
         Ok(report) => report,
-        Err(error) => {
-            let failure = error.failure_kind().unwrap_or(SyncFailureKind::Storage);
-            let state = if failure == SyncFailureKind::Offline {
-                SyncHealthState::OfflineWillRetry
-            } else {
-                SyncHealthState::NeedsAttention
-            };
-            SyncStatusReport {
-                state,
-                label: state.label().to_owned(),
-                configured: true,
-                failure: Some(failure),
-                recovery_action: Some(failure.recovery_action().to_owned()),
-                ..SyncStatusReport::default()
-            }
-        }
+        Err(error) => return status_from_error(error, in_progress),
+    };
+    apply_live_progress(&mut report, in_progress);
+    report
+}
+
+fn status_from_error(error: SyncServiceError, in_progress: bool) -> SyncStatusReport {
+    let failure = error.failure_kind().unwrap_or(SyncFailureKind::Storage);
+    let state = if failure == SyncFailureKind::Offline {
+        SyncHealthState::OfflineWillRetry
+    } else {
+        SyncHealthState::NeedsAttention
+    };
+    let mut report = SyncStatusReport {
+        state,
+        label: state.label().to_owned(),
+        configured: true,
+        failure: Some(failure),
+        recovery_action: Some(failure.recovery_action().to_owned()),
+        ..SyncStatusReport::default()
     };
     apply_live_progress(&mut report, in_progress);
     report
@@ -122,7 +250,9 @@ fn report_from_health(
     health: SyncHealth,
 ) -> SyncStatusReport {
     // `Syncing` is a live-owner fact, not a durable terminal state. Seeing it on disk means the
-    // process which began the attempt disappeared before recording success or failure.
+    // process which began the attempt may have disappeared before recording success or failure.
+    // Only the owner's in-memory `in_progress` flag may overlay it below; being a read-only
+    // secondary is not evidence that the writer is still running.
     let (state, failure) = if health.state == SyncHealthState::Syncing {
         (
             SyncHealthState::NeedsAttention,
@@ -204,6 +334,14 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     use super::*;
+    use crate::personal_state::{
+        CausalStamp, DeviceId, DeviceRecord, Dot, Operation, OperationEnvelope, OperationOrigin,
+        VersionVector,
+    };
+    use crate::sync::{
+        CheckpointAnchor, DeviceSecretMaterial, MembershipAnchor, MembershipChain,
+        PrivateStoreSnapshot, RecoveryKit, SignedCheckpoint, SignedMembershipRoot, WebDavProfile,
+    };
 
     struct TempRoot(std::path::PathBuf);
 
@@ -215,7 +353,7 @@ mod tests {
                 "yututui-sync-status-{}-{sequence}",
                 std::process::id()
             ));
-            std::fs::create_dir_all(&root).unwrap();
+            crate::util::safe_fs::ensure_private_dir(&root).unwrap();
             Self(root)
         }
     }
@@ -224,6 +362,136 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.0);
         }
+    }
+
+    fn state_with_device(dataset_id: &str, device: &DeviceRecord) -> PersonalStateV2 {
+        let dot = Dot {
+            device_id: device.device_id.clone(),
+            sequence: 1,
+        };
+        let mut state = PersonalStateV2::empty(dataset_id.to_owned()).unwrap();
+        state.operations.push(OperationEnvelope {
+            operation_id: "initial-device".to_owned(),
+            stamp: CausalStamp {
+                dot: dot.clone(),
+                observed: VersionVector::default(),
+                recorded_at_unix: 1,
+            },
+            origin: OperationOrigin::Local,
+            operation: Operation::AddDevice {
+                device: device.clone(),
+            },
+        });
+        state.version_vector.observe(&dot);
+        crate::personal_state::refresh_device_registry(&mut state).unwrap();
+        state.normalize().unwrap();
+        state
+    }
+
+    fn install_revoked_profile(paths: &SyncPaths) -> PersonalStateV2 {
+        const DATASET_ID: &str = "dataset-status-revoked";
+        let recovery = RecoveryKit::generate(DATASET_ID, None).unwrap();
+        let device = DeviceSecretMaterial::generate_for("status-revoked-device").unwrap();
+        let device_record = DeviceRecord {
+            device_id: DeviceId::new(device.device_id()).unwrap(),
+            name: "Revoked device".to_owned(),
+            revoked: false,
+            public_identity: Some(device.public_identity()),
+        };
+        let root = SignedMembershipRoot::create(
+            DATASET_ID,
+            recovery.recovery_recipient(),
+            &recovery.signing_key().unwrap(),
+            device_record.clone(),
+        )
+        .unwrap();
+        let root_hash = root.hash().unwrap();
+        let membership = MembershipChain::new(root);
+        let state = state_with_device(DATASET_ID, &device_record);
+        let checkpoint = SignedCheckpoint::create(
+            membership,
+            &MembershipAnchor::RootHash(root_hash.clone()),
+            device_record.device_id,
+            device.signing_key(),
+            &CheckpointAnchor::default(),
+            state.clone(),
+        )
+        .unwrap();
+        let mut private = PrivateStoreSnapshot::pending_ledger_commit(
+            device,
+            recovery.recovery_recipient(),
+            recovery.recovery_verifying_key().unwrap(),
+            root_hash,
+            &checkpoint,
+        )
+        .unwrap();
+        private.mark_active(&checkpoint, &state).unwrap();
+        private.mark_revoked().unwrap();
+
+        std::fs::create_dir_all(paths.root()).unwrap();
+        PrivateStore::new(paths.private_store())
+            .unwrap()
+            .create(&mut private)
+            .unwrap();
+        let mut profile = WebDavProfile::new(
+            DATASET_ID,
+            private.device(),
+            "https://dav.example.test/state",
+        )
+        .unwrap();
+        WebDavProfileStore::new(paths.profile())
+            .unwrap()
+            .create(&mut profile, private.device())
+            .unwrap();
+
+        let health_store = SyncHealthStore::new(paths.health()).unwrap();
+        let health = health_store.load(true).unwrap();
+        health_store.save(&health, health.succeeded(7)).unwrap();
+        state
+    }
+
+    #[test]
+    fn cleanup_overview_survives_the_status_error_with_actionable_storage_health() {
+        let root = TempRoot::new();
+        let paths = SyncPaths::for_data_root(root.0.clone());
+        std::fs::create_dir_all(paths.root()).unwrap();
+        std::fs::write(paths.profile(), b"orphaned-profile").unwrap();
+        let state = PersonalStateV2::empty("dataset-cleanup-overview".to_owned()).unwrap();
+
+        assert_eq!(
+            read_lifecycle(&paths).unwrap(),
+            SyncLifecycleState::NeedsCleanup
+        );
+        assert_eq!(
+            read_status(&paths),
+            Err(SyncServiceError::InvalidRemoteData)
+        );
+
+        let overview = read_overview(&paths, &state, true, 10).unwrap();
+        assert_eq!(overview.lifecycle, SyncLifecycleState::NeedsCleanup);
+        assert_eq!(overview.status.state, SyncHealthState::NeedsAttention);
+        assert_eq!(overview.status.label, "Needs attention");
+        assert!(overview.status.configured);
+        assert_eq!(overview.status.failure, Some(SyncFailureKind::Storage));
+        assert_eq!(
+            overview.status.recovery_action.as_deref(),
+            Some("Review sync audit")
+        );
+    }
+
+    #[test]
+    fn revoked_overview_ignores_health_from_the_former_active_lifecycle() {
+        let root = TempRoot::new();
+        let paths = SyncPaths::for_data_root(root.0.clone());
+        let state = install_revoked_profile(&paths);
+
+        assert_eq!(read_lifecycle(&paths).unwrap(), SyncLifecycleState::Revoked);
+        assert_eq!(read_status(&paths), Err(SyncServiceError::Storage));
+
+        let overview = read_overview(&paths, &state, false, 10).unwrap();
+        assert_eq!(overview.lifecycle, SyncLifecycleState::Revoked);
+        assert_eq!(overview.status, SyncStatusReport::default());
+        assert_eq!(overview.devices.len(), 1);
     }
 
     #[test]
@@ -240,7 +508,7 @@ mod tests {
             .unwrap()
             .load(true)
             .unwrap();
-        let mut report = report_from_health(true, Some("device-a".to_owned()), reloaded);
+        let mut report = report_from_health(true, Some("device-a".to_owned()), reloaded.clone());
         assert_eq!(report.state, SyncHealthState::NeedsAttention);
         assert_eq!(report.failure, Some(SyncFailureKind::LocalStateChanged));
         assert_eq!(report.recovery_action.as_deref(), Some("Retry"));
@@ -251,5 +519,9 @@ mod tests {
         assert_eq!(report.label, "Syncing");
         assert_eq!(report.failure, None);
         assert_eq!(report.recovery_action, None);
+
+        let secondary = report_from_health(true, Some("device-a".to_owned()), reloaded);
+        assert_eq!(secondary.state, SyncHealthState::NeedsAttention);
+        assert_eq!(secondary.failure, Some(SyncFailureKind::LocalStateChanged));
     }
 }

--- a/src/sync/service/transition.rs
+++ b/src/sync/service/transition.rs
@@ -235,12 +235,19 @@ impl<'a> TransitionStore<'a> {
         )?;
         checkpoint(AnchorCommitPoint::PrivateInstalled).map_err(|_| SyncServiceError::Storage)?;
         let completed_pair_join = binding.activation_kind == AnchorActivationKind::PairJoin;
-        self.complete_locked()?;
         if completed_pair_join {
-            let _ = remove_owner_only_file_durable(self.paths.pending_join_checkpoint());
-            let _ = remove_owner_only_file_durable(self.paths.pending_join_state());
-            let _ = remove_owner_only_file_durable(self.paths.pending_join_request());
+            // The signed join journal retains the one-time code. Keep the outer committed marker
+            // until every secret-bearing join artifact is durably gone, so a crash or deletion
+            // failure is retried by the same authenticated roll-forward on next startup.
+            for path in [
+                self.paths.pending_join_checkpoint(),
+                self.paths.pending_join_state(),
+                self.paths.pending_join_request(),
+            ] {
+                remove_owner_only_file_durable(path).map_err(|_| SyncServiceError::Storage)?;
+            }
         }
+        self.complete_locked()?;
         Ok(Some(installed))
     }
 }
@@ -301,6 +308,7 @@ fn commit_with_anchor_transition_using(
         return Err(SyncServiceError::InvalidRemoteData);
     }
     if target_private.enrollment() != EnrollmentState::Active
+        || target_private.dataset_id() != commit.state().dataset_id
         || target_private.checkpoint_sequence() != Some(checkpoint_sequence)
         || target_private.checkpoint_hash() != Some(checkpoint_hash)
     {
@@ -319,7 +327,9 @@ fn commit_with_anchor_transition_using(
     if installed != *current_state {
         return Err(SyncServiceError::LocalStateChanged);
     }
-    if commit.state().dataset_id != current_state.dataset_id {
+    if activation_kind != AnchorActivationKind::PairJoin
+        && commit.state().dataset_id != current_state.dataset_id
+    {
         return Err(SyncServiceError::InvalidRemoteData);
     }
     let candidate_bytes =
@@ -345,7 +355,7 @@ fn commit_with_anchor_transition_using(
     let binding = TransitionBinding {
         kind: TRANSITION_KIND.to_owned(),
         schema_version: TRANSITION_SCHEMA_VERSION,
-        dataset_id: current_state.dataset_id.clone(),
+        dataset_id: commit.state().dataset_id.clone(),
         device_id: target_private.device_id().to_owned(),
         activation_kind,
         expected_personal_revision: current_state.revision,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -49,7 +49,17 @@ pub fn render(frame: &mut Frame, app: &App) {
     // render pass knows it). Below the mini thresholds the whole UI is the miniplayer;
     // the overlay stack below still runs either way — modals capture keys, so they must
     // stay visible.
-    let tier = layout::tier(area);
+    let mut tier = layout::tier(area);
+    // Settings has a purpose-built narrow tab strip and list layout. Keep it reachable at the
+    // issue-114 keyboard-only acceptance width even though the playback surface still needs the
+    // 32-column Mini boundary for its transport controls.
+    if tier == layout::UiTier::Mini
+        && app.mode == Mode::Settings
+        && area.width >= 30
+        && area.height >= layout::MINI_MIN_H
+    {
+        tier = layout::UiTier::Full;
+    }
     app.bridges.ui_tier.set(tier);
     if tier == layout::UiTier::Mini {
         views::mini::render(frame, app, area);
@@ -178,6 +188,11 @@ pub fn render(frame: &mut Frame, app: &App) {
     }
     if app.tool_setup.is_some() {
         views::onboarding::render_tool_setup(frame, app, area);
+    }
+    // Sync setup and device lifecycle are Settings-owned but remain visible in Mini layout.
+    // Draw this move-only wizard at the top level so its fields and actions always win z-order.
+    if app.personal_state.sync_ui.modal_open() {
+        views::settings::render_sync_wizard(frame, app, area);
     }
     retro::scrub_frame(frame, app);
 }

--- a/src/ui/views/settings.rs
+++ b/src/ui/views/settings.rs
@@ -5,11 +5,16 @@
 mod dialogs;
 mod recording;
 mod spotify;
+mod sync;
+mod sync_wizard;
+mod tabs;
 
 pub use dialogs::{render_confirm, render_conflict};
 pub use recording::{render_recording_settings, render_recordings_browser};
 pub(super) use spotify::render_spotify_import_mode_dropdown_popup;
 pub use spotify::render_spotify_picker;
+pub(crate) use sync::render_sync;
+pub(crate) use sync_wizard::render_sync_wizard;
 
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
@@ -70,6 +75,9 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     render_tabs(frame, app, st, rows[0]);
     if st.tab == SettingsTab::Keys {
         render_keys(frame, app, st, rows[2]);
+    } else if st.tab == SettingsTab::Sync {
+        let model = app.sync_settings_model();
+        render_sync(frame, app, st, &model, rows[2]);
     } else {
         render_fields(frame, app, st, rows[2]);
     }
@@ -107,6 +115,19 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 "내보내기 · 암호화되지 않은 JSON · 개인 감상 기록 포함",
                 "エクスポート · 暗号化されないJSON · 個人の再生履歴を含む"
             )
+        )
+    } else if st.tab == SettingsTab::Sync {
+        format!(
+            "{}/{} {}  ·  {} {}  ·  {} {}  ·  {} {}",
+            k(Action::MoveUp),
+            k(Action::MoveDown),
+            t!("select", "선택", "選択"),
+            k(Action::Confirm),
+            t!("open", "열기", "開く"),
+            k(Action::FocusNext),
+            t!("switch tab", "탭 전환", "タブ切替"),
+            k(Action::SettingsCancel),
+            t!("close", "닫기", "閉じる"),
         )
     } else if st.tab == SettingsTab::Keys {
         let mouse_row = st.row >= keymap::editable_entries().len();
@@ -512,48 +533,7 @@ fn build_keys_column(
 }
 
 fn render_tabs(frame: &mut Frame, app: &App, st: &SettingsState, area: Rect) {
-    let theme = &st.draft.theme;
-    let active = Style::default()
-        .fg(theme.color(R::SelectionFg))
-        .bg(theme.color(R::SelectionBg))
-        .add_modifier(Modifier::BOLD);
-    let muted = theme.style(R::TextMuted);
-    // A single space between tabs (matching the old `Tabs` divider). Each tab cell is
-    // " label " (one cell of padding each side, as `Tabs` padded), and its hit rect is
-    // computed by walking the x cursor with the same width math ratatui lays the spans with.
-    const DIVIDER: &str = " ";
-    let mut spans = Vec::new();
-    let mut x = area.x;
-    for (i, t) in crate::settings::SettingsTab::ALL
-        .iter()
-        .copied()
-        .enumerate()
-    {
-        if i > 0 {
-            spans.push(Span::styled(DIVIDER, muted));
-            x = x.saturating_add(buttons::text_width(DIVIDER));
-        }
-        let label = format!(" {} ", t.label());
-        let w = buttons::text_width(&label);
-        app.register_mouse_button(
-            Rect {
-                x,
-                y: area.y,
-                width: w,
-                height: 1,
-            },
-            MouseTarget::SettingsTab(i),
-        );
-        x = x.saturating_add(w);
-        let style = if st.tab == t {
-            // A brief accent wash right after a tab switch (identity when off).
-            crate::ui::anim::active_tab_style(app, crate::ui::anim::TabPop::Inner, active)
-        } else {
-            muted
-        };
-        spans.push(Span::styled(label, style));
-    }
-    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    tabs::render(frame, app, st, area);
 }
 
 /// The list's selection marker. `HighlightSpacing::Always` reserves its width on *every* row

--- a/src/ui/views/settings/sync.rs
+++ b/src/ui/views/settings/sync.rs
@@ -1,0 +1,209 @@
+//! Presentation-only renderer for the Sync settings tab.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{HighlightSpacing, List, ListItem, ListState, Paragraph, Wrap};
+
+use crate::app::App;
+use crate::app::MouseTarget;
+use crate::settings::SettingsState;
+use crate::settings::sync::{
+    SyncAuditRow, SyncDeviceRow, SyncMergeSummary, SyncRow, SyncSettingsModel, audit_action_label,
+    audit_outcome_label, failure_label, failure_recovery_label, health_label,
+};
+use crate::sync::{SyncAuditOutcome, SyncHealthState};
+use crate::t;
+use crate::theme::ThemeRole as R;
+
+/// Render a privacy-safe Sync snapshot. Form inputs and connection secrets are intentionally
+/// absent from [`SyncSettingsModel`] and should be rendered by their owning modal.
+pub(crate) fn render_sync(
+    frame: &mut Frame,
+    app: &App,
+    settings: &SettingsState,
+    model: &SyncSettingsModel,
+    area: Rect,
+) {
+    if area.is_empty() {
+        return;
+    }
+    let theme = &settings.draft.theme;
+    let rows = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(2),
+        Constraint::Min(0),
+    ])
+    .split(area);
+
+    let state_role = match model.health {
+        SyncHealthState::Off => R::TextMuted,
+        SyncHealthState::UpToDate => R::Success,
+        SyncHealthState::Syncing => R::Accent,
+        SyncHealthState::OfflineWillRetry => R::Warning,
+        SyncHealthState::NeedsAttention => R::Error,
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                model.page.title(),
+                theme.style(R::SettingsGroup).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  ", theme.style(R::TextMuted)),
+            Span::styled(health_label(model.health), theme.style(state_role)),
+        ])),
+        rows[0],
+    );
+
+    let detail = model.failure.map_or_else(
+        || Line::from(model.page.description()).style(theme.style(R::TextMuted)),
+        |failure| {
+            Line::from(vec![
+                Span::styled(failure_label(failure), theme.style(R::Error)),
+                Span::styled("  ·  ", theme.style(R::TextMuted)),
+                Span::styled(
+                    failure_recovery_label(failure),
+                    theme.style(R::SettingsValueFocused),
+                ),
+            ])
+        },
+    );
+    frame.render_widget(Paragraph::new(detail).wrap(Wrap { trim: true }), rows[1]);
+
+    let items: Vec<ListItem<'static>> = model
+        .rows
+        .iter()
+        .map(|row| render_row(row, model.busy, settings))
+        .collect();
+    let selected = model.selected();
+    let list = List::new(items)
+        .style(theme.style(R::TextPrimary))
+        .highlight_style(
+            theme
+                .style(R::SettingsValueFocused)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ")
+        .highlight_spacing(HighlightSpacing::Always);
+    let offset = selected.map_or_else(
+        || {
+            app.bridges
+                .settings_scroll
+                .view(rows[2].height, model.rows.len())
+        },
+        |selected| {
+            app.bridges
+                .settings_scroll
+                .resolve(selected, rows[2].height, model.rows.len(), 0)
+        },
+    );
+    let mut state = ListState::default().with_offset(offset);
+    state.select(selected);
+    frame.render_stateful_widget(list, rows[2], &mut state);
+    for visible in 0..rows[2].height {
+        let row = state.offset() + visible as usize;
+        if row >= model.rows.len() {
+            break;
+        }
+        app.register_mouse_button(
+            Rect {
+                x: rows[2].x,
+                y: rows[2].y + visible,
+                width: rows[2].width,
+                height: 1,
+            },
+            MouseTarget::SettingsSyncRow(row),
+        );
+    }
+}
+
+fn render_row(row: &SyncRow, busy: bool, settings: &SettingsState) -> ListItem<'static> {
+    let theme = &settings.draft.theme;
+    match row {
+        SyncRow::Action(action) => {
+            let role = if busy { R::TextMuted } else { R::SettingsValue };
+            ListItem::new(Line::from(vec![
+                Span::styled("  ↵ ", theme.style(R::SettingsLabel)),
+                Span::styled(action.label().to_owned(), theme.style(role)),
+            ]))
+        }
+        SyncRow::Device(device) => device_row(device, settings),
+        SyncRow::Audit(audit) => audit_row(audit, settings),
+        SyncRow::MergeSummary(summary) => merge_row(*summary, settings),
+        SyncRow::Notice(notice) => ListItem::new(Line::from(vec![
+            Span::styled("  • ", theme.style(R::SettingsLabel)),
+            Span::styled(notice.label().to_owned(), theme.style(R::TextMuted)),
+        ])),
+    }
+}
+
+fn device_row(device: &SyncDeviceRow, settings: &SettingsState) -> ListItem<'static> {
+    let theme = &settings.draft.theme;
+    let marker = match (device.current, device.active) {
+        (true, true) => t!("this device", "이 기기", "このデバイス"),
+        (_, true) => t!("connected", "연결됨", "接続済み"),
+        (_, false) => t!("removed", "제거됨", "削除済み"),
+    };
+    ListItem::new(Line::from(vec![
+        Span::styled("  ", theme.style(R::SettingsLabel)),
+        Span::styled(
+            device.name().to_owned(),
+            theme.style(R::SettingsValue).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(format!("  {marker}  "), theme.style(R::TextMuted)),
+        Span::styled(device.fingerprint().to_owned(), theme.style(R::TextSubtle)),
+    ]))
+}
+
+fn audit_row(audit: &SyncAuditRow, settings: &SettingsState) -> ListItem<'static> {
+    let theme = &settings.draft.theme;
+    let outcome_role = match audit.outcome {
+        SyncAuditOutcome::Succeeded => R::Success,
+        SyncAuditOutcome::NoChanges => R::TextMuted,
+        SyncAuditOutcome::Failed => R::Error,
+    };
+    let changes = audit.local_changes.saturating_add(audit.remote_changes);
+    let suffix = if changes == 0 {
+        String::new()
+    } else {
+        format!("  ·  {} {changes}", t!("changes", "변경", "件の変更"))
+    };
+    let mut spans = vec![
+        Span::styled("  ", theme.style(R::SettingsLabel)),
+        Span::styled(
+            audit_action_label(audit.action).to_owned(),
+            theme.style(R::SettingsValue),
+        ),
+        Span::styled("  ·  ", theme.style(R::TextMuted)),
+        Span::styled(
+            audit_outcome_label(audit.outcome).to_owned(),
+            theme.style(outcome_role),
+        ),
+        Span::styled(suffix, theme.style(R::TextMuted)),
+    ];
+    if let Some(failure) = audit.failure {
+        spans.extend([
+            Span::styled("  ·  ", theme.style(R::TextMuted)),
+            Span::styled(failure_label(failure).to_owned(), theme.style(R::Error)),
+        ]);
+    }
+    ListItem::new(Line::from(spans))
+}
+
+fn merge_row(summary: SyncMergeSummary, settings: &SettingsState) -> ListItem<'static> {
+    let theme = &settings.draft.theme;
+    let text = format!(
+        "{} {}  ·  {} {}  ·  {} {}",
+        t!("This device", "이 기기", "このデバイス"),
+        summary.local_changes,
+        t!("Other devices", "다른 기기", "ほかのデバイス"),
+        summary.remote_changes,
+        t!("Already present", "이미 있음", "既に存在"),
+        summary.duplicates_skipped,
+    );
+    ListItem::new(Line::from(Span::styled(
+        format!("  {text}"),
+        theme.style(R::SettingsValue),
+    )))
+}

--- a/src/ui/views/settings/sync_wizard.rs
+++ b/src/ui/views/settings/sync_wizard.rs
@@ -1,0 +1,53 @@
+//! Top-level modal rendering for personal-sync setup and device lifecycle.
+//!
+//! Move-only connection and pairing values stay in `App`. These renderers borrow them only for
+//! the current frame and publish semantic mouse targets that contain no secret data.
+
+mod form;
+mod lifecycle;
+mod support;
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+
+use crate::app::{App, SyncWizard};
+
+pub(crate) fn render_sync_wizard(frame: &mut Frame, app: &App, area: Rect) {
+    let Some(wizard) = app.personal_state.sync_ui.wizard.as_ref() else {
+        return;
+    };
+    match wizard {
+        SyncWizard::Setup { form, confirm } => {
+            form::render_connection(frame, app, area, form, false, *confirm)
+        }
+        SyncWizard::Join { form, confirm } => {
+            form::render_connection(frame, app, area, form, true, *confirm)
+        }
+        SyncWizard::Host {
+            code,
+            expires_at_unix,
+            host: _,
+            review,
+        } => lifecycle::render_host(
+            frame,
+            app,
+            area,
+            code.as_str(),
+            *expires_at_unix,
+            review.as_deref(),
+        ),
+        SyncWizard::JoinWaiting(_) => lifecycle::render_join_waiting(frame, app, area),
+        SyncWizard::JoinPreview(preview) => {
+            lifecycle::render_join_preview(frame, app, area, &preview.summary)
+        }
+        SyncWizard::DiscardJoinConfirm => lifecycle::render_discard_join(frame, app, area),
+        SyncWizard::Revoke {
+            device_id,
+            device_name,
+        } => lifecycle::render_revoke(frame, app, area, device_id, device_name),
+        SyncWizard::Recovery(form) => form::render_recovery(frame, app, area, form),
+        SyncWizard::Result { success, message } => {
+            lifecycle::render_result(frame, app, area, *success, message)
+        }
+    }
+}

--- a/src/ui/views/settings/sync_wizard/form.rs
+++ b/src/ui/views/settings/sync_wizard/form.rs
@@ -1,0 +1,448 @@
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::widgets::{Paragraph, Wrap};
+
+use super::support::{FORM_WIDTH, actions, centered, finish, render_field, shell, wrapped_height};
+use crate::app::{App, MouseTarget, SyncConnectionField, SyncConnectionForm, SyncRecoveryForm};
+use crate::t;
+use crate::theme::ThemeRole as R;
+
+const CONNECTION_HEIGHT: u16 = 23;
+const RECOVERY_HEIGHT: u16 = 15;
+
+pub(super) fn render_connection(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    form: &SyncConnectionForm,
+    join: bool,
+    confirming: bool,
+) {
+    let popup = centered(area, FORM_WIDTH, CONNECTION_HEIGHT);
+    let title = if join {
+        t!(
+            " Join personal sync ",
+            " 개인 동기화에 연결 ",
+            " 個人データ同期に参加 "
+        )
+    } else {
+        t!(
+            " Set up personal sync ",
+            " 개인 동기화 설정 ",
+            " 個人データ同期を設定 "
+        )
+    };
+    let inner = shell(frame, app, popup, title, R::BorderPrimary);
+    let show_description = inner.height >= 18;
+    let show_hint = inner.height >= 16;
+    let description = if join {
+        t!(
+            "Enter the same storage login and the one-time code.",
+            "같은 저장소 로그인과 일회용 코드를 입력하세요.",
+            "同じ保存先のログイン情報と一回限りのコードを入力します。"
+        )
+    } else {
+        t!(
+            "Your listening data is encrypted before it leaves this device.",
+            "감상 데이터는 이 기기를 떠나기 전에 암호화됩니다.",
+            "再生データはこのデバイスから送信される前に暗号化されます。"
+        )
+    };
+    let prompt = confirming.then(|| {
+        if join {
+            t!(
+                "Connect with these details? You will review the merge before saving.",
+                "이 정보로 연결할까요? 저장 전 병합 내용을 확인합니다.",
+                "この情報で接続しますか？保存前に統合内容を確認します。"
+            )
+        } else {
+            t!(
+                "The recovery kit must be saved to finish setup.",
+                "설정을 마치려면 복구 키트를 저장해야 합니다.",
+                "設定を完了するには復旧キットの保存が必要です。"
+            )
+        }
+    });
+    let description_height =
+        u16::from(show_description).saturating_mul(wrapped_height(description, inner.width, 3));
+    let prompt_height = prompt.map_or(0, |copy| wrapped_height(copy, inner.width, 3));
+    let rows = Layout::vertical([
+        Constraint::Length(description_height),
+        Constraint::Length(prompt_height),
+        Constraint::Min(1),
+        Constraint::Length(u16::from(show_hint)),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+
+    if show_description {
+        frame.render_widget(
+            Paragraph::new(description)
+                .wrap(Wrap { trim: true })
+                .style(crate::ui::popup_style(app, R::TextMuted)),
+            rows[0],
+        );
+    }
+    if let Some(prompt) = prompt {
+        frame.render_widget(
+            Paragraph::new(prompt)
+                .wrap(Wrap { trim: true })
+                .style(crate::ui::popup_style(app, R::Warning)),
+            rows[1],
+        );
+    }
+
+    render_connection_fields(frame, app, rows[2], form, join, confirming);
+    if show_hint {
+        let hint = if form.current_field(join).is_secret()
+            && form.current_secret_is_revealed(join)
+            && !confirming
+        {
+            t!(
+                "Ctrl+R hide · Enter continue · Esc cancel",
+                "Ctrl+R 숨기기 · Enter 계속 · Esc 취소",
+                "Ctrl+R 隠す · Enter 続行 · Esc キャンセル"
+            )
+        } else if form.current_field(join).is_secret() && !confirming {
+            t!(
+                "Ctrl+R show · Enter continue · Esc cancel",
+                "Ctrl+R 보기 · Enter 계속 · Esc 취소",
+                "Ctrl+R 表示 · Enter 続行 · Esc キャンセル"
+            )
+        } else {
+            t!(
+                "↑/↓ field · Enter continue · Esc cancel",
+                "↑/↓ 항목 · Enter 계속 · Esc 취소",
+                "↑/↓ 項目 · Enter 続行 · Esc キャンセル"
+            )
+        };
+        frame.render_widget(
+            Paragraph::new(hint)
+                .alignment(Alignment::Center)
+                .style(crate::ui::popup_style(app, R::TextMuted)),
+            rows[3],
+        );
+    }
+    let reveal =
+        form.current_field(join)
+            .is_secret()
+            .then_some(if form.current_secret_is_revealed(join) {
+                t!(" Hide ", " 숨기기 ", " 隠す ")
+            } else {
+                t!(" Show ", " 보기 ", " 表示 ")
+            });
+    let primary = if join {
+        t!(" Join ", " 연결 ", " 接続 ")
+    } else if confirming {
+        t!(" Confirm ", " 확인 ", " 確認 ")
+    } else {
+        t!(" Continue ", " 계속 ", " 続行 ")
+    };
+    actions(
+        frame,
+        app,
+        rows[4],
+        reveal,
+        primary,
+        Some(if confirming {
+            t!(" Back ", " 뒤로 ", " 戻る ")
+        } else {
+            t!(" Cancel ", " 취소 ", " キャンセル ")
+        }),
+    );
+    finish(frame, app, popup);
+}
+
+fn render_connection_fields(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    form: &SyncConnectionForm,
+    join: bool,
+    confirming: bool,
+) {
+    let fields = form.fields(join);
+    if area.height == 0 || fields.is_empty() {
+        return;
+    }
+    let show_all = area.height as usize >= fields.len();
+    let visible: Vec<(usize, SyncConnectionField)> = if show_all {
+        fields.iter().copied().enumerate().collect()
+    } else {
+        let index = form.field.min(fields.len() - 1);
+        vec![(index, fields[index])]
+    };
+    let row_height = if show_all && area.height as usize >= fields.len().saturating_mul(2) {
+        2
+    } else {
+        1
+    };
+    for (visible_index, (field_index, field)) in visible.iter().copied().enumerate() {
+        let y = area
+            .y
+            .saturating_add((visible_index as u16).saturating_mul(row_height));
+        if y >= area.bottom() {
+            break;
+        }
+        let rect = Rect {
+            x: area.x,
+            y,
+            width: area.width,
+            height: row_height.min(area.bottom().saturating_sub(y)),
+        };
+        app.register_mouse_button(rect, MouseTarget::SyncWizardField(field_index));
+        let selected = form.field == field_index;
+        let editor = (selected && !confirming).then(|| {
+            (
+                form.current_value(join),
+                form.cursor.byte_index(form.current_value(join)),
+                field.is_secret() && !form.current_secret_is_revealed(join),
+            )
+        });
+        render_field(
+            frame,
+            app,
+            rect,
+            field_label(field),
+            &form.display_value(field),
+            selected,
+            editor,
+        );
+    }
+}
+
+pub(super) fn render_recovery(frame: &mut Frame, app: &App, area: Rect, form: &SyncRecoveryForm) {
+    let popup = centered(area, FORM_WIDTH, RECOVERY_HEIGHT);
+    let inner = shell(
+        frame,
+        app,
+        popup,
+        t!(
+            " Save recovery kit ",
+            " 복구 키트 저장 ",
+            " 復旧キットを保存 "
+        ),
+        R::BorderPrimary,
+    );
+    let description = t!(
+        "Copy the existing kit to a safe folder. The sync password is not included.",
+        "기존 키트를 안전한 폴더에 복사하세요. 동기화 비밀번호는 포함되지 않습니다.",
+        "既存のキットを安全なフォルダへコピーします。同期パスワードは含まれません。"
+    );
+    let confirm_copy = t!(
+        "Confirm that the destination is private and safe.",
+        "저장 위치가 안전하고 비공개인지 확인하세요.",
+        "保存先が安全で非公開であることを確認してください。"
+    );
+    let rows = Layout::vertical([
+        Constraint::Length(wrapped_height(description, inner.width, 3)),
+        Constraint::Min(4),
+        Constraint::Length(u16::from(form.confirm).saturating_mul(wrapped_height(
+            confirm_copy,
+            inner.width,
+            2,
+        ))),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+    frame.render_widget(
+        Paragraph::new(description)
+            .wrap(Wrap { trim: true })
+            .style(crate::ui::popup_style(app, R::TextPrimary)),
+        rows[0],
+    );
+    let field_height = (rows[1].height / 2).max(1);
+    for (index, (label, value)) in [
+        (
+            t!("Current kit", "현재 키트", "現在のキット"),
+            form.source.as_str(),
+        ),
+        (
+            t!("Save in", "저장 위치", "保存先"),
+            form.destination.as_str(),
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let y = rows[1]
+            .y
+            .saturating_add((index as u16).saturating_mul(field_height));
+        if y >= rows[1].bottom() {
+            break;
+        }
+        let rect = Rect {
+            x: rows[1].x,
+            y,
+            width: rows[1].width,
+            height: field_height.min(rows[1].bottom().saturating_sub(y)),
+        };
+        app.register_mouse_button(rect, MouseTarget::SyncWizardField(index));
+        let selected = form.field == index;
+        let editor =
+            (selected && !form.confirm).then(|| (value, form.cursor.byte_index(value), false));
+        render_field(frame, app, rect, label, value, selected, editor);
+    }
+    if form.confirm {
+        frame.render_widget(
+            Paragraph::new(confirm_copy)
+                .wrap(Wrap { trim: true })
+                .style(crate::ui::popup_style(app, R::Warning)),
+            rows[2],
+        );
+    }
+    actions(
+        frame,
+        app,
+        rows[3],
+        None,
+        t!(" Save ", " 저장 ", " 保存 "),
+        Some(if form.confirm {
+            t!(" Back ", " 뒤로 ", " 戻る ")
+        } else {
+            t!(" Cancel ", " 취소 ", " キャンセル ")
+        }),
+    );
+    finish(frame, app, popup);
+}
+
+fn field_label(field: SyncConnectionField) -> &'static str {
+    match field {
+        SyncConnectionField::Endpoint => {
+            t!("Sync address", "동기화 주소", "同期アドレス")
+        }
+        SyncConnectionField::Username => t!("Username", "사용자 이름", "ユーザー名"),
+        SyncConnectionField::Secret => t!(
+            "Password or access token",
+            "비밀번호 또는 액세스 토큰",
+            "パスワードまたはアクセストークン"
+        ),
+        SyncConnectionField::DeviceName => t!("Device name", "기기 이름", "デバイス名"),
+        SyncConnectionField::CustomCa => t!(
+            "CA certificate (optional)",
+            "CA 인증서 (선택)",
+            "CA 証明書（任意）"
+        ),
+        SyncConnectionField::RecoveryFile => {
+            t!("Recovery kit file", "복구 키트 파일", "復旧キットファイル")
+        }
+        SyncConnectionField::PairingCode => {
+            t!("One-time code", "일회용 코드", "一回限りのコード")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::super::render_sync_wizard;
+    use crate::app::{App, SyncConnectionForm, SyncWizard};
+
+    fn draw(app: &App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_sync_wizard(frame, app, frame.area()))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn join_form_masks_password_and_pairing_code_by_default() {
+        let mut form = SyncConnectionForm::join();
+        *form.current_value_mut(true) = "https://sync.example.invalid/dav".to_owned();
+        form.select_field(true, 1);
+        *form.current_value_mut(true) = "listener".to_owned();
+        form.select_field(true, 1);
+        *form.current_value_mut(true) = "password-sentinel".to_owned();
+        form.select_field(true, 1);
+        *form.current_value_mut(true) = "Laptop".to_owned();
+        form.select_field(true, 1);
+        *form.current_value_mut(true) = "/private/custom-ca.pem".to_owned();
+        form.select_field(true, 1);
+        *form.current_value_mut(true) = "PAIRING-CODE-SENTINEL".to_owned();
+
+        let mut app = App::new(100);
+        app.personal_state.sync_ui.wizard = Some(SyncWizard::Join {
+            form,
+            confirm: false,
+        });
+        let text = draw(&app, 80, 30);
+
+        assert!(text.contains("sync.example.invalid"));
+        assert!(text.contains('•'));
+        assert!(!text.contains("password-sentinel"));
+        assert!(!text.contains("PAIRING-CODE-SENTINEL"));
+    }
+
+    #[test]
+    fn thirty_by_thirty_keeps_title_current_field_and_buttons_visible() {
+        let mut form = SyncConnectionForm::join();
+        form.select_field(true, 2);
+        *form.current_value_mut(true) = "hidden".to_owned();
+        let mut app = App::new(100);
+        app.personal_state.sync_ui.wizard = Some(SyncWizard::Join {
+            form,
+            confirm: false,
+        });
+
+        let text = draw(&app, 30, 30);
+        assert!(text.contains("Join personal sync"));
+        assert!(text.contains("Password or access"));
+        assert!(text.contains("Join"));
+        assert!(text.contains("Cancel"));
+        assert!(!text.contains("hidden"));
+    }
+
+    #[test]
+    fn thirty_column_setup_keeps_the_complete_encryption_notice_in_every_language() {
+        let _guard = crate::i18n::lock_for_test();
+        for (language, final_phrase) in [
+            (crate::i18n::Language::English, "this device"),
+            (crate::i18n::Language::Korean, "암호화됩니다"),
+            (crate::i18n::Language::Japanese, "暗号化されます"),
+        ] {
+            crate::i18n::set_language(language);
+            let mut app = App::new(100);
+            app.personal_state.sync_ui.wizard = Some(SyncWizard::Setup {
+                form: SyncConnectionForm::setup(),
+                confirm: false,
+            });
+            let text = draw(&app, 30, 30);
+            let compact = text
+                .chars()
+                .filter(|ch| !ch.is_whitespace())
+                .collect::<String>();
+            let expected = final_phrase
+                .chars()
+                .filter(|ch| !ch.is_whitespace())
+                .collect::<String>();
+            assert!(compact.contains(&expected), "{language:?}: {text}");
+        }
+    }
+
+    #[test]
+    fn long_selected_value_scrolls_to_the_text_cursor() {
+        let mut form = SyncConnectionForm::join();
+        *form.current_value_mut(true) =
+            "https://sync.example.invalid/very/long/path/TAIL-END".to_owned();
+        form.cursor = crate::util::text_edit::TextCursor::at_end(form.current_value(true));
+        let mut app = App::new(100);
+        app.personal_state.sync_ui.wizard = Some(SyncWizard::Join {
+            form,
+            confirm: false,
+        });
+
+        let text = draw(&app, 30, 30);
+        assert!(text.contains("TAIL-END"), "{text}");
+        assert!(!text.contains("sync.example.invalid"), "{text}");
+    }
+}

--- a/src/ui/views/settings/sync_wizard/lifecycle.rs
+++ b/src/ui/views/settings/sync_wizard/lifecycle.rs
@@ -1,0 +1,571 @@
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Wrap};
+use unicode_width::UnicodeWidthStr;
+
+use super::support::{
+    SIMPLE_WIDTH, actions, centered, clipped_line, finish, message_modal, shell, single_line,
+    wrapped_height,
+};
+use crate::app::App;
+use crate::personal_state::ImportSummary;
+use crate::t;
+use crate::theme::ThemeRole as R;
+
+pub(super) fn render_host(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    code: &str,
+    expires_at_unix: i64,
+    review: Option<&crate::sync::service::PairingReview>,
+) {
+    let popup = centered(area, SIMPLE_WIDTH, 16);
+    let inner = shell(
+        frame,
+        app,
+        popup,
+        t!(" Add a device ", " 기기 추가 ", " デバイスを追加 "),
+        R::BorderPrimary,
+    );
+    let intro = if review.is_some() {
+        t!(
+            "Check the device name and fingerprint before approving.",
+            "승인 전에 기기 이름과 지문을 확인하세요.",
+            "承認前にデバイス名とフィンガープリントを確認してください。"
+        )
+    } else {
+        t!(
+            "Enter this one-time code on the new device.",
+            "새 기기에 이 일회용 코드를 입력하세요.",
+            "新しいデバイスでこの一回限りのコードを入力します。"
+        )
+    };
+    let rows = Layout::vertical([
+        Constraint::Length(wrapped_height(intro, inner.width, 3)),
+        Constraint::Length(2),
+        Constraint::Length(1),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+    frame.render_widget(
+        Paragraph::new(intro)
+            .wrap(Wrap { trim: true })
+            .style(crate::ui::popup_style(app, R::TextPrimary)),
+        rows[0],
+    );
+    let remaining = expires_at_unix.saturating_sub(crate::signals::unix_now());
+    let expiry = if remaining <= 0 {
+        t!("Code expired", "코드가 만료됨", "コードの期限が切れました").to_owned()
+    } else {
+        let minutes = remaining.saturating_add(59) / 60;
+        match crate::i18n::current() {
+            crate::i18n::Language::Korean => format!("{minutes}분 후 만료"),
+            crate::i18n::Language::Japanese => format!("あと{minutes}分で期限切れ"),
+            _ => format!("Expires in {minutes} min"),
+        }
+    };
+    let code_lines = balanced_code_lines(code, rows[1].width as usize)
+        .into_iter()
+        .map(|line| {
+            Line::from(Span::styled(
+                line,
+                crate::ui::popup_style(app, R::Accent).add_modifier(Modifier::BOLD),
+            ))
+        })
+        .collect::<Vec<_>>();
+    frame.render_widget(
+        Paragraph::new(code_lines).alignment(Alignment::Center),
+        rows[1],
+    );
+    frame.render_widget(
+        Paragraph::new(clipped_line(&expiry, rows[2].width as usize))
+            .alignment(Alignment::Center)
+            .style(crate::ui::popup_style(app, R::TextMuted)),
+        rows[2],
+    );
+    if let Some(review) = review {
+        frame.render_widget(
+            Paragraph::new(vec![
+                detail_line(
+                    app,
+                    t!("Device", "기기", "デバイス"),
+                    &review.device_name,
+                    rows[3].width,
+                ),
+                detail_line(
+                    app,
+                    t!("Fingerprint", "지문", "フィンガープリント"),
+                    &review.fingerprint,
+                    rows[3].width,
+                ),
+            ]),
+            rows[3],
+        );
+        actions(
+            frame,
+            app,
+            rows[4],
+            None,
+            t!(" Approve ", " 승인 ", " 承認 "),
+            secondary_when_idle(app, t!(" Reject ", " 거절 ", " 拒否 ")),
+        );
+    } else {
+        frame.render_widget(
+            Paragraph::new(t!(
+                "Waiting for the new device…",
+                "새 기기를 기다리는 중…",
+                "新しいデバイスを待っています…"
+            ))
+            .style(crate::ui::popup_style(app, R::TextMuted)),
+            rows[3],
+        );
+        actions(
+            frame,
+            app,
+            rows[4],
+            None,
+            t!(" Check again ", " 다시 확인 ", " 再確認 "),
+            secondary_when_idle(app, t!(" Cancel ", " 취소 ", " キャンセル ")),
+        );
+    }
+    finish(frame, app, popup);
+}
+
+fn balanced_code_lines(code: &str, width: usize) -> Vec<String> {
+    let code = single_line(code);
+    if width == 0 || UnicodeWidthStr::width(code.as_str()) <= width {
+        return vec![code];
+    }
+
+    let groups = code.split('-').collect::<Vec<_>>();
+    let mut best: Option<(usize, usize, String, String)> = None;
+    for split in 1..groups.len() {
+        let left = groups[..split].join("-");
+        let right = groups[split..].join("-");
+        let left_width = UnicodeWidthStr::width(left.as_str());
+        let right_width = UnicodeWidthStr::width(right.as_str());
+        if left_width > width || right_width > width {
+            continue;
+        }
+        let imbalance = left_width.abs_diff(right_width);
+        let widest = left_width.max(right_width);
+        if best
+            .as_ref()
+            .is_none_or(|(best_imbalance, best_widest, _, _)| {
+                (imbalance, widest) < (*best_imbalance, *best_widest)
+            })
+        {
+            best = Some((imbalance, widest, left, right));
+        }
+    }
+    if let Some((_, _, left, right)) = best {
+        return vec![left, right];
+    }
+
+    vec![clipped_line(&code, width)]
+}
+
+fn secondary_when_idle<'a>(app: &App, label: &'a str) -> Option<&'a str> {
+    app.personal_state.sync_ui.busy.is_none().then_some(label)
+}
+
+fn detail_line(app: &App, label: &str, value: &str, width: u16) -> Line<'static> {
+    let prefix = format!("{label}: ");
+    let prefix_width = UnicodeWidthStr::width(prefix.as_str()) as u16;
+    Line::from(vec![
+        Span::styled(prefix, crate::ui::popup_style(app, R::TextMuted)),
+        Span::styled(
+            clipped_line(value, width.saturating_sub(prefix_width) as usize),
+            crate::ui::popup_style(app, R::SettingsValue),
+        ),
+    ])
+}
+
+pub(super) fn render_join_waiting(frame: &mut Frame, app: &App, area: Rect) {
+    message_modal(
+        frame,
+        app,
+        area,
+        t!(
+            " Waiting for approval ",
+            " 승인 대기 중 ",
+            " 承認を待っています "
+        ),
+        t!(
+            "Approve this device on an existing device. Closing keeps the approval waiting safely.",
+            "기존 기기에서 이 기기를 승인하세요. 화면을 닫아도 승인 대기 상태는 안전하게 유지됩니다.",
+            "既存のデバイスでこのデバイスを承認してください。閉じても承認待ちの状態は安全に保持されます。"
+        ),
+        R::BorderPrimary,
+        (
+            t!(" Check again ", " 다시 확인 ", " 再確認 "),
+            secondary_when_idle(app, t!(" Close ", " 닫기 ", " 閉じる ")),
+        ),
+    );
+}
+
+pub(super) fn render_join_preview(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    summary: &ImportSummary,
+) {
+    let popup = centered(area, SIMPLE_WIDTH, 15);
+    let inner = shell(
+        frame,
+        app,
+        popup,
+        t!(" Review changes ", " 변경 사항 확인 ", " 変更内容を確認 "),
+        R::BorderPrimary,
+    );
+    let introduction = t!(
+        "The first merge keeps both sides. Nothing is deleted.",
+        "첫 병합은 양쪽 데이터를 모두 유지하며 삭제하지 않습니다.",
+        "最初の統合では両方のデータを残し、削除しません。"
+    );
+    let later_copy = t!(
+        "Choose Later to keep this approved merge ready without changing local data.",
+        "나중에를 선택하면 승인된 병합을 유지하며 로컬 데이터는 바꾸지 않습니다.",
+        "「後で」を選ぶと、ローカルデータを変更せず承認済みの統合を保持します。"
+    );
+    let rows = Layout::vertical([
+        Constraint::Length(wrapped_height(introduction, inner.width, 3)),
+        Constraint::Min(3),
+        Constraint::Length(wrapped_height(later_copy, inner.width, 3)),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+    frame.render_widget(
+        Paragraph::new(introduction)
+            .wrap(Wrap { trim: true })
+            .style(crate::ui::popup_style(app, R::TextPrimary)),
+        rows[0],
+    );
+    frame.render_widget(
+        Paragraph::new(merge_summary_lines(summary))
+            .style(crate::ui::popup_style(app, R::SettingsValue)),
+        rows[1],
+    );
+    frame.render_widget(
+        Paragraph::new(later_copy)
+            .wrap(Wrap { trim: true })
+            .style(crate::ui::popup_style(app, R::TextMuted)),
+        rows[2],
+    );
+    actions(
+        frame,
+        app,
+        rows[3],
+        None,
+        t!(" Merge ", " 병합 ", " 統合 "),
+        secondary_when_idle(app, t!(" Later ", " 나중에 ", " 後で ")),
+    );
+    finish(frame, app, popup);
+}
+
+pub(super) fn render_revoke(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    device_id: &str,
+    device_name: &str,
+) {
+    let name = if device_name.trim().is_empty() {
+        device_id
+    } else {
+        device_name
+    };
+    let detail = format!(
+        "{}\n{}: {}",
+        t!(
+            "Removing stops future changes, but cannot erase data already downloaded. Change the shared storage password if the device may be compromised.",
+            "제거하면 이후 변경은 중단되지만 이미 받은 데이터는 지울 수 없습니다. 기기가 노출되었을 수 있다면 공유 저장소 비밀번호도 바꾸세요.",
+            "削除すると今後の変更は止まりますが、取得済みのデータは消去できません。侵害された可能性がある場合は共有保存先のパスワードも変更してください。"
+        ),
+        t!("Device", "기기", "デバイス"),
+        clipped_line(name, 40),
+    );
+    message_modal(
+        frame,
+        app,
+        area,
+        t!(" Remove device ", " 기기 제거 ", " デバイスを削除 "),
+        &detail,
+        R::Warning,
+        (
+            t!(" Remove ", " 제거 ", " 削除 "),
+            secondary_when_idle(app, t!(" Cancel ", " 취소 ", " キャンセル ")),
+        ),
+    );
+}
+
+pub(super) fn render_discard_join(frame: &mut Frame, app: &App, area: Rect) {
+    message_modal(
+        frame,
+        app,
+        area,
+        t!(
+            " Discard unfinished connection? ",
+            " 완료되지 않은 연결을 버릴까요? ",
+            " 未完了の接続を破棄しますか？ "
+        ),
+        t!(
+            "Only discard this attempt if it was never approved. If another device already approved it, keep it and remove the old device there before connecting again. Local listening data will not be removed.",
+            "승인되지 않은 연결만 버리세요. 다른 기기에서 이미 승인했다면 이 연결을 유지하고, 다시 연결하기 전에 그 기기에서 이전 기기를 제거하세요. 이 기기의 감상 데이터는 삭제되지 않습니다.",
+            "未承認の接続だけを破棄してください。別のデバイスで承認済みの場合はこの接続を保持し、再接続する前にそのデバイスで古いデバイスを削除してください。ローカルの再生データは削除されません。"
+        ),
+        R::Warning,
+        (
+            t!(" Discard ", " 버리기 ", " 破棄 "),
+            secondary_when_idle(app, t!(" Keep ", " 유지 ", " 保持 ")),
+        ),
+    );
+}
+
+pub(super) fn render_result(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    success: bool,
+    message: &str,
+) {
+    message_modal(
+        frame,
+        app,
+        area,
+        if success {
+            t!(" Sync ready ", " 동기화 준비 완료 ", " 同期の準備完了 ")
+        } else {
+            t!(
+                " Sync needs attention ",
+                " 동기화 확인 필요 ",
+                " 同期を確認してください "
+            )
+        },
+        &single_line(message),
+        if success { R::Success } else { R::Error },
+        (t!(" Done ", " 완료 ", " 完了 "), None),
+    );
+}
+
+fn merge_summary_lines(summary: &ImportSummary) -> Vec<Line<'static>> {
+    let total_items = summary
+        .favorites_added
+        .saturating_add(summary.history_added)
+        .saturating_add(summary.radio_favorites_added)
+        .saturating_add(summary.playlists_added)
+        .saturating_add(summary.playlist_entries_added)
+        .saturating_add(summary.signal_tracks_added);
+    match crate::i18n::current() {
+        crate::i18n::Language::Korean => vec![
+            Line::from(format!("새 변경 {}개", summary.operations_added)),
+            Line::from(format!("유지할 항목 {total_items}개")),
+            Line::from(format!(
+                "이미 있는 중복 {}개 건너뜀",
+                summary.duplicate_operations
+            )),
+        ],
+        crate::i18n::Language::Japanese => vec![
+            Line::from(format!("新しい変更: {}", summary.operations_added)),
+            Line::from(format!("保持する項目: {total_items}")),
+            Line::from(format!(
+                "既存の重複をスキップ: {}",
+                summary.duplicate_operations
+            )),
+        ],
+        _ => vec![
+            Line::from(format!("New changes: {}", summary.operations_added)),
+            Line::from(format!("Items kept: {total_items}")),
+            Line::from(format!(
+                "Duplicates already present: {}",
+                summary.duplicate_operations
+            )),
+        ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+    use crate::app::{DataMsg, Msg, SyncUiEvent};
+    use crate::sync::service::PairingJoinWaiting;
+
+    fn buffer_text(terminal: &Terminal<TestBackend>, width: u16) -> String {
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(width as usize)
+            .map(|row| row.iter().map(|cell| cell.symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn draw_host(app: &App, width: u16, height: u16, code: &str) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_host(
+                    frame,
+                    app,
+                    frame.area(),
+                    code,
+                    crate::signals::unix_now().saturating_add(600),
+                    None,
+                );
+            })
+            .unwrap();
+        buffer_text(&terminal, width)
+    }
+
+    fn draw_join_waiting(app: &App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_join_waiting(frame, app, frame.area()))
+            .unwrap();
+        buffer_text(&terminal, width)
+    }
+
+    fn draw_revoke(app: &App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_revoke(frame, app, frame.area(), "device-remote", "Living room");
+            })
+            .unwrap();
+        buffer_text(&terminal, width)
+    }
+
+    fn draw_discard_join(app: &App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_discard_join(frame, app, frame.area()))
+            .unwrap();
+        buffer_text(&terminal, width)
+    }
+
+    #[test]
+    fn merge_summary_uses_deletion_free_counts() {
+        let summary = ImportSummary {
+            operations_added: 4,
+            duplicate_operations: 2,
+            favorites_added: 1,
+            history_added: 2,
+            ..ImportSummary::default()
+        };
+        let text = merge_summary_lines(&summary)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("New changes: 4"));
+        assert!(text.contains("Items kept: 3"));
+        assert!(text.contains("Duplicates already present: 2"));
+    }
+
+    #[test]
+    fn thirty_by_thirty_host_keeps_the_complete_pairing_code() {
+        let _guard = crate::i18n::lock_for_test();
+        crate::i18n::set_language(crate::i18n::Language::English);
+        let app = App::new(100);
+        let code = "ABCDE-FGHIJ-KLMNO-PQRST-UVWXY-Z";
+
+        assert_eq!(
+            balanced_code_lines(code, 28),
+            vec!["ABCDE-FGHIJ-KLMNO", "PQRST-UVWXY-Z"]
+        );
+        let text = draw_host(&app, 30, 30, code);
+
+        assert!(text.contains("ABCDE-FGHIJ-KLMNO"));
+        assert!(text.contains("PQRST-UVWXY-Z"));
+        assert!(text.contains("Expires in"));
+    }
+
+    #[test]
+    fn busy_lifecycle_modal_hides_its_secondary_action() {
+        let _guard = crate::i18n::lock_for_test();
+        crate::i18n::set_language(crate::i18n::Language::English);
+        let mut app = App::new(100);
+        app.personal_state.sync_ui.flow_id = 1;
+        let _ = app.update(Msg::Data(DataMsg::SyncUi(SyncUiEvent::JoinStarted {
+            flow_id: 1,
+            result: Box::new(Ok(PairingJoinWaiting {
+                device_id: "dev-waiting".to_owned(),
+                expires_at_unix: crate::signals::unix_now().saturating_add(600),
+                resumed: false,
+            })),
+        })));
+
+        let text = draw_join_waiting(&app, 30, 30);
+
+        assert!(text.contains("Working"));
+        assert!(!text.contains("Close"));
+    }
+
+    #[test]
+    fn revoke_warns_that_downloaded_data_cannot_be_erased_in_every_language() {
+        let _guard = crate::i18n::lock_for_test();
+        for (language, warning) in [
+            (crate::i18n::Language::English, "already downloaded"),
+            (crate::i18n::Language::Korean, "이미 받은 데이터"),
+            (crate::i18n::Language::Japanese, "取得済みのデータ"),
+        ] {
+            crate::i18n::set_language(language);
+            let text = draw_revoke(&App::new(100), 30, 30);
+            let compact = text
+                .chars()
+                .filter(|ch| !ch.is_whitespace())
+                .collect::<String>();
+            let expected = warning
+                .chars()
+                .filter(|ch| !ch.is_whitespace())
+                .collect::<String>();
+            assert!(compact.contains(&expected), "{language:?}: {text}");
+        }
+    }
+
+    #[test]
+    fn discard_join_warns_about_prior_approval_in_every_language() {
+        let _guard = crate::i18n::lock_for_test();
+        for (language, approval_a, approval_b, preserved) in [
+            (
+                crate::i18n::Language::English,
+                "already",
+                "approved",
+                "removed",
+            ),
+            (crate::i18n::Language::Korean, "이미", "승인", "삭제되지"),
+            (
+                crate::i18n::Language::Japanese,
+                "承認",
+                "場合",
+                "されません",
+            ),
+        ] {
+            crate::i18n::set_language(language);
+            let text = draw_discard_join(&App::new(100), 30, 30);
+            let compact = text
+                .chars()
+                .filter(|ch| !ch.is_whitespace())
+                .collect::<String>();
+            for expected in [approval_a, approval_b, preserved] {
+                let expected = expected
+                    .chars()
+                    .filter(|ch| !ch.is_whitespace())
+                    .collect::<String>();
+                assert!(compact.contains(&expected), "{language:?}: {text}");
+            }
+        }
+    }
+}

--- a/src/ui/views/settings/sync_wizard/support.rs
+++ b/src/ui/views/settings/sync_wizard/support.rs
@@ -1,0 +1,306 @@
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::app::{App, MouseTarget};
+use crate::t;
+use crate::theme::ThemeRole as R;
+use crate::ui::buttons::{self, Seg};
+
+pub(super) const FORM_WIDTH: u16 = 68;
+pub(super) const SIMPLE_WIDTH: u16 = 58;
+
+pub(super) fn message_modal(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    title: &str,
+    message: &str,
+    border_role: R,
+    modal_actions: (&str, Option<&str>),
+) {
+    let popup = centered(area, SIMPLE_WIDTH, 15);
+    let inner = shell(frame, app, popup, title, border_role);
+    let rows = Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).split(inner);
+    frame.render_widget(
+        Paragraph::new(message)
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: true })
+            .style(crate::ui::popup_style(app, R::TextPrimary)),
+        rows[0],
+    );
+    actions(frame, app, rows[1], None, modal_actions.0, modal_actions.1);
+    finish(frame, app, popup);
+}
+
+pub(super) fn wrapped_height(value: &str, width: u16, maximum: u16) -> u16 {
+    if value.is_empty() || width == 0 || maximum == 0 {
+        return 0;
+    }
+    let cells = UnicodeWidthStr::width(value);
+    let width = usize::from(width);
+    let hard_wrapped = cells.saturating_add(width - 1) / width;
+    // Ratatui wraps at word boundaries, which can consume one more row than a pure cell-count
+    // estimate on a narrow popup. Reserve that row rather than clipping safety copy.
+    let conservative = hard_wrapped.saturating_add(usize::from(width < 40));
+    u16::try_from(conservative)
+        .unwrap_or(maximum)
+        .clamp(1, maximum)
+}
+
+pub(super) fn render_field(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    label: &str,
+    value: &str,
+    selected: bool,
+    editor: Option<(&str, usize, bool)>,
+) {
+    if area.height == 0 {
+        return;
+    }
+    let marker = if selected { "› " } else { "  " };
+    let marker_style = crate::ui::popup_style(app, if selected { R::Accent } else { R::TextMuted });
+    let label_style = crate::ui::popup_style(
+        app,
+        if selected {
+            R::SettingsLabel
+        } else {
+            R::TextMuted
+        },
+    );
+    let value_style = crate::ui::popup_style(
+        app,
+        if selected {
+            R::SettingsValue
+        } else {
+            R::TextPrimary
+        },
+    );
+    if area.height >= 2 {
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(marker, marker_style),
+                Span::styled(
+                    clipped_line(label, area.width.saturating_sub(2) as usize),
+                    label_style,
+                ),
+            ])),
+            Rect { height: 1, ..area },
+        );
+        frame.render_widget(
+            field_value(
+                app,
+                value,
+                editor,
+                area.width.saturating_sub(4) as usize,
+                value_style,
+            ),
+            Rect {
+                x: area.x.saturating_add(4),
+                y: area.y.saturating_add(1),
+                width: area.width.saturating_sub(4),
+                height: 1,
+            },
+        );
+    } else {
+        let prefix = format!("{marker}{label}: ");
+        let available = area
+            .width
+            .saturating_sub(UnicodeWidthStr::width(prefix.as_str()) as u16);
+        frame.render_widget(
+            Paragraph::new({
+                let mut line = vec![Span::styled(prefix, label_style)];
+                line.extend(field_value(app, value, editor, available as usize, value_style).spans);
+                Line::from(line)
+            }),
+            area,
+        );
+    }
+}
+
+fn field_value<'a>(
+    app: &'a App,
+    value: &str,
+    editor: Option<(&str, usize, bool)>,
+    width: usize,
+    style: ratatui::style::Style,
+) -> Line<'a> {
+    let Some((raw, cursor, masked)) = editor else {
+        return Line::from(Span::styled(
+            clipped_line(&display_or_placeholder(value), width),
+            style,
+        ));
+    };
+    let window = if masked {
+        crate::ui::text::masked_editable_window(raw, cursor, width)
+    } else {
+        crate::ui::text::editable_window(raw, cursor, width)
+    };
+    Line::from(vec![
+        Span::styled(window.before, style),
+        crate::ui::anim::caret_span(app, style, crate::ui::popup_bg(app)),
+        Span::styled(window.after, style),
+    ])
+}
+
+pub(super) fn actions(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    reveal: Option<&str>,
+    primary: &str,
+    secondary: Option<&str>,
+) {
+    let mut segments = Vec::with_capacity(5);
+    if let Some(label) = reveal {
+        segments.push(Seg::button(MouseTarget::SyncWizardReveal, label));
+        segments.push(Seg::label("  "));
+    }
+    if app.personal_state.sync_ui.busy.is_some() {
+        segments.push(Seg::label(t!(" Working… ", " 처리 중… ", " 処理中… ")));
+    } else {
+        segments.push(Seg::button(MouseTarget::SyncWizardPrimary, primary));
+    }
+    if let Some(label) = secondary {
+        segments.push(Seg::label("  "));
+        segments.push(Seg::button(MouseTarget::SyncWizardSecondary, label));
+    }
+    buttons::render_segments(
+        frame,
+        app,
+        area,
+        &segments,
+        crate::ui::confirm_button_style(app),
+        crate::ui::confirm_gap_style(app),
+        Alignment::Center,
+    );
+}
+
+pub(super) fn shell(
+    frame: &mut Frame,
+    app: &App,
+    popup: Rect,
+    title: &str,
+    border_role: R,
+) -> Rect {
+    crate::ui::render_popup_background(frame, app, popup);
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(crate::ui::popup_style(app, border_role).add_modifier(Modifier::BOLD))
+        .style(crate::ui::popup_style(app, R::TextPrimary));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+    inner
+}
+
+pub(super) fn finish(frame: &mut Frame, app: &App, popup: Rect) {
+    crate::ui::seal_popup_background(frame, app, popup);
+    crate::ui::mark_art_rows_for_popup(frame, app, popup);
+}
+
+pub(super) fn centered(area: Rect, preferred_width: u16, preferred_height: u16) -> Rect {
+    let horizontal_margin = u16::from(area.width > 34).saturating_mul(2);
+    let vertical_margin = u16::from(area.height > 16).saturating_mul(2);
+    let width = preferred_width.min(area.width.saturating_sub(horizontal_margin));
+    let height = preferred_height.min(area.height.saturating_sub(vertical_margin));
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
+
+pub(super) fn display_or_placeholder(value: &str) -> String {
+    if value.is_empty() {
+        t!("(not set)", "(입력 안 됨)", "（未入力）").to_owned()
+    } else {
+        single_line(value)
+    }
+}
+
+pub(super) fn single_line(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_control() || is_bidi_control(character) {
+                '�'
+            } else {
+                character
+            }
+        })
+        .collect()
+}
+
+pub(super) fn clipped_line(value: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let value = single_line(value);
+    if UnicodeWidthStr::width(value.as_str()) <= width {
+        return value;
+    }
+    if width == 1 {
+        return "…".to_owned();
+    }
+    let mut clipped = String::new();
+    let limit = width - 1;
+    let mut used = 0usize;
+    for character in value.chars() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
+        if used.saturating_add(character_width) > limit {
+            break;
+        }
+        clipped.push(character);
+        used = used.saturating_add(character_width);
+    }
+    clipped.push('…');
+    clipped
+}
+
+fn is_bidi_control(character: char) -> bool {
+    matches!(
+        character,
+        '\u{061c}'
+            | '\u{200e}'
+            | '\u{200f}'
+            | '\u{202a}'..='\u{202e}'
+            | '\u{2066}'..='\u{2069}'
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clipping_replaces_line_and_bidi_controls() {
+        let clipped = clipped_line("folder\nsafe\u{202e}txt/long-name", 12);
+        assert!(!clipped.contains('\n'));
+        assert!(!clipped.contains('\u{202e}'));
+        assert!(clipped.ends_with('…'));
+        assert!(UnicodeWidthStr::width(clipped.as_str()) <= 12);
+    }
+
+    #[test]
+    fn wrapped_height_counts_narrow_localized_copy() {
+        assert_eq!(
+            wrapped_height(
+                "Your listening data is encrypted before it leaves this device.",
+                28,
+                4,
+            ),
+            4
+        );
+        assert_eq!(
+            wrapped_height("감상 데이터는 이 기기를 떠나기 전에 암호화됩니다.", 28, 4,),
+            3
+        );
+    }
+}

--- a/src/ui/views/settings/tabs.rs
+++ b/src/ui/views/settings/tabs.rs
@@ -1,0 +1,156 @@
+//! Width-aware Settings tab strip.
+
+use std::ops::Range;
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+
+use crate::app::{App, MouseTarget};
+use crate::settings::{SettingsState, SettingsTab};
+use crate::theme::ThemeRole as R;
+use crate::ui::buttons;
+
+const DIVIDER: &str = " ";
+const BEFORE: &str = "‹ ";
+const AFTER: &str = " ›";
+
+pub(super) fn render(frame: &mut Frame, app: &App, settings: &SettingsState, area: Rect) {
+    if area.is_empty() {
+        return;
+    }
+    let theme = &settings.draft.theme;
+    let active_style = Style::default()
+        .fg(theme.color(R::SelectionFg))
+        .bg(theme.color(R::SelectionBg))
+        .add_modifier(Modifier::BOLD);
+    let muted = theme.style(R::TextMuted);
+    let visible = visible_range(settings.tab.index(), area.width);
+    let mut spans = Vec::new();
+    let mut x = area.x;
+
+    if visible.start > 0 {
+        spans.push(Span::styled(BEFORE, muted));
+        x = x.saturating_add(buttons::text_width(BEFORE));
+    }
+    for index in visible.clone() {
+        if index > visible.start {
+            spans.push(Span::styled(DIVIDER, muted));
+            x = x.saturating_add(buttons::text_width(DIVIDER));
+        }
+        let tab = SettingsTab::ALL[index];
+        let label = padded_label(tab);
+        let width = buttons::text_width(&label);
+        let available = area.right().saturating_sub(x);
+        if available > 0 {
+            app.register_mouse_button(
+                Rect {
+                    x,
+                    y: area.y,
+                    width: width.min(available),
+                    height: 1,
+                },
+                MouseTarget::SettingsTab(index),
+            );
+        }
+        x = x.saturating_add(width);
+        let style = if settings.tab == tab {
+            crate::ui::anim::active_tab_style(app, crate::ui::anim::TabPop::Inner, active_style)
+        } else {
+            muted
+        };
+        spans.push(Span::styled(label, style));
+    }
+    if visible.end < SettingsTab::ALL.len() {
+        spans.push(Span::styled(AFTER, muted));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn visible_range(active: usize, width: u16) -> Range<usize> {
+    let len = SettingsTab::ALL.len();
+    if len == 0 {
+        return 0..0;
+    }
+    let active = active.min(len - 1);
+    let mut best: Option<(usize, usize, usize, usize)> = None;
+    for start in 0..=active {
+        for end in active + 1..=len {
+            let used = range_width(start..end);
+            if used > width {
+                continue;
+            }
+            let count = end - start;
+            let imbalance = (active - start).abs_diff(end - active - 1);
+            let candidate = (count, usize::MAX - imbalance, start, end);
+            if best.is_none_or(|current| candidate > current) {
+                best = Some(candidate);
+            }
+        }
+    }
+    best.map_or(active..active + 1, |(_, _, start, end)| start..end)
+}
+
+fn range_width(range: Range<usize>) -> u16 {
+    let tabs = range
+        .clone()
+        .map(|index| buttons::text_width(&padded_label(SettingsTab::ALL[index])))
+        .fold(0u16, u16::saturating_add);
+    let dividers = range
+        .len()
+        .saturating_sub(1)
+        .saturating_mul(buttons::text_width(DIVIDER) as usize) as u16;
+    let before = if range.start > 0 {
+        buttons::text_width(BEFORE)
+    } else {
+        0
+    };
+    let after = if range.end < SettingsTab::ALL.len() {
+        buttons::text_width(AFTER)
+    } else {
+        0
+    };
+    tabs.saturating_add(dividers)
+        .saturating_add(before)
+        .saturating_add(after)
+}
+
+fn padded_label(tab: SettingsTab) -> String {
+    format!(" {} ", tab.label())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::i18n::Language;
+
+    #[test]
+    fn narrow_ranges_always_fit_and_keep_the_active_tab() {
+        let _guard = crate::i18n::lock_for_test();
+        for language in [Language::English, Language::Korean, Language::Japanese] {
+            crate::i18n::set_language(language);
+            for width in [28, 30, 32] {
+                for active in 0..SettingsTab::ALL.len() {
+                    let range = visible_range(active, width);
+                    assert!(range.contains(&active), "{language:?} {width} {active}");
+                    assert!(
+                        range_width(range.clone()) <= width,
+                        "{language:?} {width} {active}: {range:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn wide_range_shows_every_tab() {
+        let _guard = crate::i18n::lock_for_test();
+        crate::i18n::set_language(Language::English);
+        assert_eq!(
+            visible_range(SettingsTab::Sync.index(), 200),
+            0..SettingsTab::ALL.len()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add a new **Settings → Sync** surface for manual personal-state sync, with status, activity, device, and recovery views
- guide users through encrypted vault creation, recovery-kit confirmation, joining, device approval, deletion-free merge preview, revocation, retry, and safe unfinished-connection recovery
- keep primary-writer ownership and crash-consistent activation boundaries intact; secondary instances remain observational
- add keyboard, mouse, 30×30 narrow-layout, and English/Korean/Japanese coverage
- harden remote device-name validation and ensure daemon status reads the daemon-owned sync paths

## Why

This is the TUI-first UX milestone for cross-device personal-state sync. It exposes the encrypted WebDAV and device lifecycle built in the preceding milestones without leaking technical protocol terms or allowing cancellation to orphan an already-approved remote device.

Part of #114. Automatic sync and compaction remain for the next milestone.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (4,077 library tests passed, 1 ignored; all binary/integration/doc tests passed)
- `~/.fable-harness/bin/run-gates .` — all canonical gates passed
- isolated `verify` tmux runs at 80×24 and 30×30, with no playback or real credentials; verified setup/join forms, secret reveal/hide hints, recoverable unfinished-connection actions, and the discard warning/cancel path
