### PR TITLE
feat(sync): automate vault sync and compact engagement history

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,11 +134,10 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 # Spotify OAuth PKCE code challenge (SHA-256). RustCrypto, pure Rust.
 sha2 = "0.10"
-# Only the process APIs are used (reaping a leaked mpv, the Windows kill backstop — see
-# `player::lifetime`), so drop the default disk/network/component/user feature groups: it
-# trims a slice of unused code on every platform (and the `objc2-open-directory` crate on
-# macOS) with zero behaviour change.
-sysinfo = { version = "0.39.5", default-features = false, features = ["system"] }
+# Process APIs power the mpv lifetime backstops; network APIs provide local interface addresses
+# for the parked automatic-sync reconnect watcher. Keep the unrelated disk/component/user groups
+# disabled (including objc2-open-directory on macOS).
+sysinfo = { version = "0.39.5", default-features = false, features = ["network", "system"] }
 tao = { version = "0.34", optional = true }
 # Optional player eye-candy (the Animations settings tab). A ratatui-native spinner used
 # for the "now playing" throbber; nothing renders unless the user enables it. Permissive

--- a/src/app/automatic_sync.rs
+++ b/src/app/automatic_sync.rs
@@ -1,0 +1,603 @@
+//! TUI owner-lane adapter for the shared automatic personal-sync scheduler.
+
+use super::*;
+use crate::sync::service::SyncServiceError;
+
+impl App {
+    pub(super) fn finish_personal_sync_schedule(
+        &mut self,
+        reply: &PersonalSyncReply,
+        error: SyncServiceError,
+    ) -> Vec<Cmd> {
+        let Some(token) = reply.token() else {
+            return Vec::new();
+        };
+        let outcome = match error {
+            SyncServiceError::Offline => {
+                crate::sync::SyncAttemptOutcome::Offline { retry_after: None }
+            }
+            SyncServiceError::RateLimited(retry_after) => {
+                crate::sync::SyncAttemptOutcome::Offline { retry_after }
+            }
+            _ => crate::sync::SyncAttemptOutcome::Failed,
+        };
+        self.finish_personal_sync_token(token, outcome)
+    }
+
+    pub(super) fn finish_personal_sync_schedule_success(
+        &mut self,
+        reply: &PersonalSyncReply,
+    ) -> Vec<Cmd> {
+        let Some(token) = reply.token() else {
+            return Vec::new();
+        };
+        self.finish_personal_sync_token(token, crate::sync::SyncAttemptOutcome::Succeeded)
+    }
+
+    fn finish_personal_sync_token(
+        &mut self,
+        token: crate::sync::SyncAttemptToken,
+        outcome: crate::sync::SyncAttemptOutcome,
+    ) -> Vec<Cmd> {
+        let mut commands = match self.personal_state.sync.scheduler.finish(
+            token,
+            outcome,
+            std::time::Instant::now(),
+        ) {
+            crate::sync::SyncFinish::Accepted { next: Some(next) } => {
+                self.start_automatic_sync(next)
+            }
+            crate::sync::SyncFinish::Accepted { next: None } | crate::sync::SyncFinish::Stale => {
+                Vec::new()
+            }
+        };
+        commands.extend(self.refresh_open_sync_ui());
+        commands
+    }
+
+    fn start_automatic_sync(&mut self, token: crate::sync::SyncAttemptToken) -> Vec<Cmd> {
+        if self.personal_sync_lane_busy() {
+            match self.personal_state.sync.deferred_automatic {
+                Some(deferred) => debug_assert_eq!(deferred, token),
+                None => self.personal_state.sync.deferred_automatic = Some(token),
+            }
+            return Vec::new();
+        }
+        let mut commands = self.start_personal_sync_with_reply(
+            PersonalSyncAction::AutomaticSync,
+            PersonalSyncReply::automatic(token),
+        );
+        commands.extend(self.refresh_open_sync_ui());
+        commands
+    }
+
+    fn personal_sync_lane_busy(&self) -> bool {
+        self.personal_state.sync.in_progress
+            || self.personal_state.sync_ui.remote_mutation_in_progress()
+    }
+
+    pub(super) fn resume_automatic_sync_if_ready(&mut self) -> Vec<Cmd> {
+        if self.personal_sync_lane_busy() {
+            return Vec::new();
+        }
+        if let Some(token) = self.personal_state.sync.deferred_automatic.take() {
+            return self.start_automatic_sync(token);
+        }
+        self.poll_automatic_sync()
+    }
+
+    pub(crate) fn enable_automatic_sync(&mut self) -> Vec<Cmd> {
+        if let Some(device_id) = self.personal_state.device_id.as_ref() {
+            self.personal_state
+                .sync
+                .scheduler
+                .configure_jitter(crate::sync::BackoffJitter::stable_for(device_id.as_str()));
+        }
+        let token = self
+            .personal_state
+            .sync
+            .scheduler
+            .enable(std::time::Instant::now());
+        token.map_or_else(Vec::new, |token| self.start_automatic_sync(token))
+    }
+
+    pub(crate) fn disable_automatic_sync(&mut self) {
+        self.personal_state.sync.scheduler.disable();
+        if let Some(token) = self.personal_state.sync.deferred_automatic.take() {
+            let _ = self.personal_state.sync.scheduler.finish(
+                token,
+                crate::sync::SyncAttemptOutcome::Failed,
+                std::time::Instant::now(),
+            );
+        }
+    }
+
+    pub(crate) fn automatic_sync_deadline(&self) -> Option<std::time::Instant> {
+        if self.personal_sync_lane_busy() {
+            return None;
+        }
+        self.personal_state.sync.scheduler.next_deadline()
+    }
+
+    pub(crate) fn automatic_sync_waiting_for_connectivity(&self) -> bool {
+        !self.personal_sync_lane_busy()
+            && self
+                .personal_state
+                .sync
+                .scheduler
+                .waiting_for_connectivity()
+    }
+
+    pub(crate) fn poll_automatic_sync(&mut self) -> Vec<Cmd> {
+        if self.personal_sync_lane_busy() {
+            return Vec::new();
+        }
+        let token = self
+            .personal_state
+            .sync
+            .scheduler
+            .poll(std::time::Instant::now());
+        token.map_or_else(Vec::new, |token| self.start_automatic_sync(token))
+    }
+
+    pub(crate) fn note_personal_state_mutation(&mut self) -> Vec<Cmd> {
+        let token = self
+            .personal_state
+            .sync
+            .scheduler
+            .local_mutation(std::time::Instant::now());
+        token.map_or_else(Vec::new, |token| self.start_automatic_sync(token))
+    }
+
+    pub(crate) fn note_webdav_connectivity(&mut self) -> Vec<Cmd> {
+        let token = self
+            .personal_state
+            .sync
+            .scheduler
+            .network_reconnected(std::time::Instant::now());
+        token.map_or_else(Vec::new, |token| self.start_automatic_sync(token))
+    }
+
+    fn refresh_open_sync_ui(&mut self) -> Vec<Cmd> {
+        if self.mode != Mode::Settings
+            || !self
+                .settings
+                .as_ref()
+                .is_some_and(|settings| settings.tab == SettingsTab::Sync)
+            || self.personal_state.sync_ui.flow_id == 0
+        {
+            return Vec::new();
+        }
+        self.queue_sync_ui_refresh();
+        self.start_pending_sync_ui_refresh()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::*;
+    use crate::app::sync_ui::SyncBusy;
+    use tokio::sync::oneshot;
+
+    fn configured_app(device_id: &str) -> App {
+        let mut app = App::new(50);
+        app.personal_state.device_id =
+            Some(crate::personal_state::DeviceId::new(device_id).unwrap());
+        app
+    }
+
+    #[test]
+    fn activation_race_defers_the_exact_automatic_token() {
+        let mut app = configured_app("device-a");
+        app.personal_state.sync.in_progress = true;
+
+        assert!(app.enable_automatic_sync().is_empty());
+        let token = app
+            .personal_state
+            .sync
+            .scheduler
+            .in_flight()
+            .expect("startup token remains owned");
+        assert_eq!(
+            token.kind(),
+            crate::sync::SyncAttemptKind::Automatic(crate::sync::AutomaticSyncTrigger::Startup)
+        );
+        assert_eq!(app.personal_state.sync.deferred_automatic, Some(token));
+        assert_eq!(app.automatic_sync_deadline(), None);
+
+        app.personal_state.sync.in_progress = false;
+        assert!(matches!(
+            app.resume_automatic_sync_if_ready().as_slice(),
+            [Cmd::Data(DataCmd::PersonalSync {
+                action: PersonalSyncAction::AutomaticSync,
+                ..
+            })]
+        ));
+        assert_eq!(app.personal_state.sync.scheduler.in_flight(), Some(token));
+        assert_eq!(app.personal_state.sync.deferred_automatic, None);
+    }
+
+    #[test]
+    fn pairing_mutation_defers_automatic_sync_until_the_owner_lane_settles() {
+        let mut app = configured_app("device-a");
+        app.personal_state.sync_ui.busy = Some(SyncBusy::PairHostApprove);
+
+        assert!(app.enable_automatic_sync().is_empty());
+        let token = app
+            .personal_state
+            .sync
+            .scheduler
+            .in_flight()
+            .expect("startup token remains owned");
+        assert_eq!(app.personal_state.sync.deferred_automatic, Some(token));
+
+        app.personal_state.sync_ui.busy = None;
+        assert!(matches!(
+            app.start_pending_sync_ui_refresh().as_slice(),
+            [Cmd::Data(DataCmd::PersonalSync {
+                action: PersonalSyncAction::AutomaticSync,
+                ..
+            })]
+        ));
+        assert_eq!(app.personal_state.sync.scheduler.in_flight(), Some(token));
+        assert_eq!(app.personal_state.sync.deferred_automatic, None);
+    }
+
+    #[test]
+    fn due_automatic_cause_is_not_consumed_while_pairing_mutates_the_vault() {
+        let mut app = configured_app("device-a");
+        let due_at = Instant::now()
+            .checked_sub(crate::sync::FALLBACK_INTERVAL)
+            .expect("test clock has a fallback interval");
+        let startup = app.personal_state.sync.scheduler.enable(due_at).unwrap();
+        let _ = app.personal_state.sync.scheduler.finish(
+            startup,
+            crate::sync::SyncAttemptOutcome::Succeeded,
+            due_at,
+        );
+        app.personal_state.sync_ui.busy = Some(SyncBusy::PairHostApprove);
+
+        assert!(app.poll_automatic_sync().is_empty());
+        assert_eq!(app.personal_state.sync.scheduler.in_flight(), None);
+
+        app.personal_state.sync_ui.busy = None;
+        assert!(matches!(
+            app.resume_automatic_sync_if_ready().as_slice(),
+            [Cmd::Data(DataCmd::PersonalSync {
+                action: PersonalSyncAction::AutomaticSync,
+                ..
+            })]
+        ));
+        assert!(matches!(
+            app.personal_state
+                .sync
+                .scheduler
+                .in_flight()
+                .unwrap()
+                .kind(),
+            crate::sync::SyncAttemptKind::Automatic(crate::sync::AutomaticSyncTrigger::Fallback)
+        ));
+    }
+
+    #[test]
+    fn refresh_and_recovery_work_do_not_block_personal_sync() {
+        for busy in [SyncBusy::Refresh, SyncBusy::RecoveryExport] {
+            let mut app = configured_app("device-a");
+            app.personal_state.sync_ui.busy = Some(busy);
+
+            assert!(matches!(
+                app.enable_automatic_sync().as_slice(),
+                [Cmd::Data(DataCmd::PersonalSync {
+                    action: PersonalSyncAction::AutomaticSync,
+                    ..
+                })]
+            ));
+        }
+    }
+
+    #[test]
+    fn remote_sync_now_is_rejected_while_pairing_mutates_the_vault() {
+        let mut app = configured_app("device-a");
+        app.personal_state.sync_ui.busy = Some(SyncBusy::PairHostApprove);
+        let (reply, mut response) = oneshot::channel();
+
+        let commands = app.start_personal_sync(PersonalSyncAction::SyncNow, reply.into());
+
+        assert!(commands.is_empty());
+        assert_eq!(
+            response.try_recv().unwrap().reason.as_deref(),
+            Some("sync_busy")
+        );
+        assert!(!app.personal_state.sync.in_progress);
+        assert_eq!(app.personal_state.sync.scheduler.in_flight(), None);
+    }
+
+    #[test]
+    fn successful_webdav_pairing_poll_bypasses_only_latched_offline_backoff() {
+        let mut app = configured_app("device-a");
+        let _ = app.enable_automatic_sync();
+        let startup = app.personal_state.sync.scheduler.in_flight().unwrap();
+        let retry_due_before = Instant::now();
+        let _ = app.personal_state.sync.scheduler.finish(
+            startup,
+            crate::sync::SyncAttemptOutcome::Offline { retry_after: None },
+            retry_due_before,
+        );
+        app.personal_state.sync.in_progress = false;
+        app.personal_state.sync.pending_reply = None;
+        app.personal_state.sync_ui.flow_id = 1;
+        app.personal_state.sync_ui.busy = Some(SyncBusy::PairJoinPoll);
+
+        let commands = app.reduce_sync_ui_event(SyncUiEvent::JoinPolled {
+            flow_id: 1,
+            result: Box::new(Ok(None)),
+        });
+        assert!(commands.iter().any(|command| matches!(
+            command,
+            Cmd::Data(DataCmd::PersonalSync {
+                action: PersonalSyncAction::AutomaticSync,
+                ..
+            })
+        )));
+        assert!(matches!(
+            app.personal_state
+                .sync
+                .scheduler
+                .in_flight()
+                .unwrap()
+                .kind(),
+            crate::sync::SyncAttemptKind::Automatic(
+                crate::sync::AutomaticSyncTrigger::NetworkReconnect
+            )
+        ));
+    }
+
+    #[test]
+    fn successful_webdav_work_without_offline_latch_does_not_add_an_attempt() {
+        let mut app = configured_app("device-a");
+        let _ = app.enable_automatic_sync();
+        let startup = app.personal_state.sync.scheduler.in_flight().unwrap();
+        let now = Instant::now();
+        let _ = app.personal_state.sync.scheduler.finish(
+            startup,
+            crate::sync::SyncAttemptOutcome::Succeeded,
+            now,
+        );
+        app.personal_state.sync.in_progress = false;
+        app.personal_state.sync.pending_reply = None;
+        let fallback_due = app.personal_state.sync.scheduler.next_deadline();
+        app.personal_state.sync_ui.flow_id = 1;
+        app.personal_state.sync_ui.busy = Some(SyncBusy::PairJoinPoll);
+
+        assert!(
+            app.reduce_sync_ui_event(SyncUiEvent::JoinPolled {
+                flow_id: 1,
+                result: Box::new(Ok(None)),
+            })
+            .is_empty()
+        );
+        assert_eq!(app.personal_state.sync.scheduler.in_flight(), None);
+        assert_eq!(
+            app.personal_state.sync.scheduler.next_deadline(),
+            fallback_due
+        );
+    }
+
+    #[test]
+    fn an_open_sync_page_refreshes_for_automatic_start_and_settlement() {
+        let mut app = configured_app("device-a");
+        app.open_settings();
+        app.settings.as_mut().unwrap().tab = SettingsTab::Sync;
+        app.personal_state.sync_ui.flow_id = 7;
+
+        let started = app.enable_automatic_sync();
+        assert!(started.iter().any(|command| matches!(
+            command,
+            Cmd::Data(DataCmd::PersonalSync {
+                action: PersonalSyncAction::AutomaticSync,
+                ..
+            })
+        )));
+        assert!(started.iter().any(|command| matches!(
+            command,
+            Cmd::Data(DataCmd::SyncUi(SyncUiCommand::Refresh {
+                flow_id: 7,
+                in_progress: true,
+                ..
+            }))
+        )));
+
+        let reply = app
+            .personal_state
+            .sync
+            .pending_reply
+            .clone()
+            .expect("automatic reply");
+        app.personal_state.sync.in_progress = false;
+        app.personal_state.sync.pending_reply = None;
+        app.personal_state.sync_ui.busy = None;
+        app.personal_state.sync_ui.refresh_in_flight = None;
+        let settled = app.finish_personal_sync_schedule(&reply, SyncServiceError::Offline);
+        assert!(settled.iter().any(|command| matches!(
+            command,
+            Cmd::Data(DataCmd::SyncUi(SyncUiCommand::Refresh {
+                flow_id: 7,
+                in_progress: false,
+                ..
+            }))
+        )));
+    }
+
+    #[test]
+    fn a_previously_visited_sync_page_does_not_refresh_while_closed() {
+        let mut app = configured_app("device-a");
+        app.personal_state.sync_ui.flow_id = 7;
+
+        let commands = app.enable_automatic_sync();
+
+        assert!(commands.iter().any(|command| matches!(
+            command,
+            Cmd::Data(DataCmd::PersonalSync {
+                action: PersonalSyncAction::AutomaticSync,
+                ..
+            })
+        )));
+        assert!(!commands.iter().any(|command| matches!(
+            command,
+            Cmd::Data(DataCmd::SyncUi(SyncUiCommand::Refresh { .. }))
+        )));
+    }
+
+    #[test]
+    fn debounce_starts_only_for_the_latest_durable_personal_state_revision() {
+        let mut app = configured_app("device-a");
+        app.personal_state.ledger.revision = 7;
+        let now = Instant::now();
+        let startup = app.personal_state.sync.scheduler.enable(now).unwrap();
+        let _ = app.personal_state.sync.scheduler.finish(
+            startup,
+            crate::sync::SyncAttemptOutcome::Succeeded,
+            now,
+        );
+        let fallback = app.personal_state.sync.scheduler.next_deadline();
+        let state_identity = app.personal_state.ledger.identity().unwrap();
+
+        assert!(
+            app.update(Msg::PersonalStatePersisted {
+                revision: 6,
+                state_identity: state_identity.clone(),
+            })
+            .is_empty()
+        );
+        assert_eq!(app.personal_state.sync.scheduler.next_deadline(), fallback);
+        assert!(
+            app.update(Msg::PersonalStatePersisted {
+                revision: 7,
+                state_identity: "stale-state-identity".to_owned(),
+            })
+            .is_empty()
+        );
+        assert_eq!(app.personal_state.sync.scheduler.next_deadline(), fallback);
+
+        let before = Instant::now();
+        assert!(
+            app.update(Msg::PersonalStatePersisted {
+                revision: 7,
+                state_identity,
+            })
+            .is_empty()
+        );
+        let debounce = app
+            .personal_state
+            .sync
+            .scheduler
+            .next_deadline()
+            .unwrap()
+            .duration_since(before);
+        assert!(debounce >= crate::sync::LOCAL_MUTATION_DEBOUNCE);
+        assert!(debounce <= crate::sync::LOCAL_MUTATION_DEBOUNCE + Duration::from_secs(1));
+    }
+
+    #[test]
+    fn owner_configures_stable_device_jitter_before_enabling() {
+        let mut app = configured_app("device-a");
+        assert_eq!(app.enable_automatic_sync().len(), 1);
+        let token = app
+            .personal_state
+            .sync
+            .scheduler
+            .in_flight()
+            .expect("startup token");
+        let now = Instant::now();
+        let _ = app.personal_state.sync.scheduler.finish(
+            token,
+            crate::sync::SyncAttemptOutcome::Offline { retry_after: None },
+            now,
+        );
+
+        let mut expected = crate::sync::AutomaticSyncScheduler::new(
+            crate::sync::BackoffJitter::stable_for("device-a"),
+        );
+        let expected_token = expected.enable(now).unwrap();
+        let _ = expected.finish(
+            expected_token,
+            crate::sync::SyncAttemptOutcome::Offline { retry_after: None },
+            now,
+        );
+        let actual_delay = app
+            .personal_state
+            .sync
+            .scheduler
+            .next_deadline()
+            .unwrap()
+            .duration_since(now);
+        assert_eq!(
+            actual_delay,
+            expected.next_deadline().unwrap().duration_since(now)
+        );
+        assert!(actual_delay >= crate::sync::BACKOFF_MIN);
+    }
+
+    #[test]
+    fn youtube_api_success_does_not_bypass_webdav_backoff() {
+        let mut app = configured_app("device-a");
+        let _ = app.enable_automatic_sync();
+        let token = app
+            .personal_state
+            .sync
+            .scheduler
+            .in_flight()
+            .expect("startup token");
+        let now = Instant::now();
+        let _ = app.personal_state.sync.scheduler.finish(
+            token,
+            crate::sync::SyncAttemptOutcome::Offline { retry_after: None },
+            now,
+        );
+        app.personal_state.sync.in_progress = false;
+        app.personal_state.sync.pending_reply = None;
+        let retry_due = app.personal_state.sync.scheduler.next_deadline();
+
+        let _ = app.update(Msg::ApiModeResolved {
+            mode: ApiMode::Authenticated,
+            had_cookie: false,
+        });
+
+        assert_eq!(app.personal_state.sync.scheduler.in_flight(), None);
+        assert_eq!(app.personal_state.sync.scheduler.next_deadline(), retry_due);
+    }
+
+    #[test]
+    fn rate_limit_retry_hint_is_forwarded_to_the_scheduler() {
+        let mut app = configured_app("device-a");
+        let _ = app.enable_automatic_sync();
+        let token = app
+            .personal_state
+            .sync
+            .scheduler
+            .in_flight()
+            .expect("startup token");
+        let reply = PersonalSyncReply::automatic(token);
+        let before = Instant::now();
+
+        assert!(
+            app.finish_personal_sync_schedule(
+                &reply,
+                SyncServiceError::RateLimited(Some(Duration::from_secs(75))),
+            )
+            .is_empty()
+        );
+
+        let delay = app
+            .personal_state
+            .sync
+            .scheduler
+            .next_deadline()
+            .unwrap()
+            .duration_since(before);
+        assert!(delay >= Duration::from_secs(75));
+        assert!(delay <= Duration::from_secs(76));
+    }
+}

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -11,6 +11,7 @@ impl App {
             &StationStore::default(),
         )
         .unwrap_or_default();
+        let revision_guard = crate::sync::OwnerRevisionGuard::new(personal_state.revision);
         Self {
             should_quit: false,
             dirty: true,
@@ -32,6 +33,7 @@ impl App {
             personal_export: PersonalDataExportState::default(),
             personal_state: PersonalStateRuntime {
                 ledger: personal_state,
+                revision_guard,
                 sync_ui: SyncUiState::default(),
                 ..PersonalStateRuntime::default()
             },

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -84,6 +84,7 @@ pub use search_types::*;
 mod types;
 pub use types::*;
 
+mod automatic_sync;
 mod bootstrap;
 mod data_export;
 mod feedback;

--- a/src/app/personal_sync.rs
+++ b/src/app/personal_sync.rs
@@ -11,6 +11,7 @@ const MAX_STALE_RETRIES: u8 = 3;
 #[derive(Clone)]
 pub enum PersonalSyncAction {
     SyncNow,
+    AutomaticSync,
     Revoke(crate::personal_state::DeviceId),
 }
 
@@ -24,6 +25,8 @@ pub struct PersonalSyncReply(std::sync::Arc<PersonalSyncReplyInner>);
 struct PersonalSyncReplyInner {
     remote: std::sync::Mutex<Option<crate::remote::RemoteReply>>,
     tui_flow_id: Option<u64>,
+    token: std::sync::Mutex<Option<crate::sync::SyncAttemptToken>>,
+    automatic: bool,
 }
 
 impl PersonalSyncReply {
@@ -31,6 +34,8 @@ impl PersonalSyncReply {
         Self(std::sync::Arc::new(PersonalSyncReplyInner {
             remote: std::sync::Mutex::new(Some(reply)),
             tui_flow_id: None,
+            token: std::sync::Mutex::new(None),
+            automatic: false,
         }))
     }
 
@@ -38,11 +43,42 @@ impl PersonalSyncReply {
         Self(std::sync::Arc::new(PersonalSyncReplyInner {
             remote: std::sync::Mutex::new(None),
             tui_flow_id: Some(flow_id),
+            token: std::sync::Mutex::new(None),
+            automatic: false,
+        }))
+    }
+
+    pub(super) fn automatic(token: crate::sync::SyncAttemptToken) -> Self {
+        Self(std::sync::Arc::new(PersonalSyncReplyInner {
+            remote: std::sync::Mutex::new(None),
+            tui_flow_id: None,
+            token: std::sync::Mutex::new(Some(token)),
+            automatic: true,
         }))
     }
 
     pub(crate) fn tui_flow_id(&self) -> Option<u64> {
         self.0.tui_flow_id
+    }
+
+    fn bind_token(&self, token: crate::sync::SyncAttemptToken) {
+        *self
+            .0
+            .token
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(token);
+    }
+
+    pub(super) fn token(&self) -> Option<crate::sync::SyncAttemptToken> {
+        *self
+            .0
+            .token
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn is_automatic(&self) -> bool {
+        self.0.automatic
     }
 
     pub(crate) fn respond(&self, response: crate::remote::proto::RemoteResponse) {
@@ -104,6 +140,9 @@ pub struct PersonalSyncPersisted {
 pub(crate) struct PersonalSyncState {
     pub(crate) in_progress: bool,
     pub(crate) pending_reply: Option<PersonalSyncReply>,
+    pub(super) scheduler: crate::sync::AutomaticSyncScheduler,
+    pub(super) deferred_automatic: Option<crate::sync::SyncAttemptToken>,
+    last_automatic_failure: Option<SyncServiceError>,
     shutdown_context: Option<PersonalSyncShutdownContext>,
 }
 
@@ -115,8 +154,23 @@ pub(crate) struct PersonalSyncState {
 pub(crate) struct PersonalStateRuntime {
     pub(crate) ledger: crate::personal_state::PersonalStateV2,
     pub(crate) device_id: Option<crate::personal_state::DeviceId>,
+    pub(crate) revision_guard: crate::sync::OwnerRevisionGuard,
     pub(crate) sync: PersonalSyncState,
     pub(crate) sync_ui: SyncUiState,
+}
+
+impl PersonalStateRuntime {
+    pub(crate) fn replace_ledger(&mut self, state: crate::personal_state::PersonalStateV2) {
+        if self.ledger != state {
+            self.revision_guard.publish(state.revision);
+        }
+        self.ledger = state;
+    }
+
+    fn guard_for_revision(&self, revision: u64) -> crate::sync::OwnerRevisionGuard {
+        debug_assert_eq!(self.ledger.revision, revision);
+        self.revision_guard.clone()
+    }
 }
 
 #[derive(Clone)]
@@ -145,11 +199,18 @@ impl App {
         self.start_personal_sync_with_reply(action, PersonalSyncReply::tui(flow_id))
     }
 
-    fn start_personal_sync_with_reply(
+    pub(super) fn start_personal_sync_with_reply(
         &mut self,
         action: PersonalSyncAction,
         reply: PersonalSyncReply,
     ) -> Vec<Cmd> {
+        if self.personal_state.sync_ui.remote_mutation_in_progress() {
+            reply.respond(RemoteResponse::err_with_message(
+                "sync_busy",
+                "personal sync is already running".to_owned(),
+            ));
+            return Vec::new();
+        }
         if self.personal_state.sync.in_progress {
             if let Some(flow_id) = reply.tui_flow_id() {
                 self.finish_tui_personal_sync_error(flow_id, SyncServiceError::LocalStateChanged);
@@ -160,27 +221,59 @@ impl App {
             ));
             return Vec::new();
         }
+        if !reply.is_automatic() {
+            let token = match self
+                .personal_state
+                .sync
+                .scheduler
+                .begin_manual(std::time::Instant::now())
+            {
+                Ok(token) => token,
+                Err(_) => {
+                    if let Some(flow_id) = reply.tui_flow_id() {
+                        self.finish_tui_personal_sync_error(
+                            flow_id,
+                            SyncServiceError::LocalStateChanged,
+                        );
+                    }
+                    reply.respond(RemoteResponse::err_with_message(
+                        "sync_busy",
+                        "personal sync is already running".to_owned(),
+                    ));
+                    return Vec::new();
+                }
+            };
+            reply.bind_token(token);
+        }
         if self.personal_state.device_id.is_none() {
             if let Some(flow_id) = reply.tui_flow_id() {
                 self.finish_tui_personal_sync_error(flow_id, SyncServiceError::NotConfigured);
             }
             reply.respond(sync_error_response(SyncServiceError::NotConfigured));
+            let _ = self.finish_personal_sync_schedule(&reply, SyncServiceError::NotConfigured);
             return Vec::new();
         }
         self.personal_state.sync.in_progress = true;
         self.personal_state.sync.pending_reply = Some(reply.clone());
-        self.status.text = crate::t!(
-            "Syncing personal state…",
-            "개인 상태 동기화 중…",
-            "個人状態を同期中…"
-        )
-        .to_owned();
-        self.status.kind = StatusKind::Info;
-        self.dirty = true;
+        if !reply.is_automatic() {
+            self.status.text = crate::t!(
+                "Syncing personal state…",
+                "개인 상태 동기화 중…",
+                "個人状態を同期中…"
+            )
+            .to_owned();
+            self.status.kind = StatusKind::Info;
+            self.dirty = true;
+        }
+        let personal_state = self.personal_state.ledger.clone();
+        let revision_guard = self
+            .personal_state
+            .guard_for_revision(personal_state.revision);
         vec![Cmd::Data(DataCmd::PersonalSync {
             action,
             attempt: 1,
-            personal_state: Box::new(self.personal_state.ledger.clone()),
+            personal_state: Box::new(personal_state),
+            revision_guard,
             reply,
         })]
     }
@@ -195,8 +288,7 @@ impl App {
         let current_state = match self.reconcile_personal_state(&self.playlists) {
             Ok(state) => state,
             Err(_) => {
-                self.finish_personal_sync_error(&prepared.reply, SyncServiceError::Storage);
-                return Vec::new();
+                return self.finish_personal_sync_error(&prepared.reply, SyncServiceError::Storage);
             }
         };
         match prepared.result {
@@ -229,10 +321,7 @@ impl App {
                     },
                 )))]
             }
-            Err(error) => {
-                self.finish_personal_sync_error(&prepared.reply, error);
-                Vec::new()
-            }
+            Err(error) => self.finish_personal_sync_error(&prepared.reply, error),
         }
     }
 
@@ -249,15 +338,14 @@ impl App {
         } = persisted;
         match outcome {
             PersonalSyncPersistOutcome::Failed(error) => {
-                self.finish_personal_sync_error(&commit.reply, error);
-                Vec::new()
+                self.finish_personal_sync_error(&commit.reply, error)
             }
             PersonalSyncPersistOutcome::Superseded => {
                 let current = match self.reconcile_personal_state(&self.playlists) {
                     Ok(state) => state,
                     Err(_) => {
-                        self.finish_personal_sync_error(&commit.reply, SyncServiceError::Storage);
-                        return Vec::new();
+                        return self
+                            .finish_personal_sync_error(&commit.reply, SyncServiceError::Storage);
                     }
                 };
                 self.retry_personal_sync(commit.action, commit.attempt, current, commit.reply)
@@ -266,19 +354,18 @@ impl App {
                 let current = match self.reconcile_personal_state(&self.playlists) {
                     Ok(state) => state,
                     Err(_) => {
-                        self.finish_personal_sync_error(&commit.reply, SyncServiceError::Storage);
-                        return Vec::new();
+                        return self
+                            .finish_personal_sync_error(&commit.reply, SyncServiceError::Storage);
                     }
                 };
                 if current != commit.observed_local_state {
                     let local_device = match &self.personal_state.device_id {
                         Some(device) => device,
                         None => {
-                            self.finish_personal_sync_error(
+                            return self.finish_personal_sync_error(
                                 &commit.reply,
                                 SyncServiceError::NotConfigured,
                             );
-                            return Vec::new();
                         }
                     };
                     let rebased = match rebase_local_operations(
@@ -289,8 +376,7 @@ impl App {
                     ) {
                         Ok(state) => state,
                         Err(error) => {
-                            self.finish_personal_sync_error(&commit.reply, error);
-                            return Vec::new();
+                            return self.finish_personal_sync_error(&commit.reply, error);
                         }
                     };
                     commit.observed_local_state = current;
@@ -302,8 +388,7 @@ impl App {
                     return vec![Cmd::Persist(PersistCmd::PersonalSyncCommit(commit))];
                 }
                 if let Err(error) = self.install_personal_sync_runtime(*durable_state) {
-                    self.finish_personal_sync_error(&commit.reply, error);
-                    return Vec::new();
+                    return self.finish_personal_sync_error(&commit.reply, error);
                 }
                 self.personal_state.sync.in_progress = false;
                 self.personal_state.sync.pending_reply = None;
@@ -312,18 +397,19 @@ impl App {
                 commit.reply.respond(RemoteResponse::ok(message.clone()));
                 if let Some(flow_id) = commit.reply.tui_flow_id() {
                     self.finish_tui_personal_sync(flow_id, &commit.action, &commit.summary);
-                    return Vec::new();
-                } else {
+                } else if !commit.reply.is_automatic() {
                     self.status.text = message;
                     self.status.kind = StatusKind::Info;
                     self.dirty = true;
                 }
-                Vec::new()
+                self.personal_state.sync.last_automatic_failure = None;
+                self.finish_personal_sync_schedule_success(&commit.reply)
             }
         }
     }
 
     pub(crate) fn settle_personal_sync_shutdown(&mut self) {
+        self.disable_automatic_sync();
         self.personal_state.sync.in_progress = false;
         if let Some(reply) = self.personal_state.sync.pending_reply.take() {
             reply.respond(RemoteResponse::err(
@@ -400,26 +486,44 @@ impl App {
         reply: PersonalSyncReply,
     ) -> Vec<Cmd> {
         if attempt >= MAX_STALE_RETRIES {
-            self.finish_personal_sync_error(&reply, SyncServiceError::LocalStateChanged);
-            return Vec::new();
+            return self.finish_personal_sync_error(&reply, SyncServiceError::LocalStateChanged);
         }
+        let revision_guard = self
+            .personal_state
+            .guard_for_revision(current_state.revision);
         vec![Cmd::Data(DataCmd::PersonalSync {
             action,
             attempt: attempt.saturating_add(1),
             personal_state: Box::new(current_state),
+            revision_guard,
             reply,
         })]
     }
 
-    fn finish_personal_sync_error(&mut self, reply: &PersonalSyncReply, error: SyncServiceError) {
+    fn finish_personal_sync_error(
+        &mut self,
+        reply: &PersonalSyncReply,
+        error: SyncServiceError,
+    ) -> Vec<Cmd> {
+        let automatic_failure = match error {
+            SyncServiceError::RateLimited(_) => SyncServiceError::Offline,
+            error => error,
+        };
         self.personal_state.sync.in_progress = false;
         self.personal_state.sync.pending_reply = None;
+        self.personal_state.sync.shutdown_context = None;
         reply.respond(sync_error_response(error));
         if let Some(flow_id) = reply.tui_flow_id() {
             self.finish_tui_personal_sync_error(flow_id, error);
-        } else {
+        } else if !reply.is_automatic()
+            || self.personal_state.sync.last_automatic_failure != Some(automatic_failure)
+        {
             self.set_status_error(error.to_string());
         }
+        if reply.is_automatic() {
+            self.personal_state.sync.last_automatic_failure = Some(automatic_failure);
+        }
+        self.finish_personal_sync_schedule(reply, error)
     }
 
     pub(in crate::app) fn install_personal_sync_runtime(
@@ -433,7 +537,7 @@ impl App {
         .map_err(SyncServiceError::from)?;
         let (library, mut playlists, signals, station) = prepared.runtime_stores();
         playlists.inherit_revision_from(&self.playlists);
-        self.personal_state.ledger = prepared.state().clone();
+        self.personal_state.replace_ledger(prepared.state().clone());
         self.library = Arc::new(library);
         self.playlists = Arc::new(playlists);
         self.signals = Arc::new(signals);
@@ -575,6 +679,35 @@ mod tests {
             second_response.try_recv().unwrap().reason.as_deref(),
             Some("sync_busy")
         );
+    }
+
+    #[test]
+    fn delayed_max_revision_persist_event_cannot_confirm_different_live_content() {
+        let mut app = App::new(50);
+        let mut durable = app.personal_state.ledger.clone();
+        durable.revision = u64::MAX;
+        let stale_identity = durable.identity().unwrap();
+        let mut live = durable;
+        live.metadata.source_app_version = "different-live-content".to_owned();
+        app.personal_state.replace_ledger(live);
+
+        let now = std::time::Instant::now();
+        let startup = app.personal_state.sync.scheduler.enable(now).unwrap();
+        let _ = app.personal_state.sync.scheduler.finish(
+            startup,
+            crate::sync::SyncAttemptOutcome::Succeeded,
+            now,
+        );
+        let fallback = app.personal_state.sync.scheduler.next_deadline();
+
+        assert!(
+            app.update(Msg::PersonalStatePersisted {
+                revision: u64::MAX,
+                state_identity: stale_identity,
+            })
+            .is_empty()
+        );
+        assert_eq!(app.personal_state.sync.scheduler.next_deadline(), fallback);
     }
 
     #[test]
@@ -796,6 +929,7 @@ mod tests {
             Cmd::Data(DataCmd::PersonalSync {
                 attempt,
                 personal_state,
+                revision_guard,
                 ..
             }),
         ] = commands.as_slice()
@@ -804,9 +938,44 @@ mod tests {
         };
         assert_eq!(*attempt, 2);
         assert_eq!(personal_state.revision, app.personal_state.ledger.revision);
+        assert_eq!(revision_guard.current(), personal_state.revision);
+        let mut next = app.personal_state.ledger.clone();
+        next.revision = next.revision.checked_add(1).unwrap();
+        app.personal_state.replace_ledger(next);
+        assert_eq!(revision_guard.current(), personal_state.revision + 1);
         assert!(response.try_recv().is_err());
         assert!(app.personal_state.sync.in_progress);
         assert!(app.personal_state.sync.shutdown_context.is_none());
+    }
+
+    #[test]
+    fn rate_limit_and_offline_share_one_automatic_failure_notification() {
+        let mut app = App::new(50);
+        app.personal_state.device_id =
+            Some(crate::personal_state::DeviceId::new("device-a").unwrap());
+        let first_token = app
+            .personal_state
+            .sync
+            .scheduler
+            .enable(std::time::Instant::now())
+            .unwrap();
+        let first_reply = PersonalSyncReply::automatic(first_token);
+        app.personal_state.sync.in_progress = true;
+
+        let _ = app.finish_personal_sync_error(
+            &first_reply,
+            SyncServiceError::RateLimited(Some(std::time::Duration::from_secs(75))),
+        );
+        let first_message = app.status.text.clone();
+        assert!(first_message.contains("75 seconds"));
+
+        let retry_due = app.personal_state.sync.scheduler.next_deadline().unwrap();
+        let retry_token = app.personal_state.sync.scheduler.poll(retry_due).unwrap();
+        let retry_reply = PersonalSyncReply::automatic(retry_token);
+        app.personal_state.sync.in_progress = true;
+        let _ = app.finish_personal_sync_error(&retry_reply, SyncServiceError::Offline);
+
+        assert_eq!(app.status.text, first_message);
     }
 
     #[test]

--- a/src/app/reducer.rs
+++ b/src/app/reducer.rs
@@ -1112,6 +1112,7 @@ impl App {
                 return self.handle_api_mode_resolved(mode, had_cookie);
             }
             Msg::StatusTick => return self.handle_status_tick(),
+            Msg::AutomaticSyncTick => return self.poll_automatic_sync(),
             Msg::LyricsTick => {
                 if self.lyrics_tick_at(Instant::now()) {
                     self.dirty = true;
@@ -1191,6 +1192,22 @@ impl App {
             } => return self.apply_deleted_downloads(root, deleted, failed),
             Msg::PersistFailed { store, error } => {
                 return self.handle_persist_failed(store, error);
+            }
+            Msg::PersonalStatePersisted {
+                revision,
+                state_identity,
+            } => {
+                return if self.personal_state.ledger.revision == revision
+                    && self
+                        .personal_state
+                        .ledger
+                        .identity()
+                        .is_ok_and(|identity| identity == state_identity)
+                {
+                    self.note_personal_state_mutation()
+                } else {
+                    Vec::new()
+                };
             }
             Msg::Streaming(sm) => return self.handle_streaming(sm),
             // --- DJ Gem assistant intents ---------------------------------------

--- a/src/app/settings_reducer/transfer.rs
+++ b/src/app/settings_reducer/transfer.rs
@@ -132,9 +132,10 @@ impl App {
                         self.plan_transfer_playlist_commit(request, patch, true)
                     }
                     TargetFlushOutcome::CommittedExact => {
+                        let previous_personal_revision = self.personal_state.ledger.revision;
                         self.playlists = std::sync::Arc::new(candidate);
                         if let Some(personal_state) = personal_state {
-                            self.personal_state.ledger = personal_state;
+                            self.personal_state.replace_ledger(personal_state);
                         }
                         self.reconcile_playlists_reload();
                         self.dirty = true;
@@ -143,7 +144,11 @@ impl App {
                                 outcome,
                             ),
                         ));
-                        Vec::new()
+                        if self.personal_state.ledger.revision != previous_personal_revision {
+                            self.note_personal_state_mutation()
+                        } else {
+                            Vec::new()
+                        }
                     }
                 }
             }
@@ -477,6 +482,54 @@ mod tests {
         };
         assert_eq!(outcome.rows[0].checkpoint_index, 4);
         assert_eq!(outcome.rows[0].result, AddResult::Added);
+    }
+
+    #[test]
+    fn exact_transfer_commit_arms_the_automatic_sync_debounce() {
+        let mut app = App::new(50);
+        let (commit, mut reply) = begin(&mut app, 6);
+        let prepared = app
+            .reconcile_personal_state(&commit.candidate)
+            .and_then(|state| {
+                crate::personal_state::PersonalStateCommit::prepare_for_runtime(
+                    state,
+                    commit.candidate.revision(),
+                )
+            })
+            .unwrap();
+        let now = std::time::Instant::now();
+        let startup = app.personal_state.sync.scheduler.enable(now).unwrap();
+        let _ = app.personal_state.sync.scheduler.finish(
+            startup,
+            crate::sync::SyncAttemptOutcome::Succeeded,
+            now,
+        );
+        let before = std::time::Instant::now();
+
+        assert!(
+            app.on_transfer_playlist_persisted_with_personal_state(
+                *commit,
+                TargetFlushOutcome::CommittedExact,
+                prepared.state().clone(),
+            )
+            .is_empty()
+        );
+
+        let due = app
+            .personal_state
+            .sync
+            .scheduler
+            .next_deadline()
+            .expect("transfer mutation debounce");
+        assert!(due >= before + crate::sync::LOCAL_MUTATION_DEBOUNCE);
+        assert!(
+            due <= std::time::Instant::now() + crate::sync::LOCAL_MUTATION_DEBOUNCE,
+            "the transfer mutation must replace the 15-minute fallback"
+        );
+        assert!(matches!(
+            reply.try_recv().expect("durable reply"),
+            Ok(LocalPlaylistOwnerReply::Applied(_))
+        ));
     }
 
     #[test]

--- a/src/app/sync_activation.rs
+++ b/src/app/sync_activation.rs
@@ -80,7 +80,7 @@ impl SyncActivationKind {
                     crate::personal_state::plan_join_import(durable, current, &device_id)?
                         .candidate;
                 if candidate != *current && candidate.revision <= current.revision {
-                    candidate.revision = current.revision.saturating_add(1);
+                    candidate.revision = current.next_revision()?;
                     candidate.projection_fingerprint = None;
                     candidate.normalize()?;
                 }
@@ -279,7 +279,11 @@ impl App {
                     .sync_ui
                     .finish_activation_success(&commit.kind);
                 self.dirty = true;
-                Vec::new()
+                if self.personal_state.device_id.is_some() {
+                    self.enable_automatic_sync()
+                } else {
+                    Vec::new()
+                }
             }
         }
     }

--- a/src/app/sync_ui/event_reducer.rs
+++ b/src/app/sync_ui/event_reducer.rs
@@ -71,7 +71,8 @@ impl super::super::App {
         if !self.personal_state.sync_ui.is_current(flow_id) {
             return Vec::new();
         }
-        match event {
+        let webdav_connectivity = successful_webdav_work(&event);
+        let mut commands = match event {
             SyncUiEvent::Refreshed {
                 request_id, result, ..
             } => {
@@ -359,7 +360,11 @@ impl super::super::App {
                     Vec::new()
                 }
             },
+        };
+        if webdav_connectivity {
+            commands.extend(self.note_webdav_connectivity());
         }
+        commands
     }
 
     fn sync_worker_failed(&mut self, error: crate::sync::service::SyncServiceError) {
@@ -386,6 +391,9 @@ impl super::super::App {
         flow_id: u64,
     ) -> Vec<super::super::Cmd> {
         self.personal_state.sync_ui.auto_poll_enabled = true;
+        if self.personal_state.sync.in_progress {
+            return Vec::new();
+        }
         self.personal_state.sync_ui.busy = Some(SyncBusy::PairJoinPoll);
         self.personal_state.sync_ui.last_poll_unix = Some(crate::signals::unix_now());
         vec![super::super::Cmd::Data(super::super::DataCmd::SyncUi(
@@ -445,6 +453,27 @@ impl super::super::App {
         }
     }
 }
+
+fn successful_webdav_work(event: &SyncUiEvent) -> bool {
+    match event {
+        SyncUiEvent::SetupPrepared { result, .. } => result.is_ok(),
+        SyncUiEvent::HostCreated { result, .. } => result.is_ok(),
+        SyncUiEvent::HostPolled { result, .. } => result.is_ok(),
+        SyncUiEvent::HostApprovalPrepared { result, .. } => result.is_ok(),
+        SyncUiEvent::JoinStarted { result, .. } => result.is_ok(),
+        // A pending join can return `Ok(None)` only after successfully reading the WebDAV
+        // request/approval objects. `Ok(Some(_))` may instead be rebuilt from a cached local
+        // checkpoint, so it is deliberately not connectivity evidence.
+        SyncUiEvent::JoinPolled { result, .. } => matches!(result.as_ref(), Ok(None)),
+        SyncUiEvent::Refreshed { .. }
+        | SyncUiEvent::RecoveryExported { .. }
+        | SyncUiEvent::HostCancelled { .. }
+        | SyncUiEvent::JoinResumed { .. }
+        | SyncUiEvent::JoinDiscarded { .. }
+        | SyncUiEvent::JoinActivationPrepared { .. } => false,
+    }
+}
+
 fn sync_event_flow_id(event: &SyncUiEvent) -> u64 {
     match event {
         SyncUiEvent::Refreshed { flow_id, .. }
@@ -486,6 +515,7 @@ fn host_error_can_retry(error: crate::sync::service::SyncServiceError) -> bool {
             | E::Authentication
             | E::Certificate
             | E::Offline
+            | E::RateLimited(_)
             | E::LocalStateChanged
             | E::Storage
     )
@@ -501,5 +531,48 @@ fn localized_discard_error(error: crate::sync::service::SyncServiceError) -> Str
         )
         .to_owned(),
         _ => localized_sync_error(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_refresh_and_recovery_results_are_not_connectivity_evidence() {
+        assert!(!successful_webdav_work(&SyncUiEvent::Refreshed {
+            flow_id: 1,
+            request_id: 1,
+            result: Box::new(Ok(crate::sync::service::SyncOverview {
+                status: crate::sync::service::SyncStatusReport::default(),
+                lifecycle: crate::sync::service::SyncLifecycleState::Absent,
+                devices: Vec::new(),
+                audit: Vec::new(),
+            })),
+        }));
+        assert!(!successful_webdav_work(&SyncUiEvent::RecoveryExported {
+            flow_id: 1,
+            result: Box::new(Ok(crate::sync::service::RecoveryExportResult {
+                checksum: "redacted-checksum".to_owned(),
+            })),
+        }));
+    }
+
+    #[test]
+    fn join_poll_waiting_result_proves_webdav_connectivity() {
+        assert!(successful_webdav_work(&SyncUiEvent::JoinPolled {
+            flow_id: 1,
+            result: Box::new(Ok(None)),
+        }));
+    }
+
+    #[test]
+    fn join_poll_does_not_start_while_personal_sync_owns_the_lane() {
+        let mut app = super::super::super::App::new(50);
+        app.personal_state.sync.in_progress = true;
+
+        assert!(app.start_join_poll(1).is_empty());
+        assert!(app.personal_state.sync_ui.busy.is_none());
+        assert!(app.personal_state.sync_ui.auto_poll_enabled);
     }
 }

--- a/src/app/sync_ui/mod.rs
+++ b/src/app/sync_ui/mod.rs
@@ -194,6 +194,24 @@ pub(crate) enum SyncBusy {
     RecoveryExport,
 }
 
+impl SyncBusy {
+    /// Whether this worker may mutate the encrypted WebDAV vault.
+    ///
+    /// Personal sync shares one primary-owner network lane with these pairing/setup phases.
+    /// Poll-only host review, local recovery/refresh work, and the personal-sync variants
+    /// themselves deliberately stay outside this classification.
+    pub(crate) fn blocks_personal_sync(self) -> bool {
+        matches!(
+            self,
+            Self::Setup
+                | Self::PairHostCreate
+                | Self::PairHostApprove
+                | Self::PairJoinStart
+                | Self::PairJoinPoll
+        )
+    }
+}
+
 pub(crate) enum SyncWizard {
     Setup {
         form: SyncConnectionForm,
@@ -309,6 +327,10 @@ impl SyncUiState {
         self.busy.is_some() || self.status.state == SyncHealthState::Syncing
     }
 
+    pub(crate) fn remote_mutation_in_progress(&self) -> bool {
+        self.busy.is_some_and(SyncBusy::blocks_personal_sync)
+    }
+
     pub(crate) fn modal_open(&self) -> bool {
         self.wizard.as_ref().is_some_and(SyncWizard::is_modal)
     }
@@ -371,11 +393,12 @@ impl super::App {
     }
 
     pub(crate) fn start_pending_sync_ui_refresh(&mut self) -> Vec<super::Cmd> {
+        let mut commands = self.resume_automatic_sync_if_ready();
         if !self.personal_state.sync_ui.refresh_pending
             || self.personal_state.sync_ui.refresh_in_flight.is_some()
             || self.personal_state.sync_ui.busy.is_some()
         {
-            return Vec::new();
+            return commands;
         }
         let flow_id = self.personal_state.sync_ui.flow_id.max(1);
         if self.personal_state.sync_ui.flow_id == 0 {
@@ -385,14 +408,15 @@ impl super::App {
         self.personal_state.sync_ui.refresh_pending = false;
         self.personal_state.sync_ui.refresh_in_flight = Some(request_id);
         self.personal_state.sync_ui.busy = Some(SyncBusy::Refresh);
-        vec![super::Cmd::Data(super::DataCmd::SyncUi(
+        commands.push(super::Cmd::Data(super::DataCmd::SyncUi(
             SyncUiCommand::Refresh {
                 flow_id,
                 request_id,
                 state: Box::new(self.personal_state.ledger.clone()),
                 in_progress: self.personal_state.sync.in_progress,
             },
-        ))]
+        )));
+        commands
     }
 
     pub(in crate::app) fn finish_sync_ui_event(&mut self, event: SyncUiEvent) -> Vec<super::Cmd> {
@@ -499,7 +523,7 @@ pub(crate) fn localized_sync_error(error: crate::sync::service::SyncServiceError
             "서버 인증서를 확인할 수 없어요.",
             "サーバー証明書を確認できません。"
         ),
-        Error::Offline => crate::t!(
+        Error::Offline | Error::RateLimited(_) => crate::t!(
             "Offline — try again when the server is reachable.",
             "오프라인 — 서버에 연결되면 다시 시도하세요.",
             "オフライン — サーバーに接続できたら再試行してください。"
@@ -536,6 +560,31 @@ pub(crate) fn localized_sync_error(error: crate::sync::service::SyncServiceError
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn personal_sync_blocking_busy_variants_are_exact() {
+        for busy in [
+            SyncBusy::Setup,
+            SyncBusy::PairHostCreate,
+            SyncBusy::PairHostApprove,
+            SyncBusy::PairJoinStart,
+            SyncBusy::PairJoinPoll,
+        ] {
+            assert!(busy.blocks_personal_sync());
+        }
+        for busy in [
+            SyncBusy::Refresh,
+            SyncBusy::SyncNow,
+            SyncBusy::PairHostPoll,
+            SyncBusy::PairHostCancel,
+            SyncBusy::PairJoinDiscard,
+            SyncBusy::PairJoinApply,
+            SyncBusy::Revoke,
+            SyncBusy::RecoveryExport,
+        ] {
+            assert!(!busy.blocks_personal_sync());
+        }
+    }
 
     #[test]
     fn local_device_is_never_a_revoke_row() {

--- a/src/app/sync_ui/wizard_reducer.rs
+++ b/src/app/sync_ui/wizard_reducer.rs
@@ -172,6 +172,20 @@ impl super::super::App {
         form: SyncConnectionForm,
         join: bool,
     ) -> Vec<super::super::Cmd> {
+        if self.personal_state.sync.in_progress {
+            self.personal_state.sync_ui.wizard = Some(if join {
+                SyncWizard::Join {
+                    form,
+                    confirm: true,
+                }
+            } else {
+                SyncWizard::Setup {
+                    form,
+                    confirm: true,
+                }
+            });
+            return Vec::new();
+        }
         let input = match form.into_input(join) {
             Ok(input) => input,
             Err(error) => {
@@ -208,6 +222,15 @@ impl super::super::App {
         review: Option<Box<PairingReview>>,
     ) -> Vec<super::super::Cmd> {
         if self.personal_state.sync_ui.busy.is_some() {
+            self.personal_state.sync_ui.wizard = Some(SyncWizard::Host {
+                code,
+                expires_at_unix,
+                host,
+                review,
+            });
+            return Vec::new();
+        }
+        if key.code == KeyCode::Enter && review.is_some() && self.personal_state.sync.in_progress {
             self.personal_state.sync_ui.wizard = Some(SyncWizard::Host {
                 code,
                 expires_at_unix,

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -163,6 +163,8 @@ pub enum Msg {
     /// Periodic wake-up while transient status or lyric-sync OSD state is showing. Lets the
     /// reducer expire the status after [`STATUS_TTL`] and collapse the OSD after three seconds.
     StatusTick,
+    /// Monotonic owner-lane wake for a due automatic personal-state synchronization.
+    AutomaticSyncTick,
     /// 100 ms synced-lyrics clock. The runtime arms it only while the full Player lyric panel is
     /// visible and actively playing; the reducer redraws only when the stored active row changes.
     LyricsTick,
@@ -211,6 +213,8 @@ pub enum Msg {
         store: crate::persist::StoreKind,
         error: String,
     },
+    #[rustfmt::skip]
+    PersonalStatePersisted { revision: u64, state_identity: String },
     /// A streaming/autoplay pipeline message — a prefetched/resolved direct URL, related-track
     /// candidates, the metadata-preflighted picks, a fallback failure, or the DJ Gem reranker's
     /// chosen picks. See [`StreamingMsg`].
@@ -327,6 +331,7 @@ pub enum DataCmd {
         action: PersonalSyncAction,
         attempt: u8,
         personal_state: Box<crate::personal_state::PersonalStateV2>,
+        revision_guard: crate::sync::OwnerRevisionGuard,
         reply: PersonalSyncReply,
     },
     SyncUi(SyncUiCommand),

--- a/src/daemon/engine.rs
+++ b/src/daemon/engine.rs
@@ -143,6 +143,7 @@ pub struct DaemonEngine {
     signals: Signals,
     station: StationStore,
     personal_state: crate::personal_state::PersonalStateV2,
+    personal_state_revision_guard: crate::sync::OwnerRevisionGuard,
     personal_state_device_id: Option<crate::personal_state::DeviceId>,
     personal_sync_in_progress: bool,
     #[cfg(test)]
@@ -277,7 +278,7 @@ impl DaemonEngine {
             player::lifetime::reap_orphans(&dir);
         }
         let mut engine = Self::with_state(state, Arc::new(emit));
-        engine.personal_state = personal_state;
+        engine.install_personal_state(personal_state);
         engine.personal_state_device_id = personal_state_device_id;
 
         // Resolve which yt-dlp/mpv this process runs (managed vs system vs override)
@@ -350,6 +351,7 @@ impl DaemonEngine {
             library_invalidations: 0,
             signals,
             station,
+            personal_state_revision_guard: Default::default(),
             personal_state,
             personal_state_device_id: None,
             personal_sync_in_progress: false,

--- a/src/daemon/engine/persistence_gate.rs
+++ b/src/daemon/engine/persistence_gate.rs
@@ -225,7 +225,7 @@ impl DaemonEngine {
         }
         let (library, mut playlists, signals, station) = commit.runtime_stores();
         let playlists_changed = playlists.inherit_revision_from(&self.playlists);
-        self.personal_state = installed.clone();
+        self.install_personal_state(installed.clone());
         self.library = library;
         self.playlists = playlists;
         self.signals = signals;
@@ -274,21 +274,28 @@ impl DaemonEngine {
                 "failed to resolve personal-state storage: {error}"
             ))
         })?;
-        match save_store(StoreKind::Playlists, || {
-            commit
-                .commit(&paths)
-                .map(|_| ())
-                .map_err(std::io::Error::other)
+        let installed = match save_store(StoreKind::Playlists, || {
+            commit.commit(&paths).map_err(std::io::Error::other)
         }) {
-            Ok(()) => {
-                self.personal_state = commit.state().clone();
-                Ok(())
-            }
+            Ok(installed) => installed,
             Err(error) => {
                 let message = format!("failed to save daemon transfer playlists: {error}");
                 self.record_persistence_failure("daemon transfer playlists", error);
-                Err(crate::transfer::local_playlist::LocalPlaylistStoreError::resumable(message))
+                return Err(
+                    crate::transfer::local_playlist::LocalPlaylistStoreError::resumable(message),
+                );
             }
+        };
+        if installed != *commit.state() {
+            let error = std::io::Error::other(
+                "personal state changed while the daemon transfer was installing",
+            );
+            let message = format!("failed to save daemon transfer playlists: {error}");
+            self.record_persistence_failure("daemon transfer playlists", error);
+            Err(crate::transfer::local_playlist::LocalPlaylistStoreError::resumable(message))
+        } else {
+            self.install_personal_state(installed);
+            Ok(())
         }
     }
 

--- a/src/daemon/engine/persistence_gate_tests.rs
+++ b/src/daemon/engine/persistence_gate_tests.rs
@@ -110,7 +110,7 @@ fn mutating_commands() -> Vec<RemoteCommand> {
 fn synced_daemon_persistence_authors_changes_as_the_bound_device() {
     let mut engine = engine_with_queue(&[]);
     let (state, device_id) = synced_state();
-    engine.personal_state = state;
+    engine.install_personal_state(state);
     engine.personal_state_device_id = Some(device_id.clone());
     engine.library.toggle_favorite(&crate::api::Song::remote(
         "daemon-bound-rating",
@@ -134,6 +134,35 @@ fn synced_daemon_persistence_authors_changes_as_the_bound_device() {
         })
         .expect("rating operation");
     assert_eq!(rating.stamp.dot.device_id, device_id);
+}
+
+#[test]
+fn durable_personal_commit_immediately_retires_a_detached_worker() {
+    let mut engine = engine_with_queue(&[]);
+    let expected_revision = engine.personal_state_revision();
+    let worker_guard = engine.personal_state_revision_guard();
+    let (release_worker, wait_for_commit) = std::sync::mpsc::sync_channel(0);
+    let worker = std::thread::spawn(move || {
+        wait_for_commit.recv().unwrap();
+        crate::sync::manual::LocalRevisionGuard::ensure_current(&worker_guard, expected_revision)
+    });
+
+    engine.library.toggle_favorite(&crate::api::Song::remote(
+        "guarded-after-commit",
+        "Guarded after commit",
+        "Artist",
+        "3:00",
+    ));
+    engine.save_library("revision fence test");
+
+    assert!(engine.personal_state_revision() > expected_revision);
+    // Stay inside this owner handler: no outer-loop `PersonalSync::observe` runs before the
+    // detached worker resumes and checks the fence published by the persistence gate.
+    release_worker.send(()).unwrap();
+    assert_eq!(
+        worker.join().unwrap(),
+        Err(crate::sync::VaultError::RevisionConflict)
+    );
 }
 
 #[test]

--- a/src/daemon/engine/personal_sync.rs
+++ b/src/daemon/engine/personal_sync.rs
@@ -7,10 +7,27 @@ use crate::sync::service::{AppliedManualSync, PreparedManualSync, SyncServiceErr
 #[derive(Clone)]
 pub(in crate::daemon) enum PersonalSyncAction {
     SyncNow,
+    AutomaticSync,
     Revoke(DeviceId),
 }
 
 impl DaemonEngine {
+    pub(in crate::daemon) fn install_personal_state(
+        &mut self,
+        state: crate::personal_state::PersonalStateV2,
+    ) {
+        if self.personal_state != state {
+            self.personal_state_revision_guard.publish(state.revision);
+        }
+        self.personal_state = state;
+    }
+
+    pub(in crate::daemon) fn personal_state_revision_guard(
+        &self,
+    ) -> crate::sync::OwnerRevisionGuard {
+        self.personal_state_revision_guard.clone()
+    }
+
     pub(in crate::daemon) fn set_personal_sync_in_progress(&mut self, in_progress: bool) {
         self.personal_sync_in_progress = in_progress;
     }
@@ -78,6 +95,15 @@ impl DaemonEngine {
                 &personal_paths,
                 &sync_paths,
             )?,
+            PersonalSyncAction::AutomaticSync => {
+                crate::sync::service::apply_prepared_automatic_sync_now(
+                    &current_state,
+                    self.playlists.revision(),
+                    candidate,
+                    &personal_paths,
+                    &sync_paths,
+                )?
+            }
             PersonalSyncAction::Revoke(device_id) => {
                 crate::sync::service::apply_prepared_revoke_now(
                     &current_state,
@@ -91,6 +117,25 @@ impl DaemonEngine {
         };
         self.install_personal_sync_runtime(&applied)?;
         Ok(applied)
+    }
+
+    pub(in crate::daemon) fn personal_state_revision(&self) -> u64 {
+        self.personal_state.revision
+    }
+
+    pub(in crate::daemon) fn personal_sync_device_id(&self) -> Option<&DeviceId> {
+        self.personal_state_device_id.as_ref()
+    }
+
+    pub(in crate::daemon) fn automatic_sync_is_configured(&self) -> bool {
+        if self.personal_state_device_id.is_none() {
+            return false;
+        }
+        let Ok(paths) = self.personal_state_paths() else {
+            return false;
+        };
+        crate::sync::service::read_status(&crate::sync::SyncPaths::for_data_root(paths.data_root))
+            .is_ok_and(|status| status.configured)
     }
 
     #[cfg(test)]
@@ -113,7 +158,7 @@ impl DaemonEngine {
             .commit(&self.personal_state_paths)
             .expect("commit daemon personal-sync fixture");
         let (library, playlists, signals, station) = commit.runtime_stores();
-        self.personal_state = installed;
+        self.install_personal_state(installed);
         self.personal_state_device_id = Some(device_id);
         self.library = library;
         self.playlists = playlists;
@@ -133,7 +178,7 @@ impl DaemonEngine {
         .map_err(SyncServiceError::from)?;
         let (library, mut playlists, signals, station) = prepared.runtime_stores();
         let playlists_changed = playlists.inherit_revision_from(&self.playlists);
-        self.personal_state = prepared.state().clone();
+        self.install_personal_state(prepared.state().clone());
         self.library = library;
         self.playlists = playlists;
         self.signals = signals;
@@ -190,7 +235,7 @@ mod tests {
         .unwrap();
         let installed = commit.commit(&engine.personal_state_paths).unwrap();
         let (library, playlists, signals, station) = commit.runtime_stores();
-        engine.personal_state = installed;
+        engine.install_personal_state(installed);
         engine.personal_state_device_id = Some(device_id.clone());
         engine.library = library;
         engine.playlists = playlists;

--- a/src/daemon/engine/tests.rs
+++ b/src/daemon/engine/tests.rs
@@ -33,6 +33,13 @@ pub(in crate::daemon) fn radio_station(id: &str) -> Song {
 pub(in crate::daemon) fn engine_with_queue(ids: &[&str]) -> DaemonEngine {
     let mut queue = Queue::default();
     queue.set(ids.iter().map(|id| song(id)).collect(), 0);
+    let personal_state = crate::personal_state::legacy_state(
+        &Library::default(),
+        &crate::playlists::Playlists::default(),
+        &Signals::default(),
+        &StationStore::default(),
+    )
+    .expect("default personal state");
     DaemonEngine {
         maintainer: crate::util::background_task::BackgroundTask::disabled("yt-dlp maintainer"),
         player: None,
@@ -48,13 +55,10 @@ pub(in crate::daemon) fn engine_with_queue(ids: &[&str]) -> DaemonEngine {
             speed: 1.0,
         },
         config: Config::default(),
-        personal_state: crate::personal_state::legacy_state(
-            &Library::default(),
-            &crate::playlists::Playlists::default(),
-            &Signals::default(),
-            &StationStore::default(),
-        )
-        .expect("default personal state"),
+        personal_state_revision_guard: crate::sync::OwnerRevisionGuard::new(
+            personal_state.revision,
+        ),
+        personal_state,
         personal_state_device_id: None,
         personal_sync_in_progress: false,
         personal_state_paths: personal_state_paths(),

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -392,7 +392,7 @@ async fn run_owner_loop(
             initial_effects,
         ));
     }
-
+    personal_sync.enable_automatic(&mut engine, &event_tx, &shutdown);
     'owner: loop {
         effect_tasks.reap_finished();
         gui_search_pending.prune_closed();
@@ -408,6 +408,10 @@ async fn run_owner_loop(
                 _ = shutdown.wait() => {
                     engine.suppress_transport_recovery_for_shutdown();
                     break 'owner;
+                },
+                wake = personal_sync.wait_for_automatic_wake() => {
+                    personal_sync.handle_automatic_wake(wake, &mut engine, &event_tx, &shutdown);
+                    continue;
                 },
                 _ = tokio::time::sleep_until(tokio::time::Instant::from_std(
                     media.retry_deadline().unwrap_or_else(Instant::now)
@@ -733,6 +737,7 @@ async fn run_owner_loop(
             engine.suppress_transport_recovery_for_shutdown();
             break;
         }
+        personal_sync.observe(&mut engine, &event_tx, &shutdown);
         // Queue/session/settings mutations can invalidate an in-flight autoplay request even
         // when the seed id still exists. Settle that owner generation before publishing this
         // turn so a later pool/preflight result cannot mutate the replacement session.

--- a/src/daemon/personal_sync.rs
+++ b/src/daemon/personal_sync.rs
@@ -1,5 +1,7 @@
 //! Detached WebDAV preparation with primary-owner installation and bounded stale retry.
 
+use std::time::Instant;
+
 use super::DaemonEventSender;
 use super::engine::DaemonEngine;
 use super::engine::personal_sync::PersonalSyncAction;
@@ -13,13 +15,23 @@ const MAX_STALE_RETRIES: u8 = 3;
 pub(super) struct PersonalSync {
     next_generation: u64,
     pending: Option<Pending>,
+    scheduler: crate::sync::AutomaticSyncScheduler,
+    observed_revision: Option<u64>,
+    network_changes: Option<crate::sync::NetworkChangeWatch>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum AutomaticWake {
+    Deadline,
+    NetworkReconnect,
 }
 
 struct Pending {
     generation: u64,
     attempt: u8,
     action: PersonalSyncAction,
-    reply: RemoteReply,
+    token: crate::sync::SyncAttemptToken,
+    reply: Option<RemoteReply>,
 }
 
 pub(super) struct Finished {
@@ -54,18 +66,209 @@ impl PersonalSync {
                 return;
             }
         };
+        let token = match self.scheduler.begin_manual(Instant::now()) {
+            Ok(token) => token,
+            Err(_) => {
+                let _ = reply.send(RemoteResponse::err_with_message(
+                    "sync_busy",
+                    "personal sync is already running".to_owned(),
+                ));
+                return;
+            }
+        };
+        self.observe_revision(state.revision);
+        self.start_attempt(
+            action,
+            token,
+            Some(reply),
+            state,
+            paths,
+            engine,
+            event_tx,
+            shutdown,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn start_attempt(
+        &mut self,
+        action: PersonalSyncAction,
+        token: crate::sync::SyncAttemptToken,
+        reply: Option<RemoteReply>,
+        state: crate::personal_state::PersonalStateV2,
+        paths: crate::sync::SyncPaths,
+        engine: &mut DaemonEngine,
+        event_tx: &DaemonEventSender,
+        shutdown: &ShutdownLatch,
+    ) {
         let generation = self.next_generation();
         self.pending = Some(Pending {
             generation,
             attempt: 1,
             action: action.clone(),
+            token,
             reply,
         });
         engine.set_personal_sync_in_progress(true);
-        if !schedule_prepare(event_tx, shutdown, generation, action, state, paths) {
+        let revision_guard = engine.personal_state_revision_guard();
+        if !schedule_prepare(
+            event_tx,
+            shutdown,
+            generation,
+            action,
+            state,
+            paths,
+            revision_guard,
+        ) {
             engine.set_personal_sync_in_progress(false);
             self.settle_generation(generation, RemoteResponse::err("shutting_down"));
+            self.finish_token(
+                token,
+                crate::sync::SyncAttemptOutcome::Failed,
+                engine,
+                event_tx,
+                shutdown,
+            );
         }
+    }
+
+    pub(super) fn enable_automatic(
+        &mut self,
+        engine: &mut DaemonEngine,
+        event_tx: &DaemonEventSender,
+        shutdown: &ShutdownLatch,
+    ) {
+        if shutdown.is_triggered() {
+            return;
+        }
+        self.observe_revision(engine.personal_state_revision());
+        if !engine.automatic_sync_is_configured() {
+            return;
+        }
+        if self.network_changes.is_none() {
+            self.network_changes = crate::sync::NetworkChangeWatch::start();
+        }
+        if let Some(device_id) = engine.personal_sync_device_id() {
+            self.scheduler
+                .configure_jitter(crate::sync::BackoffJitter::stable_for(device_id.as_str()));
+        }
+        if let Some(token) = self.scheduler.enable(Instant::now()) {
+            self.start_automatic(token, engine, event_tx, shutdown);
+        }
+    }
+
+    pub(super) fn next_deadline(&self) -> Option<Instant> {
+        self.scheduler.next_deadline()
+    }
+
+    async fn wait_until_due(&self) {
+        let Some(deadline) = self.next_deadline() else {
+            std::future::pending::<()>().await;
+            return;
+        };
+        tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
+    }
+
+    async fn wait_for_network_reconnect(&self) {
+        let Some(network_changes) = self.network_changes.as_ref() else {
+            std::future::pending::<()>().await;
+            return;
+        };
+        network_changes.changed().await;
+    }
+
+    pub(super) async fn wait_for_automatic_wake(&self) -> AutomaticWake {
+        let waiting_for_connectivity = self.scheduler.waiting_for_connectivity();
+        if !waiting_for_connectivity && let Some(network_changes) = self.network_changes.as_ref() {
+            network_changes.park();
+        }
+        tokio::select! {
+            _ = self.wait_until_due() => AutomaticWake::Deadline,
+            _ = self.wait_for_network_reconnect(),
+                if waiting_for_connectivity => AutomaticWake::NetworkReconnect,
+        }
+    }
+
+    pub(super) fn handle_automatic_wake(
+        &mut self,
+        wake: AutomaticWake,
+        engine: &mut DaemonEngine,
+        event_tx: &DaemonEventSender,
+        shutdown: &ShutdownLatch,
+    ) {
+        match wake {
+            AutomaticWake::Deadline => self.poll(engine, event_tx, shutdown),
+            AutomaticWake::NetworkReconnect => {
+                self.network_reconnected(engine, event_tx, shutdown);
+            }
+        }
+    }
+
+    pub(super) fn poll(
+        &mut self,
+        engine: &mut DaemonEngine,
+        event_tx: &DaemonEventSender,
+        shutdown: &ShutdownLatch,
+    ) {
+        if let Some(token) = self.scheduler.poll(Instant::now()) {
+            self.start_automatic(token, engine, event_tx, shutdown);
+        }
+    }
+
+    pub(super) fn network_reconnected(
+        &mut self,
+        engine: &mut DaemonEngine,
+        event_tx: &DaemonEventSender,
+        shutdown: &ShutdownLatch,
+    ) {
+        if let Some(token) = self.scheduler.network_reconnected(Instant::now()) {
+            self.start_automatic(token, engine, event_tx, shutdown);
+        }
+    }
+
+    pub(super) fn observe(
+        &mut self,
+        engine: &mut DaemonEngine,
+        event_tx: &DaemonEventSender,
+        shutdown: &ShutdownLatch,
+    ) {
+        let revision = engine.personal_state_revision();
+        let changed = self.observe_revision(revision);
+        let now = Instant::now();
+        if changed && let Some(token) = self.scheduler.local_mutation(now) {
+            self.start_automatic(token, engine, event_tx, shutdown);
+        }
+    }
+
+    fn start_automatic(
+        &mut self,
+        token: crate::sync::SyncAttemptToken,
+        engine: &mut DaemonEngine,
+        event_tx: &DaemonEventSender,
+        shutdown: &ShutdownLatch,
+    ) {
+        if crate::persist::ensure_persistence_writes_allowed().is_err() {
+            self.finish_scheduler(token, SyncServiceError::Storage, engine, event_tx, shutdown);
+            return;
+        }
+        let (state, paths) = match engine.personal_sync_source() {
+            Ok(source) => source,
+            Err(error) => {
+                self.finish_scheduler(token, error, engine, event_tx, shutdown);
+                return;
+            }
+        };
+        self.observe_revision(state.revision);
+        self.start_attempt(
+            PersonalSyncAction::AutomaticSync,
+            token,
+            None,
+            state,
+            paths,
+            engine,
+            event_tx,
+            shutdown,
+        );
     }
 
     pub(super) fn start_command(
@@ -109,37 +312,44 @@ impl PersonalSync {
             return;
         };
         let action = pending.action.clone();
-        let response = match finished.result {
+        let token = pending.token;
+        let (response, outcome) = match finished.result {
             Ok(candidate) => {
                 match engine.personal_sync_source_is_current(candidate.expected_local_revision) {
                     Ok(false) => return self.retry_stale(engine, event_tx, shutdown),
-                    Err(error) => error_response(error),
+                    Err(error) => (error_response(error), scheduler_outcome(error)),
                     Ok(true) => {
                         match engine.apply_personal_sync_candidate(action.clone(), candidate) {
-                            Ok(applied) => {
-                                RemoteResponse::ok(sync_summary(&action, &applied.summary))
-                            }
+                            Ok(applied) => (
+                                RemoteResponse::ok(sync_summary(&action, &applied.summary)),
+                                crate::sync::SyncAttemptOutcome::Succeeded,
+                            ),
                             Err(SyncServiceError::LocalStateChanged) => {
                                 return self.retry_stale(engine, event_tx, shutdown);
                             }
-                            Err(error) => error_response(error),
+                            Err(error) => (error_response(error), scheduler_outcome(error)),
                         }
                     }
                 }
             }
-            Err(error) => error_response(error),
+            Err(error) => (error_response(error), scheduler_outcome(error)),
         };
         engine.set_personal_sync_in_progress(false);
         self.settle_generation(finished.generation, response);
+        self.observe_revision(engine.personal_state_revision());
+        self.finish_token(token, outcome, engine, event_tx, shutdown);
     }
 
     pub(super) fn shutdown(&mut self) {
+        self.scheduler.disable();
         let Some(pending) = self.pending.take() else {
             return;
         };
-        let _ = pending.reply.send(RemoteResponse::err(
-            crate::remote::proto::CONFIRMATION_LOST_REASON,
-        ));
+        if let Some(reply) = pending.reply {
+            let _ = reply.send(RemoteResponse::err(
+                crate::remote::proto::CONFIRMATION_LOST_REASON,
+            ));
+        }
     }
 
     fn retry_stale(
@@ -151,40 +361,72 @@ impl PersonalSync {
         let Some(pending) = self.pending.as_ref() else {
             return;
         };
-        if pending.attempt >= MAX_STALE_RETRIES {
-            let generation = pending.generation;
+        let current_generation = pending.generation;
+        let current_attempt = pending.attempt;
+        let action = pending.action.clone();
+        let token = pending.token;
+        if current_attempt >= MAX_STALE_RETRIES {
             engine.set_personal_sync_in_progress(false);
             self.settle_generation(
-                generation,
+                current_generation,
                 error_response(SyncServiceError::LocalStateChanged),
+            );
+            self.finish_token(
+                token,
+                crate::sync::SyncAttemptOutcome::Failed,
+                engine,
+                event_tx,
+                shutdown,
             );
             return;
         }
         if crate::persist::ensure_persistence_writes_allowed().is_err() {
-            let generation = pending.generation;
             engine.set_personal_sync_in_progress(false);
-            self.settle_generation(generation, persistence_unavailable());
+            self.settle_generation(current_generation, persistence_unavailable());
+            self.finish_token(
+                token,
+                crate::sync::SyncAttemptOutcome::Failed,
+                engine,
+                event_tx,
+                shutdown,
+            );
             return;
         }
         let (state, paths) = match engine.personal_sync_source() {
             Ok(source) => source,
             Err(error) => {
-                let generation = pending.generation;
                 engine.set_personal_sync_in_progress(false);
-                self.settle_generation(generation, error_response(error));
+                self.settle_generation(current_generation, error_response(error));
+                self.finish_token(token, scheduler_outcome(error), engine, event_tx, shutdown);
                 return;
             }
         };
-        let action = pending.action.clone();
-        let attempt = pending.attempt.saturating_add(1);
+        self.observe_revision(state.revision);
+        let attempt = current_attempt.saturating_add(1);
         let generation = self.next_generation();
         if let Some(pending) = self.pending.as_mut() {
             pending.generation = generation;
             pending.attempt = attempt;
         }
-        if !schedule_prepare(event_tx, shutdown, generation, action, state, paths) {
+        let revision_guard = engine.personal_state_revision_guard();
+        if !schedule_prepare(
+            event_tx,
+            shutdown,
+            generation,
+            action,
+            state,
+            paths,
+            revision_guard,
+        ) {
             engine.set_personal_sync_in_progress(false);
             self.settle_generation(generation, RemoteResponse::err("shutting_down"));
+            self.finish_token(
+                token,
+                crate::sync::SyncAttemptOutcome::Failed,
+                engine,
+                event_tx,
+                shutdown,
+            );
         }
     }
 
@@ -196,14 +438,47 @@ impl PersonalSync {
         self.next_generation
     }
 
+    fn observe_revision(&mut self, revision: u64) -> bool {
+        self.observed_revision
+            .replace(revision)
+            .is_some_and(|observed| observed != revision)
+    }
+
     fn settle_generation(&mut self, generation: u64, response: RemoteResponse) {
         if self
             .pending
             .as_ref()
             .is_some_and(|pending| pending.generation == generation)
             && let Some(pending) = self.pending.take()
+            && let Some(reply) = pending.reply
         {
-            let _ = pending.reply.send(response);
+            let _ = reply.send(response);
+        }
+    }
+
+    fn finish_scheduler(
+        &mut self,
+        token: crate::sync::SyncAttemptToken,
+        error: SyncServiceError,
+        engine: &mut DaemonEngine,
+        event_tx: &DaemonEventSender,
+        shutdown: &ShutdownLatch,
+    ) {
+        self.finish_token(token, scheduler_outcome(error), engine, event_tx, shutdown);
+    }
+
+    fn finish_token(
+        &mut self,
+        token: crate::sync::SyncAttemptToken,
+        outcome: crate::sync::SyncAttemptOutcome,
+        engine: &mut DaemonEngine,
+        event_tx: &DaemonEventSender,
+        shutdown: &ShutdownLatch,
+    ) {
+        if let crate::sync::SyncFinish::Accepted { next: Some(next) } =
+            self.scheduler.finish(token, outcome, Instant::now())
+        {
+            self.start_automatic(next, engine, event_tx, shutdown);
         }
     }
 }
@@ -215,6 +490,7 @@ fn schedule_prepare(
     action: PersonalSyncAction,
     state: crate::personal_state::PersonalStateV2,
     paths: crate::sync::SyncPaths,
+    revision_guard: crate::sync::OwnerRevisionGuard,
 ) -> bool {
     if shutdown.is_triggered() {
         return false;
@@ -222,7 +498,7 @@ fn schedule_prepare(
     let tx = event_tx.clone();
     let completion_shutdown = shutdown.clone();
     crate::sync::spawn_detached_prepare(
-        move || prepare(action, state, paths),
+        move || prepare(action, state, paths, revision_guard),
         move |result| {
             let _ = super::effects::deliver_terminal_blocking(
                 &tx,
@@ -237,12 +513,24 @@ fn prepare(
     action: PersonalSyncAction,
     state: crate::personal_state::PersonalStateV2,
     paths: crate::sync::SyncPaths,
+    revision_guard: crate::sync::OwnerRevisionGuard,
 ) -> Result<PreparedManualSync, SyncServiceError> {
     let revoke_target = match &action {
-        PersonalSyncAction::SyncNow => None,
+        PersonalSyncAction::SyncNow | PersonalSyncAction::AutomaticSync => None,
         PersonalSyncAction::Revoke(device_id) => Some(device_id),
     };
-    crate::sync::service::prepare_owner_sync(&state, revoke_target, &paths)
+    let kind = if matches!(action, PersonalSyncAction::AutomaticSync) {
+        crate::sync::service::SyncAttemptKind::Automatic
+    } else {
+        crate::sync::service::SyncAttemptKind::Manual
+    };
+    crate::sync::service::prepare_owner_sync_as(
+        &state,
+        revoke_target,
+        &paths,
+        kind,
+        &revision_guard,
+    )
 }
 
 fn error_response(error: SyncServiceError) -> RemoteResponse {
@@ -254,6 +542,16 @@ fn persistence_unavailable() -> RemoteResponse {
         "persistence_unavailable",
         "the primary persistence owner is unavailable".to_owned(),
     )
+}
+
+fn scheduler_outcome(error: SyncServiceError) -> crate::sync::SyncAttemptOutcome {
+    match error {
+        SyncServiceError::Offline => crate::sync::SyncAttemptOutcome::Offline { retry_after: None },
+        SyncServiceError::RateLimited(retry_after) => {
+            crate::sync::SyncAttemptOutcome::Offline { retry_after }
+        }
+        _ => crate::sync::SyncAttemptOutcome::Failed,
+    }
 }
 
 fn sync_summary(
@@ -331,14 +629,20 @@ mod tests {
         let (events, _rx) = event_channel();
         let shutdown = ShutdownLatch::new();
         let (first_reply, mut first_response) = oneshot::channel();
+        let mut scheduler = crate::sync::AutomaticSyncScheduler::default();
+        let token = scheduler.begin_manual(Instant::now()).unwrap();
         let mut host = PersonalSync {
             next_generation: 1,
             pending: Some(Pending {
                 generation: 1,
                 attempt: 1,
                 action: PersonalSyncAction::SyncNow,
-                reply: first_reply.into(),
+                token,
+                reply: Some(first_reply.into()),
             }),
+            scheduler,
+            observed_revision: None,
+            network_changes: None,
         };
         let mut engine = super::super::engine::tests::engine_with_queue(&[]);
         let (reply, mut response) = oneshot::channel();
@@ -427,14 +731,20 @@ mod tests {
         let (events, _rx) = event_channel();
         let shutdown = ShutdownLatch::new();
         let (current_reply, mut current_response) = oneshot::channel();
+        let mut scheduler = crate::sync::AutomaticSyncScheduler::default();
+        let token = scheduler.begin_manual(Instant::now()).unwrap();
         let mut host = PersonalSync {
             next_generation: 2,
             pending: Some(Pending {
                 generation: 2,
                 attempt: 2,
                 action: PersonalSyncAction::SyncNow,
-                reply: current_reply.into(),
+                token,
+                reply: Some(current_reply.into()),
             }),
+            scheduler,
+            observed_revision: None,
+            network_changes: None,
         };
         let mut engine = super::super::engine::tests::engine_with_queue(&[]);
 
@@ -458,6 +768,65 @@ mod tests {
         assert_eq!(
             current_response.try_recv().unwrap().reason.as_deref(),
             Some(crate::remote::proto::CONFIRMATION_LOST_REASON)
+        );
+    }
+
+    #[test]
+    fn unrelated_api_activity_cannot_bypass_webdav_backoff() {
+        let (events, _rx) = event_channel();
+        let shutdown = ShutdownLatch::new();
+        let mut host = PersonalSync::default();
+        let mut engine = super::super::engine::tests::engine_with_queue(&[]);
+        let now = Instant::now();
+        let token = host.scheduler.enable(now).unwrap();
+        let _ = host.scheduler.finish(
+            token,
+            crate::sync::SyncAttemptOutcome::Offline { retry_after: None },
+            now,
+        );
+        host.observed_revision = Some(engine.personal_state_revision());
+        let retry_due = host.scheduler.next_deadline();
+
+        host.observe(&mut engine, &events, &shutdown);
+
+        assert!(host.pending.is_none());
+        assert_eq!(host.scheduler.in_flight(), None);
+        assert_eq!(host.scheduler.next_deadline(), retry_due);
+    }
+
+    #[test]
+    fn reconnect_wakeup_cannot_bypass_retry_after() {
+        let (events, _rx) = event_channel();
+        let shutdown = ShutdownLatch::new();
+        let mut host = PersonalSync::default();
+        let mut engine = super::super::engine::tests::engine_with_queue(&[]);
+        let now = Instant::now();
+        let token = host.scheduler.enable(now).unwrap();
+        let _ = host.scheduler.finish(
+            token,
+            crate::sync::SyncAttemptOutcome::Offline {
+                retry_after: Some(std::time::Duration::from_secs(75)),
+            },
+            now,
+        );
+        let retry_due = host.scheduler.next_deadline();
+
+        host.network_reconnected(&mut engine, &events, &shutdown);
+
+        assert!(host.pending.is_none());
+        assert_eq!(host.scheduler.in_flight(), None);
+        assert_eq!(host.scheduler.next_deadline(), retry_due);
+    }
+
+    #[test]
+    fn rate_limit_is_an_offline_outcome_with_the_server_hint() {
+        assert_eq!(
+            scheduler_outcome(SyncServiceError::RateLimited(Some(
+                std::time::Duration::from_secs(75),
+            ))),
+            crate::sync::SyncAttemptOutcome::Offline {
+                retry_after: Some(std::time::Duration::from_secs(75)),
+            }
         );
     }
 }

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -137,7 +137,24 @@ impl StoreKind {
 
 #[derive(Debug, Clone)]
 pub enum PersistEvent {
-    WriteFailed { store: StoreKind, error: String },
+    WriteFailed {
+        store: StoreKind,
+        error: String,
+    },
+    PersonalStateCommitted {
+        revision: u64,
+        state_identity: String,
+    },
+}
+
+#[cfg(test)]
+impl PersistEvent {
+    pub(crate) fn write_failure(&self) -> Option<(&StoreKind, &String)> {
+        match self {
+            Self::WriteFailed { store, error } => Some((store, error)),
+            Self::PersonalStateCommitted { .. } => None,
+        }
+    }
 }
 
 type EventSink = Arc<dyn Fn(PersistEvent) + Send + Sync + 'static>;
@@ -1471,10 +1488,20 @@ async fn write_stores_with_inflight_tracking(
                 );
             }
             Ok((Ok(()), operation)) => {
+                let personal_state_commit = operation.ordinary_personal_state_commit();
                 remove_inflight_if_order(inflight, kind, order);
                 panic_shadow.clear_through(kind, order);
                 retries.remove(&operation.kind());
                 completions.record(kind, order);
+                if let Some(Ok((revision, state_identity))) = personal_state_commit {
+                    emit_persist_event(
+                        events,
+                        PersistEvent::PersonalStateCommitted {
+                            revision,
+                            state_identity,
+                        },
+                    );
+                }
             }
         }
     }

--- a/src/persist/owned_snapshot.rs
+++ b/src/persist/owned_snapshot.rs
@@ -114,6 +114,20 @@ impl OwnedSnapshot {
         }
     }
 
+    pub(super) fn ordinary_personal_state_commit(
+        &self,
+    ) -> Option<Result<(u64, String), crate::personal_state::PersonalStateError>> {
+        match self {
+            Self::PersonalState(value) => Some(
+                value
+                    .state()
+                    .identity()
+                    .map(|identity| (value.state().revision, identity)),
+            ),
+            _ => None,
+        }
+    }
+
     pub(super) fn write(&self) -> std::io::Result<()> {
         match self {
             Self::PersonalState(value) => {

--- a/src/persist/snapshot_state.rs
+++ b/src/persist/snapshot_state.rs
@@ -88,6 +88,17 @@ impl PendingOperation {
         self.kind
     }
 
+    pub(super) fn ordinary_personal_state_commit(
+        &self,
+    ) -> Option<Result<(u64, String), crate::personal_state::PersonalStateError>> {
+        match self.action.as_ref() {
+            PendingAction::Save(snapshot) => snapshot.ordinary_personal_state_commit(),
+            PendingAction::DeleteRomanizedTitles => None,
+            #[cfg(test)]
+            PendingAction::TestDeleteRomanizedTitles { .. } => None,
+        }
+    }
+
     pub(super) fn action(&self) -> &PendingAction {
         self.action.as_ref()
     }

--- a/src/persist/tests.rs
+++ b/src/persist/tests.rs
@@ -1206,7 +1206,7 @@ async fn disk_full_during_write_preserves_a_newer_coalesced_snapshot() {
             .lock()
             .unwrap_or_else(PoisonError::into_inner);
         assert_eq!(failures.len(), 1);
-        let PersistEvent::WriteFailed { store, error } = &failures[0];
+        let (store, error) = failures[0].write_failure().unwrap();
         assert_eq!(*store, StoreKind::Config);
         assert!(error.contains("no space left on device"));
     }
@@ -1297,7 +1297,7 @@ async fn first_high_value_failure_emits_one_status_event() {
 
     let guard = events.lock().unwrap();
     assert_eq!(guard.len(), 1);
-    let PersistEvent::WriteFailed { store, error } = &guard[0];
+    let (store, error) = guard[0].write_failure().unwrap();
     assert_eq!(*store, StoreKind::Library);
     assert!(error.contains("permission denied"));
 }

--- a/src/persist/tests/personal_state.rs
+++ b/src/persist/tests/personal_state.rs
@@ -47,3 +47,71 @@ fn panic_operation_commits_the_complete_personal_state_transaction() {
     });
     let _ = std::fs::remove_dir_all(directory);
 }
+
+#[test]
+fn actor_emits_a_mutation_only_for_an_ordinary_personal_state_commit() {
+    let directory = temp_dir("personal-state-commit-event");
+    let override_value = directory.to_string_lossy().into_owned();
+    crate::test_util::env::with_var("YTM_DATA_DIR", Some(&override_value), || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let state = crate::personal_state::legacy_state(
+                    &crate::library::Library::default(),
+                    &crate::playlists::Playlists::default(),
+                    &crate::signals::Signals::default(),
+                    &crate::station::StationStore::default(),
+                )
+                .unwrap();
+                let commit = crate::personal_state::PersonalStateCommit::prepare(state).unwrap();
+                let committed_state = commit.state().clone();
+                let expected_revision = committed_state.revision;
+                let expected_identity = committed_state.identity().unwrap();
+                let events = Arc::new(Mutex::new(Vec::new()));
+                let captured = Arc::clone(&events);
+                let handle = spawn();
+                handle.set_event_sink(move |event| {
+                    captured.lock().unwrap().push(event);
+                });
+
+                let _ = handle
+                    .save(Snapshot::PersonalState(Box::new(commit)))
+                    .unwrap();
+                assert!(handle.flush(Duration::from_secs(5)).await);
+                assert!(handle.flush(Duration::from_secs(5)).await);
+                {
+                    let emitted = events.lock().unwrap();
+                    assert!(matches!(
+                        emitted.as_slice(),
+                        [PersistEvent::PersonalStateCommitted {
+                            revision,
+                            state_identity,
+                        }] if *revision == expected_revision
+                            && state_identity == &expected_identity
+                    ));
+                }
+
+                events.lock().unwrap().clear();
+                let personal_paths = crate::personal_state::PersonalStatePaths::current().unwrap();
+                let sync_paths = crate::sync::SyncPaths::current().unwrap();
+                let targeted = crate::sync::service::PersonalSyncPersistence::reconcile(
+                    committed_state.clone(),
+                    committed_state.clone(),
+                    committed_state,
+                    0,
+                    personal_paths,
+                    sync_paths,
+                )
+                .unwrap();
+                assert!(
+                    OwnedSnapshot::from(Snapshot::PersonalSync(targeted))
+                        .ordinary_personal_state_commit()
+                        .is_none(),
+                    "targeted sync persistence must not re-arm automatic sync"
+                );
+            });
+    });
+    let _ = std::fs::remove_dir_all(directory);
+}

--- a/src/personal_state.rs
+++ b/src/personal_state.rs
@@ -3,6 +3,7 @@
 //! The v2 ledger is the synchronization source of truth. Existing runtime stores remain
 //! projections so the playback and recommendation paths do not depend on a network backend.
 
+mod compaction;
 mod coordinator;
 mod import;
 pub(crate) mod legacy;
@@ -10,6 +11,10 @@ mod model;
 mod reducer;
 mod transaction;
 
+pub(crate) use compaction::operation_survives_checkpoint;
+pub use compaction::{
+    EngagementCompactionPlan, engagement_compaction_leader, plan_engagement_compaction,
+};
 pub(crate) use coordinator::reconcile_runtime;
 pub use coordinator::{append_operation_as, reconcile_runtime_as};
 pub(crate) use import::validate_join_import_extension;
@@ -19,11 +24,11 @@ pub use legacy::{LegacyProjection, legacy_state};
 pub(crate) use model::derive_device_registry;
 pub(crate) use model::refresh_device_registry;
 pub use model::{
-    CausalStamp, CompactionCheckpoint, DeviceId, DevicePublicIdentity, DeviceRecord,
-    DeviceRegistry, Dot, EngagementKind, Operation, OperationEnvelope, OperationOrigin,
-    PERSONAL_STATE_KIND, PERSONAL_STATE_SCHEMA_VERSION, PersonalStateError, PersonalStateMetadata,
-    PersonalStateV2, PlaylistEntryId, PlaylistId, PortableTrack, PortableTrackKey, Rating,
-    VersionVector,
+    CausalStamp, CompactionCheckpoint, CompactionLeaderAuthorization, DeviceId,
+    DevicePublicIdentity, DeviceRecord, DeviceRegistry, Dot, EngagementKind, Operation,
+    OperationEnvelope, OperationOrigin, PERSONAL_STATE_KIND, PERSONAL_STATE_SCHEMA_VERSION,
+    PersonalStateError, PersonalStateMetadata, PersonalStateV2, PlaylistEntryId, PlaylistId,
+    PortableTrack, PortableTrackKey, Rating, VersionVector,
 };
 pub(crate) use reducer::runtime_fingerprint;
 pub use reducer::{MergeSummary, PersonalProjection, merge, project};

--- a/src/personal_state/compaction.rs
+++ b/src/personal_state/compaction.rs
@@ -1,0 +1,385 @@
+//! Deterministic, network-independent engagement compaction.
+//!
+//! This module only builds and merges the canonical personal-state checkpoint. Publishing that
+//! checkpoint, collecting authenticated device acknowledgements, and deleting remote objects are
+//! sync-protocol responsibilities.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+
+use super::legacy::{ENGAGEMENT_EVENTS_MAX, sha256_hex};
+use super::reducer::{project_at, stamp_order};
+use super::{
+    CompactionCheckpoint, DeviceId, Operation, OperationEnvelope, PersonalStateError,
+    PersonalStateV2, VersionVector,
+};
+
+const COMPACTION_HASH_KIND: &str = "yututui-engagement-compaction-v1";
+pub(crate) const RAW_EVENT_RETENTION_SECS: i64 = 365 * 24 * 60 * 60;
+
+/// A deterministic local candidate. It contains no credential, endpoint, or network result.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EngagementCompactionPlan {
+    pub candidate: PersonalStateV2,
+    pub pruned_engagement_operations: usize,
+}
+
+/// The lowest active device id is the sole compaction leader.
+pub fn engagement_compaction_leader(state: &PersonalStateV2) -> Option<DeviceId> {
+    state
+        .device_registry
+        .values()
+        .filter(|device| !device.revoked && device.device_id.as_str() != "legacy")
+        .map(|device| device.device_id.clone())
+        .min()
+}
+
+/// Build a projection-preserving engagement compaction candidate.
+///
+/// `now_unix` is injected because wall time decides only the 365-day retention boundary. Given
+/// identical state and `now_unix`, the candidate and checkpoint id are byte-for-byte deterministic.
+/// `Ok(None)` means the ledger already contains exactly the bounded raw engagement window.
+pub fn plan_engagement_compaction(
+    state: &PersonalStateV2,
+    local_device_id: &DeviceId,
+    now_unix: i64,
+    prior_compaction_has_quorum: bool,
+) -> Result<Option<EngagementCompactionPlan>, PersonalStateError> {
+    state.validate()?;
+    let leader = engagement_compaction_leader(state).ok_or(
+        PersonalStateError::InvalidOperation("personal state has no active compaction leader"),
+    )?;
+    if leader != *local_device_id {
+        return Err(PersonalStateError::InvalidOperation(
+            "only the lowest active device may compact personal state",
+        ));
+    }
+    // Every active device must durably install the signed vault checkpoint containing the current
+    // compaction before the leader may replace it. Otherwise an offline device could skip an
+    // intermediate generation and no longer prove which raw events the grandchild removed.
+    if state.compaction_checkpoint.is_some() && !prior_compaction_has_quorum {
+        return Ok(None);
+    }
+
+    let retained = retained_engagement_operation_ids(state.operations.as_slice(), now_unix)
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let pruned_engagement_operations = state
+        .operations
+        .iter()
+        .filter(|operation| {
+            matches!(operation.operation, Operation::RecordEngagement { .. })
+                && !retained.contains(operation.operation_id.as_str())
+        })
+        .count();
+    if pruned_engagement_operations == 0 {
+        return Ok(None);
+    }
+    let _ = state.next_revision()?;
+
+    let coverage = state.version_vector.clone();
+    let previous_checkpoint_hash = state
+        .compaction_checkpoint
+        .as_ref()
+        .map(|checkpoint| checkpoint.checkpoint_id.clone());
+    let compaction_generation =
+        state
+            .compaction_checkpoint
+            .as_ref()
+            .map_or(Ok(1), |checkpoint| {
+                checkpoint.compaction_generation.checked_add(1).ok_or(
+                    PersonalStateError::InvalidOperation("compaction generation exhausted"),
+                )
+            })?;
+    let checkpoint_id = checkpoint_id_for(
+        &state.dataset_id,
+        compaction_generation,
+        &coverage,
+        previous_checkpoint_hash.as_deref(),
+        &retained,
+        &state.operations,
+    )?;
+    let checkpoint = CompactionCheckpoint {
+        checkpoint_id,
+        compaction_generation,
+        coverage,
+        previous_checkpoint_hash,
+        retained_engagement_operations: retained.clone(),
+        leader_authorization: None,
+        // Acknowledgements are sync-protocol objects signed by each device. Portable state must
+        // never manufacture or union them.
+        acknowledged_by: BTreeSet::new(),
+    };
+
+    let before = project_at(state, now_unix)?;
+    let mut candidate = state.clone();
+    candidate.operations.retain(|operation| {
+        !matches!(operation.operation, Operation::RecordEngagement { .. })
+            || retained.contains(operation.operation_id.as_str())
+    });
+    candidate.compaction_checkpoint = Some(checkpoint);
+    candidate.projection_fingerprint = None;
+    candidate.normalize()?;
+    let after = project_at(&candidate, now_unix)?;
+    if before.fingerprint != after.fingerprint || before.legacy != after.legacy {
+        return Err(PersonalStateError::ProjectionMismatch);
+    }
+
+    Ok(Some(EngagementCompactionPlan {
+        candidate,
+        pruned_engagement_operations,
+    }))
+}
+
+/// Select a checkpoint without trusting or combining its unsigned acknowledgement cache.
+pub(crate) fn select_checkpoint(
+    left: Option<&CompactionCheckpoint>,
+    right: Option<&CompactionCheckpoint>,
+) -> Result<Option<CompactionCheckpoint>, PersonalStateError> {
+    let selected = match (left, right) {
+        (None, None) => return Ok(None),
+        (Some(checkpoint), None) | (None, Some(checkpoint)) => checkpoint.clone(),
+        (Some(left), Some(right)) if checkpoint_content_eq(left, right) => left.clone(),
+        (Some(left), Some(right)) if left.compaction_generation > right.compaction_generation => {
+            require_newer_checkpoint(left, right)?;
+            left.clone()
+        }
+        (Some(left), Some(right)) if right.compaction_generation > left.compaction_generation => {
+            require_newer_checkpoint(right, left)?;
+            right.clone()
+        }
+        (Some(_), Some(_)) => return Err(checkpoint_fork()),
+    };
+    Ok(Some(without_acknowledgements(selected)))
+}
+
+pub(crate) fn operation_survives_checkpoint(
+    checkpoint: Option<&CompactionCheckpoint>,
+    operation: &OperationEnvelope,
+) -> bool {
+    let Some(checkpoint) = checkpoint else {
+        return true;
+    };
+    !matches!(operation.operation, Operation::RecordEngagement { .. })
+        || !checkpoint.coverage.covers(&operation.stamp.dot)
+        || checkpoint
+            .retained_engagement_operations
+            .contains(&operation.operation_id)
+}
+
+pub(crate) fn retained_engagement_operation_ids(
+    operations: &[OperationEnvelope],
+    now_unix: i64,
+) -> Vec<String> {
+    let mut winners = BTreeMap::<&str, &OperationEnvelope>::new();
+    for operation in operations {
+        let Operation::RecordEngagement { event_id, .. } = &operation.operation else {
+            continue;
+        };
+        let replace = winners.get(event_id.as_str()).is_none_or(|current| {
+            stamp_order(
+                &operation.stamp,
+                &operation.operation_id,
+                &current.stamp,
+                &current.operation_id,
+            )
+            .is_gt()
+        });
+        if replace {
+            winners.insert(event_id, operation);
+        }
+    }
+
+    let cutoff = now_unix.saturating_sub(RAW_EVENT_RETENTION_SECS);
+    let mut retained = winners
+        .into_iter()
+        .filter(|(_, operation)| {
+            // Legacy imports use zero when the original store had no trustworthy event time.
+            // Preserve those events until the deterministic 20,000-event cap evicts them.
+            operation.stamp.recorded_at_unix == 0 || operation.stamp.recorded_at_unix >= cutoff
+        })
+        .collect::<Vec<_>>();
+    retained.sort_by(|(left_event_id, left), (right_event_id, right)| {
+        right
+            .stamp
+            .recorded_at_unix
+            .cmp(&left.stamp.recorded_at_unix)
+            .then(right.stamp.dot.cmp(&left.stamp.dot))
+            .then(left_event_id.cmp(right_event_id))
+    });
+    retained.truncate(ENGAGEMENT_EVENTS_MAX);
+    retained.reverse();
+    retained
+        .into_iter()
+        .map(|(_, operation)| operation.operation_id.clone())
+        .collect()
+}
+
+pub(crate) fn validate_checkpoint(
+    state: &PersonalStateV2,
+    checkpoint: &CompactionCheckpoint,
+) -> Result<(), PersonalStateError> {
+    if checkpoint.retained_engagement_operations.len() > ENGAGEMENT_EVENTS_MAX
+        || checkpoint
+            .coverage
+            .0
+            .iter()
+            .any(|(device, sequence)| state.version_vector.observed(device) < *sequence)
+        || !valid_hash(&checkpoint.checkpoint_id)
+        || checkpoint
+            .previous_checkpoint_hash
+            .as_deref()
+            .is_some_and(|hash| !valid_hash(hash))
+    {
+        return Err(PersonalStateError::InvalidOperation(
+            "invalid engagement compaction checkpoint",
+        ));
+    }
+    let expected = checkpoint_id_for(
+        &state.dataset_id,
+        checkpoint.compaction_generation,
+        &checkpoint.coverage,
+        checkpoint.previous_checkpoint_hash.as_deref(),
+        &checkpoint.retained_engagement_operations,
+        &state.operations,
+    )?;
+    if checkpoint.checkpoint_id != expected {
+        return Err(PersonalStateError::InvalidOperation(
+            "engagement compaction checkpoint hash does not match",
+        ));
+    }
+
+    let operations = state
+        .operations
+        .iter()
+        .map(|operation| (operation.operation_id.as_str(), operation))
+        .collect::<BTreeMap<_, _>>();
+    for operation_id in &checkpoint.retained_engagement_operations {
+        let Some(operation) = operations.get(operation_id.as_str()) else {
+            return Err(PersonalStateError::InvalidOperation(
+                "compaction retained engagement operation is missing",
+            ));
+        };
+        if !matches!(operation.operation, Operation::RecordEngagement { .. })
+            || !checkpoint.coverage.covers(&operation.stamp.dot)
+        {
+            return Err(PersonalStateError::InvalidOperation(
+                "compaction retained engagement operation is invalid",
+            ));
+        }
+    }
+    if state.operations.iter().any(|operation| {
+        matches!(operation.operation, Operation::RecordEngagement { .. })
+            && checkpoint.coverage.covers(&operation.stamp.dot)
+            && !checkpoint
+                .retained_engagement_operations
+                .contains(&operation.operation_id)
+    }) {
+        return Err(PersonalStateError::InvalidOperation(
+            "compacted engagement operation was resurrected",
+        ));
+    }
+    Ok(())
+}
+
+fn require_newer_checkpoint(
+    newer: &CompactionCheckpoint,
+    older: &CompactionCheckpoint,
+) -> Result<(), PersonalStateError> {
+    if !vector_dominates(&newer.coverage, &older.coverage) {
+        return Err(PersonalStateError::InvalidOperation(
+            "compaction checkpoint coverage moved backwards",
+        ));
+    }
+    if older.compaction_generation.checked_add(1) == Some(newer.compaction_generation)
+        && newer.previous_checkpoint_hash.as_deref() != Some(older.checkpoint_id.as_str())
+    {
+        return Err(checkpoint_fork());
+    }
+    Ok(())
+}
+
+fn checkpoint_fork() -> PersonalStateError {
+    PersonalStateError::InvalidOperation("compaction checkpoint history forked")
+}
+
+fn vector_dominates(candidate: &VersionVector, ancestor: &VersionVector) -> bool {
+    ancestor
+        .0
+        .iter()
+        .all(|(device, sequence)| candidate.observed(device) >= *sequence)
+}
+
+fn checkpoint_content_eq(left: &CompactionCheckpoint, right: &CompactionCheckpoint) -> bool {
+    left.checkpoint_id == right.checkpoint_id
+        && left.compaction_generation == right.compaction_generation
+        && left.coverage == right.coverage
+        && left.previous_checkpoint_hash == right.previous_checkpoint_hash
+        && left.retained_engagement_operations == right.retained_engagement_operations
+        && left.leader_authorization == right.leader_authorization
+}
+
+fn without_acknowledgements(mut checkpoint: CompactionCheckpoint) -> CompactionCheckpoint {
+    checkpoint.acknowledged_by.clear();
+    checkpoint
+}
+
+#[derive(Serialize)]
+struct CheckpointHashMaterial<'a> {
+    kind: &'static str,
+    dataset_id: &'a str,
+    compaction_generation: u64,
+    coverage: &'a VersionVector,
+    previous_checkpoint_hash: Option<&'a str>,
+    retained_engagement_operations: &'a BTreeSet<String>,
+    // Commit to every surviving covered operation, not only engagement ids. Otherwise an older
+    // state could replace a pruned engagement dot with a rating or membership operation.
+    retained_covered_operations: Vec<&'a OperationEnvelope>,
+}
+
+pub(crate) fn checkpoint_id_for(
+    dataset_id: &str,
+    compaction_generation: u64,
+    coverage: &VersionVector,
+    previous_checkpoint_hash: Option<&str>,
+    retained_engagement_operations: &BTreeSet<String>,
+    operations: &[OperationEnvelope],
+) -> Result<String, PersonalStateError> {
+    let mut retained_covered_operations = operations
+        .iter()
+        .filter(|operation| {
+            coverage.covers(&operation.stamp.dot)
+                && (!matches!(operation.operation, Operation::RecordEngagement { .. })
+                    || retained_engagement_operations.contains(&operation.operation_id))
+        })
+        .collect::<Vec<_>>();
+    retained_covered_operations.sort_by(|left, right| {
+        left.stamp
+            .dot
+            .cmp(&right.stamp.dot)
+            .then(left.operation_id.cmp(&right.operation_id))
+    });
+    retained_covered_operations.dedup_by(|left, right| left.operation_id == right.operation_id);
+    let material = CheckpointHashMaterial {
+        kind: COMPACTION_HASH_KIND,
+        dataset_id,
+        compaction_generation,
+        coverage,
+        previous_checkpoint_hash,
+        retained_engagement_operations,
+        retained_covered_operations,
+    };
+    Ok(sha256_hex(&serde_json::to_vec(&material)?))
+}
+
+fn valid_hash(hash: &str) -> bool {
+    hash.len() == 64
+        && hash
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+#[cfg(test)]
+#[path = "compaction_tests.rs"]
+mod tests;

--- a/src/personal_state/compaction_tests.rs
+++ b/src/personal_state/compaction_tests.rs
@@ -1,0 +1,676 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::sync::DeviceSecretMaterial;
+
+use super::*;
+use crate::personal_state::{
+    CausalStamp, DevicePublicIdentity, DeviceRecord, Dot, EngagementKind, OperationOrigin,
+    PortableTrack, PortableTrackKey,
+};
+
+const DAY: i64 = 24 * 60 * 60;
+const NOW: i64 = 500 * DAY;
+
+fn track(id: &str) -> PortableTrack {
+    PortableTrack {
+        key: PortableTrackKey::Catalog {
+            provider: "youtube".to_owned(),
+            exact_catalog_id: id.to_owned(),
+        },
+        title: id.to_owned(),
+        artist: "Artist".to_owned(),
+        album: None,
+        duration_secs: Some(180),
+        isrc: None,
+    }
+}
+
+fn device_record(secret: &DeviceSecretMaterial) -> DeviceRecord {
+    DeviceRecord {
+        device_id: DeviceId::new(secret.device_id()).unwrap(),
+        name: secret.device_id().to_owned(),
+        revoked: false,
+        public_identity: Some(DevicePublicIdentity {
+            age_recipient: secret.public_identity().age_recipient,
+            ed25519_verifying_key: secret.public_identity().ed25519_verifying_key,
+        }),
+    }
+}
+
+fn state_with_devices(ids: &[&str]) -> (PersonalStateV2, Vec<DeviceSecretMaterial>) {
+    assert!(!ids.is_empty());
+    let secrets = ids
+        .iter()
+        .map(|id| DeviceSecretMaterial::generate_for(*id).unwrap())
+        .collect::<Vec<_>>();
+    let author = DeviceId::new(secrets[0].device_id()).unwrap();
+    let mut state = PersonalStateV2::empty(format!("compaction-{}", ids.join("-"))).unwrap();
+    for (index, secret) in secrets.iter().enumerate() {
+        let sequence = index as u64 + 1;
+        let dot = Dot {
+            device_id: author.clone(),
+            sequence,
+        };
+        state.operations.push(OperationEnvelope {
+            operation_id: format!("membership-{sequence}"),
+            stamp: CausalStamp {
+                dot: dot.clone(),
+                observed: state.version_vector.clone(),
+                recorded_at_unix: 0,
+            },
+            origin: OperationOrigin::Local,
+            operation: Operation::AddDevice {
+                device: device_record(secret),
+            },
+        });
+        state.version_vector.observe(&dot);
+    }
+    super::super::refresh_device_registry(&mut state).unwrap();
+    state.normalize().unwrap();
+    (state, secrets)
+}
+
+fn push_engagement(
+    state: &mut PersonalStateV2,
+    author: &DeviceId,
+    event_id: impl Into<String>,
+    recorded_at_unix: i64,
+) -> String {
+    let sequence = state.version_vector.observed(author) + 1;
+    let event_id = event_id.into();
+    let operation_id = format!("{}:{sequence}", author.as_str());
+    let dot = Dot {
+        device_id: author.clone(),
+        sequence,
+    };
+    state.operations.push(OperationEnvelope {
+        operation_id: operation_id.clone(),
+        stamp: CausalStamp {
+            dot: dot.clone(),
+            observed: state.version_vector.clone(),
+            recorded_at_unix,
+        },
+        origin: OperationOrigin::Local,
+        operation: Operation::RecordEngagement {
+            event_id,
+            track: track(&format!("track-{sequence}")),
+            engagement: EngagementKind::Play,
+            played_duration_ms: Some(90_000),
+            total_duration_ms: Some(180_000),
+            artist_key: "artist".to_owned(),
+        },
+    });
+    state.version_vector.observe(&dot);
+    operation_id
+}
+
+#[test]
+fn only_the_lowest_active_device_can_plan_compaction() {
+    let (mut state, secrets) = state_with_devices(&["device-z", "device-a"]);
+    let device_z = DeviceId::new(secrets[0].device_id()).unwrap();
+    let device_a = DeviceId::new(secrets[1].device_id()).unwrap();
+    push_engagement(
+        &mut state,
+        &device_z,
+        "expired",
+        NOW - RAW_EVENT_RETENTION_SECS - 1,
+    );
+    state.normalize().unwrap();
+
+    assert_eq!(engagement_compaction_leader(&state), Some(device_a.clone()));
+    assert!(matches!(
+        plan_engagement_compaction(&state, &device_z, NOW, false),
+        Err(PersonalStateError::InvalidOperation(
+            "only the lowest active device may compact personal state"
+        ))
+    ));
+    let compacted = plan_engagement_compaction(&state, &device_a, NOW, false)
+        .unwrap()
+        .unwrap();
+    let repeated = plan_engagement_compaction(&state, &device_a, NOW, false)
+        .unwrap()
+        .unwrap();
+    assert_eq!(compacted.candidate, repeated.candidate);
+    assert_eq!(compacted.pruned_engagement_operations, 1);
+    assert_eq!(
+        compacted
+            .candidate
+            .operations
+            .iter()
+            .filter(|operation| matches!(operation.operation, Operation::AddDevice { .. }))
+            .count(),
+        2
+    );
+
+    let revoked = crate::personal_state::append_operation_as(
+        &state,
+        &device_z,
+        Operation::RevokeDevice {
+            device_id: device_a,
+        },
+        NOW,
+    )
+    .unwrap();
+    assert_eq!(
+        engagement_compaction_leader(&revoked),
+        Some(device_z.clone())
+    );
+    assert!(
+        plan_engagement_compaction(&revoked, &device_z, NOW, false)
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[test]
+fn retention_boundary_is_inclusive_and_projection_is_unchanged() {
+    let (mut state, secrets) = state_with_devices(&["boundary-device"]);
+    let device = DeviceId::new(secrets[0].device_id()).unwrap();
+    let expired = push_engagement(
+        &mut state,
+        &device,
+        "expired",
+        NOW - RAW_EVENT_RETENTION_SECS - 1,
+    );
+    let boundary = push_engagement(
+        &mut state,
+        &device,
+        "boundary",
+        NOW - RAW_EVENT_RETENTION_SECS,
+    );
+    state.normalize().unwrap();
+    let before = project_at(&state, NOW).unwrap();
+
+    let plan = plan_engagement_compaction(&state, &device, NOW, false)
+        .unwrap()
+        .unwrap();
+    let after = project_at(&plan.candidate, NOW).unwrap();
+    assert_eq!(plan.pruned_engagement_operations, 1);
+    assert_eq!(before.fingerprint, after.fingerprint);
+    assert_eq!(before.legacy, after.legacy);
+    assert!(
+        !plan
+            .candidate
+            .operations
+            .iter()
+            .any(|operation| operation.operation_id == expired)
+    );
+    assert!(
+        plan.candidate
+            .operations
+            .iter()
+            .any(|operation| operation.operation_id == boundary)
+    );
+    assert_eq!(
+        plan.candidate
+            .compaction_checkpoint
+            .as_ref()
+            .unwrap()
+            .coverage,
+        state.version_vector
+    );
+    assert!(
+        plan.candidate
+            .compaction_checkpoint
+            .as_ref()
+            .unwrap()
+            .acknowledged_by
+            .is_empty()
+    );
+    assert!(
+        plan_engagement_compaction(&plan.candidate, &device, NOW, false)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn newest_twenty_thousand_events_are_retained_with_a_stable_dot_tie_break() {
+    let (mut state, secrets) = state_with_devices(&["cap-device"]);
+    let device = DeviceId::new(secrets[0].device_id()).unwrap();
+    let mut operation_ids = Vec::new();
+    for index in 0..20_001 {
+        operation_ids.push(push_engagement(
+            &mut state,
+            &device,
+            format!("same-time-{index}"),
+            NOW,
+        ));
+    }
+    state.normalize().unwrap();
+    let before = project_at(&state, NOW).unwrap();
+
+    let plan = plan_engagement_compaction(&state, &device, NOW, false)
+        .unwrap()
+        .unwrap();
+    let checkpoint = plan.candidate.compaction_checkpoint.as_ref().unwrap();
+    assert_eq!(plan.pruned_engagement_operations, 1);
+    assert_eq!(checkpoint.retained_engagement_operations.len(), 20_000);
+    assert!(
+        !checkpoint
+            .retained_engagement_operations
+            .contains(&operation_ids[0])
+    );
+    assert!(operation_ids[1..].iter().all(|operation_id| {
+        checkpoint
+            .retained_engagement_operations
+            .contains(operation_id)
+    }));
+    assert_eq!(plan.candidate.operations.len(), 20_001);
+    assert_eq!(
+        before.fingerprint,
+        project_at(&plan.candidate, NOW).unwrap().fingerprint
+    );
+}
+
+#[test]
+fn merge_does_not_resurrect_covered_pruned_events() {
+    let (mut original, secrets) = state_with_devices(&["merge-device"]);
+    let device = DeviceId::new(secrets[0].device_id()).unwrap();
+    let expired = push_engagement(
+        &mut original,
+        &device,
+        "expired",
+        NOW - RAW_EVENT_RETENTION_SECS - 1,
+    );
+    push_engagement(&mut original, &device, "kept", NOW);
+    original.normalize().unwrap();
+    let compacted = plan_engagement_compaction(&original, &device, NOW, false)
+        .unwrap()
+        .unwrap()
+        .candidate;
+
+    let (left, left_summary) = crate::personal_state::merge(&compacted, &original).unwrap();
+    let (right, _) = crate::personal_state::merge(&original, &compacted).unwrap();
+    assert_eq!(left.operations, compacted.operations);
+    assert_eq!(right.operations, compacted.operations);
+    assert_eq!(left.compaction_checkpoint, compacted.compaction_checkpoint);
+    assert_eq!(right.compaction_checkpoint, compacted.compaction_checkpoint);
+    assert_eq!(left_summary.added_operations, 0);
+    assert!(
+        !left
+            .operations
+            .iter()
+            .any(|operation| operation.operation_id == expired)
+    );
+}
+
+#[test]
+fn merge_rejects_a_non_engagement_operation_substituted_at_a_pruned_dot() {
+    let (mut original, secrets) = state_with_devices(&["substitution-device"]);
+    let device = DeviceId::new(secrets[0].device_id()).unwrap();
+    let expired = push_engagement(
+        &mut original,
+        &device,
+        "expired",
+        NOW - RAW_EVENT_RETENTION_SECS - 1,
+    );
+    original.normalize().unwrap();
+    let compacted = plan_engagement_compaction(&original, &device, NOW, false)
+        .unwrap()
+        .unwrap()
+        .candidate;
+
+    let mut substituted = original;
+    let operation = substituted
+        .operations
+        .iter_mut()
+        .find(|operation| operation.operation_id == expired)
+        .unwrap();
+    operation.operation = Operation::SetRating {
+        track: track("forged-rating"),
+        rating: crate::personal_state::Rating::Liked,
+    };
+    substituted.normalize().unwrap();
+
+    assert!(matches!(
+        crate::personal_state::merge(&compacted, &substituted),
+        Err(PersonalStateError::InvalidOperation(
+            "engagement compaction checkpoint hash does not match"
+        ))
+    ));
+}
+
+#[test]
+fn later_compaction_links_to_and_dominates_the_previous_checkpoint() {
+    let (mut state, secrets) = state_with_devices(&["chain-device"]);
+    let device = DeviceId::new(secrets[0].device_id()).unwrap();
+    push_engagement(
+        &mut state,
+        &device,
+        "first-expired",
+        NOW - RAW_EVENT_RETENTION_SECS - 1,
+    );
+    state.normalize().unwrap();
+    let first = plan_engagement_compaction(&state, &device, NOW, false)
+        .unwrap()
+        .unwrap()
+        .candidate;
+    let first_checkpoint = first.compaction_checkpoint.as_ref().unwrap().clone();
+    assert_eq!(first_checkpoint.compaction_generation, 1);
+
+    let mut advanced = crate::personal_state::append_operation_as(
+        &first,
+        &device,
+        Operation::RecordEngagement {
+            event_id: "second-expired".to_owned(),
+            track: track("second-expired"),
+            engagement: EngagementKind::Play,
+            played_duration_ms: Some(1),
+            total_duration_ms: Some(100),
+            artist_key: "artist".to_owned(),
+        },
+        NOW - RAW_EVENT_RETENTION_SECS - 1,
+    )
+    .unwrap();
+    advanced.projection_fingerprint = None;
+    assert!(
+        plan_engagement_compaction(&advanced, &device, NOW, false)
+            .unwrap()
+            .is_none(),
+        "a descendant compaction must wait for explicit authenticated quorum"
+    );
+    let second = plan_engagement_compaction(&advanced, &device, NOW, true)
+        .unwrap()
+        .unwrap()
+        .candidate;
+    let second_checkpoint = second.compaction_checkpoint.as_ref().unwrap();
+    assert_eq!(second_checkpoint.compaction_generation, 2);
+    assert_eq!(
+        second_checkpoint.previous_checkpoint_hash.as_deref(),
+        Some(first_checkpoint.checkpoint_id.as_str())
+    );
+    assert!(vector_dominates(
+        &second_checkpoint.coverage,
+        &first_checkpoint.coverage
+    ));
+
+    let (merged, _) = crate::personal_state::merge(&first, &second).unwrap();
+    assert_eq!(
+        merged.compaction_checkpoint.as_ref().unwrap().checkpoint_id,
+        second_checkpoint.checkpoint_id
+    );
+}
+
+#[test]
+fn non_adjacent_compaction_generations_merge_and_import_in_both_directions() {
+    let (mut original, secrets) = state_with_devices(&["generation-device"]);
+    let device = DeviceId::new(secrets[0].device_id()).unwrap();
+    push_engagement(
+        &mut original,
+        &device,
+        "generation-one-expired",
+        NOW - RAW_EVENT_RETENTION_SECS - 1,
+    );
+    original.normalize().unwrap();
+    let first = plan_engagement_compaction(&original, &device, NOW, false)
+        .unwrap()
+        .unwrap()
+        .candidate;
+
+    let mut after_first = crate::personal_state::append_operation_as(
+        &first,
+        &device,
+        Operation::RecordEngagement {
+            event_id: "generation-two-expired".to_owned(),
+            track: track("generation-two-expired"),
+            engagement: EngagementKind::Play,
+            played_duration_ms: Some(1),
+            total_duration_ms: Some(100),
+            artist_key: "artist".to_owned(),
+        },
+        NOW - RAW_EVENT_RETENTION_SECS - 1,
+    )
+    .unwrap();
+    after_first.projection_fingerprint = None;
+    let second = plan_engagement_compaction(&after_first, &device, NOW, true)
+        .unwrap()
+        .unwrap()
+        .candidate;
+
+    let mut after_second = crate::personal_state::append_operation_as(
+        &second,
+        &device,
+        Operation::RecordEngagement {
+            event_id: "generation-three-expired".to_owned(),
+            track: track("generation-three-expired"),
+            engagement: EngagementKind::Play,
+            played_duration_ms: Some(1),
+            total_duration_ms: Some(100),
+            artist_key: "artist".to_owned(),
+        },
+        NOW - RAW_EVENT_RETENTION_SECS - 1,
+    )
+    .unwrap();
+    after_second.projection_fingerprint = None;
+    let third = plan_engagement_compaction(&after_second, &device, NOW, true)
+        .unwrap()
+        .unwrap()
+        .candidate;
+
+    assert_eq!(
+        [
+            first
+                .compaction_checkpoint
+                .as_ref()
+                .unwrap()
+                .compaction_generation,
+            second
+                .compaction_checkpoint
+                .as_ref()
+                .unwrap()
+                .compaction_generation,
+            third
+                .compaction_checkpoint
+                .as_ref()
+                .unwrap()
+                .compaction_generation,
+        ],
+        [1, 2, 3]
+    );
+
+    let (first_then_third, _) = crate::personal_state::merge(&first, &third).unwrap();
+    let (third_then_first, _) = crate::personal_state::merge(&third, &first).unwrap();
+    assert_eq!(first_then_third, third);
+    assert_eq!(third_then_first, third);
+
+    let import_old = crate::personal_state::plan_import(&third, &first).unwrap();
+    let import_new = crate::personal_state::plan_import(&first, &third).unwrap();
+    assert_eq!(import_old.candidate, third);
+    assert_eq!(import_new.candidate.operations, third.operations);
+    assert_eq!(import_new.candidate.version_vector, third.version_vector);
+    assert_eq!(
+        import_new.candidate.compaction_checkpoint,
+        third.compaction_checkpoint
+    );
+
+    let (first_second, _) = crate::personal_state::merge(&first, &second).unwrap();
+    let (left_associated, _) = crate::personal_state::merge(&first_second, &third).unwrap();
+    let (second_third, _) = crate::personal_state::merge(&second, &third).unwrap();
+    let (right_associated, _) = crate::personal_state::merge(&first, &second_third).unwrap();
+    assert_eq!(left_associated, right_associated);
+    assert_eq!(left_associated, third);
+}
+
+#[test]
+fn compaction_generation_overflow_fails_closed() {
+    let (mut original, secrets) = state_with_devices(&["generation-overflow-device"]);
+    let device = DeviceId::new(secrets[0].device_id()).unwrap();
+    push_engagement(
+        &mut original,
+        &device,
+        "initial-expired",
+        NOW - RAW_EVENT_RETENTION_SECS - 1,
+    );
+    original.normalize().unwrap();
+    let mut exhausted = plan_engagement_compaction(&original, &device, NOW, false)
+        .unwrap()
+        .unwrap()
+        .candidate;
+    let (coverage, previous, retained) = {
+        let checkpoint = exhausted.compaction_checkpoint.as_ref().unwrap();
+        (
+            checkpoint.coverage.clone(),
+            checkpoint.previous_checkpoint_hash.clone(),
+            checkpoint.retained_engagement_operations.clone(),
+        )
+    };
+    let exhausted_id = checkpoint_id_for(
+        &exhausted.dataset_id,
+        u64::MAX,
+        &coverage,
+        previous.as_deref(),
+        &retained,
+        &exhausted.operations,
+    )
+    .unwrap();
+    let checkpoint = exhausted.compaction_checkpoint.as_mut().unwrap();
+    checkpoint.compaction_generation = u64::MAX;
+    checkpoint.checkpoint_id = exhausted_id;
+    exhausted.normalize().unwrap();
+
+    let mut advanced = crate::personal_state::append_operation_as(
+        &exhausted,
+        &device,
+        Operation::RecordEngagement {
+            event_id: "overflow-expired".to_owned(),
+            track: track("overflow-expired"),
+            engagement: EngagementKind::Play,
+            played_duration_ms: Some(1),
+            total_duration_ms: Some(100),
+            artist_key: "artist".to_owned(),
+        },
+        NOW - RAW_EVENT_RETENTION_SECS - 1,
+    )
+    .unwrap();
+    advanced.projection_fingerprint = None;
+
+    assert!(matches!(
+        plan_engagement_compaction(&advanced, &device, NOW, true),
+        Err(PersonalStateError::InvalidOperation(
+            "compaction generation exhausted"
+        ))
+    ));
+}
+
+#[test]
+fn terminal_personal_state_revision_blocks_compaction_before_candidate_creation() {
+    let (mut state, secrets) = state_with_devices(&["revision-exhausted-device"]);
+    let device = DeviceId::new(secrets[0].device_id()).unwrap();
+    push_engagement(
+        &mut state,
+        &device,
+        "revision-exhausted-event",
+        NOW - RAW_EVENT_RETENTION_SECS - 1,
+    );
+    state.revision = u64::MAX;
+    state.normalize().unwrap();
+
+    assert!(matches!(
+        plan_engagement_compaction(&state, &device, NOW, false),
+        Err(PersonalStateError::InvalidOperation(
+            "personal-state revision exhausted"
+        ))
+    ));
+    assert!(state.compaction_checkpoint.is_none());
+    assert!(state.operations.iter().any(|operation| {
+        matches!(
+            &operation.operation,
+            Operation::RecordEngagement { event_id, .. }
+                if event_id == "revision-exhausted-event"
+        )
+    }));
+}
+
+#[test]
+fn incomparable_or_backward_checkpoint_history_is_rejected() {
+    let device_a = DeviceId::new("device-a").unwrap();
+    let device_b = DeviceId::new("device-b").unwrap();
+    let ancestor_coverage = VersionVector(BTreeMap::from([
+        (device_a.clone(), 5),
+        (device_b.clone(), 2),
+    ]));
+    let ancestor = checkpoint("fork-dataset", 1, ancestor_coverage, None);
+    let backward = checkpoint(
+        "fork-dataset",
+        2,
+        VersionVector(BTreeMap::from([
+            (device_a.clone(), 4),
+            (device_b.clone(), 3),
+        ])),
+        Some(&ancestor.checkpoint_id),
+    );
+    assert!(select_checkpoint(Some(&ancestor), Some(&backward)).is_err());
+    let wrong_parent = checkpoint(
+        "fork-dataset",
+        2,
+        VersionVector(BTreeMap::from([
+            (device_a.clone(), 6),
+            (device_b.clone(), 2),
+        ])),
+        Some(&"f".repeat(64)),
+    );
+    assert!(select_checkpoint(Some(&ancestor), Some(&wrong_parent)).is_err());
+
+    let left = checkpoint(
+        "fork-dataset",
+        2,
+        VersionVector(BTreeMap::from([
+            (device_a.clone(), 7),
+            (device_b.clone(), 2),
+        ])),
+        Some(&ancestor.checkpoint_id),
+    );
+    let right = checkpoint(
+        "fork-dataset",
+        2,
+        VersionVector(BTreeMap::from([(device_a, 5), (device_b, 4)])),
+        Some(&ancestor.checkpoint_id),
+    );
+    assert!(select_checkpoint(Some(&left), Some(&right)).is_err());
+}
+
+#[test]
+fn unsigned_acknowledgement_sets_are_never_unioned() {
+    let device = DeviceId::new("device-a").unwrap();
+    let checkpoint = checkpoint(
+        "ack-dataset",
+        1,
+        VersionVector(BTreeMap::from([(device.clone(), 1)])),
+        None,
+    );
+    let mut with_ack = checkpoint.clone();
+    with_ack.acknowledged_by.insert(device);
+
+    let selected = select_checkpoint(Some(&checkpoint), Some(&with_ack))
+        .unwrap()
+        .unwrap();
+    assert!(selected.acknowledged_by.is_empty());
+    assert_eq!(selected.checkpoint_id, checkpoint.checkpoint_id);
+}
+
+fn checkpoint(
+    dataset_id: &str,
+    compaction_generation: u64,
+    coverage: VersionVector,
+    previous_checkpoint_hash: Option<&str>,
+) -> CompactionCheckpoint {
+    let retained_engagement_operations = BTreeSet::new();
+    CompactionCheckpoint {
+        checkpoint_id: checkpoint_id_for(
+            dataset_id,
+            compaction_generation,
+            &coverage,
+            previous_checkpoint_hash,
+            &retained_engagement_operations,
+            &[],
+        )
+        .unwrap(),
+        compaction_generation,
+        coverage,
+        previous_checkpoint_hash: previous_checkpoint_hash.map(str::to_owned),
+        retained_engagement_operations,
+        leader_authorization: None,
+        acknowledged_by: BTreeSet::new(),
+    }
+}

--- a/src/personal_state/coordinator.rs
+++ b/src/personal_state/coordinator.rs
@@ -122,6 +122,11 @@ impl<'a> OperationAppender<'a> {
         operation: Operation,
         recorded_at_unix: i64,
     ) -> Result<Dot, PersonalStateError> {
+        // A different durable state must never reuse the terminal revision. The transaction
+        // coordinator advances this revision when it publishes the candidate; rejecting here
+        // keeps a MAX-valued imported ledger immutable instead of manufacturing same-revision
+        // content which a detached sync worker could mistake for its original snapshot.
+        let _ = self.state.next_revision()?;
         let sequence = self.next_sequence()?;
         let dot = Dot {
             device_id: self.device.clone(),

--- a/src/personal_state/import.rs
+++ b/src/personal_state/import.rs
@@ -61,7 +61,8 @@ pub fn plan_import(
         || candidate.version_vector != current.version_vector
         || candidate.compaction_checkpoint != current.compaction_checkpoint;
     if changed {
-        candidate.revision = candidate.revision.max(current.revision).saturating_add(1);
+        candidate.revision =
+            PersonalStateV2::revision_after(candidate.revision.max(current.revision))?;
         candidate.projection_fingerprint = None;
     } else {
         candidate.revision = current.revision;
@@ -150,7 +151,7 @@ pub fn plan_join_import(
         ));
     }
 
-    candidate.revision = authenticated_remote.revision.saturating_add(1);
+    candidate.revision = authenticated_remote.next_revision()?;
     validate_join_import_extension(authenticated_remote, &candidate, local_device_id)?;
     let summary = summarize(&before, &after, 1, 0, true);
     Ok(ImportPlan { candidate, summary })

--- a/src/personal_state/model.rs
+++ b/src/personal_state/model.rs
@@ -362,12 +362,41 @@ impl DeviceRecord {
 
 pub type DeviceRegistry = BTreeMap<DeviceId, DeviceRecord>;
 
+/// Vault-authenticated authorization for one engagement compaction transition.
+///
+/// The signature is created by the lowest device id active in the recorded membership epoch.
+/// Keeping the historical epoch and membership head with the portable checkpoint lets later
+/// vault checkpoints retain and verify the authorization even after membership changes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompactionLeaderAuthorization {
+    pub membership_epoch: u64,
+    pub membership_head_hash: String,
+    pub leader_device_id: DeviceId,
+    pub introducing_checkpoint_sequence: u64,
+    pub introducing_checkpoint_parent_hash: String,
+    pub signature: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CompactionCheckpoint {
     pub checkpoint_id: String,
+    /// Monotonic generation in the engagement-compaction lineage.
+    ///
+    /// This advances exactly once per compaction, allowing a portable replica to recognize a
+    /// valid newer checkpoint even when intermediate generations are no longer present.
+    pub compaction_generation: u64,
     pub coverage: VersionVector,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub previous_checkpoint_hash: Option<String>,
+    /// Raw engagement operations deliberately retained by this checkpoint.
+    ///
+    /// Coverage is a version vector, so it can cover both pruned events and newer events that
+    /// remain useful as the bounded recent-history window. Keeping their operation ids in the
+    /// checkpoint lets merge discard only the covered events that were actually compacted.
+    #[serde(default)]
+    pub retained_engagement_operations: BTreeSet<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub leader_authorization: Option<CompactionLeaderAuthorization>,
     #[serde(default)]
     pub acknowledged_by: BTreeSet<DeviceId>,
 }
@@ -436,6 +465,22 @@ impl Default for PersonalStateV2 {
 }
 
 impl PersonalStateV2 {
+    pub(crate) fn next_revision(&self) -> Result<u64, PersonalStateError> {
+        Self::revision_after(self.revision)
+    }
+
+    pub(crate) fn revision_after(revision: u64) -> Result<u64, PersonalStateError> {
+        revision
+            .checked_add(1)
+            .ok_or(PersonalStateError::InvalidOperation(
+                "personal-state revision exhausted",
+            ))
+    }
+
+    pub(crate) fn identity(&self) -> Result<String, PersonalStateError> {
+        Ok(super::legacy::sha256_hex(&serde_json::to_vec(self)?))
+    }
+
     pub fn empty(dataset_id: String) -> Result<Self, PersonalStateError> {
         validate_id("dataset id", &dataset_id, 128)?;
         Ok(Self {
@@ -486,6 +531,11 @@ impl PersonalStateV2 {
             validate_device_record(device, true)?;
         }
         if let Some(checkpoint) = &self.compaction_checkpoint {
+            if checkpoint.compaction_generation == 0 {
+                return Err(PersonalStateError::InvalidOperation(
+                    "compaction generation is invalid",
+                ));
+            }
             validate_id("checkpoint id", &checkpoint.checkpoint_id, 256)?;
             if checkpoint.coverage.0.len() > MAX_DEVICES
                 || checkpoint.acknowledged_by.len() > MAX_DEVICES
@@ -502,6 +552,35 @@ impl PersonalStateV2 {
             }
             if let Some(previous_hash) = &checkpoint.previous_checkpoint_hash {
                 validate_id("previous checkpoint hash", previous_hash, 128)?;
+            }
+            if let Some(authorization) = &checkpoint.leader_authorization {
+                if authorization.membership_epoch == 0
+                    || authorization.introducing_checkpoint_sequence < 2
+                {
+                    return Err(PersonalStateError::InvalidOperation(
+                        "compaction authorization sequence is invalid",
+                    ));
+                }
+                validate_id(
+                    "compaction authorization membership head",
+                    &authorization.membership_head_hash,
+                    128,
+                )?;
+                validate_id(
+                    "compaction authorization leader device",
+                    authorization.leader_device_id.as_str(),
+                    MAX_TRACK_ID_CHARS,
+                )?;
+                validate_id(
+                    "compaction authorization checkpoint parent",
+                    &authorization.introducing_checkpoint_parent_hash,
+                    128,
+                )?;
+                validate_id(
+                    "compaction authorization signature",
+                    &authorization.signature,
+                    256,
+                )?;
             }
         }
 
@@ -566,6 +645,9 @@ impl PersonalStateV2 {
             return Err(PersonalStateError::InvalidOperation(
                 "device registry does not match membership operations",
             ));
+        }
+        if let Some(checkpoint) = &self.compaction_checkpoint {
+            super::compaction::validate_checkpoint(self, checkpoint)?;
         }
         Ok(())
     }

--- a/src/personal_state/reducer.rs
+++ b/src/personal_state/reducer.rs
@@ -1,6 +1,9 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
+use super::compaction::{
+    operation_survives_checkpoint, retained_engagement_operation_ids, select_checkpoint,
+};
 use super::legacy::{
     ENGAGEMENT_EVENTS_MAX, FAVORITES_MAX, HISTORY_MAX, LegacyPlayEvent, LegacyPlaylist,
     LegacyPlaylistEntry, LegacyProjection, LegacySignals, LegacyStation, LegacyTrackSignal,
@@ -14,7 +17,6 @@ use super::{
     VersionVector,
 };
 
-const RAW_EVENT_RETENTION_SECS: i64 = 365 * 24 * 60 * 60;
 const ARTIST_WEIGHT_MIN: f32 = -2.0;
 const ARTIST_WEIGHT_MAX: f32 = 2.0;
 
@@ -162,13 +164,19 @@ pub fn merge(
             }
         }
     }
+    let checkpoint = select_checkpoint(
+        merged.compaction_checkpoint.as_ref(),
+        remote.compaction_checkpoint.as_ref(),
+    )?;
+    operations.retain(|_, operation| operation_survives_checkpoint(checkpoint.as_ref(), operation));
+    summary.added_operations = operations
+        .values()
+        .filter(|operation| !local_ids.contains(operation.operation_id.as_str()))
+        .count();
     merged.operations = operations.into_values().collect();
     merged.version_vector.merge(&remote.version_vector);
     merged.device_registry = derive_device_registry(&merged.operations)?;
-    merged.compaction_checkpoint = choose_checkpoint(
-        merged.compaction_checkpoint.as_ref(),
-        remote.compaction_checkpoint.as_ref(),
-    );
+    merged.compaction_checkpoint = checkpoint;
     merged.revision = local.revision.max(remote.revision);
     merged.projection_fingerprint = None;
     merged.normalize()?;
@@ -390,7 +398,8 @@ pub(crate) fn project_at(
     apply_disliked_projection(&mut legacy.signals, &ratings);
     legacy.radio_favorites = projected_radio(&radio);
 
-    let retained_events = retained_events(events.into_values(), now_unix);
+    let retained_operation_ids = retained_engagement_operation_ids(&state.operations, now_unix);
+    let retained_events = retained_events(events.into_values(), &retained_operation_ids);
     apply_engagement_projection(&mut legacy, &retained_events);
     apply_rating_affinity_delta(&mut legacy.signals, &baseline_ratings, &ratings);
 
@@ -483,7 +492,7 @@ fn update_optional_register<T>(
     }
 }
 
-fn stamp_order(
+pub(crate) fn stamp_order(
     candidate: &CausalStamp,
     candidate_id: &str,
     current: &CausalStamp,
@@ -546,28 +555,16 @@ fn projected_radio(
 
 fn retained_events(
     events: impl IntoIterator<Item = EngagementEvent>,
-    now_unix: i64,
+    retained_operation_ids: &[String],
 ) -> Vec<EngagementEvent> {
-    let cutoff = now_unix.saturating_sub(RAW_EVENT_RETENTION_SECS);
     let mut events = events
         .into_iter()
-        .filter(|event| {
-            event.envelope.stamp.recorded_at_unix == 0
-                || event.envelope.stamp.recorded_at_unix >= cutoff
-        })
-        .collect::<Vec<_>>();
-    events.sort_by(|left, right| {
-        right
-            .envelope
-            .stamp
-            .recorded_at_unix
-            .cmp(&left.envelope.stamp.recorded_at_unix)
-            .then(right.envelope.stamp.dot.cmp(&left.envelope.stamp.dot))
-            .then(left.event_id.cmp(&right.event_id))
-    });
-    events.truncate(ENGAGEMENT_EVENTS_MAX);
-    events.reverse();
-    events
+        .map(|event| (event.envelope.operation_id.clone(), event))
+        .collect::<HashMap<_, _>>();
+    retained_operation_ids
+        .iter()
+        .filter_map(|operation_id| events.remove(operation_id))
+        .collect()
 }
 
 fn apply_engagement_projection(legacy: &mut LegacyProjection, events: &[EngagementEvent]) {
@@ -988,33 +985,4 @@ fn empty_legacy() -> LegacyProjection {
         signals: LegacySignals::default(),
         station: LegacyStation::default(),
     }
-}
-
-fn choose_checkpoint(
-    left: Option<&super::CompactionCheckpoint>,
-    right: Option<&super::CompactionCheckpoint>,
-) -> Option<super::CompactionCheckpoint> {
-    match (left, right) {
-        (Some(left), Some(right)) => Some(
-            if checkpoint_order(left, right).is_ge() {
-                left
-            } else {
-                right
-            }
-            .clone(),
-        ),
-        (Some(checkpoint), None) | (None, Some(checkpoint)) => Some(checkpoint.clone()),
-        (None, None) => None,
-    }
-}
-
-fn checkpoint_order(
-    left: &super::CompactionCheckpoint,
-    right: &super::CompactionCheckpoint,
-) -> Ordering {
-    let left_coverage = left.coverage.0.values().copied().sum::<u64>();
-    let right_coverage = right.coverage.0.values().copied().sum::<u64>();
-    left_coverage
-        .cmp(&right_coverage)
-        .then(left.checkpoint_id.cmp(&right.checkpoint_id))
 }

--- a/src/personal_state/tests.rs
+++ b/src/personal_state/tests.rs
@@ -1141,6 +1141,56 @@ fn divergent_commits_at_the_same_revision_are_rejected() {
     std::fs::remove_dir_all(root).unwrap();
 }
 
+#[test]
+fn terminal_revision_rejects_mutation_import_and_commit_preparation() {
+    let base = state_with_keyed_devices(&["revision-device"]);
+    let device = DeviceId::new("revision-device").unwrap();
+    let changed = append_operation_as(
+        &base,
+        &device,
+        Operation::SetRating {
+            track: track("revision-exhaustion"),
+            rating: Rating::Liked,
+        },
+        1,
+    )
+    .unwrap();
+
+    let mut exhausted = base.clone();
+    exhausted.revision = u64::MAX;
+    assert!(matches!(
+        append_operation_as(
+            &exhausted,
+            &device,
+            Operation::SetRating {
+                track: track("blocked-mutation"),
+                rating: Rating::Liked,
+            },
+            2,
+        ),
+        Err(PersonalStateError::InvalidOperation(
+            "personal-state revision exhausted"
+        ))
+    ));
+
+    assert!(matches!(
+        plan_import(&exhausted, &changed),
+        Err(PersonalStateError::InvalidOperation(
+            "personal-state revision exhausted"
+        ))
+    ));
+
+    let mut changed_at_max = changed;
+    changed_at_max.revision = u64::MAX;
+    changed_at_max.projection_fingerprint = None;
+    assert!(matches!(
+        PersonalStateCommit::prepare(changed_at_max),
+        Err(PersonalStateError::InvalidOperation(
+            "personal-state revision exhausted"
+        ))
+    ));
+}
+
 fn assert_projection_files_match(paths: &PersonalStatePaths, state: &PersonalStateV2) {
     let library: crate::library::Library =
         serde_json::from_slice(&std::fs::read(&paths.library).unwrap()).unwrap();

--- a/src/personal_state/transaction.rs
+++ b/src/personal_state/transaction.rs
@@ -108,7 +108,7 @@ impl PersonalStateCommit {
         state.validate()?;
         let projection = project(&state)?;
         if state.projection_fingerprint.as_deref() != Some(projection.fingerprint.as_str()) {
-            state.revision = state.revision.saturating_add(1);
+            state.revision = state.next_revision()?;
         }
         state.device_registry = projection.device_registry.clone();
         state.version_vector = projection.version_vector.clone();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -420,6 +420,13 @@ impl From<RuntimeEvent> for Msg {
             RuntimeEvent::Persist(crate::persist::PersistEvent::WriteFailed { store, error }) => {
                 Msg::PersistFailed { store, error }
             }
+            RuntimeEvent::Persist(crate::persist::PersistEvent::PersonalStateCommitted {
+                revision,
+                state_identity,
+            }) => Msg::PersonalStatePersisted {
+                revision,
+                state_identity,
+            },
             RuntimeEvent::Remote(crate::remote::server::RemoteEvent::Command(cmd, reply)) => {
                 Msg::Remote(cmd, reply)
             }

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -184,6 +184,7 @@ impl RuntimeHandles {
                     action,
                     attempt,
                     personal_state,
+                    revision_guard,
                     reply,
                 } => {
                     let emitter = self.background_tasks.emitter(self.worker_tx.clone());
@@ -196,15 +197,26 @@ impl RuntimeHandles {
                                 .map_err(crate::sync::service::SyncServiceError::from)
                                 .and_then(|paths| {
                                     let revoke_target = match &action {
-                                        crate::app::PersonalSyncAction::SyncNow => None,
+                                        crate::app::PersonalSyncAction::SyncNow
+                                        | crate::app::PersonalSyncAction::AutomaticSync => None,
                                         crate::app::PersonalSyncAction::Revoke(device_id) => {
                                             Some(device_id)
                                         }
                                     };
-                                    crate::sync::service::prepare_owner_sync(
+                                    let kind = if matches!(
+                                        action,
+                                        crate::app::PersonalSyncAction::AutomaticSync
+                                    ) {
+                                        crate::sync::service::SyncAttemptKind::Automatic
+                                    } else {
+                                        crate::sync::service::SyncAttemptKind::Manual
+                                    };
+                                    crate::sync::service::prepare_owner_sync_as(
                                         &personal_state,
                                         revoke_target,
                                         &paths,
+                                        kind,
+                                        &revision_guard,
                                     )
                                 })
                         },

--- a/src/runtime/event_policy.rs
+++ b/src/runtime/event_policy.rs
@@ -69,11 +69,14 @@ pub(super) fn app_msg_policy(msg: &Msg) -> EventPolicy {
         Msg::TrackResolved { .. } => EventPolicy::DropIfStale {
             stale_key: Key::ResolverVideo,
         },
-        Msg::Noop | Msg::StatusTick | Msg::LyricsTick | Msg::AnimTick | Msg::RecordingTick => {
-            EventPolicy::BestEffort {
-                reason: "loop-owned ticks and inert messages are redraw/status hints",
-            }
-        }
+        Msg::Noop
+        | Msg::StatusTick
+        | Msg::AutomaticSyncTick
+        | Msg::LyricsTick
+        | Msg::AnimTick
+        | Msg::RecordingTick => EventPolicy::BestEffort {
+            reason: "loop-owned ticks and inert messages are redraw/status hints",
+        },
         Msg::Key(_)
         | Msg::MouseClick { .. }
         | Msg::MouseDoubleClick { .. }
@@ -105,6 +108,7 @@ pub(super) fn app_msg_policy(msg: &Msg) -> EventPolicy {
             | crate::app::DownloadMsg::DirError { .. },
         )
         | Msg::PersistFailed { .. }
+        | Msg::PersonalStatePersisted { .. }
         | Msg::Ai(_)
         | Msg::Scrobble(_)
         | Msg::Tools(

--- a/src/runtime/persist_delivery.rs
+++ b/src/runtime/persist_delivery.rs
@@ -43,7 +43,7 @@ fn admit_personal_state(handle: &PersistHandle, app: &mut App) -> DeliveryResult
         }
     };
     let (library, playlists, signals, station) = commit.runtime_stores();
-    app.personal_state.ledger = commit.state().clone();
+    app.personal_state.replace_ledger(commit.state().clone());
     app.library = std::sync::Arc::new(library);
     app.playlists = std::sync::Arc::new(playlists);
     app.signals = std::sync::Arc::new(signals);
@@ -119,7 +119,7 @@ mod tests {
         let handle = crate::persist::spawn();
         let mut app = App::new(50);
         let (state, device_id) = synced_state();
-        app.personal_state.ledger = state;
+        app.personal_state.replace_ledger(state);
         app.personal_state.device_id = Some(device_id.clone());
         app.library_mut().toggle_favorite(&crate::api::Song::remote(
             "bound-rating",

--- a/src/runtime/personal_sync_commit.rs
+++ b/src/runtime/personal_sync_commit.rs
@@ -123,6 +123,9 @@ fn prepare_writer(
             candidate.as_ref().clone(),
             match &commit.action {
                 crate::app::PersonalSyncAction::SyncNow => PersonalSyncApplyKind::SyncNow,
+                crate::app::PersonalSyncAction::AutomaticSync => {
+                    PersonalSyncApplyKind::AutomaticSync
+                }
                 crate::app::PersonalSyncAction::Revoke(device_id) => {
                     PersonalSyncApplyKind::Revoke(device_id.clone())
                 }
@@ -292,7 +295,7 @@ mod tests {
         assert!(attempts.load(Ordering::Acquire) >= 2);
         let failures = failures.lock().unwrap();
         assert_eq!(failures.len(), 1);
-        let crate::persist::PersistEvent::WriteFailed { store, error } = &failures[0];
+        let (store, error) = failures[0].write_failure().unwrap();
         assert_eq!(*store, crate::persist::StoreKind::PersonalState);
         assert!(error.contains("temporary storage failure"));
     }

--- a/src/runtime/read_only.rs
+++ b/src/runtime/read_only.rs
@@ -163,6 +163,7 @@ mod tests {
             action: crate::app::PersonalSyncAction::SyncNow,
             attempt: 1,
             personal_state: Box::new(crate::personal_state::PersonalStateV2::default()),
+            revision_guard: crate::sync::OwnerRevisionGuard::default(),
             reply: crate::app::PersonalSyncReply::new(reply.into()),
         });
 

--- a/src/settings/sync.rs
+++ b/src/settings/sync.rs
@@ -477,6 +477,11 @@ pub fn audit_action_label(action: SyncAuditAction) -> &'static str {
             "개인 데이터를 동기화했습니다",
             "個人データを同期しました"
         ),
+        SyncAuditAction::AutomaticSync => t!(
+            "Personal data was synced automatically",
+            "개인 데이터를 자동으로 동기화했습니다",
+            "個人データを自動同期しました"
+        ),
         SyncAuditAction::PairCreate => t!(
             "A device connection was started",
             "기기 연결을 시작했습니다",

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -4,8 +4,11 @@
 //! configuration, merge policy, and live-state publication remain in separate owners so a WebDAV
 //! failure cannot bypass the local-first persistence path.
 
+pub mod automatic;
 mod batch;
 mod checkpoint;
+mod compaction;
+mod connectivity;
 mod crypto;
 mod error;
 mod local_state;
@@ -15,11 +18,17 @@ mod pairing;
 mod private_store;
 mod profile;
 mod recovery;
+mod revision_guard;
 pub mod service;
 mod transport;
 pub mod webdav;
 mod worker;
 
+pub use automatic::{
+    AutomaticSyncScheduler, AutomaticSyncTrigger, BACKOFF_MAX, BACKOFF_MIN, BackoffJitter,
+    FALLBACK_INTERVAL, LOCAL_MUTATION_DEBOUNCE, SyncAttemptKind, SyncAttemptOutcome,
+    SyncAttemptToken, SyncFinish, SyncStartError,
+};
 pub use batch::{
     BatchAcceptance, BatchAnchor, OperationBatchPayload, SignedOperationBatch,
     apply_operation_batch,
@@ -28,6 +37,11 @@ pub use checkpoint::{
     CheckpointAcceptance, CheckpointAnchor, CheckpointBatchAnchor, CheckpointPayload,
     SignedCheckpoint,
 };
+pub use compaction::{
+    CompactionAckPayload, SignedCompactionAck, authorize_compaction, compaction_ack_key,
+    compaction_ack_prefix, compaction_quorum, verify_compaction_authorization,
+};
+pub(crate) use connectivity::NetworkChangeWatch;
 pub use crypto::{
     DeviceSecretMaterial, EncryptedObject, decrypt_json_with_identity, encrypt_json_to_recipients,
 };
@@ -51,9 +65,10 @@ pub use private_store::{
 };
 pub use profile::{MAX_CUSTOM_CA_PEM_BYTES, SyncPaths, WebDavProfile, WebDavProfileStore};
 pub use recovery::{RecoveryKit, RecoveryResult};
+pub use revision_guard::OwnerRevisionGuard;
 pub use transport::{
-    FileVaultTransport, ListCost, ListLimits, ListOutcome, ObjectCondition, ObjectKey,
-    ObjectMetadata, ObjectWriteResult, VaultDeadline, VaultTransport,
+    FileVaultTransport, ListCost, ListLimits, ListOutcome, ObjectCondition, ObjectDeleteResult,
+    ObjectKey, ObjectMetadata, ObjectWriteResult, VaultDeadline, VaultTransport,
 };
 pub(crate) use worker::spawn_detached_prepare;
 

--- a/src/sync/automatic.rs
+++ b/src/sync/automatic.rs
@@ -1,0 +1,978 @@
+//! Pure owner-lane scheduling for automatic personal-state synchronization.
+//!
+//! This module performs no I/O and owns no worker. The TUI and daemon each embed one scheduler
+//! beside their existing primary-owner sync coordinator, feed it monotonic time, and execute the
+//! generation-tagged attempts it returns. Keeping policy here gives both owners identical debounce,
+//! fallback, coalescing, and retry behavior without creating a second state writer.
+
+use std::time::{Duration, Instant};
+
+/// Wait for a quiet period after the latest local personal-state mutation.
+pub const LOCAL_MUTATION_DEBOUNCE: Duration = Duration::from_secs(30);
+/// Poll the encrypted vault even when no local mutation or reconnect was observed.
+pub const FALLBACK_INTERVAL: Duration = Duration::from_secs(15 * 60);
+/// First retry delay after an offline attempt, before bounded jitter.
+pub const BACKOFF_MIN: Duration = Duration::from_secs(2);
+/// Longest client-selected exponential retry delay, including jitter.
+///
+/// A server-provided `Retry-After` is an independent lower bound and may be longer.
+pub const BACKOFF_MAX: Duration = Duration::from_secs(15 * 60);
+
+/// The automatic cause which won when one coalesced sync attempt started.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutomaticSyncTrigger {
+    Startup,
+    LocalMutation,
+    Fallback,
+    Retry,
+    NetworkReconnect,
+}
+
+/// Whether an attempt was automatic or explicitly requested by the user.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncAttemptKind {
+    Automatic(AutomaticSyncTrigger),
+    Manual,
+}
+
+/// An opaque generation token which must accompany a completion.
+///
+/// A token is intentionally created only by [`AutomaticSyncScheduler`]. Comparing the complete
+/// value prevents an old detached worker from settling a newer attempt after disable/re-enable,
+/// retry, or owner restart boundaries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SyncAttemptToken {
+    generation: u64,
+    kind: SyncAttemptKind,
+}
+
+impl SyncAttemptToken {
+    pub fn generation(self) -> u64 {
+        self.generation
+    }
+
+    pub fn kind(self) -> SyncAttemptKind {
+        self.kind
+    }
+}
+
+/// Scheduling-relevant terminal result of one owner-accepted sync attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncAttemptOutcome {
+    Succeeded,
+    /// A transport failure which should retry automatically.
+    ///
+    /// `retry_after` is redacted protocol metadata, never an endpoint or response body. The
+    /// scheduler treats it as an independent lower bound; client-selected backoff remains capped.
+    Offline {
+        retry_after: Option<Duration>,
+    },
+    /// A non-retryable failure. The 15-minute fallback remains armed while automatic sync is on,
+    /// allowing corrected credentials or local state to recover without a process restart.
+    Failed,
+}
+
+/// Result of settling one generation-tagged attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncFinish {
+    Stale,
+    Accepted {
+        /// A coalesced cause which was already due when the accepted attempt finished.
+        next: Option<SyncAttemptToken>,
+    },
+}
+
+/// An explicit request cannot start while either owner mode already has a network attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncStartError {
+    AlreadyInFlight,
+}
+
+impl std::fmt::Display for SyncStartError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("personal sync is already running")
+    }
+}
+
+impl std::error::Error for SyncStartError {}
+
+/// Stable, injectable jitter for retry scheduling.
+///
+/// Runtime owners may derive the seed from device-local identity. Tests use either [`Self::none`]
+/// for the exact exponential ladder or a fixed seed to prove stable bounded jitter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackoffJitter {
+    seed: u64,
+    enabled: bool,
+}
+
+impl BackoffJitter {
+    pub const fn none() -> Self {
+        Self {
+            seed: 0,
+            enabled: false,
+        }
+    }
+
+    pub const fn stable(seed: u64) -> Self {
+        Self {
+            seed,
+            enabled: true,
+        }
+    }
+
+    /// Derive a non-secret, stable spread from device-local identity.
+    pub fn stable_for(device_id: &str) -> Self {
+        let seed = device_id
+            .as_bytes()
+            .iter()
+            .fold(0xcbf2_9ce4_8422_2325_u64, |hash, byte| {
+                (hash ^ u64::from(*byte)).wrapping_mul(0x0000_0100_0000_01b3)
+            });
+        Self::stable(seed)
+    }
+
+    fn apply(self, base: Duration, generation: u64, step: u8) -> Duration {
+        if !self.enabled || base >= BACKOFF_MAX {
+            return base.min(BACKOFF_MAX);
+        }
+        let base_millis = duration_millis(base);
+        let max_millis = duration_millis(BACKOFF_MAX);
+        let room = max_millis.saturating_sub(base_millis);
+        let window = (base_millis / 4).min(room);
+        if window == 0 {
+            return base;
+        }
+        let mixed = mix64(self.seed ^ generation.rotate_left(17) ^ u64::from(step).rotate_left(41));
+        Duration::from_millis(base_millis + mixed % (window + 1))
+    }
+}
+
+/// Shared automatic-sync policy state. It must live on the primary owner's lane.
+#[derive(Debug)]
+pub struct AutomaticSyncScheduler {
+    enabled: bool,
+    next_generation: u64,
+    in_flight: Option<SyncAttemptToken>,
+    immediate: Option<AutomaticSyncTrigger>,
+    local_due: Option<Instant>,
+    retry_due: Option<Instant>,
+    retry_not_before: Option<Instant>,
+    fallback_due: Option<Instant>,
+    backoff_step: u8,
+    offline_latched: bool,
+    jitter: BackoffJitter,
+}
+
+impl AutomaticSyncScheduler {
+    pub fn new(jitter: BackoffJitter) -> Self {
+        Self {
+            enabled: false,
+            next_generation: 0,
+            in_flight: None,
+            immediate: None,
+            local_due: None,
+            retry_due: None,
+            retry_not_before: None,
+            fallback_due: None,
+            backoff_step: 0,
+            offline_latched: false,
+            jitter,
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn in_flight(&self) -> Option<SyncAttemptToken> {
+        self.in_flight
+    }
+
+    /// Whether the owner should listen for a positive local connectivity transition.
+    pub fn waiting_for_connectivity(&self) -> bool {
+        self.enabled
+            && self.in_flight.is_none()
+            && self.offline_latched
+            && self.immediate != Some(AutomaticSyncTrigger::NetworkReconnect)
+    }
+
+    /// Configure retry spread before this owner enables or starts synchronization.
+    pub fn configure_jitter(&mut self, jitter: BackoffJitter) {
+        if !self.enabled && self.in_flight.is_none() {
+            self.jitter = jitter;
+        }
+    }
+
+    /// Enable automatic sync and start the startup attempt immediately when the owner is idle.
+    ///
+    /// Enabling while a manual or previous automatic attempt is running coalesces Startup behind
+    /// that attempt instead of creating a second worker.
+    pub fn enable(&mut self, now: Instant) -> Option<SyncAttemptToken> {
+        if !self.enabled {
+            self.enabled = true;
+            self.immediate.get_or_insert(AutomaticSyncTrigger::Startup);
+        }
+        self.poll(now)
+    }
+
+    /// Disable future automatic work without cancelling a worker which may already have written
+    /// immutable remote objects. Its exact token may still settle safely; no follow-up is armed.
+    pub fn disable(&mut self) {
+        self.enabled = false;
+        self.clear_automatic_work();
+        self.backoff_step = 0;
+        self.offline_latched = false;
+    }
+
+    /// Record one newly durable local personal-state mutation.
+    pub fn local_mutation(&mut self, now: Instant) -> Option<SyncAttemptToken> {
+        if !self.enabled {
+            return None;
+        }
+        self.local_due = Some(deadline_after(now, LOCAL_MUTATION_DEBOUNCE));
+        self.poll(now)
+    }
+
+    /// Positive connectivity evidence bypasses a pending transport backoff.
+    ///
+    /// Owners call this only after this scheduler latched an offline WebDAV result. Arbitrary
+    /// successful UI events therefore cannot produce extra network traffic. A server-provided
+    /// retry lower bound remains authoritative even after connectivity returns.
+    pub fn network_reconnected(&mut self, now: Instant) -> Option<SyncAttemptToken> {
+        if !self.enabled || !self.offline_latched {
+            return None;
+        }
+        self.immediate = Some(AutomaticSyncTrigger::NetworkReconnect);
+        if self
+            .retry_not_before
+            .is_some_and(|not_before| now < not_before)
+        {
+            return None;
+        }
+        self.offline_latched = false;
+        self.retry_due = None;
+        self.poll(now)
+    }
+
+    /// Start an explicit sync through the same single-flight gate.
+    ///
+    /// A manual pass consumes every cause observed before it starts because its owner snapshot
+    /// covers that state. Causes received after it starts remain pending for a follow-up.
+    pub fn begin_manual(&mut self, _now: Instant) -> Result<SyncAttemptToken, SyncStartError> {
+        if self.in_flight.is_some() {
+            return Err(SyncStartError::AlreadyInFlight);
+        }
+        Ok(self.start(SyncAttemptKind::Manual))
+    }
+
+    /// Start automatic work whose deadline has arrived, if the owner lane is idle.
+    pub fn poll(&mut self, now: Instant) -> Option<SyncAttemptToken> {
+        if !self.enabled || self.in_flight.is_some() {
+            return None;
+        }
+        if self
+            .retry_not_before
+            .is_some_and(|not_before| now < not_before)
+        {
+            return None;
+        }
+        let trigger = if self.offline_latched {
+            self.immediate
+                .filter(|trigger| *trigger == AutomaticSyncTrigger::NetworkReconnect)
+                .or_else(|| due(self.retry_due, now).then_some(AutomaticSyncTrigger::Retry))
+        } else {
+            self.immediate.or_else(|| {
+                due(self.retry_due, now)
+                    .then_some(AutomaticSyncTrigger::Retry)
+                    .or_else(|| {
+                        due(self.local_due, now).then_some(AutomaticSyncTrigger::LocalMutation)
+                    })
+                    .or_else(|| {
+                        due(self.fallback_due, now).then_some(AutomaticSyncTrigger::Fallback)
+                    })
+            })
+        }?;
+        Some(self.start(SyncAttemptKind::Automatic(trigger)))
+    }
+
+    /// Earliest timer the owner needs to park in its event loop.
+    ///
+    /// There is no timer while a worker is active: causes continue to coalesce, and its completion
+    /// immediately evaluates anything which became due in the meantime.
+    pub fn next_deadline(&self) -> Option<Instant> {
+        if !self.enabled || self.in_flight.is_some() {
+            return None;
+        }
+        if self.offline_latched {
+            if self.immediate == Some(AutomaticSyncTrigger::NetworkReconnect) {
+                return self.retry_not_before.or(self.retry_due);
+            }
+            return self.retry_due;
+        }
+        let pending = [self.retry_due, self.local_due, self.fallback_due]
+            .into_iter()
+            .flatten()
+            .min();
+        match (pending, self.retry_not_before) {
+            (Some(pending), Some(not_before)) => Some(pending.max(not_before)),
+            (pending, None) => pending,
+            (None, Some(_)) => None,
+        }
+    }
+
+    /// Settle one exact worker generation and return an already-due coalesced follow-up.
+    pub fn finish(
+        &mut self,
+        token: SyncAttemptToken,
+        outcome: SyncAttemptOutcome,
+        now: Instant,
+    ) -> SyncFinish {
+        if self.in_flight != Some(token) {
+            return SyncFinish::Stale;
+        }
+        self.in_flight = None;
+        if !self.enabled {
+            self.clear_automatic_work();
+            self.backoff_step = 0;
+            self.offline_latched = false;
+            return SyncFinish::Accepted { next: None };
+        }
+        match outcome {
+            SyncAttemptOutcome::Succeeded => {
+                self.clear_reconnect_signal();
+                self.backoff_step = 0;
+                self.offline_latched = false;
+                self.retry_due = None;
+                self.retry_not_before = None;
+                self.arm_fallback(now);
+            }
+            SyncAttemptOutcome::Offline { retry_after } => {
+                // A connectivity edge observed before this newer failed request is stale. Keeping
+                // it would immediately bypass the backoff which this failure is about to arm.
+                self.clear_reconnect_signal();
+                self.offline_latched = true;
+                self.arm_fallback(now);
+                if self.enabled {
+                    let base = backoff_base(self.backoff_step);
+                    let delay = self.jitter.apply(base, token.generation, self.backoff_step);
+                    self.backoff_step = self.backoff_step.saturating_add(1);
+                    let existing_embargo =
+                        self.retry_not_before.filter(|not_before| *not_before > now);
+                    let hinted_embargo =
+                        retry_after.map(|hint| deadline_after_saturating(now, hint));
+                    self.retry_not_before = match (existing_embargo, hinted_embargo) {
+                        (Some(existing), Some(hinted)) => Some(existing.max(hinted)),
+                        (existing, hinted) => existing.or(hinted),
+                    };
+                    let retry_due = deadline_after(now, delay);
+                    self.retry_due = Some(
+                        self.retry_not_before
+                            .map_or(retry_due, |not_before| retry_due.max(not_before)),
+                    );
+                }
+            }
+            SyncAttemptOutcome::Failed => {
+                self.clear_reconnect_signal();
+                self.backoff_step = 0;
+                self.offline_latched = false;
+                self.retry_due = None;
+                self.retry_not_before =
+                    self.retry_not_before.filter(|not_before| *not_before > now);
+                self.arm_fallback(now);
+            }
+        }
+        SyncFinish::Accepted {
+            next: self.poll(now),
+        }
+    }
+
+    fn start(&mut self, kind: SyncAttemptKind) -> SyncAttemptToken {
+        debug_assert!(self.in_flight.is_none());
+        self.next_generation = self.next_generation.wrapping_add(1);
+        if self.next_generation == 0 {
+            self.next_generation = 1;
+        }
+        let token = SyncAttemptToken {
+            generation: self.next_generation,
+            kind,
+        };
+        self.in_flight = Some(token);
+        self.immediate = None;
+        self.local_due = None;
+        self.retry_due = None;
+        self.fallback_due = None;
+        token
+    }
+
+    fn clear_automatic_work(&mut self) {
+        self.immediate = None;
+        self.local_due = None;
+        self.retry_due = None;
+        self.retry_not_before = None;
+        self.fallback_due = None;
+    }
+
+    fn arm_fallback(&mut self, now: Instant) {
+        self.fallback_due = self.enabled.then(|| deadline_after(now, FALLBACK_INTERVAL));
+    }
+
+    fn clear_reconnect_signal(&mut self) {
+        if self.immediate == Some(AutomaticSyncTrigger::NetworkReconnect) {
+            self.immediate = None;
+        }
+    }
+}
+
+impl Default for AutomaticSyncScheduler {
+    fn default() -> Self {
+        Self::new(BackoffJitter::none())
+    }
+}
+
+fn due(deadline: Option<Instant>, now: Instant) -> bool {
+    deadline.is_some_and(|deadline| deadline <= now)
+}
+
+fn deadline_after(now: Instant, duration: Duration) -> Instant {
+    now.checked_add(duration).unwrap_or(now)
+}
+
+fn deadline_after_saturating(now: Instant, duration: Duration) -> Instant {
+    if let Some(deadline) = now.checked_add(duration) {
+        return deadline;
+    }
+    let mut lower = 0_u64;
+    let mut upper = duration.as_secs();
+    while lower < upper {
+        let midpoint = lower + (upper - lower).div_ceil(2);
+        if now.checked_add(Duration::from_secs(midpoint)).is_some() {
+            lower = midpoint;
+        } else {
+            upper = midpoint - 1;
+        }
+    }
+    now.checked_add(Duration::from_secs(lower)).unwrap_or(now)
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    duration.as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+fn backoff_base(step: u8) -> Duration {
+    let multiplier = 1_u64.checked_shl(u32::from(step)).unwrap_or(u64::MAX);
+    Duration::from_secs(
+        BACKOFF_MIN
+            .as_secs()
+            .saturating_mul(multiplier)
+            .min(BACKOFF_MAX.as_secs()),
+    )
+}
+
+fn mix64(mut value: u64) -> u64 {
+    value ^= value >> 30;
+    value = value.wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value ^= value >> 27;
+    value = value.wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn accepted_next(result: SyncFinish) -> Option<SyncAttemptToken> {
+        match result {
+            SyncFinish::Accepted { next } => next,
+            SyncFinish::Stale => panic!("the current token must be accepted"),
+        }
+    }
+
+    fn automatic_trigger(token: SyncAttemptToken) -> AutomaticSyncTrigger {
+        match token.kind() {
+            SyncAttemptKind::Automatic(trigger) => trigger,
+            SyncAttemptKind::Manual => panic!("expected an automatic token"),
+        }
+    }
+
+    #[test]
+    fn enabled_startup_is_immediate_and_success_arms_the_fallback() {
+        let now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::default();
+
+        let startup = scheduler.enable(now).expect("startup attempt");
+        assert_eq!(startup.generation(), 1);
+        assert_eq!(automatic_trigger(startup), AutomaticSyncTrigger::Startup);
+        assert_eq!(scheduler.in_flight(), Some(startup));
+        assert_eq!(scheduler.next_deadline(), None);
+
+        assert_eq!(
+            accepted_next(scheduler.finish(startup, SyncAttemptOutcome::Succeeded, now)),
+            None
+        );
+        assert_eq!(scheduler.next_deadline(), Some(now + FALLBACK_INTERVAL));
+    }
+
+    #[test]
+    fn local_mutations_use_a_trailing_thirty_second_debounce() {
+        let now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::default();
+        let startup = scheduler.enable(now).unwrap();
+        let _ = scheduler.finish(startup, SyncAttemptOutcome::Succeeded, now);
+
+        assert_eq!(scheduler.local_mutation(now + Duration::from_secs(3)), None);
+        assert_eq!(
+            scheduler.next_deadline(),
+            Some(now + Duration::from_secs(33))
+        );
+        assert_eq!(
+            scheduler.local_mutation(now + Duration::from_secs(20)),
+            None
+        );
+        let due = now + Duration::from_secs(50);
+        assert_eq!(scheduler.next_deadline(), Some(due));
+        assert_eq!(scheduler.poll(due - Duration::from_nanos(1)), None);
+
+        let local = scheduler.poll(due).expect("debounced attempt");
+        assert_eq!(
+            automatic_trigger(local),
+            AutomaticSyncTrigger::LocalMutation
+        );
+    }
+
+    #[test]
+    fn fallback_runs_every_fifteen_minutes_without_other_causes() {
+        let now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::default();
+        let startup = scheduler.enable(now).unwrap();
+        let _ = scheduler.finish(startup, SyncAttemptOutcome::Succeeded, now);
+
+        assert_eq!(
+            scheduler.poll(now + FALLBACK_INTERVAL - Duration::from_nanos(1)),
+            None
+        );
+        let fallback = scheduler
+            .poll(now + FALLBACK_INTERVAL)
+            .expect("fallback attempt");
+        assert_eq!(automatic_trigger(fallback), AutomaticSyncTrigger::Fallback);
+    }
+
+    #[test]
+    fn causes_coalesce_while_one_attempt_is_in_flight() {
+        let now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::default();
+        let startup = scheduler.enable(now).unwrap();
+
+        assert_eq!(scheduler.local_mutation(now + Duration::from_secs(1)), None);
+        assert_eq!(
+            scheduler.local_mutation(now + Duration::from_secs(10)),
+            None
+        );
+        let next = accepted_next(scheduler.finish(
+            startup,
+            SyncAttemptOutcome::Succeeded,
+            now + Duration::from_secs(45),
+        ))
+        .expect("the quiet period elapsed while startup was running");
+        assert_eq!(automatic_trigger(next), AutomaticSyncTrigger::LocalMutation);
+        assert_eq!(next.generation(), startup.generation() + 1);
+        assert_eq!(scheduler.poll(now + Duration::from_secs(45)), None);
+    }
+
+    #[test]
+    fn offline_backoff_doubles_from_two_seconds_to_fifteen_minutes() {
+        let mut now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::new(BackoffJitter::none());
+        let mut token = scheduler.enable(now).unwrap();
+        let expected = [2, 4, 8, 16, 32, 64, 128, 256, 512, 900, 900];
+
+        for seconds in expected {
+            assert_eq!(
+                accepted_next(scheduler.finish(
+                    token,
+                    SyncAttemptOutcome::Offline { retry_after: None },
+                    now,
+                )),
+                None
+            );
+            let due = now + Duration::from_secs(seconds);
+            assert_eq!(scheduler.next_deadline(), Some(due));
+            token = scheduler.poll(due).expect("retry attempt");
+            assert_eq!(automatic_trigger(token), AutomaticSyncTrigger::Retry);
+            now = due;
+        }
+    }
+
+    #[test]
+    fn retry_after_is_an_unclamped_lower_bound() {
+        let now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::new(BackoffJitter::none());
+        let startup = scheduler.enable(now).unwrap();
+        let _ = scheduler.finish(
+            startup,
+            SyncAttemptOutcome::Offline {
+                retry_after: Some(Duration::from_secs(75)),
+            },
+            now,
+        );
+        assert_eq!(
+            scheduler.next_deadline(),
+            Some(now + Duration::from_secs(75))
+        );
+
+        let retry = scheduler.poll(now + Duration::from_secs(75)).unwrap();
+        let _ = scheduler.finish(
+            retry,
+            SyncAttemptOutcome::Offline {
+                retry_after: Some(BACKOFF_MAX + Duration::from_secs(3_600)),
+            },
+            now + Duration::from_secs(75),
+        );
+        assert_eq!(
+            scheduler.next_deadline(),
+            Some(now + Duration::from_secs(75) + BACKOFF_MAX + Duration::from_secs(3_600))
+        );
+    }
+
+    #[test]
+    fn manual_failure_cannot_shorten_an_existing_server_embargo() {
+        let now = Instant::now();
+        let embargo = now + Duration::from_secs(600);
+        let mut scheduler = AutomaticSyncScheduler::new(BackoffJitter::none());
+        let startup = scheduler.enable(now).unwrap();
+        let _ = scheduler.finish(
+            startup,
+            SyncAttemptOutcome::Offline {
+                retry_after: Some(Duration::from_secs(600)),
+            },
+            now,
+        );
+
+        let manual = scheduler
+            .begin_manual(now + Duration::from_secs(1))
+            .unwrap();
+        assert_eq!(manual.kind(), SyncAttemptKind::Manual);
+        let _ = scheduler.finish(
+            manual,
+            SyncAttemptOutcome::Offline { retry_after: None },
+            now + Duration::from_secs(2),
+        );
+
+        assert_eq!(scheduler.next_deadline(), Some(embargo));
+        assert_eq!(scheduler.poll(embargo - Duration::from_nanos(1)), None);
+        assert_eq!(
+            automatic_trigger(scheduler.poll(embargo).expect("embargo elapsed")),
+            AutomaticSyncTrigger::Retry
+        );
+    }
+
+    #[test]
+    fn a_successful_manual_override_clears_the_server_embargo() {
+        let now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::new(BackoffJitter::none());
+        let startup = scheduler.enable(now).unwrap();
+        let _ = scheduler.finish(
+            startup,
+            SyncAttemptOutcome::Offline {
+                retry_after: Some(Duration::from_secs(600)),
+            },
+            now,
+        );
+        let manual = scheduler
+            .begin_manual(now + Duration::from_secs(1))
+            .unwrap();
+
+        let _ = scheduler.finish(
+            manual,
+            SyncAttemptOutcome::Succeeded,
+            now + Duration::from_secs(2),
+        );
+
+        assert_eq!(
+            scheduler.next_deadline(),
+            Some(now + Duration::from_secs(2) + FALLBACK_INTERVAL)
+        );
+    }
+
+    #[test]
+    fn oversized_retry_after_saturates_to_a_distant_deadline() {
+        let now = Instant::now();
+        let deadline = deadline_after_saturating(now, Duration::MAX);
+
+        assert!(deadline > now + BACKOFF_MAX);
+        assert_eq!(
+            deadline_after_saturating(now, Duration::from_secs(75)),
+            now + Duration::from_secs(75)
+        );
+    }
+
+    #[test]
+    fn local_mutations_cannot_bypass_an_offline_retry_hint() {
+        let now = Instant::now();
+        let server_hint = BACKOFF_MAX + Duration::from_secs(3_600);
+        let mut scheduler = AutomaticSyncScheduler::new(BackoffJitter::none());
+        let startup = scheduler.enable(now).unwrap();
+        let _ = scheduler.finish(
+            startup,
+            SyncAttemptOutcome::Offline {
+                retry_after: Some(server_hint),
+            },
+            now,
+        );
+        let retry_due = now + server_hint;
+
+        assert_eq!(scheduler.local_mutation(now + Duration::from_secs(1)), None);
+        assert_eq!(scheduler.next_deadline(), Some(retry_due));
+        assert_eq!(
+            scheduler.poll(now + LOCAL_MUTATION_DEBOUNCE + Duration::from_secs(1)),
+            None
+        );
+        let retry = scheduler.poll(retry_due).expect("bounded retry");
+        assert_eq!(automatic_trigger(retry), AutomaticSyncTrigger::Retry);
+    }
+
+    #[test]
+    fn reconnect_cannot_bypass_a_server_retry_hint() {
+        let now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::new(BackoffJitter::none());
+        let startup = scheduler.enable(now).unwrap();
+        let _ = scheduler.finish(
+            startup,
+            SyncAttemptOutcome::Offline {
+                retry_after: Some(Duration::from_secs(75)),
+            },
+            now,
+        );
+        let retry_due = now + Duration::from_secs(75);
+        assert!(scheduler.waiting_for_connectivity());
+
+        assert_eq!(
+            scheduler.network_reconnected(now + Duration::from_secs(1)),
+            None
+        );
+        assert!(!scheduler.waiting_for_connectivity());
+        assert_eq!(scheduler.next_deadline(), Some(retry_due));
+        assert_eq!(
+            scheduler.poll(now + Duration::from_secs(74)),
+            None,
+            "connectivity evidence must not override Retry-After"
+        );
+        let reconnect = scheduler
+            .poll(retry_due)
+            .expect("queued reconnect starts after the retry lower bound");
+        assert_eq!(
+            automatic_trigger(reconnect),
+            AutomaticSyncTrigger::NetworkReconnect
+        );
+    }
+
+    #[test]
+    fn reconnect_bypasses_only_the_transport_backoff_after_a_short_server_hint() {
+        let now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::new(BackoffJitter::none());
+        let startup = scheduler.enable(now).unwrap();
+        let _ = scheduler.finish(
+            startup,
+            SyncAttemptOutcome::Offline {
+                retry_after: Some(Duration::from_secs(1)),
+            },
+            now,
+        );
+        assert_eq!(
+            scheduler.next_deadline(),
+            Some(now + BACKOFF_MIN),
+            "without connectivity evidence, exponential backoff remains active"
+        );
+
+        assert_eq!(
+            scheduler.network_reconnected(now + Duration::from_millis(100)),
+            None
+        );
+        let retry_not_before = now + Duration::from_secs(1);
+        assert_eq!(scheduler.next_deadline(), Some(retry_not_before));
+        let reconnect = scheduler
+            .poll(retry_not_before)
+            .expect("connectivity resumes work after the server lower bound");
+        assert_eq!(
+            automatic_trigger(reconnect),
+            AutomaticSyncTrigger::NetworkReconnect
+        );
+    }
+
+    #[test]
+    fn stable_jitter_is_repeatable_bounded_and_never_exceeds_the_cap() {
+        let now = Instant::now();
+        let device_jitter = BackoffJitter::stable_for("device-a");
+        assert_eq!(device_jitter, BackoffJitter::stable_for("device-a"));
+        assert_ne!(device_jitter, BackoffJitter::stable_for("device-b"));
+        let mut left = AutomaticSyncScheduler::new(device_jitter);
+        let mut right = AutomaticSyncScheduler::new(device_jitter);
+        let left_start = left.enable(now).unwrap();
+        let right_start = right.enable(now).unwrap();
+        let _ = left.finish(
+            left_start,
+            SyncAttemptOutcome::Offline { retry_after: None },
+            now,
+        );
+        let _ = right.finish(
+            right_start,
+            SyncAttemptOutcome::Offline { retry_after: None },
+            now,
+        );
+
+        let left_delay = left.next_deadline().unwrap().duration_since(now);
+        let right_delay = right.next_deadline().unwrap().duration_since(now);
+        assert_eq!(left_delay, right_delay);
+        assert!(left_delay >= BACKOFF_MIN);
+        assert!(left_delay <= BACKOFF_MIN + BACKOFF_MIN / 4);
+
+        let capped = BackoffJitter::stable(9).apply(BACKOFF_MAX, 99, u8::MAX);
+        assert_eq!(capped, BACKOFF_MAX);
+    }
+
+    #[test]
+    fn reconnect_is_absorbed_but_a_newer_local_mutation_remains_due() {
+        let now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::default();
+        let startup = scheduler.enable(now).unwrap();
+        let _ = scheduler.finish(
+            startup,
+            SyncAttemptOutcome::Offline { retry_after: None },
+            now,
+        );
+        let manual = scheduler
+            .begin_manual(now + Duration::from_secs(1))
+            .unwrap();
+
+        assert_eq!(
+            scheduler.network_reconnected(now + Duration::from_secs(1)),
+            None
+        );
+        assert_eq!(scheduler.local_mutation(now + Duration::from_secs(1)), None);
+        let next = accepted_next(scheduler.finish(
+            manual,
+            SyncAttemptOutcome::Succeeded,
+            now + Duration::from_secs(1),
+        ));
+        assert_eq!(next, None);
+        assert_eq!(
+            scheduler.next_deadline(),
+            Some(now + Duration::from_secs(1) + LOCAL_MUTATION_DEBOUNCE)
+        );
+    }
+
+    #[test]
+    fn failed_in_flight_attempt_supersedes_an_older_reconnect_edge() {
+        let now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::default();
+        let startup = scheduler.enable(now).unwrap();
+        let _ = scheduler.finish(
+            startup,
+            SyncAttemptOutcome::Offline { retry_after: None },
+            now,
+        );
+        let manual = scheduler
+            .begin_manual(now + Duration::from_secs(1))
+            .unwrap();
+        assert_eq!(
+            scheduler.network_reconnected(now + Duration::from_secs(1)),
+            None
+        );
+
+        assert_eq!(
+            accepted_next(scheduler.finish(
+                manual,
+                SyncAttemptOutcome::Offline {
+                    retry_after: Some(Duration::from_secs(75)),
+                },
+                now + Duration::from_secs(2),
+            )),
+            None
+        );
+        assert_eq!(
+            scheduler.next_deadline(),
+            Some(now + Duration::from_secs(77))
+        );
+    }
+
+    #[test]
+    fn manual_attempts_share_single_flight_and_cover_existing_causes() {
+        let now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::default();
+        let startup = scheduler.enable(now).unwrap();
+        let _ = scheduler.finish(startup, SyncAttemptOutcome::Succeeded, now);
+        let _ = scheduler.local_mutation(now + Duration::from_secs(1));
+
+        let manual = scheduler
+            .begin_manual(now + Duration::from_secs(2))
+            .unwrap();
+        assert_eq!(manual.kind(), SyncAttemptKind::Manual);
+        assert_eq!(
+            scheduler.begin_manual(now + Duration::from_secs(2)),
+            Err(SyncStartError::AlreadyInFlight)
+        );
+        assert_eq!(scheduler.next_deadline(), None);
+
+        let _ = scheduler.local_mutation(now + Duration::from_secs(3));
+        assert_eq!(
+            accepted_next(scheduler.finish(
+                manual,
+                SyncAttemptOutcome::Succeeded,
+                now + Duration::from_secs(10),
+            )),
+            None
+        );
+        assert_eq!(
+            scheduler.next_deadline(),
+            Some(now + Duration::from_secs(33))
+        );
+    }
+
+    #[test]
+    fn stale_completion_cannot_settle_the_current_generation() {
+        let now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::default();
+        let startup = scheduler.enable(now).unwrap();
+        let _ = scheduler.finish(startup, SyncAttemptOutcome::Succeeded, now);
+        let fallback = scheduler.poll(now + FALLBACK_INTERVAL).unwrap();
+
+        assert_eq!(
+            scheduler.finish(
+                startup,
+                SyncAttemptOutcome::Offline { retry_after: None },
+                now + FALLBACK_INTERVAL,
+            ),
+            SyncFinish::Stale
+        );
+        assert_eq!(scheduler.in_flight(), Some(fallback));
+        assert_eq!(scheduler.next_deadline(), None);
+    }
+
+    #[test]
+    fn disable_drops_automatic_deadlines_but_allows_safe_in_flight_settlement() {
+        let now = Instant::now();
+        let mut scheduler = AutomaticSyncScheduler::default();
+        let startup = scheduler.enable(now).unwrap();
+        let _ = scheduler.local_mutation(now + Duration::from_secs(1));
+
+        scheduler.disable();
+        assert!(!scheduler.enabled());
+        assert_eq!(scheduler.next_deadline(), None);
+        assert_eq!(scheduler.poll(now + Duration::from_secs(60)), None);
+        assert_eq!(
+            scheduler.finish(
+                startup,
+                SyncAttemptOutcome::Offline {
+                    retry_after: Some(Duration::from_secs(75)),
+                },
+                now,
+            ),
+            SyncFinish::Accepted { next: None }
+        );
+        assert_eq!(scheduler.next_deadline(), None);
+
+        let restarted = scheduler.enable(now).expect("fresh startup after enable");
+        assert_eq!(automatic_trigger(restarted), AutomaticSyncTrigger::Startup);
+        assert!(restarted.generation() > startup.generation());
+    }
+}

--- a/src/sync/checkpoint.rs
+++ b/src/sync/checkpoint.rs
@@ -124,7 +124,7 @@ impl SignedCheckpoint {
             batch_anchors,
             state,
         };
-        validate_payload(&payload, &verified)?;
+        validate_payload(&payload, &verified, membership_anchor)?;
         let signature = sign_serializable(CHECKPOINT_SIGNATURE_DOMAIN, signing_key, &payload)?;
         let checkpoint = Self { payload, signature };
         checkpoint.verify(membership_anchor)?;
@@ -137,7 +137,7 @@ impl SignedCheckpoint {
         membership_anchor: &MembershipAnchor,
     ) -> Result<VerifiedMembership, VaultError> {
         let verified = self.payload.membership.verify(membership_anchor)?;
-        validate_payload(&self.payload, &verified)?;
+        validate_payload(&self.payload, &verified, membership_anchor)?;
         let signer = active_signer(&verified, &self.payload.signer_device_id)?;
         verify_serializable(
             CHECKPOINT_SIGNATURE_DOMAIN,
@@ -274,6 +274,7 @@ fn classify_anchor(
 fn validate_payload(
     payload: &CheckpointPayload,
     membership: &VerifiedMembership,
+    membership_anchor: &MembershipAnchor,
 ) -> Result<(), VaultError> {
     if payload.kind != CHECKPOINT_KIND
         || payload.schema_version != super::VAULT_SCHEMA_VERSION
@@ -300,6 +301,25 @@ fn validate_payload(
         .is_some_and(|checkpoint| !checkpoint.acknowledged_by.is_empty())
     {
         return Err(VaultError::InvalidEncryptedObject);
+    }
+    if let Some(compaction) = payload.state.compaction_checkpoint.as_ref() {
+        super::compaction::verify_compaction_authorization(
+            &payload.dataset_id,
+            compaction,
+            &payload.membership,
+            membership_anchor,
+        )?;
+        let authorization = compaction
+            .leader_authorization
+            .as_ref()
+            .ok_or(VaultError::InvalidEncryptedObject)?;
+        if payload.checkpoint_sequence < authorization.introducing_checkpoint_sequence
+            || (payload.checkpoint_sequence == authorization.introducing_checkpoint_sequence
+                && payload.previous_checkpoint_hash.as_deref()
+                    != Some(authorization.introducing_checkpoint_parent_hash.as_str()))
+        {
+            return Err(VaultError::InvalidEncryptedObject);
+        }
     }
     if payload.state.device_registry != membership.devices {
         return Err(VaultError::RegistryMismatch);
@@ -822,8 +842,11 @@ mod tests {
         let mut fixture = fixture();
         fixture.state.compaction_checkpoint = Some(CompactionCheckpoint {
             checkpoint_id: "compaction-one".to_owned(),
+            compaction_generation: 1,
             coverage: VersionVector::default(),
             previous_checkpoint_hash: None,
+            retained_engagement_operations: BTreeSet::new(),
+            leader_authorization: None,
             acknowledged_by: BTreeSet::from([fixture.device_one.device_id.clone()]),
         });
         assert_eq!(

--- a/src/sync/compaction.rs
+++ b/src/sync/compaction.rs
@@ -1,0 +1,742 @@
+//! Authenticated acknowledgements for a personal-state compaction checkpoint.
+//!
+//! The portable ledger's `acknowledged_by` field is deliberately not trusted by the vault.
+//! Acknowledgement is instead a per-device signed high-water object updated with a strong ETag
+//! compare-and-swap after that device durably installs a checkpoint carrying the generation.
+//! Physical cleanup may proceed only when every device active in the same membership epoch has
+//! signed and every installed checkpoint anchor is on the authenticated current lineage.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::personal_state::{
+    CompactionCheckpoint, CompactionLeaderAuthorization, DeviceId, VersionVector,
+};
+
+use super::crypto::{
+    DeviceSecretMaterial, EncryptedObject, base64url_encode, decrypt_json_with_identity,
+    encrypt_json_to_recipients, sha256_domain_hex, sign_serializable, verify_serializable,
+};
+use super::{
+    MembershipAnchor, MembershipChain, ObjectKey, VAULT_SCHEMA_VERSION, VaultError,
+    VerifiedMembership,
+};
+
+const ACK_KIND: &str = "yututui_vault_compaction_ack";
+const ACK_SIGNATURE_DOMAIN: &[u8] = b"yututui-vault-compaction-ack-signature-v1";
+const ACK_HASH_DOMAIN: &[u8] = b"yututui-vault-compaction-ack-hash-v1";
+const GENERATION_HASH_DOMAIN: &[u8] = b"yututui-vault-compaction-generation-hash-v1";
+const AUTHORIZATION_KIND: &str = "yututui_vault_compaction_leader_authorization";
+const AUTHORIZATION_SIGNATURE_DOMAIN: &[u8] =
+    b"yututui-vault-compaction-leader-authorization-signature-v1";
+
+#[derive(Serialize)]
+struct CompactionAuthorizationMaterial<'a> {
+    kind: &'static str,
+    schema_version: u32,
+    dataset_id: &'a str,
+    checkpoint_id: &'a str,
+    compaction_generation: u64,
+    coverage: &'a VersionVector,
+    previous_checkpoint_hash: Option<&'a str>,
+    retained_engagement_operations: &'a BTreeSet<String>,
+    membership_epoch: u64,
+    membership_head_hash: &'a str,
+    leader_device_id: &'a DeviceId,
+    introducing_checkpoint_sequence: u64,
+    introducing_checkpoint_parent_hash: &'a str,
+}
+
+#[derive(Serialize)]
+struct CompactionGenerationMaterial<'a> {
+    dataset_id: &'a str,
+    checkpoint_id: &'a str,
+    compaction_generation: u64,
+    coverage: &'a VersionVector,
+    previous_checkpoint_hash: Option<&'a str>,
+    retained_engagement_operations: &'a BTreeSet<String>,
+    leader_authorization: &'a Option<CompactionLeaderAuthorization>,
+}
+
+/// Sign one compaction transition with the lowest device id active in the exact membership epoch.
+pub fn authorize_compaction(
+    dataset_id: &str,
+    compaction: &CompactionCheckpoint,
+    membership: &VerifiedMembership,
+    local_device_id: DeviceId,
+    device: &DeviceSecretMaterial,
+    introducing_checkpoint_sequence: u64,
+    introducing_checkpoint_parent_hash: &str,
+) -> Result<CompactionLeaderAuthorization, VaultError> {
+    if compaction.leader_authorization.is_some()
+        || compaction.compaction_generation == 0
+        || dataset_id != membership.dataset_id
+        || local_device_id.as_str() != device.device_id()
+        || compaction.checkpoint_id.is_empty()
+        || introducing_checkpoint_sequence < 2
+        || !valid_hash(introducing_checkpoint_parent_hash)
+    {
+        return Err(VaultError::InvalidEncryptedObject);
+    }
+    let leader = compaction_leader(membership)?;
+    if leader != local_device_id {
+        return Err(VaultError::RevokedOrUnknownDevice);
+    }
+    let signer = active_signer(membership, &leader)?;
+    if signer.ed25519_verifying_key
+        != base64url_encode(device.signing_key().verifying_key().as_bytes())
+    {
+        return Err(VaultError::InvalidSigningKey);
+    }
+    let mut authorization = CompactionLeaderAuthorization {
+        membership_epoch: membership.epoch,
+        membership_head_hash: membership.head_hash.clone(),
+        leader_device_id: leader,
+        introducing_checkpoint_sequence,
+        introducing_checkpoint_parent_hash: introducing_checkpoint_parent_hash.to_owned(),
+        signature: String::new(),
+    };
+    authorization.signature = sign_serializable(
+        AUTHORIZATION_SIGNATURE_DOMAIN,
+        device.signing_key(),
+        &authorization_material(dataset_id, compaction, &authorization),
+    )?;
+    Ok(authorization)
+}
+
+/// Verify a retained leader authorization against its exact historical membership epoch.
+pub fn verify_compaction_authorization(
+    dataset_id: &str,
+    compaction: &CompactionCheckpoint,
+    membership: &MembershipChain,
+    membership_anchor: &MembershipAnchor,
+) -> Result<(), VaultError> {
+    let authorization = compaction
+        .leader_authorization
+        .as_ref()
+        .ok_or(VaultError::InvalidEncryptedObject)?;
+    if compaction.compaction_generation == 0
+        || authorization.introducing_checkpoint_sequence < 2
+        || !valid_hash(&authorization.introducing_checkpoint_parent_hash)
+    {
+        return Err(VaultError::InvalidEncryptedObject);
+    }
+    let historical = membership.verify_epoch_head(
+        membership_anchor,
+        authorization.membership_epoch,
+        &authorization.membership_head_hash,
+    )?;
+    if historical.dataset_id != dataset_id
+        || compaction_leader(&historical)? != authorization.leader_device_id
+    {
+        return Err(VaultError::RevokedOrUnknownDevice);
+    }
+    let signer = active_signer(&historical, &authorization.leader_device_id)?;
+    verify_serializable(
+        AUTHORIZATION_SIGNATURE_DOMAIN,
+        &signer.ed25519_verifying_key,
+        &authorization_material(dataset_id, compaction, authorization),
+        &authorization.signature,
+    )
+}
+
+fn authorization_material<'a>(
+    dataset_id: &'a str,
+    compaction: &'a CompactionCheckpoint,
+    authorization: &'a CompactionLeaderAuthorization,
+) -> CompactionAuthorizationMaterial<'a> {
+    CompactionAuthorizationMaterial {
+        kind: AUTHORIZATION_KIND,
+        schema_version: VAULT_SCHEMA_VERSION,
+        dataset_id,
+        checkpoint_id: &compaction.checkpoint_id,
+        compaction_generation: compaction.compaction_generation,
+        coverage: &compaction.coverage,
+        previous_checkpoint_hash: compaction.previous_checkpoint_hash.as_deref(),
+        retained_engagement_operations: &compaction.retained_engagement_operations,
+        membership_epoch: authorization.membership_epoch,
+        membership_head_hash: &authorization.membership_head_hash,
+        leader_device_id: &authorization.leader_device_id,
+        introducing_checkpoint_sequence: authorization.introducing_checkpoint_sequence,
+        introducing_checkpoint_parent_hash: &authorization.introducing_checkpoint_parent_hash,
+    }
+}
+
+fn compaction_leader(membership: &VerifiedMembership) -> Result<DeviceId, VaultError> {
+    membership
+        .active_devices()
+        .filter(|device| device.device_id.as_str() != "legacy")
+        .map(|device| device.device_id.clone())
+        .min()
+        .ok_or(VaultError::LastActiveDevice)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompactionAckPayload {
+    pub kind: String,
+    pub schema_version: u32,
+    pub dataset_id: String,
+    pub compaction_id: String,
+    pub compaction_generation_hash: String,
+    pub coverage: VersionVector,
+    pub installed_checkpoint_sequence: u64,
+    pub installed_checkpoint_hash: String,
+    pub membership_epoch: u64,
+    pub membership_head_hash: String,
+    pub signer_device_id: DeviceId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SignedCompactionAck {
+    pub payload: CompactionAckPayload,
+    pub signature: String,
+}
+
+impl SignedCompactionAck {
+    #[allow(clippy::too_many_arguments)]
+    pub fn create(
+        dataset_id: &str,
+        compaction: &CompactionCheckpoint,
+        checkpoint_sequence: u64,
+        checkpoint_hash: &str,
+        membership: &VerifiedMembership,
+        signer_device_id: DeviceId,
+        device: &DeviceSecretMaterial,
+    ) -> Result<Self, VaultError> {
+        if signer_device_id.as_str() != device.device_id() {
+            return Err(VaultError::InvalidDeviceIdentity);
+        }
+        let signer = active_signer(membership, &signer_device_id)?;
+        if signer.ed25519_verifying_key
+            != base64url_encode(device.signing_key().verifying_key().as_bytes())
+        {
+            return Err(VaultError::InvalidSigningKey);
+        }
+        let payload = CompactionAckPayload {
+            kind: ACK_KIND.to_owned(),
+            schema_version: VAULT_SCHEMA_VERSION,
+            dataset_id: dataset_id.to_owned(),
+            compaction_id: compaction.checkpoint_id.clone(),
+            compaction_generation_hash: compaction_generation_hash(dataset_id, compaction)?,
+            coverage: compaction.coverage.clone(),
+            installed_checkpoint_sequence: checkpoint_sequence,
+            installed_checkpoint_hash: checkpoint_hash.to_owned(),
+            membership_epoch: membership.epoch,
+            membership_head_hash: membership.head_hash.clone(),
+            signer_device_id,
+        };
+        validate_payload(&payload, compaction, membership)?;
+        let signature = sign_serializable(ACK_SIGNATURE_DOMAIN, device.signing_key(), &payload)?;
+        let acknowledgement = Self { payload, signature };
+        acknowledgement.verify(compaction, membership)?;
+        Ok(acknowledgement)
+    }
+
+    pub fn verify(
+        &self,
+        compaction: &CompactionCheckpoint,
+        membership: &VerifiedMembership,
+    ) -> Result<(), VaultError> {
+        validate_payload(&self.payload, compaction, membership)?;
+        let signer = active_signer(membership, &self.payload.signer_device_id)?;
+        verify_serializable(
+            ACK_SIGNATURE_DOMAIN,
+            &signer.ed25519_verifying_key,
+            &self.payload,
+            &self.signature,
+        )
+    }
+
+    pub fn hash(&self) -> Result<String, VaultError> {
+        let bytes = serde_json::to_vec(self).map_err(|_| VaultError::SerializationFailed)?;
+        Ok(sha256_domain_hex(ACK_HASH_DOMAIN, &[&bytes]))
+    }
+
+    pub fn encrypt(
+        &self,
+        compaction: &CompactionCheckpoint,
+        membership: &VerifiedMembership,
+    ) -> Result<EncryptedObject, VaultError> {
+        self.verify(compaction, membership)?;
+        encrypt_json_to_recipients(self, &membership.active_recipients()?)
+    }
+
+    pub fn decrypt_for_device(
+        object: &EncryptedObject,
+        device: &DeviceSecretMaterial,
+        compaction: &CompactionCheckpoint,
+        membership: &VerifiedMembership,
+    ) -> Result<Self, VaultError> {
+        let acknowledgement: Self = decrypt_json_with_identity(object, device.age_identity())?;
+        acknowledgement.verify(compaction, membership)?;
+        let recipient_id =
+            DeviceId::new(device.device_id()).map_err(|_| VaultError::InvalidDeviceIdentity)?;
+        let recipient = membership
+            .devices
+            .get(&recipient_id)
+            .filter(|record| !record.revoked)
+            .ok_or(VaultError::RevokedOrUnknownDevice)?;
+        if !device.matches_personal_record(recipient) {
+            return Err(VaultError::InvalidDeviceIdentity);
+        }
+        Ok(acknowledgement)
+    }
+}
+
+/// Return true only when every device active in the exact membership epoch signed the checkpoint.
+///
+/// Duplicate acknowledgements are harmless. An acknowledgement from a revoked/unknown device or
+/// from another epoch/checkpoint is rejected instead of being silently ignored.
+pub fn compaction_quorum(
+    acknowledgements: &[SignedCompactionAck],
+    compaction: &CompactionCheckpoint,
+    membership: &VerifiedMembership,
+) -> Result<bool, VaultError> {
+    let mut acknowledged = BTreeSet::new();
+    for acknowledgement in acknowledgements {
+        acknowledgement.verify(compaction, membership)?;
+        acknowledged.insert(acknowledgement.payload.signer_device_id.clone());
+    }
+    let active = membership
+        .active_devices()
+        .map(|device| device.device_id.clone())
+        .collect::<BTreeSet<_>>();
+    Ok(!active.is_empty() && acknowledged == active)
+}
+
+pub fn compaction_ack_prefix(
+    dataset_id: &str,
+    compaction: &CompactionCheckpoint,
+    membership: &VerifiedMembership,
+) -> Result<ObjectKey, VaultError> {
+    validate_component(dataset_id)?;
+    validate_component(&compaction.checkpoint_id)?;
+    let generation_hash = compaction_generation_hash(dataset_id, compaction)?;
+    if membership.dataset_id != dataset_id || !valid_hash(&membership.head_hash) {
+        return Err(VaultError::InvalidObjectKey);
+    }
+    ObjectKey::new(format!(
+        "yututui/v2/{dataset_id}/compaction-acks/{}/{generation_hash}/{}",
+        compaction.checkpoint_id, membership.head_hash
+    ))
+}
+
+pub fn compaction_ack_key(
+    dataset_id: &str,
+    compaction: &CompactionCheckpoint,
+    membership: &VerifiedMembership,
+    device_id: &DeviceId,
+) -> Result<ObjectKey, VaultError> {
+    ObjectKey::new(format!(
+        "{}/{}.age",
+        compaction_ack_prefix(dataset_id, compaction, membership)?.as_str(),
+        device_id.as_str()
+    ))
+}
+
+fn validate_payload(
+    payload: &CompactionAckPayload,
+    compaction: &CompactionCheckpoint,
+    membership: &VerifiedMembership,
+) -> Result<(), VaultError> {
+    if payload.kind != ACK_KIND
+        || payload.schema_version != VAULT_SCHEMA_VERSION
+        || payload.dataset_id != membership.dataset_id
+        || payload.compaction_id != compaction.checkpoint_id
+        || compaction.compaction_generation == 0
+        || payload.compaction_generation_hash
+            != compaction_generation_hash(&payload.dataset_id, compaction)?
+        || payload.coverage != compaction.coverage
+        || payload.membership_epoch != membership.epoch
+        || payload.membership_head_hash != membership.head_hash
+        || payload.installed_checkpoint_sequence == 0
+        || !valid_hash(&payload.installed_checkpoint_hash)
+        || !compaction.acknowledged_by.is_empty()
+    {
+        return Err(VaultError::InvalidEncryptedObject);
+    }
+    validate_component(&payload.dataset_id)?;
+    validate_component(&payload.compaction_id)?;
+    if payload.coverage.0.iter().any(|(device_id, sequence)| {
+        *sequence == 0
+            || !(membership.accepts_sequence(device_id, *sequence)
+                || device_id.as_str() == "legacy" && *sequence == 1)
+    }) {
+        return Err(VaultError::RevokedOrUnknownDevice);
+    }
+    active_signer(membership, &payload.signer_device_id)?;
+    Ok(())
+}
+
+fn compaction_generation_hash(
+    dataset_id: &str,
+    compaction: &CompactionCheckpoint,
+) -> Result<String, VaultError> {
+    let material = CompactionGenerationMaterial {
+        dataset_id,
+        checkpoint_id: &compaction.checkpoint_id,
+        compaction_generation: compaction.compaction_generation,
+        coverage: &compaction.coverage,
+        previous_checkpoint_hash: compaction.previous_checkpoint_hash.as_deref(),
+        retained_engagement_operations: &compaction.retained_engagement_operations,
+        leader_authorization: &compaction.leader_authorization,
+    };
+    let bytes = serde_json::to_vec(&material).map_err(|_| VaultError::SerializationFailed)?;
+    Ok(sha256_domain_hex(GENERATION_HASH_DOMAIN, &[&bytes]))
+}
+
+fn active_signer<'a>(
+    membership: &'a VerifiedMembership,
+    device_id: &DeviceId,
+) -> Result<&'a crate::personal_state::DevicePublicIdentity, VaultError> {
+    membership
+        .devices
+        .get(device_id)
+        .filter(|device| !device.revoked)
+        .and_then(|device| device.public_identity.as_ref())
+        .ok_or(VaultError::RevokedOrUnknownDevice)
+}
+
+fn validate_component(value: &str) -> Result<(), VaultError> {
+    if value.is_empty()
+        || value.len() > 512
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return Err(VaultError::InvalidObjectKey);
+    }
+    Ok(())
+}
+
+fn valid_hash(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::personal_state::{DeviceRecord, VersionVector};
+    use crate::sync::{
+        MembershipAction, MembershipAnchor, MembershipChain, RecoveryKit, SignedMembershipRoot,
+    };
+
+    struct Fixture {
+        first: DeviceSecretMaterial,
+        second: DeviceSecretMaterial,
+        membership: MembershipChain,
+        anchor: MembershipAnchor,
+        compaction: CompactionCheckpoint,
+    }
+
+    impl Fixture {
+        fn verified(&self) -> VerifiedMembership {
+            self.membership.verify(&self.anchor).unwrap()
+        }
+    }
+
+    fn device_record(device: &DeviceSecretMaterial) -> DeviceRecord {
+        DeviceRecord {
+            device_id: DeviceId::new(device.device_id()).unwrap(),
+            name: device.device_id().to_owned(),
+            revoked: false,
+            public_identity: Some(device.public_identity()),
+        }
+    }
+
+    fn fixture() -> Fixture {
+        let dataset_id = "compaction-ack-dataset";
+        let recovery = RecoveryKit::generate(dataset_id, None).unwrap();
+        let first = DeviceSecretMaterial::generate_for("device-a").unwrap();
+        let second = DeviceSecretMaterial::generate_for("device-b").unwrap();
+        let root = SignedMembershipRoot::create(
+            dataset_id,
+            recovery.recovery_recipient(),
+            &recovery.signing_key().unwrap(),
+            device_record(&first),
+        )
+        .unwrap();
+        let anchor = MembershipAnchor::RootHash(root.hash().unwrap());
+        let mut membership = MembershipChain::new(root);
+        membership
+            .append_device_action(
+                &anchor,
+                &DeviceId::new(first.device_id()).unwrap(),
+                first.signing_key(),
+                MembershipAction::AddDevice {
+                    device: device_record(&second),
+                },
+            )
+            .unwrap();
+        let compaction = CompactionCheckpoint {
+            checkpoint_id: "compaction-001".to_owned(),
+            compaction_generation: 1,
+            coverage: VersionVector(BTreeMap::from([
+                (DeviceId::new(first.device_id()).unwrap(), 7),
+                (DeviceId::new(second.device_id()).unwrap(), 5),
+            ])),
+            previous_checkpoint_hash: None,
+            retained_engagement_operations: BTreeSet::new(),
+            leader_authorization: None,
+            acknowledged_by: BTreeSet::new(),
+        };
+        Fixture {
+            first,
+            second,
+            membership,
+            anchor,
+            compaction,
+        }
+    }
+
+    fn acknowledgement(fixture: &Fixture, device: &DeviceSecretMaterial) -> SignedCompactionAck {
+        let membership = fixture.verified();
+        SignedCompactionAck::create(
+            &membership.dataset_id,
+            &fixture.compaction,
+            4,
+            &"a".repeat(64),
+            &membership,
+            DeviceId::new(device.device_id()).unwrap(),
+            device,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn only_historical_leader_can_authorize_a_compaction() {
+        let mut fixture = fixture();
+        let historical = fixture.verified();
+        let leader_id = DeviceId::new(fixture.first.device_id()).unwrap();
+        let second_id = DeviceId::new(fixture.second.device_id()).unwrap();
+        let mut zero_generation = fixture.compaction.clone();
+        zero_generation.compaction_generation = 0;
+        assert_eq!(
+            authorize_compaction(
+                &historical.dataset_id,
+                &zero_generation,
+                &historical,
+                leader_id.clone(),
+                &fixture.first,
+                4,
+                &"a".repeat(64),
+            ),
+            Err(VaultError::InvalidEncryptedObject)
+        );
+
+        assert_eq!(
+            authorize_compaction(
+                &historical.dataset_id,
+                &fixture.compaction,
+                &historical,
+                second_id.clone(),
+                &fixture.second,
+                4,
+                &"a".repeat(64),
+            ),
+            Err(VaultError::RevokedOrUnknownDevice)
+        );
+
+        let authorization = authorize_compaction(
+            &historical.dataset_id,
+            &fixture.compaction,
+            &historical,
+            leader_id.clone(),
+            &fixture.first,
+            4,
+            &"a".repeat(64),
+        )
+        .unwrap();
+        let mut authorized = fixture.compaction.clone();
+        authorized.leader_authorization = Some(authorization);
+        verify_compaction_authorization(
+            &historical.dataset_id,
+            &authorized,
+            &fixture.membership,
+            &fixture.anchor,
+        )
+        .unwrap();
+
+        let mut forged = CompactionLeaderAuthorization {
+            membership_epoch: historical.epoch,
+            membership_head_hash: historical.head_hash.clone(),
+            leader_device_id: second_id.clone(),
+            introducing_checkpoint_sequence: 4,
+            introducing_checkpoint_parent_hash: "a".repeat(64),
+            signature: String::new(),
+        };
+        forged.signature = sign_serializable(
+            AUTHORIZATION_SIGNATURE_DOMAIN,
+            fixture.second.signing_key(),
+            &authorization_material(&historical.dataset_id, &fixture.compaction, &forged),
+        )
+        .unwrap();
+        let mut forged_compaction = fixture.compaction.clone();
+        forged_compaction.leader_authorization = Some(forged);
+        assert_eq!(
+            verify_compaction_authorization(
+                &historical.dataset_id,
+                &forged_compaction,
+                &fixture.membership,
+                &fixture.anchor,
+            ),
+            Err(VaultError::RevokedOrUnknownDevice)
+        );
+
+        fixture
+            .membership
+            .append_device_action(
+                &fixture.anchor,
+                &second_id,
+                fixture.second.signing_key(),
+                MembershipAction::RevokeDevice {
+                    device_id: leader_id,
+                    last_accepted_sequence: 7,
+                },
+            )
+            .unwrap();
+        verify_compaction_authorization(
+            &historical.dataset_id,
+            &authorized,
+            &fixture.membership,
+            &fixture.anchor,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn quorum_requires_every_active_device_and_accepts_duplicate_objects() {
+        let fixture = fixture();
+        let membership = fixture.verified();
+        let first = acknowledgement(&fixture, &fixture.first);
+        let second = SignedCompactionAck::create(
+            &membership.dataset_id,
+            &fixture.compaction,
+            5,
+            &"b".repeat(64),
+            &membership,
+            DeviceId::new(fixture.second.device_id()).unwrap(),
+            &fixture.second,
+        )
+        .unwrap();
+
+        assert!(
+            !compaction_quorum(
+                std::slice::from_ref(&first),
+                &fixture.compaction,
+                &membership,
+            )
+            .unwrap()
+        );
+        assert!(
+            compaction_quorum(
+                &[first.clone(), first, second],
+                &fixture.compaction,
+                &membership,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn acknowledgement_is_encrypted_and_bound_to_generation_and_membership() {
+        let fixture = fixture();
+        let membership = fixture.verified();
+        let acknowledgement = acknowledgement(&fixture, &fixture.first);
+        let encrypted = acknowledgement
+            .encrypt(&fixture.compaction, &membership)
+            .unwrap();
+        let decoded = SignedCompactionAck::decrypt_for_device(
+            &encrypted,
+            &fixture.second,
+            &fixture.compaction,
+            &membership,
+        )
+        .unwrap();
+        assert_eq!(decoded, acknowledgement);
+        let mut other_generation = fixture.compaction.clone();
+        other_generation.checkpoint_id = "compaction-002".to_owned();
+        assert!(
+            SignedCompactionAck::decrypt_for_device(
+                &encrypted,
+                &fixture.second,
+                &other_generation,
+                &membership,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn tamper_and_revocation_invalidate_an_acknowledgement() {
+        let mut fixture = fixture();
+        let old_membership = fixture.verified();
+        let old_epoch_ack = acknowledgement(&fixture, &fixture.first);
+        let mut acknowledgement = acknowledgement(&fixture, &fixture.second);
+        acknowledgement.payload.installed_checkpoint_hash = "b".repeat(64);
+        assert!(
+            acknowledgement
+                .verify(&fixture.compaction, &old_membership)
+                .is_err()
+        );
+
+        fixture
+            .membership
+            .append_device_action(
+                &fixture.anchor,
+                &DeviceId::new(fixture.first.device_id()).unwrap(),
+                fixture.first.signing_key(),
+                MembershipAction::RevokeDevice {
+                    device_id: DeviceId::new(fixture.second.device_id()).unwrap(),
+                    last_accepted_sequence: 5,
+                },
+            )
+            .unwrap();
+        let revoked_membership = fixture.verified();
+        assert!(
+            old_epoch_ack
+                .verify(&fixture.compaction, &revoked_membership)
+                .is_err(),
+            "an acknowledgement is bound to the exact membership epoch"
+        );
+    }
+
+    #[test]
+    fn acknowledgement_keys_are_dataset_and_device_scoped() {
+        let fixture = fixture();
+        let membership = fixture.verified();
+        let device = DeviceId::new("device-a").unwrap();
+        let generation_hash =
+            compaction_generation_hash("compaction-ack-dataset", &fixture.compaction).unwrap();
+        assert_eq!(
+            compaction_ack_key(
+                "compaction-ack-dataset",
+                &fixture.compaction,
+                &membership,
+                &device,
+            )
+            .unwrap()
+            .as_str(),
+            format!(
+                "yututui/v2/compaction-ack-dataset/compaction-acks/compaction-001/{generation_hash}/{}/device-a.age",
+                membership.head_hash
+            )
+        );
+        assert!(compaction_ack_prefix("../dataset", &fixture.compaction, &membership).is_err());
+        let mut wrong_membership = membership;
+        wrong_membership.head_hash = "not-a-hash".to_owned();
+        assert!(
+            compaction_ack_prefix(
+                "compaction-ack-dataset",
+                &fixture.compaction,
+                &wrong_membership,
+            )
+            .is_err()
+        );
+    }
+}

--- a/src/sync/connectivity.rs
+++ b/src/sync/connectivity.rs
@@ -1,0 +1,387 @@
+//! Bounded local-address polling for automatic sync reconnect wakeups.
+//!
+//! This watcher never probes an endpoint or handles credentials. It only compares addresses
+//! reported by the operating system and turns an added usable address into one coalesced wakeup.
+
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tokio::runtime::Handle;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Owns the single polling task and coalesces its observations into owner-lane wakeups.
+pub(crate) struct NetworkChangeWatch {
+    task: JoinHandle<()>,
+    activation: Arc<Activation>,
+    wake: Arc<CoalescedWake>,
+}
+
+#[derive(Default)]
+struct Activation {
+    active: AtomicBool,
+    changed: Notify,
+}
+
+impl Activation {
+    fn set(&self, active: bool) {
+        if self.active.swap(active, Ordering::AcqRel) != active {
+            self.changed.notify_one();
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        self.active.load(Ordering::Acquire)
+    }
+
+    async fn wait_for(&self, active: bool) {
+        loop {
+            let notified = self.changed.notified();
+            if self.is_active() == active {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+#[derive(Default)]
+struct CoalescedWake {
+    pending: AtomicBool,
+    changed: Notify,
+}
+
+impl CoalescedWake {
+    fn signal(&self) {
+        if !self.pending.swap(true, Ordering::AcqRel) {
+            self.changed.notify_one();
+        }
+    }
+
+    async fn wait(&self) {
+        loop {
+            let notified = self.changed.notified();
+            if self.pending.swap(false, Ordering::AcqRel) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    fn clear(&self) {
+        self.pending.store(false, Ordering::Release);
+    }
+}
+
+#[derive(Default)]
+struct AddressSetReducer {
+    previous: Option<HashSet<IpAddr>>,
+}
+
+impl AddressSetReducer {
+    fn observe(&mut self, current: HashSet<IpAddr>) -> bool {
+        let reconnect = self
+            .previous
+            .as_ref()
+            .is_some_and(|previous| current.iter().any(|address| !previous.contains(address)));
+        self.previous = Some(current);
+        reconnect
+    }
+}
+
+impl NetworkChangeWatch {
+    /// Start one parked task immediately, or leave the caller on its timed fallback.
+    pub(crate) fn start() -> Option<Self> {
+        let runtime = match Handle::try_current() {
+            Ok(runtime) => runtime,
+            Err(_) => {
+                watcher_unavailable();
+                return None;
+            }
+        };
+        let activation = Arc::new(Activation::default());
+        let wake = Arc::new(CoalescedWake::default());
+        let task_activation = Arc::clone(&activation);
+        let task_wake = Arc::clone(&wake);
+        let task_runtime = runtime.clone();
+        let task = runtime.spawn(async move {
+            watch_networks(task_runtime, task_activation, task_wake).await;
+        });
+        Some(Self {
+            task,
+            activation,
+            wake,
+        })
+    }
+
+    /// Wait for the next coalesced usable-address addition.
+    pub(crate) async fn changed(&self) {
+        self.activation.set(true);
+        self.wake.wait().await;
+    }
+
+    /// Stop address snapshots while automatic sync is not waiting on connectivity.
+    pub(crate) fn park(&self) {
+        self.activation.set(false);
+        self.wake.clear();
+    }
+
+    /// A disabled watcher remains pending while the scheduler's timed fallback stays active.
+    pub(crate) async fn changed_or_pending(watch: Option<&Self>) {
+        let Some(watch) = watch else {
+            std::future::pending::<()>().await;
+            return;
+        };
+        watch.changed().await;
+    }
+}
+
+impl Drop for NetworkChangeWatch {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn watch_networks(runtime: Handle, activation: Arc<Activation>, wake: Arc<CoalescedWake>) {
+    loop {
+        activation.wait_for(true).await;
+        let Some((mut networks, initial)) =
+            refresh_snapshot(&runtime, sysinfo::Networks::new()).await
+        else {
+            watcher_unavailable();
+            return;
+        };
+        if !activation.is_active() {
+            continue;
+        }
+        let mut reducer = AddressSetReducer::default();
+        let initial_is_reconnect = reducer.observe(initial);
+        debug_assert!(!initial_is_reconnect);
+        let start = tokio::time::Instant::now() + POLL_INTERVAL;
+        let mut interval = tokio::time::interval_at(start, POLL_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                biased;
+                _ = activation.wait_for(false) => break,
+                _ = interval.tick() => {
+                    let Some((refreshed, current)) =
+                        refresh_snapshot(&runtime, networks).await
+                    else {
+                        watcher_unavailable();
+                        return;
+                    };
+                    networks = refreshed;
+                    if !activation.is_active() {
+                        break;
+                    }
+                    if reducer.observe(current) {
+                        wake.signal();
+                        if activation.is_active() {
+                            activation.set(false);
+                        } else {
+                            wake.clear();
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn refresh_snapshot(
+    runtime: &Handle,
+    mut networks: sysinfo::Networks,
+) -> Option<(sysinfo::Networks, HashSet<IpAddr>)> {
+    let refresh = runtime.spawn_blocking(move || {
+        networks.refresh(true);
+        let mut addresses = HashSet::new();
+        for network in networks.values() {
+            extend_usable_addresses(
+                &mut addresses,
+                network.operational_state(),
+                network.ip_networks().iter().map(|network| network.addr),
+            );
+        }
+        (networks, addresses)
+    });
+    tokio::time::timeout(SNAPSHOT_TIMEOUT, refresh)
+        .await
+        .ok()?
+        .ok()
+}
+
+fn watcher_unavailable() {
+    tracing::debug!("network-change watcher unavailable; automatic sync will use timed retry");
+}
+
+fn extend_usable_addresses(
+    output: &mut HashSet<IpAddr>,
+    state: sysinfo::InterfaceOperationalState,
+    addresses: impl IntoIterator<Item = IpAddr>,
+) {
+    if potentially_operational(state) {
+        output.extend(addresses.into_iter().filter(|address| usable_ip(*address)));
+    }
+}
+
+fn potentially_operational(state: sysinfo::InterfaceOperationalState) -> bool {
+    !matches!(
+        state,
+        sysinfo::InterfaceOperationalState::Down
+            | sysinfo::InterfaceOperationalState::Testing
+            | sysinfo::InterfaceOperationalState::NotPresent
+            | sysinfo::InterfaceOperationalState::LowerLayerDown
+    )
+}
+
+fn usable_ip(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => usable_ipv4(address),
+        IpAddr::V6(address) => address
+            .to_ipv4_mapped()
+            .map_or_else(|| usable_ipv6(address), usable_ipv4),
+    }
+}
+
+fn usable_ipv4(address: Ipv4Addr) -> bool {
+    !address.is_unspecified()
+        && !address.is_loopback()
+        && !address.is_multicast()
+        && !address.is_link_local()
+        && !address.is_broadcast()
+}
+
+fn usable_ipv6(address: Ipv6Addr) -> bool {
+    !address.is_unspecified()
+        && !address.is_loopback()
+        && !address.is_multicast()
+        && !address.is_unicast_link_local()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addresses(values: &[&str]) -> HashSet<IpAddr> {
+        values
+            .iter()
+            .map(|address| address.parse().unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn initial_snapshot_is_baseline_only() {
+        let mut reducer = AddressSetReducer::default();
+
+        assert!(!reducer.observe(addresses(&["10.0.0.20", "fd00::20"])));
+        assert!(!reducer.observe(addresses(&["10.0.0.20", "fd00::20"])));
+    }
+
+    #[test]
+    fn added_address_signals_reconnect() {
+        let mut reducer = AddressSetReducer::default();
+        reducer.observe(addresses(&["10.0.0.20"]));
+
+        assert!(reducer.observe(addresses(&["10.0.0.20", "192.168.1.20"])));
+    }
+
+    #[test]
+    fn removals_do_not_signal_but_reappearance_does() {
+        let mut reducer = AddressSetReducer::default();
+        reducer.observe(addresses(&["10.0.0.20"]));
+
+        assert!(!reducer.observe(HashSet::new()));
+        assert!(reducer.observe(addresses(&["10.0.0.20"])));
+    }
+
+    #[test]
+    fn down_to_up_with_the_same_address_signals_reconnect() {
+        let address: IpAddr = "10.0.0.20".parse().unwrap();
+        let snapshot = |state| {
+            let mut output = HashSet::new();
+            extend_usable_addresses(&mut output, state, [address]);
+            output
+        };
+        let mut reducer = AddressSetReducer::default();
+
+        assert!(!reducer.observe(snapshot(sysinfo::InterfaceOperationalState::Down)));
+        assert!(reducer.observe(snapshot(sysinfo::InterfaceOperationalState::Up)));
+    }
+
+    #[test]
+    fn operational_state_filter_matches_sysinfo_guidance() {
+        for state in [
+            sysinfo::InterfaceOperationalState::Up,
+            sysinfo::InterfaceOperationalState::Dormant,
+            sysinfo::InterfaceOperationalState::Unknown,
+        ] {
+            assert!(potentially_operational(state));
+        }
+        for state in [
+            sysinfo::InterfaceOperationalState::Down,
+            sysinfo::InterfaceOperationalState::Testing,
+            sysinfo::InterfaceOperationalState::NotPresent,
+            sysinfo::InterfaceOperationalState::LowerLayerDown,
+        ] {
+            assert!(!potentially_operational(state));
+        }
+    }
+
+    #[test]
+    fn unusable_addresses_are_filtered() {
+        for address in [
+            "0.0.0.0",
+            "127.0.0.1",
+            "169.254.1.1",
+            "224.0.0.1",
+            "255.255.255.255",
+            "::",
+            "::1",
+            "fe80::1",
+            "ff02::1",
+            "::ffff:127.0.0.1",
+        ] {
+            assert!(
+                !usable_ip(address.parse().unwrap()),
+                "{address} must not wake automatic sync"
+            );
+        }
+    }
+
+    #[test]
+    fn private_and_global_addresses_are_usable() {
+        for address in [
+            "10.0.0.20",
+            "192.168.1.20",
+            "1.1.1.1",
+            "fd00::20",
+            "2001:4860:4860::8888",
+        ] {
+            assert!(
+                usable_ip(address.parse().unwrap()),
+                "{address} must be eligible for a reconnect wakeup"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn clearing_a_ready_wake_discards_the_stale_edge() {
+        let wake = CoalescedWake::default();
+        wake.signal();
+        wake.clear();
+
+        let mut waiting = Box::pin(wake.wait());
+        assert!(futures::poll!(waiting.as_mut()).is_pending());
+
+        wake.signal();
+        waiting.await;
+    }
+}

--- a/src/sync/error.rs
+++ b/src/sync/error.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::time::Duration;
 
 /// A redacted error from the encrypted personal-state vault.
 ///
@@ -47,6 +48,7 @@ pub enum VaultError {
     RemoteAuthentication,
     RemoteCertificate,
     RemoteUnavailable,
+    RemoteRateLimited(Option<Duration>),
     RemoteUnsupported,
     StorageFailed,
     StorageBusy,
@@ -99,6 +101,14 @@ impl fmt::Display for VaultError {
             Self::RemoteAuthentication => "the remote credential was rejected",
             Self::RemoteCertificate => "the remote certificate could not be verified",
             Self::RemoteUnavailable => "the remote service is unavailable",
+            Self::RemoteRateLimited(Some(delay)) => {
+                return write!(
+                    f,
+                    "the remote service asked the client to retry in {} seconds",
+                    delay.as_secs()
+                );
+            }
+            Self::RemoteRateLimited(None) => "the remote service asked the client to retry later",
             Self::RemoteUnsupported => "the remote service is not supported",
             Self::StorageFailed => "the protected state could not be stored",
             Self::StorageBusy => "the protected state is in use",

--- a/src/sync/local_state.rs
+++ b/src/sync/local_state.rs
@@ -203,6 +203,7 @@ impl SyncHealthStore {
 pub enum SyncAuditAction {
     Setup,
     ManualSync,
+    AutomaticSync,
     PairCreate,
     PairJoin,
     RevokeDevice,
@@ -214,6 +215,7 @@ impl SyncAuditAction {
         match self {
             Self::Setup => "Personal sync was set up",
             Self::ManualSync => "Personal state was synced",
+            Self::AutomaticSync => "Personal state was synced automatically",
             Self::PairCreate => "A device connection was started",
             Self::PairJoin => "This device joined personal sync",
             Self::RevokeDevice => "A device was removed",

--- a/src/sync/manual/budget.rs
+++ b/src/sync/manual/budget.rs
@@ -1,0 +1,195 @@
+//! Whole-attempt resource and deadline accounting for encrypted vault synchronization.
+
+use std::time::Duration;
+
+use crate::sync::{
+    EncryptedObject, ListCost, ListLimits, MAX_VAULT_PAYLOAD_BYTES, ObjectCondition,
+    ObjectDeleteResult, ObjectKey, ObjectMetadata, ObjectWriteResult, VaultDeadline, VaultError,
+    VaultTransport,
+};
+
+const MAX_LISTED_OBJECTS: usize = 10_000;
+const MAX_READ_REQUESTS: usize = 20_000;
+const MAX_LIST_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+const MAX_SCANNED_COLLECTIONS: usize = 10_000;
+const MAX_SCANNED_RESOURCES: usize = 10_000;
+const MAX_SYNC_DURATION: Duration = Duration::from_secs(5 * 60);
+
+pub struct ManualSyncBudget {
+    consumed: usize,
+    requests: usize,
+    listed_objects: usize,
+    list_response_bytes: usize,
+    scanned_collections: usize,
+    scanned_resources: usize,
+    deadline: VaultDeadline,
+}
+
+impl Default for ManualSyncBudget {
+    fn default() -> Self {
+        Self::with_deadline(VaultDeadline::from_now(MAX_SYNC_DURATION))
+    }
+}
+
+impl ManualSyncBudget {
+    pub fn with_deadline(deadline: VaultDeadline) -> Self {
+        Self {
+            consumed: 0,
+            requests: 0,
+            listed_objects: 0,
+            list_response_bytes: 0,
+            scanned_collections: 0,
+            scanned_resources: 0,
+            deadline,
+        }
+    }
+
+    pub fn check_deadline(&self) -> Result<(), VaultError> {
+        self.deadline.check()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn consumed_requests(&self) -> usize {
+        self.requests
+    }
+
+    pub fn get<T: VaultTransport + ?Sized>(
+        &mut self,
+        transport: &T,
+        key: &ObjectKey,
+        max_bytes: usize,
+    ) -> Result<Option<(EncryptedObject, ObjectMetadata)>, VaultError> {
+        self.check_deadline()?;
+        self.consume_requests(1)?;
+        let result = transport.get_with_deadline(key, max_bytes, self.deadline);
+        self.check_deadline()?;
+        let result = result?;
+        if let Some((object, metadata)) = &result {
+            let actual_length: u64 = object
+                .as_bytes()
+                .len()
+                .try_into()
+                .map_err(|_| VaultError::PayloadTooLarge)?;
+            self.consume_ciphertext(metadata.content_length.max(actual_length))?;
+        }
+        Ok(result)
+    }
+
+    pub(super) fn list<T: VaultTransport + ?Sized>(
+        &mut self,
+        transport: &T,
+        prefix: &ObjectKey,
+    ) -> Result<Vec<ObjectMetadata>, VaultError> {
+        self.check_deadline()?;
+        let limits = self.list_limits()?;
+        let outcome = transport.list_with_limits(prefix, limits, self.deadline);
+        self.check_deadline()?;
+        let outcome = outcome?;
+        outcome.validate(limits)?;
+        self.consume_list_cost(outcome.cost)?;
+        Ok(outcome.objects)
+    }
+
+    pub(super) fn put<T: VaultTransport + ?Sized>(
+        &mut self,
+        transport: &T,
+        key: &ObjectKey,
+        object: &EncryptedObject,
+        condition: ObjectCondition,
+    ) -> Result<ObjectWriteResult, VaultError> {
+        self.check_deadline()?;
+        let result = transport.put_with_deadline(key, object, condition, self.deadline);
+        self.check_deadline()?;
+        result
+    }
+
+    pub(super) fn delete<T: VaultTransport + ?Sized>(
+        &mut self,
+        transport: &T,
+        key: &ObjectKey,
+        expected_etag: &str,
+    ) -> Result<ObjectDeleteResult, VaultError> {
+        self.check_deadline()?;
+        let result = transport.delete_with_deadline(key, expected_etag, self.deadline);
+        self.check_deadline()?;
+        result
+    }
+
+    fn consume_ciphertext(&mut self, bytes: u64) -> Result<(), VaultError> {
+        let bytes: usize = bytes.try_into().map_err(|_| VaultError::PayloadTooLarge)?;
+        self.consume(bytes)
+    }
+
+    fn consume(&mut self, bytes: usize) -> Result<(), VaultError> {
+        self.consumed = self
+            .consumed
+            .checked_add(bytes)
+            .ok_or(VaultError::PayloadTooLarge)?;
+        if self.consumed > MAX_VAULT_PAYLOAD_BYTES {
+            return Err(VaultError::PayloadTooLarge);
+        }
+        Ok(())
+    }
+
+    fn consume_requests(&mut self, requests: usize) -> Result<(), VaultError> {
+        self.requests = self
+            .requests
+            .checked_add(requests)
+            .ok_or(VaultError::ResourceLimitExceeded)?;
+        if self.requests > MAX_READ_REQUESTS {
+            return Err(VaultError::ResourceLimitExceeded);
+        }
+        Ok(())
+    }
+
+    fn list_limits(&self) -> Result<ListLimits, VaultError> {
+        Ok(ListLimits {
+            requests: remaining(MAX_READ_REQUESTS, self.requests)?,
+            response_bytes: remaining(MAX_LIST_RESPONSE_BYTES, self.list_response_bytes)?,
+            scanned_collections: remaining(MAX_SCANNED_COLLECTIONS, self.scanned_collections)?,
+            scanned_resources: remaining(MAX_SCANNED_RESOURCES, self.scanned_resources)?,
+            returned_objects: remaining(MAX_LISTED_OBJECTS, self.listed_objects)?,
+        })
+    }
+
+    fn consume_list_cost(&mut self, cost: ListCost) -> Result<(), VaultError> {
+        self.consume_requests(cost.requests)?;
+        self.list_response_bytes = checked_total(
+            self.list_response_bytes,
+            cost.response_bytes,
+            MAX_LIST_RESPONSE_BYTES,
+        )?;
+        self.scanned_collections = checked_total(
+            self.scanned_collections,
+            cost.scanned_collections,
+            MAX_SCANNED_COLLECTIONS,
+        )?;
+        self.scanned_resources = checked_total(
+            self.scanned_resources,
+            cost.scanned_resources,
+            MAX_SCANNED_RESOURCES,
+        )?;
+        self.listed_objects = self
+            .listed_objects
+            .checked_add(cost.returned_objects)
+            .ok_or(VaultError::ResourceLimitExceeded)?;
+        if self.listed_objects > MAX_LISTED_OBJECTS {
+            return Err(VaultError::ResourceLimitExceeded);
+        }
+        Ok(())
+    }
+}
+
+fn remaining(maximum: usize, consumed: usize) -> Result<usize, VaultError> {
+    maximum
+        .checked_sub(consumed)
+        .filter(|remaining| *remaining > 0)
+        .ok_or(VaultError::ResourceLimitExceeded)
+}
+
+fn checked_total(current: usize, added: usize, maximum: usize) -> Result<usize, VaultError> {
+    current
+        .checked_add(added)
+        .filter(|total| *total <= maximum)
+        .ok_or(VaultError::ResourceLimitExceeded)
+}

--- a/src/sync/manual/engine.rs
+++ b/src/sync/manual/engine.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::time::Duration;
 
-use crate::personal_state::{DeviceId, OperationEnvelope, PersonalStateV2, merge};
+use crate::personal_state::{
+    DeviceId, OperationEnvelope, PersonalStateV2, engagement_compaction_leader, merge,
+    operation_survives_checkpoint, plan_engagement_compaction,
+};
 
 use super::super::batch::{
     BatchAcceptance, BatchAnchor, SignedOperationBatch, apply_operation_batch,
@@ -12,20 +14,16 @@ use super::super::crypto::{
 };
 use super::super::membership::{MembershipAnchor, MembershipChain, VerifiedMembership};
 use super::super::{
-    ListCost, ListLimits, MAX_BATCH_OPERATIONS, MAX_BATCH_PLAINTEXT_BYTES, MAX_VAULT_PAYLOAD_BYTES,
-    ObjectCondition, ObjectKey, ObjectMetadata, ObjectWriteResult, VaultDeadline, VaultError,
-    VaultTransport,
+    MAX_BATCH_OPERATIONS, MAX_BATCH_PLAINTEXT_BYTES, MAX_VAULT_PAYLOAD_BYTES, ObjectCondition,
+    ObjectKey, ObjectMetadata, ObjectWriteResult, VaultDeadline, VaultError, VaultTransport,
+    authorize_compaction, verify_compaction_authorization,
 };
+use super::budget::ManualSyncBudget;
 use super::protocol::{SignedDeviceHead, SignedVaultManifest, segment_bounds};
 
 const MAX_SYNC_ATTEMPTS: usize = 8;
-const MAX_LISTED_OBJECTS: usize = 10_000;
-const MAX_READ_REQUESTS: usize = 20_000;
-const MAX_LIST_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
-const MAX_SCANNED_COLLECTIONS: usize = 10_000;
-const MAX_SCANNED_RESOURCES: usize = 10_000;
-const MAX_SYNC_DURATION: Duration = Duration::from_secs(5 * 60);
 const SMALL_OBJECT_LIMIT: usize = 2 * 1024 * 1024;
+type ReadBudget = ManualSyncBudget;
 
 /// A hook supplied by the primary state owner.
 ///
@@ -65,6 +63,13 @@ pub struct ManualSyncSummary {
     pub uploaded_segments: usize,
     pub checkpoint_written: bool,
     pub manifest_written: bool,
+    pub compacted_engagement_operations: usize,
+    pub compaction_acknowledgements_written: usize,
+    pub compaction_quorum_reached: bool,
+    pub compacted_segments_deleted: usize,
+    pub old_checkpoints_deleted: usize,
+    pub obsolete_compaction_acknowledgements_retained: usize,
+    pub compaction_gc_deferred: bool,
     pub remote_writes: usize,
 }
 
@@ -169,6 +174,24 @@ impl<'a, T: VaultTransport + ?Sized> ManualSyncEngine<'a, T> {
 
         let (mut remote_state, stream_anchors, mut summary) =
             self.download_visible_segments(input, &checkpoint, &remote_membership, budget)?;
+        let maintenance = super::maintenance::acknowledge_and_collect(
+            self.transport,
+            input,
+            revision_guard,
+            &checkpoint,
+            &remote_membership,
+            budget,
+        )?;
+        summary.compaction_acknowledgements_written = maintenance.acknowledgements_written;
+        summary.compaction_quorum_reached = maintenance.quorum.is_some();
+        summary.compacted_segments_deleted = maintenance.segments_deleted;
+        summary.old_checkpoints_deleted = maintenance.checkpoints_deleted;
+        summary.obsolete_compaction_acknowledgements_retained =
+            maintenance.obsolete_acknowledgements_retained;
+        summary.compaction_gc_deferred = maintenance.gc_deferred;
+        summary.remote_writes = summary
+            .remote_writes
+            .saturating_add(maintenance.remote_writes);
         let selected_membership = select_membership(
             input.membership,
             &manifest.payload.membership,
@@ -223,6 +246,69 @@ impl<'a, T: VaultTransport + ?Sized> ManualSyncEngine<'a, T> {
 
         if merged.device_registry != selected_verified.devices {
             return Err(VaultError::RegistryMismatch);
+        }
+        let local_device_id = DeviceId::new(input.device.device_id())
+            .map_err(|_| VaultError::InvalidDeviceIdentity)?;
+        let remote_compaction = checkpoint.payload.state.compaction_checkpoint.as_ref();
+        let merged_compaction = merged.compaction_checkpoint.as_ref();
+        if remote_compaction != merged_compaction {
+            let (Some(previous), Some(descendant), Some(quorum)) = (
+                remote_compaction,
+                merged_compaction,
+                maintenance.quorum.as_ref(),
+            ) else {
+                return Err(VaultError::InvalidEncryptedObject);
+            };
+            if !is_adjacent_compaction_transition(previous, descendant)
+                || !quorum.authorizes(previous, &remote_membership)
+            {
+                return Err(VaultError::InvalidEncryptedObject);
+            }
+            verify_compaction_authorization(
+                &merged.dataset_id,
+                descendant,
+                &selected_membership,
+                input.membership_anchor,
+            )?;
+        }
+        let prior_compaction_has_quorum = merged_compaction.is_some_and(|compaction| {
+            maintenance
+                .quorum
+                .as_ref()
+                .is_some_and(|quorum| quorum.authorizes(compaction, &selected_verified))
+        });
+        if engagement_compaction_leader(&merged).as_ref() == Some(&local_device_id)
+            && let Some(plan) = plan_engagement_compaction(
+                &merged,
+                &local_device_id,
+                crate::signals::unix_now(),
+                prior_compaction_has_quorum,
+            )
+            .map_err(|_| VaultError::InvalidEncryptedObject)?
+        {
+            summary.compacted_engagement_operations = plan.pruned_engagement_operations;
+            let mut candidate = plan.candidate;
+            let compaction = candidate
+                .compaction_checkpoint
+                .as_mut()
+                .ok_or(VaultError::InvalidEncryptedObject)?;
+            compaction.leader_authorization = Some(authorize_compaction(
+                &candidate.dataset_id,
+                compaction,
+                &selected_verified,
+                local_device_id.clone(),
+                input.device,
+                checkpoint
+                    .payload
+                    .checkpoint_sequence
+                    .checked_add(1)
+                    .ok_or(VaultError::InvalidEncryptedObject)?,
+                &checkpoint.hash()?,
+            )?);
+            candidate
+                .validate()
+                .map_err(|_| VaultError::InvalidEncryptedObject)?;
+            merged = candidate;
         }
         let remote_changed =
             !sync_equivalent(&checkpoint.payload.state, &merged) || membership_advanced;
@@ -1010,12 +1096,7 @@ impl<'a, T: VaultTransport + ?Sized> ManualSyncEngine<'a, T> {
         condition: ObjectCondition,
         budget: &mut ReadBudget,
     ) -> Result<ObjectWriteResult, VaultError> {
-        budget.check_deadline()?;
-        let result = self
-            .transport
-            .put_with_deadline(key, object, condition, budget.deadline);
-        budget.check_deadline()?;
-        result
+        budget.put(self.transport, key, object, condition)
     }
 
     fn list_device_segments(
@@ -1042,162 +1123,6 @@ struct UploadSummary {
     operations: usize,
     segments: usize,
     writes: usize,
-}
-
-pub struct ManualSyncBudget {
-    consumed: usize,
-    requests: usize,
-    listed_objects: usize,
-    list_response_bytes: usize,
-    scanned_collections: usize,
-    scanned_resources: usize,
-    deadline: VaultDeadline,
-}
-
-type ReadBudget = ManualSyncBudget;
-
-impl Default for ManualSyncBudget {
-    fn default() -> Self {
-        Self::with_deadline(VaultDeadline::from_now(MAX_SYNC_DURATION))
-    }
-}
-
-impl ManualSyncBudget {
-    pub fn with_deadline(deadline: VaultDeadline) -> Self {
-        Self {
-            consumed: 0,
-            requests: 0,
-            listed_objects: 0,
-            list_response_bytes: 0,
-            scanned_collections: 0,
-            scanned_resources: 0,
-            deadline,
-        }
-    }
-
-    pub fn check_deadline(&self) -> Result<(), VaultError> {
-        self.deadline.check()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn consumed_requests(&self) -> usize {
-        self.requests
-    }
-
-    pub fn get<T: VaultTransport + ?Sized>(
-        &mut self,
-        transport: &T,
-        key: &ObjectKey,
-        max_bytes: usize,
-    ) -> Result<Option<(EncryptedObject, ObjectMetadata)>, VaultError> {
-        self.check_deadline()?;
-        self.consume_requests(1)?;
-        let result = transport.get_with_deadline(key, max_bytes, self.deadline);
-        self.check_deadline()?;
-        let result = result?;
-        if let Some((object, metadata)) = &result {
-            let actual_length: u64 = object
-                .as_bytes()
-                .len()
-                .try_into()
-                .map_err(|_| VaultError::PayloadTooLarge)?;
-            self.consume_ciphertext(metadata.content_length.max(actual_length))?;
-        }
-        Ok(result)
-    }
-
-    fn list<T: VaultTransport + ?Sized>(
-        &mut self,
-        transport: &T,
-        prefix: &ObjectKey,
-    ) -> Result<Vec<ObjectMetadata>, VaultError> {
-        self.check_deadline()?;
-        let limits = self.list_limits()?;
-        let outcome = transport.list_with_limits(prefix, limits, self.deadline);
-        self.check_deadline()?;
-        let outcome = outcome?;
-        outcome.validate(limits)?;
-        self.consume_list_cost(outcome.cost)?;
-        Ok(outcome.objects)
-    }
-
-    fn consume_ciphertext(&mut self, bytes: u64) -> Result<(), VaultError> {
-        let bytes: usize = bytes.try_into().map_err(|_| VaultError::PayloadTooLarge)?;
-        self.consume(bytes)
-    }
-
-    fn consume(&mut self, bytes: usize) -> Result<(), VaultError> {
-        self.consumed = self
-            .consumed
-            .checked_add(bytes)
-            .ok_or(VaultError::PayloadTooLarge)?;
-        if self.consumed > MAX_VAULT_PAYLOAD_BYTES {
-            return Err(VaultError::PayloadTooLarge);
-        }
-        Ok(())
-    }
-
-    fn consume_requests(&mut self, requests: usize) -> Result<(), VaultError> {
-        self.requests = self
-            .requests
-            .checked_add(requests)
-            .ok_or(VaultError::ResourceLimitExceeded)?;
-        if self.requests > MAX_READ_REQUESTS {
-            return Err(VaultError::ResourceLimitExceeded);
-        }
-        Ok(())
-    }
-
-    fn list_limits(&self) -> Result<ListLimits, VaultError> {
-        Ok(ListLimits {
-            requests: remaining(MAX_READ_REQUESTS, self.requests)?,
-            response_bytes: remaining(MAX_LIST_RESPONSE_BYTES, self.list_response_bytes)?,
-            scanned_collections: remaining(MAX_SCANNED_COLLECTIONS, self.scanned_collections)?,
-            scanned_resources: remaining(MAX_SCANNED_RESOURCES, self.scanned_resources)?,
-            returned_objects: remaining(MAX_LISTED_OBJECTS, self.listed_objects)?,
-        })
-    }
-
-    fn consume_list_cost(&mut self, cost: ListCost) -> Result<(), VaultError> {
-        self.consume_requests(cost.requests)?;
-        self.list_response_bytes = checked_total(
-            self.list_response_bytes,
-            cost.response_bytes,
-            MAX_LIST_RESPONSE_BYTES,
-        )?;
-        self.scanned_collections = checked_total(
-            self.scanned_collections,
-            cost.scanned_collections,
-            MAX_SCANNED_COLLECTIONS,
-        )?;
-        self.scanned_resources = checked_total(
-            self.scanned_resources,
-            cost.scanned_resources,
-            MAX_SCANNED_RESOURCES,
-        )?;
-        self.listed_objects = self
-            .listed_objects
-            .checked_add(cost.returned_objects)
-            .ok_or(VaultError::ResourceLimitExceeded)?;
-        if self.listed_objects > MAX_LISTED_OBJECTS {
-            return Err(VaultError::ResourceLimitExceeded);
-        }
-        Ok(())
-    }
-}
-
-fn remaining(maximum: usize, consumed: usize) -> Result<usize, VaultError> {
-    maximum
-        .checked_sub(consumed)
-        .filter(|remaining| *remaining > 0)
-        .ok_or(VaultError::ResourceLimitExceeded)
-}
-
-fn checked_total(current: usize, added: usize, maximum: usize) -> Result<usize, VaultError> {
-    current
-        .checked_add(added)
-        .filter(|total| *total <= maximum)
-        .ok_or(VaultError::ResourceLimitExceeded)
 }
 
 fn validate_input(input: &ManualSyncInput<'_>) -> Result<(), VaultError> {
@@ -1277,6 +1202,9 @@ fn pending_local_operations(
             Some(_) => return Err(VaultError::InvalidEncryptedObject),
             None => {}
         }
+        if !operation_survives_checkpoint(remote.compaction_checkpoint.as_ref(), operation) {
+            continue;
+        }
         if remote_dots.contains(&operation.stamp.dot) {
             return Err(VaultError::InvalidEncryptedObject);
         }
@@ -1351,6 +1279,14 @@ fn sync_equivalent(left: &PersonalStateV2, right: &PersonalStateV2) -> bool {
         && left.version_vector == right.version_vector
         && left.operations == right.operations
         && left.compaction_checkpoint == right.compaction_checkpoint
+}
+
+pub(super) fn is_adjacent_compaction_transition(
+    remote: &crate::personal_state::CompactionCheckpoint,
+    local: &crate::personal_state::CompactionCheckpoint,
+) -> bool {
+    remote.compaction_generation.checked_add(1) == Some(local.compaction_generation)
+        && local.previous_checkpoint_hash.as_deref() == Some(remote.checkpoint_id.as_str())
 }
 
 fn canonical_checkpoint_state(state: &PersonalStateV2) -> PersonalStateV2 {

--- a/src/sync/manual/maintenance.rs
+++ b/src/sync/manual/maintenance.rs
@@ -1,0 +1,612 @@
+//! Authenticated compaction acknowledgement and conservative remote garbage collection.
+//!
+//! A device may acknowledge only the exact signed checkpoint already recorded in its durable
+//! private rollback anchor. The lowest active device performs deletion only after every device
+//! active in that checkpoint's membership epoch has published the same authenticated
+//! acknowledgement.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
+
+use crate::personal_state::{CompactionCheckpoint, DeviceId, engagement_compaction_leader};
+
+use super::protocol::segment_bounds;
+use super::{LocalRevisionGuard, ManualSyncBudget, ManualSyncInput};
+use crate::sync::{
+    EncryptedObject, ObjectCondition, ObjectDeleteResult, ObjectKey, ObjectMetadata,
+    ObjectWriteResult, SignedCheckpoint, SignedCompactionAck, VaultDeadline, VaultError,
+    VaultTransport, VerifiedMembership, compaction_ack_key, compaction_ack_prefix,
+    compaction_quorum,
+};
+
+const MAX_ACK_BYTES: usize = 2 * 1024 * 1024;
+const RETAINED_CHECKPOINTS: usize = 3;
+const GC_DEADLINE: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Default)]
+pub(super) struct MaintenanceSummary {
+    pub(super) acknowledgements_written: usize,
+    pub(super) quorum: Option<CompactionQuorumEvidence>,
+    pub(super) segments_deleted: usize,
+    pub(super) checkpoints_deleted: usize,
+    pub(super) obsolete_acknowledgements_retained: usize,
+    pub(super) gc_deferred: bool,
+    pub(super) remote_writes: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct CompactionQuorumEvidence {
+    compaction: CompactionCheckpoint,
+    membership_epoch: u64,
+    membership_head_hash: String,
+    installed_checkpoint_sequence: u64,
+    installed_checkpoint_hash: String,
+    minimum_installed_checkpoint_sequence: u64,
+}
+
+impl CompactionQuorumEvidence {
+    pub(super) fn authorizes(
+        &self,
+        compaction: &CompactionCheckpoint,
+        membership: &VerifiedMembership,
+    ) -> bool {
+        self.compaction == *compaction
+            && self.membership_epoch == membership.epoch
+            && self.membership_head_hash == membership.head_hash
+            && self.installed_checkpoint_sequence > 0
+            && !self.installed_checkpoint_hash.is_empty()
+            && self.minimum_installed_checkpoint_sequence > 0
+    }
+}
+
+#[derive(Debug, Default)]
+struct DeletionOutcome {
+    deleted: usize,
+    deferred: bool,
+    acknowledgements_verified: bool,
+}
+
+#[derive(Debug, Default)]
+struct ResidualOutcome {
+    retained: usize,
+    deferred: bool,
+}
+
+pub(super) fn acknowledge_and_collect<T: VaultTransport + ?Sized, G: LocalRevisionGuard>(
+    transport: &T,
+    input: &ManualSyncInput<'_>,
+    revision_guard: &G,
+    checkpoint: &SignedCheckpoint,
+    membership: &VerifiedMembership,
+    budget: &mut ManualSyncBudget,
+) -> Result<MaintenanceSummary, VaultError> {
+    let checkpoint_hash = checkpoint.hash()?;
+    if input.checkpoint_anchor.checkpoint_sequence != checkpoint.payload.checkpoint_sequence
+        || input.checkpoint_anchor.checkpoint_hash.as_deref() != Some(checkpoint_hash.as_str())
+    {
+        return Ok(MaintenanceSummary::default());
+    }
+    let Some(compaction) = checkpoint.payload.state.compaction_checkpoint.as_ref() else {
+        return Ok(MaintenanceSummary::default());
+    };
+    let local_device_id =
+        DeviceId::new(input.device.device_id()).map_err(|_| VaultError::InvalidDeviceIdentity)?;
+    let acknowledgement = SignedCompactionAck::create(
+        &checkpoint.payload.dataset_id,
+        compaction,
+        checkpoint.payload.checkpoint_sequence,
+        &checkpoint_hash,
+        membership,
+        local_device_id.clone(),
+        input.device,
+    )?;
+    let acknowledgement_key = compaction_ack_key(
+        &checkpoint.payload.dataset_id,
+        compaction,
+        membership,
+        &local_device_id,
+    )?;
+    let encrypted = acknowledgement.encrypt(compaction, membership)?;
+    revision_guard.ensure_current(input.expected_local_revision)?;
+    let wrote = put_acknowledgement(
+        transport,
+        input,
+        membership,
+        compaction,
+        &acknowledgement_key,
+        &acknowledgement,
+        &encrypted,
+        budget,
+    )?;
+
+    let acknowledgements = load_acknowledgements(transport, input, membership, compaction, budget)?;
+    let mut summary = MaintenanceSummary {
+        acknowledgements_written: usize::from(wrote),
+        remote_writes: usize::from(wrote),
+        ..MaintenanceSummary::default()
+    };
+    let has_quorum = compaction_quorum(&acknowledgements, compaction, membership)?;
+    if engagement_compaction_leader(&checkpoint.payload.state).as_ref() != Some(&local_device_id)
+        || !has_quorum
+    {
+        return Ok(summary);
+    }
+
+    // Optional physical cleanup has its own short deadline and accounting. Exhausting it must not
+    // consume the budget needed for the merge, segment upload, or manifest CAS below.
+    let mut gc_budget = ManualSyncBudget::with_deadline(VaultDeadline::from_now(GC_DEADLINE));
+    let checkpoint_gc = delete_old_checkpoints(
+        transport,
+        input,
+        revision_guard,
+        checkpoint,
+        &checkpoint_hash,
+        &acknowledgements,
+        &mut gc_budget,
+    )?;
+    let segment_gc = if checkpoint_gc.acknowledgements_verified {
+        delete_covered_segments(transport, input, revision_guard, compaction, &mut gc_budget)?
+    } else {
+        DeletionOutcome {
+            deferred: true,
+            ..DeletionOutcome::default()
+        }
+    };
+    let acknowledgement_residual =
+        count_obsolete_acknowledgements(transport, input, compaction, membership, &mut gc_budget)?;
+    summary.segments_deleted = segment_gc.deleted;
+    summary.checkpoints_deleted = checkpoint_gc.deleted;
+    summary.obsolete_acknowledgements_retained = acknowledgement_residual.retained;
+    summary.gc_deferred =
+        segment_gc.deferred || checkpoint_gc.deferred || acknowledgement_residual.deferred;
+    if checkpoint_gc.acknowledgements_verified {
+        summary.quorum = Some(CompactionQuorumEvidence {
+            compaction: compaction.clone(),
+            membership_epoch: membership.epoch,
+            membership_head_hash: membership.head_hash.clone(),
+            installed_checkpoint_sequence: checkpoint.payload.checkpoint_sequence,
+            installed_checkpoint_hash: checkpoint_hash.clone(),
+            minimum_installed_checkpoint_sequence: acknowledgements
+                .iter()
+                .map(|acknowledgement| acknowledgement.payload.installed_checkpoint_sequence)
+                .min()
+                .ok_or(VaultError::InvalidEncryptedObject)?,
+        });
+    }
+    summary.remote_writes = summary
+        .remote_writes
+        .saturating_add(summary.segments_deleted)
+        .saturating_add(summary.checkpoints_deleted);
+    Ok(summary)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn put_acknowledgement<T: VaultTransport + ?Sized>(
+    transport: &T,
+    input: &ManualSyncInput<'_>,
+    membership: &VerifiedMembership,
+    compaction: &CompactionCheckpoint,
+    key: &ObjectKey,
+    acknowledgement: &SignedCompactionAck,
+    encrypted: &EncryptedObject,
+    budget: &mut ManualSyncBudget,
+) -> Result<bool, VaultError> {
+    match budget.put(transport, key, encrypted, ObjectCondition::CreateOnly) {
+        Ok(ObjectWriteResult::Created(_) | ObjectWriteResult::Updated(_)) => Ok(true),
+        Ok(ObjectWriteResult::AlreadyPresent(_))
+        | Err(VaultError::PreconditionFailed)
+        | Err(VaultError::StorageFailed)
+        | Err(VaultError::RemoteUnavailable) => {
+            let Some((existing, metadata)) = budget.get(transport, key, MAX_ACK_BYTES)? else {
+                return Err(VaultError::RemoteUnavailable);
+            };
+            let existing = SignedCompactionAck::decrypt_for_device(
+                &existing,
+                input.device,
+                compaction,
+                membership,
+            )?;
+            match compare_acknowledgement_high_water(&existing, acknowledgement)? {
+                std::cmp::Ordering::Equal | std::cmp::Ordering::Greater => return Ok(false),
+                std::cmp::Ordering::Less => {}
+            }
+            match budget.put(
+                transport,
+                key,
+                encrypted,
+                ObjectCondition::Match(metadata.etag),
+            ) {
+                Ok(ObjectWriteResult::Created(_) | ObjectWriteResult::Updated(_)) => Ok(true),
+                Ok(ObjectWriteResult::AlreadyPresent(_))
+                | Err(VaultError::PreconditionFailed)
+                | Err(VaultError::StorageFailed)
+                | Err(VaultError::RemoteUnavailable) => {
+                    let Some((readback, _)) = budget.get(transport, key, MAX_ACK_BYTES)? else {
+                        return Err(VaultError::RemoteUnavailable);
+                    };
+                    let readback = SignedCompactionAck::decrypt_for_device(
+                        &readback,
+                        input.device,
+                        compaction,
+                        membership,
+                    )?;
+                    match compare_acknowledgement_high_water(&readback, acknowledgement)? {
+                        std::cmp::Ordering::Equal | std::cmp::Ordering::Greater => Ok(true),
+                        std::cmp::Ordering::Less => Err(VaultError::PreconditionFailed),
+                    }
+                }
+                Err(error) => Err(error),
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn compare_acknowledgement_high_water(
+    existing: &SignedCompactionAck,
+    candidate: &SignedCompactionAck,
+) -> Result<std::cmp::Ordering, VaultError> {
+    if existing.payload.signer_device_id != candidate.payload.signer_device_id
+        || existing.payload.dataset_id != candidate.payload.dataset_id
+        || existing.payload.compaction_id != candidate.payload.compaction_id
+        || existing.payload.compaction_generation_hash
+            != candidate.payload.compaction_generation_hash
+        || existing.payload.membership_epoch != candidate.payload.membership_epoch
+        || existing.payload.membership_head_hash != candidate.payload.membership_head_hash
+    {
+        return Err(VaultError::MembershipFork);
+    }
+    let ordering = existing
+        .payload
+        .installed_checkpoint_sequence
+        .cmp(&candidate.payload.installed_checkpoint_sequence);
+    if ordering.is_eq()
+        && existing.payload.installed_checkpoint_hash != candidate.payload.installed_checkpoint_hash
+    {
+        return Err(VaultError::MembershipFork);
+    }
+    Ok(ordering)
+}
+
+fn load_acknowledgements<T: VaultTransport + ?Sized>(
+    transport: &T,
+    input: &ManualSyncInput<'_>,
+    membership: &VerifiedMembership,
+    compaction: &CompactionCheckpoint,
+    budget: &mut ManualSyncBudget,
+) -> Result<Vec<SignedCompactionAck>, VaultError> {
+    let prefix = compaction_ack_prefix(&input.local_state.dataset_id, compaction, membership)?;
+    let mut by_device = BTreeMap::new();
+    for metadata in budget.list(transport, &prefix)? {
+        let device_id = acknowledgement_device_id(&metadata.key)?;
+        if metadata.key
+            != compaction_ack_key(
+                &input.local_state.dataset_id,
+                compaction,
+                membership,
+                &device_id,
+            )?
+        {
+            return Err(VaultError::InvalidObjectKey);
+        }
+        let (object, _) = budget
+            .get(transport, &metadata.key, MAX_ACK_BYTES)?
+            .ok_or(VaultError::SequenceGap)?;
+        let acknowledgement =
+            SignedCompactionAck::decrypt_for_device(&object, input.device, compaction, membership)?;
+        if acknowledgement.payload.signer_device_id != device_id
+            || by_device.insert(device_id, acknowledgement).is_some()
+        {
+            return Err(VaultError::MembershipFork);
+        }
+    }
+    Ok(by_device.into_values().collect())
+}
+
+fn delete_covered_segments<T: VaultTransport + ?Sized, G: LocalRevisionGuard>(
+    transport: &T,
+    input: &ManualSyncInput<'_>,
+    revision_guard: &G,
+    compaction: &CompactionCheckpoint,
+    budget: &mut ManualSyncBudget,
+) -> Result<DeletionOutcome, VaultError> {
+    let mut outcome = DeletionOutcome::default();
+    for (device_id, covered_sequence) in &compaction.coverage.0 {
+        let prefix = super::segment_prefix(&input.local_state.dataset_id, device_id)?;
+        let metadata = match budget.list(transport, &prefix) {
+            Ok(metadata) => metadata,
+            Err(error @ VaultError::RemoteRateLimited(_)) => return Err(error),
+            Err(_) => {
+                outcome.deferred = true;
+                continue;
+            }
+        };
+        for metadata in metadata {
+            let (first, last) = match segment_bounds(&metadata.key) {
+                Ok(bounds) => bounds,
+                Err(_) => {
+                    outcome.deferred = true;
+                    continue;
+                }
+            };
+            if metadata.key
+                != super::segment_key(&input.local_state.dataset_id, device_id, first, last)?
+            {
+                outcome.deferred = true;
+                continue;
+            }
+            if last <= *covered_sequence {
+                match delete_exact(transport, input, revision_guard, &metadata, budget) {
+                    Ok(deleted) => outcome.deleted = outcome.deleted.saturating_add(deleted),
+                    Err(VaultError::RevisionConflict) => {
+                        return Err(VaultError::RevisionConflict);
+                    }
+                    Err(error @ VaultError::RemoteRateLimited(_)) => return Err(error),
+                    Err(_) => outcome.deferred = true,
+                }
+            }
+        }
+    }
+    Ok(outcome)
+}
+
+fn delete_old_checkpoints<T: VaultTransport + ?Sized, G: LocalRevisionGuard>(
+    transport: &T,
+    input: &ManualSyncInput<'_>,
+    revision_guard: &G,
+    latest: &SignedCheckpoint,
+    latest_hash: &str,
+    acknowledgements: &[SignedCompactionAck],
+    budget: &mut ManualSyncBudget,
+) -> Result<DeletionOutcome, VaultError> {
+    let mut outcome = DeletionOutcome::default();
+    let prefix = super::checkpoint_prefix(&latest.payload.dataset_id)?;
+    let mut checkpoints = BTreeMap::<String, (SignedCheckpoint, ObjectMetadata)>::new();
+    let metadata = match budget.list(transport, &prefix) {
+        Ok(metadata) => metadata,
+        Err(error @ VaultError::RemoteRateLimited(_)) => return Err(error),
+        Err(_) => {
+            outcome.deferred = true;
+            return Ok(outcome);
+        }
+    };
+    for metadata in metadata {
+        let Some(hash) = checkpoint_hash_from_key(&metadata.key) else {
+            outcome.deferred = true;
+            continue;
+        };
+        let object = match budget.get(
+            transport,
+            &metadata.key,
+            crate::sync::MAX_VAULT_PAYLOAD_BYTES,
+        ) {
+            Ok(Some((object, _))) => object,
+            Err(error @ VaultError::RemoteRateLimited(_)) => return Err(error),
+            Ok(None) | Err(_) => {
+                outcome.deferred = true;
+                continue;
+            }
+        };
+        let checkpoint = match SignedCheckpoint::decrypt_for_device(
+            &object,
+            input.device,
+            input.membership_anchor,
+        ) {
+            Ok(checkpoint) => checkpoint,
+            Err(_) => {
+                outcome.deferred = true;
+                continue;
+            }
+        };
+        if checkpoint.hash()? != hash
+            || metadata.key
+                != super::checkpoint_key(
+                    &latest.payload.dataset_id,
+                    checkpoint.payload.membership_epoch,
+                    &hash,
+                )?
+            || checkpoints.insert(hash, (checkpoint, metadata)).is_some()
+        {
+            outcome.deferred = true;
+        }
+    }
+    let Some((stored_latest, _)) = checkpoints.get(latest_hash) else {
+        outcome.deferred = true;
+        return Ok(outcome);
+    };
+    if stored_latest != latest {
+        outcome.deferred = true;
+        return Ok(outcome);
+    }
+
+    let minimum_installed_sequence = acknowledgements
+        .iter()
+        .map(|acknowledgement| acknowledgement.payload.installed_checkpoint_sequence)
+        .min()
+        .ok_or(VaultError::InvalidEncryptedObject)?;
+    let mut current_hash = latest_hash.to_owned();
+    let mut visited = BTreeSet::new();
+    let mut lineage = Vec::new();
+    let mut required_bridge_verified = false;
+    while let Some((current, metadata)) = checkpoints.get(&current_hash) {
+        if !visited.insert(current_hash.clone()) {
+            outcome.deferred = true;
+            return Ok(outcome);
+        }
+        lineage.push((current_hash.clone(), current.clone(), metadata.clone()));
+        if current.payload.checkpoint_sequence <= minimum_installed_sequence
+            && lineage.len() >= RETAINED_CHECKPOINTS
+        {
+            required_bridge_verified = true;
+        }
+        let previous_hash = current.payload.previous_checkpoint_hash.clone();
+        let Some(previous_hash) = previous_hash else {
+            break;
+        };
+        let Some((previous, _)) = checkpoints.get(&previous_hash) else {
+            if !required_bridge_verified {
+                outcome.deferred = true;
+                return Ok(outcome);
+            }
+            break;
+        };
+        if previous.payload.checkpoint_sequence.saturating_add(1)
+            != current.payload.checkpoint_sequence
+        {
+            outcome.deferred = true;
+            return Ok(outcome);
+        }
+        current_hash = previous_hash;
+    }
+
+    let lineage_by_sequence = lineage
+        .iter()
+        .map(|(hash, checkpoint, _)| (checkpoint.payload.checkpoint_sequence, hash.as_str()))
+        .collect::<BTreeMap<_, _>>();
+    for acknowledgement in acknowledgements {
+        if lineage_by_sequence
+            .get(&acknowledgement.payload.installed_checkpoint_sequence)
+            .copied()
+            != Some(acknowledgement.payload.installed_checkpoint_hash.as_str())
+        {
+            outcome.deferred = true;
+            return Ok(outcome);
+        }
+    }
+    outcome.acknowledgements_verified = true;
+    let lineage_hashes = lineage
+        .iter()
+        .map(|(hash, _, _)| hash.as_str())
+        .collect::<BTreeSet<_>>();
+    if checkpoints
+        .keys()
+        .any(|hash| !lineage_hashes.contains(hash.as_str()))
+    {
+        outcome.deferred = true;
+    }
+    for (depth, (_, checkpoint, metadata)) in lineage.into_iter().enumerate() {
+        if depth < RETAINED_CHECKPOINTS
+            || checkpoint.payload.checkpoint_sequence >= minimum_installed_sequence
+        {
+            continue;
+        }
+        match delete_exact(transport, input, revision_guard, &metadata, budget) {
+            Ok(deleted) => outcome.deleted = outcome.deleted.saturating_add(deleted),
+            Err(VaultError::RevisionConflict) => return Err(VaultError::RevisionConflict),
+            Err(error @ VaultError::RemoteRateLimited(_)) => return Err(error),
+            Err(_) => outcome.deferred = true,
+        }
+    }
+    Ok(outcome)
+}
+
+fn count_obsolete_acknowledgements<T: VaultTransport + ?Sized>(
+    transport: &T,
+    input: &ManualSyncInput<'_>,
+    compaction: &CompactionCheckpoint,
+    membership: &VerifiedMembership,
+    budget: &mut ManualSyncBudget,
+) -> Result<ResidualOutcome, VaultError> {
+    let mut outcome = ResidualOutcome::default();
+    let root = ObjectKey::new(format!(
+        "yututui/v2/{}/compaction-acks",
+        input.local_state.dataset_id
+    ))?;
+    let current = compaction_ack_prefix(&input.local_state.dataset_id, compaction, membership)?;
+    let current_prefix = format!("{}/", current.as_str());
+    let metadata = match budget.list(transport, &root) {
+        Ok(metadata) => metadata,
+        Err(error @ VaultError::RemoteRateLimited(_)) => return Err(error),
+        Err(_) => {
+            outcome.deferred = true;
+            return Ok(outcome);
+        }
+    };
+    for metadata in metadata {
+        if metadata.key.as_str().starts_with(&current_prefix) {
+            continue;
+        }
+        if !valid_acknowledgement_key(&root, &metadata.key) {
+            outcome.deferred = true;
+            continue;
+        }
+        // A non-current namespace may belong to a newer manifest observed by another client.
+        // Retain it unless its exact introducing checkpoint is authenticated as an ancestor being
+        // retired. We currently report the residual instead of risking a stale-client deletion.
+        outcome.retained = outcome.retained.saturating_add(1);
+    }
+    Ok(outcome)
+}
+
+fn delete_exact<T: VaultTransport + ?Sized, G: LocalRevisionGuard>(
+    transport: &T,
+    input: &ManualSyncInput<'_>,
+    revision_guard: &G,
+    metadata: &ObjectMetadata,
+    budget: &mut ManualSyncBudget,
+) -> Result<usize, VaultError> {
+    revision_guard.ensure_current(input.expected_local_revision)?;
+    match budget.delete(transport, &metadata.key, &metadata.etag)? {
+        ObjectDeleteResult::Deleted => Ok(1),
+        ObjectDeleteResult::AlreadyAbsent => Ok(0),
+    }
+}
+
+fn acknowledgement_device_id(key: &ObjectKey) -> Result<DeviceId, VaultError> {
+    key.as_str()
+        .rsplit('/')
+        .next()
+        .and_then(|file| file.strip_suffix(".age"))
+        .ok_or(VaultError::InvalidObjectKey)
+        .and_then(|device_id| DeviceId::new(device_id).map_err(|_| VaultError::InvalidObjectKey))
+}
+
+fn valid_acknowledgement_key(root: &ObjectKey, key: &ObjectKey) -> bool {
+    let Some(relative) = key
+        .as_str()
+        .strip_prefix(root.as_str())
+        .and_then(|relative| relative.strip_prefix('/'))
+    else {
+        return false;
+    };
+    let mut components = relative.split('/');
+    let (
+        Some(compaction_id),
+        Some(generation_hash),
+        Some(membership_hash),
+        Some(device_file),
+        None,
+    ) = (
+        components.next(),
+        components.next(),
+        components.next(),
+        components.next(),
+        components.next(),
+    )
+    else {
+        return false;
+    };
+    !compaction_id.is_empty()
+        && is_lower_hash(generation_hash)
+        && is_lower_hash(membership_hash)
+        && device_file
+            .strip_suffix(".age")
+            .and_then(|device_id| DeviceId::new(device_id).ok())
+            .is_some()
+}
+
+fn checkpoint_hash_from_key(key: &ObjectKey) -> Option<String> {
+    let hash = key.as_str().rsplit('/').next()?.strip_suffix(".age")?;
+    is_lower_hash(hash).then(|| hash.to_owned())
+}
+
+fn is_lower_hash(hash: &str) -> bool {
+    hash.len() == 64
+        && hash
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+#[cfg(test)]
+#[path = "maintenance_tests.rs"]
+mod tests;

--- a/src/sync/manual/maintenance_tests.rs
+++ b/src/sync/manual/maintenance_tests.rs
@@ -1,0 +1,1062 @@
+use crate::personal_state::{
+    CausalStamp, DeviceId, DeviceRecord, Dot, EngagementKind, Operation, OperationEnvelope,
+    OperationOrigin, PersonalStateV2, PortableTrack, PortableTrackKey, Rating, VersionVector,
+    append_operation_as,
+};
+use crate::sync::{
+    CheckpointAnchor, DeviceSecretMaterial, EncryptedObject, FileVaultTransport, MembershipAction,
+    MembershipAnchor, MembershipChain, ObjectCondition, ObjectDeleteResult, ObjectKey,
+    ObjectMetadata, ObjectWriteResult, RecoveryKit, SignedCheckpoint, SignedCompactionAck,
+    SignedMembershipRoot, VaultError, VaultTransport, authorize_compaction, compaction_ack_key,
+};
+
+use super::super::{
+    ManualSyncCandidate, ManualSyncEngine, ManualSyncInput, checkpoint_key, checkpoint_prefix,
+    segment_prefix,
+};
+
+struct TempRoot(std::path::PathBuf);
+
+impl TempRoot {
+    fn new() -> Self {
+        static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let sequence = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "yututui-compaction-maintenance-{}-{sequence}",
+            std::process::id()
+        ));
+        Self(path)
+    }
+}
+
+impl Drop for TempRoot {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+struct Fixture {
+    devices: Vec<DeviceSecretMaterial>,
+    membership: MembershipChain,
+    anchor: MembershipAnchor,
+    state: PersonalStateV2,
+}
+
+fn fixture() -> Fixture {
+    let recovery = RecoveryKit::generate("maintenance-dataset", None).unwrap();
+    let devices = ["device-1", "device-2"]
+        .into_iter()
+        .map(|id| DeviceSecretMaterial::generate_for(id).unwrap())
+        .collect::<Vec<_>>();
+    let records = devices
+        .iter()
+        .map(|device| DeviceRecord {
+            device_id: DeviceId::new(device.device_id()).unwrap(),
+            name: device.device_id().to_owned(),
+            revoked: false,
+            public_identity: Some(device.public_identity()),
+        })
+        .collect::<Vec<_>>();
+    let root = SignedMembershipRoot::create(
+        "maintenance-dataset",
+        recovery.recovery_recipient(),
+        &recovery.signing_key().unwrap(),
+        records[0].clone(),
+    )
+    .unwrap();
+    let anchor = MembershipAnchor::RootHash(root.hash().unwrap());
+    let mut membership = MembershipChain::new(root);
+    membership
+        .append_device_action(
+            &anchor,
+            &records[0].device_id,
+            devices[0].signing_key(),
+            MembershipAction::AddDevice {
+                device: records[1].clone(),
+            },
+        )
+        .unwrap();
+
+    let first_dot = Dot {
+        device_id: records[0].device_id.clone(),
+        sequence: 1,
+    };
+    let mut state = PersonalStateV2::empty("maintenance-dataset".to_owned()).unwrap();
+    state.operations.push(OperationEnvelope {
+        operation_id: "initial-device".to_owned(),
+        stamp: CausalStamp {
+            dot: first_dot.clone(),
+            observed: VersionVector::default(),
+            recorded_at_unix: 0,
+        },
+        origin: OperationOrigin::Local,
+        operation: Operation::AddDevice {
+            device: records[0].clone(),
+        },
+    });
+    state.version_vector.observe(&first_dot);
+    crate::personal_state::refresh_device_registry(&mut state).unwrap();
+    state.normalize().unwrap();
+    state = append_operation_as(
+        &state,
+        &records[0].device_id,
+        Operation::AddDevice {
+            device: records[1].clone(),
+        },
+        0,
+    )
+    .unwrap();
+    Fixture {
+        devices,
+        membership,
+        anchor,
+        state,
+    }
+}
+
+fn synchronize<T: VaultTransport + ?Sized>(
+    transport: &T,
+    fixture: &Fixture,
+    device_index: usize,
+    state: &PersonalStateV2,
+    checkpoint_anchor: &CheckpointAnchor,
+) -> Result<ManualSyncCandidate, VaultError> {
+    ManualSyncEngine::new(transport).synchronize(
+        &ManualSyncInput {
+            local_state: state,
+            membership: &fixture.membership,
+            membership_anchor: &fixture.anchor,
+            device: &fixture.devices[device_index],
+            checkpoint_anchor,
+            bootstrap_checkpoint: None,
+            expected_local_revision: state.revision,
+        },
+        &|expected| {
+            if expected == state.revision {
+                Ok(())
+            } else {
+                Err(VaultError::RevisionConflict)
+            }
+        },
+    )
+}
+
+struct DeleteUnsupportedTransport<'a>(&'a FileVaultTransport);
+
+impl VaultTransport for DeleteUnsupportedTransport<'_> {
+    fn get(
+        &self,
+        key: &ObjectKey,
+        max_bytes: usize,
+    ) -> Result<Option<(EncryptedObject, ObjectMetadata)>, VaultError> {
+        self.0.get(key, max_bytes)
+    }
+
+    fn put(
+        &self,
+        key: &ObjectKey,
+        object: &EncryptedObject,
+        condition: ObjectCondition,
+    ) -> Result<ObjectWriteResult, VaultError> {
+        self.0.put(key, object, condition)
+    }
+
+    fn list(
+        &self,
+        prefix: &ObjectKey,
+        max_resources: usize,
+    ) -> Result<Vec<ObjectMetadata>, VaultError> {
+        self.0.list(prefix, max_resources)
+    }
+}
+
+struct RateLimitedDeleteTransport<'a> {
+    inner: &'a FileVaultTransport,
+    delete_attempts: std::sync::atomic::AtomicUsize,
+}
+
+impl VaultTransport for RateLimitedDeleteTransport<'_> {
+    fn get(
+        &self,
+        key: &ObjectKey,
+        max_bytes: usize,
+    ) -> Result<Option<(EncryptedObject, ObjectMetadata)>, VaultError> {
+        self.inner.get(key, max_bytes)
+    }
+
+    fn put(
+        &self,
+        key: &ObjectKey,
+        object: &EncryptedObject,
+        condition: ObjectCondition,
+    ) -> Result<ObjectWriteResult, VaultError> {
+        self.inner.put(key, object, condition)
+    }
+
+    fn delete(
+        &self,
+        _key: &ObjectKey,
+        _expected_etag: &str,
+    ) -> Result<ObjectDeleteResult, VaultError> {
+        self.delete_attempts
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Err(VaultError::RemoteRateLimited(Some(
+            std::time::Duration::from_secs(75),
+        )))
+    }
+
+    fn list(
+        &self,
+        prefix: &ObjectKey,
+        max_resources: usize,
+    ) -> Result<Vec<ObjectMetadata>, VaultError> {
+        self.inner.list(prefix, max_resources)
+    }
+}
+
+fn expired_engagement(fixture: &Fixture, state: &PersonalStateV2) -> PersonalStateV2 {
+    append_operation_as(
+        state,
+        &DeviceId::new(fixture.devices[0].device_id()).unwrap(),
+        Operation::RecordEngagement {
+            event_id: "expired-play".to_owned(),
+            track: PortableTrack {
+                key: PortableTrackKey::Catalog {
+                    provider: "youtube".to_owned(),
+                    exact_catalog_id: "expired-track".to_owned(),
+                },
+                title: "Expired track".to_owned(),
+                artist: "Artist".to_owned(),
+                album: None,
+                duration_secs: Some(180),
+                isrc: None,
+            },
+            engagement: EngagementKind::Play,
+            played_duration_ms: Some(90_000),
+            total_duration_ms: Some(180_000),
+            artist_key: "artist".to_owned(),
+        },
+        crate::signals::unix_now().saturating_sub(366 * 24 * 60 * 60),
+    )
+    .unwrap()
+}
+
+fn like_track(fixture: &Fixture, state: &PersonalStateV2, id: &str) -> PersonalStateV2 {
+    append_operation_as(
+        state,
+        &DeviceId::new(fixture.devices[0].device_id()).unwrap(),
+        Operation::SetRating {
+            track: PortableTrack {
+                key: PortableTrackKey::Catalog {
+                    provider: "youtube".to_owned(),
+                    exact_catalog_id: id.to_owned(),
+                },
+                title: id.to_owned(),
+                artist: "Artist".to_owned(),
+                album: None,
+                duration_secs: Some(180),
+                isrc: None,
+            },
+            rating: Rating::Liked,
+        },
+        crate::signals::unix_now(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn every_active_device_must_ack_before_the_leader_deletes_covered_segments() {
+    let fixture = fixture();
+    let temp = TempRoot::new();
+    let transport = FileVaultTransport::create(temp.0.clone()).unwrap();
+    let bootstrap = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    let with_expired_event = expired_engagement(&fixture, &bootstrap.state);
+    let compacted = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &with_expired_event,
+        &bootstrap.checkpoint_anchor,
+    )
+    .unwrap();
+    assert_eq!(compacted.summary.compacted_engagement_operations, 1);
+    assert!(compacted.state.compaction_checkpoint.is_some());
+
+    let leader = DeviceId::new(fixture.devices[0].device_id()).unwrap();
+    let segment_prefix = segment_prefix(&compacted.state.dataset_id, &leader).unwrap();
+    assert!(!transport.list(&segment_prefix, 10).unwrap().is_empty());
+
+    let follower_download = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        follower_download
+            .summary
+            .compaction_acknowledgements_written,
+        0,
+        "downloading a checkpoint is not yet a durable acknowledgement"
+    );
+    assert!(!transport.list(&segment_prefix, 10).unwrap().is_empty());
+
+    let follower_ack = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &follower_download.state,
+        &follower_download.checkpoint_anchor,
+    )
+    .unwrap();
+    assert_eq!(follower_ack.summary.compaction_acknowledgements_written, 1);
+    assert!(!transport.list(&segment_prefix, 10).unwrap().is_empty());
+
+    let leader_ack = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &compacted.state,
+        &compacted.checkpoint_anchor,
+    )
+    .unwrap();
+    assert_eq!(leader_ack.summary.compaction_acknowledgements_written, 1);
+    assert!(leader_ack.summary.compacted_segments_deleted >= 1);
+    assert!(transport.list(&segment_prefix, 10).unwrap().is_empty());
+
+    let repeated = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &leader_ack.state,
+        &leader_ack.checkpoint_anchor,
+    )
+    .unwrap();
+    assert_eq!(repeated.summary.remote_writes, 0);
+    assert_eq!(repeated.summary.compacted_segments_deleted, 0);
+}
+
+#[test]
+fn offline_device_blocks_a_grandchild_compaction_until_it_acknowledges() {
+    let fixture = fixture();
+    let temp = TempRoot::new();
+    let transport = FileVaultTransport::create(temp.0.clone()).unwrap();
+    let bootstrap = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    let first = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &expired_engagement(&fixture, &bootstrap.state),
+        &bootstrap.checkpoint_anchor,
+    )
+    .unwrap();
+    let first_compaction = first.state.compaction_checkpoint.as_ref().unwrap().clone();
+
+    let second_expired = expired_engagement(&fixture, &first.state);
+    let leader_id = DeviceId::new(fixture.devices[0].device_id()).unwrap();
+    let mut supplied_descendant = crate::personal_state::plan_engagement_compaction(
+        &second_expired,
+        &leader_id,
+        crate::signals::unix_now(),
+        true,
+    )
+    .unwrap()
+    .unwrap()
+    .candidate;
+    let membership = fixture.membership.verify(&fixture.anchor).unwrap();
+    let descendant_dataset_id = supplied_descendant.dataset_id.clone();
+    let descendant_compaction = supplied_descendant.compaction_checkpoint.as_mut().unwrap();
+    descendant_compaction.leader_authorization = Some(
+        authorize_compaction(
+            &descendant_dataset_id,
+            descendant_compaction,
+            &membership,
+            leader_id,
+            &fixture.devices[0],
+            first
+                .checkpoint_anchor
+                .checkpoint_sequence
+                .checked_add(1)
+                .unwrap(),
+            first.checkpoint_anchor.checkpoint_hash.as_deref().unwrap(),
+        )
+        .unwrap(),
+    );
+    let supplied_result = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &supplied_descendant,
+        &first.checkpoint_anchor,
+    );
+    assert!(
+        supplied_result.is_err(),
+        "unexpected descendant result: {:?}",
+        supplied_result.err()
+    );
+
+    let blocked = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &second_expired,
+        &first.checkpoint_anchor,
+    )
+    .unwrap();
+    assert_eq!(blocked.summary.compacted_engagement_operations, 0);
+    assert!(!blocked.summary.compaction_quorum_reached);
+    assert_eq!(
+        blocked
+            .state
+            .compaction_checkpoint
+            .as_ref()
+            .unwrap()
+            .checkpoint_id,
+        first_compaction.checkpoint_id
+    );
+
+    let follower_download = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        follower_download
+            .state
+            .compaction_checkpoint
+            .as_ref()
+            .unwrap()
+            .checkpoint_id,
+        first_compaction.checkpoint_id
+    );
+    let follower_ack = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &follower_download.state,
+        &follower_download.checkpoint_anchor,
+    )
+    .unwrap();
+    let grandchild = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &blocked.state,
+        &blocked.checkpoint_anchor,
+    )
+    .unwrap();
+    let grandchild_compaction = grandchild.state.compaction_checkpoint.as_ref().unwrap();
+    assert!(grandchild.summary.compaction_quorum_reached);
+    assert_eq!(grandchild.summary.compacted_engagement_operations, 1);
+    assert_eq!(
+        grandchild_compaction.previous_checkpoint_hash.as_deref(),
+        Some(first_compaction.checkpoint_id.as_str())
+    );
+    assert_ne!(
+        grandchild_compaction.checkpoint_id,
+        first_compaction.checkpoint_id
+    );
+    assert_eq!(
+        grandchild.checkpoint_anchor.checkpoint_sequence,
+        follower_ack
+            .checkpoint_anchor
+            .checkpoint_sequence
+            .saturating_add(1)
+    );
+    let grandchild_hash = grandchild
+        .checkpoint_anchor
+        .checkpoint_hash
+        .as_deref()
+        .unwrap();
+    let grandchild_key = checkpoint_key(
+        &grandchild.state.dataset_id,
+        fixture.membership.verify(&fixture.anchor).unwrap().epoch,
+        grandchild_hash,
+    )
+    .unwrap();
+    let grandchild_object = transport
+        .get(&grandchild_key, 2 * 1024 * 1024)
+        .unwrap()
+        .unwrap()
+        .0;
+    let signed_grandchild = SignedCheckpoint::decrypt_for_device(
+        &grandchild_object,
+        &fixture.devices[1],
+        &fixture.anchor,
+    )
+    .unwrap();
+    assert_eq!(
+        signed_grandchild.payload.previous_checkpoint_hash,
+        follower_ack.checkpoint_anchor.checkpoint_hash
+    );
+
+    let follower_grandchild_download = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &follower_ack.state,
+        &follower_ack.checkpoint_anchor,
+    )
+    .unwrap();
+    let _follower_grandchild_ack = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &follower_grandchild_download.state,
+        &follower_grandchild_download.checkpoint_anchor,
+    )
+    .unwrap();
+    let leader_grandchild_ack = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &grandchild.state,
+        &grandchild.checkpoint_anchor,
+    )
+    .unwrap();
+    assert!(
+        leader_grandchild_ack
+            .summary
+            .obsolete_compaction_acknowledgements_retained
+            >= 2,
+        "retired acknowledgement namespaces are reported, not deleted speculatively"
+    );
+}
+
+#[test]
+fn unsupported_delete_defers_gc_without_failing_the_merge() {
+    let fixture = fixture();
+    let temp = TempRoot::new();
+    let transport = FileVaultTransport::create(temp.0.clone()).unwrap();
+    let bootstrap = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    let compacted = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &expired_engagement(&fixture, &bootstrap.state),
+        &bootstrap.checkpoint_anchor,
+    )
+    .unwrap();
+    let leader = DeviceId::new(fixture.devices[0].device_id()).unwrap();
+    let segment_prefix = segment_prefix(&compacted.state.dataset_id, &leader).unwrap();
+
+    let follower_download = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    let _follower_ack = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &follower_download.state,
+        &follower_download.checkpoint_anchor,
+    )
+    .unwrap();
+    let unsupported = DeleteUnsupportedTransport(&transport);
+    let leader_ack = synchronize(
+        &unsupported,
+        &fixture,
+        0,
+        &compacted.state,
+        &compacted.checkpoint_anchor,
+    )
+    .unwrap();
+
+    assert!(leader_ack.summary.compaction_quorum_reached);
+    assert!(leader_ack.summary.compaction_gc_deferred);
+    assert_eq!(leader_ack.summary.compacted_segments_deleted, 0);
+    assert!(!transport.list(&segment_prefix, 10).unwrap().is_empty());
+}
+
+#[test]
+fn retry_after_during_gc_stops_the_pass_and_reaches_the_scheduler_boundary() {
+    let fixture = fixture();
+    let temp = TempRoot::new();
+    let transport = FileVaultTransport::create(temp.0.clone()).unwrap();
+    let bootstrap = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    let compacted = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &expired_engagement(&fixture, &bootstrap.state),
+        &bootstrap.checkpoint_anchor,
+    )
+    .unwrap();
+    let follower_download = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    let _follower_ack = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &follower_download.state,
+        &follower_download.checkpoint_anchor,
+    )
+    .unwrap();
+    let rate_limited = RateLimitedDeleteTransport {
+        inner: &transport,
+        delete_attempts: std::sync::atomic::AtomicUsize::new(0),
+    };
+
+    let error = match synchronize(
+        &rate_limited,
+        &fixture,
+        0,
+        &compacted.state,
+        &compacted.checkpoint_anchor,
+    ) {
+        Ok(_) => panic!("the maintenance pass unexpectedly ignored Retry-After"),
+        Err(error) => error,
+    };
+
+    assert_eq!(
+        error,
+        VaultError::RemoteRateLimited(Some(std::time::Duration::from_secs(75)))
+    );
+    assert_eq!(
+        rate_limited
+            .delete_attempts
+            .load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "a server retry hint must stop the current maintenance pass"
+    );
+    assert_eq!(
+        crate::sync::service::SyncServiceError::from(error),
+        crate::sync::service::SyncServiceError::RateLimited(Some(std::time::Duration::from_secs(
+            75
+        ),))
+    );
+}
+
+#[test]
+fn a_signed_fork_ack_does_not_authorize_a_descendant_compaction() {
+    let fixture = fixture();
+    let temp = TempRoot::new();
+    let transport = FileVaultTransport::create(temp.0.clone()).unwrap();
+    let bootstrap = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    let compacted = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &expired_engagement(&fixture, &bootstrap.state),
+        &bootstrap.checkpoint_anchor,
+    )
+    .unwrap();
+    let leader_ack = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &compacted.state,
+        &compacted.checkpoint_anchor,
+    )
+    .unwrap();
+    let membership = fixture.membership.verify(&fixture.anchor).unwrap();
+    let compaction = leader_ack.state.compaction_checkpoint.as_ref().unwrap();
+    let follower_id = DeviceId::new(fixture.devices[1].device_id()).unwrap();
+    let forged = SignedCompactionAck::create(
+        &leader_ack.state.dataset_id,
+        compaction,
+        leader_ack.checkpoint_anchor.checkpoint_sequence,
+        &"f".repeat(64),
+        &membership,
+        follower_id.clone(),
+        &fixture.devices[1],
+    )
+    .unwrap();
+    let forged_key = compaction_ack_key(
+        &leader_ack.state.dataset_id,
+        compaction,
+        &membership,
+        &follower_id,
+    )
+    .unwrap();
+    transport
+        .put(
+            &forged_key,
+            &forged.encrypt(compaction, &membership).unwrap(),
+            ObjectCondition::CreateOnly,
+        )
+        .unwrap();
+
+    let with_next_expired = expired_engagement(&fixture, &leader_ack.state);
+    let blocked = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &with_next_expired,
+        &leader_ack.checkpoint_anchor,
+    )
+    .unwrap();
+    assert!(!blocked.summary.compaction_quorum_reached);
+    assert_eq!(blocked.summary.compacted_engagement_operations, 0);
+    assert_eq!(
+        blocked
+            .state
+            .compaction_checkpoint
+            .as_ref()
+            .unwrap()
+            .checkpoint_id,
+        compaction.checkpoint_id
+    );
+}
+
+#[test]
+fn checkpoint_gc_keeps_the_bridge_after_an_old_generation_ack() {
+    let fixture = fixture();
+    let temp = TempRoot::new();
+    let transport = FileVaultTransport::create(temp.0.clone()).unwrap();
+    let bootstrap = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    let compacted = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &expired_engagement(&fixture, &bootstrap.state),
+        &bootstrap.checkpoint_anchor,
+    )
+    .unwrap();
+    let follower_download = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    let follower_ack = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &follower_download.state,
+        &follower_download.checkpoint_anchor,
+    )
+    .unwrap();
+    let mut latest = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &compacted.state,
+        &compacted.checkpoint_anchor,
+    )
+    .unwrap();
+    let acknowledged_sequence = follower_ack.checkpoint_anchor.checkpoint_sequence;
+
+    for index in 0..10 {
+        let changed = like_track(&fixture, &latest.state, &format!("bridge-{index}"));
+        latest = synchronize(&transport, &fixture, 0, &changed, &latest.checkpoint_anchor).unwrap();
+    }
+    assert!(
+        latest
+            .checkpoint_anchor
+            .checkpoint_sequence
+            .saturating_sub(acknowledged_sequence)
+            >= 10
+    );
+
+    let checkpoint_prefix = checkpoint_prefix(&latest.state.dataset_id).unwrap();
+    let retained = transport.list(&checkpoint_prefix, 30).unwrap();
+    assert!(
+        retained.len() >= 10,
+        "every checkpoint after the oldest installed acknowledgement must remain"
+    );
+    let caught_up = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &follower_ack.state,
+        &follower_ack.checkpoint_anchor,
+    )
+    .unwrap();
+    assert_eq!(
+        caught_up.checkpoint_anchor, latest.checkpoint_anchor,
+        "the offline device must retain a continuous authenticated checkpoint path"
+    );
+    let _follower_high_water = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &caught_up.state,
+        &caught_up.checkpoint_anchor,
+    )
+    .unwrap();
+    let leader_gc = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &latest.state,
+        &latest.checkpoint_anchor,
+    )
+    .unwrap();
+    assert_eq!(
+        transport.list(&checkpoint_prefix, 30).unwrap().len(),
+        3,
+        "advancing every acknowledgement high-water should resume bounded GC"
+    );
+    let repeated = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &leader_gc.state,
+        &leader_gc.checkpoint_anchor,
+    )
+    .unwrap();
+    assert_eq!(repeated.summary.remote_writes, 0);
+}
+
+#[test]
+fn minimum_ack_checkpoint_remains_a_quorum_anchor_while_a_device_is_offline() {
+    let fixture = fixture();
+    let temp = TempRoot::new();
+    let transport = FileVaultTransport::create(temp.0.clone()).unwrap();
+    let bootstrap = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    let compacted = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &expired_engagement(&fixture, &bootstrap.state),
+        &bootstrap.checkpoint_anchor,
+    )
+    .unwrap();
+    let first_compaction = compacted
+        .state
+        .compaction_checkpoint
+        .as_ref()
+        .unwrap()
+        .clone();
+    let follower_download = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    let follower_ack = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &follower_download.state,
+        &follower_download.checkpoint_anchor,
+    )
+    .unwrap();
+    let mut latest = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &compacted.state,
+        &compacted.checkpoint_anchor,
+    )
+    .unwrap();
+
+    for index in 0..6 {
+        let changed = like_track(&fixture, &latest.state, &format!("offline-{index}"));
+        latest = synchronize(&transport, &fixture, 0, &changed, &latest.checkpoint_anchor).unwrap();
+    }
+    let minimum_ack_hash = follower_ack
+        .checkpoint_anchor
+        .checkpoint_hash
+        .as_deref()
+        .unwrap();
+    let minimum_ack_key = checkpoint_key(
+        &latest.state.dataset_id,
+        fixture.membership.verify(&fixture.anchor).unwrap().epoch,
+        minimum_ack_hash,
+    )
+    .unwrap();
+    assert!(
+        transport
+            .get(&minimum_ack_key, 2 * 1024 * 1024)
+            .unwrap()
+            .is_some(),
+        "the minimum installed acknowledgement must remain available for lineage verification"
+    );
+
+    let maintenance = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &latest.state,
+        &latest.checkpoint_anchor,
+    )
+    .unwrap();
+    assert!(
+        maintenance.summary.compaction_quorum_reached,
+        "an offline device's authenticated acknowledgement remains valid across ordinary checkpoints"
+    );
+    let next = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &expired_engagement(&fixture, &maintenance.state),
+        &maintenance.checkpoint_anchor,
+    )
+    .unwrap();
+    assert!(next.summary.compaction_quorum_reached);
+    assert_eq!(next.summary.compacted_engagement_operations, 1);
+    assert_eq!(
+        next.state
+            .compaction_checkpoint
+            .as_ref()
+            .unwrap()
+            .previous_checkpoint_hash
+            .as_deref(),
+        Some(first_compaction.checkpoint_id.as_str())
+    );
+}
+
+#[test]
+fn quorum_gc_keeps_the_three_newest_checkpoint_generations() {
+    let fixture = fixture();
+    let temp = TempRoot::new();
+    let transport = FileVaultTransport::create(temp.0.clone()).unwrap();
+    let bootstrap = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    let orphan_state = like_track(&fixture, &bootstrap.state, "unrelated-checkpoint");
+    let orphan = SignedCheckpoint::create(
+        fixture.membership.clone(),
+        &fixture.anchor,
+        DeviceId::new(fixture.devices[0].device_id()).unwrap(),
+        fixture.devices[0].signing_key(),
+        &bootstrap.checkpoint_anchor,
+        orphan_state,
+    )
+    .unwrap();
+    let orphan_hash = orphan.hash().unwrap();
+    let orphan_key = checkpoint_key(
+        &bootstrap.state.dataset_id,
+        orphan.payload.membership_epoch,
+        &orphan_hash,
+    )
+    .unwrap();
+    transport
+        .put(
+            &orphan_key,
+            &orphan.encrypt(&fixture.anchor).unwrap(),
+            ObjectCondition::CreateOnly,
+        )
+        .unwrap();
+    let with_expired_event = expired_engagement(&fixture, &bootstrap.state);
+    let mut latest = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &with_expired_event,
+        &bootstrap.checkpoint_anchor,
+    )
+    .unwrap();
+    for index in 0..3 {
+        let changed = like_track(&fixture, &latest.state, &format!("later-{index}"));
+        latest = synchronize(&transport, &fixture, 0, &changed, &latest.checkpoint_anchor).unwrap();
+    }
+    let checkpoint_prefix = checkpoint_prefix(&latest.state.dataset_id).unwrap();
+    assert!(transport.list(&checkpoint_prefix, 20).unwrap().len() >= 5);
+
+    let follower_download = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    )
+    .unwrap();
+    let _follower_ack = synchronize(
+        &transport,
+        &fixture,
+        1,
+        &follower_download.state,
+        &follower_download.checkpoint_anchor,
+    )
+    .unwrap();
+    let leader_gc = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &latest.state,
+        &latest.checkpoint_anchor,
+    )
+    .unwrap();
+
+    assert!(leader_gc.summary.old_checkpoints_deleted >= 2);
+    assert_eq!(transport.list(&checkpoint_prefix, 20).unwrap().len(), 4);
+    assert!(
+        transport
+            .get(&orphan_key, 2 * 1024 * 1024)
+            .unwrap()
+            .is_some(),
+        "valid checkpoints outside the authenticated latest lineage are never GC targets"
+    );
+    let acknowledgement_root = ObjectKey::new(format!(
+        "yututui/v2/{}/compaction-acks",
+        latest.state.dataset_id
+    ))
+    .unwrap();
+    assert_eq!(transport.list(&acknowledgement_root, 20).unwrap().len(), 2);
+}

--- a/src/sync/manual/mod.rs
+++ b/src/sync/manual/mod.rs
@@ -4,16 +4,18 @@
 //! WebDAV request construction live in the adapter; automatic scheduling is intentionally a
 //! later layer.
 
+mod budget;
 mod engine;
+mod maintenance;
 mod protocol;
 
 use crate::personal_state::DeviceId;
 
 use super::{ObjectKey, VaultError};
 
+pub use budget::ManualSyncBudget;
 pub use engine::{
-    LocalRevisionGuard, ManualSyncBudget, ManualSyncCandidate, ManualSyncEngine, ManualSyncInput,
-    ManualSyncSummary,
+    LocalRevisionGuard, ManualSyncCandidate, ManualSyncEngine, ManualSyncInput, ManualSyncSummary,
 };
 pub use protocol::{
     DeviceHeadPayload, SignedDeviceHead, SignedVaultManifest, VaultManifestPayload,

--- a/src/sync/manual/tests.rs
+++ b/src/sync/manual/tests.rs
@@ -1,18 +1,18 @@
 use std::cell::{Cell, RefCell};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::personal_state::{
-    CausalStamp, DeviceId, DeviceRecord, Dot, Operation, OperationEnvelope, OperationOrigin,
-    PersonalStateV2, PortableTrack, PortableTrackKey, Rating, VersionVector, append_operation_as,
-    project,
+    CausalStamp, CompactionCheckpoint, DeviceId, DeviceRecord, Dot, Operation, OperationEnvelope,
+    OperationOrigin, PersonalStateV2, PortableTrack, PortableTrackKey, Rating, VersionVector,
+    append_operation_as, project,
 };
 
 use super::super::crypto::{DeviceSecretMaterial, EncryptedObject, sha256_domain_hex};
 use super::super::{
     CheckpointAnchor, ListCost, ListLimits, ListOutcome, MAX_VAULT_PAYLOAD_BYTES, MembershipAction,
-    MembershipAnchor, MembershipChain, ObjectCondition, ObjectKey, ObjectMetadata,
-    ObjectWriteResult, RecoveryKit, SignedMembershipRoot, VaultDeadline, VaultError,
-    VaultTransport,
+    MembershipAnchor, MembershipChain, ObjectCondition, ObjectDeleteResult, ObjectKey,
+    ObjectMetadata, ObjectWriteResult, OwnerRevisionGuard, RecoveryKit, SignedMembershipRoot,
+    VaultDeadline, VaultError, VaultTransport,
 };
 use super::*;
 
@@ -27,6 +27,9 @@ struct MemoryTransport {
     next_reported_length: Cell<Option<u64>>,
     list_cost: Cell<Option<(usize, usize, usize, usize)>>,
     observed_list_limits: RefCell<Vec<ListLimits>>,
+    revision_flip_on_get: RefCell<Option<(ObjectKey, OwnerRevisionGuard, u64)>>,
+    revision_flipped: Cell<bool>,
+    mutations_after_flip: Cell<usize>,
 }
 
 impl MemoryTransport {
@@ -42,6 +45,9 @@ impl MemoryTransport {
             next_reported_length: Cell::new(None),
             list_cost: Cell::new(None),
             observed_list_limits: RefCell::new(Vec::new()),
+            revision_flip_on_get: RefCell::new(None),
+            revision_flipped: Cell::new(false),
+            mutations_after_flip: Cell::new(0),
         }
     }
 
@@ -92,6 +98,16 @@ impl MemoryTransport {
     fn observed_list_limits(&self) -> Vec<ListLimits> {
         self.observed_list_limits.borrow().clone()
     }
+
+    fn flip_revision_on_get(&self, key: ObjectKey, guard: OwnerRevisionGuard, revision: u64) {
+        *self.revision_flip_on_get.borrow_mut() = Some((key, guard, revision));
+        self.revision_flipped.set(false);
+        self.mutations_after_flip.set(0);
+    }
+
+    fn mutations_after_flip(&self) -> usize {
+        self.mutations_after_flip.get()
+    }
 }
 
 impl VaultTransport for MemoryTransport {
@@ -100,6 +116,21 @@ impl VaultTransport for MemoryTransport {
         key: &ObjectKey,
         max_bytes: usize,
     ) -> Result<Option<(EncryptedObject, ObjectMetadata)>, VaultError> {
+        let revision_flip = {
+            let mut staged = self.revision_flip_on_get.borrow_mut();
+            if staged
+                .as_ref()
+                .is_some_and(|(staged_key, _, _)| staged_key == key)
+            {
+                staged.take()
+            } else {
+                None
+            }
+        };
+        if let Some((_, guard, revision)) = revision_flip {
+            guard.publish(revision);
+            self.revision_flipped.set(true);
+        }
         if self.hide_once.borrow().as_ref() == Some(key) {
             self.hide_once.borrow_mut().take();
             return Ok(None);
@@ -141,6 +172,10 @@ impl VaultTransport for MemoryTransport {
         object: &EncryptedObject,
         condition: ObjectCondition,
     ) -> Result<ObjectWriteResult, VaultError> {
+        if self.revision_flipped.get() {
+            self.mutations_after_flip
+                .set(self.mutations_after_flip.get().saturating_add(1));
+        }
         if !object.is_locally_produced() {
             return Err(VaultError::InvalidEncryptedObject);
         }
@@ -179,6 +214,18 @@ impl VaultTransport for MemoryTransport {
         } else {
             ObjectWriteResult::Created(result_metadata)
         })
+    }
+
+    fn delete(
+        &self,
+        _key: &ObjectKey,
+        _expected_etag: &str,
+    ) -> Result<ObjectDeleteResult, VaultError> {
+        if self.revision_flipped.get() {
+            self.mutations_after_flip
+                .set(self.mutations_after_flip.get().saturating_add(1));
+        }
+        Err(VaultError::RemoteUnsupported)
     }
 
     fn list(
@@ -595,6 +642,50 @@ fn stale_revision_is_rejected_before_any_remote_write() {
 }
 
 #[test]
+fn live_owner_content_change_at_same_revision_stops_subsequent_remote_mutations() {
+    let fixture = fixture(2);
+    let transport = MemoryTransport::new();
+    let bootstrap = synchronize(
+        &transport,
+        &fixture,
+        0,
+        &fixture.state,
+        &CheckpointAnchor::default(),
+    );
+    let changed = rate(
+        &bootstrap.state,
+        &fixture.devices[0],
+        "local-race",
+        Rating::Liked,
+    );
+    let guard = OwnerRevisionGuard::new(changed.revision);
+    transport.flip_revision_on_get(
+        manifest_key(&changed.dataset_id).unwrap(),
+        guard.clone(),
+        changed.revision,
+    );
+    let writes_before = transport.writes();
+    let input = ManualSyncInput {
+        local_state: &changed,
+        membership: &fixture.membership,
+        membership_anchor: &fixture.anchor,
+        device: &fixture.devices[0],
+        checkpoint_anchor: &bootstrap.checkpoint_anchor,
+        bootstrap_checkpoint: None,
+        expected_local_revision: changed.revision,
+    };
+
+    assert_eq!(
+        ManualSyncEngine::new(&transport)
+            .synchronize(&input, &guard)
+            .err(),
+        Some(VaultError::RevisionConflict)
+    );
+    assert_eq!(transport.writes(), writes_before);
+    assert_eq!(transport.mutations_after_flip(), 0);
+}
+
+#[test]
 fn expired_whole_sync_deadline_fails_before_transport_io() {
     let fixture = fixture(2);
     let transport = MemoryTransport::new();
@@ -863,5 +954,38 @@ fn unreadable_head_with_uncheckpointed_segments_is_rejected() {
         )
         .err(),
         Some(VaultError::DecryptionFailed)
+    );
+}
+
+#[test]
+fn local_compaction_publication_requires_the_immediate_remote_generation() {
+    fn checkpoint(
+        generation: u64,
+        checkpoint_id: char,
+        previous_checkpoint_hash: Option<char>,
+    ) -> CompactionCheckpoint {
+        CompactionCheckpoint {
+            checkpoint_id: checkpoint_id.to_string().repeat(64),
+            compaction_generation: generation,
+            coverage: VersionVector::default(),
+            previous_checkpoint_hash: previous_checkpoint_hash
+                .map(|hash| hash.to_string().repeat(64)),
+            retained_engagement_operations: BTreeSet::new(),
+            leader_authorization: None,
+            acknowledged_by: BTreeSet::new(),
+        }
+    }
+
+    let remote_first = checkpoint(1, 'a', None);
+    let local_second = checkpoint(2, 'b', Some('a'));
+    let local_third = checkpoint(3, 'c', Some('b'));
+
+    assert!(super::engine::is_adjacent_compaction_transition(
+        &remote_first,
+        &local_second
+    ));
+    assert!(
+        !super::engine::is_adjacent_compaction_transition(&remote_first, &local_third),
+        "a local C3 cannot be published over remote C1 without proving C2 quorum"
     );
 }

--- a/src/sync/membership.rs
+++ b/src/sync/membership.rs
@@ -217,6 +217,38 @@ impl MembershipChain {
         Ok(verified)
     }
 
+    /// Verify and reconstruct the exact historical membership named by an authenticated object.
+    ///
+    /// The complete chain is verified first, then the requested prefix is independently replayed.
+    /// This permits durable signatures made by a device that was active at that epoch to remain
+    /// valid after a later membership addition, revocation, or recovery.
+    pub(crate) fn verify_epoch_head(
+        &self,
+        anchor: &MembershipAnchor,
+        epoch: u64,
+        head_hash: &str,
+    ) -> Result<VerifiedMembership, VaultError> {
+        let current = self.verify(anchor)?;
+        let root_epoch = self.root.payload.membership_epoch;
+        let change_count: usize = epoch
+            .checked_sub(root_epoch)
+            .and_then(|count| count.try_into().ok())
+            .filter(|count: &usize| *count <= self.changes.len())
+            .ok_or(VaultError::MembershipFork)?;
+        if epoch > current.epoch {
+            return Err(VaultError::MembershipFork);
+        }
+        let historical = Self {
+            root: self.root.clone(),
+            changes: self.changes[..change_count].to_vec(),
+        }
+        .verify(anchor)?;
+        if historical.epoch != epoch || historical.head_hash != head_hash {
+            return Err(VaultError::MembershipFork);
+        }
+        Ok(historical)
+    }
+
     pub fn append_device_action(
         &mut self,
         anchor: &MembershipAnchor,

--- a/src/sync/private_store/transition.rs
+++ b/src/sync/private_store/transition.rs
@@ -92,7 +92,7 @@ impl PrivateStore {
         target_revision: u64,
         payload_hash: &str,
     ) -> Result<(), VaultError> {
-        if target_revision != expected_revision.saturating_add(1) {
+        if expected_revision.checked_add(1) != Some(target_revision) {
             return Err(VaultError::InvalidPrivateStore);
         }
         let bytes = Zeroizing::new(

--- a/src/sync/revision_guard.rs
+++ b/src/sync/revision_guard.rs
@@ -1,0 +1,119 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
+
+use super::{VaultError, manual::LocalRevisionGuard};
+
+/// A live revision fence shared by the primary owner and detached sync workers.
+///
+/// The owner publishes every accepted ledger revision. Workers retain a clone and check it
+/// immediately before each remote mutation, so a newer local generation retires stale network
+/// work before it can publish or delete more vault objects.
+#[derive(Debug)]
+pub struct OwnerRevisionGuard {
+    shared: Arc<OwnerRevisionState>,
+    expected_generation: u64,
+}
+
+#[derive(Debug, Default)]
+struct OwnerRevisionState {
+    revision: AtomicU64,
+    generation: AtomicU64,
+    poisoned: AtomicBool,
+}
+
+impl Clone for OwnerRevisionGuard {
+    fn clone(&self) -> Self {
+        Self {
+            shared: Arc::clone(&self.shared),
+            expected_generation: self.shared.generation.load(Ordering::Acquire),
+        }
+    }
+}
+
+impl Default for OwnerRevisionGuard {
+    fn default() -> Self {
+        Self::new(0)
+    }
+}
+
+impl OwnerRevisionGuard {
+    pub fn new(revision: u64) -> Self {
+        Self {
+            shared: Arc::new(OwnerRevisionState {
+                revision: AtomicU64::new(revision),
+                generation: AtomicU64::new(0),
+                poisoned: AtomicBool::new(false),
+            }),
+            expected_generation: 0,
+        }
+    }
+
+    /// Publish one accepted owner content replacement.
+    ///
+    /// Generation changes even when a corrupt or legacy caller tries to reuse the same revision,
+    /// so an already detached worker fails closed. Production personal-state mutation paths also
+    /// reject revision exhaustion before reaching this defensive fence.
+    pub fn publish(&self, revision: u64) {
+        if self
+            .shared
+            .generation
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |generation| {
+                generation.checked_add(1)
+            })
+            .is_err()
+        {
+            self.shared.poisoned.store(true, Ordering::Release);
+        }
+        self.shared.revision.store(revision, Ordering::Release);
+    }
+
+    pub fn current(&self) -> u64 {
+        self.shared.revision.load(Ordering::Acquire)
+    }
+}
+
+impl LocalRevisionGuard for OwnerRevisionGuard {
+    fn ensure_current(&self, expected_revision: u64) -> Result<(), VaultError> {
+        if !self.shared.poisoned.load(Ordering::Acquire)
+            && self.shared.generation.load(Ordering::Acquire) == self.expected_generation
+            && self.current() == expected_revision
+        {
+            Ok(())
+        } else {
+            Err(VaultError::RevisionConflict)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clones_observe_owner_revision_changes() {
+        let owner = OwnerRevisionGuard::new(7);
+        let worker = owner.clone();
+
+        assert_eq!(worker.ensure_current(7), Ok(()));
+        owner.publish(8);
+        assert_eq!(worker.ensure_current(7), Err(VaultError::RevisionConflict));
+        assert_eq!(worker.ensure_current(8), Err(VaultError::RevisionConflict));
+        assert_eq!(owner.clone().ensure_current(8), Ok(()));
+    }
+
+    #[test]
+    fn same_revision_content_replacement_retires_an_existing_worker() {
+        let owner = OwnerRevisionGuard::new(u64::MAX);
+        let worker = owner.clone();
+
+        owner.publish(u64::MAX);
+
+        assert_eq!(
+            worker.ensure_current(u64::MAX),
+            Err(VaultError::RevisionConflict)
+        );
+        assert_eq!(owner.clone().ensure_current(u64::MAX), Ok(()));
+    }
+}

--- a/src/sync/service/devices.rs
+++ b/src/sync/service/devices.rs
@@ -4,17 +4,21 @@ use crate::personal_state::{
     DeviceId, DeviceRecord, Operation, PersonalStateV2, append_operation_as,
 };
 
-use super::super::manual::ManualSyncBudget;
+use super::super::manual::{LocalRevisionGuard, ManualSyncBudget};
 use super::super::{
-    EnrollmentState, MembershipAction, PrivateStore, SyncAuditAction, SyncAuditEntry,
-    SyncAuditOutcome, SyncAuditStore, SyncHealthStore, SyncPaths, VaultTransport,
-    WebDavProfileStore,
+    EnrollmentState, MembershipAction, OwnerRevisionGuard, PrivateStore, SyncAuditAction,
+    SyncAuditEntry, SyncAuditOutcome, SyncAuditStore, SyncHealthStore, SyncPaths, VaultError,
+    VaultTransport, WebDavProfileStore,
 };
 use super::manual::{
-    AppliedManualSync, PreparedManualSync, membership_anchor, prepare_manual_sync_with_budget,
-    record_sync_failure, record_sync_started, validate_active_context,
+    AppliedManualSync, PreparedManualSync, membership_anchor,
+    prepare_manual_sync_with_budget_guarded, record_sync_failure, record_sync_started,
+    validate_active_context,
 };
 use super::{SyncServiceError, apply_manual_sync, open_saved_webdav_transport};
+
+#[cfg(test)]
+use super::manual::prepare_manual_sync_with_budget;
 
 const MAX_REVOKE_RACE_ATTEMPTS: usize = 8;
 
@@ -41,6 +45,16 @@ pub fn revoke_device(
     current_state: &PersonalStateV2,
     target: &DeviceId,
     paths: &SyncPaths,
+) -> Result<PreparedManualSync, SyncServiceError> {
+    let revision_guard = OwnerRevisionGuard::new(current_state.revision);
+    revoke_device_guarded(current_state, target, paths, &revision_guard)
+}
+
+pub(super) fn revoke_device_guarded<G: LocalRevisionGuard>(
+    current_state: &PersonalStateV2,
+    target: &DeviceId,
+    paths: &SyncPaths,
+    revision_guard: &G,
 ) -> Result<PreparedManualSync, SyncServiceError> {
     let private_store = PrivateStore::new(paths.private_store())?;
     let private = private_store.load()?;
@@ -75,7 +89,7 @@ pub fn revoke_device(
     let transport = open_saved_webdav_transport(&profile, credential)?;
     // The persisted profile was capability-tested during setup or the fresh pairing join.
     // Revocation shares the normal sync transport and must not rewrite the probe marker.
-    revoke_with_transport(current_state, target, &private, &transport)
+    revoke_with_transport_guarded(current_state, target, &private, &transport, revision_guard)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -177,16 +191,36 @@ pub(super) fn record_revoke_success(
     Ok(())
 }
 
+#[cfg(test)]
 fn revoke_with_transport<T: VaultTransport + ?Sized>(
     current_state: &PersonalStateV2,
     target: &DeviceId,
     private: &super::super::PrivateStoreSnapshot,
     transport: &T,
 ) -> Result<PreparedManualSync, SyncServiceError> {
-    let mut budget = ManualSyncBudget::default();
-    revoke_with_transport_and_budget(current_state, target, private, transport, &mut budget)
+    let revision_guard = OwnerRevisionGuard::new(current_state.revision);
+    revoke_with_transport_guarded(current_state, target, private, transport, &revision_guard)
 }
 
+fn revoke_with_transport_guarded<T: VaultTransport + ?Sized, G: LocalRevisionGuard>(
+    current_state: &PersonalStateV2,
+    target: &DeviceId,
+    private: &super::super::PrivateStoreSnapshot,
+    transport: &T,
+    revision_guard: &G,
+) -> Result<PreparedManualSync, SyncServiceError> {
+    let mut budget = ManualSyncBudget::default();
+    revoke_with_transport_and_budget_guarded(
+        current_state,
+        target,
+        private,
+        transport,
+        revision_guard,
+        &mut budget,
+    )
+}
+
+#[cfg(test)]
 fn revoke_with_transport_and_budget<T: VaultTransport + ?Sized>(
     current_state: &PersonalStateV2,
     target: &DeviceId,
@@ -194,12 +228,37 @@ fn revoke_with_transport_and_budget<T: VaultTransport + ?Sized>(
     transport: &T,
     budget: &mut ManualSyncBudget,
 ) -> Result<PreparedManualSync, SyncServiceError> {
+    let revision_guard = OwnerRevisionGuard::new(current_state.revision);
+    revoke_with_transport_and_budget_guarded(
+        current_state,
+        target,
+        private,
+        transport,
+        &revision_guard,
+        budget,
+    )
+}
+
+fn revoke_with_transport_and_budget_guarded<T: VaultTransport + ?Sized, G: LocalRevisionGuard>(
+    current_state: &PersonalStateV2,
+    target: &DeviceId,
+    private: &super::super::PrivateStoreSnapshot,
+    transport: &T,
+    revision_guard: &G,
+    budget: &mut ManualSyncBudget,
+) -> Result<PreparedManualSync, SyncServiceError> {
     let mut completed_summary = super::super::manual::ManualSyncSummary::default();
     for attempt in 1..=MAX_REVOKE_RACE_ATTEMPTS {
         // Establish the target's latest authenticated high-water before freezing the revocation
         // cutoff. Revoking directly from the caller's snapshot can strand a valid unseen segment:
         // the resulting checkpoint must attest the exact accepted sequence.
-        let synced = prepare_manual_sync_with_budget(current_state, private, transport, budget)?;
+        let synced = prepare_manual_sync_with_budget_guarded(
+            current_state,
+            private,
+            transport,
+            revision_guard,
+            budget,
+        )?;
         merge_summary(&mut completed_summary, &synced.summary);
         if synced
             .state
@@ -212,7 +271,15 @@ fn revoke_with_transport_and_budget<T: VaultTransport + ?Sized>(
                 ..synced
             });
         }
-        match revoke_synced_state(current_state, target, private, transport, synced, budget) {
+        match revoke_synced_state(
+            current_state,
+            target,
+            private,
+            transport,
+            synced,
+            revision_guard,
+            budget,
+        ) {
             Ok(mut candidate) => {
                 merge_summary(&mut completed_summary, &candidate.summary);
                 candidate.summary = completed_summary;
@@ -229,12 +296,13 @@ fn revoke_with_transport_and_budget<T: VaultTransport + ?Sized>(
     Err(SyncServiceError::InvalidRemoteData)
 }
 
-fn revoke_synced_state<T: VaultTransport + ?Sized>(
+fn revoke_synced_state<T: VaultTransport + ?Sized, G: LocalRevisionGuard>(
     original_state: &PersonalStateV2,
     target: &DeviceId,
     private: &super::super::PrivateStoreSnapshot,
     transport: &T,
     synced: PreparedManualSync,
+    revision_guard: &G,
     budget: &mut ManualSyncBudget,
 ) -> Result<PreparedManualSync, SyncServiceError> {
     let anchor = membership_anchor(private)?;
@@ -273,18 +341,12 @@ fn revoke_synced_state<T: VaultTransport + ?Sized>(
         bootstrap_checkpoint: None,
         expected_local_revision: state.revision,
     };
+    let owner_guard = RevokeRevisionGuard {
+        inner: revision_guard,
+        owner_revision: original_state.revision,
+    };
     let candidate = super::super::manual::ManualSyncEngine::new(transport)
-        .synchronize_with_budget(
-            &input,
-            &|expected| {
-                if expected == state.revision {
-                    Ok(())
-                } else {
-                    Err(super::super::VaultError::RevisionConflict)
-                }
-            },
-            budget,
-        )?;
+        .synchronize_with_budget(&input, &owner_guard, budget)?;
     Ok(PreparedManualSync {
         state: candidate.state,
         membership: candidate.membership,
@@ -294,6 +356,17 @@ fn revoke_synced_state<T: VaultTransport + ?Sized>(
         local_device_id: local_device,
         summary: candidate.summary,
     })
+}
+
+struct RevokeRevisionGuard<'a, G> {
+    inner: &'a G,
+    owner_revision: u64,
+}
+
+impl<G: LocalRevisionGuard> LocalRevisionGuard for RevokeRevisionGuard<'_, G> {
+    fn ensure_current(&self, _synthetic_revision: u64) -> Result<(), VaultError> {
+        self.inner.ensure_current(self.owner_revision)
+    }
 }
 
 fn merge_summary(

--- a/src/sync/service/manual.rs
+++ b/src/sync/service/manual.rs
@@ -1,17 +1,17 @@
 use crate::personal_state::{DeviceId, DeviceRegistry, PersonalStateCommit, PersonalStateV2};
 
 use super::super::manual::{
-    ManualSyncBudget, ManualSyncCandidate, ManualSyncEngine, ManualSyncInput, ManualSyncSummary,
-    manifest_key,
+    LocalRevisionGuard, ManualSyncBudget, ManualSyncCandidate, ManualSyncEngine, ManualSyncInput,
+    ManualSyncSummary, manifest_key,
 };
 use super::super::{
     CheckpointAnchor, EnrollmentState, MAX_VAULT_PAYLOAD_BYTES, MembershipAnchor, MembershipChain,
-    PrivateStore, PrivateStoreSnapshot, SyncAuditAction, SyncAuditEntry, SyncAuditOutcome,
-    SyncAuditStore, SyncFailureKind, SyncHealthStore, SyncPaths, VaultError, VaultTransport,
+    OwnerRevisionGuard, PrivateStore, PrivateStoreSnapshot, SyncAuditAction, SyncAuditEntry,
+    SyncAuditOutcome, SyncAuditStore, SyncFailureKind, SyncHealthStore, SyncPaths, VaultTransport,
     WebDavProfile, WebDavProfileStore,
 };
 use super::transition::{AnchorActivationKind, commit_with_anchor_transition};
-use super::{SyncServiceError, open_saved_webdav_transport};
+use super::{SyncAttemptKind, SyncServiceError, open_saved_webdav_transport};
 
 /// A network-produced candidate which contains no endpoint, credential, or private key.
 #[derive(Clone)]
@@ -42,9 +42,24 @@ pub fn prepare_manual_sync(
     local_state: &PersonalStateV2,
     paths: &SyncPaths,
 ) -> Result<PreparedManualSync, SyncServiceError> {
-    prepare_manual_sync_using(local_state, paths, open_saved_webdav_transport)
+    let revision_guard = OwnerRevisionGuard::new(local_state.revision);
+    prepare_manual_sync_guarded(local_state, paths, &revision_guard)
 }
 
+pub(super) fn prepare_manual_sync_guarded<G: LocalRevisionGuard>(
+    local_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    revision_guard: &G,
+) -> Result<PreparedManualSync, SyncServiceError> {
+    prepare_manual_sync_using_guarded(
+        local_state,
+        paths,
+        revision_guard,
+        open_saved_webdav_transport,
+    )
+}
+
+#[cfg(test)]
 pub(super) fn prepare_manual_sync_using<T, F>(
     local_state: &PersonalStateV2,
     paths: &SyncPaths,
@@ -53,6 +68,21 @@ pub(super) fn prepare_manual_sync_using<T, F>(
 where
     T: VaultTransport,
     F: FnOnce(&WebDavProfile, &super::super::VaultCredential) -> Result<T, SyncServiceError>,
+{
+    let revision_guard = OwnerRevisionGuard::new(local_state.revision);
+    prepare_manual_sync_using_guarded(local_state, paths, &revision_guard, open)
+}
+
+fn prepare_manual_sync_using_guarded<T, F, G>(
+    local_state: &PersonalStateV2,
+    paths: &SyncPaths,
+    revision_guard: &G,
+    open: F,
+) -> Result<PreparedManualSync, SyncServiceError>
+where
+    T: VaultTransport,
+    F: FnOnce(&WebDavProfile, &super::super::VaultCredential) -> Result<T, SyncServiceError>,
+    G: LocalRevisionGuard,
 {
     let private_store = PrivateStore::new(paths.private_store())?;
     let private = private_store.load()?;
@@ -65,7 +95,7 @@ where
     let transport = open(&profile, credential)?;
     // Setup or the fresh pairing join already proved the saved profile's WebDAV behavior.
     // Re-running that state-changing probe here would rewrite its marker on every no-op sync.
-    prepare_manual_sync_with_transport(local_state, &private, &transport)
+    prepare_manual_sync_with_transport_guarded(local_state, &private, &transport, revision_guard)
 }
 
 pub fn prepare_manual_sync_with_transport<T: VaultTransport + ?Sized>(
@@ -73,14 +103,51 @@ pub fn prepare_manual_sync_with_transport<T: VaultTransport + ?Sized>(
     private: &PrivateStoreSnapshot,
     transport: &T,
 ) -> Result<PreparedManualSync, SyncServiceError> {
-    let mut budget = ManualSyncBudget::default();
-    prepare_manual_sync_with_budget(local_state, private, transport, &mut budget)
+    let revision_guard = OwnerRevisionGuard::new(local_state.revision);
+    prepare_manual_sync_with_transport_guarded(local_state, private, transport, &revision_guard)
 }
 
+fn prepare_manual_sync_with_transport_guarded<T: VaultTransport + ?Sized, G: LocalRevisionGuard>(
+    local_state: &PersonalStateV2,
+    private: &PrivateStoreSnapshot,
+    transport: &T,
+    revision_guard: &G,
+) -> Result<PreparedManualSync, SyncServiceError> {
+    let mut budget = ManualSyncBudget::default();
+    prepare_manual_sync_with_budget_guarded(
+        local_state,
+        private,
+        transport,
+        revision_guard,
+        &mut budget,
+    )
+}
+
+#[cfg(test)]
 pub(super) fn prepare_manual_sync_with_budget<T: VaultTransport + ?Sized>(
     local_state: &PersonalStateV2,
     private: &PrivateStoreSnapshot,
     transport: &T,
+    budget: &mut ManualSyncBudget,
+) -> Result<PreparedManualSync, SyncServiceError> {
+    let revision_guard = OwnerRevisionGuard::new(local_state.revision);
+    prepare_manual_sync_with_budget_guarded(
+        local_state,
+        private,
+        transport,
+        &revision_guard,
+        budget,
+    )
+}
+
+pub(super) fn prepare_manual_sync_with_budget_guarded<
+    T: VaultTransport + ?Sized,
+    G: LocalRevisionGuard,
+>(
+    local_state: &PersonalStateV2,
+    private: &PrivateStoreSnapshot,
+    transport: &T,
+    revision_guard: &G,
     budget: &mut ManualSyncBudget,
 ) -> Result<PreparedManualSync, SyncServiceError> {
     validate_active_private(local_state, private)?;
@@ -113,17 +180,7 @@ pub(super) fn prepare_manual_sync_with_budget<T: VaultTransport + ?Sized>(
         checkpoint_anchor,
         expected_local_revision,
         summary,
-    } = ManualSyncEngine::new(transport).synchronize_with_budget(
-        &input,
-        &|expected| {
-            if expected == local_state.revision {
-                Ok(())
-            } else {
-                Err(VaultError::RevisionConflict)
-            }
-        },
-        budget,
-    )?;
+    } = ManualSyncEngine::new(transport).synchronize_with_budget(&input, revision_guard, budget)?;
     Ok(PreparedManualSync {
         state,
         membership,
@@ -229,6 +286,41 @@ pub fn apply_prepared_sync_now(
     personal_paths: &crate::personal_state::PersonalStatePaths,
     sync_paths: &SyncPaths,
 ) -> Result<AppliedManualSync, SyncServiceError> {
+    apply_prepared_sync_now_as(
+        current_state,
+        playlist_revision,
+        candidate,
+        personal_paths,
+        sync_paths,
+        SyncAttemptKind::Manual,
+    )
+}
+
+pub fn apply_prepared_automatic_sync_now(
+    current_state: &PersonalStateV2,
+    playlist_revision: u64,
+    candidate: PreparedManualSync,
+    personal_paths: &crate::personal_state::PersonalStatePaths,
+    sync_paths: &SyncPaths,
+) -> Result<AppliedManualSync, SyncServiceError> {
+    apply_prepared_sync_now_as(
+        current_state,
+        playlist_revision,
+        candidate,
+        personal_paths,
+        sync_paths,
+        SyncAttemptKind::Automatic,
+    )
+}
+
+fn apply_prepared_sync_now_as(
+    current_state: &PersonalStateV2,
+    playlist_revision: u64,
+    candidate: PreparedManualSync,
+    personal_paths: &crate::personal_state::PersonalStatePaths,
+    sync_paths: &SyncPaths,
+    kind: SyncAttemptKind,
+) -> Result<AppliedManualSync, SyncServiceError> {
     let now = crate::signals::unix_now();
     record_sync_started(sync_paths, now)?;
     let summary = candidate.summary.clone();
@@ -242,10 +334,10 @@ pub fn apply_prepared_sync_now(
     .map(|state| AppliedManualSync { state, summary });
     match &result {
         Ok(applied) => {
-            let _ = record_sync_success(sync_paths, now, &applied.summary);
+            let _ = record_sync_success_as(sync_paths, now, &applied.summary, kind);
         }
         Err(error) => {
-            let _ = record_sync_failure(sync_paths, now, *error);
+            let _ = record_sync_failure_as(sync_paths, now, *error, kind);
         }
     }
     result
@@ -266,6 +358,15 @@ pub(super) fn record_sync_success(
     now_unix: i64,
     summary: &ManualSyncSummary,
 ) -> Result<(), SyncServiceError> {
+    record_sync_success_as(paths, now_unix, summary, SyncAttemptKind::Manual)
+}
+
+pub(super) fn record_sync_success_as(
+    paths: &SyncPaths,
+    now_unix: i64,
+    summary: &ManualSyncSummary,
+    kind: SyncAttemptKind,
+) -> Result<(), SyncServiceError> {
     let health_store = SyncHealthStore::new(paths.health())?;
     let current = health_store.load(true)?;
     let _ = health_store.save(&current, current.succeeded(now_unix))?;
@@ -274,7 +375,7 @@ pub(super) fn record_sync_success(
     } else {
         SyncAuditOutcome::Succeeded
     };
-    let mut entry = SyncAuditEntry::new(now_unix, SyncAuditAction::ManualSync, outcome)?;
+    let mut entry = SyncAuditEntry::new(now_unix, audit_action(kind), outcome)?;
     entry.local_operations = summary.uploaded_operations;
     entry.remote_operations = summary.downloaded_operations;
     let _ = SyncAuditStore::new(paths.audit())?.append(now_unix, entry)?;
@@ -286,20 +387,32 @@ pub(super) fn record_sync_failure(
     now_unix: i64,
     error: SyncServiceError,
 ) -> Result<(), SyncServiceError> {
+    record_sync_failure_as(paths, now_unix, error, SyncAttemptKind::Manual)
+}
+
+pub(super) fn record_sync_failure_as(
+    paths: &SyncPaths,
+    now_unix: i64,
+    error: SyncServiceError,
+    kind: SyncAttemptKind,
+) -> Result<(), SyncServiceError> {
     let failure = error
         .failure_kind()
         .unwrap_or(SyncFailureKind::InvalidRemoteData);
     let health_store = SyncHealthStore::new(paths.health())?;
     let current = health_store.load(true)?;
     let _ = health_store.save(&current, current.failed(now_unix, failure))?;
-    let mut entry = SyncAuditEntry::new(
-        now_unix,
-        SyncAuditAction::ManualSync,
-        SyncAuditOutcome::Failed,
-    )?;
+    let mut entry = SyncAuditEntry::new(now_unix, audit_action(kind), SyncAuditOutcome::Failed)?;
     entry.failure = Some(failure);
     let _ = SyncAuditStore::new(paths.audit())?.append(now_unix, entry)?;
     Ok(())
+}
+
+fn audit_action(kind: SyncAttemptKind) -> SyncAuditAction {
+    match kind {
+        SyncAttemptKind::Manual => SyncAuditAction::ManualSync,
+        SyncAttemptKind::Automatic => SyncAuditAction::AutomaticSync,
+    }
 }
 
 pub(super) fn validate_active_context(

--- a/src/sync/service/mod.rs
+++ b/src/sync/service/mod.rs
@@ -14,13 +14,15 @@ mod transition;
 
 use std::fmt;
 
-use super::{SyncFailureKind, SyncPaths, VaultCredential, VaultError, WebDavProfile};
+use super::{
+    OwnerRevisionGuard, SyncFailureKind, SyncPaths, VaultCredential, VaultError, WebDavProfile,
+};
 use crate::personal_state::{DeviceId, PersonalStateV2};
 
 pub use devices::{DeviceSummary, apply_prepared_revoke_now, revoke_device, revoke_device_now};
 pub use manual::{
-    AppliedManualSync, PreparedManualSync, apply_manual_sync, apply_prepared_sync_now,
-    prepare_manual_sync, prepare_manual_sync_with_transport, sync_now,
+    AppliedManualSync, PreparedManualSync, apply_manual_sync, apply_prepared_automatic_sync_now,
+    apply_prepared_sync_now, prepare_manual_sync, prepare_manual_sync_with_transport, sync_now,
 };
 pub use pairing::{
     PairingHostInvite, PairingJoinPreview, PairingJoinWaiting, PairingReview,
@@ -45,6 +47,12 @@ pub use status::{
 };
 pub(crate) use transition::recover_pending_anchor_transition;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncAttemptKind {
+    Manual,
+    Automatic,
+}
+
 /// Prepare one primary-owner sync attempt while retaining redacted attempt/failure state.
 ///
 /// The TUI and daemon both use this entry point so a network failure is observable through the
@@ -56,21 +64,39 @@ pub fn prepare_owner_sync(
     revoke_target: Option<&DeviceId>,
     paths: &SyncPaths,
 ) -> Result<PreparedManualSync, SyncServiceError> {
-    track_owner_preparation(paths, || match revoke_target {
-        Some(target) => revoke_device(state, target, paths),
-        None => prepare_manual_sync(state, paths),
+    let revision_guard = OwnerRevisionGuard::new(state.revision);
+    prepare_owner_sync_as(
+        state,
+        revoke_target,
+        paths,
+        SyncAttemptKind::Manual,
+        &revision_guard,
+    )
+}
+
+pub fn prepare_owner_sync_as(
+    state: &PersonalStateV2,
+    revoke_target: Option<&DeviceId>,
+    paths: &SyncPaths,
+    kind: SyncAttemptKind,
+    revision_guard: &OwnerRevisionGuard,
+) -> Result<PreparedManualSync, SyncServiceError> {
+    track_owner_preparation(paths, kind, || match revoke_target {
+        Some(target) => devices::revoke_device_guarded(state, target, paths, revision_guard),
+        None => manual::prepare_manual_sync_guarded(state, paths, revision_guard),
     })
 }
 
 fn track_owner_preparation<T>(
     paths: &SyncPaths,
+    kind: SyncAttemptKind,
     prepare: impl FnOnce() -> Result<T, SyncServiceError>,
 ) -> Result<T, SyncServiceError> {
     let now = crate::signals::unix_now();
     let _ = manual::record_sync_started(paths, now);
     let result = prepare();
     if let Err(error) = &result {
-        let _ = manual::record_sync_failure(paths, now, *error);
+        let _ = manual::record_sync_failure_as(paths, now, *error, kind);
     }
     result
 }
@@ -104,6 +130,7 @@ pub enum SyncServiceError {
     Authentication,
     Certificate,
     Offline,
+    RateLimited(Option<std::time::Duration>),
     InvalidRemoteData,
     LocalStateChanged,
     Storage,
@@ -125,6 +152,7 @@ impl SyncServiceError {
             Self::Authentication => "sync_authentication_failed",
             Self::Certificate => "sync_certificate_failed",
             Self::Offline => "sync_offline",
+            Self::RateLimited(_) => "sync_offline",
             Self::InvalidRemoteData => "sync_invalid_remote_data",
             Self::LocalStateChanged => "sync_local_state_changed",
             Self::Storage => "sync_storage_failed",
@@ -140,6 +168,7 @@ impl SyncServiceError {
             Self::Authentication => Some(SyncFailureKind::Authentication),
             Self::Certificate => Some(SyncFailureKind::Certificate),
             Self::Offline => Some(SyncFailureKind::Offline),
+            Self::RateLimited(_) => Some(SyncFailureKind::Offline),
             Self::PendingApproval => Some(SyncFailureKind::DeviceApproval),
             Self::InvalidRemoteData | Self::PairingRejected | Self::PairingNeedsCleanup => {
                 Some(SyncFailureKind::InvalidRemoteData)
@@ -168,6 +197,14 @@ impl fmt::Display for SyncServiceError {
             Self::Authentication => "the WebDAV credential was rejected",
             Self::Certificate => "the server certificate could not be verified",
             Self::Offline => "the sync server is unavailable",
+            Self::RateLimited(Some(delay)) => {
+                return write!(
+                    formatter,
+                    "the sync server asked to retry in {} seconds",
+                    delay.as_secs()
+                );
+            }
+            Self::RateLimited(None) => "the sync server asked to retry later",
             Self::InvalidRemoteData => "the encrypted remote state could not be verified",
             Self::LocalStateChanged => "local personal state changed; retrying is safe",
             Self::Storage => "personal sync state could not be stored",
@@ -190,6 +227,7 @@ impl From<VaultError> for SyncServiceError {
             VaultError::RemoteAuthentication => Self::Authentication,
             VaultError::RemoteCertificate => Self::Certificate,
             VaultError::RemoteUnavailable => Self::Offline,
+            VaultError::RemoteRateLimited(delay) => Self::RateLimited(delay),
             VaultError::RemoteUnsupported => Self::UnsupportedServer,
             VaultError::StorageFailed | VaultError::StorageBusy => Self::Storage,
             VaultError::PairingExpired | VaultError::PairingConsumed => Self::PairingExpired,
@@ -224,10 +262,10 @@ fn map_webdav_error(error: super::webdav::WebDavError) -> SyncServiceError {
         }
         WebDavError::CertificateFailed => SyncServiceError::Certificate,
         WebDavError::MethodUnsupported => SyncServiceError::UnsupportedServer,
-        WebDavError::RequestFailed
-        | WebDavError::RateLimited
-        | WebDavError::ServerUnavailable
-        | WebDavError::Locked => SyncServiceError::Offline,
+        WebDavError::RateLimited(delay) => SyncServiceError::RateLimited(delay),
+        WebDavError::RequestFailed | WebDavError::ServerUnavailable | WebDavError::Locked => {
+            SyncServiceError::Offline
+        }
         WebDavError::PreconditionFailed => SyncServiceError::LocalStateChanged,
         WebDavError::InvalidEndpoint
         | WebDavError::UnsupportedScheme

--- a/src/sync/service/pairing.rs
+++ b/src/sync/service/pairing.rs
@@ -1292,9 +1292,7 @@ pub(super) fn prepare_pairing_join_commit(
     // Joining replaces the fresh device's local dataset with the authenticated remote dataset.
     // PersonalState transactions are still ordered by one local revision counter, so the first
     // remote candidate must be strictly newer than whichever local ledger is currently visible.
-    candidate.revision = candidate
-        .revision
-        .max(current_state.revision.saturating_add(1));
+    candidate.revision = candidate.revision.max(current_state.next_revision()?);
     let commit = PersonalStateCommit::prepare_for_runtime(candidate, playlist_revision)?;
     if commit.state().revision <= current_state.revision {
         return Err(SyncServiceError::LocalStateChanged);

--- a/src/sync/service/persistence.rs
+++ b/src/sync/service/persistence.rs
@@ -16,22 +16,24 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::personal_state::{
     DeviceId, Operation, OperationEnvelope, OperationOrigin, PersonalStateCommit,
-    PersonalStatePaths, PersonalStateV2, append_operation_as, load_ledger,
+    PersonalStatePaths, PersonalStateV2, append_operation_as, load_ledger, merge,
 };
 
 use super::super::{EnrollmentState, PrivateStore, SyncPaths};
 use super::devices::record_revoke_success;
 use super::manual::{
-    PreparedManualSync, record_sync_failure, record_sync_started, record_sync_success,
+    PreparedManualSync, record_sync_failure, record_sync_failure_as, record_sync_started,
+    record_sync_success, record_sync_success_as,
 };
 use super::{
-    PreparedPairingApproval, PreparedPairingJoinActivation, PreparedSetup, SyncServiceError,
-    apply_manual_sync, recover_pending_anchor_transition,
+    PreparedPairingApproval, PreparedPairingJoinActivation, PreparedSetup, SyncAttemptKind,
+    SyncServiceError, apply_manual_sync, recover_pending_anchor_transition,
 };
 
 #[derive(Clone)]
 pub enum PersonalSyncApplyKind {
     SyncNow,
+    AutomaticSync,
     Revoke(DeviceId),
     PairApprove(Box<PreparedPairingApproval>),
 }
@@ -201,6 +203,16 @@ impl PersonalSyncPersistence {
         accepted_states.dedup();
         let commit = PersonalStateCommit::prepare_for_runtime(candidate, playlist_revision)?;
         let target_state = commit.state().clone();
+        let mut extends_accepted_state = false;
+        for accepted in &accepted_states {
+            if verified_state_extension(accepted, &target_state)? {
+                extends_accepted_state = true;
+                break;
+            }
+        }
+        if !extends_accepted_state {
+            return Err(SyncServiceError::LocalStateChanged);
+        }
         Ok(Self(Arc::new(PersonalSyncPersistenceInner {
             write: PersonalSyncWrite::Reconcile {
                 accepted_states,
@@ -466,6 +478,14 @@ impl PersonalSyncPersistence {
                 PersonalSyncApplyKind::SyncNow => {
                     let _ = record_sync_success(&self.0.sync_paths, now, &candidate.summary);
                 }
+                PersonalSyncApplyKind::AutomaticSync => {
+                    let _ = record_sync_success_as(
+                        &self.0.sync_paths,
+                        now,
+                        &candidate.summary,
+                        SyncAttemptKind::Automatic,
+                    );
+                }
                 PersonalSyncApplyKind::Revoke(device_id) => {
                     let _ = record_revoke_success(
                         &self.0.sync_paths,
@@ -476,9 +496,19 @@ impl PersonalSyncPersistence {
                 }
                 PersonalSyncApplyKind::PairApprove(_) => {}
             },
-            Err(error) => {
-                let _ = record_sync_failure(&self.0.sync_paths, now, *error);
-            }
+            Err(error) => match action {
+                PersonalSyncApplyKind::AutomaticSync => {
+                    let _ = record_sync_failure_as(
+                        &self.0.sync_paths,
+                        now,
+                        *error,
+                        SyncAttemptKind::Automatic,
+                    );
+                }
+                _ => {
+                    let _ = record_sync_failure(&self.0.sync_paths, now, *error);
+                }
+            },
         }
         result
     }
@@ -515,7 +545,7 @@ impl PersonalSyncPersistence {
             == Some(candidate.checkpoint_anchor.checkpoint_sequence)
             && private.checkpoint_hash() == Some(target_hash);
         let revision_matches = private.revision() == candidate.expected_private_revision
-            || private.revision() == candidate.expected_private_revision.saturating_add(1);
+            || candidate.expected_private_revision.checked_add(1) == Some(private.revision());
         Ok(anchor_matches
             && revision_matches
             && private.dataset_id() == self.0.target_state.dataset_id
@@ -688,10 +718,20 @@ fn verified_state_extension(
     if base == extension {
         return Ok(true);
     }
-    if extension.revision <= base.revision
-        || extension.dataset_id != base.dataset_id
+    if extension.revision <= base.revision {
+        return Ok(false);
+    }
+    merge_preserves_extension(base, extension)
+}
+
+fn merge_preserves_extension(
+    base: &PersonalStateV2,
+    extension: &PersonalStateV2,
+) -> Result<bool, SyncServiceError> {
+    base.validate()?;
+    extension.validate()?;
+    if extension.dataset_id != base.dataset_id
         || extension.metadata != base.metadata
-        || extension.compaction_checkpoint != base.compaction_checkpoint
         || base
             .version_vector
             .0
@@ -700,18 +740,16 @@ fn verified_state_extension(
     {
         return Ok(false);
     }
-
-    let extension_by_id: BTreeMap<&str, &OperationEnvelope> = extension
-        .operations
-        .iter()
-        .map(|operation| (operation.operation_id.as_str(), operation))
-        .collect();
-    Ok(base.operations.iter().all(|operation| {
-        extension_by_id
-            .get(operation.operation_id.as_str())
-            .copied()
-            == Some(operation)
-    }))
+    // Personal-state merge owns the trust rules for compaction checkpoint ancestry, covered
+    // engagement pruning, and anti-resurrection. If joining the prior state into the candidate
+    // produces the candidate itself, it is either a plain operation extension or a legitimate
+    // compaction descendant. Arbitrary operation deletion cannot satisfy this fixed-point check.
+    let Ok((mut joined, _)) = merge(base, extension) else {
+        return Ok(false);
+    };
+    // This fingerprint is a local runtime projection cache, not part of causal merge identity.
+    joined.projection_fingerprint = extension.projection_fingerprint.clone();
+    Ok(joined == *extension)
 }
 
 fn shutdown_anchor_matches(
@@ -747,9 +785,13 @@ pub(crate) fn rebase_local_operations(
         || current.dataset_id != observed.dataset_id
         || durable.metadata != observed.metadata
         || current.metadata != observed.metadata
-        || durable.compaction_checkpoint != observed.compaction_checkpoint
         || current.compaction_checkpoint != observed.compaction_checkpoint
     {
+        return Err(SyncServiceError::LocalStateChanged);
+    }
+    // Detached manual-sync candidates deliberately keep the observed local revision until the
+    // persistence owner prepares them. Their causal content must still be a merge fixed point.
+    if !merge_preserves_extension(observed, durable)? {
         return Err(SyncServiceError::LocalStateChanged);
     }
 
@@ -775,17 +817,6 @@ pub(crate) fn rebase_local_operations(
         .iter()
         .map(|operation| (operation.operation_id.as_str(), operation))
         .collect();
-    if observed_by_id
-        .iter()
-        .any(|(id, operation)| durable_by_id.get(id).copied() != Some(*operation))
-        || observed
-            .version_vector
-            .0
-            .iter()
-            .any(|(device, sequence)| durable.version_vector.observed(device) < *sequence)
-    {
-        return Err(SyncServiceError::LocalStateChanged);
-    }
     let mut additions: Vec<&OperationEnvelope> = current
         .operations
         .iter()
@@ -837,7 +868,7 @@ pub(crate) fn rebase_local_operations(
         appended = true;
     }
     if appended {
-        rebased.revision = durable.revision.max(current.revision).saturating_add(1);
+        rebased.revision = PersonalStateV2::revision_after(durable.revision.max(current.revision))?;
         rebased.projection_fingerprint = None;
         rebased.normalize()?;
     }

--- a/src/sync/service/persistence/tests.rs
+++ b/src/sync/service/persistence/tests.rs
@@ -1,5 +1,174 @@
 use super::tests::shutdown_fixture;
 use super::*;
+use crate::personal_state::{EngagementKind, PortableTrack, PortableTrackKey};
+
+const COMPACTION_NOW: i64 = 2_000_000_000;
+
+fn expired_engagement_state(fixture: &super::tests::ShutdownFixture) -> PersonalStateV2 {
+    let state = append_operation_as(
+        &fixture.initial,
+        &fixture.device_id,
+        Operation::RecordEngagement {
+            event_id: "expired-persistence-event".to_owned(),
+            track: PortableTrack {
+                key: PortableTrackKey::Catalog {
+                    provider: "youtube".to_owned(),
+                    exact_catalog_id: "expired-persistence-track".to_owned(),
+                },
+                title: "Expired persistence track".to_owned(),
+                artist: "Persistence artist".to_owned(),
+                album: None,
+                duration_secs: Some(180),
+                isrc: None,
+            },
+            engagement: EngagementKind::Play,
+            played_duration_ms: Some(90_000),
+            total_duration_ms: Some(180_000),
+            artist_key: "persistence artist".to_owned(),
+        },
+        1,
+    )
+    .unwrap();
+    PersonalStateCommit::prepare_for_runtime(state, 7)
+        .unwrap()
+        .state()
+        .clone()
+}
+
+fn compacted_state(observed: &PersonalStateV2, device_id: &DeviceId) -> PersonalStateV2 {
+    let candidate = crate::personal_state::plan_engagement_compaction(
+        observed,
+        device_id,
+        COMPACTION_NOW,
+        false,
+    )
+    .unwrap()
+    .unwrap()
+    .candidate;
+    PersonalStateCommit::prepare_for_runtime(candidate, 7)
+        .unwrap()
+        .state()
+        .clone()
+}
+
+fn compacted_candidate(
+    fixture: &super::tests::ShutdownFixture,
+    observed: &PersonalStateV2,
+    compacted: PersonalStateV2,
+) -> PreparedManualSync {
+    let mut candidate = fixture.candidate.clone();
+    candidate.expected_local_revision = observed.revision;
+    candidate.state = compacted;
+    candidate
+}
+
+#[test]
+fn initial_and_reconcile_accept_valid_compaction_but_reject_plain_deletion() {
+    let fixture = shutdown_fixture();
+    let observed = expired_engagement_state(&fixture);
+    let compacted = compacted_state(&observed, &fixture.device_id);
+    assert!(verified_state_extension(&observed, &compacted).unwrap());
+
+    let initial = PersonalSyncPersistence::initial(
+        observed.clone(),
+        7,
+        compacted_candidate(&fixture, &observed, compacted.clone()),
+        PersonalSyncApplyKind::SyncNow,
+        fixture.personal_paths.clone(),
+        SyncPaths::for_data_root(fixture.root.clone()),
+    )
+    .unwrap();
+    assert_eq!(
+        initial.state().compaction_checkpoint,
+        compacted.compaction_checkpoint
+    );
+
+    let reconciled = PersonalSyncPersistence::reconcile(
+        observed.clone(),
+        observed.clone(),
+        compacted,
+        7,
+        fixture.personal_paths.clone(),
+        SyncPaths::for_data_root(fixture.root.clone()),
+    )
+    .unwrap();
+    assert!(reconciled.state().compaction_checkpoint.is_some());
+
+    let mut deleted = observed.clone();
+    deleted
+        .operations
+        .retain(|operation| !matches!(operation.operation, Operation::RecordEngagement { .. }));
+    deleted.revision = deleted.revision.saturating_add(1);
+    deleted.projection_fingerprint = None;
+    let deleted = PersonalStateCommit::prepare_for_runtime(deleted, 7)
+        .unwrap()
+        .state()
+        .clone();
+    assert!(!verified_state_extension(&observed, &deleted).unwrap());
+    assert!(matches!(
+        PersonalSyncPersistence::reconcile(
+            observed.clone(),
+            observed,
+            deleted,
+            7,
+            fixture.personal_paths.clone(),
+            SyncPaths::for_data_root(fixture.root.clone()),
+        ),
+        Err(SyncServiceError::LocalStateChanged)
+    ));
+}
+
+#[test]
+fn shutdown_rebases_raced_local_mutation_after_compacted_candidate() {
+    let fixture = shutdown_fixture();
+    let observed = expired_engagement_state(&fixture);
+    let compacted = compacted_state(&observed, &fixture.device_id);
+    let current = append_operation_as(
+        &observed,
+        &fixture.device_id,
+        Operation::SetAvoidArtist {
+            artist_key: "raced-after-compaction".to_owned(),
+            avoid: true,
+        },
+        COMPACTION_NOW,
+    )
+    .unwrap();
+    let current = PersonalStateCommit::prepare_for_runtime(current, 7)
+        .unwrap()
+        .state()
+        .clone();
+
+    let writer = PersonalSyncPersistence::shutdown(
+        observed.clone(),
+        current,
+        7,
+        compacted_candidate(&fixture, &observed, compacted.clone()),
+        &fixture.device_id,
+        fixture.personal_paths.clone(),
+        SyncPaths::for_data_root(fixture.root.clone()),
+    )
+    .unwrap();
+
+    assert_eq!(
+        writer.state().compaction_checkpoint,
+        compacted.compaction_checkpoint
+    );
+    assert!(
+        !writer
+            .state()
+            .operations
+            .iter()
+            .any(|operation| matches!(operation.operation, Operation::RecordEngagement { .. }))
+    );
+    assert!(writer.state().operations.iter().any(|operation| matches!(
+        operation.operation,
+        Operation::SetAvoidArtist {
+            ref artist_key,
+            avoid: true
+        } if artist_key == "raced-after-compaction"
+    )));
+    assert!(verified_state_extension(&compacted, writer.state()).unwrap());
+}
 
 #[test]
 fn pairing_join_retargets_three_times_from_the_durable_import_baseline() {

--- a/src/sync/service/tests.rs
+++ b/src/sync/service/tests.rs
@@ -1,6 +1,8 @@
 use crate::personal_state::{PersonalStatePaths, PersonalStateV2};
 
-use super::{SyncServiceError, load_personal_state_read_only, read_status, sync_now};
+use super::{
+    SyncAttemptKind, SyncServiceError, load_personal_state_read_only, read_status, sync_now,
+};
 use crate::sync::{
     SyncAuditOutcome, SyncAuditStore, SyncFailureKind, SyncHealthState, SyncHealthStore, SyncPaths,
 };
@@ -51,6 +53,7 @@ fn public_errors_and_reasons_are_redacted_fixed_vocabulary() {
         SyncServiceError::Authentication,
         SyncServiceError::Certificate,
         SyncServiceError::Offline,
+        SyncServiceError::RateLimited(Some(std::time::Duration::from_secs(75))),
         SyncServiceError::InvalidRemoteData,
         SyncServiceError::LocalStateChanged,
         SyncServiceError::Storage,
@@ -70,8 +73,9 @@ fn owner_prepare_failure_is_retained_without_replacing_the_primary_error() {
     let paths = SyncPaths::for_data_root(temp.0.clone());
     std::fs::create_dir_all(paths.root()).unwrap();
 
-    let result =
-        super::track_owner_preparation::<()>(&paths, || Err(SyncServiceError::Authentication));
+    let result = super::track_owner_preparation::<()>(&paths, SyncAttemptKind::Manual, || {
+        Err(SyncServiceError::Authentication)
+    });
 
     assert_eq!(result, Err(SyncServiceError::Authentication));
     let health = SyncHealthStore::new(paths.health())
@@ -98,7 +102,9 @@ fn owner_prepare_error_wins_when_health_storage_is_unavailable() {
     std::fs::write(temp.0.join("sync"), b"not a directory").unwrap();
     let paths = SyncPaths::for_data_root(temp.0.clone());
 
-    let result = super::track_owner_preparation::<()>(&paths, || Err(SyncServiceError::Offline));
+    let result = super::track_owner_preparation::<()>(&paths, SyncAttemptKind::Manual, || {
+        Err(SyncServiceError::Offline)
+    });
 
     assert_eq!(result, Err(SyncServiceError::Offline));
 }

--- a/src/sync/service/transition.rs
+++ b/src/sync/service/transition.rs
@@ -396,7 +396,7 @@ fn validate_binding(binding: &TransitionBinding) -> Result<(), SyncServiceError>
         || binding.schema_version != TRANSITION_SCHEMA_VERSION
         || binding.device_id.is_empty()
         || binding.expected_private_revision == 0
-        || binding.target_private_revision != binding.expected_private_revision.saturating_add(1)
+        || binding.expected_private_revision.checked_add(1) != Some(binding.target_private_revision)
         || binding.checkpoint_sequence == 0
         || !valid_hash(&binding.expected_personal_hash)
         || !valid_hash(&binding.candidate_personal_hash)

--- a/src/sync/service/transition/tests.rs
+++ b/src/sync/service/transition/tests.rs
@@ -363,6 +363,44 @@ fn actor_retry_after_ledger_install_finishes_recovery_without_a_second_transitio
     assert_transition_artifacts_removed(&fixture.sync_paths);
 }
 
+#[test]
+fn terminal_private_revision_cannot_alias_the_next_transition() {
+    let candidate_hash = "a".repeat(64);
+    let target_private_hash = "b".repeat(64);
+    let checkpoint_hash = "c".repeat(64);
+    let checkpoint_sequence = 2;
+    let activation_hash = super::activation_hash(
+        AnchorActivationKind::ManualSync,
+        &candidate_hash,
+        &target_private_hash,
+        checkpoint_sequence,
+        &checkpoint_hash,
+    );
+    let binding = super::TransitionBinding {
+        kind: super::TRANSITION_KIND.to_owned(),
+        schema_version: super::TRANSITION_SCHEMA_VERSION,
+        dataset_id: "terminal-private-revision".to_owned(),
+        device_id: "device-a".to_owned(),
+        activation_kind: AnchorActivationKind::ManualSync,
+        expected_personal_revision: 1,
+        expected_personal_hash: "d".repeat(64),
+        candidate_personal_revision: 2,
+        candidate_personal_hash: candidate_hash,
+        playlist_revision: 0,
+        expected_private_revision: u64::MAX,
+        target_private_revision: u64::MAX,
+        target_private_hash,
+        checkpoint_sequence,
+        checkpoint_hash,
+        activation_hash,
+    };
+
+    assert_eq!(
+        super::validate_binding(&binding),
+        Err(super::SyncServiceError::InvalidRemoteData)
+    );
+}
+
 fn assert_transition_artifacts_removed(paths: &SyncPaths) {
     for path in [
         paths.anchor_transition_manifest(),

--- a/src/sync/tests.rs
+++ b/src/sync/tests.rs
@@ -678,6 +678,90 @@ fn file_transport_is_conditional_idempotent_and_ciphertext_only() {
     std::fs::remove_dir_all(directory).unwrap();
 }
 
+#[test]
+fn file_transport_delete_is_exact_idempotent_and_deadline_bounded() {
+    let fixture = bootstrap();
+    let directory = test_directory("transport-delete");
+    let transport = FileVaultTransport::create(directory.clone()).unwrap();
+    let key = ObjectKey::new("yututui/v2/dataset-integration/checkpoints/1/obsolete.age").unwrap();
+    let metadata = match transport
+        .put(
+            &key,
+            &fixture.encrypted_checkpoint,
+            ObjectCondition::CreateOnly,
+        )
+        .unwrap()
+    {
+        ObjectWriteResult::Created(metadata) => metadata,
+        other => panic!("unexpected write result: {other:?}"),
+    };
+
+    assert_eq!(
+        transport.delete(&key, &"0".repeat(64)),
+        Err(VaultError::PreconditionFailed)
+    );
+    assert!(
+        transport
+            .get(&key, MAX_VAULT_PAYLOAD_BYTES)
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(
+        transport.delete_with_deadline(&key, &metadata.etag, VaultDeadline::expired()),
+        Err(VaultError::RemoteUnavailable)
+    );
+    assert!(
+        transport
+            .get(&key, MAX_VAULT_PAYLOAD_BYTES)
+            .unwrap()
+            .is_some()
+    );
+
+    assert_eq!(
+        transport.delete(&key, &metadata.etag).unwrap(),
+        ObjectDeleteResult::Deleted
+    );
+    assert!(
+        transport
+            .get(&key, MAX_VAULT_PAYLOAD_BYTES)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        transport.delete(&key, &metadata.etag).unwrap(),
+        ObjectDeleteResult::AlreadyAbsent
+    );
+
+    std::fs::remove_dir_all(directory).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn file_transport_delete_never_follows_a_parent_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let root = test_directory("transport-delete-symlink");
+    let outside = test_directory("transport-delete-outside");
+    let outside_v2 = outside.join("v2");
+    crate::util::safe_fs::ensure_private_dir(&outside_v2).unwrap();
+    let outside_object = outside_v2.join("obsolete.age");
+    std::fs::write(&outside_object, b"must remain").unwrap();
+    symlink(&outside, root.join("redirect")).unwrap();
+    let transport = FileVaultTransport::open(root.clone()).unwrap();
+
+    assert_eq!(
+        transport.delete(
+            &ObjectKey::new("redirect/v2/obsolete.age").unwrap(),
+            &"0".repeat(64),
+        ),
+        Err(VaultError::StorageFailed)
+    );
+    assert_eq!(std::fs::read(&outside_object).unwrap(), b"must remain");
+
+    std::fs::remove_dir_all(root).unwrap();
+    std::fs::remove_dir_all(outside).unwrap();
+}
+
 #[cfg(unix)]
 #[test]
 fn recovery_export_preserves_user_directory_permissions_and_never_replaces() {

--- a/src/sync/transport.rs
+++ b/src/sync/transport.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsStr;
 use std::fs;
+use std::io::Read as _;
 use std::path::{Component, Path, PathBuf};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -67,6 +68,12 @@ pub enum ObjectWriteResult {
     Created(ObjectMetadata),
     Updated(ObjectMetadata),
     AlreadyPresent(ObjectMetadata),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectDeleteResult {
+    Deleted,
+    AlreadyAbsent,
 }
 
 /// One whole-operation deadline shared by all transport calls and retry attempts.
@@ -219,6 +226,34 @@ pub trait VaultTransport {
         result
     }
 
+    /// Delete one exact object generation.
+    ///
+    /// `expected_etag` must be the strong entity tag returned by a prior GET or bounded listing.
+    /// Implementations must fail closed instead of deleting a replacement object.
+    fn delete(
+        &self,
+        _key: &ObjectKey,
+        _expected_etag: &str,
+    ) -> Result<ObjectDeleteResult, VaultError> {
+        Err(VaultError::RemoteUnsupported)
+    }
+
+    /// Delete one exact object generation under a caller-owned whole-operation deadline.
+    ///
+    /// The compatibility implementation is appropriate for deterministic transports. Network
+    /// transports must override it so the request and any ambiguity readback share one deadline.
+    fn delete_with_deadline(
+        &self,
+        key: &ObjectKey,
+        expected_etag: &str,
+        deadline: VaultDeadline,
+    ) -> Result<ObjectDeleteResult, VaultError> {
+        deadline.check()?;
+        let result = self.delete(key, expected_etag);
+        deadline.check()?;
+        result
+    }
+
     fn list(
         &self,
         prefix: &ObjectKey,
@@ -303,11 +338,28 @@ impl FileVaultTransport {
     }
 
     fn acquire_lock(&self) -> Result<crate::util::safe_fs::AdvisoryFileLock, VaultError> {
-        let deadline = Instant::now() + LOCK_WAIT;
+        self.acquire_lock_until(None)
+    }
+
+    fn acquire_lock_until(
+        &self,
+        operation_deadline: Option<VaultDeadline>,
+    ) -> Result<crate::util::safe_fs::AdvisoryFileLock, VaultError> {
+        let lock_deadline = Instant::now() + LOCK_WAIT;
         loop {
+            if let Some(deadline) = operation_deadline {
+                deadline.check()?;
+            }
             match crate::util::safe_fs::try_lock_private_file(&self.lock_path) {
                 Ok(Some(lock)) => return Ok(lock),
-                Ok(None) if Instant::now() < deadline => thread::sleep(Duration::from_millis(5)),
+                Ok(None) if Instant::now() < lock_deadline => {
+                    let delay = operation_deadline
+                        .map(VaultDeadline::remaining)
+                        .transpose()?
+                        .unwrap_or(Duration::from_millis(5))
+                        .min(Duration::from_millis(5));
+                    thread::sleep(delay);
+                }
                 Ok(None) => return Err(VaultError::StorageBusy),
                 Err(_) => return Err(VaultError::StorageFailed),
             }
@@ -343,6 +395,83 @@ impl FileVaultTransport {
             .map_err(|_| VaultError::InvalidEncryptedObject)?;
         let metadata = metadata_for(key, &bytes)?;
         Ok(Some((object, metadata)))
+    }
+
+    fn delete_locked(
+        &self,
+        key: &ObjectKey,
+        expected_etag: &str,
+        deadline: Option<VaultDeadline>,
+    ) -> Result<ObjectDeleteResult, VaultError> {
+        if expected_etag.len() != 64
+            || !expected_etag
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        {
+            return Err(VaultError::PreconditionFailed);
+        }
+        if let Some(deadline) = deadline {
+            deadline.check()?;
+        }
+        let path = self.path_for(key)?;
+        let parent = path.parent().ok_or(VaultError::InvalidObjectKey)?;
+        let relative_parent = parent
+            .strip_prefix(&self.root)
+            .map_err(|_| VaultError::InvalidObjectKey)?;
+        let pinned_parent = match crate::util::safe_fs::PinnedDir::open_private_existing(
+            &self.root,
+            relative_parent,
+        ) {
+            Ok(parent) => parent,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(ObjectDeleteResult::AlreadyAbsent);
+            }
+            Err(_) => return Err(VaultError::StorageFailed),
+        };
+        let basename = path.file_name().ok_or(VaultError::InvalidObjectKey)?;
+        let generation = match pinned_parent.open_child_readonly(basename) {
+            Ok(generation) => generation,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(ObjectDeleteResult::AlreadyAbsent);
+            }
+            Err(_) => return Err(VaultError::StorageFailed),
+        };
+        let file = generation
+            .file()
+            .and_then(std::fs::File::try_clone)
+            .map_err(|_| VaultError::StorageFailed)?;
+        let metadata = file.metadata().map_err(|_| VaultError::StorageFailed)?;
+        let hard_limit = super::MAX_VAULT_PAYLOAD_BYTES
+            .saturating_add(CIPHERTEXT_OVERHEAD_LIMIT)
+            .min(super::crypto::MAX_ENCRYPTED_OBJECT_BYTES);
+        if metadata.len() > hard_limit as u64 {
+            return Err(VaultError::PayloadTooLarge);
+        }
+        let mut bytes = Vec::new();
+        file.take(hard_limit.saturating_add(1) as u64)
+            .read_to_end(&mut bytes)
+            .map_err(|_| VaultError::StorageFailed)?;
+        if bytes.len() > hard_limit {
+            return Err(VaultError::PayloadTooLarge);
+        }
+        if metadata_for(key, &bytes)?.etag != expected_etag {
+            return Err(VaultError::PreconditionFailed);
+        }
+        if let Some(deadline) = deadline {
+            deadline.check()?;
+        }
+        generation
+            .remove_from_private_parent()
+            .map_err(|error| match error.kind() {
+                std::io::ErrorKind::AlreadyExists | std::io::ErrorKind::NotFound => {
+                    VaultError::PreconditionFailed
+                }
+                _ => VaultError::StorageFailed,
+            })?;
+        if let Some(deadline) = deadline {
+            deadline.check()?;
+        }
+        Ok(ObjectDeleteResult::Deleted)
     }
 }
 
@@ -400,6 +529,25 @@ impl VaultTransport for FileVaultTransport {
             Some(_) => Ok(ObjectWriteResult::Updated(metadata)),
             None => Ok(ObjectWriteResult::Created(metadata)),
         }
+    }
+
+    fn delete(
+        &self,
+        key: &ObjectKey,
+        expected_etag: &str,
+    ) -> Result<ObjectDeleteResult, VaultError> {
+        let _lock = self.acquire_lock()?;
+        self.delete_locked(key, expected_etag, None)
+    }
+
+    fn delete_with_deadline(
+        &self,
+        key: &ObjectKey,
+        expected_etag: &str,
+        deadline: VaultDeadline,
+    ) -> Result<ObjectDeleteResult, VaultError> {
+        let _lock = self.acquire_lock_until(Some(deadline))?;
+        self.delete_locked(key, expected_etag, Some(deadline))
     }
 
     fn list(

--- a/src/sync/webdav/delete.rs
+++ b/src/sync/webdav/delete.rs
@@ -1,0 +1,112 @@
+use super::*;
+
+impl WebDavClient {
+    pub async fn delete(
+        &self,
+        key: &ObjectKey,
+        expected_etag: &str,
+        credential: &VaultCredential,
+    ) -> Result<ObjectDeleteResult, WebDavError> {
+        self.delete_inner(key, expected_etag, credential, None)
+            .await
+    }
+
+    pub(super) async fn delete_with_deadline(
+        &self,
+        key: &ObjectKey,
+        expected_etag: &str,
+        credential: &VaultCredential,
+        deadline: VaultDeadline,
+    ) -> Result<ObjectDeleteResult, WebDavError> {
+        self.delete_inner(key, expected_etag, credential, Some(deadline))
+            .await
+    }
+
+    async fn delete_inner(
+        &self,
+        key: &ObjectKey,
+        expected_etag: &str,
+        credential: &VaultCredential,
+        deadline: Option<VaultDeadline>,
+    ) -> Result<ObjectDeleteResult, WebDavError> {
+        let response = match self
+            .send_conditional_delete(key, expected_etag, credential, deadline)
+            .await
+        {
+            Ok(response) => response,
+            Err(WebDavError::RequestFailed) => {
+                return self
+                    .verify_ambiguous_delete(key, expected_etag, credential, deadline)
+                    .await;
+            }
+            Err(error) => return Err(error),
+        };
+        match response.status() {
+            StatusCode::OK | StatusCode::NO_CONTENT => Ok(ObjectDeleteResult::Deleted),
+            StatusCode::NOT_FOUND => Ok(ObjectDeleteResult::AlreadyAbsent),
+            StatusCode::PRECONDITION_FAILED => Err(WebDavError::PreconditionFailed),
+            StatusCode::ACCEPTED => {
+                self.verify_ambiguous_delete(key, expected_etag, credential, deadline)
+                    .await
+            }
+            status if status.is_server_error() => match status_error(&response) {
+                error @ WebDavError::RateLimited(_) => Err(error),
+                _ => {
+                    self.verify_ambiguous_delete(key, expected_etag, credential, deadline)
+                        .await
+                }
+            },
+            _ => Err(status_error(&response)),
+        }
+    }
+
+    async fn send_conditional_delete(
+        &self,
+        key: &ObjectKey,
+        expected_etag: &str,
+        credential: &VaultCredential,
+        deadline: Option<VaultDeadline>,
+    ) -> Result<Response, WebDavError> {
+        let mut request =
+            self.authenticated_request(Method::DELETE, self.object_url(key)?, credential)?;
+        apply_match_condition(request.headers_mut(), expected_etag)?;
+        self.execute_inner(request, deadline).await
+    }
+
+    async fn verify_ambiguous_delete(
+        &self,
+        key: &ObjectKey,
+        expected_etag: &str,
+        credential: &VaultCredential,
+        deadline: Option<VaultDeadline>,
+    ) -> Result<ObjectDeleteResult, WebDavError> {
+        match self
+            .get_inner(key, credential, MAX_PROTECTED_PAYLOAD_BYTES, deadline)
+            .await
+        {
+            Ok(None) => Ok(ObjectDeleteResult::Deleted),
+            Ok(Some((_, metadata))) if metadata.etag != expected_etag => {
+                Err(WebDavError::PreconditionFailed)
+            }
+            Ok(Some(_)) => Err(WebDavError::AmbiguousWrite),
+            Err(
+                error @ (WebDavError::AuthenticationRequired
+                | WebDavError::PermissionDenied
+                | WebDavError::RequestFailed
+                | WebDavError::MethodUnsupported
+                | WebDavError::Locked
+                | WebDavError::RateLimited(_)
+                | WebDavError::ServerUnavailable),
+            ) => Err(error),
+            Err(_) => Err(WebDavError::AmbiguousWrite),
+        }
+    }
+}
+
+fn apply_match_condition(headers: &mut HeaderMap, raw: &str) -> Result<(), WebDavError> {
+    let etag = EntityTag::parse(raw)?;
+    etag.require_strong()?;
+    let value = HeaderValue::from_str(etag.as_str()).map_err(|_| WebDavError::InvalidEntityTag)?;
+    headers.insert(IF_MATCH, value);
+    Ok(())
+}

--- a/src/sync/webdav/delete_tests.rs
+++ b/src/sync/webdav/delete_tests.rs
@@ -1,0 +1,406 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use age::secrecy::SecretString;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Mutex;
+
+use super::*;
+use crate::sync::{DeviceSecretMaterial, encrypt_json_to_recipients};
+
+fn credential() -> VaultCredential {
+    VaultCredential::password("sync-user", SecretString::from("sync-password")).unwrap()
+}
+
+fn encrypted_object() -> EncryptedObject {
+    let device = DeviceSecretMaterial::generate_for("webdav-delete-test").unwrap();
+    encrypt_json_to_recipients(
+        &serde_json::json!({"protected": true}),
+        &[device.public_identity().age_recipient],
+    )
+    .unwrap()
+}
+
+async fn read_request(stream: &mut TcpStream) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    loop {
+        let read = stream.read(&mut buffer).await.unwrap();
+        assert!(read > 0, "request ended before its headers");
+        bytes.extend_from_slice(&buffer[..read]);
+        assert!(bytes.len() <= 64 * 1024, "test request exceeded cap");
+        if bytes.windows(4).any(|part| part == b"\r\n\r\n") {
+            return bytes;
+        }
+    }
+}
+
+async fn respond(stream: &mut TcpStream, head: &str, body: &[u8]) {
+    stream.write_all(head.as_bytes()).await.unwrap();
+    stream.write_all(body).await.unwrap();
+    stream.shutdown().await.unwrap();
+}
+
+fn endpoint(listener: &TcpListener) -> String {
+    format!("http://{}/vault", listener.local_addr().unwrap())
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn blocking_delete_sends_strong_if_match_and_maps_success() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = endpoint(&listener);
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let server_capture = Arc::clone(&captured);
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        *server_capture.lock().await = read_request(&mut stream).await;
+        respond(
+            &mut stream,
+            "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+    });
+
+    let result = tokio::task::spawn_blocking(move || {
+        let credential = credential();
+        BlockingWebDavTransport::new(&url, &credential)
+            .unwrap()
+            .delete_with_deadline(
+                &ObjectKey::new("checkpoints/old.age").unwrap(),
+                "\"generation-7\"",
+                VaultDeadline::from_now(Duration::from_secs(5)),
+            )
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(result, ObjectDeleteResult::Deleted);
+    let request = String::from_utf8_lossy(&captured.lock().await).to_ascii_lowercase();
+    assert!(request.starts_with("delete /vault/checkpoints/old.age http/1.1\r\n"));
+    assert!(request.contains("\r\nif-match: \"generation-7\"\r\n"));
+    assert!(request.contains("\r\nauthorization: basic "));
+    server.await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn delete_rejects_weak_etag_before_network_io() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let client = WebDavClient::new(&endpoint(&listener)).unwrap();
+
+    assert_eq!(
+        client
+            .delete(
+                &ObjectKey::new("checkpoints/old.age").unwrap(),
+                "W/\"generation-7\"",
+                &credential(),
+            )
+            .await,
+        Err(WebDavError::MissingStrongEntityTag)
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), listener.accept())
+            .await
+            .is_err(),
+        "invalid precondition must not start DELETE"
+    );
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn delete_redirect_must_stay_on_the_exact_origin() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        read_request(&mut stream).await;
+        respond(
+            &mut stream,
+            "HTTP/1.1 307 Temporary Redirect\r\nLocation: http://127.0.0.1:9/stolen\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+    });
+
+    let error = WebDavClient::new(&format!("http://{address}/vault"))
+        .unwrap()
+        .delete(
+            &ObjectKey::new("checkpoints/old.age").unwrap(),
+            "\"generation-7\"",
+            &credential(),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(error, WebDavError::CrossOriginRedirect);
+    server.await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn ambiguous_delete_uses_get_readback() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut delete, _) = listener.accept().await.unwrap();
+        let request = read_request(&mut delete).await;
+        let request = String::from_utf8_lossy(&request).to_ascii_lowercase();
+        assert!(request.starts_with("delete /vault/checkpoints/old.age http/1.1\r\n"));
+        assert!(request.contains("\r\nif-match: \"generation-7\"\r\n"));
+        respond(
+            &mut delete,
+            "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+
+        let (mut readback, _) = listener.accept().await.unwrap();
+        let request = read_request(&mut readback).await;
+        assert!(
+            String::from_utf8_lossy(&request)
+                .starts_with("GET /vault/checkpoints/old.age HTTP/1.1\r\n")
+        );
+        respond(
+            &mut readback,
+            "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+    });
+
+    let result = WebDavClient::new(&format!("http://{address}/vault"))
+        .unwrap()
+        .delete(
+            &ObjectKey::new("checkpoints/old.age").unwrap(),
+            "\"generation-7\"",
+            &credential(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result, ObjectDeleteResult::Deleted);
+    server.await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn ambiguous_delete_never_removes_a_replacement_generation() {
+    let replacement = encrypted_object();
+    let response_body = replacement.as_bytes().to_vec();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut delete, _) = listener.accept().await.unwrap();
+        read_request(&mut delete).await;
+        respond(
+            &mut delete,
+            "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+
+        let (mut readback, _) = listener.accept().await.unwrap();
+        read_request(&mut readback).await;
+        respond(
+            &mut readback,
+            &format!(
+                "HTTP/1.1 200 OK\r\nETag: \"replacement-8\"\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                response_body.len()
+            ),
+            &response_body,
+        )
+        .await;
+    });
+
+    let error = WebDavClient::new(&format!("http://{address}/vault"))
+        .unwrap()
+        .delete(
+            &ObjectKey::new("checkpoints/old.age").unwrap(),
+            "\"generation-7\"",
+            &credential(),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(error, WebDavError::PreconditionFailed);
+    server.await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn ambiguous_delete_readback_reuses_original_deadline() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut delete, _) = listener.accept().await.unwrap();
+        read_request(&mut delete).await;
+        respond(
+            &mut delete,
+            "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+
+        let (mut readback, _) = listener.accept().await.unwrap();
+        read_request(&mut readback).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        drop(readback);
+    });
+
+    let client = WebDavClient::new(&format!("http://{address}/vault")).unwrap();
+    let started = std::time::Instant::now();
+    let error = client
+        .delete_with_deadline(
+            &ObjectKey::new("checkpoints/old.age").unwrap(),
+            "\"generation-7\"",
+            &credential(),
+            VaultDeadline::from_now(Duration::from_millis(75)),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(error, WebDavError::RequestFailed);
+    assert!(
+        started.elapsed() < Duration::from_millis(200),
+        "DELETE and ambiguity GET must share one deadline"
+    );
+    server.await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn retry_after_delta_seconds_survives_the_blocking_transport_boundary() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = endpoint(&listener);
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        read_request(&mut stream).await;
+        respond(
+            &mut stream,
+            "HTTP/1.1 429 Too Many Requests\r\nRetry-After: 75\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+    });
+
+    let error = tokio::task::spawn_blocking(move || {
+        let credential = credential();
+        BlockingWebDavTransport::new(&url, &credential)
+            .unwrap()
+            .delete_with_deadline(
+                &ObjectKey::new("checkpoints/old.age").unwrap(),
+                "\"generation-7\"",
+                VaultDeadline::from_now(Duration::from_secs(5)),
+            )
+            .unwrap_err()
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        error,
+        VaultError::RemoteRateLimited(Some(Duration::from_secs(75)))
+    );
+    assert_eq!(
+        crate::sync::service::SyncServiceError::from(error),
+        crate::sync::service::SyncServiceError::RateLimited(Some(Duration::from_secs(75)))
+    );
+    server.await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn delete_service_unavailable_preserves_retry_after_without_readback() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = endpoint(&listener);
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        read_request(&mut stream).await;
+        respond(
+            &mut stream,
+            "HTTP/1.1 503 Service Unavailable\r\nRetry-After: 90\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+    });
+
+    let error = WebDavClient::new(&url)
+        .unwrap()
+        .delete(
+            &ObjectKey::new("checkpoints/old.age").unwrap(),
+            "\"generation-7\"",
+            &credential(),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        WebDavError::RateLimited(Some(Duration::from_secs(90)))
+    );
+    server.await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn service_unavailable_retry_after_is_preserved() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        read_request(&mut stream).await;
+        respond(
+            &mut stream,
+            "HTTP/1.1 503 Service Unavailable\r\nRetry-After: 90\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+    });
+
+    let error = WebDavClient::new(&format!("http://{address}/vault"))
+        .unwrap()
+        .get(
+            &ObjectKey::new("manifest").unwrap(),
+            &credential(),
+            MAX_PROTECTED_PAYLOAD_BYTES,
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        WebDavError::RateLimited(Some(Duration::from_secs(90)))
+    );
+    server.await.unwrap();
+}

--- a/src/sync/webdav/mod.rs
+++ b/src/sync/webdav/mod.rs
@@ -4,6 +4,8 @@
 //! follows at most three exact-origin redirects, and never includes endpoint or credential text in
 //! its errors. Merge policy, retries, scheduling, and primary-writer ownership live above it.
 
+mod delete;
+mod retry_after;
 mod xml;
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -26,9 +28,9 @@ use super::crypto::{
     encrypt_json_to_recipients, random_id_hex, sha256_domain_hex,
 };
 use super::{
-    EncryptedObject, ListCost, ListLimits, ListOutcome, ObjectCondition, ObjectKey, ObjectMetadata,
-    ObjectWriteResult, VaultCredential, VaultCredentialKind, VaultDeadline, VaultError,
-    VaultTransport,
+    EncryptedObject, ListCost, ListLimits, ListOutcome, ObjectCondition, ObjectDeleteResult,
+    ObjectKey, ObjectMetadata, ObjectWriteResult, VaultCredential, VaultCredentialKind,
+    VaultDeadline, VaultError, VaultTransport,
 };
 
 pub const MAX_PROPFIND_BYTES: usize = 4 * 1024 * 1024;
@@ -76,7 +78,7 @@ pub enum WebDavError {
     Conflict,
     PreconditionFailed,
     Locked,
-    RateLimited,
+    RateLimited(Option<Duration>),
     ServerUnavailable,
     UnexpectedStatus(u16),
     ResourceLimitExceeded,
@@ -119,7 +121,14 @@ impl fmt::Display for WebDavError {
                 f.write_str("the WebDAV resource changed before it was written")
             }
             Self::Locked => f.write_str("the WebDAV resource is locked"),
-            Self::RateLimited => f.write_str("the WebDAV server asked the client to retry later"),
+            Self::RateLimited(Some(delay)) => write!(
+                f,
+                "the WebDAV server asked the client to retry in {} seconds",
+                delay.as_secs()
+            ),
+            Self::RateLimited(None) => {
+                f.write_str("the WebDAV server asked the client to retry later")
+            }
             Self::ServerUnavailable => f.write_str("the WebDAV server is temporarily unavailable"),
             Self::UnexpectedStatus(status) => {
                 write!(f, "the WebDAV server returned HTTP {status}")
@@ -292,7 +301,7 @@ impl WebDavClient {
         let request = self.authenticated_request(Method::OPTIONS, self.base.clone(), credential)?;
         let response = self.execute(request).await?;
         if response.status() != StatusCode::OK && response.status() != StatusCode::NO_CONTENT {
-            return Err(status_error(response.status()));
+            return Err(status_error(&response));
         }
         parse_capabilities(response.headers())
     }
@@ -326,7 +335,7 @@ impl WebDavClient {
         match response.status() {
             StatusCode::CREATED => Ok(CollectionWriteResult::Created),
             StatusCode::METHOD_NOT_ALLOWED => Ok(CollectionWriteResult::AlreadyPresent),
-            status => Err(status_error(status)),
+            _ => Err(status_error(&response)),
         }
     }
 
@@ -367,7 +376,7 @@ impl WebDavClient {
 
         let response = self.execute(request).await?;
         if response.status() != StatusCode::MULTI_STATUS {
-            return Err(status_error(response.status()));
+            return Err(status_error(&response));
         }
         let response_url = response.url().clone();
         let bytes = read_limited(response, max_body_bytes).await?;
@@ -416,7 +425,7 @@ impl WebDavClient {
             return Ok(None);
         }
         if response.status() != StatusCode::OK {
-            return Err(status_error(response.status()));
+            return Err(status_error(&response));
         }
         let etag = strong_etag(response.headers())?;
         let bytes = await_with_deadline(deadline, read_limited(response, body_limit)).await?;
@@ -485,9 +494,22 @@ impl WebDavClient {
             return Err(WebDavError::PreconditionFailed);
         }
         if status.is_server_error() {
-            return self
+            let server_error = status_error(&response);
+            let readback = self
                 .verify_ambiguous_put(key, object, credential, deadline)
                 .await;
+            return match (readback, server_error) {
+                (Ok(result), _) => Ok(result),
+                (
+                    Err(WebDavError::RateLimited(readback_delay)),
+                    WebDavError::RateLimited(server_delay),
+                ) => Err(WebDavError::RateLimited(longer_retry_after(
+                    server_delay,
+                    readback_delay,
+                ))),
+                (Err(_), error @ WebDavError::RateLimited(_)) => Err(error),
+                (Err(error), _) => Err(error),
+            };
         }
         let created = match (&condition, status) {
             (ObjectCondition::CreateOnly, StatusCode::CREATED) => true,
@@ -496,7 +518,7 @@ impl WebDavClient {
             | (ObjectCondition::Match(_), StatusCode::CREATED) => {
                 return Err(WebDavError::MethodUnsupported);
             }
-            _ => return Err(status_error(status)),
+            _ => return Err(status_error(&response)),
         };
 
         if let Some(etag) = optional_etag(response.headers())?
@@ -818,7 +840,7 @@ impl WebDavClient {
                 | WebDavError::RequestFailed
                 | WebDavError::MethodUnsupported
                 | WebDavError::Locked
-                | WebDavError::RateLimited
+                | WebDavError::RateLimited(_)
                 | WebDavError::ServerUnavailable),
             ) => Err(error),
             Err(_) => Err(WebDavError::AmbiguousWrite),
@@ -1116,6 +1138,30 @@ impl VaultTransport for BlockingWebDavTransport {
         .map_err(|error| map_vault_error(error, TransportOperation::Put))
     }
 
+    fn delete(
+        &self,
+        key: &ObjectKey,
+        expected_etag: &str,
+    ) -> Result<ObjectDeleteResult, VaultError> {
+        self.block_on(self.client.delete(key, expected_etag, &self.credential))
+            .map_err(|error| map_vault_error(error, TransportOperation::Delete))
+    }
+
+    fn delete_with_deadline(
+        &self,
+        key: &ObjectKey,
+        expected_etag: &str,
+        deadline: VaultDeadline,
+    ) -> Result<ObjectDeleteResult, VaultError> {
+        self.block_on(self.client.delete_with_deadline(
+            key,
+            expected_etag,
+            &self.credential,
+            deadline,
+        ))
+        .map_err(|error| map_vault_error(error, TransportOperation::Delete))
+    }
+
     fn list(
         &self,
         prefix: &ObjectKey,
@@ -1144,6 +1190,7 @@ impl VaultTransport for BlockingWebDavTransport {
 enum TransportOperation {
     Get,
     Put,
+    Delete,
     List,
 }
 
@@ -1155,9 +1202,9 @@ fn map_vault_error(error: WebDavError, operation: TransportOperation) -> VaultEr
         }
         WebDavError::CertificateFailed => VaultError::RemoteCertificate,
         WebDavError::MethodUnsupported => VaultError::RemoteUnsupported,
+        WebDavError::RateLimited(delay) => VaultError::RemoteRateLimited(delay),
         WebDavError::RequestFailed
         | WebDavError::Locked
-        | WebDavError::RateLimited
         | WebDavError::ServerUnavailable
         | WebDavError::AmbiguousWrite => VaultError::RemoteUnavailable,
         WebDavError::ResourceLimitExceeded => VaultError::ResourceLimitExceeded,
@@ -1420,8 +1467,8 @@ fn classify_request_error(error: &reqwest::Error) -> WebDavError {
     WebDavError::RequestFailed
 }
 
-fn status_error(status: StatusCode) -> WebDavError {
-    match status {
+fn status_error(response: &Response) -> WebDavError {
+    match response.status() {
         StatusCode::UNAUTHORIZED => WebDavError::AuthenticationRequired,
         StatusCode::FORBIDDEN => WebDavError::PermissionDenied,
         StatusCode::NOT_FOUND => WebDavError::NotFound,
@@ -1431,14 +1478,33 @@ fn status_error(status: StatusCode) -> WebDavError {
         StatusCode::CONFLICT => WebDavError::Conflict,
         StatusCode::PRECONDITION_FAILED => WebDavError::PreconditionFailed,
         StatusCode::LOCKED => WebDavError::Locked,
-        StatusCode::TOO_MANY_REQUESTS => WebDavError::RateLimited,
+        StatusCode::TOO_MANY_REQUESTS => WebDavError::RateLimited(retry_after(response.headers())),
+        StatusCode::SERVICE_UNAVAILABLE => retry_after(response.headers())
+            .map_or(WebDavError::ServerUnavailable, |delay| {
+                WebDavError::RateLimited(Some(delay))
+            }),
         status if status.is_server_error() => WebDavError::ServerUnavailable,
         status => WebDavError::UnexpectedStatus(status.as_u16()),
     }
 }
 
+fn retry_after(headers: &HeaderMap) -> Option<Duration> {
+    retry_after::parse(headers)
+}
+
+fn longer_retry_after(left: Option<Duration>, right: Option<Duration>) -> Option<Duration> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (left, right) => left.or(right),
+    }
+}
+
+#[cfg(test)]
+mod delete_tests;
 #[cfg(test)]
 mod proxy_tests;
+#[cfg(test)]
+mod put_retry_tests;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]

--- a/src/sync/webdav/put_retry_tests.rs
+++ b/src/sync/webdav/put_retry_tests.rs
@@ -1,0 +1,142 @@
+use std::time::Duration;
+
+use age::secrecy::SecretString;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::{TcpListener, TcpStream};
+
+use super::*;
+use crate::sync::{DeviceSecretMaterial, encrypt_json_to_recipients};
+
+fn credential() -> VaultCredential {
+    VaultCredential::password("sync-user", SecretString::from("sync-password")).unwrap()
+}
+
+fn encrypted_object() -> EncryptedObject {
+    let device = DeviceSecretMaterial::generate_for("put-retry-test-device").unwrap();
+    encrypt_json_to_recipients(
+        &serde_json::json!({"protected": true}),
+        &[device.public_identity().age_recipient],
+    )
+    .unwrap()
+}
+
+async fn read_request(stream: &mut TcpStream) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    let header_end = loop {
+        let read = stream.read(&mut buffer).await.unwrap();
+        assert!(read > 0, "request ended before its headers");
+        bytes.extend_from_slice(&buffer[..read]);
+        assert!(bytes.len() <= 2 * 1024 * 1024, "test request exceeded cap");
+        if let Some(position) = bytes.windows(4).position(|part| part == b"\r\n\r\n") {
+            break position + 4;
+        }
+    };
+    let headers = String::from_utf8_lossy(&bytes[..header_end]);
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().unwrap())
+        })
+        .unwrap_or(0);
+    while bytes.len() < header_end + content_length {
+        let read = stream.read(&mut buffer).await.unwrap();
+        assert!(read > 0, "request ended before its body");
+        bytes.extend_from_slice(&buffer[..read]);
+    }
+    bytes
+}
+
+async fn respond(stream: &mut TcpStream, head: &str, body: &[u8]) {
+    stream.write_all(head.as_bytes()).await.unwrap();
+    stream.write_all(body).await.unwrap();
+    stream.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn put_service_unavailable_preserves_retry_after_when_readback_fails() {
+    let object = encrypted_object();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut put, _) = listener.accept().await.unwrap();
+        read_request(&mut put).await;
+        respond(
+            &mut put,
+            "HTTP/1.1 503 Service Unavailable\r\nRetry-After: 600\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+
+        let (mut get, _) = listener.accept().await.unwrap();
+        let request = read_request(&mut get).await;
+        assert!(String::from_utf8_lossy(&request).starts_with("GET /vault/manifest HTTP/1.1"));
+        respond(
+            &mut get,
+            "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+    });
+
+    let key = ObjectKey::new("manifest").unwrap();
+    let error = WebDavClient::new(&format!("http://{address}/vault"))
+        .unwrap()
+        .put(&key, &object, ObjectCondition::CreateOnly, &credential())
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        WebDavError::RateLimited(Some(Duration::from_secs(600)))
+    );
+    server.await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn put_service_unavailable_accepts_a_matching_readback() {
+    let object = encrypted_object();
+    let expected_bytes = object.as_bytes().to_vec();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut put, _) = listener.accept().await.unwrap();
+        read_request(&mut put).await;
+        respond(
+            &mut put,
+            "HTTP/1.1 503 Service Unavailable\r\nRetry-After: 600\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+
+        let (mut get, _) = listener.accept().await.unwrap();
+        read_request(&mut get).await;
+        respond(
+            &mut get,
+            &format!(
+                "HTTP/1.1 200 OK\r\nETag: \"verified\"\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                expected_bytes.len()
+            ),
+            &expected_bytes,
+        )
+        .await;
+    });
+
+    let key = ObjectKey::new("manifest").unwrap();
+    let result = WebDavClient::new(&format!("http://{address}/vault"))
+        .unwrap()
+        .put(&key, &object, ObjectCondition::CreateOnly, &credential())
+        .await
+        .unwrap();
+    assert!(matches!(result, ObjectWriteResult::AlreadyPresent(_)));
+    server.await.unwrap();
+}

--- a/src/sync/webdav/retry_after.rs
+++ b/src/sync/webdav/retry_after.rs
@@ -1,0 +1,147 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use reqwest::header::{HeaderMap, RETRY_AFTER};
+
+pub(super) fn parse(headers: &HeaderMap) -> Option<Duration> {
+    let value = headers.get(RETRY_AFTER)?.to_str().ok()?.trim();
+    parse_value(value, unix_now())
+}
+
+fn parse_value(value: &str, now_unix: u64) -> Option<Duration> {
+    if !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()) {
+        let seconds = value.bytes().fold(0_u64, |seconds, byte| {
+            seconds
+                .saturating_mul(10)
+                .saturating_add(u64::from(byte - b'0'))
+        });
+        return Some(Duration::from_secs(seconds));
+    }
+    let target = parse_imf_fixdate(value)?;
+    Some(Duration::from_secs(target.saturating_sub(now_unix)))
+}
+
+fn parse_imf_fixdate(value: &str) -> Option<u64> {
+    let bytes = value.as_bytes();
+    if bytes.len() != 29
+        || !matches!(
+            &bytes[0..3],
+            b"Mon" | b"Tue" | b"Wed" | b"Thu" | b"Fri" | b"Sat" | b"Sun"
+        )
+        || &bytes[3..5] != b", "
+        || bytes[7] != b' '
+        || bytes[11] != b' '
+        || bytes[16] != b' '
+        || bytes[19] != b':'
+        || bytes[22] != b':'
+        || &bytes[25..29] != b" GMT"
+    {
+        return None;
+    }
+    let day = decimal(&bytes[5..7])?;
+    let month = match &bytes[8..11] {
+        b"Jan" => 1,
+        b"Feb" => 2,
+        b"Mar" => 3,
+        b"Apr" => 4,
+        b"May" => 5,
+        b"Jun" => 6,
+        b"Jul" => 7,
+        b"Aug" => 8,
+        b"Sep" => 9,
+        b"Oct" => 10,
+        b"Nov" => 11,
+        b"Dec" => 12,
+        _ => return None,
+    };
+    let year = decimal(&bytes[12..16])?;
+    let hour = decimal(&bytes[17..19])?;
+    let minute = decimal(&bytes[20..22])?;
+    let second = decimal(&bytes[23..25])?;
+    if year < 1970
+        || day == 0
+        || day > days_in_month(year, month)
+        || hour > 23
+        || minute > 59
+        || second > 59
+    {
+        return None;
+    }
+    let years = year.checked_sub(1970)?;
+    let leap_days = leap_years_before(year).checked_sub(leap_years_before(1970))?;
+    let mut days = years.checked_mul(365)?.checked_add(leap_days)?;
+    for prior_month in 1..month {
+        days = days.checked_add(days_in_month(year, prior_month))?;
+    }
+    days = days.checked_add(day.checked_sub(1)?)?;
+    days.checked_mul(86_400)?
+        .checked_add(hour.checked_mul(3_600)?)?
+        .checked_add(minute.checked_mul(60)?)?
+        .checked_add(second)
+}
+
+fn decimal(bytes: &[u8]) -> Option<u64> {
+    bytes.iter().try_fold(0_u64, |value, byte| {
+        value
+            .checked_mul(10)?
+            .checked_add(u64::from(byte.checked_sub(b'0')?))
+            .filter(|_| byte.is_ascii_digit())
+    })
+}
+
+fn days_in_month(year: u64, month: u64) -> u64 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: u64) -> bool {
+    year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400))
+}
+
+fn leap_years_before(year: u64) -> u64 {
+    let prior = year.saturating_sub(1);
+    prior / 4 - prior / 100 + prior / 400
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_delta_seconds_and_imf_fixdate() {
+        assert_eq!(parse_value("75", 1_000), Some(Duration::from_secs(75)));
+        assert_eq!(
+            parse_value("Sun, 06 Nov 1994 08:49:37 GMT", 784_111_700),
+            Some(Duration::from_secs(77))
+        );
+    }
+
+    #[test]
+    fn past_date_is_an_immediate_hint_and_invalid_dates_are_ignored() {
+        assert_eq!(
+            parse_value("Sun, 06 Nov 1994 08:49:37 GMT", 784_111_777),
+            Some(Duration::ZERO)
+        );
+        assert_eq!(parse_value("Sun, 31 Feb 2026 08:49:37 GMT", 0), None);
+        assert_eq!(parse_value("not a date", 0), None);
+    }
+
+    #[test]
+    fn oversized_delta_seconds_saturate_instead_of_dropping_the_embargo() {
+        assert_eq!(
+            parse_value("999999999999999999999999999999999999", 0),
+            Some(Duration::from_secs(u64::MAX))
+        );
+    }
+}

--- a/src/terminal_runtime/runner.rs
+++ b/src/terminal_runtime/runner.rs
@@ -593,7 +593,7 @@ pub async fn run(
         station,
         romanization,
     } = persistent;
-    app.personal_state.ledger = personal_state;
+    app.personal_state.replace_ledger(personal_state);
     app.personal_state.device_id = personal_state_device_id;
     app.library = Arc::new(library);
     app.signals = Arc::new(signals);
@@ -923,6 +923,19 @@ pub async fn run(
         scrobble_handle,
         persist.clone(),
     );
+    let network_changes = crate::sync::NetworkChangeWatch::start();
+
+    let automatic_sync_active = !persistence_read_only
+        && app.personal_state.device_id.is_some()
+        && crate::sync::SyncPaths::current()
+            .ok()
+            .and_then(|paths| crate::sync::service::read_status(&paths).ok())
+            .is_some_and(|status| status.configured);
+    if automatic_sync_active {
+        for command in app.enable_automatic_sync() {
+            handles.dispatch(&mut app, command);
+        }
+    }
 
     if let Some(cmd) = app.take_beginner_startup_persist() {
         handles.dispatch(&mut app, cmd);
@@ -1089,6 +1102,7 @@ pub async fn run(
 
     enum OwnerTurnInput {
         Local(Msg),
+        NetworkReconnect,
         BufferedWorker(RuntimeEvent),
         Worker(RuntimeEvent),
     }
@@ -1122,6 +1136,10 @@ pub async fn run(
         // Mostly blocks until input or a worker message arrives. Outside text-entry fields,
         // a low-rate redraw scrubs IME preedit text that some terminals paint without
         // sending an input event to the app.
+        let waiting_for_connectivity = app.automatic_sync_waiting_for_connectivity();
+        if !waiting_for_connectivity && let Some(network_changes) = network_changes.as_ref() {
+            network_changes.park();
+        }
         let input = if let Some(pending) =
             pending_worker_events.pop_current(|event| handles.player_event_is_current(event))
         {
@@ -1136,6 +1154,9 @@ pub async fn run(
                     handles.begin_player_shutdown(&mut app);
                     break 'owner;
                 },
+                _ = crate::sync::NetworkChangeWatch::changed_or_pending(
+                    network_changes.as_ref()
+                ), if waiting_for_connectivity => OwnerTurnInput::NetworkReconnect,
                 _ = tokio::time::sleep_until(tokio::time::Instant::from_std(
                     media.retry_deadline().unwrap_or_else(Instant::now)
                 )), if media.retry_deadline().is_some() => {
@@ -1273,6 +1294,9 @@ pub async fn run(
                     perf.maybe_log(&app);
                     continue;
                 },
+                _ = tokio::time::sleep_until(tokio::time::Instant::from_std(
+                    app.automatic_sync_deadline().unwrap_or_else(Instant::now)
+                )), if app.automatic_sync_deadline().is_some() => OwnerTurnInput::Local(Msg::AutomaticSyncTick),
                 _ = status_tick.tick(), if app.status_visible() || app.lyrics.delay_osd_until.is_some() => OwnerTurnInput::Local(Msg::StatusTick),
                 _ = lyrics_tick.tick(), if app.lyrics_clock_active() => OwnerTurnInput::Local(Msg::LyricsTick),
                 _ = anim_tick.tick(), if app.animation_active() => OwnerTurnInput::Local(Msg::AnimTick),
@@ -1297,7 +1321,7 @@ pub async fn run(
             match input {
                 OwnerTurnInput::BufferedWorker(event) => pending_worker_events.push_front(event),
                 OwnerTurnInput::Worker(event) => pending_shutdown_events.push_back(event),
-                OwnerTurnInput::Local(_) => {}
+                OwnerTurnInput::Local(_) | OwnerTurnInput::NetworkReconnect => {}
             }
             handles.begin_player_shutdown(&mut app);
             break;
@@ -1305,6 +1329,12 @@ pub async fn run(
 
         let msg = match input {
             OwnerTurnInput::Local(msg) => msg,
+            OwnerTurnInput::NetworkReconnect => {
+                for command in app.note_webdav_connectivity() {
+                    handles.dispatch(&mut app, command);
+                }
+                continue;
+            }
             // Owner lane (docs/gui/02 §8/§14): session subscribe ops run here, between reducer
             // turns, and never become a Msg. Keeping it as RuntimeEvent through the shutdown
             // latch check preserves the correlated request if shutdown wins this turn.


### PR DESCRIPTION
## Summary

Implements PR 5 of the cross-device sync rollout in #114.

- add one shared owner-lane automatic sync scheduler for the TUI and daemon
- sync on startup, after a 30-second durable-mutation debounce, on a 15-minute fallback, and after a positive network transition
- coalesce triggers behind a single in-flight attempt with bounded exponential backoff, stable jitter, and preserved `Retry-After` lower bounds
- compact engagement history deterministically to the newest 365 days / 20,000 raw events without changing recommendation projections
- authenticate compaction leadership and per-device acknowledgements, require active-device quorum, retain three checkpoints, and perform conditional conservative GC
- reject stale detached work using live content generations and fail closed on revision or compaction counter exhaustion
- add bounded WebDAV DELETE/readback behavior and preserve server retry hints across ambiguous PUT/DELETE outcomes

## Why

Manual sync from PR 3 and the TUI flow from PR 4 left sync dependent on explicit user action and allowed engagement ledgers to grow indefinitely. This keeps the app local-first while making encrypted vault sync self-maintaining and ensuring offline devices cannot be skipped during compaction or garbage collection.

## User impact

Configured primary owners now synchronize automatically without blocking local search, playback, or shutdown. Offline failures retry quietly, server retry instructions are honored, and status notifications change only when the state changes. No device is revoked for inactivity and no plaintext state is introduced.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (4,176 passed, 1 ignored in the main lib suite; all workspace suites green)
- `~/.fable-harness/bin/run-gates .` (all root, vendored, architecture, file-size, docs, patch, and unsafe-inventory gates green)
- `cargo deny --all-features check advisories`
- `cargo deny check bans licenses sources`
- `cargo audit` (no new vulnerabilities; 12 existing allowed warnings)
- isolated tmux TUI verification at 80×24 and 30×30; Sync create/cancel left no credential or profile file
- release `ytt` size: 19,670,320 → 19,912,008 bytes (+241,688 / +1.229%); Cargo.lock unchanged and no new crate added

## Notes

- This PR does not touch release workflows, packaging, GUI, or tags.
- The ignored implementation plan remains local and is not part of the commit.