### PR TITLE
feat: add OpenSubsonic library and secure playback

### DIFF
--- a/gui/src/generated/protocol/SearchSource.ts
+++ b/gui/src/generated/protocol/SearchSource.ts
@@ -3,4 +3,4 @@
 /**
  * Search/playback source selected from the Search screen and persisted in config.
  */
-export type SearchSource = "youtube" | "sound_cloud" | "audius" | "jamendo" | "internet_archive" | "radio_browser" | "all";
+export type SearchSource = "youtube" | "sound_cloud" | "audius" | "jamendo" | "internet_archive" | "open_subsonic" | "radio_browser" | "all";

--- a/gui/src/views/SearchView.svelte
+++ b/gui/src/views/SearchView.svelte
@@ -23,8 +23,14 @@
     { id: 'internet_archive', label: 'Internet Archive' },
     { id: 'radio_browser', label: 'Radio Browser' },
   ]);
+  // The embedded GUI does not expose server setup until the GUI-parity milestone, but a daemon
+  // may already return a server group. Keep that source out of the selectable chips while still
+  // giving the result group a human label.
   const LABELS: Record<SearchSource, string> = $derived(
-    Object.fromEntries(SOURCES.map((s) => [s.id, s.label])) as Record<SearchSource, string>,
+    Object.fromEntries([
+      ...SOURCES.map((s) => [s.id, s.label]),
+      ['open_subsonic', 'Music server'],
+    ]) as Record<SearchSource, string>,
   );
 
   let query = $state('');
@@ -91,11 +97,13 @@
               {#each g.tracks as track (track.video_id)}
                 <TrackRow {track} ondblclick={() => search.play(track)}>
                   {#snippet actions()}
-                    <button
-                      class="enq"
-                      title={t('search.download')}
-                      onclick={() => downloads.download(track)}>⬇</button
-                    >
+                    {#if track.source !== 'open_subsonic'}
+                      <button
+                        class="enq"
+                        title={t('search.download')}
+                        onclick={() => downloads.download(track)}>⬇</button
+                      >
+                    {/if}
                     <button
                       class="enq"
                       title={t('search.addToQueue')}

--- a/gui/src/views/settings/GeneralTab.svelte
+++ b/gui/src/views/settings/GeneralTab.svelte
@@ -89,6 +89,9 @@
       onchange={(e) =>
         settings.apply('search', 'default_source', e.currentTarget.value as SearchSource)}
     >
+      {#if search?.default_source === 'open_subsonic'}
+        <option value="open_subsonic" selected disabled>Music server</option>
+      {/if}
       {#each SOURCES as [value, label] (value)}
         <option {value} selected={(search?.default_source ?? 'youtube') === value}>{label}</option>
       {/each}

--- a/scripts/app-fields.allow
+++ b/scripts/app-fields.allow
@@ -47,6 +47,7 @@ romanization
 runtime_tool_checks
 search
 search_filter
+server
 session
 settings
 should_quit

--- a/src/api/actor.rs
+++ b/src/api/actor.rs
@@ -11,14 +11,16 @@ use crate::streaming::{CandidateSource, StreamingMode};
 use crate::util::sanitize;
 
 use super::{
-    ApiCmd, ApiEvent, ApiHandle, ApiMode, ArtistIntent, GuiSearchGroup, PlaylistIntent, Song,
-    ytmusic,
+    ApiCmd, ApiEvent, ApiHandle, ApiMode, ArtistIntent, GuiSearchGroup, GuiSearchRequestId,
+    PlaylistIntent, Song, ytmusic,
 };
 
 const STREAMING_YTDLP_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 pub(super) const STREAMING_YTDLP_CACHE_MAX: usize = 512;
 const API_INTERACTIVE_QUEUE: usize = 256;
 const API_BULK_QUEUE: usize = 256;
+const API_SEARCH_RESULT_LIMIT: usize = 50;
+const ALL_SERVER_SEARCH_BUDGET: Duration = Duration::from_millis(1_500);
 
 /// Spawn the API actor, returning its handle immediately.
 ///
@@ -63,36 +65,201 @@ async fn gui_search_groups(
     source: SearchSource,
     config: &SearchConfig,
 ) -> Vec<GuiSearchGroup> {
-    let url_like = crate::media::parse_youtube_playlist_id(query).is_some()
-        || crate::media::parse_youtube_video_id(query).is_some();
-    let targets: Vec<SearchSource> = if source == SearchSource::All && !url_like {
+    let targets = gui_search_targets(query, source, config);
+    futures::future::join_all(targets.into_iter().map(|target| async move {
+        let result = if target == SearchSource::OpenSubsonic {
+            budget_server_search(search_open_subsonic(query, config))
+                .await
+                .0
+        } else {
+            search_one_interactive_source(api, query, target, config).await
+        };
+        match result {
+            Ok(songs) => GuiSearchGroup {
+                source: target,
+                songs,
+                error: None,
+            },
+            Err(error) => GuiSearchGroup {
+                source: target,
+                songs: Vec::new(),
+                error: Some(sanitize::sanitize_error_text(format!("{error:#}"))),
+            },
+        }
+    }))
+    .await
+}
+
+fn gui_search_targets(
+    query: &str,
+    source: SearchSource,
+    config: &SearchConfig,
+) -> Vec<SearchSource> {
+    if is_youtube_url_query(query) {
+        vec![SearchSource::Youtube]
+    } else if source == SearchSource::All {
         let enabled = config.enabled_sources();
         if enabled.is_empty() {
             vec![SearchSource::Youtube]
         } else {
             enabled
         }
-    } else if source == SearchSource::All {
-        vec![SearchSource::Youtube]
     } else {
         vec![source]
-    };
-    let mut groups = Vec::with_capacity(targets.len());
-    for target in targets {
-        match api.search_songs(query, target, config).await {
-            Ok(songs) => groups.push(GuiSearchGroup {
-                source: target,
-                songs,
-                error: None,
-            }),
-            Err(e) => groups.push(GuiSearchGroup {
-                source: target,
-                songs: Vec::new(),
-                error: Some(sanitize::sanitize_error_text(format!("{e:#}"))),
-            }),
+    }
+}
+
+async fn search_one_interactive_source(
+    api: &ytmusic::YtMusicApi,
+    query: &str,
+    source: SearchSource,
+    config: &SearchConfig,
+) -> anyhow::Result<Vec<Song>> {
+    if source == SearchSource::OpenSubsonic {
+        search_open_subsonic(query, config).await
+    } else {
+        api.search_songs(query, source, config).await
+    }
+}
+
+async fn search_interactive_reported(
+    api: &ytmusic::YtMusicApi,
+    query: &str,
+    source: SearchSource,
+    config: &SearchConfig,
+) -> anyhow::Result<(Vec<Song>, bool)> {
+    if is_youtube_url_query(query) {
+        return api.search_songs_reported(query, source, config).await;
+    }
+    match source {
+        SearchSource::OpenSubsonic => {
+            let (result, timed_out) =
+                budget_server_search(search_open_subsonic(query, config)).await;
+            Ok((result?, timed_out))
+        }
+        SearchSource::All => {
+            let public_enabled = !config.enabled_public_sources().is_empty();
+            let server_enabled = config.is_enabled(SearchSource::OpenSubsonic);
+            let public = async {
+                if public_enabled {
+                    Some(
+                        api.search_songs_reported(query, SearchSource::All, config)
+                            .await,
+                    )
+                } else {
+                    None
+                }
+            };
+            let server = async {
+                if server_enabled {
+                    Some(budget_server_search(search_open_subsonic(query, config)).await)
+                } else {
+                    None
+                }
+            };
+            let (public, server) = tokio::join!(public, server);
+            merge_all_search_results(public, server)
+        }
+        _ => api.search_songs_reported(query, source, config).await,
+    }
+}
+
+async fn search_open_subsonic(query: &str, config: &SearchConfig) -> anyhow::Result<Vec<Song>> {
+    if !config.is_enabled(SearchSource::OpenSubsonic) {
+        anyhow::bail!(
+            "{} is disabled in Settings → General",
+            SearchSource::OpenSubsonic.label()
+        );
+    }
+    let handle = crate::open_subsonic::current_handle()
+        .ok_or_else(|| anyhow::anyhow!("music server is off"))?;
+    handle
+        .search(query, API_SEARCH_RESULT_LIMIT as u32)
+        .await
+        .map(|songs| songs.into_iter().map(Song::from_open_subsonic).collect())
+        .map_err(|error| anyhow::anyhow!("{error}"))
+}
+
+async fn budget_server_search<F>(future: F) -> (anyhow::Result<Vec<Song>>, bool)
+where
+    F: std::future::Future<Output = anyhow::Result<Vec<Song>>>,
+{
+    match tokio::time::timeout(ALL_SERVER_SEARCH_BUDGET, future).await {
+        Ok(result) => (result, false),
+        Err(_) => (Err(anyhow::anyhow!("music server search timed out")), true),
+    }
+}
+
+fn merge_all_search_results(
+    public: Option<anyhow::Result<(Vec<Song>, bool)>>,
+    server: Option<(anyhow::Result<Vec<Song>>, bool)>,
+) -> anyhow::Result<(Vec<Song>, bool)> {
+    let mut public_songs = Vec::new();
+    let mut server_songs = Vec::new();
+    let mut errors = Vec::new();
+    let mut had_success = false;
+    let mut timed_out = false;
+
+    if let Some(result) = public {
+        match result {
+            Ok((incoming, public_timed_out)) => {
+                had_success = true;
+                timed_out = public_timed_out;
+                public_songs = incoming;
+            }
+            Err(error) => errors.push(sanitize::sanitize_error_text(format!("{error:#}"))),
         }
     }
-    groups
+    if let Some((result, server_timed_out)) = server {
+        timed_out |= server_timed_out;
+        match result {
+            Ok(incoming) => {
+                had_success = true;
+                server_songs = incoming;
+            }
+            Err(error) => errors.push(sanitize::sanitize_error_text(format!("{error:#}"))),
+        }
+    }
+    let songs = interleave_unique(public_songs, server_songs, API_SEARCH_RESULT_LIMIT);
+    if songs.is_empty() && !errors.is_empty() && !had_success {
+        anyhow::bail!("all enabled sources failed ({})", errors.join("; "));
+    }
+    for error in errors {
+        tracing::warn!(error = %error, "one search source failed; returning partial results");
+    }
+    Ok((songs, timed_out))
+}
+
+fn interleave_unique(public: Vec<Song>, server: Vec<Song>, limit: usize) -> Vec<Song> {
+    if limit == 0 {
+        return Vec::new();
+    }
+    let mut songs = Vec::with_capacity(limit.min(public.len().saturating_add(server.len())));
+    let mut seen = HashSet::new();
+    let mut public = public.into_iter();
+    let mut server = server.into_iter();
+    loop {
+        let mut advanced = false;
+        for next in [&mut public, &mut server] {
+            if let Some(song) = next.next() {
+                advanced = true;
+                if seen.insert(song.video_id.clone()) {
+                    songs.push(song);
+                    if songs.len() >= limit {
+                        return songs;
+                    }
+                }
+            }
+        }
+        if !advanced {
+            return songs;
+        }
+    }
+}
+
+fn is_youtube_url_query(query: &str) -> bool {
+    crate::media::parse_youtube_playlist_id(query).is_some()
+        || crate::media::parse_youtube_video_id(query).is_some()
 }
 
 async fn init_api(cookie: Option<String>) -> (ytmusic::YtMusicApi, ApiMode) {
@@ -109,6 +276,68 @@ async fn init_api(cookie: Option<String>) -> (ytmusic::YtMusicApi, ApiMode) {
     (api, mode)
 }
 
+async fn interactive_search_event(
+    api: &ytmusic::YtMusicApi,
+    request_id: u64,
+    query: String,
+    source: SearchSource,
+    config: SearchConfig,
+) -> ApiEvent {
+    match search_interactive_reported(api, &query, source, &config).await {
+        Ok((songs, timed_out)) => {
+            let query_log = crate::util::query::query_log_preview(&query);
+            tracing::info!(
+                count = songs.len(),
+                query_bytes = query_log.bytes,
+                query_chars = query_log.chars,
+                query_preview = %query_log.preview,
+                query_truncated = query_log.truncated,
+                source = %source.code(),
+                timed_out,
+                "search results"
+            );
+            ApiEvent::SearchResults {
+                request_id,
+                query,
+                source,
+                songs,
+                timed_out,
+            }
+        }
+        Err(error) => {
+            let error = sanitize::sanitize_error_text(format!("{error:#}"));
+            tracing::warn!(source = %source.code(), error = %error, "search failed");
+            ApiEvent::SearchError {
+                request_id,
+                source,
+                error,
+            }
+        }
+    }
+}
+
+async fn gui_search_event(
+    api: &ytmusic::YtMusicApi,
+    request_id: GuiSearchRequestId,
+    query: String,
+    source: SearchSource,
+    config: SearchConfig,
+) -> ApiEvent {
+    let groups = gui_search_groups(api, &query, source, &config).await;
+    let query_log = crate::util::query::query_log_preview(&query);
+    tracing::info!(
+        request_id = ?request_id,
+        query_bytes = query_log.bytes,
+        query_chars = query_log.chars,
+        query_preview = %query_log.preview,
+        query_truncated = query_log.truncated,
+        source = %source.code(),
+        groups = groups.len(),
+        "gui search completed"
+    );
+    ApiEvent::GuiSearchCompleted { request_id, groups }
+}
+
 async fn run_interactive_actor<F>(
     api: Arc<ytmusic::YtMusicApi>,
     mut rx: Receiver<ApiCmd>,
@@ -116,6 +345,7 @@ async fn run_interactive_actor<F>(
 ) where
     F: Fn(ApiEvent) + Send + Sync + 'static,
 {
+    let mut dedicated_server_search: Option<tokio::task::JoinHandle<()>> = None;
     while let Some(cmd) = rx.recv().await {
         match cmd {
             ApiCmd::Search {
@@ -124,38 +354,20 @@ async fn run_interactive_actor<F>(
                 source,
                 config,
             } => {
-                let event = match api.search_songs_reported(&query, source, &config).await {
-                    Ok((songs, timed_out)) => {
-                        let query_log = crate::util::query::query_log_preview(&query);
-                        tracing::info!(
-                            count = songs.len(),
-                            query_bytes = query_log.bytes,
-                            query_chars = query_log.chars,
-                            query_preview = %query_log.preview,
-                            query_truncated = query_log.truncated,
-                            source = %source.code(),
-                            timed_out,
-                            "search results"
+                if source == SearchSource::OpenSubsonic {
+                    if let Some(task) = dedicated_server_search.take() {
+                        task.abort();
+                    }
+                    let api = Arc::clone(&api);
+                    let emit = Arc::clone(&emit);
+                    dedicated_server_search = Some(tokio::spawn(async move {
+                        emit(
+                            interactive_search_event(&api, request_id, query, source, config).await,
                         );
-                        ApiEvent::SearchResults {
-                            request_id,
-                            query,
-                            source,
-                            songs,
-                            timed_out,
-                        }
-                    }
-                    Err(e) => {
-                        let error = sanitize::sanitize_error_text(format!("{e:#}"));
-                        tracing::warn!(source = %source.code(), error = %error, "search failed");
-                        ApiEvent::SearchError {
-                            request_id,
-                            source,
-                            error,
-                        }
-                    }
-                };
-                emit(event);
+                    }));
+                } else {
+                    emit(interactive_search_event(&api, request_id, query, source, config).await);
+                }
             }
             ApiCmd::GuiSearch {
                 request_id,
@@ -163,19 +375,18 @@ async fn run_interactive_actor<F>(
                 source,
                 config,
             } => {
-                let groups = gui_search_groups(&api, &query, source, &config).await;
-                let query_log = crate::util::query::query_log_preview(&query);
-                tracing::info!(
-                    request_id = ?request_id,
-                    query_bytes = query_log.bytes,
-                    query_chars = query_log.chars,
-                    query_preview = %query_log.preview,
-                    query_truncated = query_log.truncated,
-                    source = %source.code(),
-                    groups = groups.len(),
-                    "gui search completed"
-                );
-                emit(ApiEvent::GuiSearchCompleted { request_id, groups });
+                if source == SearchSource::OpenSubsonic {
+                    if let Some(task) = dedicated_server_search.take() {
+                        task.abort();
+                    }
+                    let api = Arc::clone(&api);
+                    let emit = Arc::clone(&emit);
+                    dedicated_server_search = Some(tokio::spawn(async move {
+                        emit(gui_search_event(&api, request_id, query, source, config).await);
+                    }));
+                } else {
+                    emit(gui_search_event(&api, request_id, query, source, config).await);
+                }
             }
             ApiCmd::ResolveTrack { seq, query, config } => {
                 // The same innertube→yt-dlp search as the Search screen, but the answer
@@ -276,6 +487,9 @@ async fn run_interactive_actor<F>(
                 );
             }
         }
+    }
+    if let Some(task) = dedicated_server_search {
+        task.abort();
     }
 }
 
@@ -602,5 +816,105 @@ pub(super) fn enforce_streaming_cache_cap(
             return;
         };
         cache.remove(&oldest);
+    }
+}
+
+#[cfg(test)]
+mod open_subsonic_search_tests {
+    use super::*;
+
+    fn song(id: &str) -> Song {
+        Song::remote(id, format!("Song {id}"), "Artist", "3:00")
+    }
+
+    #[test]
+    fn all_search_keeps_public_results_when_server_is_offline() {
+        let result = merge_all_search_results(
+            Some(Ok((vec![song("public")], false))),
+            Some((Err(anyhow::anyhow!("music server is offline")), false)),
+        )
+        .unwrap();
+        assert_eq!(result.0.len(), 1);
+        assert_eq!(result.0[0].video_id, "public");
+        assert!(!result.1);
+    }
+
+    #[test]
+    fn all_search_keeps_server_results_when_public_sources_fail() {
+        let result = merge_all_search_results(
+            Some(Err(anyhow::anyhow!("public source failed"))),
+            Some((Ok(vec![song("server")]), false)),
+        )
+        .unwrap();
+        assert_eq!(result.0[0].video_id, "server");
+    }
+
+    #[test]
+    fn all_search_deduplicates_and_only_fails_when_every_source_fails() {
+        let result = merge_all_search_results(
+            Some(Ok((vec![song("same")], true))),
+            Some((Ok(vec![song("same"), song("other")]), false)),
+        )
+        .unwrap();
+        assert_eq!(
+            result
+                .0
+                .iter()
+                .map(|song| song.video_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["same", "other"]
+        );
+        assert!(result.1);
+        assert!(
+            merge_all_search_results(
+                Some(Err(anyhow::anyhow!("public failed"))),
+                Some((Err(anyhow::anyhow!("server failed")), false)),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn all_search_fairly_includes_server_rows_when_public_hits_the_limit() {
+        let public = (0..API_SEARCH_RESULT_LIMIT)
+            .map(|index| song(&format!("public-{index}")))
+            .collect();
+        let result = merge_all_search_results(
+            Some(Ok((public, false))),
+            Some((Ok(vec![song("server-only")]), false)),
+        )
+        .unwrap();
+        assert_eq!(result.0.len(), API_SEARCH_RESULT_LIMIT);
+        assert!(result.0.iter().any(|song| song.video_id == "server-only"));
+        assert_eq!(result.0[0].video_id, "public-0");
+        assert_eq!(result.0[1].video_id, "server-only");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn all_search_server_branch_has_an_independent_latency_budget() {
+        let task = tokio::spawn(budget_server_search(std::future::pending::<
+            anyhow::Result<Vec<Song>>,
+        >()));
+        tokio::time::advance(ALL_SERVER_SEARCH_BUDGET).await;
+        let (result, timed_out) = task.await.unwrap();
+        assert!(result.is_err());
+        assert!(timed_out);
+    }
+
+    #[test]
+    fn youtube_urls_short_circuit_every_gui_source_selection() {
+        let mut config = SearchConfig::default();
+        config.set_enabled(SearchSource::OpenSubsonic, true);
+        assert_eq!(
+            gui_search_targets(
+                "https://youtu.be/dQw4w9WgXcQ",
+                SearchSource::OpenSubsonic,
+                &config,
+            ),
+            vec![SearchSource::Youtube]
+        );
+        let all = gui_search_targets("ordinary query", SearchSource::All, &config);
+        assert!(all.contains(&SearchSource::Youtube));
+        assert!(all.contains(&SearchSource::OpenSubsonic));
     }
 }

--- a/src/api/domain.rs
+++ b/src/api/domain.rs
@@ -4,7 +4,10 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::playback_target::{PlayableUrlError, validate_playable_url};
+pub use crate::open_subsonic::OpenSubsonicItemRef;
+use crate::playback_target::{
+    CredentialedPlaybackRef, PlayableUrlError, PlaybackDestination, validate_playable_url,
+};
 use crate::search_source::SearchSource;
 
 /// Marker prefix for *playlist* rows in search results — their `video_id` is
@@ -236,6 +239,13 @@ pub enum PlayableRef {
         file: String,
         url: String,
     },
+    /// Exact server/account/item identity. Upstream URLs and credentials deliberately stay in
+    /// the OpenSubsonic owner; playback must first mint a short-lived loopback proxy route.
+    OpenSubsonic {
+        item: OpenSubsonicItemRef,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cover_art_id: Option<crate::open_subsonic::CoverArtId>,
+    },
     RadioStream {
         url: String,
     },
@@ -312,10 +322,12 @@ impl Song {
         let title = title.into();
         let artist = artist.into();
         let duration = duration.into();
-        let video_id = if source == SearchSource::Youtube {
-            source_id.clone()
-        } else {
-            format!("{}:{source_id}", source.id_prefix())
+        let video_id = match (&source, &playable) {
+            (SearchSource::Youtube, _) => source_id.clone(),
+            (SearchSource::OpenSubsonic, PlayableRef::OpenSubsonic { item, .. }) => {
+                item.stable_track_id()
+            }
+            _ => format!("{}:{source_id}", source.id_prefix()),
         };
         Self {
             video_id,
@@ -345,6 +357,37 @@ impl Song {
             local_path: None,
             yt_video_id: None,
         }
+    }
+
+    /// Convert one sanitized OpenSubsonic catalog row into the common playable song model.
+    ///
+    /// The opaque `(backend, account, item)` tuple remains the identity and playback target;
+    /// no authenticated upstream URL is materialized in UI state or handed directly to mpv.
+    pub fn from_open_subsonic(server: crate::open_subsonic::ServerSong) -> Self {
+        let duration = server.duration_secs.map_or_else(String::new, |seconds| {
+            let minutes = seconds / 60;
+            let remainder = seconds % 60;
+            format!("{minutes}:{remainder:02}")
+        });
+        let item = server.item.clone();
+        let cover_art_id = server.cover_art_id.clone();
+        let source_id = item.stable_track_id();
+        let mut song = Self::from_source(
+            SearchSource::OpenSubsonic,
+            source_id,
+            server.title,
+            server.artist,
+            duration,
+            PlayableRef::OpenSubsonic { item, cover_art_id },
+        );
+        song.artists = sanitize_metadata_vec(server.artists, MAX_ARTIST_CHARS);
+        song.album = sanitize_optional_metadata(server.album, MAX_ALBUM_CHARS);
+        song.album_artist = sanitize_optional_metadata(server.album_artist, MAX_ARTIST_CHARS);
+        song.album_artists = song.album_artist.iter().cloned().collect();
+        song.disc_number = server.disc_number.filter(|number| *number > 0);
+        song.track_number = server.track_number.filter(|number| *number > 0);
+        song.duration_secs = server.duration_secs;
+        song
     }
 
     /// Build a locally playable track from a file path. Rich metadata parsing is intentionally
@@ -568,12 +611,44 @@ impl Song {
             .unwrap_or_else(|| self.watch_url_checked())
     }
 
+    /// A player-ready direct target or an exact credentialed reference for the owner to resolve.
+    ///
+    /// OpenSubsonic credentials and upstream URLs never enter [`Song`]. The playback owner turns
+    /// this exact reference into a short-lived loopback route before using the ordinary direct
+    /// handoff path.
+    pub fn playback_destination_checked(&self) -> Result<PlaybackDestination, PlayableUrlError> {
+        if let Some(path) = &self.local_path {
+            return Ok(PlaybackDestination::Direct(
+                path.to_string_lossy().into_owned(),
+            ));
+        }
+        match &self.playable {
+            Some(PlayableRef::OpenSubsonic { item, .. }) => Ok(PlaybackDestination::Credentialed(
+                CredentialedPlaybackRef::OpenSubsonic {
+                    backend_id: item.backend_id().as_str().to_owned(),
+                    account_scope_id: item.account_scope_id().as_str().to_owned(),
+                    item_id: item.item_id().as_str().to_owned(),
+                },
+            )),
+            _ => self
+                .playback_target_checked()
+                .map(PlaybackDestination::Direct),
+        }
+    }
+
     /// A URL mpv/yt-dlp can resolve and play for catalog tracks.
     pub fn watch_url(&self) -> String {
         self.watch_url_checked().unwrap_or_default()
     }
 
     pub fn watch_url_checked(&self) -> Result<String, PlayableUrlError> {
+        if self.source == SearchSource::OpenSubsonic
+            && !matches!(&self.playable, Some(PlayableRef::OpenSubsonic { .. }))
+        {
+            return Err(PlayableUrlError::Invalid(
+                "OpenSubsonic track is missing its exact server identity".to_owned(),
+            ));
+        }
         match &self.playable {
             Some(PlayableRef::YoutubeVideo { id }) if !is_definitely_non_video_youtube_ref(id) => {
                 validate_playable_url(
@@ -593,6 +668,9 @@ impl Song {
             Some(PlayableRef::ArchiveFile { url, .. }) => {
                 validate_playable_url(SearchSource::InternetArchive, url)
             }
+            Some(PlayableRef::OpenSubsonic { .. }) => Err(PlayableUrlError::Invalid(
+                "OpenSubsonic playback requires the local proxy".to_owned(),
+            )),
             Some(PlayableRef::RadioStream { url }) => {
                 validate_playable_url(SearchSource::RadioBrowser, url)
             }
@@ -620,6 +698,7 @@ impl Song {
             Some(PlayableRef::DirectUrl { .. })
             | Some(PlayableRef::JamendoTrackId { .. })
             | Some(PlayableRef::ArchiveFile { .. })
+            | Some(PlayableRef::OpenSubsonic { .. })
             | Some(PlayableRef::RadioStream { .. }) => None,
             Some(PlayableRef::YoutubeVideo { .. })
             | Some(PlayableRef::YtdlpUrl { .. })

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18,9 +18,10 @@ pub use crate::playback_target::{
 pub use actor::spawn;
 pub use domain::{
     ARTIST_ID_PREFIX, ArtistPage, MAX_ALBUM_CHARS, MAX_ARTIST_CHARS, MAX_DURATION_CHARS,
-    MAX_ORIGIN_URL_CHARS, MAX_PROVIDER_ID_CHARS, MAX_TITLE_CHARS, PLAYLIST_ID_PREFIX, PlayableRef,
-    Song, SongImportMetadata, is_youtube_video_id, sanitize_album, sanitize_artist,
-    sanitize_duration, sanitize_metadata_text, sanitize_provider_id, sanitize_title,
+    MAX_ORIGIN_URL_CHARS, MAX_PROVIDER_ID_CHARS, MAX_TITLE_CHARS, OpenSubsonicItemRef,
+    PLAYLIST_ID_PREFIX, PlayableRef, Song, SongImportMetadata, is_youtube_video_id, sanitize_album,
+    sanitize_artist, sanitize_duration, sanitize_metadata_text, sanitize_provider_id,
+    sanitize_title,
 };
 pub(crate) use gui_search::gui_search_row_id;
 pub use gui_search::{GUI_SEARCH_ROW_ID_MAX_BYTES, GuiSearchGroup, GuiSearchRequestId};

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -149,6 +149,80 @@ fn playable_refs_cover_watch_prefetch_and_share_edges() {
 }
 
 #[test]
+fn open_subsonic_refs_keep_exact_identity_without_exposing_an_upstream_url() {
+    use crate::open_subsonic::{AccountScopeId, BackendId, ItemId};
+
+    let item = OpenSubsonicItemRef::new(
+        BackendId::new("backend-a").unwrap(),
+        AccountScopeId::new("account-a").unwrap(),
+        ItemId::new("song-1").unwrap(),
+    );
+    let song = Song::from_source(
+        SearchSource::OpenSubsonic,
+        "ignored-raw-item-id",
+        "Server song",
+        "Server artist",
+        "3:00",
+        PlayableRef::OpenSubsonic {
+            item: item.clone(),
+            cover_art_id: None,
+        },
+    );
+
+    assert_eq!(song.source, SearchSource::OpenSubsonic);
+    assert_eq!(song.video_id, item.stable_track_id());
+    assert_eq!(
+        song.playable,
+        Some(PlayableRef::OpenSubsonic {
+            item: item.clone(),
+            cover_art_id: None,
+        })
+    );
+    assert!(matches!(
+        song.watch_url_checked(),
+        Err(PlayableUrlError::Invalid(message))
+            if message == "OpenSubsonic playback requires the local proxy"
+    ));
+    assert_eq!(
+        song.playback_destination_checked().unwrap(),
+        crate::playback_target::PlaybackDestination::Credentialed(
+            crate::playback_target::CredentialedPlaybackRef::OpenSubsonic {
+                backend_id: "backend-a".to_owned(),
+                account_scope_id: "account-a".to_owned(),
+                item_id: "song-1".to_owned(),
+            }
+        )
+    );
+    assert_eq!(song.watch_url(), "");
+    assert_eq!(song.playback_target(), "");
+    assert!(song.prefetch_target().is_none());
+    assert!(song.youtube_id().is_none());
+    assert!(song.share_url().is_none());
+
+    let encoded = serde_json::to_string(&song.playable).unwrap();
+    assert!(encoded.contains("\"backend_id\":\"backend-a\""));
+    assert!(encoded.contains("\"account_scope_id\":\"account-a\""));
+    assert!(encoded.contains("\"item_id\":\"song-1\""));
+    assert!(!encoded.contains("http"));
+    assert!(!encoded.contains("password"));
+    let decoded: Option<PlayableRef> = serde_json::from_str(&encoded).unwrap();
+    assert_eq!(decoded, song.playable);
+
+    let other_backend = OpenSubsonicItemRef::new(
+        BackendId::new("backend-b").unwrap(),
+        AccountScopeId::new("account-a").unwrap(),
+        ItemId::new("song-1").unwrap(),
+    );
+    let other_account = OpenSubsonicItemRef::new(
+        BackendId::new("backend-a").unwrap(),
+        AccountScopeId::new("account-b").unwrap(),
+        ItemId::new("song-1").unwrap(),
+    );
+    assert_ne!(song.video_id, other_backend.stable_track_id());
+    assert_ne!(song.video_id, other_account.stable_track_id());
+}
+
+#[test]
 fn song_constructors_sanitize_display_metadata() {
     let bidi = '\u{202e}';
     let song = Song::from_search(

--- a/src/api/ytmusic.rs
+++ b/src/api/ytmusic.rs
@@ -22,6 +22,7 @@ use crate::util::{format, http, sanitize};
 
 mod artist;
 mod official_video_search;
+mod provider_search;
 mod search_fallback;
 mod transfer_api;
 mod video_metadata;
@@ -425,7 +426,8 @@ impl YtMusicApi {
         let mut seen = HashSet::new();
         let mut errors = Vec::new();
         let mut timed_out = false;
-        for source in config.enabled_sources() {
+        let enabled_sources = config.enabled_public_sources();
+        for (index, source) in enabled_sources.iter().copied().enumerate() {
             // Check the operation budget *before* starting each source (each source already has
             // its own per-request network timeout, so total time is bounded by this deadline
             // plus at most one source's timeout — without paying `sources × timeout`). Checking
@@ -433,7 +435,7 @@ impl YtMusicApi {
             if std::time::Instant::now() >= deadline {
                 timed_out = true;
                 tracing::warn!(
-                    remaining = config.enabled_sources().len() - errors.len(),
+                    remaining = enabled_sources.len().saturating_sub(index),
                     "search hit the operation deadline; returning partial results"
                 );
                 break;
@@ -486,6 +488,9 @@ impl YtMusicApi {
             SearchSource::Audius => audius_search(query, config, SEARCH_RESULT_LIMIT).await,
             SearchSource::Jamendo => jamendo_search(query, config, SEARCH_RESULT_LIMIT).await,
             SearchSource::InternetArchive => archive_search(query, SEARCH_RESULT_LIMIT).await,
+            SearchSource::OpenSubsonic => {
+                bail!("music server search is handled by the OpenSubsonic actor")
+            }
             SearchSource::RadioBrowser => radio_browser_search(query, SEARCH_RESULT_LIMIT).await,
             SearchSource::All => bail!("internal error: nested ALL source search"),
         }
@@ -563,26 +568,6 @@ impl YtMusicApi {
 /// way (public YouTube, no auth) — hence `pub(crate)` and a caller-chosen `limit`.
 pub(crate) async fn ytdlp_search(query: &str, limit: usize) -> Result<Vec<Song>> {
     ytdlp_flat_search(SearchSource::Youtube, "ytsearch", query, limit).await
-}
-
-async fn search_external_source(
-    source: SearchSource,
-    query: &str,
-    config: &SearchConfig,
-    limit: usize,
-) -> Result<Vec<Song>> {
-    match source {
-        SearchSource::SoundCloud => {
-            ytdlp_flat_search(SearchSource::SoundCloud, "scsearch", query, limit).await
-        }
-        SearchSource::Audius => audius_search(query, config, limit).await,
-        SearchSource::Jamendo => jamendo_search(query, config, limit).await,
-        SearchSource::InternetArchive => archive_search(query, limit).await,
-        SearchSource::Youtube => ytdlp_search(query, limit).await,
-        SearchSource::RadioBrowser | SearchSource::All => {
-            bail!("{} is not a track recommendation source", source.label())
-        }
-    }
 }
 
 async fn ytdlp_flat_search(
@@ -698,7 +683,7 @@ pub(crate) async fn related_tracks_from_source(
 
             for query in streaming_queries(seed, mode) {
                 let search_limit = (limit * 2).clamp(limit, 50);
-                match search_external_source(source, &query, config, search_limit).await {
+                match provider_search::search(source, &query, config, search_limit).await {
                     Ok(songs) => {
                         had_success = true;
                         for song in songs {
@@ -723,6 +708,9 @@ pub(crate) async fn related_tracks_from_source(
         }
         SearchSource::RadioBrowser => {
             bail!("Radio Browser streams are not used for track recommendations")
+        }
+        SearchSource::OpenSubsonic => {
+            bail!("Music server is not used for automatic recommendations")
         }
         SearchSource::All => bail!("internal error: nested ALL streaming source search"),
     }

--- a/src/api/ytmusic/provider_search.rs
+++ b/src/api/ytmusic/provider_search.rs
@@ -1,0 +1,24 @@
+use anyhow::{Result, bail};
+
+use super::{Song, archive_search, audius_search, jamendo_search, ytdlp_flat_search, ytdlp_search};
+use crate::search_source::{SearchConfig, SearchSource};
+
+pub(super) async fn search(
+    source: SearchSource,
+    query: &str,
+    config: &SearchConfig,
+    limit: usize,
+) -> Result<Vec<Song>> {
+    match source {
+        SearchSource::SoundCloud => {
+            ytdlp_flat_search(SearchSource::SoundCloud, "scsearch", query, limit).await
+        }
+        SearchSource::Audius => audius_search(query, config, limit).await,
+        SearchSource::Jamendo => jamendo_search(query, config, limit).await,
+        SearchSource::InternetArchive => archive_search(query, limit).await,
+        SearchSource::Youtube => ytdlp_search(query, limit).await,
+        SearchSource::OpenSubsonic | SearchSource::RadioBrowser | SearchSource::All => {
+            bail!("{} is not a track recommendation source", source.label())
+        }
+    }
+}

--- a/src/api/ytmusic/tests.rs
+++ b/src/api/ytmusic/tests.rs
@@ -281,6 +281,30 @@ async fn disabled_sources_and_non_track_recommendation_sources_fail_before_netwo
     .to_string();
     assert!(err.contains("Radio Browser streams are not used"));
 
+    let server_cfg = SearchConfig {
+        open_subsonic: true,
+        ..SearchConfig::default()
+    };
+    let err = YtMusicApi::Anonymous
+        .search_one_source("artist", SearchSource::OpenSubsonic, &server_cfg)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("handled by the OpenSubsonic actor"));
+
+    let err = related_tracks_from_source(
+        "Song - Artist",
+        SearchSource::OpenSubsonic,
+        &server_cfg,
+        5,
+        &excluded,
+        StreamingMode::Balanced,
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("not used for automatic recommendations"));
+
     let err = related_tracks_from_source(
         "Song - Artist",
         SearchSource::All,
@@ -298,19 +322,27 @@ async fn disabled_sources_and_non_track_recommendation_sources_fail_before_netwo
 #[tokio::test]
 async fn provider_source_helpers_reject_unusable_config_without_provider_calls() {
     let cfg = SearchConfig::default();
-    let err = search_external_source(SearchSource::RadioBrowser, "q", &cfg, 5)
+    let err = provider_search::search(SearchSource::RadioBrowser, "q", &cfg, 5)
         .await
         .unwrap_err()
         .to_string();
     assert!(err.contains("not a track recommendation source"));
 
-    let err = search_external_source(SearchSource::All, "q", &cfg, 5)
+    let err = provider_search::search(SearchSource::All, "q", &cfg, 5)
         .await
         .unwrap_err()
         .to_string();
     assert!(err.contains("not a track recommendation source"));
 
-    let err = search_external_source(SearchSource::Jamendo, "q", &cfg, 5)
+    let mut server_cfg = cfg.clone();
+    server_cfg.open_subsonic = true;
+    let err = provider_search::search(SearchSource::OpenSubsonic, "q", &server_cfg, 5)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("not a track recommendation source"));
+
+    let err = provider_search::search(SearchSource::Jamendo, "q", &cfg, 5)
         .await
         .unwrap_err()
         .to_string();

--- a/src/app/artwork.rs
+++ b/src/app/artwork.rs
@@ -866,12 +866,23 @@ impl App {
         {
             return None;
         }
-        Some(match &song.local_path {
-            Some(path) => ArtSource::Local(path.clone()),
-            None => ArtSource::Remote {
-                video_id: song.youtube_id()?.to_owned(),
+        if let Some(path) = &song.local_path {
+            return Some(ArtSource::Local(path.clone()));
+        }
+        if let Some(crate::api::PlayableRef::OpenSubsonic {
+            item,
+            cover_art_id: Some(cover_art_id),
+        }) = &song.playable
+        {
+            return Some(ArtSource::OpenSubsonic {
+                item: item.clone(),
+                cover_art_id: cover_art_id.clone(),
                 quality: self.config.album_art_quality,
-            },
+            });
+        }
+        Some(ArtSource::Remote {
+            video_id: song.youtube_id()?.to_owned(),
+            quality: self.config.album_art_quality,
         })
     }
 

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -100,6 +100,7 @@ impl App {
             signals: Arc::new(Signals::default()),
             session: Session::default(),
             library_ui: LibraryView::default(),
+            server: ServerUiState::default(),
             library_rows_cache: RefCell::new(None),
             all_count_cache: Cell::new(None),
             yid_scan_memo: RefCell::new(None),
@@ -212,6 +213,7 @@ impl App {
             search.audius = false;
             search.jamendo = false;
             search.internet_archive = false;
+            search.open_subsonic = false;
             search.radio_browser = true;
             search.source = SearchSource::RadioBrowser;
         } else {

--- a/src/app/context_menu.rs
+++ b/src/app/context_menu.rs
@@ -63,6 +63,11 @@ enum ContextTarget {
         index: usize,
         playlist_id: String,
     },
+    ServerLibrary {
+        generation: u64,
+        index: usize,
+        identity: ServerLibraryRowIdentity,
+    },
     Queue {
         lo: usize,
         hi: usize,
@@ -83,11 +88,27 @@ enum ContextTarget {
     },
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ServerLibraryRowIdentity {
+    Song(crate::open_subsonic::OpenSubsonicItemRef),
+    Album(crate::open_subsonic::AlbumId),
+    Artist(crate::open_subsonic::ArtistId),
+    Playlist(crate::open_subsonic::ServerPlaylistId),
+}
+
+impl ServerLibraryRowIdentity {
+    const fn is_song(&self) -> bool {
+        matches!(self, Self::Song(_))
+    }
+}
+
 impl ContextTarget {
     const fn mouse_context(&self) -> MouseContext {
         match self {
             Self::Search { .. } => MouseContext::Search,
-            Self::LibrarySongs { .. } | Self::LibraryPlaylist { .. } => MouseContext::Library,
+            Self::LibrarySongs { .. }
+            | Self::LibraryPlaylist { .. }
+            | Self::ServerLibrary { .. } => MouseContext::Library,
             Self::Queue { .. } => MouseContext::Queue,
             Self::Local { .. } | Self::LocalFind { .. } => MouseContext::Local,
         }
@@ -207,7 +228,10 @@ impl ContextTarget {
             Self::LibrarySongs { video_ids, .. }
             | Self::Queue { video_ids, .. }
             | Self::Search { video_ids, .. } => video_ids.len(),
-            _ => 1,
+            Self::ServerLibrary { .. }
+            | Self::LibraryPlaylist { .. }
+            | Self::Local { .. }
+            | Self::LocalFind { .. } => 1,
         }
     }
 }
@@ -217,6 +241,7 @@ impl App {
     /// excluded: their semantic rows are valid context-menu targets.
     fn context_menu_blocked(&self) -> bool {
         self.personal_state.sync_ui.modal_open()
+            || self.server.settings.modal_open()
             || self.overlays.help_visible
             || self.overlays.mouse_help_visible
             || self.overlays.about_visible
@@ -356,6 +381,12 @@ impl App {
                 Mode::Library if self.local_dedicated_mode => {
                     MouseTarget::LocalRow(self.local_mode.ui.selected)
                 }
+                Mode::Library if self.server.library.source == LibrarySource::OpenSubsonic => {
+                    MouseTarget::ServerLibraryRow {
+                        generation: self.server.library.generation,
+                        index: self.server.library.selected,
+                    }
+                }
                 Mode::Library => MouseTarget::ListRow(self.library_ui.selected),
                 _ => return Vec::new(),
             }
@@ -448,6 +479,38 @@ impl App {
             menu.selected.saturating_add(1).min(last)
         };
         self.dirty = true;
+    }
+
+    fn server_library_context_identity(&self, index: usize) -> Option<ServerLibraryRowIdentity> {
+        use crate::open_subsonic::ServerLibraryDetail as Detail;
+        use crate::open_subsonic::ServerLibraryRow as Row;
+
+        match self.server.library.detail.as_ref() {
+            Some(Detail::AlbumSongs { songs, .. }) => songs
+                .get(index)
+                .map(|song| ServerLibraryRowIdentity::Song(song.item.clone())),
+            Some(Detail::ArtistAlbums { albums, .. }) => albums
+                .get(index)
+                .map(|album| ServerLibraryRowIdentity::Album(album.id.clone())),
+            Some(Detail::PlaylistEntries(playlist)) => playlist
+                .entries
+                .get(index)
+                .map(|song| ServerLibraryRowIdentity::Song(song.item.clone())),
+            None => self
+                .server
+                .library
+                .page
+                .as_ref()
+                .and_then(|page| page.rows.get(index))
+                .map(|row| match row {
+                    Row::Song(song) => ServerLibraryRowIdentity::Song(song.item.clone()),
+                    Row::Album(album) => ServerLibraryRowIdentity::Album(album.id.clone()),
+                    Row::Artist(artist) => ServerLibraryRowIdentity::Artist(artist.id.clone()),
+                    Row::Playlist(playlist) => {
+                        ServerLibraryRowIdentity::Playlist(playlist.id.clone())
+                    }
+                }),
+        }
     }
 
     fn context_target_at(&mut self, col: u16, row: u16) -> Option<ContextTarget> {
@@ -587,6 +650,20 @@ impl App {
                     download_ids,
                 })
             }
+            Mode::Library if self.server.library.source == LibrarySource::OpenSubsonic => {
+                let MouseTarget::ServerLibraryRow { generation, index } = target else {
+                    return None;
+                };
+                if generation != self.server.library.generation {
+                    return None;
+                }
+                let identity = self.server_library_context_identity(index)?;
+                Some(ContextTarget::ServerLibrary {
+                    generation,
+                    index,
+                    identity,
+                })
+            }
             Mode::Library => {
                 let index = match target {
                     MouseTarget::ListRow(index) | MouseTarget::LibraryDel(index) => index,
@@ -670,6 +747,9 @@ impl App {
                 self.library_ui.selected = *index;
                 self.library_ui.anchor = *index;
             }
+            ContextTarget::ServerLibrary {
+                generation, index, ..
+            } => self.select_server_library_row(*generation, *index),
             ContextTarget::Queue { lo, hi, .. } => {
                 let current_lo = self.queue_popup.cursor.min(self.queue_popup.anchor);
                 let current_hi = self.queue_popup.cursor.max(self.queue_popup.anchor);
@@ -715,7 +795,15 @@ impl App {
             // A multi-selection only ever holds song rows (playlist rows keep their
             // dedicated single-row menu), so the bulk commands apply directly.
             ContextTarget::Search { rows, .. } if rows.len() > 1 => {
-                vec![C::PlayNow, C::Enqueue, C::AddToPlaylist, C::Download]
+                let mut commands = vec![C::PlayNow, C::Enqueue, C::AddToPlaylist];
+                if rows.iter().all(|row| {
+                    self.search.results.get(*row).is_some_and(|song| {
+                        song.source != crate::search_source::SearchSource::OpenSubsonic
+                    })
+                }) {
+                    commands.push(C::Download);
+                }
+                commands
             }
             ContextTarget::Search {
                 rows, video_ids, ..
@@ -732,13 +820,14 @@ impl App {
                 {
                     vec![C::PlayNow, C::Enqueue, C::ImportPlaylist]
                 }
-                Some(song) if video_ids.first() == Some(&song.video_id) => vec![
-                    C::PlayNow,
-                    C::Enqueue,
-                    C::ToggleFavorite,
-                    C::AddToPlaylist,
-                    C::Download,
-                ],
+                Some(song) if video_ids.first() == Some(&song.video_id) => {
+                    let mut commands =
+                        vec![C::PlayNow, C::Enqueue, C::ToggleFavorite, C::AddToPlaylist];
+                    if song.source != crate::search_source::SearchSource::OpenSubsonic {
+                        commands.push(C::Download);
+                    }
+                    commands
+                }
                 _ => Vec::new(),
             },
             ContextTarget::LibrarySongs { tab, .. } => {
@@ -759,6 +848,10 @@ impl App {
                 C::Download,
                 C::Remove,
             ],
+            ContextTarget::ServerLibrary { identity, .. } if identity.is_song() => {
+                vec![C::PlayNow, C::Enqueue, C::AddToPlaylist]
+            }
+            ContextTarget::ServerLibrary { .. } => vec![C::Activate],
             ContextTarget::Queue { .. } => vec![C::PlayFromHere, C::Remove],
             ContextTarget::LocalFind {
                 index,
@@ -842,6 +935,11 @@ impl App {
             ContextTarget::LibraryPlaylist { index, playlist_id } => {
                 self.execute_library_playlist_context_command(index, playlist_id, command)
             }
+            ContextTarget::ServerLibrary {
+                generation,
+                index,
+                identity,
+            } => self.execute_server_library_context_command(generation, index, identity, command),
             ContextTarget::Queue {
                 lo,
                 hi,
@@ -1062,6 +1160,48 @@ impl App {
         }
     }
 
+    fn execute_server_library_context_command(
+        &mut self,
+        generation: u64,
+        index: usize,
+        identity: ServerLibraryRowIdentity,
+        command: ContextCommand,
+    ) -> Vec<Cmd> {
+        if self.mode != Mode::Library
+            || self.server.library.source != LibrarySource::OpenSubsonic
+            || generation != self.server.library.generation
+            || self.server_library_context_identity(index).as_ref() != Some(&identity)
+        {
+            return self.context_target_stale();
+        }
+        self.select_server_library_row(generation, index);
+        match command {
+            ContextCommand::Activate | ContextCommand::PlayNow => {
+                self.activate_server_library_row(generation, index)
+            }
+            ContextCommand::Enqueue if identity.is_song() => self
+                .server
+                .library
+                .row_song(index)
+                .cloned()
+                .map(crate::api::Song::from_open_subsonic)
+                .map_or_else(Vec::new, |song| self.enqueue_many(vec![song])),
+            ContextCommand::AddToPlaylist if identity.is_song() => {
+                if let Some(song) = self
+                    .server
+                    .library
+                    .row_song(index)
+                    .cloned()
+                    .map(crate::api::Song::from_open_subsonic)
+                {
+                    self.open_playlist_picker(vec![song]);
+                }
+                Vec::new()
+            }
+            _ => Vec::new(),
+        }
+    }
+
     fn execute_queue_context_command(
         &mut self,
         lo: usize,
@@ -1162,5 +1302,197 @@ impl App {
         .to_owned();
         self.dirty = true;
         Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mousemap::{MouseAction, MouseContext, MouseGesture};
+    use crate::open_subsonic::{
+        AccountScopeId, AlbumId, BackendId, ItemId, OpenSubsonicItemRef, ServerAlbum,
+        ServerLibraryPage, ServerLibraryRow, ServerLibrarySection, ServerSong,
+    };
+
+    fn server_song(id: &str) -> ServerSong {
+        ServerSong {
+            item: OpenSubsonicItemRef::new(
+                BackendId::new("backend").unwrap(),
+                AccountScopeId::new("account").unwrap(),
+                ItemId::new(id).unwrap(),
+            ),
+            title: format!("Song {id}"),
+            artist: "Artist".to_owned(),
+            artists: vec!["Artist".to_owned()],
+            album: None,
+            album_id: None,
+            album_artist: None,
+            duration_secs: Some(120),
+            track_number: None,
+            disc_number: None,
+            year: None,
+            cover_art_id: None,
+            content_type: None,
+            suffix: None,
+            starred: false,
+            user_rating: None,
+        }
+    }
+
+    fn server_album(id: &str) -> ServerAlbum {
+        ServerAlbum {
+            id: AlbumId::new(id).unwrap(),
+            name: format!("Album {id}"),
+            artist: "Artist".to_owned(),
+            artist_id: None,
+            song_count: Some(1),
+            duration_secs: None,
+            year: None,
+            cover_art_id: None,
+        }
+    }
+
+    fn server_app(rows: Vec<ServerLibraryRow>) -> App {
+        let mut app = App::new(50);
+        app.mode = Mode::Library;
+        app.server.library.source = LibrarySource::OpenSubsonic;
+        app.server.library.section = ServerLibrarySection::Songs;
+        app.server.library.generation = 9;
+        app.server.library.page = Some(ServerLibraryPage {
+            section: ServerLibrarySection::Songs,
+            rows,
+            next_offset: None,
+            warning: None,
+        });
+        app
+    }
+
+    fn register_server_row(app: &App, index: usize) -> (u16, u16) {
+        app.register_mouse_button(
+            Rect::new(1, index as u16 + 1, 20, 1),
+            MouseTarget::ServerLibraryRow {
+                generation: app.server.library.generation,
+                index,
+            },
+        );
+        (2, index as u16 + 1)
+    }
+
+    #[test]
+    fn server_song_right_click_opens_only_safe_actions() {
+        let _guard = crate::i18n::lock_for_test();
+        crate::i18n::set_language(crate::i18n::Language::English);
+        let mut app = server_app(vec![ServerLibraryRow::Song(server_song("one"))]);
+        let (col, row) = register_server_row(&app, 0);
+
+        assert!(app.on_mouse_right_click(col, row).is_empty());
+        let menu = app.overlays.context_menu.as_ref().expect("server menu");
+        let labels: Vec<String> = menu
+            .items
+            .iter()
+            .map(|item| item.label(menu.target_count()))
+            .collect();
+        assert_eq!(labels, vec!["Play now", "Add to queue", "Add to playlist"]);
+        assert!(
+            labels
+                .iter()
+                .all(|label| !label.contains("Download") && !label.contains("Favorite"))
+        );
+
+        assert!(app.activate_context_menu_item(2).is_empty());
+        assert_eq!(
+            app.playlist_picker
+                .as_ref()
+                .expect("local playlist picker")
+                .songs[0]
+                .title,
+            "Song one"
+        );
+    }
+
+    #[test]
+    fn server_right_click_obeys_disabled_enqueue_and_activate_mouse_actions() {
+        let mut disabled = server_app(vec![
+            ServerLibraryRow::Song(server_song("one")),
+            ServerLibraryRow::Song(server_song("two")),
+        ]);
+        disabled.server.library.selected = 1;
+        disabled
+            .mousemap
+            .set(
+                MouseContext::Library,
+                MouseGesture::RightClick,
+                MouseAction::Disabled,
+            )
+            .unwrap();
+        let (col, row) = register_server_row(&disabled, 0);
+        assert!(disabled.on_mouse_right_click(col, row).is_empty());
+        assert_eq!(disabled.server.library.selected, 1);
+        assert!(disabled.overlays.context_menu.is_none());
+
+        let mut enqueue = server_app(vec![ServerLibraryRow::Song(server_song("one"))]);
+        enqueue
+            .mousemap
+            .set(
+                MouseContext::Library,
+                MouseGesture::RightClick,
+                MouseAction::Enqueue,
+            )
+            .unwrap();
+        let (col, row) = register_server_row(&enqueue, 0);
+        assert!(!enqueue.on_mouse_right_click(col, row).is_empty());
+        assert_eq!(enqueue.server.library.selected, 0);
+        assert!(enqueue.overlays.context_menu.is_none());
+
+        let mut activate = server_app(vec![ServerLibraryRow::Album(server_album("album"))]);
+        activate
+            .mousemap
+            .set(
+                MouseContext::Library,
+                MouseGesture::RightClick,
+                MouseAction::Activate,
+            )
+            .unwrap();
+        let (col, row) = register_server_row(&activate, 0);
+        let commands = activate.on_mouse_right_click(col, row);
+        assert!(matches!(
+            commands.as_slice(),
+            [Cmd::ServerLibrary(ServerLibraryCommand::LoadDetail {
+                target: ServerLibraryDetailTarget::Album(id),
+                ..
+            })] if id.as_str() == "album"
+        ));
+    }
+
+    #[test]
+    fn delayed_server_menu_action_validates_generation_and_stable_identity() {
+        let mut app = server_app(vec![ServerLibraryRow::Song(server_song("one"))]);
+        let (col, row) = register_server_row(&app, 0);
+        app.on_mouse_right_click(col, row);
+
+        app.server.library.page.as_mut().unwrap().rows[0] =
+            ServerLibraryRow::Song(server_song("replacement"));
+        assert!(app.activate_context_menu_item(0).is_empty());
+        assert!(app.overlays.context_menu.is_none());
+        assert!(app.status.text.contains("list changed"));
+
+        let (col, row) = register_server_row(&app, 0);
+        app.on_mouse_right_click(col, row);
+        app.server.library.generation += 1;
+        assert!(app.activate_context_menu_item(0).is_empty());
+        assert!(app.status.text.contains("list changed"));
+    }
+
+    #[test]
+    fn server_container_context_menu_exposes_activate_only() {
+        let _guard = crate::i18n::lock_for_test();
+        crate::i18n::set_language(crate::i18n::Language::English);
+        let mut app = server_app(vec![ServerLibraryRow::Album(server_album("album"))]);
+        let (col, row) = register_server_row(&app, 0);
+
+        app.on_mouse_right_click(col, row);
+        let menu = app.overlays.context_menu.as_ref().expect("container menu");
+        assert_eq!(menu.items.len(), 1);
+        assert_eq!(menu.items[0].label(1), "Activate");
     }
 }

--- a/src/app/download.rs
+++ b/src/app/download.rs
@@ -23,6 +23,17 @@ impl App {
     /// same pending/pump path as bulk downloads; a lone song dispatches immediately since the
     /// in-flight cap dwarfs 1, so the visible behavior is unchanged.
     pub(in crate::app) fn start_download(&mut self, song: Song) -> Vec<Cmd> {
+        if song.source == crate::search_source::SearchSource::OpenSubsonic {
+            self.status.kind = StatusKind::Info;
+            self.status.text = t!(
+                "Music-server downloads are not available yet",
+                "음악 서버 곡 다운로드는 아직 지원하지 않아요",
+                "音楽サーバーの曲はまだダウンロードできません"
+            )
+            .to_owned();
+            self.dirty = true;
+            return Vec::new();
+        }
         if song.is_local() {
             self.status.text = format!(
                 "{}: {}",
@@ -53,7 +64,10 @@ impl App {
             .filter(|song| {
                 // Local files are already on disk; radio stations are live streams, not
                 // downloadable tracks — neither belongs in a bulk fetch.
-                if song.is_local() || song.is_radio_station() {
+                if song.is_local()
+                    || song.is_radio_station()
+                    || song.source == crate::search_source::SearchSource::OpenSubsonic
+                {
                     return false;
                 }
                 if let Some(yt) = song.youtube_id()

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -37,6 +37,11 @@ impl App {
         if self.tool_setup.is_some() {
             return self.on_key_tool_setup(k);
         }
+        // Music-server setup is move-only and Settings-owned. It captures input before global
+        // shortcuts so typed credentials can never trigger the screen underneath it.
+        if self.server.settings.modal_open() {
+            return self.on_key_music_server_settings(k);
+        }
         // Sync setup and pairing are Settings-owned, top-level modals. They keep ownership even
         // if the terminal shrinks to Mini or the underlying Settings screen is closed.
         if self.personal_state.sync_ui.modal_open() {

--- a/src/app/library.rs
+++ b/src/app/library.rs
@@ -193,6 +193,16 @@ impl App {
         if self.library_ui.filter_editing {
             return self.on_key_library_filter(k);
         }
+        // The remote server is a separate read-only surface. Dispatch it before local tab,
+        // filter, favorite, and delete actions so a server row can never mutate local stores.
+        if !self.local_dedicated_mode && self.server.library.source == LibrarySource::OpenSubsonic {
+            return self.on_key_server_library(k);
+        }
+        // Horizontal navigation enters the configured-server source selector. Local Library
+        // otherwise has no left/right list action, so this is additive and remapping-safe.
+        if !self.local_dedicated_mode && k.code == KeyCode::Right {
+            return self.select_library_source(LibrarySource::OpenSubsonic);
+        }
         // Esc isn't a Library keybinding, but with a filter applied it should clear it — the
         // natural "get me out of this filtered view" gesture, matching the box's Esc-to-cancel.
         if k.code == KeyCode::Esc && !self.library_ui.filter_query.is_empty() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -83,6 +83,20 @@ mod search_types;
 pub use search_types::*;
 mod types;
 pub use types::*;
+mod server_library;
+pub use server_library::{
+    LibrarySource, SERVER_LIBRARY_PAGE_LIMIT, ServerLibraryCommand, ServerLibraryDetailTarget,
+    ServerLibraryEvent, ServerLibraryFailure, ServerLibraryState,
+};
+mod server_settings;
+pub use server_settings::{
+    MusicServerBusy, MusicServerCommand, MusicServerCredentialMode, MusicServerEvent,
+    MusicServerFailure, MusicServerHealth, MusicServerIdentityIntent, MusicServerRefreshOutcome,
+    MusicServerSettingsState, MusicServerSetupField, MusicServerSetupForm, MusicServerSetupInput,
+    MusicServerSummary, MusicServerWizard, SyncArea,
+};
+mod server;
+pub use server::{ServerEvent, ServerUiState};
 
 mod automatic_sync;
 mod bootstrap;
@@ -410,6 +424,8 @@ pub struct App {
     /// Library-screen state: active tab, list cursor + multi-select anchor, local
     /// download-folder rows, and the pending file-delete confirmation.
     pub library_ui: LibraryView,
+    /// OpenSubsonic browsing and redacted settings state, isolated from the local library.
+    pub server: ServerUiState,
     /// Cross-frame cache of the visible library rows (dedup + filter are O(library) and
     /// used to run on every frame *and* every navigation event). Keyed on the source
     /// revisions/lengths + tab + filter; see `library_reducer`. Interior mutability so

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -199,6 +199,9 @@ impl App {
         if let Some(commands) = self.artist_mouse_double_click(target.as_ref()) {
             return commands;
         }
+        if let Some(commands) = self.server_library_mouse_double_click(target.as_ref()) {
+            return commands;
+        }
         match target {
             Some(MouseTarget::Nav(Mode::Player)) if self.mode == Mode::Player => {
                 self.request_radio_mode_switch()
@@ -504,11 +507,7 @@ impl App {
         }
         match self.mode {
             Mode::Library => {
-                let len = if self.local_dedicated_mode {
-                    self.local_rows_len()
-                } else {
-                    self.library_len()
-                };
+                let len = self.library_rows_len_for_wheel();
                 self.bridges.library_scroll.wheel(up, n, len);
                 self.dirty = true;
             }

--- a/src/app/mouse_routing.rs
+++ b/src/app/mouse_routing.rs
@@ -9,6 +9,17 @@ impl App {
         row: u16,
         multi: bool,
     ) -> Vec<Cmd> {
+        if self.server.settings.modal_open() {
+            return match self.mouse_target_at(col, row) {
+                Some(
+                    target @ (MouseTarget::MusicServerWizardField(_)
+                    | MouseTarget::MusicServerWizardPrimary
+                    | MouseTarget::MusicServerWizardSecondary
+                    | MouseTarget::MusicServerWizardReveal),
+                ) => self.on_music_server_wizard_mouse_target(target),
+                _ => Vec::new(),
+            };
+        }
         // The Sync wizard is rendered last and owns the whole screen while open. Only its
         // explicit controls act; every other click is consumed to prevent click-through.
         if self.personal_state.sync_ui.modal_open() {
@@ -602,6 +613,51 @@ impl App {
                 Vec::new()
             }
             MouseTarget::LibraryTab(_) => Vec::new(),
+            MouseTarget::LibrarySource(source)
+                if self.mode == Mode::Library && !self.local_dedicated_mode =>
+            {
+                self.select_library_source(source)
+            }
+            MouseTarget::LibrarySource(_) => Vec::new(),
+            MouseTarget::ServerLibrarySection(section)
+                if self.mode == Mode::Library
+                    && self.server.library.source == LibrarySource::OpenSubsonic =>
+            {
+                self.select_server_library_section(section)
+            }
+            MouseTarget::ServerLibrarySection(_) => Vec::new(),
+            MouseTarget::ServerLibraryRow { generation, index }
+                if self.mode == Mode::Library
+                    && self.server.library.source == LibrarySource::OpenSubsonic =>
+            {
+                self.select_server_library_row(generation, index);
+                Vec::new()
+            }
+            MouseTarget::ServerLibraryRow { .. } => Vec::new(),
+            MouseTarget::ServerLibraryBack { generation }
+                if self.mode == Mode::Library
+                    && self.server.library.source == LibrarySource::OpenSubsonic
+                    && generation == self.server.library.generation =>
+            {
+                self.back_server_library()
+            }
+            MouseTarget::ServerLibraryBack { .. } => Vec::new(),
+            MouseTarget::ServerLibraryPreviousPage { generation }
+                if self.mode == Mode::Library
+                    && self.server.library.source == LibrarySource::OpenSubsonic
+                    && generation == self.server.library.generation =>
+            {
+                self.previous_server_library_page()
+            }
+            MouseTarget::ServerLibraryPreviousPage { .. } => Vec::new(),
+            MouseTarget::ServerLibraryNextPage { generation }
+                if self.mode == Mode::Library
+                    && self.server.library.source == LibrarySource::OpenSubsonic
+                    && generation == self.server.library.generation =>
+            {
+                self.next_server_library_page()
+            }
+            MouseTarget::ServerLibraryNextPage { .. } => Vec::new(),
             MouseTarget::LocalNav(i) if self.mode == Mode::Library && self.local_dedicated_mode => {
                 let Some(section) = LocalSection::ALL.get(i).copied() else {
                     return Vec::new();
@@ -654,6 +710,33 @@ impl App {
                 self.activate_sync_row()
             }
             MouseTarget::SettingsSyncRow(_) => Vec::new(),
+            MouseTarget::SettingsSyncArea(area)
+                if self.mode == Mode::Settings
+                    && self
+                        .settings
+                        .as_ref()
+                        .is_some_and(|settings| settings.tab == SettingsTab::Sync) =>
+            {
+                self.select_sync_area(area)
+            }
+            MouseTarget::SettingsSyncArea(_) => Vec::new(),
+            MouseTarget::SettingsMusicServerRow(index)
+                if self.mode == Mode::Settings
+                    && self
+                        .settings
+                        .as_ref()
+                        .is_some_and(|settings| settings.tab == SettingsTab::Sync)
+                    && self.server.settings.area == SyncArea::MusicServer =>
+            {
+                self.activate_music_server_row(index)
+            }
+            MouseTarget::SettingsMusicServerRow(_) => Vec::new(),
+            target @ (MouseTarget::MusicServerWizardField(_)
+            | MouseTarget::MusicServerWizardPrimary
+            | MouseTarget::MusicServerWizardSecondary
+            | MouseTarget::MusicServerWizardReveal) => {
+                self.on_music_server_wizard_mouse_target(target)
+            }
             target @ (MouseTarget::SyncWizardField(_)
             | MouseTarget::SyncWizardPrimary
             | MouseTarget::SyncWizardSecondary

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -213,7 +213,7 @@ impl App {
             self.dirty = true;
         }
         if entered_sync {
-            self.request_sync_ui_refresh()
+            self.select_sync_area(self.server.settings.area)
         } else {
             Vec::new()
         }

--- a/src/app/player_transport.rs
+++ b/src/app/player_transport.rs
@@ -95,7 +95,7 @@ impl App {
             cmds.push(Cmd::PlayerControl(PlayerControl::Restart { restore }));
             return cmds;
         };
-        let target = match song.playback_target_checked() {
+        let target = match song.playback_destination_checked() {
             Ok(target) => target,
             Err(error) => {
                 tracing::warn!(
@@ -165,7 +165,7 @@ impl App {
             cmds.push(Cmd::PlayerControl(PlayerControl::Restart { restore }));
             return cmds;
         };
-        let target = match song.playback_target_checked() {
+        let target = match song.playback_destination_checked() {
             Ok(target) => target,
             Err(error) => {
                 tracing::warn!(

--- a/src/app/reducer.rs
+++ b/src/app/reducer.rs
@@ -1022,6 +1022,16 @@ impl App {
                 _ => {}
             }
         }
+        if self.server.settings.modal_open() {
+            match &msg {
+                Msg::MouseDoubleClick { .. }
+                | Msg::MouseRightClick { .. }
+                | Msg::MouseRightDoubleClick { .. }
+                | Msg::MouseDrag { .. }
+                | Msg::MouseScroll { .. } => return Vec::new(),
+                _ => {}
+            }
+        }
         // A picker-opening/applying press owns its paired double-click. Check this before the
         // open-modal route: the second press of a swatch double-click arrives after the first has
         // opened the picker and must not be reinterpreted against the newly rendered popup.
@@ -1101,6 +1111,12 @@ impl App {
             }
             Msg::Data(DataMsg::SyncUi(event)) => {
                 return self.finish_sync_ui_event(event);
+            }
+            Msg::Server(ServerEvent::Settings(event)) => {
+                return self.finish_music_server_event(event);
+            }
+            Msg::Server(ServerEvent::Library(event)) => {
+                return self.finish_server_library_event(event);
             }
             Msg::Media(cmd) => return self.apply_media(cmd),
             Msg::MediaArtworkReady(ready) => {

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -1,0 +1,18 @@
+//! App-owned music-server domain state and result bucket.
+
+use super::{MusicServerEvent, MusicServerSettingsState, ServerLibraryEvent, ServerLibraryState};
+
+/// All OpenSubsonic UI state owned by the primary reducer.
+#[derive(Default)]
+pub struct ServerUiState {
+    /// Read-only source, paging, and drill-down state.
+    pub library: ServerLibraryState,
+    /// Redacted connection status plus the move-only setup wizard.
+    pub settings: MusicServerSettingsState,
+}
+
+/// Results from bounded music-server workers.
+pub enum ServerEvent {
+    Settings(MusicServerEvent),
+    Library(ServerLibraryEvent),
+}

--- a/src/app/server_library.rs
+++ b/src/app/server_library.rs
@@ -1,0 +1,1016 @@
+//! Read-only OpenSubsonic library state and reducer.
+//!
+//! The local YuTuTui library remains authoritative and fully usable when this surface is
+//! unavailable. Server pages are bounded, generation-stamped snapshots; no server rating or
+//! playlist mutation is reachable from this module.
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+use super::{App, Cmd, Mode, MouseTarget, StatusKind};
+use crate::api::Song;
+use crate::keymap::{Action, Chord, KeyContext};
+use crate::open_subsonic::model::{
+    AlbumId, ArtistId, ServerLibraryDetail, ServerLibraryPage, ServerLibraryRow,
+    ServerLibrarySection, ServerPlaylistId, ServerSong,
+};
+
+pub const SERVER_LIBRARY_PAGE_LIMIT: u32 = 50;
+const SERVER_LIBRARY_MAX_OFFSET: u32 = 20_000;
+const SERVER_LIBRARY_MAX_PAGE_HISTORY: usize = 100;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum LibrarySource {
+    #[default]
+    Yututui,
+    OpenSubsonic,
+}
+
+impl LibrarySource {
+    pub fn label(self, server_name: &str) -> &str {
+        match self {
+            Self::Yututui => "YuTuTui",
+            Self::OpenSubsonic => server_name,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ServerLibraryFailure {
+    Offline,
+    Authentication,
+    Unsupported,
+    InvalidResponse,
+    Unavailable,
+}
+
+impl ServerLibraryFailure {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Offline => crate::t!(
+                "Server is offline. Your local library still works.",
+                "서버가 오프라인이에요. 로컬 보관함은 계속 사용할 수 있어요.",
+                "サーバーはオフラインです。ローカルライブラリは引き続き使えます。"
+            ),
+            Self::Authentication => crate::t!(
+                "Server sign-in needs attention.",
+                "서버 로그인을 확인해 주세요.",
+                "サーバーへのログインを確認してください。"
+            ),
+            Self::Unsupported => crate::t!(
+                "This server does not support this section.",
+                "이 서버는 이 섹션을 지원하지 않아요.",
+                "このサーバーはこのセクションに対応していません。"
+            ),
+            Self::InvalidResponse => crate::t!(
+                "The server returned an unreadable response.",
+                "서버 응답을 읽을 수 없어요.",
+                "サーバーの応答を読み取れません。"
+            ),
+            Self::Unavailable => crate::t!(
+                "Set up a music server in Settings → Sync.",
+                "설정 → 동기화에서 음악 서버를 설정해 주세요.",
+                "設定 → 同期で音楽サーバーを設定してください。"
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ServerLibraryDetailTarget {
+    Album(AlbumId),
+    Artist(ArtistId),
+    Playlist(ServerPlaylistId),
+}
+
+pub enum ServerLibraryCommand {
+    LoadPage {
+        generation: u64,
+        section: ServerLibrarySection,
+        offset: u32,
+        limit: u32,
+    },
+    LoadDetail {
+        generation: u64,
+        target: ServerLibraryDetailTarget,
+    },
+}
+
+pub enum ServerLibraryEvent {
+    PageLoaded {
+        generation: u64,
+        offset: u32,
+        result: Result<ServerLibraryPage, ServerLibraryFailure>,
+    },
+    DetailLoaded {
+        generation: u64,
+        result: Result<ServerLibraryDetail, ServerLibraryFailure>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ServerLibraryBusy {
+    Page,
+    Detail,
+}
+
+pub struct ServerLibraryState {
+    pub source: LibrarySource,
+    pub section: ServerLibrarySection,
+    pub selected: usize,
+    pub offset: u32,
+    pub previous_offsets: Vec<u32>,
+    pub page: Option<ServerLibraryPage>,
+    pub detail: Option<ServerLibraryDetail>,
+    pub generation: u64,
+    pub busy: Option<ServerLibraryBusy>,
+    pub failure: Option<ServerLibraryFailure>,
+}
+
+impl Default for ServerLibraryState {
+    fn default() -> Self {
+        Self {
+            source: LibrarySource::Yututui,
+            section: ServerLibrarySection::RecentlyPlayed,
+            selected: 0,
+            offset: 0,
+            previous_offsets: Vec::new(),
+            page: None,
+            detail: None,
+            generation: 0,
+            busy: None,
+            failure: None,
+        }
+    }
+}
+
+impl ServerLibraryState {
+    fn next_generation(&mut self) -> u64 {
+        self.generation = self.generation.wrapping_add(1).max(1);
+        self.generation
+    }
+
+    pub fn rows_len(&self) -> usize {
+        match self.detail.as_ref() {
+            Some(ServerLibraryDetail::AlbumSongs { songs, .. }) => songs.len(),
+            Some(ServerLibraryDetail::ArtistAlbums { albums, .. }) => albums.len(),
+            Some(ServerLibraryDetail::PlaylistEntries(playlist)) => playlist.entries.len(),
+            None => self.page.as_ref().map_or(0, |page| page.rows.len()),
+        }
+    }
+
+    pub fn row_song(&self, index: usize) -> Option<&ServerSong> {
+        match self.detail.as_ref() {
+            Some(ServerLibraryDetail::AlbumSongs { songs, .. }) => songs.get(index),
+            Some(ServerLibraryDetail::ArtistAlbums { .. }) => None,
+            Some(ServerLibraryDetail::PlaylistEntries(playlist)) => playlist.entries.get(index),
+            None => self
+                .page
+                .as_ref()
+                .and_then(|page| page.rows.get(index))
+                .and_then(|row| match row {
+                    ServerLibraryRow::Song(song) => Some(song),
+                    ServerLibraryRow::Album(_)
+                    | ServerLibraryRow::Artist(_)
+                    | ServerLibraryRow::Playlist(_) => None,
+                }),
+        }
+    }
+
+    pub fn visible_songs(&self) -> Vec<Song> {
+        match self.detail.as_ref() {
+            Some(ServerLibraryDetail::AlbumSongs { songs, .. }) => songs
+                .iter()
+                .cloned()
+                .map(Song::from_open_subsonic)
+                .collect(),
+            Some(ServerLibraryDetail::ArtistAlbums { .. }) => Vec::new(),
+            Some(ServerLibraryDetail::PlaylistEntries(playlist)) => playlist
+                .entries
+                .iter()
+                .cloned()
+                .map(Song::from_open_subsonic)
+                .collect(),
+            None => self
+                .page
+                .iter()
+                .flat_map(|page| &page.rows)
+                .filter_map(|row| match row {
+                    ServerLibraryRow::Song(song) => Some(Song::from_open_subsonic(song.clone())),
+                    ServerLibraryRow::Album(_)
+                    | ServerLibraryRow::Artist(_)
+                    | ServerLibraryRow::Playlist(_) => None,
+                })
+                .collect(),
+        }
+    }
+
+    pub fn next_offset(&self) -> Option<u32> {
+        self.detail
+            .is_none()
+            .then(|| self.page.as_ref().and_then(|page| page.next_offset))
+            .flatten()
+            .filter(|offset| *offset > self.offset && *offset <= SERVER_LIBRARY_MAX_OFFSET)
+    }
+
+    pub fn reset_after_profile_removal(&mut self) {
+        self.source = LibrarySource::Yututui;
+        self.invalidate_after_profile_change();
+    }
+
+    pub fn invalidate_after_profile_change(&mut self) {
+        self.page = None;
+        self.detail = None;
+        self.previous_offsets.clear();
+        self.offset = 0;
+        self.selected = 0;
+        self.failure = None;
+        self.busy = None;
+        self.next_generation();
+    }
+}
+
+impl App {
+    pub(in crate::app) fn server_library_mouse_double_click(
+        &mut self,
+        target: Option<&MouseTarget>,
+    ) -> Option<Vec<Cmd>> {
+        let Some(MouseTarget::ServerLibraryRow { generation, index }) = target else {
+            return None;
+        };
+        (self.mode == Mode::Library && self.server.library.source == LibrarySource::OpenSubsonic)
+            .then(|| self.activate_server_library_row(*generation, *index))
+    }
+
+    pub(in crate::app) fn library_rows_len_for_wheel(&self) -> usize {
+        if self.local_dedicated_mode {
+            self.local_rows_len()
+        } else if self.server.library.source == LibrarySource::OpenSubsonic {
+            self.server.library.rows_len()
+        } else {
+            self.library_len()
+        }
+    }
+
+    pub(in crate::app) fn select_library_source(&mut self, source: LibrarySource) -> Vec<Cmd> {
+        if self.local_dedicated_mode {
+            return Vec::new();
+        }
+        // The local filter editor is not rendered on the server surface. End its capture before
+        // switching so typed server shortcuts cannot silently mutate the hidden local query.
+        if source == LibrarySource::OpenSubsonic && self.library_ui.filter_editing {
+            self.library_ui.filter_editing = false;
+            self.dirty = true;
+        }
+        if self.server.library.source == source {
+            return Vec::new();
+        }
+        // Fence any page/detail completion owned by the source we are leaving. In particular,
+        // returning to the local library while a server request is in flight must not leave a
+        // stale `busy` latch that prevents a later fresh server request.
+        self.server.library.next_generation();
+        self.server.library.busy = None;
+        self.server.library.source = source;
+        self.server.library.selected = 0;
+        self.bridges.library_scroll.reset();
+        self.interaction.drag_selection = None;
+        self.interaction.drag_scrollbar = None;
+        self.dirty = true;
+        match source {
+            LibrarySource::Yututui => Vec::new(),
+            LibrarySource::OpenSubsonic => self.request_server_library_page(0, false),
+        }
+    }
+
+    pub(in crate::app) fn select_server_library_section(
+        &mut self,
+        section: ServerLibrarySection,
+    ) -> Vec<Cmd> {
+        if self.server.library.source != LibrarySource::OpenSubsonic
+            || self.server.library.busy.is_some()
+            || self.server.library.section == section
+        {
+            return Vec::new();
+        }
+        self.server.library.section = section;
+        self.server.library.previous_offsets.clear();
+        self.server.library.detail = None;
+        self.server.library.selected = 0;
+        self.bridges.library_scroll.reset();
+        self.request_server_library_page(0, false)
+    }
+
+    fn step_server_library_section(&mut self, forward: bool) -> Vec<Cmd> {
+        let sections = [
+            ServerLibrarySection::RecentlyPlayed,
+            ServerLibrarySection::Albums,
+            ServerLibrarySection::Artists,
+            ServerLibrarySection::Songs,
+            ServerLibrarySection::Playlists,
+        ];
+        let index = sections
+            .iter()
+            .position(|section| *section == self.server.library.section)
+            .unwrap_or(0);
+        let next = if forward {
+            (index + 1) % sections.len()
+        } else {
+            (index + sections.len() - 1) % sections.len()
+        };
+        self.select_server_library_section(sections[next])
+    }
+
+    pub(in crate::app) fn request_server_library_page(
+        &mut self,
+        offset: u32,
+        remember_current: bool,
+    ) -> Vec<Cmd> {
+        if self.server.library.busy.is_some() || offset > SERVER_LIBRARY_MAX_OFFSET {
+            return Vec::new();
+        }
+        if remember_current {
+            if self.server.library.previous_offsets.len() == SERVER_LIBRARY_MAX_PAGE_HISTORY {
+                self.server.library.previous_offsets.remove(0);
+            }
+            self.server
+                .library
+                .previous_offsets
+                .push(self.server.library.offset);
+        }
+        let generation = self.server.library.next_generation();
+        self.server.library.busy = Some(ServerLibraryBusy::Page);
+        self.server.library.failure = None;
+        // A page belongs to the generation and section that produced it. Drop it before
+        // dispatch so a failed section/page request cannot leave stale rows reachable through
+        // keyboard or mouse activation.
+        self.server.library.page = None;
+        self.server.library.detail = None;
+        self.server.library.selected = 0;
+        self.bridges.library_scroll.reset();
+        self.dirty = true;
+        vec![Cmd::ServerLibrary(ServerLibraryCommand::LoadPage {
+            generation,
+            section: self.server.library.section,
+            offset,
+            limit: SERVER_LIBRARY_PAGE_LIMIT,
+        })]
+    }
+
+    pub(in crate::app) fn next_server_library_page(&mut self) -> Vec<Cmd> {
+        let Some(offset) = self.server.library.next_offset() else {
+            return Vec::new();
+        };
+        self.request_server_library_page(offset, true)
+    }
+
+    pub(in crate::app) fn previous_server_library_page(&mut self) -> Vec<Cmd> {
+        if self.server.library.busy.is_some() {
+            return Vec::new();
+        }
+        let Some(offset) = self.server.library.previous_offsets.pop() else {
+            return Vec::new();
+        };
+        self.request_server_library_page(offset, false)
+    }
+
+    pub(in crate::app) fn select_server_library_row(&mut self, generation: u64, index: usize) {
+        if self.server.library.source == LibrarySource::OpenSubsonic
+            && generation == self.server.library.generation
+            && index < self.server.library.rows_len()
+        {
+            self.server.library.selected = index;
+            self.dirty = true;
+        }
+    }
+
+    pub(in crate::app) fn activate_server_library_row(
+        &mut self,
+        generation: u64,
+        index: usize,
+    ) -> Vec<Cmd> {
+        if generation != self.server.library.generation
+            || self.server.library.busy.is_some()
+            || index >= self.server.library.rows_len()
+        {
+            return Vec::new();
+        }
+        self.server.library.selected = index;
+        if let Some(song) = self.server.library.row_song(index).cloned() {
+            return self.play_now_many(vec![Song::from_open_subsonic(song)]);
+        }
+        let target = match self.server.library.detail.as_ref() {
+            Some(ServerLibraryDetail::ArtistAlbums { albums, .. }) => albums
+                .get(index)
+                .map(|album| ServerLibraryDetailTarget::Album(album.id.clone())),
+            Some(
+                ServerLibraryDetail::AlbumSongs { .. } | ServerLibraryDetail::PlaylistEntries(_),
+            ) => None,
+            None => self
+                .server
+                .library
+                .page
+                .as_ref()
+                .and_then(|page| page.rows.get(index))
+                .and_then(|row| match row {
+                    ServerLibraryRow::Song(_) => None,
+                    ServerLibraryRow::Album(album) => {
+                        Some(ServerLibraryDetailTarget::Album(album.id.clone()))
+                    }
+                    ServerLibraryRow::Artist(artist) => {
+                        Some(ServerLibraryDetailTarget::Artist(artist.id.clone()))
+                    }
+                    ServerLibraryRow::Playlist(playlist) => {
+                        Some(ServerLibraryDetailTarget::Playlist(playlist.id.clone()))
+                    }
+                }),
+        };
+        let Some(target) = target else {
+            return Vec::new();
+        };
+        let generation = self.server.library.next_generation();
+        self.server.library.busy = Some(ServerLibraryBusy::Detail);
+        self.server.library.failure = None;
+        self.dirty = true;
+        vec![Cmd::ServerLibrary(ServerLibraryCommand::LoadDetail {
+            generation,
+            target,
+        })]
+    }
+
+    pub(in crate::app) fn back_server_library(&mut self) -> Vec<Cmd> {
+        if self.server.library.busy.is_some() {
+            return Vec::new();
+        }
+        if self.server.library.detail.take().is_some() {
+            self.server.library.selected = 0;
+            self.bridges.library_scroll.reset();
+            self.server.library.next_generation();
+            self.dirty = true;
+            return Vec::new();
+        }
+        if !self.server.library.previous_offsets.is_empty() {
+            return self.previous_server_library_page();
+        }
+        self.select_library_source(LibrarySource::Yututui)
+    }
+
+    fn move_server_library_cursor(&mut self, up: bool, step: usize) {
+        let len = self.server.library.rows_len();
+        self.server.library.selected = if up {
+            self.server.library.selected.saturating_sub(step)
+        } else {
+            self.server
+                .library
+                .selected
+                .saturating_add(step)
+                .min(len.saturating_sub(1))
+        };
+        self.dirty = true;
+    }
+
+    fn enqueue_selected_server_library_song(&mut self) -> Vec<Cmd> {
+        self.server
+            .library
+            .row_song(self.server.library.selected)
+            .cloned()
+            .map(Song::from_open_subsonic)
+            .map_or_else(Vec::new, |song| self.enqueue_many(vec![song]))
+    }
+
+    fn add_selected_server_library_song_to_playlist(&mut self) -> Vec<Cmd> {
+        if let Some(song) = self
+            .server
+            .library
+            .row_song(self.server.library.selected)
+            .cloned()
+            .map(Song::from_open_subsonic)
+        {
+            self.open_playlist_picker(vec![song]);
+        }
+        Vec::new()
+    }
+
+    fn handle_server_library_action(&mut self, action: Action) -> Option<Vec<Cmd>> {
+        let commands = match action {
+            Action::Back => {
+                if self.server.library.detail.is_some()
+                    || !self.server.library.previous_offsets.is_empty()
+                {
+                    self.back_server_library()
+                } else {
+                    self.mode = Mode::Player;
+                    self.dirty = true;
+                    Vec::new()
+                }
+            }
+            Action::FocusNext => self.step_server_library_section(true),
+            Action::FocusPrev => self.step_server_library_section(false),
+            Action::MoveUp => {
+                let step = self.nav_repeat_step(Action::MoveUp);
+                self.move_server_library_cursor(true, step);
+                Vec::new()
+            }
+            Action::MoveDown => {
+                let step = self.nav_repeat_step(Action::MoveDown);
+                self.move_server_library_cursor(false, step);
+                Vec::new()
+            }
+            Action::PageUp => {
+                self.move_server_library_cursor(true, self.page_step());
+                Vec::new()
+            }
+            Action::PageDown => {
+                self.move_server_library_cursor(false, self.page_step());
+                Vec::new()
+            }
+            Action::JumpTop => {
+                self.server.library.selected = 0;
+                self.dirty = true;
+                Vec::new()
+            }
+            Action::JumpBottom => {
+                self.server.library.selected = self.server.library.rows_len().saturating_sub(1);
+                self.dirty = true;
+                Vec::new()
+            }
+            Action::Confirm => self.activate_server_library_row(
+                self.server.library.generation,
+                self.server.library.selected,
+            ),
+            Action::Enqueue => self.enqueue_selected_server_library_song(),
+            Action::PlayAll => self.play_now_many(self.server.library.visible_songs()),
+            Action::AddToPlaylist => self.add_selected_server_library_song_to_playlist(),
+            _ => return None,
+        };
+        Some(commands)
+    }
+
+    pub(in crate::app) fn on_key_server_library(&mut self, key: KeyEvent) -> Vec<Cmd> {
+        // Resolve the same semantic Library/Common actions as the local Library. Unsupported
+        // local mutations (favorite, remove, filter, download) deliberately fall through to a
+        // no-op on this read-only surface.
+        let action = self.keymap.action(KeyContext::Library, Chord::from(key));
+        if let Some(commands) = action.and_then(|action| self.handle_server_library_action(action))
+        {
+            return commands;
+        }
+
+        // Server-only navigation stays fixed and intentionally uses otherwise-unclaimed default
+        // Library chords. Configured supported actions above win if a user assigns one of them.
+        match key.code {
+            KeyCode::Left if key.modifiers.is_empty() => {
+                self.select_library_source(LibrarySource::Yututui)
+            }
+            KeyCode::Esc => self.back_server_library(),
+            KeyCode::Char('1') if key.modifiers.is_empty() => {
+                self.select_server_library_section(ServerLibrarySection::RecentlyPlayed)
+            }
+            KeyCode::Char('2') if key.modifiers.is_empty() => {
+                self.select_server_library_section(ServerLibrarySection::Albums)
+            }
+            KeyCode::Char('3') if key.modifiers.is_empty() => {
+                self.select_server_library_section(ServerLibrarySection::Artists)
+            }
+            KeyCode::Char('4') if key.modifiers.is_empty() => {
+                self.select_server_library_section(ServerLibrarySection::Songs)
+            }
+            KeyCode::Char('5') if key.modifiers.is_empty() => {
+                self.select_server_library_section(ServerLibrarySection::Playlists)
+            }
+            KeyCode::Char('[') if key.modifiers.is_empty() => self.previous_server_library_page(),
+            KeyCode::Char(']') if key.modifiers.is_empty() => self.next_server_library_page(),
+            _ => Vec::new(),
+        }
+    }
+
+    pub(in crate::app) fn finish_server_library_event(
+        &mut self,
+        event: ServerLibraryEvent,
+    ) -> Vec<Cmd> {
+        let event_generation = match &event {
+            ServerLibraryEvent::PageLoaded { generation, .. }
+            | ServerLibraryEvent::DetailLoaded { generation, .. } => *generation,
+        };
+        if event_generation != self.server.library.generation
+            || self.server.library.source != LibrarySource::OpenSubsonic
+        {
+            return Vec::new();
+        }
+        self.server.library.busy = None;
+        match event {
+            ServerLibraryEvent::PageLoaded { offset, result, .. } => match result {
+                Ok(mut page) => {
+                    page.rows.truncate(SERVER_LIBRARY_PAGE_LIMIT as usize);
+                    if page.section != self.server.library.section {
+                        return Vec::new();
+                    }
+                    self.server.library.offset = offset;
+                    self.server.library.page = Some(page);
+                    self.server.library.detail = None;
+                    self.server.library.failure = None;
+                    self.server.library.selected = 0;
+                }
+                Err(failure) => {
+                    self.server.library.page = None;
+                    self.server.library.failure = Some(failure);
+                    self.status.kind = StatusKind::Error;
+                    self.status.text = failure.label().to_owned();
+                }
+            },
+            ServerLibraryEvent::DetailLoaded { result, .. } => match result {
+                Ok(detail) => {
+                    // Detail endpoints are already bounded to 20,000 rows by the catalog
+                    // decoder. Retain the complete occurrence-preserving result so rows after
+                    // the first page remain browsable and playable.
+                    self.server.library.detail = Some(detail);
+                    self.server.library.failure = None;
+                    self.server.library.selected = 0;
+                    self.bridges.library_scroll.reset();
+                }
+                Err(failure) => {
+                    self.server.library.failure = Some(failure);
+                    self.status.kind = StatusKind::Error;
+                    self.status.text = failure.label().to_owned();
+                }
+            },
+        }
+        self.dirty = true;
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::keymap::KeyMap;
+    use crate::open_subsonic::model::{AccountScopeId, BackendId, ItemId, OpenSubsonicItemRef};
+
+    fn song(id: &str) -> ServerSong {
+        ServerSong {
+            item: OpenSubsonicItemRef::new(
+                BackendId::new("backend").unwrap(),
+                AccountScopeId::new("account").unwrap(),
+                ItemId::new(id).unwrap(),
+            ),
+            title: format!("Song {id}"),
+            artist: "Artist".to_owned(),
+            artists: vec!["Artist".to_owned()],
+            album: None,
+            album_id: None,
+            album_artist: None,
+            duration_secs: Some(125),
+            track_number: None,
+            disc_number: None,
+            year: None,
+            cover_art_id: None,
+            content_type: None,
+            suffix: None,
+            starred: false,
+            user_rating: None,
+        }
+    }
+
+    fn server_song_page(ids: &[&str], next_offset: Option<u32>) -> ServerLibraryPage {
+        ServerLibraryPage {
+            section: ServerLibrarySection::Songs,
+            rows: ids
+                .iter()
+                .map(|id| ServerLibraryRow::Song(song(id)))
+                .collect(),
+            next_offset,
+            warning: None,
+        }
+    }
+
+    fn server_library_app(ids: &[&str]) -> App {
+        let mut app = App::new(50);
+        app.mode = Mode::Library;
+        app.server.library.source = LibrarySource::OpenSubsonic;
+        app.server.library.section = ServerLibrarySection::Songs;
+        app.server.library.generation = 7;
+        app.server.library.page = Some(server_song_page(ids, None));
+        app
+    }
+
+    #[test]
+    fn stale_page_is_ignored_after_source_switch() {
+        let mut app = App::new(50);
+        app.server.library.source = LibrarySource::OpenSubsonic;
+        let commands = app.request_server_library_page(0, false);
+        assert_eq!(commands.len(), 1);
+        let stale_generation = app.server.library.generation;
+        app.select_library_source(LibrarySource::Yututui);
+        app.finish_server_library_event(ServerLibraryEvent::PageLoaded {
+            generation: stale_generation,
+            offset: 0,
+            result: Ok(ServerLibraryPage {
+                section: ServerLibrarySection::RecentlyPlayed,
+                rows: vec![ServerLibraryRow::Song(song("one"))],
+                next_offset: None,
+                warning: None,
+            }),
+        });
+        assert!(app.server.library.page.is_none());
+    }
+
+    #[test]
+    fn source_round_trip_clears_in_flight_busy_and_starts_a_fresh_request() {
+        let mut app = App::new(50);
+        app.server.library.source = LibrarySource::OpenSubsonic;
+        let commands = app.request_server_library_page(0, false);
+        assert_eq!(commands.len(), 1);
+        let stale_generation = app.server.library.generation;
+        assert_eq!(app.server.library.busy, Some(ServerLibraryBusy::Page));
+
+        assert!(app.select_library_source(LibrarySource::Yututui).is_empty());
+        assert!(app.server.library.busy.is_none());
+        let fresh = app.select_library_source(LibrarySource::OpenSubsonic);
+        assert_eq!(fresh.len(), 1);
+        assert!(app.server.library.generation > stale_generation);
+
+        app.finish_server_library_event(ServerLibraryEvent::PageLoaded {
+            generation: stale_generation,
+            offset: 0,
+            result: Ok(ServerLibraryPage {
+                section: ServerLibrarySection::RecentlyPlayed,
+                rows: vec![ServerLibraryRow::Song(song("stale"))],
+                next_offset: None,
+                warning: None,
+            }),
+        });
+        assert!(app.server.library.page.is_none());
+        assert_eq!(app.server.library.busy, Some(ServerLibraryBusy::Page));
+    }
+
+    #[test]
+    fn page_results_are_bounded_again_on_the_owner_lane() {
+        let mut app = App::new(50);
+        app.server.library.source = LibrarySource::OpenSubsonic;
+        let generation = app.server.library.next_generation();
+        app.server.library.busy = Some(ServerLibraryBusy::Page);
+        app.finish_server_library_event(ServerLibraryEvent::PageLoaded {
+            generation,
+            offset: 0,
+            result: Ok(ServerLibraryPage {
+                section: ServerLibrarySection::RecentlyPlayed,
+                rows: (0..80)
+                    .map(|index| ServerLibraryRow::Song(song(&index.to_string())))
+                    .collect(),
+                next_offset: Some(80),
+                warning: None,
+            }),
+        });
+        assert_eq!(
+            app.server.library.page.as_ref().unwrap().rows.len(),
+            SERVER_LIBRARY_PAGE_LIMIT as usize
+        );
+    }
+
+    #[test]
+    fn detail_keeps_rows_and_duplicate_occurrences_after_the_first_page() {
+        let mut app = App::new(50);
+        app.server.library.source = LibrarySource::OpenSubsonic;
+        let generation = app.server.library.next_generation();
+        app.server.library.busy = Some(ServerLibraryBusy::Detail);
+        let mut entries = (0..60)
+            .map(|index| song(&format!("song-{index}")))
+            .collect::<Vec<_>>();
+        entries[50] = entries[49].clone();
+        app.finish_server_library_event(ServerLibraryEvent::DetailLoaded {
+            generation,
+            result: Ok(ServerLibraryDetail::PlaylistEntries(
+                crate::open_subsonic::ServerPlaylist {
+                    summary: crate::open_subsonic::ServerPlaylistSummary {
+                        id: ServerPlaylistId::new("playlist").unwrap(),
+                        name: "Long playlist".to_owned(),
+                        owner: None,
+                        song_count: Some(60),
+                        duration_secs: None,
+                        public: None,
+                        cover_art_id: None,
+                    },
+                    entries,
+                },
+            )),
+        });
+
+        assert_eq!(app.server.library.rows_len(), 60);
+        assert_eq!(
+            app.server.library.row_song(49).unwrap().item,
+            app.server.library.row_song(50).unwrap().item
+        );
+        assert!(app.server.library.row_song(59).is_some());
+    }
+
+    #[test]
+    fn server_errors_do_not_change_local_library() {
+        let mut app = App::new(50);
+        let favorites_before = app.library.favorites.clone();
+        let history_before = app.library.history.clone();
+        app.server.library.source = LibrarySource::OpenSubsonic;
+        let generation = app.server.library.next_generation();
+        app.server.library.busy = Some(ServerLibraryBusy::Page);
+        app.finish_server_library_event(ServerLibraryEvent::PageLoaded {
+            generation,
+            offset: 0,
+            result: Err(ServerLibraryFailure::Offline),
+        });
+        assert_eq!(app.library.favorites, favorites_before);
+        assert_eq!(app.library.history, history_before);
+        assert_eq!(
+            app.server.library.failure,
+            Some(ServerLibraryFailure::Offline)
+        );
+    }
+
+    #[test]
+    fn failed_section_load_cannot_expose_or_activate_previous_rows() {
+        let mut app = App::new(50);
+        app.server.library.source = LibrarySource::OpenSubsonic;
+        app.server.library.section = ServerLibrarySection::Songs;
+        app.server.library.page = Some(ServerLibraryPage {
+            section: ServerLibrarySection::Songs,
+            rows: vec![ServerLibraryRow::Song(song("old"))],
+            next_offset: None,
+            warning: None,
+        });
+
+        let commands = app.select_server_library_section(ServerLibrarySection::Albums);
+        assert_eq!(commands.len(), 1);
+        let generation = app.server.library.generation;
+        assert!(app.server.library.page.is_none());
+        assert!(app.server.library.row_song(0).is_none());
+        assert!(app.activate_server_library_row(generation, 0).is_empty());
+
+        app.finish_server_library_event(ServerLibraryEvent::PageLoaded {
+            generation,
+            offset: 0,
+            result: Err(ServerLibraryFailure::Offline),
+        });
+        assert!(app.server.library.page.is_none());
+        assert_eq!(app.server.library.rows_len(), 0);
+        assert!(app.activate_server_library_row(generation, 0).is_empty());
+    }
+
+    #[test]
+    fn page_history_keeps_latest_hundred_and_back_does_not_skip() {
+        let mut app = App::new(50);
+        app.server.library.source = LibrarySource::OpenSubsonic;
+        app.server.library.section = ServerLibrarySection::Songs;
+        app.server.library.page = Some(ServerLibraryPage {
+            section: ServerLibrarySection::Songs,
+            rows: vec![ServerLibraryRow::Song(song("page-0"))],
+            next_offset: Some(SERVER_LIBRARY_PAGE_LIMIT),
+            warning: None,
+        });
+
+        for page_number in 1..=101 {
+            let expected_offset = page_number * SERVER_LIBRARY_PAGE_LIMIT;
+            let commands = app.next_server_library_page();
+            assert_eq!(commands.len(), 1);
+            assert!(matches!(
+                &commands[0],
+                Cmd::ServerLibrary(ServerLibraryCommand::LoadPage { offset, .. })
+                    if *offset == expected_offset
+            ));
+            let generation = app.server.library.generation;
+            app.finish_server_library_event(ServerLibraryEvent::PageLoaded {
+                generation,
+                offset: expected_offset,
+                result: Ok(ServerLibraryPage {
+                    section: ServerLibrarySection::Songs,
+                    rows: vec![ServerLibraryRow::Song(song(&format!("page-{page_number}")))],
+                    next_offset: Some(expected_offset + SERVER_LIBRARY_PAGE_LIMIT),
+                    warning: None,
+                }),
+            });
+        }
+
+        assert_eq!(
+            app.server.library.previous_offsets.len(),
+            SERVER_LIBRARY_MAX_PAGE_HISTORY
+        );
+        assert_eq!(
+            app.server.library.previous_offsets.first(),
+            Some(&SERVER_LIBRARY_PAGE_LIMIT)
+        );
+        assert_eq!(
+            app.server.library.previous_offsets.last(),
+            Some(&(100 * SERVER_LIBRARY_PAGE_LIMIT))
+        );
+
+        let commands = app.previous_server_library_page();
+        assert_eq!(commands.len(), 1);
+        assert!(matches!(
+            &commands[0],
+            Cmd::ServerLibrary(ServerLibraryCommand::LoadPage { offset, .. })
+                if *offset == 100 * SERVER_LIBRARY_PAGE_LIMIT
+        ));
+    }
+
+    #[test]
+    fn switching_to_server_ends_hidden_local_filter_editing() {
+        let mut app = App::new(50);
+        app.mode = Mode::Library;
+        app.library_ui.filter_editing = true;
+        app.library_ui.filter_query = "kept for local".to_owned();
+
+        let commands = app.select_library_source(LibrarySource::OpenSubsonic);
+
+        assert_eq!(commands.len(), 1);
+        assert!(!app.library_ui.filter_editing);
+        assert_eq!(app.library_ui.filter_query, "kept for local");
+        assert_eq!(app.server.library.source, LibrarySource::OpenSubsonic);
+    }
+
+    #[test]
+    fn configured_library_and_common_actions_drive_server_rows() {
+        let mut overrides = BTreeMap::new();
+        overrides.insert("common.move_down".to_owned(), "j".to_owned());
+        overrides.insert("common.focus_next".to_owned(), "x".to_owned());
+        overrides.insert("library.enqueue".to_owned(), "e".to_owned());
+        overrides.insert("library.add_to_playlist".to_owned(), "t".to_owned());
+        overrides.insert("library.back".to_owned(), "b".to_owned());
+        let mut app = server_library_app(&["one", "two"]);
+        app.keymap = KeyMap::from_overrides(&overrides);
+
+        assert!(
+            app.on_key_server_library(KeyEvent::from(KeyCode::Char('j')))
+                .is_empty()
+        );
+        assert_eq!(app.server.library.selected, 1);
+
+        assert!(
+            !app.on_key_server_library(KeyEvent::from(KeyCode::Char('e')))
+                .is_empty(),
+            "the remapped enqueue action should reach the selected server song"
+        );
+
+        app.on_key_server_library(KeyEvent::from(KeyCode::Char('t')));
+        assert_eq!(
+            app.playlist_picker.as_ref().expect("playlist picker").songs[0].title,
+            "Song two"
+        );
+        app.playlist_picker = None;
+
+        app.server.library.busy = None;
+        app.on_key_server_library(KeyEvent::from(KeyCode::Char('x')));
+        assert_eq!(app.server.library.section, ServerLibrarySection::Playlists);
+
+        app.server.library.busy = None;
+        app.server.library.detail = None;
+        app.server.library.previous_offsets.clear();
+        app.on_key_server_library(KeyEvent::from(KeyCode::Char('b')));
+        assert_eq!(app.mode, Mode::Player);
+    }
+
+    #[test]
+    fn default_add_to_playlist_no_longer_collides_with_page_navigation() {
+        let mut app = server_library_app(&["one"]);
+        app.server.library.page.as_mut().unwrap().next_offset = Some(SERVER_LIBRARY_PAGE_LIMIT);
+
+        assert!(
+            app.on_key_server_library(KeyEvent::from(KeyCode::Char('p')))
+                .is_empty()
+        );
+        assert!(app.playlist_picker.is_some());
+        assert_eq!(app.server.library.offset, 0);
+        assert!(app.server.library.busy.is_none());
+
+        app.playlist_picker = None;
+        let commands = app.on_key_server_library(KeyEvent::from(KeyCode::Char(']')));
+        assert!(matches!(
+            commands.as_slice(),
+            [Cmd::ServerLibrary(ServerLibraryCommand::LoadPage { offset, .. })]
+                if *offset == SERVER_LIBRARY_PAGE_LIMIT
+        ));
+    }
+
+    #[test]
+    fn fixed_section_numbers_reach_every_server_section() {
+        let cases = [
+            ('1', ServerLibrarySection::RecentlyPlayed),
+            ('2', ServerLibrarySection::Albums),
+            ('3', ServerLibrarySection::Artists),
+            ('4', ServerLibrarySection::Songs),
+            ('5', ServerLibrarySection::Playlists),
+        ];
+        for (key, expected) in cases {
+            let mut app = server_library_app(&["one"]);
+            app.on_key_server_library(KeyEvent::from(KeyCode::Char(key)));
+            assert_eq!(app.server.library.section, expected);
+        }
+
+        let mut app = server_library_app(&["one"]);
+        app.on_key_server_library(KeyEvent::new(
+            KeyCode::Char('1'),
+            crossterm::event::KeyModifiers::CONTROL,
+        ));
+        assert_eq!(
+            app.server.library.section,
+            ServerLibrarySection::Songs,
+            "modified digits are not fixed server shortcuts"
+        );
+    }
+}

--- a/src/app/server_settings.rs
+++ b/src/app/server_settings.rs
@@ -1,0 +1,1393 @@
+//! Music-server settings state and reducer.
+//!
+//! This domain deliberately lives outside [`crate::settings::SettingsDraft`]. Connection
+//! material is move-only, zeroized on drop, and reaches durable storage only after the
+//! connection test has produced a prepared core transaction.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use zeroize::{Zeroize, Zeroizing};
+
+use super::{App, Cmd, MouseTarget, PersistCmd, StatusKind};
+use crate::keymap::Action;
+use crate::open_subsonic::PreparedSetup;
+use crate::search_source::SearchSource;
+use crate::util::text_edit::TextCursor;
+
+const MAX_SETUP_DISPLAY_NAME_BYTES: usize = 1_024;
+const MAX_SETUP_ORIGIN_BYTES: usize = 4_096;
+const MAX_SETUP_USERNAME_BYTES: usize = 1_024;
+const MAX_SETUP_PASSWORD_BYTES: usize = 64 * 1_024;
+const MAX_SETUP_API_KEY_BYTES: usize = 2_048;
+const MAX_SETUP_CA_PATH_BYTES: usize = 16 * 1_024;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SyncArea {
+    #[default]
+    Status,
+    PersonalState,
+    MusicServer,
+    DevicesRecovery,
+}
+
+impl SyncArea {
+    pub const ALL: [Self; 4] = [
+        Self::Status,
+        Self::PersonalState,
+        Self::MusicServer,
+        Self::DevicesRecovery,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Status => crate::t!("Status", "상태", "状態"),
+            Self::PersonalState => {
+                crate::t!("Personal state", "개인 상태", "個人データ")
+            }
+            Self::MusicServer => {
+                crate::t!("Music server", "음악 서버", "音楽サーバー")
+            }
+            Self::DevicesRecovery => {
+                crate::t!("Devices & recovery", "기기 및 복구", "デバイスと復旧")
+            }
+        }
+    }
+
+    fn stepped(self, forward: bool) -> Self {
+        let index = Self::ALL.iter().position(|area| *area == self).unwrap_or(0);
+        let next = if forward {
+            (index + 1) % Self::ALL.len()
+        } else {
+            (index + Self::ALL.len() - 1) % Self::ALL.len()
+        };
+        Self::ALL[next]
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MusicServerHealth {
+    #[default]
+    Off,
+    UpToDate,
+    NeedsAttention,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MusicServerSummary {
+    pub health: MusicServerHealth,
+    pub configured: bool,
+    pub display_name: Option<String>,
+    pub credential_label: Option<String>,
+    pub lan_http: bool,
+    pub custom_ca: bool,
+}
+
+impl MusicServerSummary {
+    pub fn display_name(&self) -> &str {
+        self.display_name
+            .as_deref()
+            .unwrap_or_else(|| crate::t!("Music server", "음악 서버", "音楽サーバー"))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MusicServerFailure {
+    Authentication,
+    Certificate,
+    Connection,
+    InvalidInput,
+    Storage,
+    Unavailable,
+}
+
+impl MusicServerFailure {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Authentication => crate::t!(
+                "The sign-in details were rejected.",
+                "로그인 정보가 거부되었어요.",
+                "ログイン情報が拒否されました。"
+            ),
+            Self::Certificate => crate::t!(
+                "The server certificate could not be verified.",
+                "서버 인증서를 확인할 수 없어요.",
+                "サーバー証明書を確認できません。"
+            ),
+            Self::Connection => crate::t!(
+                "The music server could not be reached.",
+                "음악 서버에 연결할 수 없어요.",
+                "音楽サーバーに接続できません。"
+            ),
+            Self::InvalidInput => crate::t!(
+                "Check the connection details.",
+                "연결 정보를 확인해 주세요.",
+                "接続情報を確認してください。"
+            ),
+            Self::Storage => crate::t!(
+                "Music server settings could not be saved.",
+                "음악 서버 설정을 저장할 수 없어요.",
+                "音楽サーバー設定を保存できません。"
+            ),
+            Self::Unavailable => crate::t!(
+                "Music server support is not available right now.",
+                "지금은 음악 서버 기능을 사용할 수 없어요.",
+                "現在、音楽サーバー機能を利用できません。"
+            ),
+        }
+    }
+
+    pub fn recovery_label(self) -> &'static str {
+        match self {
+            Self::Authentication => {
+                crate::t!("Update password", "비밀번호 업데이트", "パスワードを更新")
+            }
+            Self::Certificate => {
+                crate::t!("Choose CA file", "CA 파일 선택", "CAファイルを選択")
+            }
+            Self::Connection => crate::t!("Try again", "다시 시도", "再試行"),
+            Self::InvalidInput => {
+                crate::t!("Edit connection", "연결 정보 수정", "接続情報を編集")
+            }
+            Self::Storage => crate::t!("Try again", "다시 시도", "再試行"),
+            Self::Unavailable => crate::t!("Close", "닫기", "閉じる"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MusicServerCredentialMode {
+    #[default]
+    Password,
+    ApiKey,
+}
+
+impl MusicServerCredentialMode {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Password => crate::t!("Password", "비밀번호", "パスワード"),
+            Self::ApiKey => crate::t!("API key", "API 키", "APIキー"),
+        }
+    }
+
+    fn toggled(self) -> Self {
+        match self {
+            Self::Password => Self::ApiKey,
+            Self::ApiKey => Self::Password,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MusicServerIdentityIntent {
+    Create,
+    UpdateSameServerAndAccount,
+    ReplaceServerOrAccount,
+}
+
+/// Move-only, secret-bearing request sent from the reducer to the runtime worker.
+///
+/// It intentionally implements neither `Debug` nor `Clone`; every text field is zeroized even
+/// though only the final credential is cryptographic secret material. This keeps URLs and account
+/// names out of retained crash/debug values too.
+pub struct MusicServerSetupInput {
+    pub(crate) display_name: Zeroizing<String>,
+    pub(crate) origin: Zeroizing<String>,
+    pub(crate) username: Zeroizing<String>,
+    pub(crate) secret: Zeroizing<String>,
+    pub(crate) credential_mode: MusicServerCredentialMode,
+    pub(crate) custom_ca_path: Zeroizing<String>,
+    pub(crate) allow_lan_http: bool,
+    pub(crate) identity_intent: MusicServerIdentityIntent,
+}
+
+pub enum MusicServerCommand {
+    Refresh {
+        generation: u64,
+    },
+    TestAndPrepare {
+        generation: u64,
+        input: MusicServerSetupInput,
+    },
+    Commit {
+        generation: u64,
+        prepared: Box<PreparedSetup>,
+    },
+    Remove {
+        generation: u64,
+    },
+}
+
+pub enum MusicServerEvent {
+    Refreshed {
+        generation: u64,
+        result: Result<MusicServerRefreshOutcome, MusicServerFailure>,
+    },
+    Prepared {
+        generation: u64,
+        result: Result<Box<PreparedSetup>, MusicServerFailure>,
+    },
+    Committed {
+        generation: u64,
+        result: Result<MusicServerSummary, MusicServerFailure>,
+    },
+    Removed {
+        generation: u64,
+        result: Result<(), MusicServerFailure>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MusicServerRefreshOutcome {
+    pub summary: MusicServerSummary,
+    pub failure: Option<MusicServerFailure>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MusicServerBusy {
+    Refresh,
+    Testing,
+    Saving,
+    Removing,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MusicServerSetupField {
+    DisplayName,
+    Origin,
+    Identity,
+    CredentialMode,
+    Username,
+    Secret,
+    CustomCa,
+    AllowLanHttp,
+    SaveAndTest,
+    Cancel,
+}
+
+impl MusicServerSetupField {
+    pub const ALL: [Self; 10] = [
+        Self::DisplayName,
+        Self::Origin,
+        Self::Identity,
+        Self::CredentialMode,
+        Self::Username,
+        Self::Secret,
+        Self::CustomCa,
+        Self::AllowLanHttp,
+        Self::SaveAndTest,
+        Self::Cancel,
+    ];
+}
+
+/// Secret-owning setup form. No `Debug`/`Clone`; dropping or cancelling it wipes all input.
+pub struct MusicServerSetupForm {
+    pub(crate) display_name: Zeroizing<String>,
+    pub(crate) origin: Zeroizing<String>,
+    pub(crate) username: Zeroizing<String>,
+    pub(crate) secret: Zeroizing<String>,
+    pub(crate) credential_mode: MusicServerCredentialMode,
+    pub(crate) custom_ca_path: Zeroizing<String>,
+    pub(crate) allow_lan_http: bool,
+    pub(crate) selected: usize,
+    pub(crate) cursor: TextCursor,
+    pub(crate) reveal_secret: bool,
+    pub(crate) identity_intent: Option<MusicServerIdentityIntent>,
+}
+
+impl Default for MusicServerSetupForm {
+    fn default() -> Self {
+        Self::new(false)
+    }
+}
+
+impl MusicServerSetupForm {
+    fn new(configured: bool) -> Self {
+        Self {
+            display_name: zeroizing_buffer(MAX_SETUP_DISPLAY_NAME_BYTES),
+            origin: zeroizing_buffer(MAX_SETUP_ORIGIN_BYTES),
+            username: zeroizing_buffer(MAX_SETUP_USERNAME_BYTES),
+            secret: zeroizing_buffer(MAX_SETUP_PASSWORD_BYTES),
+            credential_mode: MusicServerCredentialMode::Password,
+            custom_ca_path: zeroizing_buffer(MAX_SETUP_CA_PATH_BYTES),
+            allow_lan_http: false,
+            selected: 0,
+            cursor: TextCursor::default(),
+            reveal_secret: false,
+            identity_intent: (!configured).then_some(MusicServerIdentityIntent::Create),
+        }
+    }
+
+    pub(crate) fn selected_field(&self) -> MusicServerSetupField {
+        MusicServerSetupField::ALL[self.selected.min(MusicServerSetupField::ALL.len() - 1)]
+    }
+
+    pub(crate) fn text_value(&self, field: MusicServerSetupField) -> Option<&str> {
+        match field {
+            MusicServerSetupField::DisplayName => Some(self.display_name.as_str()),
+            MusicServerSetupField::Origin => Some(self.origin.as_str()),
+            MusicServerSetupField::Username => Some(self.username.as_str()),
+            MusicServerSetupField::Secret => Some(self.secret.as_str()),
+            MusicServerSetupField::CustomCa => Some(self.custom_ca_path.as_str()),
+            MusicServerSetupField::CredentialMode
+            | MusicServerSetupField::Identity
+            | MusicServerSetupField::AllowLanHttp
+            | MusicServerSetupField::SaveAndTest
+            | MusicServerSetupField::Cancel => None,
+        }
+    }
+
+    fn text_value_mut(&mut self, field: MusicServerSetupField) -> Option<&mut String> {
+        match field {
+            MusicServerSetupField::DisplayName => Some(&mut self.display_name),
+            MusicServerSetupField::Origin => Some(&mut self.origin),
+            MusicServerSetupField::Username => Some(&mut self.username),
+            MusicServerSetupField::Secret => Some(&mut self.secret),
+            MusicServerSetupField::CustomCa => Some(&mut self.custom_ca_path),
+            MusicServerSetupField::CredentialMode
+            | MusicServerSetupField::Identity
+            | MusicServerSetupField::AllowLanHttp
+            | MusicServerSetupField::SaveAndTest
+            | MusicServerSetupField::Cancel => None,
+        }
+    }
+
+    fn text_byte_limit(&self, field: MusicServerSetupField) -> Option<usize> {
+        match field {
+            MusicServerSetupField::DisplayName => Some(MAX_SETUP_DISPLAY_NAME_BYTES),
+            MusicServerSetupField::Origin => Some(MAX_SETUP_ORIGIN_BYTES),
+            MusicServerSetupField::Username => Some(MAX_SETUP_USERNAME_BYTES),
+            MusicServerSetupField::Secret => Some(match self.credential_mode {
+                MusicServerCredentialMode::Password => MAX_SETUP_PASSWORD_BYTES,
+                MusicServerCredentialMode::ApiKey => MAX_SETUP_API_KEY_BYTES,
+            }),
+            MusicServerSetupField::CustomCa => Some(MAX_SETUP_CA_PATH_BYTES),
+            MusicServerSetupField::CredentialMode
+            | MusicServerSetupField::Identity
+            | MusicServerSetupField::AllowLanHttp
+            | MusicServerSetupField::SaveAndTest
+            | MusicServerSetupField::Cancel => None,
+        }
+    }
+
+    fn set_selected(&mut self, selected: usize) {
+        self.selected = selected.min(MusicServerSetupField::ALL.len() - 1);
+        self.cursor = self
+            .text_value(self.selected_field())
+            .map(TextCursor::at_end)
+            .unwrap_or_default();
+    }
+
+    fn into_input(mut self) -> MusicServerSetupInput {
+        MusicServerSetupInput {
+            display_name: std::mem::take(&mut self.display_name),
+            origin: std::mem::take(&mut self.origin),
+            username: std::mem::take(&mut self.username),
+            secret: std::mem::take(&mut self.secret),
+            credential_mode: self.credential_mode,
+            custom_ca_path: std::mem::take(&mut self.custom_ca_path),
+            allow_lan_http: self.allow_lan_http,
+            identity_intent: self
+                .identity_intent
+                .expect("identity intent is validated before setup starts"),
+        }
+    }
+}
+
+fn zeroizing_buffer(capacity: usize) -> Zeroizing<String> {
+    Zeroizing::new(String::with_capacity(capacity))
+}
+
+impl Drop for MusicServerSetupForm {
+    fn drop(&mut self) {
+        self.display_name.zeroize();
+        self.origin.zeroize();
+        self.username.zeroize();
+        self.secret.zeroize();
+        self.custom_ca_path.zeroize();
+    }
+}
+
+pub enum MusicServerWizard {
+    Setup(MusicServerSetupForm),
+    Waiting,
+    RemoveConfirm,
+}
+
+/// Settings/UI state. It intentionally has no `Debug`/`Clone` because `wizard` may own secrets.
+pub struct MusicServerSettingsState {
+    pub area: SyncArea,
+    pub selected: usize,
+    pub generation: u64,
+    pub busy: Option<MusicServerBusy>,
+    pub summary: MusicServerSummary,
+    pub failure: Option<MusicServerFailure>,
+    pub wizard: Option<MusicServerWizard>,
+}
+
+impl Default for MusicServerSettingsState {
+    fn default() -> Self {
+        Self {
+            area: SyncArea::Status,
+            selected: 0,
+            generation: 0,
+            busy: None,
+            summary: MusicServerSummary::default(),
+            failure: None,
+            wizard: None,
+        }
+    }
+}
+
+impl MusicServerSettingsState {
+    pub fn row_count(&self) -> usize {
+        if self.summary.configured { 3 } else { 2 }
+    }
+
+    pub fn modal_open(&self) -> bool {
+        self.wizard.is_some()
+    }
+
+    fn next_generation(&mut self) -> u64 {
+        self.generation = self.generation.wrapping_add(1).max(1);
+        self.generation
+    }
+}
+
+impl App {
+    pub(in crate::app) fn on_sync_settings_action(
+        &mut self,
+        action: Option<Action>,
+        key: KeyEvent,
+    ) -> Option<Vec<Cmd>> {
+        let area = self.server.settings.area;
+        match action {
+            Some(Action::MoveUp | Action::MoveDown) if area == SyncArea::MusicServer => {
+                Some(self.on_key_music_server_settings(key))
+            }
+            Some(Action::MoveUp | Action::MoveDown)
+                if matches!(area, SyncArea::PersonalState | SyncArea::DevicesRecovery) =>
+            {
+                let delta = if matches!(action, Some(Action::MoveUp)) {
+                    -1
+                } else {
+                    1
+                };
+                self.personal_state.sync_ui.move_row(delta);
+                self.dirty = true;
+                Some(Vec::new())
+            }
+            Some(Action::MoveUp | Action::MoveDown) => Some(Vec::new()),
+            Some(Action::ChangeDecrease) => Some(self.switch_sync_area(false)),
+            Some(Action::ChangeIncrease) => Some(self.switch_sync_area(true)),
+            Some(Action::Confirm) if area == SyncArea::MusicServer => {
+                Some(self.on_key_music_server_settings(key))
+            }
+            Some(Action::Confirm)
+                if matches!(area, SyncArea::PersonalState | SyncArea::DevicesRecovery) =>
+            {
+                Some(self.activate_sync_row())
+            }
+            Some(Action::Confirm) => Some(Vec::new()),
+            _ => None,
+        }
+    }
+
+    pub(in crate::app) fn switch_sync_area(&mut self, forward: bool) -> Vec<Cmd> {
+        if self.server.settings.modal_open() {
+            return Vec::new();
+        }
+        let next = self.server.settings.area.stepped(forward);
+        self.select_sync_area(next)
+    }
+
+    pub(in crate::app) fn select_sync_area(&mut self, area: SyncArea) -> Vec<Cmd> {
+        if self.server.settings.modal_open() {
+            return Vec::new();
+        }
+        self.server.settings.area = area;
+        self.bridges.settings_scroll.reset();
+        self.dirty = true;
+        match area {
+            SyncArea::Status => {
+                self.personal_state.sync_ui.page = super::sync_ui::SyncPage::Overview;
+                self.personal_state.sync_ui.row = 0;
+                let mut commands = self.request_sync_ui_refresh();
+                commands.extend(self.request_music_server_status());
+                commands
+            }
+            SyncArea::PersonalState => {
+                self.personal_state.sync_ui.page = super::sync_ui::SyncPage::Overview;
+                self.personal_state.sync_ui.row = 0;
+                self.request_sync_ui_refresh()
+            }
+            SyncArea::MusicServer => self.request_music_server_status(),
+            SyncArea::DevicesRecovery => {
+                self.personal_state.sync_ui.page = super::sync_ui::SyncPage::Devices;
+                self.personal_state.sync_ui.row = 0;
+                self.request_sync_ui_refresh()
+            }
+        }
+    }
+
+    pub(in crate::app) fn request_music_server_status(&mut self) -> Vec<Cmd> {
+        if self.server.settings.busy.is_some() {
+            return Vec::new();
+        }
+        let generation = self.server.settings.next_generation();
+        self.server.settings.busy = Some(MusicServerBusy::Refresh);
+        self.server.settings.failure = None;
+        self.dirty = true;
+        vec![Cmd::MusicServer(MusicServerCommand::Refresh { generation })]
+    }
+
+    pub(in crate::app) fn cancel_music_server_session(&mut self) {
+        self.server.settings.next_generation();
+        self.server.settings.busy = None;
+        self.server.settings.wizard = None;
+        self.server.settings.failure = None;
+    }
+
+    fn set_music_server_search_enabled(&mut self, enabled: bool) -> Vec<Cmd> {
+        self.config
+            .search
+            .set_enabled(SearchSource::OpenSubsonic, enabled);
+        self.config.search = self.config.search.clone().normalized();
+        self.search.source = self.config.search.normalized_source(self.search.source);
+        if !enabled {
+            self.dropdowns.search_source_open = false;
+        }
+        vec![Cmd::Persist(PersistCmd::Config(Box::new(
+            self.config.clone(),
+        )))]
+    }
+
+    pub(in crate::app) fn on_key_music_server_settings(&mut self, key: KeyEvent) -> Vec<Cmd> {
+        if self.server.settings.wizard.is_some() {
+            return self.on_key_music_server_wizard(key);
+        }
+        let row_count = self.server.settings.row_count();
+        match key.code {
+            KeyCode::Up => {
+                self.server.settings.selected = self.server.settings.selected.saturating_sub(1);
+                self.dirty = true;
+                Vec::new()
+            }
+            KeyCode::Down => {
+                self.server.settings.selected =
+                    (self.server.settings.selected + 1).min(row_count.saturating_sub(1));
+                self.dirty = true;
+                Vec::new()
+            }
+            KeyCode::Enter => self.activate_music_server_row(self.server.settings.selected),
+            _ => Vec::new(),
+        }
+    }
+
+    pub(in crate::app) fn activate_music_server_row(&mut self, row: usize) -> Vec<Cmd> {
+        if self.server.settings.busy.is_some() || row >= self.server.settings.row_count() {
+            return Vec::new();
+        }
+        self.server.settings.selected = row;
+        if self.server.settings.summary.configured {
+            match row {
+                0 => self.request_music_server_status(),
+                1 => {
+                    self.open_music_server_setup();
+                    Vec::new()
+                }
+                2 => {
+                    self.server.settings.wizard = Some(MusicServerWizard::RemoveConfirm);
+                    self.dirty = true;
+                    Vec::new()
+                }
+                _ => Vec::new(),
+            }
+        } else {
+            match row {
+                0 => {
+                    self.open_music_server_setup();
+                    Vec::new()
+                }
+                1 => self.request_music_server_status(),
+                _ => Vec::new(),
+            }
+        }
+    }
+
+    pub(in crate::app) fn open_music_server_setup(&mut self) {
+        if self.server.settings.busy.is_some() {
+            return;
+        }
+        self.server.settings.next_generation();
+        self.server.settings.failure = None;
+        self.server.settings.wizard = Some(MusicServerWizard::Setup(MusicServerSetupForm::new(
+            self.server.settings.summary.configured,
+        )));
+        self.dirty = true;
+    }
+
+    fn on_key_music_server_wizard(&mut self, key: KeyEvent) -> Vec<Cmd> {
+        let durable_change_in_flight = matches!(
+            self.server.settings.busy,
+            Some(MusicServerBusy::Saving | MusicServerBusy::Removing)
+        );
+        if durable_change_in_flight {
+            return Vec::new();
+        }
+        let editing_text = matches!(
+            self.server.settings.wizard.as_ref(),
+            Some(MusicServerWizard::Setup(form)) if form.text_value(form.selected_field()).is_some()
+        );
+        if key.code == KeyCode::Esc
+            || (!editing_text
+                && key.code == KeyCode::Char('q')
+                && key.modifiers == KeyModifiers::NONE)
+        {
+            self.cancel_music_server_session();
+            self.dirty = true;
+            return Vec::new();
+        }
+        if self.server.settings.busy.is_some() {
+            return Vec::new();
+        }
+        if matches!(
+            self.server.settings.wizard,
+            Some(MusicServerWizard::RemoveConfirm)
+        ) {
+            return match key.code {
+                KeyCode::Enter => self.start_music_server_remove(),
+                _ => Vec::new(),
+            };
+        }
+
+        let Some(MusicServerWizard::Setup(form)) = self.server.settings.wizard.as_mut() else {
+            return Vec::new();
+        };
+        let field = form.selected_field();
+        match key.code {
+            KeyCode::Up | KeyCode::BackTab => {
+                form.set_selected(form.selected.saturating_sub(1));
+                self.dirty = true;
+                Vec::new()
+            }
+            KeyCode::Down | KeyCode::Tab => {
+                form.set_selected((form.selected + 1).min(MusicServerSetupField::ALL.len() - 1));
+                self.dirty = true;
+                Vec::new()
+            }
+            KeyCode::Left | KeyCode::Right | KeyCode::Char(' ')
+                if field == MusicServerSetupField::CredentialMode =>
+            {
+                form.credential_mode = form.credential_mode.toggled();
+                form.secret.clear();
+                if form.credential_mode == MusicServerCredentialMode::ApiKey {
+                    form.username.clear();
+                }
+                self.dirty = true;
+                Vec::new()
+            }
+            KeyCode::Left | KeyCode::Right | KeyCode::Char(' ')
+                if field == MusicServerSetupField::Identity
+                    && form.identity_intent != Some(MusicServerIdentityIntent::Create) =>
+            {
+                form.identity_intent = Some(match form.identity_intent {
+                    Some(MusicServerIdentityIntent::UpdateSameServerAndAccount) => {
+                        MusicServerIdentityIntent::ReplaceServerOrAccount
+                    }
+                    _ => MusicServerIdentityIntent::UpdateSameServerAndAccount,
+                });
+                self.dirty = true;
+                Vec::new()
+            }
+            KeyCode::Left | KeyCode::Right | KeyCode::Char(' ')
+                if field == MusicServerSetupField::AllowLanHttp =>
+            {
+                form.allow_lan_http = !form.allow_lan_http;
+                self.dirty = true;
+                Vec::new()
+            }
+            KeyCode::Enter if field == MusicServerSetupField::SaveAndTest => {
+                self.start_music_server_setup()
+            }
+            KeyCode::Enter if field == MusicServerSetupField::Cancel => {
+                self.cancel_music_server_session();
+                self.dirty = true;
+                Vec::new()
+            }
+            KeyCode::Enter if field == MusicServerSetupField::Secret => {
+                form.reveal_secret = !form.reveal_secret;
+                self.dirty = true;
+                Vec::new()
+            }
+            KeyCode::Backspace => {
+                let mut cursor = form.cursor;
+                if let Some(value) = form.text_value_mut(field) {
+                    cursor.delete_previous_grapheme(value);
+                    form.cursor = cursor;
+                    self.dirty = true;
+                }
+                Vec::new()
+            }
+            KeyCode::Left if form.text_value(field).is_some() => {
+                let mut cursor = form.cursor;
+                if form
+                    .text_value(field)
+                    .is_some_and(|value| cursor.move_left(value))
+                {
+                    form.cursor = cursor;
+                    self.dirty = true;
+                }
+                Vec::new()
+            }
+            KeyCode::Right if form.text_value(field).is_some() => {
+                let mut cursor = form.cursor;
+                if form
+                    .text_value(field)
+                    .is_some_and(|value| cursor.move_right(value))
+                {
+                    form.cursor = cursor;
+                    self.dirty = true;
+                }
+                Vec::new()
+            }
+            KeyCode::Char(character)
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                let mut cursor = form.cursor;
+                let may_insert = form.text_byte_limit(field).is_some_and(|limit| {
+                    form.text_value(field).is_some_and(|value| {
+                        value.len().saturating_add(character.len_utf8()) <= limit
+                    })
+                });
+                if may_insert && let Some(value) = form.text_value_mut(field) {
+                    cursor.insert_char(value, character);
+                    form.cursor = cursor;
+                    self.dirty = true;
+                }
+                Vec::new()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn start_music_server_setup(&mut self) -> Vec<Cmd> {
+        if self.server.settings.busy.is_some() {
+            return Vec::new();
+        }
+        if matches!(
+            self.server.settings.wizard.as_ref(),
+            Some(MusicServerWizard::Setup(MusicServerSetupForm {
+                identity_intent: None,
+                ..
+            }))
+        ) {
+            self.server.settings.failure = Some(MusicServerFailure::InvalidInput);
+            self.status.kind = StatusKind::Error;
+            self.status.text = crate::t!(
+                "Choose whether this is the same server and account",
+                "같은 서버와 계정인지 선택해 주세요",
+                "同じサーバーとアカウントか選択してください"
+            )
+            .to_owned();
+            self.dirty = true;
+            return Vec::new();
+        }
+        let Some(MusicServerWizard::Setup(form)) = self.server.settings.wizard.take() else {
+            return Vec::new();
+        };
+        let generation = self.server.settings.generation.max(1);
+        self.server.settings.busy = Some(MusicServerBusy::Testing);
+        self.server.settings.failure = None;
+        self.server.settings.wizard = Some(MusicServerWizard::Waiting);
+        self.dirty = true;
+        vec![Cmd::MusicServer(MusicServerCommand::TestAndPrepare {
+            generation,
+            input: form.into_input(),
+        })]
+    }
+
+    fn start_music_server_remove(&mut self) -> Vec<Cmd> {
+        if self.server.settings.busy.is_some() {
+            return Vec::new();
+        }
+        let generation = self.server.settings.generation.max(1);
+        self.server.settings.busy = Some(MusicServerBusy::Removing);
+        self.server.settings.wizard = Some(MusicServerWizard::Waiting);
+        self.dirty = true;
+        vec![Cmd::MusicServer(MusicServerCommand::Remove { generation })]
+    }
+
+    pub(in crate::app) fn on_music_server_wizard_mouse_target(
+        &mut self,
+        target: MouseTarget,
+    ) -> Vec<Cmd> {
+        if !self.server.settings.modal_open() {
+            return Vec::new();
+        }
+        match target {
+            MouseTarget::MusicServerWizardSecondary
+                if matches!(
+                    self.server.settings.busy,
+                    Some(MusicServerBusy::Saving | MusicServerBusy::Removing)
+                ) =>
+            {
+                Vec::new()
+            }
+            MouseTarget::MusicServerWizardSecondary => {
+                self.cancel_music_server_session();
+                self.dirty = true;
+                Vec::new()
+            }
+            MouseTarget::MusicServerWizardPrimary if self.server.settings.busy.is_some() => {
+                Vec::new()
+            }
+            MouseTarget::MusicServerWizardPrimary => match self.server.settings.wizard.as_ref() {
+                Some(MusicServerWizard::Setup(_)) => self.start_music_server_setup(),
+                Some(MusicServerWizard::RemoveConfirm) => self.start_music_server_remove(),
+                Some(MusicServerWizard::Waiting) | None => Vec::new(),
+            },
+            MouseTarget::MusicServerWizardReveal => {
+                if let Some(MusicServerWizard::Setup(form)) = self.server.settings.wizard.as_mut() {
+                    form.reveal_secret = !form.reveal_secret;
+                    self.dirty = true;
+                }
+                Vec::new()
+            }
+            MouseTarget::MusicServerWizardField(index) => {
+                let Some(field) = MusicServerSetupField::ALL.get(index).copied() else {
+                    return Vec::new();
+                };
+                let Some(MusicServerWizard::Setup(form)) = self.server.settings.wizard.as_mut()
+                else {
+                    return Vec::new();
+                };
+                form.set_selected(index);
+                self.dirty = true;
+                match field {
+                    MusicServerSetupField::CredentialMode
+                    | MusicServerSetupField::Identity
+                    | MusicServerSetupField::AllowLanHttp => self.on_key_music_server_wizard(
+                        KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE),
+                    ),
+                    MusicServerSetupField::SaveAndTest => self.start_music_server_setup(),
+                    MusicServerSetupField::Cancel => {
+                        self.cancel_music_server_session();
+                        Vec::new()
+                    }
+                    _ => Vec::new(),
+                }
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    pub(in crate::app) fn finish_music_server_event(
+        &mut self,
+        event: MusicServerEvent,
+    ) -> Vec<Cmd> {
+        let event_generation = match &event {
+            MusicServerEvent::Refreshed { generation, .. }
+            | MusicServerEvent::Prepared { generation, .. }
+            | MusicServerEvent::Committed { generation, .. }
+            | MusicServerEvent::Removed { generation, .. } => *generation,
+        };
+        if event_generation != self.server.settings.generation {
+            return Vec::new();
+        }
+
+        match event {
+            MusicServerEvent::Refreshed { result, .. } => {
+                self.server.settings.busy = None;
+                match result {
+                    Ok(outcome) => {
+                        self.server.settings.summary = outcome.summary;
+                        self.server.settings.failure = outcome.failure;
+                    }
+                    Err(failure) => {
+                        self.server.settings.failure = Some(failure);
+                        self.server.settings.summary.health = MusicServerHealth::NeedsAttention;
+                    }
+                }
+                self.dirty = true;
+                Vec::new()
+            }
+            MusicServerEvent::Prepared { result, .. } => match result {
+                Ok(prepared) => {
+                    self.server.settings.busy = Some(MusicServerBusy::Saving);
+                    self.dirty = true;
+                    vec![Cmd::MusicServer(MusicServerCommand::Commit {
+                        generation: event_generation,
+                        prepared,
+                    })]
+                }
+                Err(failure) => {
+                    self.server.settings.busy = None;
+                    self.server.settings.failure = Some(failure);
+                    self.server.settings.wizard = Some(MusicServerWizard::Setup(
+                        MusicServerSetupForm::new(self.server.settings.summary.configured),
+                    ));
+                    self.status.kind = StatusKind::Error;
+                    self.status.text = failure.label().to_owned();
+                    self.dirty = true;
+                    Vec::new()
+                }
+            },
+            MusicServerEvent::Committed { result, .. } => {
+                self.server.settings.busy = None;
+                let commands = match result {
+                    Ok(summary) => {
+                        let runtime_ready = summary.health == MusicServerHealth::UpToDate;
+                        self.server.settings.summary = summary;
+                        self.server.settings.failure =
+                            (!runtime_ready).then_some(MusicServerFailure::Connection);
+                        self.server.settings.wizard = None;
+                        if runtime_ready {
+                            self.status.kind = StatusKind::Info;
+                            self.status.text = crate::t!(
+                                "Music server connected",
+                                "음악 서버가 연결되었어요",
+                                "音楽サーバーに接続しました"
+                            )
+                            .to_owned();
+                        } else {
+                            self.status.kind = StatusKind::Error;
+                            self.status.text = crate::t!(
+                                "Connection saved; the server needs attention",
+                                "연결은 저장됐지만 서버 확인이 필요해요",
+                                "接続は保存されましたが、サーバーの確認が必要です"
+                            )
+                            .to_owned();
+                        }
+                        let reload_library =
+                            self.server.library.source == super::LibrarySource::OpenSubsonic;
+                        self.server.library.invalidate_after_profile_change();
+                        let mut commands = self.set_music_server_search_enabled(true);
+                        if reload_library {
+                            commands.extend(self.request_server_library_page(0, false));
+                        }
+                        commands
+                    }
+                    Err(failure) => {
+                        self.server.settings.failure = Some(failure);
+                        self.server.settings.wizard = Some(MusicServerWizard::Setup(
+                            MusicServerSetupForm::new(self.server.settings.summary.configured),
+                        ));
+                        self.status.kind = StatusKind::Error;
+                        self.status.text = failure.label().to_owned();
+                        Vec::new()
+                    }
+                };
+                self.dirty = true;
+                commands
+            }
+            MusicServerEvent::Removed { result, .. } => {
+                self.server.settings.busy = None;
+                let commands = match result {
+                    Ok(()) => {
+                        self.server.settings.summary = MusicServerSummary::default();
+                        self.server.settings.failure = None;
+                        self.server.settings.wizard = None;
+                        self.server.library.reset_after_profile_removal();
+                        self.status.kind = StatusKind::Info;
+                        self.status.text = crate::t!(
+                            "Music server removed; local music was kept",
+                            "음악 서버를 제거했어요. 로컬 음악은 그대로예요",
+                            "音楽サーバーを削除しました。ローカル音楽は保持されます"
+                        )
+                        .to_owned();
+                        self.set_music_server_search_enabled(false)
+                    }
+                    Err(failure) => {
+                        self.server.settings.failure = Some(failure);
+                        self.status.kind = StatusKind::Error;
+                        self.status.text = failure.label().to_owned();
+                        Vec::new()
+                    }
+                };
+                self.dirty = true;
+                commands
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::Msg;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn cancelling_setup_zeroizes_and_invalidates_late_result() {
+        let mut app = App::new(50);
+        app.open_music_server_setup();
+        let generation = app.server.settings.generation;
+        if let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_mut() {
+            form.secret.push_str("very-secret");
+        }
+        assert!(app.update(Msg::Key(key(KeyCode::Esc))).is_empty());
+        assert!(app.server.settings.wizard.is_none());
+        assert_ne!(app.server.settings.generation, generation);
+    }
+
+    #[test]
+    fn q_is_text_in_setup_fields_but_durable_steps_are_not_dismissed() {
+        let mut app = App::new(50);
+        app.open_music_server_setup();
+        assert!(
+            app.on_key_music_server_settings(key(KeyCode::Char('q')))
+                .is_empty()
+        );
+        let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_ref() else {
+            panic!("setup form");
+        };
+        assert_eq!(form.display_name.as_str(), "q");
+
+        let generation = app.server.settings.generation;
+        app.server.settings.wizard = Some(MusicServerWizard::Waiting);
+        app.server.settings.busy = Some(MusicServerBusy::Saving);
+        assert!(
+            app.on_key_music_server_settings(key(KeyCode::Esc))
+                .is_empty()
+        );
+        assert!(
+            app.on_music_server_wizard_mouse_target(MouseTarget::MusicServerWizardSecondary)
+                .is_empty()
+        );
+        assert_eq!(app.server.settings.generation, generation);
+        assert!(matches!(
+            app.server.settings.wizard,
+            Some(MusicServerWizard::Waiting)
+        ));
+        assert_eq!(app.server.settings.busy, Some(MusicServerBusy::Saving));
+    }
+
+    #[test]
+    fn setup_inputs_are_preallocated_and_enforce_credential_byte_limits() {
+        let mut form = MusicServerSetupForm::new(false);
+        assert!(form.secret.capacity() >= MAX_SETUP_PASSWORD_BYTES);
+        form.set_selected(MusicServerSetupField::Secret as usize);
+        form.credential_mode = MusicServerCredentialMode::ApiKey;
+        form.secret.push_str(&"x".repeat(MAX_SETUP_API_KEY_BYTES));
+
+        let mut app = App::new(50);
+        app.server.settings.wizard = Some(MusicServerWizard::Setup(form));
+        assert!(
+            app.on_key_music_server_settings(key(KeyCode::Char('é')))
+                .is_empty()
+        );
+        let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_ref() else {
+            panic!("setup form");
+        };
+        assert_eq!(form.secret.len(), MAX_SETUP_API_KEY_BYTES);
+        assert!(form.secret.capacity() >= MAX_SETUP_PASSWORD_BYTES);
+    }
+
+    #[test]
+    fn confirmed_remove_switches_to_non_cancellable_waiting_state() {
+        let mut app = App::new(50);
+        app.server.settings.summary.configured = true;
+        assert!(app.activate_music_server_row(2).is_empty());
+        let commands = app.on_key_music_server_settings(key(KeyCode::Enter));
+
+        assert_eq!(commands.len(), 1);
+        assert_eq!(app.server.settings.busy, Some(MusicServerBusy::Removing));
+        assert!(matches!(
+            app.server.settings.wizard,
+            Some(MusicServerWizard::Waiting)
+        ));
+        assert!(
+            app.on_key_music_server_settings(key(KeyCode::Esc))
+                .is_empty()
+        );
+        assert!(matches!(
+            app.server.settings.wizard,
+            Some(MusicServerWizard::Waiting)
+        ));
+    }
+
+    #[test]
+    fn wizard_mouse_fields_toggle_reveal_save_and_cancel() {
+        let index = |field| {
+            MusicServerSetupField::ALL
+                .iter()
+                .position(|candidate| *candidate == field)
+                .unwrap()
+        };
+        let mut app = App::new(50);
+        app.open_music_server_setup();
+        if let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_mut() {
+            form.secret.push_str("wipe-on-mode-change");
+        }
+        app.on_music_server_wizard_mouse_target(MouseTarget::MusicServerWizardReveal);
+        let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_ref() else {
+            panic!("setup form");
+        };
+        assert!(form.reveal_secret);
+
+        app.on_music_server_wizard_mouse_target(MouseTarget::MusicServerWizardField(index(
+            MusicServerSetupField::CredentialMode,
+        )));
+        let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_ref() else {
+            panic!("setup form");
+        };
+        assert_eq!(form.credential_mode, MusicServerCredentialMode::ApiKey);
+        assert!(form.secret.is_empty());
+
+        app.on_music_server_wizard_mouse_target(MouseTarget::MusicServerWizardField(index(
+            MusicServerSetupField::Cancel,
+        )));
+        assert!(app.server.settings.wizard.is_none());
+
+        app.open_music_server_setup();
+        let commands = app.on_music_server_wizard_mouse_target(
+            MouseTarget::MusicServerWizardField(index(MusicServerSetupField::SaveAndTest)),
+        );
+        assert_eq!(commands.len(), 1);
+        assert!(matches!(
+            app.server.settings.wizard,
+            Some(MusicServerWizard::Waiting)
+        ));
+    }
+
+    #[test]
+    fn duplicate_save_is_blocked_while_test_is_in_flight() {
+        let mut app = App::new(50);
+        app.open_music_server_setup();
+        if let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_mut() {
+            form.selected = MusicServerSetupField::SaveAndTest as usize;
+        }
+        let first = app.on_key_music_server_settings(key(KeyCode::Enter));
+        assert_eq!(first.len(), 1);
+        let second = app.on_key_music_server_settings(key(KeyCode::Enter));
+        assert!(second.is_empty());
+        assert_eq!(app.server.settings.busy, Some(MusicServerBusy::Testing));
+    }
+
+    #[test]
+    fn new_connection_identity_cannot_be_changed_from_create() {
+        let mut app = App::new(50);
+        app.open_music_server_setup();
+        let identity_index = MusicServerSetupField::ALL
+            .iter()
+            .position(|field| *field == MusicServerSetupField::Identity)
+            .unwrap();
+        if let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_mut() {
+            form.set_selected(identity_index);
+        }
+        for code in [KeyCode::Left, KeyCode::Right, KeyCode::Char(' ')] {
+            assert!(app.on_key_music_server_settings(key(code)).is_empty());
+        }
+        let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_ref() else {
+            panic!("setup form");
+        };
+        assert_eq!(
+            form.identity_intent,
+            Some(MusicServerIdentityIntent::Create)
+        );
+    }
+
+    #[test]
+    fn existing_connection_requires_an_explicit_identity_choice() {
+        let mut app = App::new(50);
+        app.server.settings.summary.configured = true;
+        app.open_music_server_setup();
+        if let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_mut() {
+            form.set_selected(MusicServerSetupField::SaveAndTest as usize);
+        }
+        assert!(
+            app.on_key_music_server_settings(key(KeyCode::Enter))
+                .is_empty()
+        );
+        assert_eq!(
+            app.server.settings.failure,
+            Some(MusicServerFailure::InvalidInput)
+        );
+
+        let identity_index = MusicServerSetupField::ALL
+            .iter()
+            .position(|field| *field == MusicServerSetupField::Identity)
+            .unwrap();
+        if let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_mut() {
+            form.set_selected(identity_index);
+        }
+        app.on_key_music_server_settings(key(KeyCode::Char(' ')));
+        let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_ref() else {
+            panic!("setup form");
+        };
+        assert_eq!(
+            form.identity_intent,
+            Some(MusicServerIdentityIntent::UpdateSameServerAndAccount)
+        );
+    }
+
+    #[test]
+    fn committed_profile_enables_and_persists_integrated_search() {
+        let mut app = App::new(50);
+        app.server.settings.generation = 7;
+        assert!(!app.config.search.open_subsonic);
+
+        let commands = app.finish_music_server_event(MusicServerEvent::Committed {
+            generation: 7,
+            result: Ok(MusicServerSummary {
+                health: MusicServerHealth::UpToDate,
+                configured: true,
+                display_name: Some("Home server".to_owned()),
+                credential_label: Some("Password".to_owned()),
+                lan_http: false,
+                custom_ca: false,
+            }),
+        });
+
+        assert!(app.config.search.open_subsonic);
+        assert!(matches!(
+            commands.as_slice(),
+            [Cmd::Persist(PersistCmd::Config(config))] if config.search.open_subsonic
+        ));
+    }
+
+    #[test]
+    fn committed_replacement_invalidates_server_library_before_reloading() {
+        let mut app = App::new(50);
+        app.server.settings.generation = 11;
+        app.server.library.source = crate::app::LibrarySource::OpenSubsonic;
+        app.server.library.generation = 4;
+        app.server.library.page = Some(crate::open_subsonic::ServerLibraryPage {
+            section: crate::open_subsonic::ServerLibrarySection::RecentlyPlayed,
+            rows: Vec::new(),
+            next_offset: None,
+            warning: None,
+        });
+
+        let commands = app.finish_music_server_event(MusicServerEvent::Committed {
+            generation: 11,
+            result: Ok(MusicServerSummary {
+                health: MusicServerHealth::UpToDate,
+                configured: true,
+                display_name: Some("Replacement".to_owned()),
+                credential_label: Some("API key".to_owned()),
+                lan_http: false,
+                custom_ca: false,
+            }),
+        });
+
+        assert!(app.server.library.page.is_none());
+        assert!(app.server.library.generation > 4);
+        assert!(commands.iter().any(|command| matches!(
+            command,
+            Cmd::ServerLibrary(crate::app::ServerLibraryCommand::LoadPage { .. })
+        )));
+    }
+
+    #[test]
+    fn durable_commit_with_runtime_failure_stays_configured_and_recoverable() {
+        let mut app = App::new(50);
+        app.server.settings.generation = 12;
+        let commands = app.finish_music_server_event(MusicServerEvent::Committed {
+            generation: 12,
+            result: Ok(MusicServerSummary {
+                health: MusicServerHealth::NeedsAttention,
+                configured: true,
+                display_name: Some("Saved server".to_owned()),
+                credential_label: Some("Password".to_owned()),
+                lan_http: false,
+                custom_ca: false,
+            }),
+        });
+
+        assert!(app.server.settings.summary.configured);
+        assert!(app.server.settings.wizard.is_none());
+        assert_eq!(
+            app.server.settings.failure,
+            Some(MusicServerFailure::Connection)
+        );
+        assert!(app.config.search.open_subsonic);
+        assert!(matches!(
+            commands.as_slice(),
+            [Cmd::Persist(PersistCmd::Config(config))] if config.search.open_subsonic
+        ));
+    }
+
+    #[test]
+    fn failed_refresh_keeps_a_saved_profile_editable_and_removable() {
+        for failure in [
+            MusicServerFailure::Connection,
+            MusicServerFailure::Authentication,
+            MusicServerFailure::Certificate,
+        ] {
+            let mut app = App::new(50);
+            app.server.settings.generation = 13;
+            app.server.settings.busy = Some(MusicServerBusy::Refresh);
+            app.finish_music_server_event(MusicServerEvent::Refreshed {
+                generation: 13,
+                result: Ok(MusicServerRefreshOutcome {
+                    summary: MusicServerSummary {
+                        health: MusicServerHealth::NeedsAttention,
+                        configured: true,
+                        display_name: Some("Saved server".to_owned()),
+                        credential_label: Some("Password".to_owned()),
+                        lan_http: false,
+                        custom_ca: false,
+                    },
+                    failure: Some(failure),
+                }),
+            });
+
+            assert!(app.server.settings.summary.configured);
+            assert_eq!(app.server.settings.row_count(), 3);
+            assert_eq!(app.server.settings.failure, Some(failure));
+            app.open_music_server_setup();
+            let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_ref() else {
+                panic!("saved profile edit form");
+            };
+            assert_eq!(form.identity_intent, None);
+        }
+    }
+
+    #[test]
+    fn removed_profile_disables_and_normalizes_selected_search_source() {
+        let mut app = App::new(50);
+        app.server.settings.generation = 9;
+        app.config
+            .search
+            .set_enabled(SearchSource::OpenSubsonic, true);
+        app.config.search.source = SearchSource::OpenSubsonic;
+        app.search.source = SearchSource::OpenSubsonic;
+        app.dropdowns.search_source_open = true;
+
+        let commands = app.finish_music_server_event(MusicServerEvent::Removed {
+            generation: 9,
+            result: Ok(()),
+        });
+
+        assert!(!app.config.search.open_subsonic);
+        assert_ne!(app.config.search.source, SearchSource::OpenSubsonic);
+        assert_ne!(app.search.source, SearchSource::OpenSubsonic);
+        assert!(!app.dropdowns.search_source_open);
+        assert!(matches!(
+            commands.as_slice(),
+            [Cmd::Persist(PersistCmd::Config(config))]
+                if !config.search.open_subsonic
+                    && config.search.source != SearchSource::OpenSubsonic
+        ));
+    }
+
+    #[test]
+    fn sync_area_labels_exist_in_all_languages() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for language in [
+            crate::i18n::Language::English,
+            crate::i18n::Language::Korean,
+            crate::i18n::Language::Japanese,
+        ] {
+            crate::i18n::set_language(language);
+            assert!(SyncArea::ALL.iter().all(|area| !area.label().is_empty()));
+        }
+        crate::i18n::set_language(original);
+    }
+}

--- a/src/app/settings_reducer.rs
+++ b/src/app/settings_reducer.rs
@@ -271,22 +271,15 @@ impl App {
             .keymap
             .action(KeyContext::Settings, k.into())
             .or_else(|| Self::settings_safety_action(k));
+        if on_sync_tab && let Some(commands) = self.on_sync_settings_action(action, k) {
+            return commands;
+        }
         match action {
             // `q`/Esc commit the draft before leaving the screen. The action name stays
             // SettingsCancel for compatibility with existing keybinding ids.
             Some(Action::SettingsCancel | Action::Back) => self.close_settings(),
             Some(Action::FocusNext) => self.settings_switch_tab(true),
             Some(Action::FocusPrev) => self.settings_switch_tab(false),
-            Some(Action::MoveUp) if on_sync_tab => {
-                self.personal_state.sync_ui.move_row(-1);
-                self.dirty = true;
-                Vec::new()
-            }
-            Some(Action::MoveDown) if on_sync_tab => {
-                self.personal_state.sync_ui.move_row(1);
-                self.dirty = true;
-                Vec::new()
-            }
             Some(Action::MoveUp) => {
                 self.settings_move_row(-1);
                 Vec::new()
@@ -305,7 +298,6 @@ impl App {
             }
             Some(Action::ChangeDecrease) if !on_keys_tab => self.settings_change(-1),
             Some(Action::ChangeIncrease) if !on_keys_tab => self.settings_change(1),
-            Some(Action::Confirm) if on_sync_tab => self.activate_sync_row(),
             Some(Action::Confirm) => {
                 if on_mouse_binding {
                     self.settings_change_mouse_binding(1);
@@ -504,7 +496,7 @@ impl App {
             self.dirty = true;
         }
         if entered_sync {
-            self.request_sync_ui_refresh()
+            self.select_sync_area(self.server.settings.area)
         } else {
             Vec::new()
         }

--- a/src/app/settings_reducer/commit.rs
+++ b/src/app/settings_reducer/commit.rs
@@ -263,6 +263,9 @@ impl App {
         self.overlays.recordings_browser = None;
         self.overlays.spotify_picker = None;
         self.overlays.audio_output_picker = None;
+        // A connection test may still be completing off-thread. Bump its generation and drop
+        // every move-only form before the Settings surface disappears; any late result is inert.
+        self.cancel_music_server_session();
         self.settings = None;
         self.mode = Mode::Player;
         self.dirty = true;

--- a/src/app/tests/downloads.rs
+++ b/src/app/tests/downloads.rs
@@ -226,6 +226,67 @@ fn downloadable_batch_skips_local_downloaded_and_dupes() {
     std::fs::remove_dir_all(root).unwrap();
 }
 
+fn open_subsonic_download_fixture() -> Song {
+    use crate::open_subsonic::{
+        AccountScopeId, BackendId, ItemId, OpenSubsonicItemRef, ServerSong,
+    };
+
+    Song::from_open_subsonic(ServerSong {
+        item: OpenSubsonicItemRef::new(
+            BackendId::new("test-backend").unwrap(),
+            AccountScopeId::new("test-account").unwrap(),
+            ItemId::new("test-song").unwrap(),
+        ),
+        title: "Server song".to_owned(),
+        artist: "Server artist".to_owned(),
+        artists: vec!["Server artist".to_owned()],
+        album: None,
+        album_id: None,
+        album_artist: None,
+        duration_secs: Some(180),
+        track_number: None,
+        disc_number: None,
+        year: None,
+        cover_art_id: None,
+        content_type: Some("audio/flac".to_owned()),
+        suffix: Some("flac".to_owned()),
+        starred: false,
+        user_rating: None,
+    })
+}
+
+#[test]
+fn music_server_download_is_rejected_before_queueing() {
+    let mut app = App::new(100);
+
+    let commands = app.start_download(open_subsonic_download_fixture());
+
+    assert!(commands.is_empty());
+    assert!(app.downloads.pending.is_empty());
+    assert_eq!(app.status.kind, StatusKind::Info);
+    assert_eq!(
+        app.status.text,
+        t!(
+            "Music-server downloads are not available yet",
+            "음악 서버 곡 다운로드는 아직 지원하지 않아요",
+            "音楽サーバーの曲はまだダウンロードできません"
+        )
+    );
+}
+
+#[test]
+fn music_server_download_is_removed_from_bulk_batches() {
+    let app = App::new(100);
+
+    let batch = app.downloadable_batch(vec![
+        open_subsonic_download_fixture(),
+        fsong("youtube-song", "YouTube song", "Artist"),
+    ]);
+
+    assert_eq!(batch.len(), 1);
+    assert_eq!(batch[0].video_id, "youtube-song");
+}
+
 #[test]
 fn downloadable_batch_retries_a_manifest_record_whose_file_is_missing() {
     let mut app = App::new(100);

--- a/src/app/tests/lyrics_art_download.rs
+++ b/src/app/tests/lyrics_art_download.rs
@@ -227,6 +227,41 @@ fn local_track_uses_local_art_source() {
 }
 
 #[test]
+fn server_track_uses_exact_actor_backed_art_source_without_a_url() {
+    let mut app = App::new(100);
+    app.config.album_art = Some(true);
+    app.art.picker = Some(Picker::halfblocks());
+    let item = crate::open_subsonic::OpenSubsonicItemRef::new(
+        crate::open_subsonic::BackendId::new("backend").unwrap(),
+        crate::open_subsonic::AccountScopeId::new("account").unwrap(),
+        crate::open_subsonic::ItemId::new("song").unwrap(),
+    );
+    let song = Song::from_source(
+        crate::search_source::SearchSource::OpenSubsonic,
+        "song",
+        "Server song",
+        "Server artist",
+        "3:00",
+        crate::api::PlayableRef::OpenSubsonic {
+            item: item.clone(),
+            cover_art_id: Some(crate::open_subsonic::CoverArtId::new("cover").unwrap()),
+        },
+    );
+
+    assert!(matches!(
+        app.artwork_source(&song),
+        Some(ArtSource::OpenSubsonic {
+            item: actual,
+            cover_art_id,
+            ..
+        }) if actual == item && cover_art_id.as_str() == "cover"
+    ));
+    let encoded = serde_json::to_string(&song).unwrap();
+    assert!(!encoded.contains("http://"));
+    assert!(!encoded.contains("https://"));
+}
+
+#[test]
 fn art_fit_rect_centers_by_aspect() {
     let mut app = App::new(100);
     app.art.picker = Some(Picker::halfblocks()); // font cell 10x20 px

--- a/src/app/tests/mini_tier.rs
+++ b/src/app/tests/mini_tier.rs
@@ -200,6 +200,29 @@ fn every_mode_uses_mini_until_the_bottom_layout_has_a_content_row() {
 }
 
 #[test]
+fn music_server_library_remains_reachable_at_issue_114_narrow_width() {
+    let mut app = app_playing(1, 0);
+    app.mode = Mode::Library;
+    app.server.library.source = LibrarySource::OpenSubsonic;
+
+    let buffer = render_app_buffer(&app, 30, 30);
+
+    assert_eq!(app.bridges.ui_tier.get(), UiTier::Full);
+    assert!(
+        buffer_contains(&buffer, t!("Recent", "최근", "最近")),
+        "the compact server section selector remains visible"
+    );
+
+    app.server.library.source = LibrarySource::Yututui;
+    render_mini(&app, 30, 30);
+    assert_eq!(
+        app.bridges.ui_tier.get(),
+        UiTier::Mini,
+        "the ordinary local-library transport keeps the existing boundary"
+    );
+}
+
+#[test]
 fn queue_pos_click_opens_the_queue_in_mini_even_with_the_bar_hidden() {
     let mut app = app_playing(3, 1);
     // Top layout: control_box_active() is false, but the mini renders the status line and

--- a/src/app/tests/sync_settings.rs
+++ b/src/app/tests/sync_settings.rs
@@ -5,6 +5,7 @@ fn keyboard_moves_and_activates_the_selected_sync_row() {
     let mut app = App::new(100);
     app.open_settings();
     app.settings.as_mut().unwrap().tab = SettingsTab::Sync;
+    app.server.settings.area = SyncArea::PersonalState;
 
     assert_eq!(app.personal_state.sync_ui.row, 0);
     app.update(Msg::Key(key(KeyCode::Down)));
@@ -38,6 +39,7 @@ fn sync_rows_have_dedicated_mouse_targets_and_activate_on_click() {
     let mut app = App::new(100);
     app.open_settings();
     app.settings.as_mut().unwrap().tab = SettingsTab::Sync;
+    app.server.settings.area = SyncArea::PersonalState;
 
     let _ = render_app_buffer(&app, 80, 24);
     assert!(
@@ -62,6 +64,7 @@ fn thirty_column_sync_layout_keeps_a_selectable_row_visible() {
     app.config.retro_mode = true;
     app.open_settings();
     app.settings.as_mut().unwrap().tab = SettingsTab::Sync;
+    app.server.settings.area = SyncArea::PersonalState;
 
     let buffer = render_app_buffer(&app, 30, 30);
     assert!(
@@ -82,6 +85,7 @@ fn renderer_uses_the_live_sync_projection() {
     app.config.retro_mode = true;
     app.open_settings();
     app.settings.as_mut().unwrap().tab = SettingsTab::Sync;
+    app.server.settings.area = SyncArea::PersonalState;
     app.personal_state.sync_ui.lifecycle = crate::sync::service::SyncLifecycleState::Active;
     app.personal_state.sync_ui.status.configured = true;
     app.personal_state.sync_ui.status.state = crate::sync::SyncHealthState::UpToDate;
@@ -99,6 +103,7 @@ fn renderer_exposes_each_recoverable_unfinished_connection_action() {
     app.config.retro_mode = true;
     app.open_settings();
     app.settings.as_mut().unwrap().tab = SettingsTab::Sync;
+    app.server.settings.area = SyncArea::PersonalState;
 
     let buffer = render_app_buffer(&app, 100, 30);
 

--- a/src/app/tests/transport_recovery.rs
+++ b/src/app/tests/transport_recovery.rs
@@ -208,7 +208,13 @@ fn replacement_cache_emergency_replays_new_item_ram_only_without_old_position() 
     assert_eq!(request.position_secs, 0.0);
     assert!(!request.paused);
     assert!(request.forces_ram_only());
-    assert!(request.url.contains("id1"), "must replay the new item");
+    assert!(
+        request
+            .destination
+            .direct_target()
+            .is_some_and(|target| target.contains("id1")),
+        "must replay the new item"
+    );
 }
 
 #[test]

--- a/src/app/track_load.rs
+++ b/src/app/track_load.rs
@@ -15,23 +15,35 @@ impl App {
         if let Some(reason) = song.unplayable_youtube_ref_reason() {
             return Err(SkippedReason::UnplayableYoutube(reason.to_owned()));
         }
-        let playback_target = song
-            .playback_target_checked()
+        let playback_destination = song
+            .playback_destination_checked()
             .map_err(|error| SkippedReason::InvalidUrl(error.to_string()))?;
         let mut invalid_prefetch = None;
-        let (url, prefetched_url) = match self.prefetch.resolved.peek_fresh_url(&song.video_id) {
-            Some(prefetched) => match crate::api::validate_playable_url(song.source, &prefetched) {
-                Ok(url) => (url, Some(prefetched)),
+        let (destination, prefetched_url) = match (
+            playback_destination,
+            self.prefetch.resolved.peek_fresh_url(&song.video_id),
+        ) {
+            (
+                crate::playback_target::PlaybackDestination::Direct(playback_target),
+                Some(prefetched),
+            ) => match crate::api::validate_playable_url(song.source, &prefetched) {
+                Ok(url) => (
+                    crate::playback_target::PlaybackDestination::Direct(url),
+                    Some(prefetched),
+                ),
                 Err(error) => {
                     invalid_prefetch = Some((song.video_id.clone(), error.to_string()));
-                    (playback_target, None)
+                    (
+                        crate::playback_target::PlaybackDestination::Direct(playback_target),
+                        None,
+                    )
                 }
             },
-            None => (playback_target, None),
+            (destination, _) => (destination, None),
         };
         Ok(PreparedTrackLoad {
             song,
-            url,
+            destination,
             prefetched_url,
             invalid_prefetch,
         })
@@ -50,7 +62,7 @@ impl App {
     ) -> Vec<Cmd> {
         let PreparedTrackLoad {
             song,
-            url,
+            destination: _,
             prefetched_url,
             invalid_prefetch,
         } = load;
@@ -66,7 +78,12 @@ impl App {
                 .claim_loaded_url(&song.video_id, prefetched);
         }
         self.prefetch.last_load_prefetched = prefetched_url.is_some();
-        tracing::info!(url = %url, prefetched = self.prefetch.last_load_prefetched, "load track");
+        tracing::info!(
+            video_id = %song.video_id,
+            source = song.source.id_prefix(),
+            prefetched = self.prefetch.last_load_prefetched,
+            "load track"
+        );
 
         self.begin_source_logical_item();
         self.reset_progress();

--- a/src/app/track_transition.rs
+++ b/src/app/track_transition.rs
@@ -72,7 +72,7 @@ pub(in crate::app) struct QueueReplacementOptions {
 #[derive(Clone)]
 pub(in crate::app) struct PreparedTrackLoad {
     pub(in crate::app) song: Song,
-    pub(in crate::app) url: String,
+    pub(in crate::app) destination: crate::playback_target::PlaybackDestination,
     pub(in crate::app) prefetched_url: Option<String>,
     pub(in crate::app) invalid_prefetch: Option<(String, String)>,
 }
@@ -572,8 +572,8 @@ impl App {
         plan.recorder = Some(recorder);
         match &plan.kind {
             TrackTransitionKind::Load { load, .. } => {
-                commands.push(PlayerCmd::load(
-                    load.url.clone(),
+                commands.push(PlayerCmd::load_destination(
+                    load.destination.clone(),
                     crate::player::MediaSourceContext::from_live(load.song.is_radio_station()),
                 ));
                 if let Some(af) = self.track_audio_filter() {

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -6,6 +6,9 @@
 
 use super::*;
 
+#[path = "types/library.rs"]
+mod library;
+pub use library::LibraryTab;
 #[path = "types/scroll_surface.rs"]
 mod scroll_surface;
 pub use scroll_surface::ScrollSurface;
@@ -183,6 +186,8 @@ pub enum Msg {
     Recorder(crate::recorder::job::RecorderEvent),
     /// Search results, playlist-track fetches, and artist-page fetches.
     Search(SearchMsg),
+    /// A redacted settings result or bounded OpenSubsonic library result.
+    Server(ServerEvent),
     /// Local-data work completed: a download scan or portable personal-data export.
     Data(DataMsg),
     /// Local Deck index load/scan result.
@@ -376,6 +381,10 @@ pub enum Cmd {
     UpdateSeen { tag: String },
     /// Search queries and remote search-row fetches.
     Search(SearchCmd),
+    /// Test, commit, refresh, or remove the one configured music-server profile.
+    MusicServer(MusicServerCommand),
+    /// Read-only OpenSubsonic library page/detail fetches.
+    ServerLibrary(ServerLibraryCommand),
     /// Persist a store to disk (or clear one) via the debounced persistence actor. The
     /// [`PersistCmd`] payload selects which store; for the marker variants the runtime clones
     /// the live snapshot from `App` at dispatch time (`Config` carries its own owned snapshot).
@@ -702,6 +711,24 @@ pub enum MouseTarget {
     SearchSourceSelect(SearchSource),
     /// A Library tab header.
     LibraryTab(LibraryTab),
+    /// Switch between the local YuTuTui library and the configured music-server library.
+    LibrarySource(LibrarySource),
+    /// One of the five read-only music-server library sections.
+    ServerLibrarySection(crate::open_subsonic::ServerLibrarySection),
+    /// A generation-stamped server row. Old frames fail closed after paging or drill-down.
+    ServerLibraryRow {
+        generation: u64,
+        index: usize,
+    },
+    ServerLibraryBack {
+        generation: u64,
+    },
+    ServerLibraryPreviousPage {
+        generation: u64,
+    },
+    ServerLibraryNextPage {
+        generation: u64,
+    },
     /// A Local Deck sidebar section, by index into [`LocalSection::ALL`].
     LocalNav(usize),
     /// A row in the Local Deck list, by display index.
@@ -738,6 +765,15 @@ pub enum MouseTarget {
     /// An action or detail row in the privacy-safe Sync settings projection. Clicking selects
     /// the row and delegates to the same action path as Enter; informational rows safely no-op.
     SettingsSyncRow(usize),
+    /// One of the four plain-language areas inside the top-level Sync settings tab.
+    SettingsSyncArea(SyncArea),
+    /// A redacted music-server settings action row.
+    SettingsMusicServerRow(usize),
+    /// A field/action in the move-only music-server setup wizard.
+    MusicServerWizardField(usize),
+    MusicServerWizardPrimary,
+    MusicServerWizardSecondary,
+    MusicServerWizardReveal,
     /// A field in the move-only Sync setup/join/recovery wizard.
     SyncWizardField(usize),
     /// The wizard's affirmative action (continue, approve, merge, remove, or finish).
@@ -1007,55 +1043,6 @@ pub enum ActiveSearchSurface {
 pub struct TrackLyrics {
     pub video_id: Arc<str>,
     pub lines: std::sync::Arc<[LyricLine]>,
-}
-
-/// The lists in the library view.
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
-pub enum LibraryTab {
-    #[default]
-    All,
-    Favorites,
-    History,
-    RadioFavorites,
-    Radio,
-    Downloads,
-    Playlists,
-}
-
-impl LibraryTab {
-    pub const NORMAL: [Self; 5] = [
-        Self::All,
-        Self::Favorites,
-        Self::History,
-        Self::Downloads,
-        Self::Playlists,
-    ];
-
-    pub const RADIO_MODE: [Self; 2] = [Self::RadioFavorites, Self::Radio];
-
-    pub fn label(self) -> &'static str {
-        match self {
-            LibraryTab::All => t!("All", "전체", "すべて"),
-            LibraryTab::Favorites => t!("Favorites", "즐겨찾기", "お気に入り"),
-            LibraryTab::History => t!("History", "기록", "履歴"),
-            LibraryTab::RadioFavorites => t!("Radio Likes", "라디오 좋아요", "ラジオ高評価"),
-            LibraryTab::Radio => t!("Radio History", "라디오 히스토리", "ラジオ履歴"),
-            LibraryTab::Downloads => t!("Downloads", "다운로드", "ダウンロード"),
-            LibraryTab::Playlists => t!("Playlists", "플레이리스트", "プレイリスト"),
-        }
-    }
-
-    pub fn compact_label(self) -> &'static str {
-        match self {
-            LibraryTab::All => t!("All", "전체", "すべて"),
-            LibraryTab::Favorites => t!("Fav", "즐겨찾기", "お気に入り"),
-            LibraryTab::History => t!("Hist", "기록", "履歴"),
-            LibraryTab::RadioFavorites => t!("R-Like", "라디오 좋아요", "ラジオ高評価"),
-            LibraryTab::Radio => t!("R-Hist", "라디오 기록", "ラジオ履歴"),
-            LibraryTab::Downloads => t!("Down", "다운", "DL"),
-            LibraryTab::Playlists => t!("Lists", "플리", "リスト"),
-        }
-    }
 }
 
 /// Pending confirmation for entering or leaving the dedicated Radio UI mode.

--- a/src/app/types/library.rs
+++ b/src/app/types/library.rs
@@ -1,0 +1,52 @@
+//! Local-library navigation types.
+
+use crate::t;
+
+/// The lists in the library view.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+pub enum LibraryTab {
+    #[default]
+    All,
+    Favorites,
+    History,
+    RadioFavorites,
+    Radio,
+    Downloads,
+    Playlists,
+}
+
+impl LibraryTab {
+    pub const NORMAL: [Self; 5] = [
+        Self::All,
+        Self::Favorites,
+        Self::History,
+        Self::Downloads,
+        Self::Playlists,
+    ];
+
+    pub const RADIO_MODE: [Self; 2] = [Self::RadioFavorites, Self::Radio];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::All => t!("All", "전체", "すべて"),
+            Self::Favorites => t!("Favorites", "즐겨찾기", "お気に入り"),
+            Self::History => t!("History", "기록", "履歴"),
+            Self::RadioFavorites => t!("Radio Likes", "라디오 좋아요", "ラジオ高評価"),
+            Self::Radio => t!("Radio History", "라디오 히스토리", "ラジオ履歴"),
+            Self::Downloads => t!("Downloads", "다운로드", "ダウンロード"),
+            Self::Playlists => t!("Playlists", "플레이리스트", "プレイリスト"),
+        }
+    }
+
+    pub fn compact_label(self) -> &'static str {
+        match self {
+            Self::All => t!("All", "전체", "すべて"),
+            Self::Favorites => t!("Fav", "즐겨찾기", "お気に入り"),
+            Self::History => t!("Hist", "기록", "履歴"),
+            Self::RadioFavorites => t!("R-Like", "라디오 좋아요", "ラジオ高評価"),
+            Self::Radio => t!("R-Hist", "라디오 기록", "ラジオ履歴"),
+            Self::Downloads => t!("Down", "다운", "DL"),
+            Self::Playlists => t!("Lists", "플리", "リスト"),
+        }
+    }
+}

--- a/src/artwork.rs
+++ b/src/artwork.rs
@@ -33,6 +33,13 @@ pub enum ArtSource {
         video_id: String,
         quality: AlbumArtQuality,
     },
+    /// Authenticated OpenSubsonic artwork. Only exact opaque IDs cross this message; the
+    /// credential, origin, and authenticated request remain inside the current server actor.
+    OpenSubsonic {
+        item: crate::open_subsonic::OpenSubsonicItemRef,
+        cover_art_id: crate::open_subsonic::CoverArtId,
+        quality: AlbumArtQuality,
+    },
     /// A local file: read its embedded cover art.
     Local(PathBuf),
 }
@@ -105,6 +112,23 @@ where
             } => (
                 match client.as_ref() {
                     Some(client) => fetch_remote(client, &id, quality).await,
+                    None => None,
+                },
+                remote_max_dimension(quality),
+                Some(quality),
+            ),
+            ArtSource::OpenSubsonic {
+                item,
+                cover_art_id,
+                quality,
+            } => (
+                match crate::open_subsonic::current_handle() {
+                    Some(handle) => handle
+                        .cover_art(item, cover_art_id)
+                        .await
+                        .ok()
+                        .flatten()
+                        .map(|payload| payload.bytes),
                     None => None,
                 },
                 remote_max_dimension(quality),

--- a/src/daemon/capabilities.rs
+++ b/src/daemon/capabilities.rs
@@ -2,6 +2,7 @@ use super::{
     LONG_FORM_SEEK_OPTIMIZATION_CAPABILITY, PERSONAL_EXPORT_CAPABILITY,
     PERSONAL_STATE_V2_CAPABILITY, RETAINED_REQUEST_OUTCOMES_CAPABILITY, WEB_DAV_SYNC_CAPABILITY,
 };
+use crate::remote::OPEN_SUBSONIC_CAPABILITY;
 
 pub(super) fn daemon_capabilities() -> Vec<String> {
     vec![
@@ -18,6 +19,7 @@ pub(super) fn daemon_capabilities() -> Vec<String> {
         PERSONAL_EXPORT_CAPABILITY.to_string(),
         PERSONAL_STATE_V2_CAPABILITY.to_string(),
         WEB_DAV_SYNC_CAPABILITY.to_string(),
+        OPEN_SUBSONIC_CAPABILITY.to_string(),
         LONG_FORM_SEEK_OPTIMIZATION_CAPABILITY.to_string(),
         // C6: the entire deferred v8 GUI command surface is dispatched (queue ops,
         // rating, video, library, playlists, downloads, AI, accounts, transfer,

--- a/src/daemon/engine.rs
+++ b/src/daemon/engine.rs
@@ -35,13 +35,13 @@ mod gui_search;
 mod gui_settings;
 mod keymap_theme;
 mod media_session;
+mod open_subsonic_runtime;
 mod persistence_gate;
 mod personal_export;
 pub(super) mod personal_sync;
 mod remote_dispatch;
 mod streaming;
 mod transport;
-
 use self::streaming::PendingStreamingRequest;
 #[cfg(test)]
 use self::streaming::StreamingRequestStage;
@@ -132,6 +132,7 @@ pub enum EngineEffect {
 pub struct DaemonEngine {
     maintainer: crate::util::background_task::BackgroundTask,
     player: Option<PlayerRuntime>,
+    open_subsonic: open_subsonic_runtime::OpenSubsonicOwner,
     player_emit: Arc<dyn Fn(PlayerEvent) + Send + Sync>,
     queue: Queue,
     playback: DaemonPlayback,
@@ -272,35 +273,30 @@ impl DaemonEngine {
             signals,
         };
         crate::persist::ensure_startup_recovery_coherent().map_err(EngineError::from)?;
-        // Orphan reaping can unlink lifeline records and kill child processes. It is safe only
-        // after all recovery-backed stores have established one coherent startup frontier.
+        // Reap only after recovery stores establish one coherent startup frontier.
         if let Some(dir) = data_dir() {
             player::lifetime::reap_orphans(&dir);
         }
         let mut engine = Self::with_state(state, Arc::new(emit));
         engine.install_personal_state(personal_state);
         engine.personal_state_device_id = personal_state_device_id;
-
-        // Resolve which yt-dlp/mpv this process runs (managed vs system vs override)
-        // before the first `ensure_player` — the mpv spawn pins ytdl_hook to it.
+        // Optional server discovery must not hold local restore or player startup hostage.
+        open_subsonic_runtime::initialize(&mut engine);
+        // External tool discovery remains required for ordinary YouTube/local playback.
         crate::tools::init(&engine.config.tools).await;
-        // Keep the managed copy fresh for long daemon runs. No-op emit: the daemon
-        // has no status line and `check_and_update` already logs its outcomes.
+        // Keep the managed copy fresh; the daemon has no status-line emitter.
         engine.maintainer =
             crate::tools::ytdlp::spawn_maintainer(engine.config.tools.clone(), |_| {});
-
         if options.resume {
             engine.restore_session_cache(session_cache);
             if engine.queue.current().is_some() {
                 engine.load_current().await?;
             }
         }
-
         Ok(engine)
     }
 
-    /// Construct the engine from explicit state — the single init path [`start`] wraps
-    /// with disk loads, and the App↔Daemon parity harness constructs hermetically
+    /// Construct explicit state; [`start`] adds disk loads, while parity tests stay hermetic
     /// (docs/gui/10 §4; the engine must be buildable without touching `ProjectDirs`).
     pub(crate) fn with_state(
         state: EngineState,
@@ -327,6 +323,7 @@ impl DaemonEngine {
         Self {
             maintainer: crate::util::background_task::BackgroundTask::disabled("yt-dlp maintainer"),
             player: None,
+            open_subsonic: Default::default(),
             player_emit,
             queue,
             playback: DaemonPlayback {
@@ -464,6 +461,7 @@ impl DaemonEngine {
 
     /// Stop the daemon-owned long-lived tasks before persistence/scrobble teardown.
     pub async fn shutdown_background(&mut self) {
+        self.open_subsonic.shutdown().await;
         self.maintainer.shutdown().await;
     }
 
@@ -477,6 +475,7 @@ impl DaemonEngine {
     pub(crate) fn shutdown_media_owners(&mut self) {
         self.video_overlay = None;
         self.player = None;
+        self.open_subsonic.retire();
     }
 
     pub fn initial_effects(&mut self) -> Vec<EngineEffect> {
@@ -1527,13 +1526,14 @@ impl DaemonEngine {
         }
 
         let emit = Arc::clone(&self.player_emit);
-        let (handle, guard) = player::spawn(
+        let (handle, guard) = player::spawn_with_route_provider(
             move |event| (emit)(event),
             data_dir(),
             self.config
                 .cookies_file_for_external_tools(data_dir().as_deref()),
             self.config.effective_gapless(),
             self.config.audio.runtime(),
+            self.open_subsonic.route_provider(),
         )
         .await
         .map_err(|e| EngineError::Player(format!("failed to start mpv: {e:#}")))?;

--- a/src/daemon/engine/open_subsonic_runtime.rs
+++ b/src/daemon/engine/open_subsonic_runtime.rs
@@ -1,0 +1,99 @@
+//! Daemon ownership for the OpenSubsonic actor and loopback playback proxy.
+
+use std::time::Duration;
+
+use super::{DaemonEngine, data_dir};
+
+const RETRY_MIN: Duration = Duration::from_secs(2);
+const RETRY_MAX: Duration = Duration::from_secs(15 * 60);
+
+fn next_retry(delay: Duration) -> Duration {
+    delay.saturating_mul(2).min(RETRY_MAX)
+}
+
+pub(super) struct OpenSubsonicOwner {
+    routes: crate::playback_target::PlaybackRouteProviderSlot,
+    loader: crate::util::background_task::BackgroundTask,
+}
+
+impl Default for OpenSubsonicOwner {
+    fn default() -> Self {
+        Self {
+            routes: Default::default(),
+            loader: crate::util::background_task::BackgroundTask::disabled(
+                "daemon music server loader",
+            ),
+        }
+    }
+}
+
+impl OpenSubsonicOwner {
+    fn start(&mut self, paths: Option<crate::open_subsonic::OpenSubsonicPaths>) {
+        self.retire();
+        let Some(paths) = paths else {
+            return;
+        };
+        let routes = self.routes.clone();
+        self.loader = crate::util::background_task::BackgroundTask::spawn(
+            "daemon music server loader",
+            async move {
+                let mut retry = RETRY_MIN;
+                loop {
+                    // The loader already runs off the daemon owner path, and every DNS/API step
+                    // inside `load_actor` has its own bound. Do not impose a shorter aggregate
+                    // deadline that can permanently reject a valid but slower server.
+                    match crate::open_subsonic::load_actor(&paths).await {
+                        Ok(Some(runtime)) => {
+                            runtime.activate();
+                            routes.install(runtime.route_provider());
+                            // This task owns the actor and proxy until daemon shutdown.
+                            std::future::pending::<()>().await;
+                            drop(runtime);
+                        }
+                        Ok(None) => return,
+                        Err(error) => {
+                            tracing::warn!(
+                                reason = %error,
+                                retry_seconds = retry.as_secs(),
+                                "daemon music server runtime is unavailable; retrying"
+                            );
+                            tokio::time::sleep(retry).await;
+                            retry = next_retry(retry);
+                        }
+                    }
+                }
+            },
+        );
+    }
+
+    pub(super) fn route_provider(&self) -> crate::playback_target::PlaybackRouteProviderHandle {
+        self.routes.handle()
+    }
+
+    pub(super) fn retire(&mut self) {
+        self.routes.disable();
+        self.loader =
+            crate::util::background_task::BackgroundTask::disabled("daemon music server loader");
+    }
+
+    pub(super) async fn shutdown(&mut self) {
+        self.routes.disable();
+        self.loader.shutdown().await;
+    }
+}
+
+pub(super) fn initialize(engine: &mut DaemonEngine) {
+    let paths = data_dir().map(crate::open_subsonic::OpenSubsonicPaths::for_data_root);
+    engine.open_subsonic.start(paths);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_backoff_is_bounded() {
+        assert_eq!(next_retry(RETRY_MIN), Duration::from_secs(4));
+        assert_eq!(next_retry(RETRY_MAX), RETRY_MAX);
+    }
+}

--- a/src/daemon/engine/tests.rs
+++ b/src/daemon/engine/tests.rs
@@ -43,6 +43,7 @@ pub(in crate::daemon) fn engine_with_queue(ids: &[&str]) -> DaemonEngine {
     DaemonEngine {
         maintainer: crate::util::background_task::BackgroundTask::disabled("yt-dlp maintainer"),
         player: None,
+        open_subsonic: Default::default(),
         player_emit: Arc::new(|_| {}),
         queue,
         playback: DaemonPlayback {

--- a/src/daemon/engine/transport.rs
+++ b/src/daemon/engine/transport.rs
@@ -372,7 +372,7 @@ impl DaemonEngine {
             self.stop_playback();
             return Ok(());
         };
-        let target = match song.playback_target_checked() {
+        let target = match song.playback_destination_checked() {
             Ok(target) => target,
             Err(error) => {
                 tracing::warn!(

--- a/src/daemon/engine/transport_tests.rs
+++ b/src/daemon/engine/transport_tests.rs
@@ -582,7 +582,13 @@ async fn replacement_cache_emergency_replays_new_item_without_old_position() {
     assert_eq!(request.position_secs, 0.0);
     assert!(!request.paused);
     assert!(request.forces_ram_only());
-    assert!(request.url.contains("new"), "must replay the new item");
+    assert!(
+        request
+            .destination
+            .direct_target()
+            .is_some_and(|target| target.contains("new")),
+        "must replay the new item"
+    );
 }
 
 #[tokio::test]

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1074,7 +1074,6 @@ async fn current_status() -> Result<StatusSnapshot, ClientError> {
     let response = client::send(RemoteCommand::Status).await?;
     response.status.ok_or(ClientError::MalformedResponse)
 }
-
 fn spawn_daemon_process(options: &StartOptions) -> Result<(), DaemonError> {
     let exe = match &options.executable {
         Some(path) => path.clone(),

--- a/src/daemon/parity_tests.rs
+++ b/src/daemon/parity_tests.rs
@@ -329,6 +329,88 @@ async fn accepted_seek_uses_fast_precision_and_one_epoch_in_both_owners() {
 }
 
 #[tokio::test]
+async fn open_subsonic_load_uses_the_same_typed_destination_and_epoch_in_both_owners() {
+    let (mut app, mut engine) = hermetic_pair();
+    let item = crate::open_subsonic::OpenSubsonicItemRef::new(
+        crate::open_subsonic::BackendId::new("backend-a").unwrap(),
+        crate::open_subsonic::AccountScopeId::new("account-a").unwrap(),
+        crate::open_subsonic::ItemId::new("song-a").unwrap(),
+    );
+    let item_id = item.item_id().as_str().to_owned();
+    let server_song = Song::from_source(
+        crate::search_source::SearchSource::OpenSubsonic,
+        item_id,
+        "Server song",
+        "Server artist",
+        "3:00",
+        crate::api::PlayableRef::OpenSubsonic {
+            item,
+            cover_art_id: None,
+        },
+    );
+    let server_video_id = server_song.video_id.clone();
+    let previous = song("previous");
+    let previous_video_id = previous.video_id.clone();
+    let mut queue = Queue::default();
+    queue.set(vec![server_song, previous], 1);
+    let snapshot = queue.snapshot();
+    app.queue.restore_snapshot(snapshot.clone());
+    engine.restore_queue_snapshot(snapshot, RNG_SEED);
+    app.install_seek_parity_state(&previous_video_id, 12.0, 180.0);
+    let mut engine_player = engine.install_seek_parity_player(&previous_video_id, 12.0, 180.0);
+    let epochs = PositionEpochs::capture(&app, &engine);
+
+    let (reply_tx, mut reply_rx) = oneshot::channel();
+    let app_commands = app.update(Msg::Remote(
+        RemoteCommand::QueuePlay { position: 0 },
+        reply_tx.into(),
+    ));
+    let app_load = app_commands
+        .iter()
+        .flat_map(Cmd::player_commands)
+        .find_map(|command| match command {
+            crate::player::PlayerCmd::Load(load) => Some(load.clone()),
+            _ => None,
+        })
+        .expect("App OpenSubsonic load");
+    admit_app_player_intents(&mut app, app_commands);
+    assert!(reply_rx.try_recv().expect("App queue-play reply").ok);
+
+    let (engine_reply, shutdown, effects) = engine
+        .handle_remote(RemoteCommand::QueuePlay { position: 0 })
+        .await;
+    assert!(engine_reply.ok);
+    assert!(!shutdown);
+    assert!(effects.is_empty());
+    let engine_load = match recv_parity_player_command(&mut engine_player).await {
+        crate::player::PlayerCmd::Load(load) => load,
+        _ => panic!("daemon OpenSubsonic load"),
+    };
+
+    assert_eq!(app_load, engine_load);
+    assert_eq!(
+        app_load.destination().credentialed_target(),
+        Some(
+            &crate::playback_target::CredentialedPlaybackRef::OpenSubsonic {
+                backend_id: "backend-a".to_owned(),
+                account_scope_id: "account-a".to_owned(),
+                item_id: "song-a".to_owned(),
+            }
+        )
+    );
+    assert_eq!(
+        app.queue.current().map(|song| song.video_id.as_str()),
+        Some(server_video_id.as_str())
+    );
+    epochs.assert_delta(
+        "OpenSubsonic queue load",
+        PositionEpochs::capture(&app, &engine),
+        1,
+    );
+    assert_parity("OpenSubsonic queue load", &app, &engine);
+}
+
+#[tokio::test]
 async fn midtrack_source_recovery_trace_and_epoch_match_in_both_owners() {
     const ERROR: &str = "connection reset while reading source";
     let (mut app, mut engine) = hermetic_pair();

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -111,6 +111,7 @@ fn daemon_capabilities_advertise_headless_playback() {
     assert!(daemon_capabilities().contains(&PERSONAL_EXPORT_CAPABILITY.to_string()));
     assert!(daemon_capabilities().contains(&PERSONAL_STATE_V2_CAPABILITY.to_string()));
     assert!(daemon_capabilities().contains(&WEB_DAV_SYNC_CAPABILITY.to_string()));
+    assert!(daemon_capabilities().contains(&crate::remote::OPEN_SUBSONIC_CAPABILITY.to_string()));
     assert!(daemon_capabilities().contains(&LONG_FORM_SEEK_OPTIMIZATION_CAPABILITY.to_string()));
 }
 

--- a/src/data_export.rs
+++ b/src/data_export.rs
@@ -953,7 +953,9 @@ fn catalog_for_song(song: &Song) -> Option<PortableCatalogId> {
             id: song.video_id.clone(),
         });
     }
-    if song.source == SearchSource::All {
+    // Schema v1 has no server/account-scoped identity. Omitting the catalog key keeps the
+    // sanitized metadata without pretending an opaque row id is a portable server identity.
+    if matches!(song.source, SearchSource::OpenSubsonic | SearchSource::All) {
         return None;
     }
     let prefix = format!("{}:", song.source.id_prefix());
@@ -1133,6 +1135,7 @@ fn source_sort_key(source: SearchSource) -> &'static str {
         SearchSource::Audius => "audius",
         SearchSource::Jamendo => "jamendo",
         SearchSource::InternetArchive => "internet_archive",
+        SearchSource::OpenSubsonic => "open_subsonic",
         SearchSource::RadioBrowser => "radio_browser",
         SearchSource::All => "all",
     }

--- a/src/data_export/live.rs
+++ b/src/data_export/live.rs
@@ -214,6 +214,12 @@ impl CloneBudget {
                 self.add_text(file)?;
                 self.add_text(url)
             }
+            PlayableRef::OpenSubsonic { item, cover_art_id } => {
+                self.add_text(item.backend_id().as_str())?;
+                self.add_text(item.account_scope_id().as_str())?;
+                self.add_text(item.item_id().as_str())?;
+                self.add_optional_text(cover_art_id.as_ref().map(|id| id.as_str()))
+            }
         }
     }
 }
@@ -268,5 +274,30 @@ mod tests {
                 NESTED_TEXT_ITEMS_LIMIT + 1
             ))
         );
+    }
+
+    #[test]
+    fn clone_budget_counts_open_subsonic_cover_identity_bytes() {
+        let item = crate::open_subsonic::OpenSubsonicItemRef::new(
+            crate::open_subsonic::BackendId::new("backend").unwrap(),
+            crate::open_subsonic::AccountScopeId::new("account").unwrap(),
+            crate::open_subsonic::ItemId::new("item").unwrap(),
+        );
+        let mut without_cover = CloneBudget::default();
+        without_cover
+            .add_playable(&PlayableRef::OpenSubsonic {
+                item: item.clone(),
+                cover_art_id: None,
+            })
+            .unwrap();
+        let cover = crate::open_subsonic::CoverArtId::new("cover-art").unwrap();
+        let mut with_cover = CloneBudget::default();
+        with_cover
+            .add_playable(&PlayableRef::OpenSubsonic {
+                item,
+                cover_art_id: Some(cover.clone()),
+            })
+            .unwrap();
+        assert_eq!(with_cover.bytes - without_cover.bytes, cover.as_str().len());
     }
 }

--- a/src/desktop/panel.rs
+++ b/src/desktop/panel.rs
@@ -585,8 +585,9 @@ fn parse_search_source(value: String) -> Result<SearchSource, serde_json::Error>
         "audius" => Ok(SearchSource::Audius),
         "jamendo" => Ok(SearchSource::Jamendo),
         "internet_archive" => Ok(SearchSource::InternetArchive),
-        // "radio_browser" is deliberately absent: live radio streams are not valid
-        // autoplay/DJ Gem candidates (see SearchConfig::normalized_streaming_source).
+        // "open_subsonic" and "radio_browser" are deliberately absent: credentialed server
+        // tracks and live radio streams are not autoplay/DJ Gem candidates (see
+        // SearchConfig::normalized_streaming_source).
         "all" => Ok(SearchSource::All),
         _ => Err(serde::de::Error::custom("unknown streaming source")),
     }

--- a/src/desktop/panel_payload.rs
+++ b/src/desktop/panel_payload.rs
@@ -278,6 +278,7 @@ fn search_source_id(source: SearchSource) -> &'static str {
         SearchSource::Audius => "audius",
         SearchSource::Jamendo => "jamendo",
         SearchSource::InternetArchive => "internet_archive",
+        SearchSource::OpenSubsonic => "open_subsonic",
         SearchSource::RadioBrowser => "radio_browser",
         SearchSource::All => "all",
     }

--- a/src/download.rs
+++ b/src/download.rs
@@ -1221,6 +1221,9 @@ async fn run_download_to_path(
         import_context,
         metadata_required,
     } = options;
+    if song.source == crate::search_source::SearchSource::OpenSubsonic {
+        bail!("music-server downloads are not supported");
+    }
     // Re-check at the actor boundary (not just in the UI reducer): a non-video YouTube ref
     // (channel/playlist) would otherwise have `playback_target()` fall back to a channel URL,
     // handing yt-dlp something that isn't a downloadable track.
@@ -1450,6 +1453,9 @@ fn parse_percent(line: &str) -> Option<f64> {
 #[cfg(test)]
 #[path = "download/import_admission_tests.rs"]
 mod import_admission_tests;
+#[cfg(all(test, unix))]
+#[path = "download/server_download_tests.rs"]
+mod server_download_tests;
 #[cfg(test)]
 #[path = "download/tests.rs"]
 mod tests;

--- a/src/download/server_download_tests.rs
+++ b/src/download/server_download_tests.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+
+use super::*;
+use crate::open_subsonic::{AccountScopeId, BackendId, ItemId, OpenSubsonicItemRef, ServerSong};
+
+#[tokio::test]
+async fn rejects_music_server_tracks_before_spawning_ytdlp() {
+    let song = Song::from_open_subsonic(ServerSong {
+        item: OpenSubsonicItemRef::new(
+            BackendId::new("test-backend").unwrap(),
+            AccountScopeId::new("test-account").unwrap(),
+            ItemId::new("test-song").unwrap(),
+        ),
+        title: "Server song".to_owned(),
+        artist: "Server artist".to_owned(),
+        artists: vec!["Server artist".to_owned()],
+        album: None,
+        album_id: None,
+        album_artist: None,
+        duration_secs: Some(180),
+        track_number: None,
+        disc_number: None,
+        year: None,
+        cover_art_id: None,
+        content_type: Some("audio/flac".to_owned()),
+        suffix: Some("flac".to_owned()),
+        starred: false,
+        user_rating: None,
+    });
+    let emit: EventSink = Arc::new(|_| Ok(DeliveryReceipt::Enqueued));
+    let root =
+        std::env::temp_dir().join(format!("ytt-reject-server-download-{}", std::process::id()));
+
+    let error = run_download_with_program(
+        root.join("must-not-exist").to_str().unwrap(),
+        &song,
+        &root,
+        None,
+        &emit,
+    )
+    .await
+    .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("music-server downloads are not supported")
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod lyrics;
 pub mod media;
 pub mod mousemap;
 pub mod notify;
+pub mod open_subsonic;
 pub(crate) mod owner_event_policy;
 pub mod paths;
 pub mod persist;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,7 @@ fn initialize_interactive_persistence_with_retry(
 }
 
 mod data_cli;
+mod server_cli;
 mod sync_cli;
 
 fn cli_identity() -> (&'static str, &'static str) {
@@ -153,6 +154,7 @@ fn run() -> Result<()> {
                 );
                 println!("       {bin} data <cmd>       Export portable personal data");
                 println!("       {bin} sync <cmd>       Encrypted personal-state sync");
+                println!("       {bin} server <cmd>     Connect an OpenSubsonic music server");
                 println!("       {bin} doctor [-v]      Check your environment and exit");
                 println!("       {bin} doctor audio [-v]");
                 println!("       {bin} doctor privacy [--cleanup]");
@@ -215,6 +217,12 @@ fn run() -> Result<()> {
             "sync" => {
                 let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
                 std::process::exit(sync_cli::run(&rest));
+            }
+            // OpenSubsonic/Navidrome connection setup. Credentials are prompted with echo
+            // disabled and are never accepted in process arguments.
+            "server" => {
+                let rest = collect_lossy_cli_args(std::env::args_os().skip(2));
+                std::process::exit(server_cli::run(&rest));
             }
             "--new-instance" => new_instance = true,
             // One-shot environment diagnostic; never touches the terminal. Exits with its

--- a/src/open_subsonic/actor.rs
+++ b/src/open_subsonic/actor.rs
@@ -1,0 +1,1002 @@
+//! Long-lived credential owner plus setup/status lifecycle facade.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock, RwLock};
+
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use zeroize::Zeroize;
+
+use super::OpenSubsonicBridgeState;
+use super::capabilities::ServerCapabilities;
+use super::catalog::OpenSubsonicCatalog;
+use super::client::{BinaryPayload, OpenSubsonicClient, ServerError};
+use super::model::{
+    AccountScopeId, AlbumId, ArtistId, BackendId, CoverArtId, OpenSubsonicItemRef,
+    ServerLibraryDetail, ServerLibraryPage, ServerLibrarySection, ServerPlaylistId, ServerSong,
+};
+use super::origin::ConfiguredPrivateOrigin;
+use super::private_store::{CredentialKind, OpenSubsonicPrivateState, ServerCredential};
+use super::profile::{OpenSubsonicPaths, OpenSubsonicProfile, StoreError};
+use super::proxy::{
+    OpenSubsonicProxyGuard, OpenSubsonicProxyHandle, ProxyUpstreamError, StreamRequest,
+    StreamSource, StreamSourceFuture, UpstreamStream,
+};
+use super::transaction::{
+    OpenSubsonicStoreSet, StoreRevisions, commit_store_set, load_store_set,
+    load_store_set_read_only, remove_store_set, reset_store_set,
+};
+
+const ACTOR_CAPACITY: usize = 32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceError {
+    Store(StoreError),
+    Server(ServerError),
+    ActorUnavailable,
+    ProxyUnavailable,
+    InvalidSetup,
+}
+
+impl std::fmt::Display for ServiceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::Store(error) => return error.fmt(formatter),
+            Self::Server(error) => return error.fmt(formatter),
+            Self::ActorUnavailable => "music server service is unavailable",
+            Self::ProxyUnavailable => "music server playback proxy is unavailable",
+            Self::InvalidSetup => "music server setup is invalid",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for ServiceError {}
+
+impl From<StoreError> for ServiceError {
+    fn from(error: StoreError) -> Self {
+        Self::Store(error)
+    }
+}
+
+impl From<ServerError> for ServiceError {
+    fn from(error: ServerError) -> Self {
+        Self::Server(error)
+    }
+}
+
+/// Secret-bearing setup input. Deliberately lacks `Debug` and `Clone`.
+pub struct SetupInput {
+    display_name: String,
+    origin: String,
+    allow_lan_http: bool,
+    custom_ca_pem: Option<Vec<u8>>,
+    credential: Option<ServerCredential>,
+    identity_intent: SetupIdentityIntent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SetupIdentityIntent {
+    Create,
+    UpdateSameServerAndAccount,
+    ReplaceServerOrAccount,
+}
+
+impl SetupInput {
+    pub fn new(
+        display_name: impl Into<String>,
+        origin: impl Into<String>,
+        allow_lan_http: bool,
+        custom_ca_pem: Option<Vec<u8>>,
+        credential: ServerCredential,
+        identity_intent: SetupIdentityIntent,
+    ) -> Self {
+        Self {
+            display_name: display_name.into(),
+            origin: origin.into(),
+            allow_lan_http,
+            custom_ca_pem,
+            credential: Some(credential),
+            identity_intent,
+        }
+    }
+}
+
+impl Drop for SetupInput {
+    fn drop(&mut self) {
+        self.origin.zeroize();
+        if let Some(pem) = &mut self.custom_ca_pem {
+            pem.zeroize();
+        }
+    }
+}
+
+/// Tested candidate with no durable side effects. Deliberately lacks `Debug`.
+pub struct PreparedSetup {
+    expected: StoreRevisions,
+    store_set: Option<OpenSubsonicStoreSet>,
+    capabilities: ServerCapabilities,
+}
+
+impl PreparedSetup {
+    pub fn capabilities(&self) -> &ServerCapabilities {
+        &self.capabilities
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenSubsonicStatusKind {
+    Off,
+    UpToDate,
+    NeedsAttention,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenSubsonicStatus {
+    pub kind: OpenSubsonicStatusKind,
+    pub display_name: Option<String>,
+    pub backend_id: Option<BackendId>,
+    pub account_scope_id: Option<AccountScopeId>,
+    pub credential_kind: Option<CredentialKind>,
+    pub uses_lan_http: bool,
+    /// Whether a user-provided certificate authority is configured.
+    ///
+    /// This deliberately exposes only the redacted presence bit, never certificate bytes,
+    /// fingerprints, paths, or the configured origin.
+    pub uses_custom_ca: bool,
+}
+
+impl OpenSubsonicStatus {
+    fn off() -> Self {
+        Self {
+            kind: OpenSubsonicStatusKind::Off,
+            display_name: None,
+            backend_id: None,
+            account_scope_id: None,
+            credential_kind: None,
+            uses_lan_http: false,
+            uses_custom_ca: false,
+        }
+    }
+
+    fn needs_attention() -> Self {
+        Self {
+            kind: OpenSubsonicStatusKind::NeedsAttention,
+            display_name: None,
+            backend_id: None,
+            account_scope_id: None,
+            credential_kind: None,
+            uses_lan_http: false,
+            uses_custom_ca: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenSubsonicProfileSummary {
+    pub display_name: String,
+    pub backend_id: BackendId,
+    pub account_scope_id: AccountScopeId,
+    pub credential_kind: CredentialKind,
+    pub uses_lan_http: bool,
+    pub capabilities: ServerCapabilities,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServerLibraryRequest {
+    pub section: ServerLibrarySection,
+    pub offset: u32,
+    pub limit: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServerLibraryDetailRequest {
+    Album(AlbumId),
+    Artist(ArtistId),
+    Playlist(ServerPlaylistId),
+}
+
+pub async fn test_and_prepare_setup(
+    paths: &OpenSubsonicPaths,
+    mut input: SetupInput,
+) -> Result<PreparedSetup, ServiceError> {
+    let current = load_store_set(paths)?;
+    let expected = current
+        .as_ref()
+        .map_or(StoreRevisions::MISSING, OpenSubsonicStoreSet::revisions);
+    let (backend_id, account_scope_id) = match (current.as_ref(), input.identity_intent) {
+        (None, SetupIdentityIntent::Create) => (
+            BackendId::random().map_err(|_| ServiceError::InvalidSetup)?,
+            AccountScopeId::random().map_err(|_| ServiceError::InvalidSetup)?,
+        ),
+        (Some(state), SetupIdentityIntent::UpdateSameServerAndAccount) => (
+            state.profile.backend_id().clone(),
+            state.profile.account_scope_id().clone(),
+        ),
+        (Some(_), SetupIdentityIntent::ReplaceServerOrAccount) => (
+            BackendId::random().map_err(|_| ServiceError::InvalidSetup)?,
+            AccountScopeId::random().map_err(|_| ServiceError::InvalidSetup)?,
+        ),
+        (None, SetupIdentityIntent::UpdateSameServerAndAccount)
+        | (None, SetupIdentityIntent::ReplaceServerOrAccount)
+        | (Some(_), SetupIdentityIntent::Create) => return Err(ServiceError::InvalidSetup),
+    };
+    let display_name = std::mem::take(&mut input.display_name);
+    let raw_origin = std::mem::take(&mut input.origin);
+    let custom_ca_pem = input.custom_ca_pem.take();
+    let credential = input.credential.take().ok_or(ServiceError::InvalidSetup)?;
+    let origin = ConfiguredPrivateOrigin::new(&raw_origin, input.allow_lan_http)
+        .map_err(|_| ServiceError::InvalidSetup)?;
+    let profile = OpenSubsonicProfile::with_ids(
+        0,
+        backend_id.clone(),
+        account_scope_id.clone(),
+        &display_name,
+        origin,
+        custom_ca_pem,
+    )?;
+    let private_state =
+        OpenSubsonicPrivateState::new(backend_id.clone(), account_scope_id.clone(), credential);
+    let bridge_state = OpenSubsonicBridgeState::new(backend_id, account_scope_id);
+    let store_set = OpenSubsonicStoreSet::new(profile, private_state, bridge_state)?;
+    let client = OpenSubsonicClient::connect(&store_set.profile).await?;
+    let capabilities =
+        ServerCapabilities::probe(&client, store_set.private_state.credential()).await?;
+    Ok(PreparedSetup {
+        expected,
+        store_set: Some(store_set),
+        capabilities,
+    })
+}
+
+pub fn commit_setup(
+    paths: &OpenSubsonicPaths,
+    mut prepared: PreparedSetup,
+) -> Result<OpenSubsonicStatus, ServiceError> {
+    let mut store_set = prepared
+        .store_set
+        .take()
+        .ok_or(ServiceError::InvalidSetup)?;
+    // A durable profile/credential change is an immediate trust-boundary change. The owner may
+    // keep the old guard while the replacement is only being tested, but once commit starts its
+    // catalog handle and every previously minted route must already be unusable. In particular,
+    // the store transaction can return an error after its commit marker is durable, so revoking
+    // after a successful return would leave the old credential owner alive on that ambiguous
+    // path.
+    clear_current_runtime();
+    commit_store_set(paths, prepared.expected, &mut store_set)?;
+    Ok(status_from_store_set(&store_set))
+}
+
+pub fn read_status(paths: &OpenSubsonicPaths) -> Result<OpenSubsonicStatus, ServiceError> {
+    match load_store_set_read_only(paths) {
+        Ok(store_set) => Ok(store_set
+            .as_ref()
+            .map_or_else(OpenSubsonicStatus::off, status_from_store_set)),
+        Err(StoreError::InvalidState | StoreError::PayloadTooLarge) => {
+            Ok(OpenSubsonicStatus::needs_attention())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+/// Verify the saved credential and exact-origin policy without changing durable state.
+pub async fn test_connection(
+    paths: &OpenSubsonicPaths,
+) -> Result<OpenSubsonicStatus, ServiceError> {
+    let Some(store_set) = load_store_set(paths)? else {
+        return Ok(OpenSubsonicStatus::off());
+    };
+    probe_store_set(&store_set).await
+}
+
+/// Read-only connection probe for one-shot status commands.
+///
+/// Unlike [`test_connection`], this never creates the store directory, takes the mutation lock,
+/// or rolls a pending transaction forward.
+pub async fn test_connection_read_only(
+    paths: &OpenSubsonicPaths,
+) -> Result<OpenSubsonicStatus, ServiceError> {
+    let Some(store_set) = load_store_set_read_only(paths)? else {
+        return Ok(OpenSubsonicStatus::off());
+    };
+    probe_store_set(&store_set).await
+}
+
+async fn probe_store_set(
+    store_set: &OpenSubsonicStoreSet,
+) -> Result<OpenSubsonicStatus, ServiceError> {
+    let client = OpenSubsonicClient::connect(&store_set.profile).await?;
+    ServerCapabilities::probe(&client, store_set.private_state.credential()).await?;
+    Ok(status_from_store_set(store_set))
+}
+
+pub fn remove_profile(paths: &OpenSubsonicPaths) -> Result<OpenSubsonicStatus, ServiceError> {
+    clear_current_runtime();
+    match load_store_set(paths) {
+        Ok(Some(store_set)) => remove_store_set(paths, store_set.revisions())?,
+        Ok(None) => {}
+        Err(StoreError::InvalidState | StoreError::PayloadTooLarge) => reset_store_set(paths)?,
+        Err(error) => return Err(error.into()),
+    }
+    Ok(OpenSubsonicStatus::off())
+}
+
+fn status_from_store_set(store_set: &OpenSubsonicStoreSet) -> OpenSubsonicStatus {
+    OpenSubsonicStatus {
+        kind: OpenSubsonicStatusKind::UpToDate,
+        display_name: Some(store_set.profile.display_name().to_owned()),
+        backend_id: Some(store_set.profile.backend_id().clone()),
+        account_scope_id: Some(store_set.profile.account_scope_id().clone()),
+        credential_kind: Some(store_set.private_state.credential_kind()),
+        uses_lan_http: store_set.profile.uses_lan_http(),
+        uses_custom_ca: store_set.profile.custom_ca_fingerprint().is_some(),
+    }
+}
+
+#[derive(Clone)]
+pub struct OpenSubsonicHandle {
+    tx: mpsc::Sender<ActorCommand>,
+}
+
+impl std::fmt::Debug for OpenSubsonicHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("OpenSubsonicHandle(<redacted>)")
+    }
+}
+
+impl OpenSubsonicHandle {
+    pub async fn search(
+        &self,
+        query: impl Into<String>,
+        limit: u32,
+    ) -> Result<Vec<ServerSong>, ServerError> {
+        self.request(|reply| ActorCommand::Search {
+            query: query.into(),
+            limit,
+            reply,
+        })
+        .await
+    }
+
+    pub async fn library_page(
+        &self,
+        request: ServerLibraryRequest,
+    ) -> Result<ServerLibraryPage, ServerError> {
+        self.request(|reply| ActorCommand::LibraryPage { request, reply })
+            .await
+    }
+
+    pub async fn library_detail(
+        &self,
+        request: ServerLibraryDetailRequest,
+    ) -> Result<ServerLibraryDetail, ServerError> {
+        self.request(|reply| ActorCommand::LibraryDetail { request, reply })
+            .await
+    }
+
+    pub async fn cover_art(
+        &self,
+        item: OpenSubsonicItemRef,
+        id: CoverArtId,
+    ) -> Result<Option<BinaryPayload>, ServerError> {
+        self.request(|reply| ActorCommand::CoverArt { item, id, reply })
+            .await
+    }
+
+    pub async fn profile_summary(&self) -> Result<OpenSubsonicProfileSummary, ServerError> {
+        self.request(|reply| ActorCommand::ProfileSummary { reply })
+            .await
+    }
+
+    async fn open_stream_response(
+        &self,
+        item: OpenSubsonicItemRef,
+        request: StreamRequest,
+    ) -> Result<UpstreamStream, ServerError> {
+        self.request(|reply| ActorCommand::OpenStream {
+            item,
+            request,
+            reply,
+        })
+        .await
+    }
+
+    async fn request<T>(
+        &self,
+        command: impl FnOnce(oneshot::Sender<Result<T, ServerError>>) -> ActorCommand,
+    ) -> Result<T, ServerError> {
+        let (reply, response) = oneshot::channel();
+        self.tx
+            .send(command(reply))
+            .await
+            .map_err(|_| ServerError::Offline)?;
+        response.await.map_err(|_| ServerError::Offline)?
+    }
+}
+
+impl StreamSource for OpenSubsonicHandle {
+    fn open_stream(&self, item: OpenSubsonicItemRef, request: StreamRequest) -> StreamSourceFuture {
+        let handle = self.clone();
+        Box::pin(async move {
+            handle
+                .open_stream_response(item, request)
+                .await
+                .map_err(proxy_error)
+        })
+    }
+}
+
+pub struct OpenSubsonicRuntime {
+    generation: u64,
+    handle: OpenSubsonicHandle,
+    proxy_handle: OpenSubsonicProxyHandle,
+    proxy_guard: Option<OpenSubsonicProxyGuard>,
+    actor_task: Option<JoinHandle<()>>,
+}
+
+impl OpenSubsonicRuntime {
+    pub fn handle(&self) -> OpenSubsonicHandle {
+        self.handle.clone()
+    }
+
+    pub fn proxy_handle(&self) -> OpenSubsonicProxyHandle {
+        self.proxy_handle.clone()
+    }
+
+    pub fn route_provider(&self) -> crate::playback_target::PlaybackRouteProviderHandle {
+        self.proxy_handle.route_provider()
+    }
+
+    /// Publish this fully constructed runtime to read-only catalog consumers.
+    ///
+    /// Loading and activation are deliberately separate: multiple setup generations may finish
+    /// out of order, and only the owner lane may decide which result is current. A discarded
+    /// candidate therefore never replaces or revokes the active profile.
+    pub(crate) fn activate(&self) {
+        install_current(
+            self.generation,
+            self.handle.clone(),
+            self.proxy_handle.clone(),
+            self.actor_task
+                .as_ref()
+                .expect("an active runtime owns its actor task")
+                .abort_handle(),
+        );
+    }
+
+    pub async fn shutdown(mut self) {
+        clear_current_generation(self.generation);
+        if let Some(guard) = self.proxy_guard.take() {
+            guard.shutdown().await;
+        }
+        if let Some(task) = self.actor_task.take() {
+            task.abort();
+        }
+    }
+}
+
+impl Drop for OpenSubsonicRuntime {
+    fn drop(&mut self) {
+        clear_current_generation(self.generation);
+        self.proxy_handle.revoke_all();
+        if let Some(task) = self.actor_task.take() {
+            task.abort();
+        }
+    }
+}
+
+pub async fn load_actor(
+    paths: &OpenSubsonicPaths,
+) -> Result<Option<OpenSubsonicRuntime>, ServiceError> {
+    let Some(store_set) = load_store_set(paths)? else {
+        return Ok(None);
+    };
+    start_actor(store_set).await.map(Some)
+}
+
+/// Start a credential owner from a coherent snapshot without creating storage, locking for
+/// mutation, or rolling a transaction forward. Read-only secondary processes use this path.
+pub async fn load_actor_read_only(
+    paths: &OpenSubsonicPaths,
+) -> Result<Option<OpenSubsonicRuntime>, ServiceError> {
+    let Some(store_set) = load_store_set_read_only(paths)? else {
+        return Ok(None);
+    };
+    start_actor(store_set).await.map(Some)
+}
+
+async fn start_actor(store_set: OpenSubsonicStoreSet) -> Result<OpenSubsonicRuntime, ServiceError> {
+    let client = OpenSubsonicClient::connect(&store_set.profile).await?;
+    let capabilities =
+        ServerCapabilities::probe(&client, store_set.private_state.credential()).await?;
+    let summary = OpenSubsonicProfileSummary {
+        display_name: store_set.profile.display_name().to_owned(),
+        backend_id: store_set.profile.backend_id().clone(),
+        account_scope_id: store_set.profile.account_scope_id().clone(),
+        credential_kind: store_set.private_state.credential_kind(),
+        uses_lan_http: store_set.profile.uses_lan_http(),
+        capabilities,
+    };
+    let (tx, rx) = mpsc::channel(ACTOR_CAPACITY);
+    let handle = OpenSubsonicHandle { tx };
+    let actor_task = tokio::spawn(run_actor(rx, store_set, client, summary));
+    let (proxy_handle, proxy_guard) = match super::proxy::start(Arc::new(handle.clone())).await {
+        Ok(proxy) => proxy,
+        Err(_) => {
+            actor_task.abort();
+            return Err(ServiceError::ProxyUnavailable);
+        }
+    };
+    let generation = NEXT_GENERATION.fetch_add(1, Ordering::Relaxed);
+    Ok(OpenSubsonicRuntime {
+        generation,
+        handle,
+        proxy_handle,
+        proxy_guard: Some(proxy_guard),
+        actor_task: Some(actor_task),
+    })
+}
+
+pub fn current_handle() -> Option<OpenSubsonicHandle> {
+    current()
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_ref()
+        .map(|entry| entry.handle.clone())
+}
+
+pub fn current_proxy_handle() -> Option<OpenSubsonicProxyHandle> {
+    current()
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_ref()
+        .map(|entry| entry.proxy.clone())
+}
+
+async fn run_actor(
+    mut rx: mpsc::Receiver<ActorCommand>,
+    store_set: OpenSubsonicStoreSet,
+    client: OpenSubsonicClient,
+    summary: OpenSubsonicProfileSummary,
+) {
+    while let Some(command) = rx.recv().await {
+        let catalog = OpenSubsonicCatalog::new(
+            &client,
+            store_set.private_state.credential(),
+            store_set.profile.backend_id(),
+            store_set.profile.account_scope_id(),
+        );
+        match command {
+            ActorCommand::Search {
+                query,
+                limit,
+                mut reply,
+            } => {
+                let result = tokio::select! {
+                    _ = reply.closed() => continue,
+                    result = catalog.search(&query, limit) => result,
+                };
+                let _ = reply.send(result);
+            }
+            ActorCommand::LibraryPage { request, mut reply } => {
+                let result = tokio::select! {
+                    _ = reply.closed() => continue,
+                    result = catalog.library_page(
+                        request.section,
+                        request.offset,
+                        request.limit,
+                    ) => result,
+                };
+                let _ = reply.send(result);
+            }
+            ActorCommand::LibraryDetail { request, mut reply } => {
+                let operation = async {
+                    match request {
+                        ServerLibraryDetailRequest::Album(id) => catalog.album_detail(&id).await,
+                        ServerLibraryDetailRequest::Artist(id) => catalog.artist_detail(&id).await,
+                        ServerLibraryDetailRequest::Playlist(id) => {
+                            catalog.playlist_detail(&id).await
+                        }
+                    }
+                };
+                let result = tokio::select! {
+                    _ = reply.closed() => continue,
+                    result = operation => result,
+                };
+                let _ = reply.send(result);
+            }
+            ActorCommand::CoverArt {
+                item,
+                id,
+                mut reply,
+            } => {
+                let operation = async {
+                    match client.validate_item_scope(&item) {
+                        Ok(()) => catalog.cover_art(&id).await,
+                        Err(error) => Err(error),
+                    }
+                };
+                let result = tokio::select! {
+                    _ = reply.closed() => continue,
+                    result = operation => result,
+                };
+                let _ = reply.send(result);
+            }
+            ActorCommand::ProfileSummary { reply } => {
+                let _ = reply.send(Ok(summary.clone()));
+            }
+            ActorCommand::OpenStream {
+                item,
+                request,
+                mut reply,
+            } => {
+                let operation = async {
+                    let origin = client.proxy_origin()?;
+                    let response = client
+                        .open_stream(store_set.private_state.credential(), &item, request)
+                        .await?;
+                    Ok(UpstreamStream::new(response, origin))
+                };
+                let result = tokio::select! {
+                    _ = reply.closed() => continue,
+                    result = operation => result,
+                };
+                let _ = reply.send(result);
+            }
+        }
+    }
+}
+
+enum ActorCommand {
+    Search {
+        query: String,
+        limit: u32,
+        reply: oneshot::Sender<Result<Vec<ServerSong>, ServerError>>,
+    },
+    LibraryPage {
+        request: ServerLibraryRequest,
+        reply: oneshot::Sender<Result<ServerLibraryPage, ServerError>>,
+    },
+    LibraryDetail {
+        request: ServerLibraryDetailRequest,
+        reply: oneshot::Sender<Result<ServerLibraryDetail, ServerError>>,
+    },
+    CoverArt {
+        item: OpenSubsonicItemRef,
+        id: CoverArtId,
+        reply: oneshot::Sender<Result<Option<BinaryPayload>, ServerError>>,
+    },
+    ProfileSummary {
+        reply: oneshot::Sender<Result<OpenSubsonicProfileSummary, ServerError>>,
+    },
+    OpenStream {
+        item: OpenSubsonicItemRef,
+        request: StreamRequest,
+        reply: oneshot::Sender<Result<UpstreamStream, ServerError>>,
+    },
+}
+
+fn proxy_error(error: ServerError) -> ProxyUpstreamError {
+    let reason = match error {
+        ServerError::AuthenticationRequired => "upstream_authentication_required",
+        ServerError::PermissionDenied => "upstream_permission_denied",
+        ServerError::WrongAccountScope => "upstream_scope_mismatch",
+        ServerError::OriginRejected | ServerError::CertificateFailed => "upstream_origin_rejected",
+        ServerError::NotFound => "upstream_not_found",
+        ServerError::RateLimited(_) => "upstream_rate_limited",
+        ServerError::UnsupportedFeature => "upstream_unsupported",
+        ServerError::InvalidResponse | ServerError::ResponseTooLarge => "upstream_invalid_response",
+        ServerError::Offline | ServerError::TemporarilyUnavailable => "upstream_unavailable",
+    };
+    ProxyUpstreamError::new(reason)
+}
+
+struct CurrentEntry {
+    generation: u64,
+    handle: OpenSubsonicHandle,
+    proxy: OpenSubsonicProxyHandle,
+    actor_abort: tokio::task::AbortHandle,
+}
+
+impl CurrentEntry {
+    fn revoke(self) {
+        self.proxy.revoke_all();
+        self.actor_abort.abort();
+    }
+}
+
+static CURRENT: OnceLock<RwLock<Option<CurrentEntry>>> = OnceLock::new();
+static NEXT_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+fn current() -> &'static RwLock<Option<CurrentEntry>> {
+    CURRENT.get_or_init(|| RwLock::new(None))
+}
+
+fn install_current(
+    generation: u64,
+    handle: OpenSubsonicHandle,
+    proxy: OpenSubsonicProxyHandle,
+    actor_abort: tokio::task::AbortHandle,
+) {
+    let mut current = current()
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(previous) = current.replace(CurrentEntry {
+        generation,
+        handle,
+        proxy,
+        actor_abort,
+    }) {
+        previous.revoke();
+    }
+}
+
+fn clear_current_runtime() {
+    let mut current = current()
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(previous) = current.take() {
+        previous.revoke();
+    }
+}
+
+fn clear_current_generation(generation: u64) {
+    let mut current = current()
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if current
+        .as_ref()
+        .is_some_and(|entry| entry.generation == generation)
+        && let Some(entry) = current.take()
+    {
+        entry.revoke();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use age::secrecy::SecretString;
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    use super::*;
+
+    static NEXT_ROOT: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn status_never_contains_origin_or_credentials() {
+        let status = OpenSubsonicStatus {
+            kind: OpenSubsonicStatusKind::UpToDate,
+            display_name: Some("Server".to_owned()),
+            backend_id: Some(BackendId::new("backend").unwrap()),
+            account_scope_id: Some(AccountScopeId::new("account").unwrap()),
+            credential_kind: Some(CredentialKind::ApiKey),
+            uses_lan_http: false,
+            uses_custom_ca: false,
+        };
+        let rendered = format!("{status:?}");
+        assert!(!rendered.contains("https://"));
+        assert!(!rendered.contains("sentinel-secret"));
+    }
+
+    #[test]
+    fn confirmed_remove_resets_corrupt_partial_and_oversized_stores() {
+        for (case, bytes) in [
+            ("corrupt", b"not-json".to_vec()),
+            (
+                "oversized",
+                vec![b'x'; crate::open_subsonic::profile::MAX_PROFILE_BYTES as usize + 1],
+            ),
+        ] {
+            let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
+            let root = std::env::temp_dir().join(format!(
+                "yututui-open-subsonic-reset-{case}-{}-{id}",
+                std::process::id()
+            ));
+            let paths = OpenSubsonicPaths::for_data_root(root.clone());
+            crate::util::safe_fs::write_owner_only_atomic(paths.profile(), &bytes).unwrap();
+
+            assert_eq!(
+                read_status(&paths).unwrap().kind,
+                OpenSubsonicStatusKind::NeedsAttention
+            );
+            assert_eq!(
+                remove_profile(&paths).unwrap().kind,
+                OpenSubsonicStatusKind::Off
+            );
+            assert_eq!(
+                read_status(&paths).unwrap().kind,
+                OpenSubsonicStatusKind::Off
+            );
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn confirmed_remove_rejects_a_symlink_without_touching_its_target() {
+        use std::os::unix::fs::symlink;
+
+        let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "yututui-open-subsonic-reset-link-{}-{id}",
+            std::process::id()
+        ));
+        let paths = OpenSubsonicPaths::for_data_root(root.clone());
+        crate::util::safe_fs::ensure_private_dir(paths.root()).unwrap();
+        let external = root.join("outside-secret");
+        std::fs::write(&external, b"must-stay").unwrap();
+        symlink(&external, paths.profile()).unwrap();
+
+        assert!(remove_profile(&paths).is_err());
+        assert_eq!(std::fs::read(&external).unwrap(), b"must-stay");
+        assert!(paths.profile().is_symlink());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn setup_input_is_move_only_and_accepts_secret_credential() {
+        let input = SetupInput::new(
+            "Server",
+            "https://music.example.test/",
+            false,
+            None,
+            ServerCredential::api_key(SecretString::from("secret".to_owned())).unwrap(),
+            SetupIdentityIntent::Create,
+        );
+        assert_eq!(input.identity_intent, SetupIdentityIntent::Create);
+    }
+
+    #[tokio::test]
+    async fn tested_setup_commits_all_stores_and_remove_is_local_only() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let replies = [
+                r#"{"subsonic-response":{"status":"ok","openSubsonicExtensions":[]}}"#,
+                r#"{"subsonic-response":{"status":"ok","version":"1.16.1"}}"#,
+            ];
+            for body in replies.into_iter().cycle().take(12) {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut request = Vec::new();
+                let mut byte = [0_u8; 1];
+                while request.len() < 16 * 1024 {
+                    if stream.read(&mut byte).await.unwrap() == 0 {
+                        break;
+                    }
+                    request.push(byte[0]);
+                    if request.ends_with(b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{body}"
+                );
+                stream.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+        let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "yututui-open-subsonic-service-{}-{id}",
+            std::process::id()
+        ));
+        crate::util::safe_fs::ensure_private_dir(&root).unwrap();
+        let paths = OpenSubsonicPaths::for_data_root(root.clone());
+        let input = SetupInput::new(
+            "Test server",
+            format!("http://127.0.0.1:{port}/"),
+            true,
+            None,
+            ServerCredential::api_key(SecretString::from("secret".to_owned())).unwrap(),
+            SetupIdentityIntent::Create,
+        );
+        let prepared = test_and_prepare_setup(&paths, input).await.unwrap();
+        let status = commit_setup(&paths, prepared).unwrap();
+        assert_eq!(status.kind, OpenSubsonicStatusKind::UpToDate);
+        let original_backend = status.backend_id.clone().unwrap();
+        let original_account = status.account_scope_id.clone().unwrap();
+        assert_eq!(read_status(&paths).unwrap().kind, status.kind);
+        assert_eq!(
+            test_connection(&paths).await.unwrap().kind,
+            OpenSubsonicStatusKind::UpToDate
+        );
+        let old_runtime = load_actor(&paths).await.unwrap().unwrap();
+        let old_handle = old_runtime.handle();
+        let old_provider = old_runtime.route_provider();
+        old_runtime.activate();
+        let old_target = crate::playback_target::CredentialedPlaybackRef::OpenSubsonic {
+            backend_id: original_backend.as_str().to_owned(),
+            account_scope_id: original_account.as_str().to_owned(),
+            item_id: "old-route-item".to_owned(),
+        };
+        let old_route = old_provider
+            .open_route(old_target.clone(), 1)
+            .await
+            .unwrap();
+        let (old_route_url, _old_route_lease) = old_route.into_parts();
+        let old_route_url = old_route_url.into_string();
+
+        let update = SetupInput::new(
+            "Renamed server",
+            format!("http://127.0.0.1:{port}/"),
+            true,
+            None,
+            ServerCredential::api_key(SecretString::from("updated-secret".to_owned())).unwrap(),
+            SetupIdentityIntent::UpdateSameServerAndAccount,
+        );
+        crate::open_subsonic::transaction::fail_after_commit_marker_once_for_test();
+        assert_eq!(
+            commit_setup(
+                &paths,
+                test_and_prepare_setup(&paths, update).await.unwrap(),
+            ),
+            Err(ServiceError::Store(StoreError::StorageUnavailable))
+        );
+        assert_eq!(
+            old_handle.profile_summary().await.unwrap_err(),
+            ServerError::Offline
+        );
+        assert_eq!(
+            old_provider
+                .open_route(old_target, 2)
+                .await
+                .unwrap_err()
+                .reason(),
+            "route_provider_unavailable"
+        );
+        assert_eq!(
+            reqwest::get(old_route_url).await.unwrap().status(),
+            reqwest::StatusCode::NOT_FOUND
+        );
+
+        // The next owner load rolls the committed candidate forward, but never revives the old
+        // handle or route.
+        load_store_set(&paths).unwrap().unwrap();
+        let updated = read_status(&paths).unwrap();
+        assert_eq!(updated.kind, OpenSubsonicStatusKind::UpToDate);
+        assert_eq!(updated.display_name.as_deref(), Some("Renamed server"));
+        assert_eq!(updated.backend_id.as_ref(), Some(&original_backend));
+        assert_eq!(updated.account_scope_id.as_ref(), Some(&original_account));
+        assert_eq!(
+            old_handle.profile_summary().await.unwrap_err(),
+            ServerError::Offline
+        );
+        drop(old_runtime);
+
+        let replacement = SetupInput::new(
+            "Replacement server",
+            format!("http://127.0.0.1:{port}/"),
+            true,
+            None,
+            ServerCredential::api_key(SecretString::from("replacement-secret".to_owned())).unwrap(),
+            SetupIdentityIntent::ReplaceServerOrAccount,
+        );
+        let replaced = commit_setup(
+            &paths,
+            test_and_prepare_setup(&paths, replacement).await.unwrap(),
+        )
+        .unwrap();
+        assert_ne!(replaced.backend_id.as_ref(), Some(&original_backend));
+        assert_ne!(replaced.account_scope_id.as_ref(), Some(&original_account));
+        let removal_runtime = load_actor(&paths).await.unwrap().unwrap();
+        let removal_handle = removal_runtime.handle();
+        removal_runtime.activate();
+        assert_eq!(
+            remove_profile(&paths).unwrap().kind,
+            OpenSubsonicStatusKind::Off
+        );
+        assert_eq!(
+            removal_handle.profile_summary().await.unwrap_err(),
+            ServerError::Offline
+        );
+        drop(removal_runtime);
+        assert_eq!(
+            read_status(&paths).unwrap().kind,
+            OpenSubsonicStatusKind::Off
+        );
+        server.await.unwrap();
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/src/open_subsonic/auth.rs
+++ b/src/open_subsonic/auth.rs
@@ -1,0 +1,129 @@
+//! Per-request OpenSubsonic authentication material.
+
+use age::secrecy::ExposeSecret as _;
+use data_encoding::HEXLOWER;
+use md5::{Digest as _, Md5};
+use zeroize::{Zeroize, Zeroizing};
+
+use super::private_store::{CredentialKind, ServerCredential};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthError {
+    RandomFailed,
+}
+
+impl std::fmt::Display for AuthError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("request authentication could not be prepared")
+    }
+}
+
+impl std::error::Error for AuthError {}
+
+/// Authentication query/form fields. Deliberately lacks `Debug` and `Clone`.
+pub struct AuthParameters {
+    fields: Vec<(String, String)>,
+}
+
+impl AuthParameters {
+    pub fn fresh(credential: &ServerCredential) -> Result<Self, AuthError> {
+        match credential.kind() {
+            CredentialKind::ApiKey => Ok(Self {
+                fields: vec![(
+                    "apiKey".to_owned(),
+                    credential.secret().expose_secret().to_owned(),
+                )],
+            }),
+            CredentialKind::Password => {
+                let mut salt_bytes = [0_u8; 16];
+                getrandom::fill(&mut salt_bytes).map_err(|_| AuthError::RandomFailed)?;
+                let salt = HEXLOWER.encode(&salt_bytes);
+                let mut token_input = Zeroizing::new(Vec::with_capacity(
+                    credential.secret().expose_secret().len() + salt.len(),
+                ));
+                token_input.extend_from_slice(credential.secret().expose_secret().as_bytes());
+                token_input.extend_from_slice(salt.as_bytes());
+                let token = HEXLOWER.encode(&Md5::digest(&token_input));
+                Ok(Self {
+                    fields: vec![
+                        (
+                            "u".to_owned(),
+                            credential
+                                .username()
+                                .expect("password credentials always have a username")
+                                .expose_secret()
+                                .to_owned(),
+                        ),
+                        ("t".to_owned(), token),
+                        ("s".to_owned(), salt),
+                    ],
+                })
+            }
+        }
+    }
+
+    pub(crate) fn fields(&self) -> &[(String, String)] {
+        &self.fields
+    }
+}
+
+impl Drop for AuthParameters {
+    fn drop(&mut self) {
+        for (name, value) in &mut self.fields {
+            name.zeroize();
+            value.zeroize();
+        }
+    }
+}
+
+pub(crate) fn common_parameters() -> [(&'static str, &'static str); 3] {
+    [("v", "1.16.1"), ("c", "yututui"), ("f", "json")]
+}
+
+#[cfg(test)]
+mod tests {
+    use age::secrecy::SecretString;
+    use data_encoding::HEXLOWER_PERMISSIVE;
+
+    use super::*;
+
+    #[test]
+    fn api_key_auth_excludes_every_legacy_parameter() {
+        let credential =
+            ServerCredential::api_key(SecretString::from("api-secret".to_owned())).unwrap();
+        let auth = AuthParameters::fresh(&credential).unwrap();
+        assert_eq!(
+            auth.fields(),
+            &[("apiKey".to_owned(), "api-secret".to_owned())]
+        );
+        for forbidden in ["u", "p", "t", "s"] {
+            assert!(!auth.fields().iter().any(|(name, _)| name == forbidden));
+        }
+    }
+
+    #[test]
+    fn password_auth_uses_fresh_salted_md5_without_cleartext_password() {
+        fn field<'a>(auth: &'a AuthParameters, name: &str) -> &'a str {
+            auth.fields()
+                .iter()
+                .find(|(field, _)| field == name)
+                .map(|(_, value)| value.as_str())
+                .unwrap()
+        }
+
+        let credential =
+            ServerCredential::password("alice", SecretString::from("password-secret".to_owned()))
+                .unwrap();
+        let first = AuthParameters::fresh(&credential).unwrap();
+        let second = AuthParameters::fresh(&credential).unwrap();
+        assert_ne!(field(&first, "s"), field(&second, "s"));
+        assert!(!first.fields().iter().any(|(name, _)| name == "p"));
+        let salt = field(&first, "s");
+        assert_eq!(
+            HEXLOWER_PERMISSIVE.decode(salt.as_bytes()).unwrap().len(),
+            16
+        );
+        let expected = HEXLOWER.encode(&Md5::digest(format!("password-secret{salt}").as_bytes()));
+        assert_eq!(field(&first, "t"), expected);
+    }
+}

--- a/src/open_subsonic/bridge_store.rs
+++ b/src/open_subsonic/bridge_store.rs
@@ -1,0 +1,105 @@
+//! Owner-only foundation for exact server observations and later projection bridges.
+
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
+
+use super::model::{AccountScopeId, BackendId};
+use super::profile::StoreError;
+
+pub(crate) const BRIDGE_KIND: &str = "yututui_open_subsonic_bridge";
+pub(crate) const BRIDGE_SCHEMA_VERSION: u32 = 1;
+pub(crate) const MAX_BRIDGE_BYTES: u64 = 16 * 1024 * 1024;
+
+/// The PR 6 bridge is deliberately empty: later rating/history work can add versioned observations
+/// without coupling the profile or credentials to portable personal state.
+pub struct OpenSubsonicBridgeState {
+    revision: u64,
+    backend_id: BackendId,
+    account_scope_id: AccountScopeId,
+}
+
+impl OpenSubsonicBridgeState {
+    pub fn new(backend_id: BackendId, account_scope_id: AccountScopeId) -> Self {
+        Self {
+            revision: 0,
+            backend_id,
+            account_scope_id,
+        }
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn backend_id(&self) -> &BackendId {
+        &self.backend_id
+    }
+
+    pub fn account_scope_id(&self) -> &AccountScopeId {
+        &self.account_scope_id
+    }
+
+    pub(crate) fn set_revision(&mut self, revision: u64) {
+        self.revision = revision;
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DiskBridgeState {
+    kind: String,
+    schema_version: u32,
+    revision: u64,
+    backend_id: BackendId,
+    account_scope_id: AccountScopeId,
+}
+
+pub(crate) fn encode_bridge(
+    state: &OpenSubsonicBridgeState,
+) -> Result<Zeroizing<Vec<u8>>, StoreError> {
+    let disk = DiskBridgeState {
+        kind: BRIDGE_KIND.to_owned(),
+        schema_version: BRIDGE_SCHEMA_VERSION,
+        revision: state.revision,
+        backend_id: state.backend_id.clone(),
+        account_scope_id: state.account_scope_id.clone(),
+    };
+    let bytes =
+        Zeroizing::new(serde_json::to_vec(&disk).map_err(|_| StoreError::SerializationFailed)?);
+    if bytes.len() as u64 > MAX_BRIDGE_BYTES {
+        return Err(StoreError::PayloadTooLarge);
+    }
+    Ok(bytes)
+}
+
+pub(crate) fn decode_bridge(bytes: &[u8]) -> Result<OpenSubsonicBridgeState, StoreError> {
+    if bytes.len() as u64 > MAX_BRIDGE_BYTES {
+        return Err(StoreError::PayloadTooLarge);
+    }
+    let disk: DiskBridgeState =
+        serde_json::from_slice(bytes).map_err(|_| StoreError::InvalidState)?;
+    if disk.kind != BRIDGE_KIND || disk.schema_version != BRIDGE_SCHEMA_VERSION {
+        return Err(StoreError::InvalidState);
+    }
+    Ok(OpenSubsonicBridgeState {
+        revision: disk.revision,
+        backend_id: disk.backend_id,
+        account_scope_id: disk.account_scope_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bridge_round_trip_preserves_scope() {
+        let bridge = OpenSubsonicBridgeState::new(
+            BackendId::new("backend").unwrap(),
+            AccountScopeId::new("account").unwrap(),
+        );
+        let decoded = decode_bridge(&encode_bridge(&bridge).unwrap()).unwrap();
+        assert_eq!(decoded.backend_id().as_str(), "backend");
+        assert_eq!(decoded.account_scope_id().as_str(), "account");
+    }
+}

--- a/src/open_subsonic/capabilities.rs
+++ b/src/open_subsonic/capabilities.rs
@@ -1,0 +1,151 @@
+//! Bounded OpenSubsonic capability discovery.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::client::{Endpoint, OpenSubsonicClient, ServerError, ServerInfo};
+use super::private_store::ServerCredential;
+use super::wire::RawExtension;
+
+const MAX_EXTENSIONS: usize = 256;
+const MAX_EXTENSION_NAME_CHARS: usize = 128;
+const MAX_VERSIONS_PER_EXTENSION: usize = 32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ServerFeature {
+    Search,
+    Albums,
+    Artists,
+    Songs,
+    Playlists,
+    CoverArt,
+    Stream,
+    FormPost,
+    ApiKeyAuthentication,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerCapabilities {
+    pub server_info: ServerInfo,
+    extensions: BTreeMap<String, BTreeSet<u32>>,
+}
+
+impl ServerCapabilities {
+    pub async fn probe(
+        client: &OpenSubsonicClient,
+        credential: &ServerCredential,
+    ) -> Result<Self, ServerError> {
+        // This endpoint is explicitly public in OpenSubsonic. A missing/broken implementation is
+        // a feature downgrade, not a failed standard Subsonic connection.
+        let extensions = match client.request_public_json(Endpoint::Extensions, &[]).await {
+            Ok(response) => bounded_extensions(response.open_subsonic_extensions),
+            Err(_) => BTreeMap::new(),
+        };
+        let server_info = client.ping(credential).await?;
+        Ok(Self {
+            server_info,
+            extensions,
+        })
+    }
+
+    pub fn supports(&self, feature: ServerFeature) -> bool {
+        match feature {
+            ServerFeature::Search
+            | ServerFeature::Albums
+            | ServerFeature::Artists
+            | ServerFeature::Songs
+            | ServerFeature::Playlists
+            | ServerFeature::CoverArt
+            | ServerFeature::Stream => true,
+            ServerFeature::FormPost => self.has_extension("formPost", 1),
+            ServerFeature::ApiKeyAuthentication => self.has_extension("apiKeyAuthentication", 1),
+        }
+    }
+
+    pub fn extension_versions(&self, name: &str) -> Option<&BTreeSet<u32>> {
+        self.extensions.get(name)
+    }
+
+    fn has_extension(&self, name: &str, version: u32) -> bool {
+        self.extensions
+            .get(name)
+            .is_some_and(|versions| versions.contains(&version))
+    }
+}
+
+fn bounded_extensions(raw: Vec<RawExtension>) -> BTreeMap<String, BTreeSet<u32>> {
+    let mut extensions = BTreeMap::new();
+    for extension in raw.into_iter().take(MAX_EXTENSIONS) {
+        let Some(name) = extension.name.filter(|name| {
+            !name.is_empty()
+                && name.chars().count() <= MAX_EXTENSION_NAME_CHARS
+                && name
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        }) else {
+            continue;
+        };
+        let versions = extension
+            .versions
+            .into_iter()
+            .take(MAX_VERSIONS_PER_EXTENSION)
+            .collect::<BTreeSet<_>>();
+        extensions
+            .entry(name)
+            .or_insert_with(BTreeSet::new)
+            .extend(versions);
+    }
+    extensions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn capabilities(extensions: Vec<RawExtension>) -> ServerCapabilities {
+        ServerCapabilities {
+            server_info: ServerInfo {
+                api_version: None,
+                server_type: None,
+                server_version: None,
+                advertises_open_subsonic: true,
+            },
+            extensions: bounded_extensions(extensions),
+        }
+    }
+
+    #[test]
+    fn exact_extension_names_gate_optional_protocols() {
+        let capabilities = capabilities(vec![
+            RawExtension {
+                name: Some("formPost".to_owned()),
+                versions: vec![1],
+            },
+            RawExtension {
+                name: Some("apiKeyAuthentication".to_owned()),
+                versions: vec![1],
+            },
+        ]);
+        assert!(capabilities.supports(ServerFeature::FormPost));
+        assert!(capabilities.supports(ServerFeature::ApiKeyAuthentication));
+        assert!(capabilities.supports(ServerFeature::Search));
+    }
+
+    #[test]
+    fn extension_lists_are_bounded_and_sanitized() {
+        let capabilities = capabilities(vec![
+            RawExtension {
+                name: Some("unsafe\u{202e}formPost".to_owned()),
+                versions: vec![1],
+            },
+            RawExtension {
+                name: Some("bounded".to_owned()),
+                versions: (0..100).collect(),
+            },
+        ]);
+        assert!(capabilities.extension_versions("unsafeformPost").is_none());
+        assert_eq!(
+            capabilities.extension_versions("bounded").unwrap().len(),
+            MAX_VERSIONS_PER_EXTENSION
+        );
+    }
+}

--- a/src/open_subsonic/catalog.rs
+++ b/src/open_subsonic/catalog.rs
@@ -1,0 +1,587 @@
+//! Search and Server Library adapters over the bounded client.
+
+use super::client::{BinaryPayload, Endpoint, OpenSubsonicClient, ServerError};
+use super::model::{
+    AccountScopeId, AlbumId, ArtistId, BackendId, CoverArtId, OpenSubsonicItemRef, ServerAlbum,
+    ServerArtist, ServerLibraryDetail, ServerLibraryPage, ServerLibraryRow, ServerLibrarySection,
+    ServerPlaylist, ServerPlaylistId, ServerPlaylistSummary, ServerSong,
+};
+use super::private_store::ServerCredential;
+use super::wire::{
+    RawAlbum, RawAlbumWithSongs, RawArtist, RawArtistWithAlbums, RawChild, RawPlaylist,
+    RawPlaylistSummary,
+};
+
+pub const MAX_PAGE_SIZE: u32 = 200;
+const MAX_QUERY_CHARS: usize = 300;
+const MAX_NESTED_ROWS: usize = 20_000;
+
+pub struct OpenSubsonicCatalog<'a> {
+    client: &'a OpenSubsonicClient,
+    credential: &'a ServerCredential,
+    backend_id: &'a BackendId,
+    account_scope_id: &'a AccountScopeId,
+}
+
+impl<'a> OpenSubsonicCatalog<'a> {
+    pub fn new(
+        client: &'a OpenSubsonicClient,
+        credential: &'a ServerCredential,
+        backend_id: &'a BackendId,
+        account_scope_id: &'a AccountScopeId,
+    ) -> Self {
+        Self {
+            client,
+            credential,
+            backend_id,
+            account_scope_id,
+        }
+    }
+
+    pub async fn search(&self, query: &str, limit: u32) -> Result<Vec<ServerSong>, ServerError> {
+        let query = crate::api::sanitize_metadata_text(query, MAX_QUERY_CHARS);
+        if query.is_empty() {
+            return Ok(Vec::new());
+        }
+        let limit = bounded_limit(limit);
+        let parameters = vec![
+            ("query", query),
+            ("artistCount", "0".to_owned()),
+            ("albumCount", "0".to_owned()),
+            ("songCount", limit.to_string()),
+            ("songOffset", "0".to_owned()),
+        ];
+        let response = self
+            .client
+            .request_json(self.credential, Endpoint::Search3, &parameters)
+            .await?;
+        let result = response
+            .search_result3
+            .ok_or(ServerError::InvalidResponse)?;
+        Ok(result
+            .song
+            .into_iter()
+            .take(limit as usize)
+            .filter_map(|song| self.song(song))
+            .collect())
+    }
+
+    pub async fn library_page(
+        &self,
+        section: ServerLibrarySection,
+        offset: u32,
+        limit: u32,
+    ) -> Result<ServerLibraryPage, ServerError> {
+        let limit = bounded_limit(limit);
+        let result = match section {
+            ServerLibrarySection::RecentlyPlayed => self.album_page("recent", offset, limit).await,
+            ServerLibrarySection::Albums => {
+                self.album_page("alphabeticalByName", offset, limit).await
+            }
+            ServerLibrarySection::Artists => self.artist_page(offset, limit).await,
+            ServerLibrarySection::Songs => self.song_page(offset, limit).await,
+            ServerLibrarySection::Playlists => self.playlist_page(offset, limit).await,
+        };
+        let (rows, next_offset) = match result {
+            Ok(page) => page,
+            Err(ServerError::UnsupportedFeature) => {
+                return Ok(ServerLibraryPage {
+                    section,
+                    rows: Vec::new(),
+                    next_offset: None,
+                    warning: Some(super::model::LibraryWarning::FeatureUnsupported),
+                });
+            }
+            Err(error) => return Err(error),
+        };
+        Ok(ServerLibraryPage {
+            section,
+            rows,
+            next_offset,
+            warning: None,
+        })
+    }
+
+    pub async fn album_detail(&self, id: &AlbumId) -> Result<ServerLibraryDetail, ServerError> {
+        let response = self
+            .client
+            .request_json(
+                self.credential,
+                Endpoint::Album,
+                &[("id", id.as_str().to_owned())],
+            )
+            .await?;
+        let raw = response.album.ok_or(ServerError::InvalidResponse)?;
+        let album = album_with_songs_summary(&raw).ok_or(ServerError::InvalidResponse)?;
+        let songs = raw
+            .song
+            .into_iter()
+            .take(MAX_NESTED_ROWS)
+            .filter_map(|song| self.song(song))
+            .collect();
+        Ok(ServerLibraryDetail::AlbumSongs { album, songs })
+    }
+
+    pub async fn artist_detail(&self, id: &ArtistId) -> Result<ServerLibraryDetail, ServerError> {
+        let response = self
+            .client
+            .request_json(
+                self.credential,
+                Endpoint::Artist,
+                &[("id", id.as_str().to_owned())],
+            )
+            .await?;
+        let raw = response.artist.ok_or(ServerError::InvalidResponse)?;
+        let artist = artist_with_albums_summary(&raw).ok_or(ServerError::InvalidResponse)?;
+        let albums = raw
+            .album
+            .into_iter()
+            .take(MAX_NESTED_ROWS)
+            .filter_map(album)
+            .collect();
+        Ok(ServerLibraryDetail::ArtistAlbums { artist, albums })
+    }
+
+    pub async fn playlist_detail(
+        &self,
+        id: &ServerPlaylistId,
+    ) -> Result<ServerLibraryDetail, ServerError> {
+        let response = self
+            .client
+            .request_json(
+                self.credential,
+                Endpoint::Playlist,
+                &[("id", id.as_str().to_owned())],
+            )
+            .await?;
+        let raw = response.playlist.ok_or(ServerError::InvalidResponse)?;
+        let summary = playlist(&raw).ok_or(ServerError::InvalidResponse)?;
+        let entries = raw
+            .entry
+            .into_iter()
+            .take(MAX_NESTED_ROWS)
+            .filter_map(|song| self.song(song))
+            .collect();
+        Ok(ServerLibraryDetail::PlaylistEntries(ServerPlaylist {
+            summary,
+            entries,
+        }))
+    }
+
+    /// Artwork is independently optional. Unsupported or unsafe images return `Ok(None)`.
+    pub async fn cover_art(&self, id: &CoverArtId) -> Result<Option<BinaryPayload>, ServerError> {
+        let payload = match self.client.get_cover_art(self.credential, id).await {
+            Ok(payload) => payload,
+            Err(
+                ServerError::UnsupportedFeature
+                | ServerError::NotFound
+                | ServerError::InvalidResponse,
+            ) => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let Some(content_type) = payload
+            .content_type
+            .as_deref()
+            .filter(|content_type| supported_image_type(content_type))
+            .map(str::to_owned)
+        else {
+            return Ok(None);
+        };
+        let bytes = payload.bytes;
+        let bytes = tokio::task::spawn_blocking(move || {
+            crate::util::art::decode_untrusted(&bytes).map(|_| bytes)
+        })
+        .await
+        .map_err(|_| ServerError::InvalidResponse)?;
+        Ok(bytes.map(|bytes| BinaryPayload {
+            bytes,
+            content_type: Some(content_type),
+        }))
+    }
+
+    async fn album_page(
+        &self,
+        list_type: &str,
+        offset: u32,
+        limit: u32,
+    ) -> Result<(Vec<ServerLibraryRow>, Option<u32>), ServerError> {
+        let response = self
+            .client
+            .request_json(
+                self.credential,
+                Endpoint::AlbumList2,
+                &[
+                    ("type", list_type.to_owned()),
+                    ("size", limit.to_string()),
+                    ("offset", offset.to_string()),
+                ],
+            )
+            .await?;
+        let albums = response
+            .album_list2
+            .ok_or(ServerError::InvalidResponse)?
+            .album;
+        let raw_count = albums.len();
+        let rows = albums
+            .into_iter()
+            .take(limit as usize)
+            .filter_map(album)
+            .map(ServerLibraryRow::Album)
+            .collect();
+        Ok((rows, next_network_offset(offset, limit, raw_count)))
+    }
+
+    async fn song_page(
+        &self,
+        offset: u32,
+        limit: u32,
+    ) -> Result<(Vec<ServerLibraryRow>, Option<u32>), ServerError> {
+        let response = self
+            .client
+            .request_json(
+                self.credential,
+                Endpoint::Search3,
+                &[
+                    ("query", String::new()),
+                    ("artistCount", "0".to_owned()),
+                    ("albumCount", "0".to_owned()),
+                    ("songCount", limit.to_string()),
+                    ("songOffset", offset.to_string()),
+                ],
+            )
+            .await?;
+        let songs = response
+            .search_result3
+            .ok_or(ServerError::InvalidResponse)?
+            .song;
+        let raw_count = songs.len();
+        let rows = songs
+            .into_iter()
+            .take(limit as usize)
+            .filter_map(|song| self.song(song))
+            .map(ServerLibraryRow::Song)
+            .collect();
+        Ok((rows, next_network_offset(offset, limit, raw_count)))
+    }
+
+    async fn artist_page(
+        &self,
+        offset: u32,
+        limit: u32,
+    ) -> Result<(Vec<ServerLibraryRow>, Option<u32>), ServerError> {
+        let response = self
+            .client
+            .request_json(self.credential, Endpoint::Artists, &[])
+            .await?;
+        let artists = response
+            .artists
+            .ok_or(ServerError::InvalidResponse)?
+            .index
+            .into_iter()
+            .flat_map(|index| index.artist)
+            .take(MAX_NESTED_ROWS)
+            .collect::<Vec<_>>();
+        let (slice, next) = local_page(artists, offset, limit);
+        Ok((
+            slice
+                .into_iter()
+                .filter_map(artist)
+                .map(ServerLibraryRow::Artist)
+                .collect(),
+            next,
+        ))
+    }
+
+    async fn playlist_page(
+        &self,
+        offset: u32,
+        limit: u32,
+    ) -> Result<(Vec<ServerLibraryRow>, Option<u32>), ServerError> {
+        let response = self
+            .client
+            .request_json(self.credential, Endpoint::Playlists, &[])
+            .await?;
+        let playlists = response
+            .playlists
+            .ok_or(ServerError::InvalidResponse)?
+            .playlist
+            .into_iter()
+            .take(MAX_NESTED_ROWS)
+            .collect();
+        let (slice, next) = local_page(playlists, offset, limit);
+        Ok((
+            slice
+                .into_iter()
+                .filter_map(playlist_summary)
+                .map(ServerLibraryRow::Playlist)
+                .collect(),
+            next,
+        ))
+    }
+
+    fn song(&self, raw: RawChild) -> Option<ServerSong> {
+        if raw.is_dir == Some(true)
+            || raw
+                .media_type
+                .as_deref()
+                .is_some_and(|media_type| media_type != "music")
+        {
+            return None;
+        }
+        let item_id = super::model::ItemId::new(raw.id?).ok()?;
+        let title = nonempty_title(raw.title?)?;
+        let artist_name = raw
+            .artist
+            .map(|value| crate::api::sanitize_artist(&value))
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "Unknown artist".to_owned());
+        let artists = raw
+            .artists
+            .into_iter()
+            .take(32)
+            .filter_map(|artist| artist.name)
+            .map(|name| crate::api::sanitize_artist(&name))
+            .filter(|name| !name.is_empty())
+            .collect();
+        Some(ServerSong {
+            item: OpenSubsonicItemRef::new(
+                self.backend_id.clone(),
+                self.account_scope_id.clone(),
+                item_id,
+            ),
+            title,
+            artist: artist_name,
+            artists,
+            album: raw
+                .album
+                .map(|value| crate::api::sanitize_album(&value))
+                .filter(|value| !value.is_empty()),
+            album_id: raw.album_id.and_then(|id| AlbumId::new(id).ok()),
+            album_artist: None,
+            duration_secs: raw.duration.and_then(to_u32),
+            track_number: raw.track.and_then(to_u32),
+            disc_number: raw.disc_number.and_then(to_u32),
+            year: raw.year.and_then(to_u32),
+            cover_art_id: raw.cover_art.and_then(|id| CoverArtId::new(id).ok()),
+            content_type: raw.content_type.and_then(safe_short_value),
+            suffix: raw.suffix.and_then(safe_short_value),
+            starred: raw.starred.is_some(),
+            user_rating: raw
+                .user_rating
+                .and_then(|rating| u8::try_from(rating).ok())
+                .filter(|rating| *rating <= 5),
+        })
+    }
+}
+
+fn album(raw: RawAlbum) -> Option<ServerAlbum> {
+    Some(ServerAlbum {
+        id: AlbumId::new(raw.id?).ok()?,
+        name: nonempty_album(raw.name.or(raw.title)?)?,
+        artist: raw
+            .artist
+            .map(|value| crate::api::sanitize_artist(&value))
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "Unknown artist".to_owned()),
+        artist_id: raw.artist_id.and_then(|id| ArtistId::new(id).ok()),
+        song_count: raw.song_count.and_then(to_u32),
+        duration_secs: raw.duration.and_then(to_u32),
+        year: raw.year.and_then(to_u32),
+        cover_art_id: raw.cover_art.and_then(|id| CoverArtId::new(id).ok()),
+    })
+}
+
+fn artist(raw: RawArtist) -> Option<ServerArtist> {
+    Some(ServerArtist {
+        id: ArtistId::new(raw.id?).ok()?,
+        name: raw
+            .name
+            .map(|value| crate::api::sanitize_artist(&value))
+            .filter(|value| !value.is_empty())?,
+        album_count: raw.album_count.and_then(to_u32),
+        cover_art_id: raw.cover_art.and_then(|id| CoverArtId::new(id).ok()),
+    })
+}
+
+fn playlist_summary(raw: RawPlaylistSummary) -> Option<ServerPlaylistSummary> {
+    playlist_fields(
+        raw.id,
+        raw.name,
+        raw.owner,
+        raw.song_count,
+        raw.duration,
+        raw.public,
+        raw.cover_art,
+    )
+}
+
+fn playlist(raw: &RawPlaylist) -> Option<ServerPlaylistSummary> {
+    playlist_fields(
+        raw.id.clone(),
+        raw.name.clone(),
+        raw.owner.clone(),
+        raw.song_count,
+        raw.duration,
+        raw.public,
+        raw.cover_art.clone(),
+    )
+}
+
+fn playlist_fields(
+    id: Option<String>,
+    name: Option<String>,
+    owner: Option<String>,
+    song_count: Option<u64>,
+    duration: Option<u64>,
+    public: Option<bool>,
+    cover_art: Option<String>,
+) -> Option<ServerPlaylistSummary> {
+    Some(ServerPlaylistSummary {
+        id: ServerPlaylistId::new(id?).ok()?,
+        name: name
+            .map(|value| crate::api::sanitize_metadata_text(&value, 300))
+            .filter(|value| !value.is_empty())?,
+        owner: owner
+            .map(|value| crate::api::sanitize_metadata_text(&value, 200))
+            .filter(|value| !value.is_empty()),
+        song_count: song_count.and_then(to_u32),
+        duration_secs: duration.and_then(to_u32),
+        public,
+        cover_art_id: cover_art.and_then(|id| CoverArtId::new(id).ok()),
+    })
+}
+
+fn album_with_songs_summary(raw: &RawAlbumWithSongs) -> Option<ServerAlbum> {
+    Some(ServerAlbum {
+        id: AlbumId::new(raw.id.clone()?).ok()?,
+        name: nonempty_album(raw.name.clone()?)?,
+        artist: raw
+            .artist
+            .as_deref()
+            .map(crate::api::sanitize_artist)
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "Unknown artist".to_owned()),
+        artist_id: raw
+            .artist_id
+            .as_ref()
+            .and_then(|id| ArtistId::new(id.clone()).ok()),
+        song_count: raw.song_count.and_then(to_u32),
+        duration_secs: raw.duration.and_then(to_u32),
+        year: raw.year.and_then(to_u32),
+        cover_art_id: raw
+            .cover_art
+            .as_ref()
+            .and_then(|id| CoverArtId::new(id.clone()).ok()),
+    })
+}
+
+fn artist_with_albums_summary(raw: &RawArtistWithAlbums) -> Option<ServerArtist> {
+    Some(ServerArtist {
+        id: ArtistId::new(raw.id.clone()?).ok()?,
+        name: raw
+            .name
+            .as_deref()
+            .map(crate::api::sanitize_artist)
+            .filter(|value| !value.is_empty())?,
+        album_count: raw.album_count.and_then(to_u32),
+        cover_art_id: raw
+            .cover_art
+            .as_ref()
+            .and_then(|id| CoverArtId::new(id.clone()).ok()),
+    })
+}
+
+fn bounded_limit(limit: u32) -> u32 {
+    limit.clamp(1, MAX_PAGE_SIZE)
+}
+
+fn next_network_offset(offset: u32, limit: u32, raw_count: usize) -> Option<u32> {
+    (raw_count >= limit as usize)
+        .then(|| offset.checked_add(limit))
+        .flatten()
+}
+
+fn local_page<T>(items: Vec<T>, offset: u32, limit: u32) -> (Vec<T>, Option<u32>) {
+    let start = usize::try_from(offset)
+        .unwrap_or(usize::MAX)
+        .min(items.len());
+    let end = start.saturating_add(limit as usize).min(items.len());
+    let has_more = end < items.len();
+    let page = items.into_iter().skip(start).take(end - start).collect();
+    let next = has_more.then(|| offset.saturating_add(limit));
+    (page, next)
+}
+
+fn nonempty_title(value: String) -> Option<String> {
+    let value = crate::api::sanitize_title(&value);
+    (!value.is_empty()).then_some(value)
+}
+
+fn nonempty_album(value: String) -> Option<String> {
+    let value = crate::api::sanitize_album(&value);
+    (!value.is_empty()).then_some(value)
+}
+
+fn safe_short_value(value: String) -> Option<String> {
+    let value = crate::api::sanitize_metadata_text(&value, 256);
+    (!value.is_empty()).then_some(value)
+}
+
+fn to_u32(value: u64) -> Option<u32> {
+    u32::try_from(value).ok()
+}
+
+fn supported_image_type(content_type: &str) -> bool {
+    let media_type = content_type
+        .split(';')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    matches!(
+        media_type.as_str(),
+        "image/jpeg" | "image/png" | "image/webp"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn image_allowlist_excludes_active_or_unknown_content() {
+        assert!(supported_image_type("image/png"));
+        assert!(supported_image_type("image/jpeg; charset=binary"));
+        assert!(!supported_image_type("image/svg+xml"));
+        assert!(!supported_image_type("text/html"));
+    }
+
+    #[test]
+    fn local_pagination_is_bounded_and_progresses() {
+        let (page, next) = local_page((0..9).collect::<Vec<_>>(), 3, 4);
+        assert_eq!(page, vec![3, 4, 5, 6]);
+        assert_eq!(next, Some(7));
+    }
+
+    #[test]
+    fn duplicate_playlist_positions_are_not_deduplicated() {
+        let raw = RawPlaylist {
+            id: Some("playlist".to_owned()),
+            name: Some("Playlist".to_owned()),
+            entry: vec![
+                RawChild {
+                    id: Some("same-song".to_owned()),
+                    title: Some("Song".to_owned()),
+                    ..RawChild::default()
+                },
+                RawChild {
+                    id: Some("same-song".to_owned()),
+                    title: Some("Song".to_owned()),
+                    ..RawChild::default()
+                },
+            ],
+            ..RawPlaylist::default()
+        };
+        assert_eq!(raw.entry.len(), 2);
+    }
+}

--- a/src/open_subsonic/client.rs
+++ b/src/open_subsonic/client.rs
@@ -1,0 +1,716 @@
+//! Bounded, redacted OpenSubsonic HTTP transport.
+
+use std::error::Error as _;
+use std::time::Duration;
+
+use reqwest::header::{CONTENT_TYPE, LOCATION, RANGE};
+use reqwest::{Method, Response, StatusCode};
+
+use super::auth::{AuthParameters, common_parameters};
+use super::model::{AccountScopeId, BackendId, CoverArtId, OpenSubsonicItemRef};
+use super::origin::{OriginError, PinnedOriginClient};
+use super::private_store::ServerCredential;
+use super::profile::OpenSubsonicProfile;
+use super::proxy::{ProxyOrigin, StreamMethod, StreamRequest};
+use super::wire::{RawResponse, WireError};
+
+const MAX_REDIRECTS: usize = 3;
+const MAX_JSON_BYTES: usize = 8 * 1024 * 1024;
+const MAX_COVER_ART_BYTES: usize = 32 * 1024 * 1024;
+const MAX_LOCATION_BYTES: usize = 4_096;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerError {
+    Offline,
+    AuthenticationRequired,
+    PermissionDenied,
+    CertificateFailed,
+    OriginRejected,
+    RateLimited(Option<Duration>),
+    UnsupportedFeature,
+    NotFound,
+    InvalidResponse,
+    ResponseTooLarge,
+    TemporarilyUnavailable,
+    WrongAccountScope,
+}
+
+impl std::fmt::Display for ServerError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::Offline => "music server is offline",
+            Self::AuthenticationRequired => "music server password needs updating",
+            Self::PermissionDenied => "music server denied this action",
+            Self::CertificateFailed => "music server certificate could not be verified",
+            Self::OriginRejected => "music server address was rejected",
+            Self::RateLimited(_) => "music server asked us to retry later",
+            Self::UnsupportedFeature => "music server does not support this feature",
+            Self::NotFound => "music server item was not found",
+            Self::InvalidResponse => "music server returned an invalid response",
+            Self::ResponseTooLarge => "music server response exceeded the safety limit",
+            Self::TemporarilyUnavailable => "music server is temporarily unavailable",
+            Self::WrongAccountScope => "music server item belongs to another profile",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for ServerError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerInfo {
+    pub api_version: Option<String>,
+    pub server_type: Option<String>,
+    pub server_version: Option<String>,
+    pub advertises_open_subsonic: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BinaryPayload {
+    pub bytes: Vec<u8>,
+    pub content_type: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum Endpoint {
+    Ping,
+    Extensions,
+    Search3,
+    AlbumList2,
+    Artists,
+    Playlists,
+    Playlist,
+    Album,
+    Artist,
+    CoverArt,
+    Stream,
+}
+
+impl Endpoint {
+    fn method_name(self) -> &'static str {
+        match self {
+            Self::Ping => "ping",
+            Self::Extensions => "getOpenSubsonicExtensions",
+            Self::Search3 => "search3",
+            Self::AlbumList2 => "getAlbumList2",
+            Self::Artists => "getArtists",
+            Self::Playlists => "getPlaylists",
+            Self::Playlist => "getPlaylist",
+            Self::Album => "getAlbum",
+            Self::Artist => "getArtist",
+            Self::CoverArt => "getCoverArt",
+            Self::Stream => "stream",
+        }
+    }
+}
+
+/// DNS-pinned transport. Credentials remain in the caller/actor.
+pub struct OpenSubsonicClient {
+    transport: PinnedOriginClient,
+    backend_id: BackendId,
+    account_scope_id: AccountScopeId,
+}
+
+impl OpenSubsonicClient {
+    pub async fn connect(profile: &OpenSubsonicProfile) -> Result<Self, ServerError> {
+        let transport = profile
+            .origin()
+            .build_pinned_client(profile.custom_ca_pem())
+            .await
+            .map_err(map_origin_error)?;
+        Ok(Self {
+            transport,
+            backend_id: profile.backend_id().clone(),
+            account_scope_id: profile.account_scope_id().clone(),
+        })
+    }
+
+    pub async fn ping(&self, credential: &ServerCredential) -> Result<ServerInfo, ServerError> {
+        let response = self.request_json(credential, Endpoint::Ping, &[]).await?;
+        Ok(ServerInfo {
+            api_version: sanitize_optional(response.version, 64),
+            server_type: sanitize_optional(response.server_type, 100),
+            server_version: sanitize_optional(response.server_version, 100),
+            advertises_open_subsonic: response.open_subsonic.unwrap_or(false),
+        })
+    }
+
+    pub async fn get_cover_art(
+        &self,
+        credential: &ServerCredential,
+        id: &CoverArtId,
+    ) -> Result<BinaryPayload, ServerError> {
+        let parameters = [("id", id.as_str().to_owned())];
+        let response = self
+            .request_response(
+                Some(credential),
+                Endpoint::CoverArt,
+                &parameters,
+                Method::GET,
+                None,
+            )
+            .await?;
+        if !response.status().is_success() {
+            return Err(status_error_for(Endpoint::CoverArt, &response));
+        }
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .and_then(sanitize_content_type);
+        let bytes = read_limited(response, MAX_COVER_ART_BYTES).await?;
+        if content_type
+            .as_deref()
+            .is_some_and(|content_type| content_type.starts_with("application/json"))
+        {
+            return match super::wire::decode(&bytes) {
+                Err(error) => Err(map_wire_error(error)),
+                Ok(_) => Err(ServerError::InvalidResponse),
+            };
+        }
+        Ok(BinaryPayload {
+            bytes,
+            content_type,
+        })
+    }
+
+    pub async fn open_stream(
+        &self,
+        credential: &ServerCredential,
+        item: &OpenSubsonicItemRef,
+        request: StreamRequest,
+    ) -> Result<Response, ServerError> {
+        self.validate_item_scope(item)?;
+        if request.range.is_some_and(|range| {
+            matches!((range.start, range.end), (None, None))
+                || matches!((range.start, range.end), (Some(a), Some(b)) if a > b)
+        }) {
+            return Err(ServerError::InvalidResponse);
+        }
+        let method = match request.method {
+            StreamMethod::Head => Method::HEAD,
+            StreamMethod::Get => Method::GET,
+        };
+        let range = request.range.map(|range| range.to_header_value());
+        let parameters = [("id", item.item_id().as_str().to_owned())];
+        let response = self
+            .request_response(
+                Some(credential),
+                Endpoint::Stream,
+                &parameters,
+                method,
+                range,
+            )
+            .await?;
+        if response.status() == StatusCode::OK
+            || response.status() == StatusCode::PARTIAL_CONTENT
+            || response.status() == StatusCode::RANGE_NOT_SATISFIABLE
+        {
+            Ok(response)
+        } else {
+            Err(status_error_for(Endpoint::Stream, &response))
+        }
+    }
+
+    pub(crate) async fn request_json(
+        &self,
+        credential: &ServerCredential,
+        endpoint: Endpoint,
+        parameters: &[(&str, String)],
+    ) -> Result<RawResponse, ServerError> {
+        let response = self
+            .request_response(Some(credential), endpoint, parameters, Method::GET, None)
+            .await?;
+        if !response.status().is_success() {
+            return Err(status_error_for(endpoint, &response));
+        }
+        let bytes = read_limited(response, MAX_JSON_BYTES).await?;
+        super::wire::decode(&bytes).map_err(map_wire_error)
+    }
+
+    pub(crate) async fn request_public_json(
+        &self,
+        endpoint: Endpoint,
+        parameters: &[(&str, String)],
+    ) -> Result<RawResponse, ServerError> {
+        let response = self
+            .request_response(None, endpoint, parameters, Method::GET, None)
+            .await?;
+        if !response.status().is_success() {
+            return Err(status_error_for(endpoint, &response));
+        }
+        let bytes = read_limited(response, MAX_JSON_BYTES).await?;
+        super::wire::decode(&bytes).map_err(map_wire_error)
+    }
+
+    pub(crate) fn proxy_origin(&self) -> Result<ProxyOrigin, ServerError> {
+        let url = self
+            .transport
+            .origin()
+            .endpoint("stream")
+            .map_err(map_origin_error)?;
+        ProxyOrigin::from_url(&url).map_err(|_| ServerError::OriginRejected)
+    }
+
+    async fn request_response(
+        &self,
+        credential: Option<&ServerCredential>,
+        endpoint: Endpoint,
+        parameters: &[(&str, String)],
+        method: Method,
+        range: Option<String>,
+    ) -> Result<Response, ServerError> {
+        let mut target = self
+            .transport
+            .origin()
+            .endpoint(endpoint.method_name())
+            .map_err(map_origin_error)?;
+        for redirects in 0..=MAX_REDIRECTS {
+            let mut request = self
+                .transport
+                .client()
+                .request(method.clone(), target.clone());
+            if request_has_total_timeout(endpoint, &method) {
+                request = request.timeout(REQUEST_TIMEOUT);
+            }
+            request = request.query(&common_parameters());
+            let auth = credential
+                .map(AuthParameters::fresh)
+                .transpose()
+                .map_err(|_| ServerError::Offline)?;
+            if let Some(auth) = &auth {
+                request = request.query(auth.fields());
+            }
+            request = request.query(parameters);
+            if let Some(range) = &range {
+                request = request.header(RANGE, range);
+            }
+            let response = request
+                .send()
+                .await
+                .map_err(|error| classify_request_error(&error))?;
+            if !response.status().is_redirection() {
+                return Ok(response);
+            }
+            if redirects == MAX_REDIRECTS {
+                return Err(ServerError::OriginRejected);
+            }
+            let location = response
+                .headers()
+                .get(LOCATION)
+                .and_then(|value| value.to_str().ok())
+                .filter(|value| value.len() <= MAX_LOCATION_BYTES)
+                .ok_or(ServerError::OriginRejected)?;
+            target = self
+                .transport
+                .origin()
+                .validate_redirect(response.url(), location)
+                .map_err(map_origin_error)?;
+        }
+        Err(ServerError::OriginRejected)
+    }
+
+    pub(crate) fn validate_item_scope(
+        &self,
+        item: &OpenSubsonicItemRef,
+    ) -> Result<(), ServerError> {
+        if item.backend_id() != &self.backend_id
+            || item.account_scope_id() != &self.account_scope_id
+        {
+            return Err(ServerError::WrongAccountScope);
+        }
+        Ok(())
+    }
+}
+
+fn request_has_total_timeout(endpoint: Endpoint, method: &Method) -> bool {
+    !matches!(endpoint, Endpoint::Stream) || *method != Method::GET
+}
+
+fn map_origin_error(error: OriginError) -> ServerError {
+    match error {
+        OriginError::InvalidCertificate => ServerError::CertificateFailed,
+        OriginError::ResolutionFailed => ServerError::Offline,
+        OriginError::ClientBuildFailed => ServerError::Offline,
+        OriginError::InvalidOrigin
+        | OriginError::InsecureOrigin
+        | OriginError::DestinationRejected
+        | OriginError::RedirectRejected => ServerError::OriginRejected,
+    }
+}
+
+fn classify_request_error(error: &reqwest::Error) -> ServerError {
+    let mut source = error.source();
+    while let Some(current) = source {
+        if current.is::<native_tls::Error>() {
+            return ServerError::CertificateFailed;
+        }
+        source = current.source();
+    }
+    ServerError::Offline
+}
+
+fn status_error_for(endpoint: Endpoint, response: &Response) -> ServerError {
+    match response.status() {
+        StatusCode::UNAUTHORIZED => ServerError::AuthenticationRequired,
+        StatusCode::FORBIDDEN => ServerError::PermissionDenied,
+        StatusCode::NOT_FOUND
+            if matches!(
+                endpoint,
+                Endpoint::Extensions
+                    | Endpoint::Search3
+                    | Endpoint::AlbumList2
+                    | Endpoint::Artists
+                    | Endpoint::Playlists
+            ) =>
+        {
+            ServerError::UnsupportedFeature
+        }
+        StatusCode::NOT_FOUND => ServerError::NotFound,
+        StatusCode::METHOD_NOT_ALLOWED | StatusCode::NOT_IMPLEMENTED => {
+            ServerError::UnsupportedFeature
+        }
+        StatusCode::TOO_MANY_REQUESTS => ServerError::RateLimited(retry_after(response.headers())),
+        StatusCode::SERVICE_UNAVAILABLE => retry_after(response.headers())
+            .map_or(ServerError::TemporarilyUnavailable, |delay| {
+                ServerError::RateLimited(Some(delay))
+            }),
+        status if status.is_server_error() => ServerError::TemporarilyUnavailable,
+        _ => ServerError::InvalidResponse,
+    }
+}
+
+fn map_wire_error(error: WireError) -> ServerError {
+    match error {
+        WireError::InvalidResponse => ServerError::InvalidResponse,
+        WireError::ApiFailure(Some(40..=44)) => ServerError::AuthenticationRequired,
+        WireError::ApiFailure(Some(50)) => ServerError::PermissionDenied,
+        WireError::ApiFailure(Some(70)) => ServerError::NotFound,
+        WireError::ApiFailure(_) => ServerError::InvalidResponse,
+    }
+}
+
+async fn read_limited(mut response: Response, max_bytes: usize) -> Result<Vec<u8>, ServerError> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > max_bytes as u64)
+    {
+        return Err(ServerError::ResponseTooLarge);
+    }
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| classify_request_error(&error))?
+    {
+        if bytes.len().saturating_add(chunk.len()) > max_bytes {
+            return Err(ServerError::ResponseTooLarge);
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+fn retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    let raw = headers
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim();
+    if !raw.is_empty() && raw.bytes().all(|byte| byte.is_ascii_digit()) {
+        let seconds = raw.bytes().fold(0_u64, |value, byte| {
+            value
+                .saturating_mul(10)
+                .saturating_add(u64::from(byte - b'0'))
+        });
+        return Some(Duration::from_secs(seconds));
+    }
+    let target = parse_imf_fixdate(raw)?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    Some(Duration::from_secs(target.saturating_sub(now)))
+}
+
+fn parse_imf_fixdate(value: &str) -> Option<u64> {
+    let bytes = value.as_bytes();
+    if bytes.len() != 29
+        || !matches!(
+            &bytes[0..3],
+            b"Mon" | b"Tue" | b"Wed" | b"Thu" | b"Fri" | b"Sat" | b"Sun"
+        )
+        || &bytes[3..5] != b", "
+        || bytes[7] != b' '
+        || bytes[11] != b' '
+        || bytes[16] != b' '
+        || bytes[19] != b':'
+        || bytes[22] != b':'
+        || &bytes[25..29] != b" GMT"
+    {
+        return None;
+    }
+    let day = decimal(&bytes[5..7])?;
+    let month = match &bytes[8..11] {
+        b"Jan" => 1,
+        b"Feb" => 2,
+        b"Mar" => 3,
+        b"Apr" => 4,
+        b"May" => 5,
+        b"Jun" => 6,
+        b"Jul" => 7,
+        b"Aug" => 8,
+        b"Sep" => 9,
+        b"Oct" => 10,
+        b"Nov" => 11,
+        b"Dec" => 12,
+        _ => return None,
+    };
+    let year = decimal(&bytes[12..16])?;
+    let hour = decimal(&bytes[17..19])?;
+    let minute = decimal(&bytes[20..22])?;
+    let second = decimal(&bytes[23..25])?;
+    if year < 1970
+        || day == 0
+        || day > days_in_month(year, month)
+        || hour > 23
+        || minute > 59
+        || second > 59
+    {
+        return None;
+    }
+    let years = year.checked_sub(1970)?;
+    let leap_days = leap_years_before(year).checked_sub(leap_years_before(1970))?;
+    let mut days = years.checked_mul(365)?.checked_add(leap_days)?;
+    for prior_month in 1..month {
+        days = days.checked_add(days_in_month(year, prior_month))?;
+    }
+    days = days.checked_add(day.checked_sub(1)?)?;
+    days.checked_mul(86_400)?
+        .checked_add(hour.checked_mul(3_600)?)?
+        .checked_add(minute.checked_mul(60)?)?
+        .checked_add(second)
+}
+
+fn decimal(bytes: &[u8]) -> Option<u64> {
+    bytes.iter().try_fold(0_u64, |value, byte| {
+        value
+            .checked_mul(10)?
+            .checked_add(u64::from(byte.checked_sub(b'0')?))
+            .filter(|_| byte.is_ascii_digit())
+    })
+}
+
+fn days_in_month(year: u64, month: u64) -> u64 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: u64) -> bool {
+    year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400))
+}
+
+fn leap_years_before(year: u64) -> u64 {
+    let prior = year.saturating_sub(1);
+    prior / 4 - prior / 100 + prior / 400
+}
+
+fn sanitize_optional(value: Option<String>, max_chars: usize) -> Option<String> {
+    value
+        .map(|value| crate::api::sanitize_metadata_text(&value, max_chars))
+        .filter(|value| !value.is_empty())
+}
+
+fn sanitize_content_type(raw: &str) -> Option<String> {
+    if raw.is_empty()
+        || raw.len() > 256
+        || !raw.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(byte, b'/' | b'+' | b'-' | b'.' | b';' | b'=' | b' ')
+        })
+    {
+        return None;
+    }
+    Some(raw.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use age::secrecy::SecretString;
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    use super::*;
+    use crate::open_subsonic::{ConfiguredPrivateOrigin, ServerCredential};
+
+    async fn test_client(port: u16) -> (OpenSubsonicClient, ServerCredential) {
+        let profile = OpenSubsonicProfile::new(
+            "Test server",
+            ConfiguredPrivateOrigin::new(&format!("http://127.0.0.1:{port}/"), true).unwrap(),
+            None,
+        )
+        .unwrap();
+        let client = OpenSubsonicClient::connect(&profile).await.unwrap();
+        let credential =
+            ServerCredential::api_key(SecretString::from("sentinel-api-key".to_owned())).unwrap();
+        (client, credential)
+    }
+
+    async fn read_request(stream: &mut tokio::net::TcpStream) -> Vec<u8> {
+        let mut request = Vec::new();
+        let mut byte = [0_u8; 1];
+        while request.len() < 32 * 1024 {
+            if stream.read(&mut byte).await.unwrap() == 0 {
+                break;
+            }
+            request.push(byte[0]);
+            if request.ends_with(b"\r\n\r\n") {
+                break;
+            }
+        }
+        request
+    }
+
+    #[tokio::test]
+    async fn fake_server_observes_exclusive_api_key_auth() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = String::from_utf8(read_request(&mut stream).await).unwrap();
+            assert!(request.contains("apiKey=sentinel-api-key"));
+            assert!(!request.contains("&u="));
+            assert!(!request.contains("&t="));
+            assert!(!request.contains("&s="));
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{\"subsonic-response\":{\"status\":\"ok\",\"version\":\"1.16.1\",\"openSubsonic\":true}}",
+                )
+                .await
+                .unwrap();
+        });
+        let (client, credential) = test_client(port).await;
+        let info = client.ping(&credential).await.unwrap();
+        assert!(info.advertises_open_subsonic);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cross_origin_redirect_is_rejected_without_contacting_target() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _ = read_request(&mut stream).await;
+            stream
+                .write_all(
+                    b"HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:9/steal\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+        });
+        let (client, credential) = test_client(port).await;
+        assert_eq!(
+            client.ping(&credential).await,
+            Err(ServerError::OriginRejected)
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn public_extension_probe_sends_no_credential() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = String::from_utf8(read_request(&mut stream).await).unwrap();
+            assert!(request.contains("getOpenSubsonicExtensions.view"));
+            assert!(!request.contains("apiKey="));
+            assert!(!request.contains("&u="));
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{\"subsonic-response\":{\"status\":\"ok\",\"openSubsonicExtensions\":[]}}",
+                )
+                .await
+                .unwrap();
+        });
+        let (client, _) = test_client(port).await;
+        client
+            .request_public_json(Endpoint::Extensions, &[])
+            .await
+            .unwrap();
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn failed_success_envelope_and_oversized_body_are_bounded() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut first, _) = listener.accept().await.unwrap();
+            let _ = read_request(&mut first).await;
+            first
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{\"subsonic-response\":{\"status\":\"failed\",\"error\":{\"code\":40}}}",
+                )
+                .await
+                .unwrap();
+            drop(first);
+            let (mut second, _) = listener.accept().await.unwrap();
+            let _ = read_request(&mut second).await;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                MAX_JSON_BYTES + 1
+            );
+            second.write_all(response.as_bytes()).await.unwrap();
+        });
+        let (client, credential) = test_client(port).await;
+        assert_eq!(
+            client.ping(&credential).await,
+            Err(ServerError::AuthenticationRequired)
+        );
+        assert_eq!(
+            client.ping(&credential).await,
+            Err(ServerError::ResponseTooLarge)
+        );
+        server.await.unwrap();
+    }
+
+    #[test]
+    fn retry_after_accepts_delta_and_bounded_http_date() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(reqwest::header::RETRY_AFTER, "75".parse().unwrap());
+        assert_eq!(retry_after(&headers), Some(Duration::from_secs(75)));
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            "Sun, 06 Nov 1994 08:49:37 GMT".parse().unwrap(),
+        );
+        assert_eq!(retry_after(&headers), Some(Duration::ZERO));
+        headers.insert(reqwest::header::RETRY_AFTER, "not a date".parse().unwrap());
+        assert_eq!(retry_after(&headers), None);
+    }
+
+    #[test]
+    fn all_errors_are_redacted_fixed_messages() {
+        let rendered = format!(
+            "{:?} {}",
+            ServerError::AuthenticationRequired,
+            ServerError::AuthenticationRequired
+        );
+        assert!(!rendered.contains("sentinel-api-key"));
+        assert!(!rendered.contains("http://"));
+    }
+
+    #[test]
+    fn only_stream_get_omits_the_whole_response_deadline() {
+        assert!(!request_has_total_timeout(Endpoint::Stream, &Method::GET));
+        assert!(request_has_total_timeout(Endpoint::Stream, &Method::HEAD));
+        assert!(request_has_total_timeout(Endpoint::Ping, &Method::GET));
+        assert!(request_has_total_timeout(Endpoint::CoverArt, &Method::GET));
+    }
+}

--- a/src/open_subsonic/mod.rs
+++ b/src/open_subsonic/mod.rs
@@ -1,0 +1,40 @@
+//! OpenSubsonic/Navidrome catalog, storage, and network integration.
+
+pub mod actor;
+pub mod auth;
+pub mod bridge_store;
+pub mod capabilities;
+pub mod catalog;
+pub mod client;
+pub mod model;
+pub mod origin;
+pub mod private_store;
+pub mod profile;
+pub mod proxy;
+pub mod transaction;
+mod wire;
+
+pub use actor::{
+    OpenSubsonicHandle, OpenSubsonicProfileSummary, OpenSubsonicRuntime, OpenSubsonicStatus,
+    OpenSubsonicStatusKind, PreparedSetup, ServerLibraryDetailRequest, ServerLibraryRequest,
+    ServiceError, SetupIdentityIntent, SetupInput, commit_setup, current_handle,
+    current_proxy_handle, load_actor, load_actor_read_only, read_status, remove_profile,
+    test_and_prepare_setup, test_connection, test_connection_read_only,
+};
+pub use bridge_store::OpenSubsonicBridgeState;
+pub use capabilities::{ServerCapabilities, ServerFeature};
+pub use catalog::{MAX_PAGE_SIZE, OpenSubsonicCatalog};
+pub use client::{BinaryPayload, OpenSubsonicClient, ServerError, ServerInfo};
+pub use model::{
+    AccountScopeId, AlbumId, ArtistId, BackendId, CoverArtId, ItemId, LibraryWarning, ModelError,
+    OpenSubsonicItemRef, Page, ServerAlbum, ServerArtist, ServerLibraryDetail, ServerLibraryPage,
+    ServerLibraryRow, ServerLibrarySection, ServerPlaylist, ServerPlaylistId,
+    ServerPlaylistSummary, ServerSong,
+};
+pub use origin::{ConfiguredPrivateOrigin, OriginError};
+pub use private_store::{CredentialKind, OpenSubsonicPrivateState, ServerCredential};
+pub use profile::{OpenSubsonicPaths, OpenSubsonicProfile, StoreError};
+pub use transaction::{
+    OpenSubsonicStoreSet, StoreRevisions, commit_store_set, load_store_set, recover_store_set,
+    remove_store_set, reset_store_set,
+};

--- a/src/open_subsonic/model.rs
+++ b/src/open_subsonic/model.rs
@@ -1,0 +1,350 @@
+//! Validated identities and sanitized catalog models for OpenSubsonic.
+
+use std::fmt;
+
+use data_encoding::HEXLOWER;
+use serde::{Deserialize, Deserializer, Serialize};
+use sha2::{Digest as _, Sha256};
+
+const MAX_SERVER_ID_BYTES: usize = 512;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelError {
+    EmptyId,
+    IdTooLong,
+    ForbiddenIdCharacter,
+    RandomFailed,
+}
+
+impl fmt::Display for ModelError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::EmptyId => "identifier is empty",
+            Self::IdTooLong => "identifier is too long",
+            Self::ForbiddenIdCharacter => "identifier contains a forbidden character",
+            Self::RandomFailed => "secure random generation failed",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for ModelError {}
+
+macro_rules! validated_id {
+    ($name:ident, $max_bytes:expr) => {
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Result<Self, ModelError> {
+                let value = value.into();
+                validate_id(&value, $max_bytes)?;
+                Ok(Self(value))
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            pub fn into_string(self) -> String {
+                self.0
+            }
+        }
+
+        impl TryFrom<String> for $name {
+            type Error = ModelError;
+
+            fn try_from(value: String) -> Result<Self, Self::Error> {
+                Self::new(value)
+            }
+        }
+
+        impl TryFrom<&str> for $name {
+            type Error = ModelError;
+
+            fn try_from(value: &str) -> Result<Self, Self::Error> {
+                Self::new(value)
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(&self.0)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::new(value).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+validated_id!(BackendId, MAX_SERVER_ID_BYTES);
+validated_id!(AccountScopeId, MAX_SERVER_ID_BYTES);
+validated_id!(ItemId, MAX_SERVER_ID_BYTES);
+validated_id!(CoverArtId, MAX_SERVER_ID_BYTES);
+validated_id!(AlbumId, MAX_SERVER_ID_BYTES);
+validated_id!(ArtistId, MAX_SERVER_ID_BYTES);
+validated_id!(ServerPlaylistId, MAX_SERVER_ID_BYTES);
+
+impl BackendId {
+    pub fn random() -> Result<Self, ModelError> {
+        random_stable_id().and_then(Self::new)
+    }
+}
+
+impl AccountScopeId {
+    pub fn random() -> Result<Self, ModelError> {
+        random_stable_id().and_then(Self::new)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OpenSubsonicItemRef {
+    backend_id: BackendId,
+    account_scope_id: AccountScopeId,
+    item_id: ItemId,
+}
+
+impl OpenSubsonicItemRef {
+    pub fn new(backend_id: BackendId, account_scope_id: AccountScopeId, item_id: ItemId) -> Self {
+        Self {
+            backend_id,
+            account_scope_id,
+            item_id,
+        }
+    }
+
+    pub fn backend_id(&self) -> &BackendId {
+        &self.backend_id
+    }
+
+    pub fn account_scope_id(&self) -> &AccountScopeId {
+        &self.account_scope_id
+    }
+
+    pub fn item_id(&self) -> &ItemId {
+        &self.item_id
+    }
+
+    /// Opaque stable identity for UI/cache rows. The exact tuple remains the semantic identity.
+    pub fn stable_track_id(&self) -> String {
+        let mut digest = Sha256::new();
+        digest.update(b"yututui-open-subsonic-track-v1\0");
+        update_length_prefixed(&mut digest, self.backend_id.as_str().as_bytes());
+        update_length_prefixed(&mut digest, self.account_scope_id.as_str().as_bytes());
+        update_length_prefixed(&mut digest, self.item_id.as_str().as_bytes());
+        format!("sub:{}", HEXLOWER.encode(&digest.finalize()))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerSong {
+    pub item: OpenSubsonicItemRef,
+    pub title: String,
+    pub artist: String,
+    pub artists: Vec<String>,
+    pub album: Option<String>,
+    pub album_id: Option<AlbumId>,
+    pub album_artist: Option<String>,
+    pub duration_secs: Option<u32>,
+    pub track_number: Option<u32>,
+    pub disc_number: Option<u32>,
+    pub year: Option<u32>,
+    pub cover_art_id: Option<CoverArtId>,
+    pub content_type: Option<String>,
+    pub suffix: Option<String>,
+    pub starred: bool,
+    pub user_rating: Option<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerAlbum {
+    pub id: AlbumId,
+    pub name: String,
+    pub artist: String,
+    pub artist_id: Option<ArtistId>,
+    pub song_count: Option<u32>,
+    pub duration_secs: Option<u32>,
+    pub year: Option<u32>,
+    pub cover_art_id: Option<CoverArtId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerArtist {
+    pub id: ArtistId,
+    pub name: String,
+    pub album_count: Option<u32>,
+    pub cover_art_id: Option<CoverArtId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerPlaylistSummary {
+    pub id: ServerPlaylistId,
+    pub name: String,
+    pub owner: Option<String>,
+    pub song_count: Option<u32>,
+    pub duration_secs: Option<u32>,
+    pub public: Option<bool>,
+    pub cover_art_id: Option<CoverArtId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerPlaylist {
+    pub summary: ServerPlaylistSummary,
+    pub entries: Vec<ServerSong>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Page<T> {
+    pub items: Vec<T>,
+    pub next_offset: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ServerLibrarySection {
+    RecentlyPlayed,
+    Albums,
+    Artists,
+    Songs,
+    Playlists,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServerLibraryRow {
+    Song(ServerSong),
+    Album(ServerAlbum),
+    Artist(ServerArtist),
+    Playlist(ServerPlaylistSummary),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LibraryWarning {
+    FeatureUnsupported,
+    PartialResults,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerLibraryPage {
+    pub section: ServerLibrarySection,
+    pub rows: Vec<ServerLibraryRow>,
+    pub next_offset: Option<u32>,
+    pub warning: Option<LibraryWarning>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServerLibraryDetail {
+    AlbumSongs {
+        album: ServerAlbum,
+        songs: Vec<ServerSong>,
+    },
+    ArtistAlbums {
+        artist: ServerArtist,
+        albums: Vec<ServerAlbum>,
+    },
+    PlaylistEntries(ServerPlaylist),
+}
+
+fn validate_id(value: &str, max_bytes: usize) -> Result<(), ModelError> {
+    if value.is_empty() {
+        return Err(ModelError::EmptyId);
+    }
+    if value.len() > max_bytes {
+        return Err(ModelError::IdTooLong);
+    }
+    if value.chars().any(is_forbidden_id_character) {
+        return Err(ModelError::ForbiddenIdCharacter);
+    }
+    Ok(())
+}
+
+fn is_forbidden_id_character(character: char) -> bool {
+    character.is_control()
+        || matches!(
+            character,
+            '\u{200b}'
+                | '\u{200c}'
+                | '\u{200d}'
+                | '\u{200e}'
+                | '\u{200f}'
+                | '\u{202a}'..='\u{202e}'
+                | '\u{2066}'..='\u{2069}'
+                | '\u{feff}'
+        )
+}
+
+fn random_stable_id() -> Result<String, ModelError> {
+    let mut bytes = [0_u8; 16];
+    getrandom::fill(&mut bytes).map_err(|_| ModelError::RandomFailed)?;
+    Ok(HEXLOWER.encode(&bytes))
+}
+
+fn update_length_prefixed(digest: &mut Sha256, bytes: &[u8]) {
+    digest.update((bytes.len() as u64).to_be_bytes());
+    digest.update(bytes);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(backend: &str, account: &str, item: &str) -> OpenSubsonicItemRef {
+        OpenSubsonicItemRef::new(
+            BackendId::new(backend).unwrap(),
+            AccountScopeId::new(account).unwrap(),
+            ItemId::new(item).unwrap(),
+        )
+    }
+
+    #[test]
+    fn item_reference_round_trips_through_serde() {
+        let original = item("backend-a", "account-a", "song-1");
+        let encoded = serde_json::to_vec(&original).unwrap();
+        let decoded: OpenSubsonicItemRef = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(decoded, original);
+        assert_eq!(decoded.backend_id().as_str(), "backend-a");
+        assert_eq!(decoded.account_scope_id().as_str(), "account-a");
+        assert_eq!(decoded.item_id().as_str(), "song-1");
+    }
+
+    #[test]
+    fn stable_track_id_includes_backend_and_account_scope() {
+        let base = item("backend-a", "account-a", "song-1");
+        assert_ne!(
+            base.stable_track_id(),
+            item("backend-b", "account-a", "song-1").stable_track_id()
+        );
+        assert_ne!(
+            base.stable_track_id(),
+            item("backend-a", "account-b", "song-1").stable_track_id()
+        );
+        assert_eq!(
+            base.stable_track_id(),
+            item("backend-a", "account-a", "song-1").stable_track_id()
+        );
+    }
+
+    #[test]
+    fn deserialization_rejects_unbounded_or_unsafe_ids() {
+        assert!(ItemId::new("").is_err());
+        assert!(ItemId::new("x".repeat(MAX_SERVER_ID_BYTES + 1)).is_err());
+        assert!(ItemId::new("unsafe\u{202e}id").is_err());
+        assert!(serde_json::from_str::<ItemId>("\"unsafe\\nvalue\"").is_err());
+    }
+
+    #[test]
+    fn length_prefix_prevents_tuple_boundary_aliases() {
+        assert_ne!(
+            item("ab", "c", "d").stable_track_id(),
+            item("a", "bc", "d").stable_track_id()
+        );
+    }
+}

--- a/src/open_subsonic/origin.rs
+++ b/src/open_subsonic/origin.rs
@@ -1,0 +1,336 @@
+//! Exact-origin network policy for a user-configured private music server.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::time::Duration;
+
+use reqwest::Url;
+
+const MAX_ORIGIN_BYTES: usize = 4_096;
+const MAX_CUSTOM_CA_BYTES: usize = 192 * 1024;
+const DNS_TIMEOUT: Duration = Duration::from_secs(3);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(8);
+const READ_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OriginError {
+    InvalidOrigin,
+    InsecureOrigin,
+    ResolutionFailed,
+    DestinationRejected,
+    InvalidCertificate,
+    ClientBuildFailed,
+    RedirectRejected,
+}
+
+impl std::fmt::Display for OriginError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::InvalidOrigin => "invalid server origin",
+            Self::InsecureOrigin => "insecure server origin is not allowed",
+            Self::ResolutionFailed => "server name could not be resolved",
+            Self::DestinationRejected => "server destination is not allowed",
+            Self::InvalidCertificate => "custom certificate authority is invalid",
+            Self::ClientBuildFailed => "secure HTTP client could not be created",
+            Self::RedirectRejected => "server redirect was rejected",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for OriginError {}
+
+/// A configured origin is intentionally not `Debug`: endpoints must not enter diagnostics.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ConfiguredPrivateOrigin {
+    base_url: Url,
+    allow_lan_http: bool,
+}
+
+impl ConfiguredPrivateOrigin {
+    pub fn new(raw: &str, allow_lan_http: bool) -> Result<Self, OriginError> {
+        if raw.is_empty()
+            || raw.len() > MAX_ORIGIN_BYTES
+            || raw.chars().any(is_forbidden_text_character)
+        {
+            return Err(OriginError::InvalidOrigin);
+        }
+        let mut base_url = Url::parse(raw).map_err(|_| OriginError::InvalidOrigin)?;
+        if !base_url.username().is_empty()
+            || base_url.password().is_some()
+            || base_url.query().is_some()
+            || base_url.fragment().is_some()
+            || base_url.host_str().is_none()
+        {
+            return Err(OriginError::InvalidOrigin);
+        }
+        match base_url.scheme() {
+            "https" => {}
+            "http" if allow_lan_http => {}
+            "http" => return Err(OriginError::InsecureOrigin),
+            _ => return Err(OriginError::InvalidOrigin),
+        }
+        if !base_url.path().ends_with('/') {
+            let path = format!("{}/", base_url.path());
+            base_url.set_path(&path);
+        }
+        Ok(Self {
+            base_url,
+            allow_lan_http,
+        })
+    }
+
+    pub fn uses_lan_http(&self) -> bool {
+        self.base_url.scheme() == "http"
+    }
+
+    pub(crate) fn canonical(&self) -> &str {
+        self.base_url.as_str()
+    }
+
+    pub(crate) fn endpoint(&self, method: &str) -> Result<Url, OriginError> {
+        if method.is_empty()
+            || !method
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+        {
+            return Err(OriginError::InvalidOrigin);
+        }
+        self.base_url
+            .join(&format!("rest/{method}.view"))
+            .map_err(|_| OriginError::InvalidOrigin)
+    }
+
+    pub async fn build_pinned_client(
+        &self,
+        custom_ca_pem: Option<&[u8]>,
+    ) -> Result<PinnedOriginClient, OriginError> {
+        let host = self.base_url.host_str().ok_or(OriginError::InvalidOrigin)?;
+        let port = self
+            .base_url
+            .port_or_known_default()
+            .ok_or(OriginError::InvalidOrigin)?;
+        let addresses = resolve_addresses(host, port).await?;
+        if addresses.is_empty() {
+            return Err(OriginError::ResolutionFailed);
+        }
+        let lan_http = self.base_url.scheme() == "http";
+        if addresses
+            .iter()
+            .any(|address| !is_acceptable_destination(address.ip(), lan_http))
+        {
+            return Err(OriginError::DestinationRejected);
+        }
+
+        let mut builder = reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(CONNECT_TIMEOUT)
+            .read_timeout(READ_TIMEOUT)
+            .user_agent("yututui-open-subsonic/1")
+            .resolve_to_addrs(host, &addresses);
+        if let Some(pem) = custom_ca_pem {
+            if pem.is_empty() || pem.len() > MAX_CUSTOM_CA_BYTES {
+                return Err(OriginError::InvalidCertificate);
+            }
+            let certificates = reqwest::Certificate::from_pem_bundle(pem)
+                .map_err(|_| OriginError::InvalidCertificate)?;
+            if certificates.is_empty() {
+                return Err(OriginError::InvalidCertificate);
+            }
+            for certificate in certificates {
+                builder = builder.add_root_certificate(certificate);
+            }
+        }
+        let client = builder
+            .build()
+            .map_err(|_| OriginError::ClientBuildFailed)?;
+        Ok(PinnedOriginClient {
+            client,
+            origin: self.clone(),
+        })
+    }
+
+    pub(crate) fn same_origin(&self, candidate: &Url) -> bool {
+        self.base_url.origin() == candidate.origin()
+    }
+
+    pub(crate) fn validate_redirect(
+        &self,
+        current: &Url,
+        location: &str,
+    ) -> Result<Url, OriginError> {
+        if location.is_empty()
+            || location.len() > MAX_ORIGIN_BYTES
+            || location.chars().any(is_forbidden_text_character)
+        {
+            return Err(OriginError::RedirectRejected);
+        }
+        let target = current
+            .join(location)
+            .map_err(|_| OriginError::RedirectRejected)?;
+        if !target.username().is_empty()
+            || target.password().is_some()
+            || target.query().is_some()
+            || target.fragment().is_some()
+            || !self.same_origin(&target)
+        {
+            return Err(OriginError::RedirectRejected);
+        }
+        Ok(target)
+    }
+}
+
+/// A client whose DNS answers and proxy/redirect policy were fixed at construction time.
+#[derive(Clone)]
+pub struct PinnedOriginClient {
+    client: reqwest::Client,
+    origin: ConfiguredPrivateOrigin,
+}
+
+impl PinnedOriginClient {
+    pub(crate) fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+
+    pub(crate) fn origin(&self) -> &ConfiguredPrivateOrigin {
+        &self.origin
+    }
+}
+
+pub fn custom_ca_fingerprint(pem: &[u8]) -> Result<String, OriginError> {
+    if pem.is_empty() || pem.len() > MAX_CUSTOM_CA_BYTES {
+        return Err(OriginError::InvalidCertificate);
+    }
+    let certificates =
+        reqwest::Certificate::from_pem_bundle(pem).map_err(|_| OriginError::InvalidCertificate)?;
+    if certificates.is_empty() {
+        return Err(OriginError::InvalidCertificate);
+    }
+    use data_encoding::HEXLOWER;
+    use sha2::{Digest as _, Sha256};
+    Ok(HEXLOWER.encode(&Sha256::digest(pem)))
+}
+
+async fn resolve_addresses(host: &str, port: u16) -> Result<Vec<SocketAddr>, OriginError> {
+    let mut addresses = if let Ok(address) = host.parse::<IpAddr>() {
+        vec![SocketAddr::new(address, port)]
+    } else {
+        tokio::time::timeout(DNS_TIMEOUT, tokio::net::lookup_host((host, port)))
+            .await
+            .map_err(|_| OriginError::ResolutionFailed)?
+            .map_err(|_| OriginError::ResolutionFailed)?
+            .collect::<Vec<_>>()
+    };
+    addresses.sort_unstable();
+    addresses.dedup();
+    Ok(addresses)
+}
+
+fn is_acceptable_destination(address: IpAddr, lan_http: bool) -> bool {
+    if lan_http {
+        return match address {
+            IpAddr::V4(address) => address.is_loopback() || address.is_private(),
+            IpAddr::V6(address) => address.is_loopback() || is_ipv6_unique_local(address),
+        };
+    }
+    match address {
+        IpAddr::V4(address) => {
+            !address.is_unspecified()
+                && !address.is_broadcast()
+                && !address.is_multicast()
+                && address != Ipv4Addr::new(255, 255, 255, 255)
+        }
+        IpAddr::V6(address) => !address.is_unspecified() && !address.is_multicast(),
+    }
+}
+
+fn is_ipv6_unique_local(address: Ipv6Addr) -> bool {
+    address.octets()[0] & 0xfe == 0xfc
+}
+
+fn is_forbidden_text_character(character: char) -> bool {
+    character.is_control()
+        || matches!(
+            character,
+            '\u{200b}'
+                | '\u{200c}'
+                | '\u{200d}'
+                | '\u{200e}'
+                | '\u{200f}'
+                | '\u{202a}'..='\u{202e}'
+                | '\u{2066}'..='\u{2069}'
+                | '\u{feff}'
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalizes_a_safe_origin_without_exposing_url_parts() {
+        let origin =
+            ConfiguredPrivateOrigin::new("https://music.example.test/navidrome", false).unwrap();
+        assert_eq!(origin.canonical(), "https://music.example.test/navidrome/");
+        assert_eq!(
+            origin.endpoint("search3").unwrap().as_str(),
+            "https://music.example.test/navidrome/rest/search3.view"
+        );
+    }
+
+    #[test]
+    fn rejects_userinfo_query_fragment_and_unapproved_http() {
+        for raw in [
+            "https://user:secret@example.test/",
+            "https://example.test/?token=secret",
+            "https://example.test/#fragment",
+            "ftp://example.test/",
+            "https://example.test/\u{202e}",
+        ] {
+            assert!(ConfiguredPrivateOrigin::new(raw, false).is_err(), "{raw}");
+        }
+        assert!(ConfiguredPrivateOrigin::new("http://127.0.0.1:4040/", false).is_err());
+    }
+
+    #[tokio::test]
+    async fn lan_http_only_accepts_private_or_loopback_destinations() {
+        assert!(
+            ConfiguredPrivateOrigin::new("http://127.0.0.1:4040/", true)
+                .unwrap()
+                .build_pinned_client(None)
+                .await
+                .is_ok()
+        );
+        assert!(
+            ConfiguredPrivateOrigin::new("http://192.0.2.1:4040/", true)
+                .unwrap()
+                .build_pinned_client(None)
+                .await
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn redirects_must_remain_on_the_exact_origin_without_parameters() {
+        let origin =
+            ConfiguredPrivateOrigin::new("https://music.example.test/base/", false).unwrap();
+        let current = origin.endpoint("ping").unwrap();
+        assert_eq!(
+            origin
+                .validate_redirect(&current, "/base/rest/ping2.view")
+                .unwrap()
+                .path(),
+            "/base/rest/ping2.view"
+        );
+        assert!(
+            origin
+                .validate_redirect(&current, "https://other.example.test/ping")
+                .is_err()
+        );
+        assert!(
+            origin
+                .validate_redirect(&current, "/ping?apiKey=secret")
+                .is_err()
+        );
+    }
+}

--- a/src/open_subsonic/private_store.rs
+++ b/src/open_subsonic/private_store.rs
@@ -1,0 +1,285 @@
+//! Owner-only OpenSubsonic credentials.
+
+use age::secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, Zeroizing};
+
+use super::model::{AccountScopeId, BackendId};
+use super::profile::StoreError;
+
+pub(crate) const PRIVATE_KIND: &str = "yututui_open_subsonic_private";
+pub(crate) const PRIVATE_SCHEMA_VERSION: u32 = 1;
+pub(crate) const MAX_PRIVATE_BYTES: u64 = 256 * 1024;
+const MAX_USERNAME_BYTES: usize = 1_024;
+const MAX_PASSWORD_BYTES: usize = 64 * 1024;
+const MAX_API_KEY_BYTES: usize = 2_048;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredentialKind {
+    ApiKey,
+    Password,
+}
+
+/// Secret-bearing setup input. Deliberately lacks `Debug`, `Clone`, and serde.
+pub struct ServerCredential {
+    kind: CredentialKind,
+    username: Option<SecretString>,
+    secret: SecretString,
+}
+
+impl ServerCredential {
+    pub fn api_key(key: SecretString) -> Result<Self, StoreError> {
+        validate_credential_part(key.expose_secret(), MAX_API_KEY_BYTES)?;
+        if encoded_query_value_len(key.expose_secret()) >= MAX_API_KEY_BYTES {
+            return Err(StoreError::InvalidState);
+        }
+        Ok(Self {
+            kind: CredentialKind::ApiKey,
+            username: None,
+            secret: key,
+        })
+    }
+
+    pub fn password(
+        username: impl Into<String>,
+        password: SecretString,
+    ) -> Result<Self, StoreError> {
+        let username = username.into();
+        validate_credential_part(&username, MAX_USERNAME_BYTES)?;
+        validate_credential_part(password.expose_secret(), MAX_PASSWORD_BYTES)?;
+        Ok(Self {
+            kind: CredentialKind::Password,
+            username: Some(SecretString::from(username)),
+            secret: password,
+        })
+    }
+
+    pub fn kind(&self) -> CredentialKind {
+        self.kind
+    }
+
+    pub(crate) fn username(&self) -> Option<&SecretString> {
+        self.username.as_ref()
+    }
+
+    pub(crate) fn secret(&self) -> &SecretString {
+        &self.secret
+    }
+}
+
+/// Credential plus stable account binding. Deliberately lacks `Debug` and `Clone`.
+pub struct OpenSubsonicPrivateState {
+    revision: u64,
+    backend_id: BackendId,
+    account_scope_id: AccountScopeId,
+    credential: ServerCredential,
+}
+
+impl OpenSubsonicPrivateState {
+    pub fn new(
+        backend_id: BackendId,
+        account_scope_id: AccountScopeId,
+        credential: ServerCredential,
+    ) -> Self {
+        Self {
+            revision: 0,
+            backend_id,
+            account_scope_id,
+            credential,
+        }
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn backend_id(&self) -> &BackendId {
+        &self.backend_id
+    }
+
+    pub fn account_scope_id(&self) -> &AccountScopeId {
+        &self.account_scope_id
+    }
+
+    pub fn credential_kind(&self) -> CredentialKind {
+        self.credential.kind()
+    }
+
+    pub(crate) fn credential(&self) -> &ServerCredential {
+        &self.credential
+    }
+
+    pub(crate) fn set_revision(&mut self, revision: u64) {
+        self.revision = revision;
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum DiskCredentialKind {
+    ApiKey,
+    Password,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DiskPrivateState {
+    kind: String,
+    schema_version: u32,
+    revision: u64,
+    backend_id: BackendId,
+    account_scope_id: AccountScopeId,
+    credential_kind: DiskCredentialKind,
+    username: Option<String>,
+    secret: String,
+}
+
+impl Drop for DiskPrivateState {
+    fn drop(&mut self) {
+        if let Some(username) = &mut self.username {
+            username.zeroize();
+        }
+        self.secret.zeroize();
+    }
+}
+
+pub(crate) fn encode_private(
+    state: &OpenSubsonicPrivateState,
+) -> Result<Zeroizing<Vec<u8>>, StoreError> {
+    let disk = DiskPrivateState {
+        kind: PRIVATE_KIND.to_owned(),
+        schema_version: PRIVATE_SCHEMA_VERSION,
+        revision: state.revision,
+        backend_id: state.backend_id.clone(),
+        account_scope_id: state.account_scope_id.clone(),
+        credential_kind: match state.credential.kind() {
+            CredentialKind::ApiKey => DiskCredentialKind::ApiKey,
+            CredentialKind::Password => DiskCredentialKind::Password,
+        },
+        username: state
+            .credential
+            .username()
+            .map(|username| username.expose_secret().to_owned()),
+        secret: state.credential.secret().expose_secret().to_owned(),
+    };
+    let bytes =
+        Zeroizing::new(serde_json::to_vec(&disk).map_err(|_| StoreError::SerializationFailed)?);
+    if bytes.len() as u64 > MAX_PRIVATE_BYTES {
+        return Err(StoreError::PayloadTooLarge);
+    }
+    Ok(bytes)
+}
+
+pub(crate) fn decode_private(bytes: &[u8]) -> Result<OpenSubsonicPrivateState, StoreError> {
+    if bytes.len() as u64 > MAX_PRIVATE_BYTES {
+        return Err(StoreError::PayloadTooLarge);
+    }
+    let disk: DiskPrivateState =
+        serde_json::from_slice(bytes).map_err(|_| StoreError::InvalidState)?;
+    if disk.kind != PRIVATE_KIND || disk.schema_version != PRIVATE_SCHEMA_VERSION {
+        return Err(StoreError::InvalidState);
+    }
+    let credential = match disk.credential_kind {
+        DiskCredentialKind::ApiKey if disk.username.is_none() => {
+            ServerCredential::api_key(SecretString::from(disk.secret.clone()))?
+        }
+        DiskCredentialKind::Password => {
+            let username = disk.username.clone().ok_or(StoreError::InvalidState)?;
+            ServerCredential::password(username, SecretString::from(disk.secret.clone()))?
+        }
+        DiskCredentialKind::ApiKey => return Err(StoreError::InvalidState),
+    };
+    Ok(OpenSubsonicPrivateState {
+        revision: disk.revision,
+        backend_id: disk.backend_id.clone(),
+        account_scope_id: disk.account_scope_id.clone(),
+        credential,
+    })
+}
+
+fn validate_credential_part(value: &str, max_bytes: usize) -> Result<(), StoreError> {
+    if value.is_empty()
+        || value.len() > max_bytes
+        || value.chars().any(|character| {
+            character.is_control()
+                || matches!(
+                    character,
+                    '\u{200b}'
+                        | '\u{200c}'
+                        | '\u{200d}'
+                        | '\u{200e}'
+                        | '\u{200f}'
+                        | '\u{202a}'..='\u{202e}'
+                        | '\u{2066}'..='\u{2069}'
+                        | '\u{feff}'
+                )
+        })
+    {
+        return Err(StoreError::InvalidState);
+    }
+    Ok(())
+}
+
+fn encoded_query_value_len(value: &str) -> usize {
+    value.bytes().fold(0_usize, |length, byte| {
+        length.saturating_add(
+            if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_') {
+                1
+            } else {
+                3
+            },
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_key_round_trip_has_no_username() {
+        let state = OpenSubsonicPrivateState::new(
+            BackendId::new("backend").unwrap(),
+            AccountScopeId::new("account").unwrap(),
+            ServerCredential::api_key(SecretString::from("secret-key".to_owned())).unwrap(),
+        );
+        let bytes = encode_private(&state).unwrap();
+        let decoded = decode_private(&bytes).unwrap();
+        assert_eq!(decoded.credential_kind(), CredentialKind::ApiKey);
+        assert!(decoded.credential().username().is_none());
+        assert_eq!(decoded.credential().secret().expose_secret(), "secret-key");
+    }
+
+    #[test]
+    fn password_round_trip_preserves_account_binding() {
+        let state = OpenSubsonicPrivateState::new(
+            BackendId::new("backend").unwrap(),
+            AccountScopeId::new("account").unwrap(),
+            ServerCredential::password("alice", SecretString::from("secret-password".to_owned()))
+                .unwrap(),
+        );
+        let decoded = decode_private(&encode_private(&state).unwrap()).unwrap();
+        assert_eq!(decoded.backend_id().as_str(), "backend");
+        assert_eq!(decoded.account_scope_id().as_str(), "account");
+        assert_eq!(
+            decoded.credential().username().unwrap().expose_secret(),
+            "alice"
+        );
+    }
+
+    #[test]
+    fn invalid_secret_shapes_fail_closed() {
+        assert!(ServerCredential::password("", SecretString::from("x".to_owned())).is_err());
+        assert!(ServerCredential::password("alice", SecretString::from(String::new())).is_err());
+        assert!(ServerCredential::api_key(SecretString::from(String::new())).is_err());
+        assert!(
+            ServerCredential::api_key(SecretString::from("x".repeat(MAX_API_KEY_BYTES + 1)))
+                .is_err()
+        );
+        assert!(
+            ServerCredential::api_key(SecretString::from("가".repeat(400))).is_err(),
+            "the URL-encoded key must remain below the protocol limit"
+        );
+        assert!(decode_private(br#"{"kind":"unknown"}"#).is_err());
+    }
+}

--- a/src/open_subsonic/profile.rs
+++ b/src/open_subsonic/profile.rs
@@ -1,0 +1,362 @@
+//! Owner-only OpenSubsonic profile metadata and storage paths.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, Zeroizing};
+
+use super::model::{AccountScopeId, BackendId};
+use super::origin::{ConfiguredPrivateOrigin, custom_ca_fingerprint};
+
+pub(crate) const PROFILE_KIND: &str = "yututui_open_subsonic_profile";
+pub(crate) const PROFILE_SCHEMA_VERSION: u32 = 1;
+pub(crate) const MAX_PROFILE_BYTES: u64 = 256 * 1024;
+const MAX_DISPLAY_NAME_CHARS: usize = 200;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoreError {
+    StorageUnavailable,
+    StorageBusy,
+    InvalidState,
+    RevisionConflict,
+    PayloadTooLarge,
+    SerializationFailed,
+}
+
+impl std::fmt::Display for StoreError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::StorageUnavailable => "music server storage is unavailable",
+            Self::StorageBusy => "music server storage is busy",
+            Self::InvalidState => "music server storage needs attention",
+            Self::RevisionConflict => "music server settings changed; retry",
+            Self::PayloadTooLarge => "music server settings are too large",
+            Self::SerializationFailed => "music server settings could not be encoded",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+/// Fixed paths for the OpenSubsonic owner-only store set. Deliberately not `Debug`.
+pub struct OpenSubsonicPaths {
+    root: PathBuf,
+    profile: PathBuf,
+    private_store: PathBuf,
+    bridge_store: PathBuf,
+    transaction_manifest: PathBuf,
+    transaction_profile: PathBuf,
+    transaction_private: PathBuf,
+    transaction_bridge: PathBuf,
+    transaction_commit: PathBuf,
+    transaction_lock: PathBuf,
+}
+
+impl OpenSubsonicPaths {
+    pub fn for_data_root(data_root: PathBuf) -> Self {
+        let root = data_root.join("open-subsonic");
+        Self {
+            profile: root.join("open-subsonic-profile-v1.json"),
+            private_store: root.join("open-subsonic-private-v1.json"),
+            bridge_store: root.join("open-subsonic-bridge-v1.json"),
+            transaction_manifest: root.join("store-set-transaction-v1.json"),
+            transaction_profile: root.join("store-set-profile-v1.stage"),
+            transaction_private: root.join("store-set-private-v1.stage"),
+            transaction_bridge: root.join("store-set-bridge-v1.stage"),
+            transaction_commit: root.join("store-set-committed-v1"),
+            transaction_lock: root.join("store-set-v1.lock"),
+            root,
+        }
+    }
+
+    pub fn current() -> Result<Self, StoreError> {
+        crate::paths::data_dir()
+            .map(Self::for_data_root)
+            .ok_or(StoreError::StorageUnavailable)
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub(crate) fn profile(&self) -> &Path {
+        &self.profile
+    }
+
+    pub(crate) fn private_store(&self) -> &Path {
+        &self.private_store
+    }
+
+    pub(crate) fn bridge_store(&self) -> &Path {
+        &self.bridge_store
+    }
+
+    pub(crate) fn transaction_manifest(&self) -> &Path {
+        &self.transaction_manifest
+    }
+
+    pub(crate) fn transaction_profile(&self) -> &Path {
+        &self.transaction_profile
+    }
+
+    pub(crate) fn transaction_private(&self) -> &Path {
+        &self.transaction_private
+    }
+
+    pub(crate) fn transaction_bridge(&self) -> &Path {
+        &self.transaction_bridge
+    }
+
+    pub(crate) fn transaction_commit(&self) -> &Path {
+        &self.transaction_commit
+    }
+
+    pub(crate) fn transaction_lock(&self) -> &Path {
+        &self.transaction_lock
+    }
+}
+
+/// A local profile deliberately lacking `Debug` and serde implementations.
+pub struct OpenSubsonicProfile {
+    revision: u64,
+    backend_id: BackendId,
+    account_scope_id: AccountScopeId,
+    display_name: String,
+    origin: ConfiguredPrivateOrigin,
+    custom_ca_pem: Option<Vec<u8>>,
+    custom_ca_fingerprint: Option<String>,
+}
+
+impl Clone for OpenSubsonicProfile {
+    fn clone(&self) -> Self {
+        Self {
+            revision: self.revision,
+            backend_id: self.backend_id.clone(),
+            account_scope_id: self.account_scope_id.clone(),
+            display_name: self.display_name.clone(),
+            origin: self.origin.clone(),
+            custom_ca_pem: self.custom_ca_pem.clone(),
+            custom_ca_fingerprint: self.custom_ca_fingerprint.clone(),
+        }
+    }
+}
+
+impl Drop for OpenSubsonicProfile {
+    fn drop(&mut self) {
+        if let Some(pem) = &mut self.custom_ca_pem {
+            pem.zeroize();
+        }
+    }
+}
+
+impl OpenSubsonicProfile {
+    pub fn new(
+        display_name: &str,
+        origin: ConfiguredPrivateOrigin,
+        custom_ca_pem: Option<Vec<u8>>,
+    ) -> Result<Self, StoreError> {
+        Self::with_ids(
+            0,
+            BackendId::random().map_err(|_| StoreError::InvalidState)?,
+            AccountScopeId::random().map_err(|_| StoreError::InvalidState)?,
+            display_name,
+            origin,
+            custom_ca_pem,
+        )
+    }
+
+    pub(crate) fn with_ids(
+        revision: u64,
+        backend_id: BackendId,
+        account_scope_id: AccountScopeId,
+        display_name: &str,
+        origin: ConfiguredPrivateOrigin,
+        custom_ca_pem: Option<Vec<u8>>,
+    ) -> Result<Self, StoreError> {
+        let display_name = sanitize_display_name(display_name)?;
+        let custom_ca_fingerprint = custom_ca_pem
+            .as_deref()
+            .map(custom_ca_fingerprint)
+            .transpose()
+            .map_err(|_| StoreError::InvalidState)?;
+        Ok(Self {
+            revision,
+            backend_id,
+            account_scope_id,
+            display_name,
+            origin,
+            custom_ca_pem,
+            custom_ca_fingerprint,
+        })
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn backend_id(&self) -> &BackendId {
+        &self.backend_id
+    }
+
+    pub fn account_scope_id(&self) -> &AccountScopeId {
+        &self.account_scope_id
+    }
+
+    pub fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    pub fn uses_lan_http(&self) -> bool {
+        self.origin.uses_lan_http()
+    }
+
+    pub fn custom_ca_fingerprint(&self) -> Option<&str> {
+        self.custom_ca_fingerprint.as_deref()
+    }
+
+    pub(crate) fn origin(&self) -> &ConfiguredPrivateOrigin {
+        &self.origin
+    }
+
+    pub(crate) fn custom_ca_pem(&self) -> Option<&[u8]> {
+        self.custom_ca_pem.as_deref()
+    }
+
+    pub(crate) fn set_revision(&mut self, revision: u64) {
+        self.revision = revision;
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DiskProfile {
+    kind: String,
+    schema_version: u32,
+    revision: u64,
+    backend_id: BackendId,
+    account_scope_id: AccountScopeId,
+    display_name: String,
+    origin: String,
+    allow_lan_http: bool,
+    custom_ca_pem: Option<String>,
+    custom_ca_fingerprint: Option<String>,
+}
+
+impl Drop for DiskProfile {
+    fn drop(&mut self) {
+        self.origin.zeroize();
+        if let Some(pem) = &mut self.custom_ca_pem {
+            pem.zeroize();
+        }
+    }
+}
+
+pub(crate) fn encode_profile(
+    profile: &OpenSubsonicProfile,
+) -> Result<Zeroizing<Vec<u8>>, StoreError> {
+    let disk = DiskProfile {
+        kind: PROFILE_KIND.to_owned(),
+        schema_version: PROFILE_SCHEMA_VERSION,
+        revision: profile.revision,
+        backend_id: profile.backend_id.clone(),
+        account_scope_id: profile.account_scope_id.clone(),
+        display_name: profile.display_name.clone(),
+        origin: profile.origin.canonical().to_owned(),
+        allow_lan_http: profile.origin.uses_lan_http(),
+        custom_ca_pem: profile
+            .custom_ca_pem
+            .as_deref()
+            .map(|pem| {
+                std::str::from_utf8(pem)
+                    .map(str::to_owned)
+                    .map_err(|_| StoreError::SerializationFailed)
+            })
+            .transpose()?,
+        custom_ca_fingerprint: profile.custom_ca_fingerprint.clone(),
+    };
+    let bytes =
+        Zeroizing::new(serde_json::to_vec(&disk).map_err(|_| StoreError::SerializationFailed)?);
+    if bytes.len() as u64 > MAX_PROFILE_BYTES {
+        return Err(StoreError::PayloadTooLarge);
+    }
+    Ok(bytes)
+}
+
+pub(crate) fn decode_profile(bytes: &[u8]) -> Result<OpenSubsonicProfile, StoreError> {
+    if bytes.len() as u64 > MAX_PROFILE_BYTES {
+        return Err(StoreError::PayloadTooLarge);
+    }
+    let mut disk: DiskProfile =
+        serde_json::from_slice(bytes).map_err(|_| StoreError::InvalidState)?;
+    if disk.kind != PROFILE_KIND || disk.schema_version != PROFILE_SCHEMA_VERSION {
+        return Err(StoreError::InvalidState);
+    }
+    let origin = ConfiguredPrivateOrigin::new(&disk.origin, disk.allow_lan_http)
+        .map_err(|_| StoreError::InvalidState)?;
+    let profile = OpenSubsonicProfile::with_ids(
+        disk.revision,
+        disk.backend_id.clone(),
+        disk.account_scope_id.clone(),
+        &disk.display_name,
+        origin,
+        disk.custom_ca_pem.take().map(String::into_bytes),
+    )?;
+    if profile.custom_ca_fingerprint != disk.custom_ca_fingerprint {
+        return Err(StoreError::InvalidState);
+    }
+    Ok(profile)
+}
+
+fn sanitize_display_name(raw: &str) -> Result<String, StoreError> {
+    let value = crate::api::sanitize_metadata_text(raw, MAX_DISPLAY_NAME_CHARS);
+    if value.is_empty() {
+        return Err(StoreError::InvalidState);
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_round_trip_preserves_stable_identity() {
+        let origin =
+            ConfiguredPrivateOrigin::new("https://music.example.test/base", false).unwrap();
+        let profile = OpenSubsonicProfile::new("My server", origin, None).unwrap();
+        let bytes = encode_profile(&profile).unwrap();
+        let decoded = decode_profile(&bytes).unwrap();
+        assert_eq!(decoded.backend_id(), profile.backend_id());
+        assert_eq!(decoded.account_scope_id(), profile.account_scope_id());
+        assert_eq!(decoded.display_name(), "My server");
+    }
+
+    #[test]
+    fn unknown_or_oversized_profiles_fail_closed() {
+        assert!(decode_profile(br#"{"kind":"unknown"}"#).is_err());
+        assert!(decode_profile(&vec![b'x'; MAX_PROFILE_BYTES as usize + 1]).is_err());
+    }
+
+    #[test]
+    fn maximum_accepted_ca_bundle_fits_the_profile_store() {
+        const MAX_CA_BYTES: usize = 192 * 1024;
+        let certificate = crate::sync::webdav::tls_tests::TEST_CA_PEM;
+        let mut bundle = Vec::with_capacity(MAX_CA_BYTES);
+        while bundle.len().saturating_add(certificate.len()) <= MAX_CA_BYTES {
+            bundle.extend_from_slice(certificate);
+        }
+        assert!(bundle.len() > MAX_CA_BYTES - certificate.len());
+
+        let origin =
+            ConfiguredPrivateOrigin::new("https://music.example.test/base", false).unwrap();
+        let profile = OpenSubsonicProfile::new("Large CA server", origin, Some(bundle)).unwrap();
+        let encoded = encode_profile(&profile).unwrap();
+        assert!(encoded.len() as u64 <= MAX_PROFILE_BYTES);
+        let decoded = decode_profile(&encoded).unwrap();
+        assert_eq!(
+            decoded.custom_ca_fingerprint(),
+            profile.custom_ca_fingerprint()
+        );
+    }
+}

--- a/src/open_subsonic/proxy.rs
+++ b/src/open_subsonic/proxy.rs
@@ -1,0 +1,1317 @@
+//! Credential-owning, one-episode loopback playback proxy.
+//!
+//! mpv receives only an unguessable `127.0.0.1` route. The upstream implementation owns
+//! credentials and redirect policy; this boundary independently checks the final origin and
+//! forwards only a small allowlist of response headers.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::Duration;
+
+use futures::StreamExt as _;
+use reqwest::header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{Semaphore, watch};
+use tokio::task::JoinHandle;
+
+use super::{AccountScopeId, BackendId, ItemId, OpenSubsonicItemRef};
+use crate::playback_target::{
+    CredentialedPlaybackRef, PlaybackRouteError, PlaybackRouteFuture, PlaybackRouteLease,
+    PlaybackRouteProvider, PlaybackRouteProviderHandle, PlaybackRouteRevocation, RoutedPlayback,
+};
+
+const MAX_REQUEST_HEADER_BYTES: usize = 16 * 1024;
+const MAX_REQUEST_HEADERS: usize = 64;
+const MAX_SAFE_HEADER_BYTES: usize = 256;
+const MAX_ACTIVE_ROUTES: usize = 64;
+const MAX_CONNECTIONS: usize = 16;
+const REQUEST_HEADER_TIMEOUT: Duration = Duration::from_secs(5);
+const UPSTREAM_OPEN_TIMEOUT: Duration = Duration::from_secs(15);
+const BODY_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+const UNUSED_ROUTE_TTL: Duration = Duration::from_secs(60);
+const TOKEN_BYTES: usize = 32;
+const TOKEN_HEX_BYTES: usize = TOKEN_BYTES * 2;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StreamMethod {
+    Head,
+    Get,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ByteRange {
+    pub start: Option<u64>,
+    pub end: Option<u64>,
+}
+
+impl ByteRange {
+    pub fn to_header_value(self) -> String {
+        match (self.start, self.end) {
+            (Some(start), Some(end)) => format!("bytes={start}-{end}"),
+            (Some(start), None) => format!("bytes={start}-"),
+            (None, Some(suffix)) => format!("bytes=-{suffix}"),
+            (None, None) => unreachable!("validated range has one bound"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StreamRequest {
+    pub method: StreamMethod,
+    pub range: Option<ByteRange>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProxyUpstreamError {
+    reason: &'static str,
+}
+
+impl ProxyUpstreamError {
+    pub const fn new(reason: &'static str) -> Self {
+        Self { reason }
+    }
+
+    pub const fn reason(self) -> &'static str {
+        self.reason
+    }
+}
+
+impl std::fmt::Display for ProxyUpstreamError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.reason)
+    }
+}
+
+impl std::error::Error for ProxyUpstreamError {}
+
+#[derive(Clone, Eq, PartialEq)]
+pub struct ProxyOrigin {
+    scheme: String,
+    host: String,
+    port: u16,
+}
+
+impl std::fmt::Debug for ProxyOrigin {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ProxyOrigin(<redacted>)")
+    }
+}
+
+impl ProxyOrigin {
+    pub fn from_url(url: &reqwest::Url) -> Result<Self, ProxyUpstreamError> {
+        let scheme = url.scheme();
+        if !matches!(scheme, "http" | "https")
+            || !url.username().is_empty()
+            || url.password().is_some()
+        {
+            return Err(ProxyUpstreamError::new("invalid_upstream_origin"));
+        }
+        let host = url
+            .host_str()
+            .ok_or_else(|| ProxyUpstreamError::new("invalid_upstream_origin"))?;
+        let port = url
+            .port_or_known_default()
+            .ok_or_else(|| ProxyUpstreamError::new("invalid_upstream_origin"))?;
+        Ok(Self {
+            scheme: scheme.to_owned(),
+            host: host.trim_end_matches('.').to_ascii_lowercase(),
+            port,
+        })
+    }
+
+    fn matches(&self, url: &reqwest::Url) -> bool {
+        url.scheme() == self.scheme
+            && url
+                .host_str()
+                .map(|host| host.trim_end_matches('.').to_ascii_lowercase())
+                .as_deref()
+                == Some(self.host.as_str())
+            && url.port_or_known_default() == Some(self.port)
+            && url.username().is_empty()
+            && url.password().is_none()
+    }
+}
+
+/// Unbuffered upstream response paired with the exact origin snapshot used for that request.
+pub struct UpstreamStream {
+    response: reqwest::Response,
+    origin: ProxyOrigin,
+}
+
+impl UpstreamStream {
+    pub fn new(response: reqwest::Response, origin: ProxyOrigin) -> Self {
+        Self { response, origin }
+    }
+}
+
+pub type StreamSourceFuture =
+    Pin<Box<dyn Future<Output = Result<UpstreamStream, ProxyUpstreamError>> + Send + 'static>>;
+
+/// Auth-owning OpenSubsonic client/actor hook.
+pub trait StreamSource: Send + Sync {
+    fn open_stream(&self, item: OpenSubsonicItemRef, request: StreamRequest) -> StreamSourceFuture;
+}
+
+struct RouteState {
+    item: OpenSubsonicItemRef,
+    revoked: AtomicBool,
+    revoked_tx: watch::Sender<bool>,
+    admission: Mutex<RouteAdmission>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RouteAdmission {
+    WaitingUntil(tokio::time::Instant),
+    Admitted,
+}
+
+impl RouteState {
+    fn new(item: OpenSubsonicItemRef, unused_ttl: Duration) -> Self {
+        let (revoked_tx, _) = watch::channel(false);
+        Self {
+            item,
+            revoked: AtomicBool::new(false),
+            revoked_tx,
+            admission: Mutex::new(RouteAdmission::WaitingUntil(
+                tokio::time::Instant::now() + unused_ttl,
+            )),
+        }
+    }
+
+    fn is_live(&self) -> bool {
+        if self.revoked.load(Ordering::Acquire) {
+            return false;
+        }
+        let expired = matches!(
+            *self
+                .admission
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            RouteAdmission::WaitingUntil(deadline) if tokio::time::Instant::now() >= deadline
+        );
+        if expired {
+            self.revoke();
+            false
+        } else {
+            true
+        }
+    }
+
+    /// Admit the first valid HTTP request before the short bearer-token deadline.
+    ///
+    /// Once admitted, the route remains reusable for HEAD/GET and Range reconnects while its
+    /// playback lease is alive. This keeps the pre-admission token exposure short without
+    /// imposing an absolute deadline on a long track.
+    fn try_admit(&self) -> bool {
+        if self.revoked.load(Ordering::Acquire) {
+            return false;
+        }
+        let mut admission = self
+            .admission
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if self.revoked.load(Ordering::Acquire) {
+            return false;
+        }
+        match *admission {
+            RouteAdmission::Admitted => true,
+            RouteAdmission::WaitingUntil(deadline) if tokio::time::Instant::now() < deadline => {
+                *admission = RouteAdmission::Admitted;
+                true
+            }
+            RouteAdmission::WaitingUntil(_) => {
+                drop(admission);
+                self.revoke();
+                false
+            }
+        }
+    }
+
+    fn subscribe(&self) -> watch::Receiver<bool> {
+        self.revoked_tx.subscribe()
+    }
+}
+
+impl PlaybackRouteRevocation for RouteState {
+    fn revoke(&self) {
+        if !self.revoked.swap(true, Ordering::AcqRel) {
+            self.revoked_tx.send_replace(true);
+        }
+    }
+}
+
+struct ProxyInner {
+    port: u16,
+    body_idle_timeout: Duration,
+    unused_route_ttl: Duration,
+    source: Arc<dyn StreamSource>,
+    routes: Mutex<HashMap<String, Arc<RouteState>>>,
+    closed: AtomicBool,
+}
+
+impl ProxyInner {
+    fn mint_route(
+        &self,
+        target: CredentialedPlaybackRef,
+    ) -> Result<RoutedPlayback, PlaybackRouteError> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(PlaybackRouteError::new("route_provider_unavailable"));
+        }
+        let item = credentialed_item(target)?;
+        let mut routes = self
+            .routes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        routes.retain(|_, route| {
+            let keep = route.is_live();
+            if !keep {
+                route.revoke();
+            }
+            keep
+        });
+        if routes.len() >= MAX_ACTIVE_ROUTES {
+            return Err(PlaybackRouteError::new("route_capacity_reached"));
+        }
+        for _ in 0..4 {
+            let token = random_token()?;
+            if routes.contains_key(&token) {
+                continue;
+            }
+            let route = Arc::new(RouteState::new(item.clone(), self.unused_route_ttl));
+            routes.insert(token.clone(), Arc::clone(&route));
+            let revocation: Arc<dyn PlaybackRouteRevocation> = route;
+            return RoutedPlayback::new(self.port, token, PlaybackRouteLease::new(revocation));
+        }
+        Err(PlaybackRouteError::new("route_token_collision"))
+    }
+
+    fn find_route(&self, token: &str) -> Option<Arc<RouteState>> {
+        let mut routes = self
+            .routes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let route = routes.get(token).cloned()?;
+        if route.try_admit() {
+            Some(route)
+        } else {
+            route.revoke();
+            routes.remove(token);
+            None
+        }
+    }
+
+    fn revoke_all(&self) {
+        self.closed.store(true, Ordering::Release);
+        let mut routes = self
+            .routes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for route in routes.values() {
+            route.revoke();
+        }
+        routes.clear();
+    }
+}
+
+#[derive(Clone)]
+pub struct OpenSubsonicProxyHandle {
+    inner: Arc<ProxyInner>,
+}
+
+impl OpenSubsonicProxyHandle {
+    pub fn route_provider(&self) -> PlaybackRouteProviderHandle {
+        PlaybackRouteProviderHandle::new(Arc::new(self.clone()))
+    }
+
+    pub fn revoke_all(&self) {
+        self.inner.revoke_all();
+    }
+}
+
+impl std::fmt::Debug for OpenSubsonicProxyHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("OpenSubsonicProxyHandle(<redacted>)")
+    }
+}
+
+impl PlaybackRouteProvider for OpenSubsonicProxyHandle {
+    fn open_route(
+        &self,
+        target: CredentialedPlaybackRef,
+        _file_generation: u64,
+    ) -> PlaybackRouteFuture {
+        let result = self.inner.mint_route(target);
+        Box::pin(async move { result })
+    }
+}
+
+pub struct OpenSubsonicProxyGuard {
+    inner: Arc<ProxyInner>,
+    shutdown_tx: watch::Sender<bool>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl OpenSubsonicProxyGuard {
+    pub async fn shutdown(mut self) {
+        self.inner.revoke_all();
+        self.shutdown_tx.send_replace(true);
+        if let Some(task) = self.task.take() {
+            let _ = task.await;
+        }
+    }
+}
+
+impl Drop for OpenSubsonicProxyGuard {
+    fn drop(&mut self) {
+        self.inner.revoke_all();
+        self.shutdown_tx.send_replace(true);
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+pub async fn start(
+    source: Arc<dyn StreamSource>,
+) -> io::Result<(OpenSubsonicProxyHandle, OpenSubsonicProxyGuard)> {
+    start_with_limits(source, BODY_IDLE_TIMEOUT, UNUSED_ROUTE_TTL).await
+}
+
+async fn start_with_limits(
+    source: Arc<dyn StreamSource>,
+    body_idle_timeout: Duration,
+    unused_route_ttl: Duration,
+) -> io::Result<(OpenSubsonicProxyHandle, OpenSubsonicProxyGuard)> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let port = listener.local_addr()?.port();
+    let inner = Arc::new(ProxyInner {
+        port,
+        body_idle_timeout,
+        unused_route_ttl,
+        source,
+        routes: Mutex::new(HashMap::new()),
+        closed: AtomicBool::new(false),
+    });
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let task = tokio::spawn(run(listener, Arc::clone(&inner), shutdown_rx));
+    Ok((
+        OpenSubsonicProxyHandle {
+            inner: Arc::clone(&inner),
+        },
+        OpenSubsonicProxyGuard {
+            inner,
+            shutdown_tx,
+            task: Some(task),
+        },
+    ))
+}
+
+async fn run(
+    listener: TcpListener,
+    inner: Arc<ProxyInner>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    let permits = Arc::new(Semaphore::new(MAX_CONNECTIONS));
+    loop {
+        tokio::select! {
+            changed = shutdown_rx.changed() => {
+                if changed.is_err() || *shutdown_rx.borrow() {
+                    return;
+                }
+            }
+            accepted = listener.accept() => {
+                let Ok((stream, peer)) = accepted else {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    continue;
+                };
+                if !peer.ip().is_loopback() {
+                    continue;
+                }
+                let Ok(permit) = Arc::clone(&permits).try_acquire_owned() else {
+                    tokio::spawn(write_empty_response(stream, 503, "Service Unavailable"));
+                    continue;
+                };
+                let inner = Arc::clone(&inner);
+                tokio::spawn(async move {
+                    let _permit = permit;
+                    let _ = serve_connection(stream, inner).await;
+                });
+            }
+        }
+    }
+}
+
+struct ParsedRequest {
+    method: StreamMethod,
+    token: String,
+    range: Option<ByteRange>,
+}
+
+async fn serve_connection(mut stream: TcpStream, inner: Arc<ProxyInner>) -> io::Result<()> {
+    let request = match tokio::time::timeout(
+        REQUEST_HEADER_TIMEOUT,
+        read_request(&mut stream, inner.port),
+    )
+    .await
+    {
+        Ok(Ok(request)) => request,
+        Ok(Err(status)) => {
+            return write_empty_response(stream, status.0, status.1).await;
+        }
+        Err(_) => {
+            return write_empty_response(stream, 408, "Request Timeout").await;
+        }
+    };
+    let Some(route) = inner.find_route(&request.token) else {
+        return write_empty_response(stream, 404, "Not Found").await;
+    };
+    let mut revoked_rx = route.subscribe();
+    if *revoked_rx.borrow_and_update() || !route.is_live() {
+        return write_empty_response(stream, 404, "Not Found").await;
+    }
+    let upstream = inner.source.open_stream(
+        route.item.clone(),
+        StreamRequest {
+            method: request.method,
+            range: request.range,
+        },
+    );
+    tokio::pin!(upstream);
+    let open_timeout = tokio::time::sleep(UPSTREAM_OPEN_TIMEOUT);
+    tokio::pin!(open_timeout);
+    let upstream = tokio::select! {
+        changed = revoked_rx.changed() => {
+            let _ = changed;
+            return Ok(());
+        }
+        _ = &mut open_timeout => {
+            return write_empty_response(stream, 504, "Gateway Timeout").await;
+        }
+        upstream = &mut upstream => upstream,
+    };
+    let upstream = match upstream {
+        Ok(upstream) => upstream,
+        Err(_) => return write_empty_response(stream, 502, "Bad Gateway").await,
+    };
+    if !upstream.origin.matches(upstream.response.url()) {
+        return write_empty_response(stream, 502, "Bad Gateway").await;
+    }
+    forward_response(
+        stream,
+        upstream.response,
+        request.method,
+        &mut revoked_rx,
+        inner.body_idle_timeout,
+    )
+    .await
+}
+
+async fn read_request(
+    stream: &mut TcpStream,
+    expected_port: u16,
+) -> Result<ParsedRequest, (u16, &'static str)> {
+    let mut bytes = Vec::with_capacity(1024);
+    let mut chunk = [0u8; 1024];
+    loop {
+        if bytes.len() >= MAX_REQUEST_HEADER_BYTES {
+            return Err((431, "Request Header Fields Too Large"));
+        }
+        let remaining = MAX_REQUEST_HEADER_BYTES - bytes.len();
+        let read_capacity = remaining.min(chunk.len());
+        let count = stream
+            .read(&mut chunk[..read_capacity])
+            .await
+            .map_err(|_| (400, "Bad Request"))?;
+        if count == 0 {
+            return Err((400, "Bad Request"));
+        }
+        bytes.extend_from_slice(&chunk[..count]);
+        if bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+    if !bytes.is_ascii() {
+        return Err((400, "Bad Request"));
+    }
+    let text = std::str::from_utf8(&bytes).map_err(|_| (400, "Bad Request"))?;
+    let mut lines = text.split("\r\n");
+    let mut request_line = lines
+        .next()
+        .ok_or((400, "Bad Request"))?
+        .split_ascii_whitespace();
+    let method = match request_line.next() {
+        Some("GET") => StreamMethod::Get,
+        Some("HEAD") => StreamMethod::Head,
+        Some(_) => return Err((405, "Method Not Allowed")),
+        None => return Err((400, "Bad Request")),
+    };
+    let path = request_line.next().ok_or((400, "Bad Request"))?;
+    if request_line.next() != Some("HTTP/1.1") || request_line.next().is_some() {
+        return Err((400, "Bad Request"));
+    }
+    let token = path
+        .strip_prefix("/stream/")
+        .filter(|token| {
+            token.len() == TOKEN_HEX_BYTES
+                && token.bytes().all(|byte| byte.is_ascii_hexdigit())
+                && !path.contains('?')
+                && !path.contains('#')
+        })
+        .ok_or((404, "Not Found"))?
+        .to_owned();
+    let mut host_seen = false;
+    let mut range = None;
+    let mut header_count = 0usize;
+    for line in lines {
+        if line.is_empty() {
+            break;
+        }
+        header_count += 1;
+        if header_count > MAX_REQUEST_HEADERS || line.len() > MAX_SAFE_HEADER_BYTES {
+            return Err((431, "Request Header Fields Too Large"));
+        }
+        let (name, value) = line.split_once(':').ok_or((400, "Bad Request"))?;
+        let value = value.trim();
+        if name.eq_ignore_ascii_case("host") {
+            if host_seen || !host_is_loopback(value, expected_port) {
+                return Err((400, "Bad Request"));
+            }
+            host_seen = true;
+        } else if name.eq_ignore_ascii_case("range") {
+            if range.is_some() {
+                return Err((400, "Bad Request"));
+            }
+            range = Some(parse_range(value)?);
+        }
+    }
+    if !host_seen {
+        return Err((400, "Bad Request"));
+    }
+    Ok(ParsedRequest {
+        method,
+        token,
+        range,
+    })
+}
+
+fn host_is_loopback(value: &str, expected_port: u16) -> bool {
+    value
+        .split_once(':')
+        .is_some_and(|(host, port)| host == "127.0.0.1" && port.parse::<u16>() == Ok(expected_port))
+}
+
+fn parse_range(value: &str) -> Result<ByteRange, (u16, &'static str)> {
+    let range = value
+        .strip_prefix("bytes=")
+        .filter(|value| !value.contains(','))
+        .ok_or((416, "Range Not Satisfiable"))?;
+    let (start, end) = range
+        .split_once('-')
+        .ok_or((416, "Range Not Satisfiable"))?;
+    let start = (!start.is_empty())
+        .then(|| start.parse::<u64>())
+        .transpose()
+        .map_err(|_| (416, "Range Not Satisfiable"))?;
+    let end = (!end.is_empty())
+        .then(|| end.parse::<u64>())
+        .transpose()
+        .map_err(|_| (416, "Range Not Satisfiable"))?;
+    if start.is_none() && end.is_none()
+        || matches!((start, end), (Some(start), Some(end)) if start > end)
+        || matches!((start, end), (None, Some(0)))
+    {
+        return Err((416, "Range Not Satisfiable"));
+    }
+    Ok(ByteRange { start, end })
+}
+
+async fn forward_response(
+    mut downstream: TcpStream,
+    upstream: reqwest::Response,
+    method: StreamMethod,
+    revoked_rx: &mut watch::Receiver<bool>,
+    body_idle_timeout: Duration,
+) -> io::Result<()> {
+    let status = upstream.status();
+    let (code, reason) = match status.as_u16() {
+        200 => (200, "OK"),
+        206 => (206, "Partial Content"),
+        416 => (416, "Range Not Satisfiable"),
+        _ => return write_empty_response(downstream, 502, "Bad Gateway").await,
+    };
+    if code != 416 && structured_error_content_type(upstream.headers()) {
+        return write_empty_response(downstream, 502, "Bad Gateway").await;
+    }
+    let headers = safe_response_headers(upstream.headers());
+    let mut response = format!("HTTP/1.1 {code} {reason}\r\nConnection: close\r\n");
+    for (name, value) in headers {
+        response.push_str(name);
+        response.push_str(": ");
+        response.push_str(&value);
+        response.push_str("\r\n");
+    }
+    response.push_str("\r\n");
+    downstream.write_all(response.as_bytes()).await?;
+    if method == StreamMethod::Head || code == 416 {
+        return downstream.shutdown().await;
+    }
+    let mut body = upstream.bytes_stream();
+    loop {
+        let idle = tokio::time::sleep(body_idle_timeout);
+        tokio::pin!(idle);
+        tokio::select! {
+            changed = revoked_rx.changed() => {
+                if changed.is_err() || *revoked_rx.borrow_and_update() {
+                    return Ok(());
+                }
+            }
+            _ = &mut idle => return Ok(()),
+            chunk = body.next() => match chunk {
+                Some(Ok(chunk)) => {
+                    let write_idle = tokio::time::sleep(body_idle_timeout);
+                    tokio::pin!(write_idle);
+                    tokio::select! {
+                        changed = revoked_rx.changed() => {
+                            let _ = changed;
+                            return Ok(());
+                        }
+                        _ = &mut write_idle => return Ok(()),
+                        result = downstream.write_all(&chunk) => result?,
+                    }
+                }
+                Some(Err(_)) => return Ok(()),
+                None => return downstream.shutdown().await,
+            }
+        }
+    }
+}
+
+fn structured_error_content_type(headers: &reqwest::header::HeaderMap) -> bool {
+    let Some(content_type) = headers
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| {
+            value
+                .split(';')
+                .next()
+                .unwrap_or(value)
+                .trim()
+                .to_ascii_lowercase()
+        })
+    else {
+        return false;
+    };
+    content_type == "application/json"
+        || content_type.ends_with("+json")
+        || content_type == "application/xml"
+        || content_type.ends_with("+xml")
+        || matches!(content_type.as_str(), "text/xml" | "text/html")
+}
+
+fn safe_response_headers(headers: &reqwest::header::HeaderMap) -> Vec<(&'static str, String)> {
+    let mut safe = Vec::with_capacity(4);
+    if let Some(value) = safe_header(headers, CONTENT_TYPE) {
+        safe.push(("Content-Type", value));
+    }
+    if let Some(value) =
+        safe_header(headers, CONTENT_LENGTH).filter(|value| value.parse::<u64>().is_ok())
+    {
+        safe.push(("Content-Length", value));
+    }
+    if let Some(value) =
+        safe_header(headers, CONTENT_RANGE).filter(|value| valid_content_range(value))
+    {
+        safe.push(("Content-Range", value));
+    }
+    if safe_header(headers, ACCEPT_RANGES).as_deref() == Some("bytes") {
+        safe.push(("Accept-Ranges", "bytes".to_owned()));
+    }
+    safe
+}
+
+fn safe_header(
+    headers: &reqwest::header::HeaderMap,
+    name: reqwest::header::HeaderName,
+) -> Option<String> {
+    let value = headers.get(name)?.to_str().ok()?;
+    (value.len() <= MAX_SAFE_HEADER_BYTES && !value.bytes().any(|byte| byte.is_ascii_control()))
+        .then(|| value.to_owned())
+}
+
+fn valid_content_range(value: &str) -> bool {
+    value
+        .strip_prefix("bytes ")
+        .and_then(|value| value.split_once('/'))
+        .is_some_and(|(range, total)| {
+            let total_valid = total == "*" || total.parse::<u64>().is_ok();
+            let range_valid = range == "*"
+                || range.split_once('-').is_some_and(|(start, end)| {
+                    start
+                        .parse::<u64>()
+                        .ok()
+                        .zip(end.parse::<u64>().ok())
+                        .is_some_and(|(start, end)| start <= end)
+                });
+            total_valid && range_valid
+        })
+}
+
+async fn write_empty_response(
+    mut stream: TcpStream,
+    status: u16,
+    reason: &'static str,
+) -> io::Result<()> {
+    stream
+        .write_all(
+            format!("HTTP/1.1 {status} {reason}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                .as_bytes(),
+        )
+        .await?;
+    stream.shutdown().await
+}
+
+fn credentialed_item(
+    target: CredentialedPlaybackRef,
+) -> Result<OpenSubsonicItemRef, PlaybackRouteError> {
+    match target {
+        CredentialedPlaybackRef::OpenSubsonic {
+            backend_id,
+            account_scope_id,
+            item_id,
+        } => Ok(OpenSubsonicItemRef::new(
+            BackendId::new(backend_id)
+                .map_err(|_| PlaybackRouteError::new("invalid_catalog_identity"))?,
+            AccountScopeId::new(account_scope_id)
+                .map_err(|_| PlaybackRouteError::new("invalid_catalog_identity"))?,
+            ItemId::new(item_id)
+                .map_err(|_| PlaybackRouteError::new("invalid_catalog_identity"))?,
+        )),
+    }
+}
+
+fn random_token() -> Result<String, PlaybackRouteError> {
+    let mut bytes = [0u8; TOKEN_BYTES];
+    getrandom::fill(&mut bytes)
+        .map_err(|_| PlaybackRouteError::new("secure_random_unavailable"))?;
+    let mut token = String::with_capacity(TOKEN_HEX_BYTES);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in bytes {
+        token.push(char::from(HEX[usize::from(byte >> 4)]));
+        token.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    Ok(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    #[derive(Clone)]
+    struct HttpStreamSource {
+        client: reqwest::Client,
+        url: reqwest::Url,
+        origin: ProxyOrigin,
+        requests: mpsc::UnboundedSender<StreamRequest>,
+    }
+
+    impl StreamSource for HttpStreamSource {
+        fn open_stream(
+            &self,
+            _item: OpenSubsonicItemRef,
+            request: StreamRequest,
+        ) -> StreamSourceFuture {
+            let client = self.client.clone();
+            let url = self.url.clone();
+            let origin = self.origin.clone();
+            let requests = self.requests.clone();
+            Box::pin(async move {
+                let _ = requests.send(request);
+                let method = match request.method {
+                    StreamMethod::Head => reqwest::Method::HEAD,
+                    StreamMethod::Get => reqwest::Method::GET,
+                };
+                let mut request_builder = client.request(method, url);
+                if let Some(range) = request.range {
+                    request_builder =
+                        request_builder.header(reqwest::header::RANGE, range.to_header_value());
+                }
+                let response = request_builder
+                    .send()
+                    .await
+                    .map_err(|_| ProxyUpstreamError::new("test_upstream_failed"))?;
+                Ok(UpstreamStream::new(response, origin))
+            })
+        }
+    }
+
+    fn item() -> OpenSubsonicItemRef {
+        OpenSubsonicItemRef::new(
+            BackendId::new("backend").unwrap(),
+            AccountScopeId::new("account").unwrap(),
+            ItemId::new("song").unwrap(),
+        )
+    }
+
+    fn credentialed_item() -> CredentialedPlaybackRef {
+        CredentialedPlaybackRef::OpenSubsonic {
+            backend_id: "backend".to_owned(),
+            account_scope_id: "account".to_owned(),
+            item_id: "song".to_owned(),
+        }
+    }
+
+    async fn source_for(
+        url: reqwest::Url,
+        origin: ProxyOrigin,
+    ) -> (
+        Arc<dyn StreamSource>,
+        mpsc::UnboundedReceiver<StreamRequest>,
+    ) {
+        let (requests_tx, requests_rx) = mpsc::unbounded_channel();
+        let source = HttpStreamSource {
+            client: reqwest::Client::builder()
+                .no_proxy()
+                .build()
+                .expect("test client"),
+            url,
+            origin,
+            requests: requests_tx,
+        };
+        (Arc::new(source), requests_rx)
+    }
+
+    async fn static_upstream(response: &'static [u8]) -> (reqwest::Url, JoinHandle<()>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0u8; 4096];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream.write_all(response).await.unwrap();
+            stream.shutdown().await.unwrap();
+        });
+        (
+            reqwest::Url::parse(&format!("http://{address}/stream")).unwrap(),
+            task,
+        )
+    }
+
+    async fn lingering_upstream() -> (reqwest::Url, JoinHandle<()>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let upstream_url =
+            reqwest::Url::parse(&format!("http://{}/stream", listener.local_addr().unwrap()))
+                .unwrap();
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0u8; 4096];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: audio/mpeg\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n3\r\nabc\r\n",
+                )
+                .await
+                .unwrap();
+            std::future::pending::<()>().await;
+        });
+        (upstream_url, task)
+    }
+
+    async fn controlled_upstream() -> (reqwest::Url, mpsc::UnboundedSender<()>, JoinHandle<()>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let upstream_url =
+            reqwest::Url::parse(&format!("http://{}/stream", listener.local_addr().unwrap()))
+                .unwrap();
+        let (finish_tx, mut finish_rx) = mpsc::unbounded_channel();
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0u8; 4096];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: audio/mpeg\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n3\r\nabc\r\n",
+                )
+                .await
+                .unwrap();
+            finish_rx.recv().await.expect("finish signal");
+            stream.write_all(b"3\r\ndef\r\n0\r\n\r\n").await.unwrap();
+            stream.shutdown().await.unwrap();
+        });
+        (upstream_url, finish_tx, task)
+    }
+
+    async fn mint_route(handle: &OpenSubsonicProxyHandle) -> (reqwest::Url, PlaybackRouteLease) {
+        let route = handle
+            .open_route(credentialed_item(), 1)
+            .await
+            .expect("route");
+        let (url, lease) = route.into_parts();
+        (
+            reqwest::Url::parse(&url.into_string()).expect("loopback URL"),
+            lease,
+        )
+    }
+
+    async fn raw_proxy_request(url: &reqwest::Url, headers: &str) -> Vec<u8> {
+        let mut stream = open_raw_proxy_request(url, headers).await;
+        let mut response = Vec::new();
+        tokio::time::timeout(Duration::from_secs(2), stream.read_to_end(&mut response))
+            .await
+            .expect("proxy response timeout")
+            .unwrap();
+        response
+    }
+
+    async fn open_raw_proxy_request(url: &reqwest::Url, headers: &str) -> TcpStream {
+        let mut stream =
+            TcpStream::connect((url.host_str().expect("host"), url.port().expect("port")))
+                .await
+                .unwrap();
+        let request = format!(
+            "GET {} HTTP/1.1\r\nHost: 127.0.0.1:{}\r\n{headers}\r\n",
+            url.path(),
+            url.port().unwrap()
+        );
+        stream.write_all(request.as_bytes()).await.unwrap();
+        stream
+    }
+
+    #[test]
+    fn accepts_only_one_well_formed_byte_range() {
+        assert_eq!(
+            parse_range("bytes=10-20").unwrap(),
+            ByteRange {
+                start: Some(10),
+                end: Some(20)
+            }
+        );
+        assert_eq!(
+            parse_range("bytes=10-").unwrap(),
+            ByteRange {
+                start: Some(10),
+                end: None
+            }
+        );
+        assert_eq!(
+            parse_range("bytes=-20").unwrap(),
+            ByteRange {
+                start: None,
+                end: Some(20)
+            }
+        );
+        for invalid in [
+            "bytes=",
+            "bytes=20-10",
+            "bytes=0-1,4-5",
+            "items=0-1",
+            "bytes=-0",
+        ] {
+            assert!(parse_range(invalid).is_err(), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn structured_api_content_types_are_not_media() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        for blocked in [
+            "application/json",
+            "application/problem+json; charset=utf-8",
+            "application/xml",
+            "text/xml",
+            "text/html",
+        ] {
+            headers.insert(CONTENT_TYPE, blocked.parse().unwrap());
+            assert!(structured_error_content_type(&headers), "{blocked}");
+        }
+        headers.insert(CONTENT_TYPE, "audio/mpeg".parse().unwrap());
+        assert!(!structured_error_content_type(&headers));
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        windows,
+        ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+    )]
+    async fn forwards_single_range_and_only_safe_response_headers() {
+        let (upstream_url, upstream_task) = static_upstream(
+            b"HTTP/1.1 206 Partial Content\r\nContent-Type: audio/mpeg\r\nContent-Length: 4\r\nContent-Range: bytes 2-5/10\r\nAccept-Ranges: bytes\r\nX-Upstream-Secret: hidden\r\nConnection: close\r\n\r\ndata",
+        )
+        .await;
+        let origin = ProxyOrigin::from_url(&upstream_url).unwrap();
+        let (source, mut requests) = source_for(upstream_url, origin).await;
+        let (handle, guard) = start(source).await.unwrap();
+        let (route_url, _lease) = mint_route(&handle).await;
+
+        let response = raw_proxy_request(&route_url, "Range: bytes=2-5\r\n").await;
+        let response = String::from_utf8(response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 206 Partial Content\r\n"));
+        assert!(response.contains("Content-Type: audio/mpeg\r\n"));
+        assert!(response.contains("Content-Range: bytes 2-5/10\r\n"));
+        assert!(response.ends_with("\r\n\r\ndata"));
+        assert!(!response.contains("X-Upstream-Secret"));
+        assert_eq!(
+            requests.recv().await.unwrap().range,
+            Some(ByteRange {
+                start: Some(2),
+                end: Some(5)
+            })
+        );
+
+        guard.shutdown().await;
+        upstream_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        windows,
+        ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+    )]
+    async fn structured_error_body_never_reaches_mpv_route() {
+        let (upstream_url, upstream_task) = static_upstream(
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 25\r\nConnection: close\r\n\r\n{\"token\":\"server-secret\"}",
+        )
+        .await;
+        let origin = ProxyOrigin::from_url(&upstream_url).unwrap();
+        let (source, _requests) = source_for(upstream_url, origin).await;
+        let (handle, guard) = start(source).await.unwrap();
+        let (route_url, _lease) = mint_route(&handle).await;
+
+        let response = raw_proxy_request(&route_url, "").await;
+        let response = String::from_utf8(response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 502 Bad Gateway\r\n"));
+        assert!(!response.contains("server-secret"));
+
+        guard.shutdown().await;
+        upstream_task.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[cfg_attr(
+        windows,
+        ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+    )]
+    async fn revoked_episode_returns_not_found() {
+        let (upstream_url, upstream_task) = static_upstream(
+            b"HTTP/1.1 200 OK\r\nContent-Type: audio/mpeg\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        )
+        .await;
+        let origin = ProxyOrigin::from_url(&upstream_url).unwrap();
+        let (source, _requests) = source_for(upstream_url, origin).await;
+        let (handle, guard) = start(source).await.unwrap();
+        let (route_url, lease) = mint_route(&handle).await;
+        drop(lease);
+
+        let response = raw_proxy_request(&route_url, "").await;
+        assert!(response.starts_with(b"HTTP/1.1 404 Not Found\r\n"));
+
+        guard.shutdown().await;
+        upstream_task.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[cfg_attr(
+        windows,
+        ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+    )]
+    async fn unused_route_expiry_returns_not_found_and_reclaims_capacity() {
+        let upstream_url = reqwest::Url::parse("http://127.0.0.1:9/unused").unwrap();
+        let origin = ProxyOrigin::from_url(&upstream_url).unwrap();
+        let (source, _requests) = source_for(upstream_url, origin).await;
+        let unused_ttl = Duration::from_secs(5);
+        let (handle, guard) = start_with_limits(source, BODY_IDLE_TIMEOUT, unused_ttl)
+            .await
+            .unwrap();
+        let mut routes = Vec::with_capacity(MAX_ACTIVE_ROUTES);
+        for _ in 0..MAX_ACTIVE_ROUTES {
+            routes.push(mint_route(&handle).await);
+        }
+        let capacity_error = handle
+            .open_route(credentialed_item(), 1)
+            .await
+            .expect_err("unexpired routes must consume capacity");
+        assert_eq!(capacity_error.reason(), "route_capacity_reached");
+
+        tokio::time::advance(unused_ttl + Duration::from_millis(1)).await;
+        let response = raw_proxy_request(&routes[0].0, "").await;
+        assert!(response.starts_with(b"HTTP/1.1 404 Not Found\r\n"));
+
+        let replacement = handle
+            .open_route(credentialed_item(), 2)
+            .await
+            .expect("expired routes must release capacity");
+        assert_eq!(
+            handle
+                .inner
+                .routes
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .len(),
+            1
+        );
+        drop(replacement);
+        drop(routes);
+        guard.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[cfg_attr(
+        windows,
+        ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+    )]
+    async fn admitted_body_stream_outlives_unused_route_deadline() {
+        let (upstream_url, finish_tx, upstream_task) = controlled_upstream().await;
+        let origin = ProxyOrigin::from_url(&upstream_url).unwrap();
+        let (source, _requests) = source_for(upstream_url, origin).await;
+        let unused_ttl = Duration::from_secs(5);
+        let (handle, guard) = start_with_limits(source, Duration::from_secs(60 * 60), unused_ttl)
+            .await
+            .unwrap();
+        let (route_url, _lease) = mint_route(&handle).await;
+        let mut downstream = open_raw_proxy_request(&route_url, "").await;
+        let mut response = Vec::new();
+        // Give the OS-backed loopback sockets real time to become readable. The admission expiry
+        // itself remains deterministic below while Tokio's clock is paused.
+        tokio::time::resume();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !response.windows(3).any(|window| window == b"abc") {
+                let mut chunk = [0u8; 1024];
+                let count = downstream.read(&mut chunk).await.unwrap();
+                assert_ne!(count, 0, "upstream closed before its first body chunk");
+                response.extend_from_slice(&chunk[..count]);
+            }
+        })
+        .await
+        .expect("initial proxy response timeout");
+
+        tokio::time::pause();
+        tokio::time::advance(unused_ttl + Duration::from_secs(1)).await;
+        tokio::time::resume();
+        finish_tx.send(()).unwrap();
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            downstream.read_to_end(&mut response),
+        )
+        .await
+        .expect("admitted route expired during a live body")
+        .unwrap();
+        assert!(response.windows(6).any(|window| window == b"abcdef"));
+
+        guard.shutdown().await;
+        upstream_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        windows,
+        ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+    )]
+    async fn dropping_episode_lease_closes_an_open_body_stream() {
+        let (upstream_url, upstream_task) = lingering_upstream().await;
+        let origin = ProxyOrigin::from_url(&upstream_url).unwrap();
+        let (source, _requests) = source_for(upstream_url, origin).await;
+        let (handle, guard) = start(source).await.unwrap();
+        let (route_url, lease) = mint_route(&handle).await;
+        let mut downstream = open_raw_proxy_request(&route_url, "").await;
+        let mut initial = [0u8; 1024];
+        let read = tokio::time::timeout(Duration::from_secs(2), downstream.read(&mut initial))
+            .await
+            .expect("initial proxy response timeout")
+            .unwrap();
+        assert!(String::from_utf8_lossy(&initial[..read]).starts_with("HTTP/1.1 200 OK\r\n"));
+
+        drop(lease);
+        let mut remainder = Vec::new();
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            downstream.read_to_end(&mut remainder),
+        )
+        .await
+        .expect("revoked route did not close its open body")
+        .unwrap();
+
+        guard.shutdown().await;
+        upstream_task.abort();
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        windows,
+        ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+    )]
+    async fn stalled_upstream_body_is_closed_after_idle_timeout() {
+        let (upstream_url, upstream_task) = lingering_upstream().await;
+        let origin = ProxyOrigin::from_url(&upstream_url).unwrap();
+        let (source, _requests) = source_for(upstream_url, origin).await;
+        let (handle, guard) =
+            start_with_limits(source, Duration::from_millis(20), UNUSED_ROUTE_TTL)
+                .await
+                .unwrap();
+        let (route_url, _lease) = mint_route(&handle).await;
+        let mut downstream = open_raw_proxy_request(&route_url, "").await;
+        let mut response = Vec::new();
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            downstream.read_to_end(&mut response),
+        )
+        .await
+        .expect("idle upstream body kept the proxy route open")
+        .unwrap();
+        assert!(response.starts_with(b"HTTP/1.1 200 OK\r\n"));
+
+        guard.shutdown().await;
+        upstream_task.abort();
+    }
+
+    #[test]
+    fn token_and_route_debug_output_are_redacted() {
+        let (lease, _) = {
+            let revoked = Arc::new(RouteState::new(item(), UNUSED_ROUTE_TTL));
+            let revocation: Arc<dyn PlaybackRouteRevocation> = revoked;
+            (
+                PlaybackRouteLease::new(revocation),
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            )
+        };
+        let route = RoutedPlayback::new(
+            1234,
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_owned(),
+            lease,
+        )
+        .unwrap();
+        let debug = format!("{route:?}");
+        assert!(!debug.contains("0123456789abcdef"));
+        assert_eq!(debug, "RoutedPlayback(<redacted>)");
+
+        let origin = ProxyOrigin::from_url(
+            &reqwest::Url::parse("https://private.example.test:8443/stream").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(format!("{origin:?}"), "ProxyOrigin(<redacted>)");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_live_episode_is_revoked_by_its_lease_not_wall_clock_time() {
+        let route = Arc::new(RouteState::new(item(), UNUSED_ROUTE_TTL));
+        let revocation: Arc<dyn PlaybackRouteRevocation> = route.clone();
+        let lease = PlaybackRouteLease::new(revocation);
+
+        assert!(route.try_admit());
+        tokio::time::advance(Duration::from_secs(5 * 60 * 60)).await;
+        assert!(route.is_live());
+        assert!(
+            route.try_admit(),
+            "admitted route supports Range reconnects"
+        );
+
+        drop(lease);
+        assert!(!route.is_live());
+        assert!(!route.try_admit());
+    }
+}

--- a/src/open_subsonic/transaction.rs
+++ b/src/open_subsonic/transaction.rs
@@ -1,0 +1,739 @@
+//! Crash-consistent installation of the profile, credential, and bridge store set.
+
+use std::fs;
+use std::path::Path;
+
+use data_encoding::HEXLOWER;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use zeroize::Zeroizing;
+
+use super::bridge_store::{
+    MAX_BRIDGE_BYTES, OpenSubsonicBridgeState, decode_bridge, encode_bridge,
+};
+use super::private_store::{
+    MAX_PRIVATE_BYTES, OpenSubsonicPrivateState, decode_private, encode_private,
+};
+use super::profile::{
+    MAX_PROFILE_BYTES, OpenSubsonicPaths, OpenSubsonicProfile, StoreError, decode_profile,
+    encode_profile,
+};
+use crate::util::safe_fs::{
+    AdvisoryFileLock, ensure_private_dir_durable, read_owner_only_limited,
+    remove_owner_only_file_durable, try_lock_private_file, validate_owner_only_file,
+    write_owner_only_atomic,
+};
+
+const MANIFEST_KIND: &str = "yututui_open_subsonic_store_set_transaction";
+const MANIFEST_SCHEMA_VERSION: u32 = 1;
+const MAX_MANIFEST_BYTES: u64 = 16 * 1024;
+const COMMIT_MARKER: &[u8] = b"yututui-open-subsonic-store-set-v1\n";
+
+#[cfg(test)]
+thread_local! {
+    static FAIL_AFTER_COMMIT_MARKER: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+pub(crate) fn fail_after_commit_marker_once_for_test() {
+    FAIL_AFTER_COMMIT_MARKER.with(|armed| armed.set(true));
+}
+
+/// The three files are always loaded and installed as one identity-bound set.
+pub struct OpenSubsonicStoreSet {
+    pub profile: OpenSubsonicProfile,
+    pub private_state: OpenSubsonicPrivateState,
+    pub bridge_state: OpenSubsonicBridgeState,
+}
+
+impl OpenSubsonicStoreSet {
+    pub fn new(
+        profile: OpenSubsonicProfile,
+        private_state: OpenSubsonicPrivateState,
+        bridge_state: OpenSubsonicBridgeState,
+    ) -> Result<Self, StoreError> {
+        let store_set = Self {
+            profile,
+            private_state,
+            bridge_state,
+        };
+        validate_identity(&store_set)?;
+        Ok(store_set)
+    }
+
+    pub fn revisions(&self) -> StoreRevisions {
+        StoreRevisions {
+            profile: Some(self.profile.revision()),
+            private_state: Some(self.private_state.revision()),
+            bridge_state: Some(self.bridge_state.revision()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StoreRevisions {
+    pub profile: Option<u64>,
+    pub private_state: Option<u64>,
+    pub bridge_state: Option<u64>,
+}
+
+impl StoreRevisions {
+    pub const MISSING: Self = Self {
+        profile: None,
+        private_state: None,
+        bridge_state: None,
+    };
+}
+
+pub fn load_store_set(
+    paths: &OpenSubsonicPaths,
+) -> Result<Option<OpenSubsonicStoreSet>, StoreError> {
+    if !path_exists(paths.root())? {
+        return Ok(None);
+    }
+    ensure_private_dir_durable(paths.root()).map_err(|_| StoreError::StorageUnavailable)?;
+    let _lock = acquire_lock(paths)?;
+    recover_locked(paths)?;
+    load_locked(paths)
+}
+
+/// Read a coherent store snapshot without creating files or rolling a transaction forward.
+///
+/// Status commands run with the process-wide mutation capability disabled, so they cannot use
+/// [`load_store_set`]. A pending transaction is deliberately reported as invalid instead of
+/// exposing a possibly mixed old/new snapshot; the primary writer will recover it on its next
+/// load.
+pub fn load_store_set_read_only(
+    paths: &OpenSubsonicPaths,
+) -> Result<Option<OpenSubsonicStoreSet>, StoreError> {
+    match fs::symlink_metadata(paths.root()) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err(StoreError::StorageUnavailable),
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(StoreError::InvalidState);
+        }
+        Ok(_) => {}
+    }
+    if transaction_artifacts_exist(paths)? {
+        return Err(StoreError::InvalidState);
+    }
+    let first = load_locked(paths)?;
+    if transaction_artifacts_exist(paths)? {
+        return Err(StoreError::InvalidState);
+    }
+    let second = load_locked(paths)?;
+    if transaction_artifacts_exist(paths)?
+        || snapshot_revisions(&first) != snapshot_revisions(&second)
+    {
+        return Err(StoreError::StorageBusy);
+    }
+    Ok(second)
+}
+
+pub fn commit_store_set(
+    paths: &OpenSubsonicPaths,
+    expected: StoreRevisions,
+    candidate: &mut OpenSubsonicStoreSet,
+) -> Result<(), StoreError> {
+    ensure_private_dir_durable(paths.root()).map_err(|_| StoreError::StorageUnavailable)?;
+    let _lock = acquire_lock(paths)?;
+    recover_locked(paths)?;
+    let current = load_locked(paths)?;
+    let actual = current
+        .as_ref()
+        .map_or(StoreRevisions::MISSING, OpenSubsonicStoreSet::revisions);
+    if actual != expected {
+        return Err(StoreError::RevisionConflict);
+    }
+    validate_identity(candidate)?;
+    candidate
+        .profile
+        .set_revision(next_revision(expected.profile)?);
+    candidate
+        .private_state
+        .set_revision(next_revision(expected.private_state)?);
+    candidate
+        .bridge_state
+        .set_revision(next_revision(expected.bridge_state)?);
+    let profile = encode_profile(&candidate.profile)?;
+    let private_state = encode_private(&candidate.private_state)?;
+    let bridge = encode_bridge(&candidate.bridge_state)?;
+    install_transaction(
+        paths,
+        Some(profile.as_slice()),
+        Some(private_state.as_slice()),
+        Some(bridge.as_slice()),
+    )
+}
+
+pub fn remove_store_set(
+    paths: &OpenSubsonicPaths,
+    expected: StoreRevisions,
+) -> Result<(), StoreError> {
+    ensure_private_dir_durable(paths.root()).map_err(|_| StoreError::StorageUnavailable)?;
+    let _lock = acquire_lock(paths)?;
+    recover_locked(paths)?;
+    let current = load_locked(paths)?;
+    let actual = current
+        .as_ref()
+        .map_or(StoreRevisions::MISSING, OpenSubsonicStoreSet::revisions);
+    if actual != expected {
+        return Err(StoreError::RevisionConflict);
+    }
+    install_transaction(paths, None, None, None)
+}
+
+/// Remove the exact OpenSubsonic store artifacts after the user explicitly confirms removal.
+///
+/// This recovery path deliberately does not decode or roll forward corrupt state. It first
+/// validates every existing target as a current-user-only regular file while holding the store
+/// lock, then removes only the fixed artifact inventory. The commit marker goes first so a crash
+/// cannot resurrect staged credentials on the next startup.
+pub fn reset_store_set(paths: &OpenSubsonicPaths) -> Result<(), StoreError> {
+    if !path_exists(paths.root())? {
+        return Ok(());
+    }
+    ensure_private_dir_durable(paths.root()).map_err(|_| StoreError::StorageUnavailable)?;
+    let _lock = acquire_lock(paths)?;
+    let artifacts = reset_artifacts(paths);
+    for path in artifacts {
+        match fs::symlink_metadata(path) {
+            Ok(_) => validate_owner_only_file(path).map_err(|_| StoreError::InvalidState)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return Err(StoreError::StorageUnavailable),
+        }
+    }
+    for path in artifacts {
+        remove_owner_only_file_durable(path).map_err(|_| StoreError::StorageUnavailable)?;
+    }
+    Ok(())
+}
+
+pub fn recover_store_set(paths: &OpenSubsonicPaths) -> Result<(), StoreError> {
+    if !path_exists(paths.root())? {
+        return Ok(());
+    }
+    ensure_private_dir_durable(paths.root()).map_err(|_| StoreError::StorageUnavailable)?;
+    let _lock = acquire_lock(paths)?;
+    recover_locked(paths)
+}
+
+fn next_revision(current: Option<u64>) -> Result<u64, StoreError> {
+    current
+        .unwrap_or(0)
+        .checked_add(1)
+        .ok_or(StoreError::RevisionConflict)
+}
+
+fn load_locked(paths: &OpenSubsonicPaths) -> Result<Option<OpenSubsonicStoreSet>, StoreError> {
+    let profile = read_optional(paths.profile(), MAX_PROFILE_BYTES)?;
+    let private_state = read_optional(paths.private_store(), MAX_PRIVATE_BYTES)?;
+    let bridge = read_optional(paths.bridge_store(), MAX_BRIDGE_BYTES)?;
+    match (profile, private_state, bridge) {
+        (None, None, None) => Ok(None),
+        (Some(profile), Some(private_state), Some(bridge)) => OpenSubsonicStoreSet::new(
+            decode_profile(&profile)?,
+            decode_private(&private_state)?,
+            decode_bridge(&bridge)?,
+        )
+        .map(Some),
+        _ => Err(StoreError::InvalidState),
+    }
+}
+
+fn install_transaction(
+    paths: &OpenSubsonicPaths,
+    profile: Option<&[u8]>,
+    private_state: Option<&[u8]>,
+    bridge: Option<&[u8]>,
+) -> Result<(), StoreError> {
+    cleanup_precommit(paths)?;
+    let entries = [
+        stage_candidate(paths.transaction_profile(), profile)?,
+        stage_candidate(paths.transaction_private(), private_state)?,
+        stage_candidate(paths.transaction_bridge(), bridge)?,
+    ];
+    let manifest = TransactionManifest {
+        kind: MANIFEST_KIND.to_owned(),
+        schema_version: MANIFEST_SCHEMA_VERSION,
+        entries,
+    };
+    let manifest_bytes =
+        serde_json::to_vec(&manifest).map_err(|_| StoreError::SerializationFailed)?;
+    if manifest_bytes.len() as u64 > MAX_MANIFEST_BYTES {
+        return Err(StoreError::PayloadTooLarge);
+    }
+    write_owner_only_atomic(paths.transaction_manifest(), &manifest_bytes)
+        .map_err(|_| StoreError::StorageUnavailable)?;
+    write_owner_only_atomic(paths.transaction_commit(), COMMIT_MARKER)
+        .map_err(|_| StoreError::StorageUnavailable)?;
+    #[cfg(test)]
+    if FAIL_AFTER_COMMIT_MARKER.with(|armed| armed.replace(false)) {
+        return Err(StoreError::StorageUnavailable);
+    }
+    roll_forward(paths, &manifest)
+}
+
+fn stage_candidate(path: &Path, bytes: Option<&[u8]>) -> Result<ManifestEntry, StoreError> {
+    if let Some(bytes) = bytes {
+        write_owner_only_atomic(path, bytes).map_err(|_| StoreError::StorageUnavailable)?;
+        Ok(ManifestEntry {
+            action: EntryAction::Write,
+            sha256: Some(hash(bytes)),
+        })
+    } else {
+        remove_owner_only_file_durable(path).map_err(|_| StoreError::StorageUnavailable)?;
+        Ok(ManifestEntry {
+            action: EntryAction::Delete,
+            sha256: None,
+        })
+    }
+}
+
+fn recover_locked(paths: &OpenSubsonicPaths) -> Result<(), StoreError> {
+    if !path_exists(paths.transaction_commit())? {
+        return cleanup_precommit(paths);
+    }
+    let marker = Zeroizing::new(
+        read_owner_only_limited(paths.transaction_commit(), COMMIT_MARKER.len() as u64)
+            .map_err(|_| StoreError::InvalidState)?,
+    );
+    if marker.as_slice() != COMMIT_MARKER {
+        return Err(StoreError::InvalidState);
+    }
+    let manifest_bytes = Zeroizing::new(
+        read_owner_only_limited(paths.transaction_manifest(), MAX_MANIFEST_BYTES)
+            .map_err(|_| StoreError::InvalidState)?,
+    );
+    let manifest: TransactionManifest =
+        serde_json::from_slice(&manifest_bytes).map_err(|_| StoreError::InvalidState)?;
+    validate_manifest(&manifest)?;
+    roll_forward(paths, &manifest)
+}
+
+fn roll_forward(
+    paths: &OpenSubsonicPaths,
+    manifest: &TransactionManifest,
+) -> Result<(), StoreError> {
+    let targets = [
+        (
+            paths.transaction_profile(),
+            paths.profile(),
+            MAX_PROFILE_BYTES,
+        ),
+        (
+            paths.transaction_private(),
+            paths.private_store(),
+            MAX_PRIVATE_BYTES,
+        ),
+        (
+            paths.transaction_bridge(),
+            paths.bridge_store(),
+            MAX_BRIDGE_BYTES,
+        ),
+    ];
+    for (entry, (stage, target, max_bytes)) in manifest.entries.iter().zip(targets) {
+        match entry.action {
+            EntryAction::Write => {
+                let expected = entry.sha256.as_deref().ok_or(StoreError::InvalidState)?;
+                if target_has_hash(target, max_bytes, expected) {
+                    continue;
+                }
+                let bytes = Zeroizing::new(
+                    read_owner_only_limited(stage, max_bytes)
+                        .map_err(|_| StoreError::InvalidState)?,
+                );
+                if hash(&bytes) != expected {
+                    return Err(StoreError::InvalidState);
+                }
+                write_owner_only_atomic(target, &bytes)
+                    .map_err(|_| StoreError::StorageUnavailable)?;
+                if !target_has_hash(target, max_bytes, expected) {
+                    return Err(StoreError::StorageUnavailable);
+                }
+            }
+            EntryAction::Delete => {
+                remove_owner_only_file_durable(target)
+                    .map_err(|_| StoreError::StorageUnavailable)?;
+            }
+        }
+    }
+    remove_owner_only_file_durable(paths.transaction_commit())
+        .map_err(|_| StoreError::StorageUnavailable)?;
+    cleanup_precommit(paths)
+}
+
+fn cleanup_precommit(paths: &OpenSubsonicPaths) -> Result<(), StoreError> {
+    for path in [
+        paths.transaction_profile(),
+        paths.transaction_private(),
+        paths.transaction_bridge(),
+        paths.transaction_manifest(),
+    ] {
+        remove_owner_only_file_durable(path).map_err(|_| StoreError::StorageUnavailable)?;
+    }
+    Ok(())
+}
+
+fn read_optional(path: &Path, max_bytes: u64) -> Result<Option<Zeroizing<Vec<u8>>>, StoreError> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => read_owner_only_limited(path, max_bytes)
+            .map(Zeroizing::new)
+            .map(Some)
+            .map_err(|_| StoreError::InvalidState),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(_) => Err(StoreError::StorageUnavailable),
+    }
+}
+
+fn path_exists(path: &Path) -> Result<bool, StoreError> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(_) => Err(StoreError::StorageUnavailable),
+    }
+}
+
+fn transaction_artifacts_exist(paths: &OpenSubsonicPaths) -> Result<bool, StoreError> {
+    for path in [
+        paths.transaction_profile(),
+        paths.transaction_private(),
+        paths.transaction_bridge(),
+        paths.transaction_manifest(),
+        paths.transaction_commit(),
+    ] {
+        if path_exists(path)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn reset_artifacts(paths: &OpenSubsonicPaths) -> [&Path; 8] {
+    [
+        paths.transaction_commit(),
+        paths.transaction_profile(),
+        paths.transaction_private(),
+        paths.transaction_bridge(),
+        paths.transaction_manifest(),
+        paths.profile(),
+        paths.private_store(),
+        paths.bridge_store(),
+    ]
+}
+
+fn snapshot_revisions(store_set: &Option<OpenSubsonicStoreSet>) -> StoreRevisions {
+    store_set
+        .as_ref()
+        .map_or(StoreRevisions::MISSING, OpenSubsonicStoreSet::revisions)
+}
+
+fn target_has_hash(path: &Path, max_bytes: u64, expected: &str) -> bool {
+    read_owner_only_limited(path, max_bytes).is_ok_and(|bytes| {
+        let bytes = Zeroizing::new(bytes);
+        hash(&bytes) == expected
+    })
+}
+
+fn hash(bytes: &[u8]) -> String {
+    HEXLOWER.encode(&Sha256::digest(bytes))
+}
+
+fn acquire_lock(paths: &OpenSubsonicPaths) -> Result<AdvisoryFileLock, StoreError> {
+    match try_lock_private_file(paths.transaction_lock()) {
+        Ok(Some(lock)) => Ok(lock),
+        Ok(None) => Err(StoreError::StorageBusy),
+        Err(_) => Err(StoreError::StorageUnavailable),
+    }
+}
+
+fn validate_identity(store_set: &OpenSubsonicStoreSet) -> Result<(), StoreError> {
+    let backend = store_set.profile.backend_id();
+    let account = store_set.profile.account_scope_id();
+    if store_set.private_state.backend_id() != backend
+        || store_set.private_state.account_scope_id() != account
+        || store_set.bridge_state.backend_id() != backend
+        || store_set.bridge_state.account_scope_id() != account
+        || store_set.private_state.revision() != store_set.profile.revision()
+        || store_set.bridge_state.revision() != store_set.profile.revision()
+    {
+        return Err(StoreError::InvalidState);
+    }
+    Ok(())
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TransactionManifest {
+    kind: String,
+    schema_version: u32,
+    entries: [ManifestEntry; 3],
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestEntry {
+    action: EntryAction,
+    sha256: Option<String>,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum EntryAction {
+    Write,
+    Delete,
+}
+
+fn validate_manifest(manifest: &TransactionManifest) -> Result<(), StoreError> {
+    if manifest.kind != MANIFEST_KIND || manifest.schema_version != MANIFEST_SCHEMA_VERSION {
+        return Err(StoreError::InvalidState);
+    }
+    for entry in &manifest.entries {
+        match (&entry.action, &entry.sha256) {
+            (EntryAction::Write, Some(hash))
+                if hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit()) => {}
+            (EntryAction::Delete, None) => {}
+            _ => return Err(StoreError::InvalidState),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use age::secrecy::SecretString;
+
+    use super::*;
+    use crate::open_subsonic::{
+        AccountScopeId, ConfiguredPrivateOrigin, OpenSubsonicProfile, ServerCredential,
+    };
+
+    static NEXT_ROOT: AtomicU64 = AtomicU64::new(0);
+
+    struct Fixture {
+        root: std::path::PathBuf,
+        paths: OpenSubsonicPaths,
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn fixture() -> Fixture {
+        let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "yututui-open-subsonic-store-set-{}-{id}",
+            std::process::id()
+        ));
+        crate::util::safe_fs::ensure_private_dir(&root).unwrap();
+        let paths = OpenSubsonicPaths::for_data_root(root.clone());
+        Fixture { root, paths }
+    }
+
+    fn candidate() -> OpenSubsonicStoreSet {
+        let profile = OpenSubsonicProfile::new(
+            "Server",
+            ConfiguredPrivateOrigin::new("https://music.example.test/", false).unwrap(),
+            None,
+        )
+        .unwrap();
+        let private_state = OpenSubsonicPrivateState::new(
+            profile.backend_id().clone(),
+            profile.account_scope_id().clone(),
+            ServerCredential::api_key(SecretString::from("secret".to_owned())).unwrap(),
+        );
+        let bridge_state = OpenSubsonicBridgeState::new(
+            profile.backend_id().clone(),
+            profile.account_scope_id().clone(),
+        );
+        OpenSubsonicStoreSet::new(profile, private_state, bridge_state).unwrap()
+    }
+
+    #[test]
+    fn commits_loads_and_removes_one_identity_bound_set() {
+        let fixture = fixture();
+        let mut candidate = candidate();
+        commit_store_set(&fixture.paths, StoreRevisions::MISSING, &mut candidate).unwrap();
+        let loaded = load_store_set(&fixture.paths).unwrap().unwrap();
+        assert_eq!(loaded.revisions().profile, Some(1));
+        assert_eq!(loaded.profile.backend_id(), candidate.profile.backend_id());
+        remove_store_set(&fixture.paths, loaded.revisions()).unwrap();
+        assert!(load_store_set(&fixture.paths).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_only_load_never_creates_storage_or_requires_mutation_capability() {
+        struct MutationRevokeGuard;
+        impl Drop for MutationRevokeGuard {
+            fn drop(&mut self) {
+                crate::util::safe_fs::clear_process_mutation_revoke_for_test();
+            }
+        }
+
+        let empty = fixture();
+        assert!(load_store_set(&empty.paths).unwrap().is_none());
+        assert!(!empty.paths.root().exists());
+        assert!(load_store_set_read_only(&empty.paths).unwrap().is_none());
+        assert!(!empty.paths.root().exists());
+
+        let fixture = fixture();
+        let mut candidate = candidate();
+        commit_store_set(&fixture.paths, StoreRevisions::MISSING, &mut candidate).unwrap();
+        let _guard = MutationRevokeGuard;
+        crate::util::safe_fs::revoke_process_mutations(std::sync::Arc::from("test"));
+        let loaded = load_store_set_read_only(&fixture.paths).unwrap().unwrap();
+        assert_eq!(loaded.revisions().profile, Some(1));
+    }
+
+    #[test]
+    fn read_only_load_never_publishes_a_pending_commit() {
+        let fixture = fixture();
+        let mut candidate = candidate();
+        candidate.profile.set_revision(1);
+        candidate.private_state.set_revision(1);
+        candidate.bridge_state.set_revision(1);
+        let entries = [
+            stage_candidate(
+                fixture.paths.transaction_profile(),
+                Some(&encode_profile(&candidate.profile).unwrap()),
+            )
+            .unwrap(),
+            stage_candidate(
+                fixture.paths.transaction_private(),
+                Some(&encode_private(&candidate.private_state).unwrap()),
+            )
+            .unwrap(),
+            stage_candidate(
+                fixture.paths.transaction_bridge(),
+                Some(&encode_bridge(&candidate.bridge_state).unwrap()),
+            )
+            .unwrap(),
+        ];
+        let manifest = TransactionManifest {
+            kind: MANIFEST_KIND.to_owned(),
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            entries,
+        };
+        write_owner_only_atomic(
+            fixture.paths.transaction_manifest(),
+            &serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+        write_owner_only_atomic(fixture.paths.transaction_commit(), COMMIT_MARKER).unwrap();
+
+        assert_eq!(
+            load_store_set_read_only(&fixture.paths)
+                .err()
+                .expect("pending commit must fail closed"),
+            StoreError::InvalidState
+        );
+        assert!(fixture.paths.transaction_commit().exists());
+        assert!(!fixture.paths.profile().exists());
+    }
+
+    #[test]
+    fn stale_revision_cannot_replace_a_store_set() {
+        let fixture = fixture();
+        let mut first = candidate();
+        commit_store_set(&fixture.paths, StoreRevisions::MISSING, &mut first).unwrap();
+        let mut second = candidate();
+        assert_eq!(
+            commit_store_set(&fixture.paths, StoreRevisions::MISSING, &mut second),
+            Err(StoreError::RevisionConflict)
+        );
+    }
+
+    #[test]
+    fn committed_transaction_is_rolled_forward_on_next_load() {
+        let fixture = fixture();
+        let mut candidate = candidate();
+        candidate.profile.set_revision(1);
+        candidate.private_state.set_revision(1);
+        candidate.bridge_state.set_revision(1);
+        let profile = encode_profile(&candidate.profile).unwrap();
+        let private_state = encode_private(&candidate.private_state).unwrap();
+        let bridge = encode_bridge(&candidate.bridge_state).unwrap();
+        let entries = [
+            stage_candidate(fixture.paths.transaction_profile(), Some(&profile)).unwrap(),
+            stage_candidate(fixture.paths.transaction_private(), Some(&private_state)).unwrap(),
+            stage_candidate(fixture.paths.transaction_bridge(), Some(&bridge)).unwrap(),
+        ];
+        let manifest = TransactionManifest {
+            kind: MANIFEST_KIND.to_owned(),
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            entries,
+        };
+        write_owner_only_atomic(
+            fixture.paths.transaction_manifest(),
+            &serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+        write_owner_only_atomic(fixture.paths.transaction_commit(), COMMIT_MARKER).unwrap();
+
+        assert!(load_store_set(&fixture.paths).unwrap().is_some());
+        assert!(!fixture.paths.transaction_commit().exists());
+    }
+
+    #[test]
+    fn uncommitted_staging_is_discarded_without_publishing() {
+        let fixture = fixture();
+        let candidate = candidate();
+        let profile = encode_profile(&candidate.profile).unwrap();
+        stage_candidate(fixture.paths.transaction_profile(), Some(&profile)).unwrap();
+        write_owner_only_atomic(
+            fixture.paths.transaction_manifest(),
+            br#"{"kind":"incomplete"}"#,
+        )
+        .unwrap();
+
+        assert!(load_store_set(&fixture.paths).unwrap().is_none());
+        assert!(!fixture.paths.transaction_profile().exists());
+        assert!(!fixture.paths.transaction_manifest().exists());
+    }
+
+    #[test]
+    fn mismatched_account_binding_is_rejected_before_staging() {
+        let fixture = fixture();
+        let profile = OpenSubsonicProfile::new(
+            "Server",
+            ConfiguredPrivateOrigin::new("https://music.example.test/", false).unwrap(),
+            None,
+        )
+        .unwrap();
+        let private_state = OpenSubsonicPrivateState::new(
+            profile.backend_id().clone(),
+            AccountScopeId::new("different-account").unwrap(),
+            ServerCredential::api_key(SecretString::from("secret".to_owned())).unwrap(),
+        );
+        let bridge_state = OpenSubsonicBridgeState::new(
+            profile.backend_id().clone(),
+            profile.account_scope_id().clone(),
+        );
+        assert!(OpenSubsonicStoreSet::new(profile, private_state, bridge_state).is_err());
+        assert!(load_store_set(&fixture.paths).unwrap().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn installed_files_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let fixture = fixture();
+        let mut candidate = candidate();
+        commit_store_set(&fixture.paths, StoreRevisions::MISSING, &mut candidate).unwrap();
+        for path in [
+            fixture.paths.profile(),
+            fixture.paths.private_store(),
+            fixture.paths.bridge_store(),
+        ] {
+            assert_eq!(
+                std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+}

--- a/src/open_subsonic/wire.rs
+++ b/src/open_subsonic/wire.rs
@@ -1,0 +1,685 @@
+//! Tolerant, allocation-bounded OpenSubsonic JSON wire models.
+//!
+//! Unknown server fields are intentionally ignored. Every server-controlled sequence is rejected
+//! at its first excess item while serde is consuming it, before a large `Vec` can be allocated.
+
+use std::fmt;
+use std::marker::PhantomData;
+
+use serde::de::{DeserializeSeed, Error as _, IgnoredAny, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+
+const MAX_WIRE_PAGE_ROWS: usize = 200;
+const MAX_WIRE_NESTED_ROWS: usize = 20_000;
+const MAX_WIRE_ARTIST_INDEXES: usize = 256;
+const MAX_WIRE_CHILD_ARTISTS: usize = 32;
+const MAX_WIRE_EXTENSIONS: usize = 256;
+const MAX_WIRE_EXTENSION_VERSIONS: usize = 32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WireError {
+    InvalidResponse,
+    ApiFailure(Option<i32>),
+}
+
+#[derive(Deserialize)]
+pub(crate) struct Envelope {
+    #[serde(rename = "subsonic-response")]
+    pub response: RawResponse,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RawResponse {
+    pub status: String,
+    pub version: Option<String>,
+    #[serde(rename = "type")]
+    pub server_type: Option<String>,
+    pub server_version: Option<String>,
+    pub open_subsonic: Option<bool>,
+    pub error: Option<RawApiError>,
+    #[serde(default, deserialize_with = "deserialize_extensions")]
+    pub open_subsonic_extensions: Vec<RawExtension>,
+    pub search_result3: Option<RawSearchResult3>,
+    pub album_list2: Option<RawAlbumList>,
+    pub artists: Option<RawArtists>,
+    pub playlists: Option<RawPlaylists>,
+    pub playlist: Option<RawPlaylist>,
+    pub album: Option<RawAlbumWithSongs>,
+    pub artist: Option<RawArtistWithAlbums>,
+}
+
+impl RawResponse {
+    pub(crate) fn ensure_ok(&self) -> Result<(), WireError> {
+        if self.status == "ok" {
+            Ok(())
+        } else {
+            Err(WireError::ApiFailure(
+                self.error.as_ref().and_then(|error| error.code),
+            ))
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub(crate) struct RawApiError {
+    pub code: Option<i32>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct RawExtension {
+    pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_extension_versions")]
+    pub versions: Vec<u32>,
+}
+
+#[derive(Default, Deserialize)]
+pub(crate) struct RawSearchResult3 {
+    #[serde(default, deserialize_with = "deserialize_page_children")]
+    pub song: Vec<RawChild>,
+}
+
+#[derive(Default, Deserialize)]
+pub(crate) struct RawAlbumList {
+    #[serde(default, deserialize_with = "deserialize_page_albums")]
+    pub album: Vec<RawAlbum>,
+}
+
+#[derive(Default, Deserialize)]
+pub(crate) struct RawArtists {
+    #[serde(default, deserialize_with = "deserialize_artist_indexes")]
+    pub index: Vec<RawArtistIndex>,
+}
+
+#[derive(Default)]
+pub(crate) struct RawArtistIndex {
+    pub artist: Vec<RawArtist>,
+}
+
+#[derive(Default, Deserialize)]
+pub(crate) struct RawPlaylists {
+    #[serde(default, deserialize_with = "deserialize_nested_playlists")]
+    pub playlist: Vec<RawPlaylistSummary>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RawPlaylist {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub owner: Option<String>,
+    pub song_count: Option<u64>,
+    pub duration: Option<u64>,
+    pub public: Option<bool>,
+    pub cover_art: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_nested_children")]
+    pub entry: Vec<RawChild>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RawPlaylistSummary {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub owner: Option<String>,
+    pub song_count: Option<u64>,
+    pub duration: Option<u64>,
+    pub public: Option<bool>,
+    pub cover_art: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RawAlbumWithSongs {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub artist: Option<String>,
+    pub artist_id: Option<String>,
+    pub song_count: Option<u64>,
+    pub duration: Option<u64>,
+    pub year: Option<u64>,
+    pub cover_art: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_nested_children")]
+    pub song: Vec<RawChild>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RawArtistWithAlbums {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub album_count: Option<u64>,
+    pub cover_art: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_nested_albums")]
+    pub album: Vec<RawAlbum>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RawChild {
+    pub id: Option<String>,
+    pub is_dir: Option<bool>,
+    pub title: Option<String>,
+    pub album: Option<String>,
+    pub artist: Option<String>,
+    pub track: Option<u64>,
+    pub year: Option<u64>,
+    pub cover_art: Option<String>,
+    pub content_type: Option<String>,
+    pub suffix: Option<String>,
+    pub duration: Option<u64>,
+    pub disc_number: Option<u64>,
+    pub album_id: Option<String>,
+    #[serde(rename = "type")]
+    pub media_type: Option<String>,
+    pub user_rating: Option<i64>,
+    pub starred: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_child_artists")]
+    pub artists: Vec<RawNamedId>,
+}
+
+#[derive(Default, Deserialize)]
+pub(crate) struct RawNamedId {
+    pub name: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RawAlbum {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub title: Option<String>,
+    pub artist: Option<String>,
+    pub artist_id: Option<String>,
+    pub song_count: Option<u64>,
+    pub duration: Option<u64>,
+    pub year: Option<u64>,
+    pub cover_art: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RawArtist {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub album_count: Option<u64>,
+    pub cover_art: Option<String>,
+}
+
+fn deserialize_bounded_vec<'de, D, T, const LIMIT: usize>(
+    deserializer: D,
+) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    struct BoundedVecVisitor<T, const LIMIT: usize>(PhantomData<T>);
+
+    impl<'de, T, const LIMIT: usize> Visitor<'de> for BoundedVecVisitor<T, LIMIT>
+    where
+        T: Deserialize<'de>,
+    {
+        type Value = Vec<T>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a bounded sequence")
+        }
+
+        fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            let mut values = Vec::with_capacity(sequence.size_hint().unwrap_or(0).min(LIMIT));
+            while values.len() < LIMIT {
+                let Some(value) = sequence.next_element()? else {
+                    return Ok(values);
+                };
+                values.push(value);
+            }
+            if sequence.next_element::<IgnoredAny>()?.is_some() {
+                return Err(A::Error::custom("sequence exceeds its item limit"));
+            }
+            Ok(values)
+        }
+    }
+
+    deserializer.deserialize_seq(BoundedVecVisitor::<T, LIMIT>(PhantomData))
+}
+
+macro_rules! bounded_sequence {
+    ($function:ident, $item:ty, $limit:expr) => {
+        fn $function<'de, D>(deserializer: D) -> Result<Vec<$item>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_bounded_vec::<D, $item, $limit>(deserializer)
+        }
+    };
+}
+
+bounded_sequence!(deserialize_extensions, RawExtension, MAX_WIRE_EXTENSIONS);
+bounded_sequence!(
+    deserialize_extension_versions,
+    u32,
+    MAX_WIRE_EXTENSION_VERSIONS
+);
+bounded_sequence!(deserialize_page_children, RawChild, MAX_WIRE_PAGE_ROWS);
+bounded_sequence!(deserialize_page_albums, RawAlbum, MAX_WIRE_PAGE_ROWS);
+bounded_sequence!(
+    deserialize_nested_playlists,
+    RawPlaylistSummary,
+    MAX_WIRE_NESTED_ROWS
+);
+bounded_sequence!(deserialize_nested_children, RawChild, MAX_WIRE_NESTED_ROWS);
+bounded_sequence!(deserialize_nested_albums, RawAlbum, MAX_WIRE_NESTED_ROWS);
+bounded_sequence!(
+    deserialize_child_artists,
+    RawNamedId,
+    MAX_WIRE_CHILD_ARTISTS
+);
+
+fn deserialize_artist_indexes<'de, D>(deserializer: D) -> Result<Vec<RawArtistIndex>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ArtistVecSeed<'a> {
+        remaining: &'a mut usize,
+    }
+
+    impl<'de> DeserializeSeed<'de> for ArtistVecSeed<'_> {
+        type Value = Vec<RawArtist>;
+
+        fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct ArtistVecVisitor<'a> {
+                remaining: &'a mut usize,
+            }
+
+            impl<'de> Visitor<'de> for ArtistVecVisitor<'_> {
+                type Value = Vec<RawArtist>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("an artist sequence within the shared row limit")
+                }
+
+                fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+                where
+                    A: SeqAccess<'de>,
+                {
+                    let capacity = sequence.size_hint().unwrap_or(0).min(*self.remaining);
+                    let mut artists = Vec::with_capacity(capacity);
+                    while *self.remaining > 0 {
+                        let Some(artist) = sequence.next_element()? else {
+                            return Ok(artists);
+                        };
+                        artists.push(artist);
+                        *self.remaining -= 1;
+                    }
+                    if sequence.next_element::<IgnoredAny>()?.is_some() {
+                        return Err(A::Error::custom(
+                            "artist sequences exceed their shared row limit",
+                        ));
+                    }
+                    Ok(artists)
+                }
+            }
+
+            deserializer.deserialize_seq(ArtistVecVisitor {
+                remaining: self.remaining,
+            })
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum ArtistIndexField {
+        Artist,
+        Other,
+    }
+
+    impl<'de> Deserialize<'de> for ArtistIndexField {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct ArtistIndexFieldVisitor;
+
+            impl<'de> Visitor<'de> for ArtistIndexFieldVisitor {
+                type Value = ArtistIndexField;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("an artist index field")
+                }
+
+                fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    Ok(if value == "artist" {
+                        ArtistIndexField::Artist
+                    } else {
+                        ArtistIndexField::Other
+                    })
+                }
+            }
+
+            deserializer.deserialize_identifier(ArtistIndexFieldVisitor)
+        }
+    }
+
+    struct ArtistIndexSeed<'a> {
+        remaining: &'a mut usize,
+    }
+
+    impl<'de> DeserializeSeed<'de> for ArtistIndexSeed<'_> {
+        type Value = RawArtistIndex;
+
+        fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct ArtistIndexVisitor<'a> {
+                remaining: &'a mut usize,
+            }
+
+            impl<'de> Visitor<'de> for ArtistIndexVisitor<'_> {
+                type Value = RawArtistIndex;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("an artist index object")
+                }
+
+                fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+                where
+                    A: MapAccess<'de>,
+                {
+                    let mut artists = None;
+                    while let Some(field) = map.next_key::<ArtistIndexField>()? {
+                        match field {
+                            ArtistIndexField::Artist => {
+                                if artists.is_some() {
+                                    return Err(A::Error::duplicate_field("artist"));
+                                }
+                                artists = Some(map.next_value_seed(ArtistVecSeed {
+                                    remaining: self.remaining,
+                                })?);
+                            }
+                            ArtistIndexField::Other => {
+                                map.next_value::<IgnoredAny>()?;
+                            }
+                        }
+                    }
+                    Ok(RawArtistIndex {
+                        artist: artists.unwrap_or_default(),
+                    })
+                }
+            }
+
+            deserializer.deserialize_map(ArtistIndexVisitor {
+                remaining: self.remaining,
+            })
+        }
+    }
+
+    struct ArtistIndexesVisitor;
+
+    impl<'de> Visitor<'de> for ArtistIndexesVisitor {
+        type Value = Vec<RawArtistIndex>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a bounded artist index sequence")
+        }
+
+        fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            let mut indexes = Vec::with_capacity(
+                sequence
+                    .size_hint()
+                    .unwrap_or(0)
+                    .min(MAX_WIRE_ARTIST_INDEXES),
+            );
+            let mut remaining = MAX_WIRE_NESTED_ROWS;
+            while indexes.len() < MAX_WIRE_ARTIST_INDEXES {
+                let Some(index) = sequence.next_element_seed(ArtistIndexSeed {
+                    remaining: &mut remaining,
+                })?
+                else {
+                    return Ok(indexes);
+                };
+                indexes.push(index);
+            }
+            if sequence.next_element::<IgnoredAny>()?.is_some() {
+                return Err(A::Error::custom("artist index sequence exceeds its limit"));
+            }
+            Ok(indexes)
+        }
+    }
+
+    deserializer.deserialize_seq(ArtistIndexesVisitor)
+}
+
+pub(crate) fn decode(bytes: &[u8]) -> Result<RawResponse, WireError> {
+    let envelope: Envelope =
+        serde_json::from_slice(bytes).map_err(|_| WireError::InvalidResponse)?;
+    envelope.response.ensure_ok()?;
+    Ok(envelope.response)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[test]
+    fn extension_array_and_unknown_fields_are_accepted() {
+        let response = decode(
+            br#"{
+                "subsonic-response": {
+                    "status": "ok",
+                    "version": "1.16.1",
+                    "futureField": {"anything": true},
+                    "openSubsonicExtensions": [
+                        {"name":"formPost","versions":[1],"future":true}
+                    ]
+                }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(response.open_subsonic_extensions.len(), 1);
+        assert_eq!(
+            response.open_subsonic_extensions[0].name.as_deref(),
+            Some("formPost")
+        );
+    }
+
+    #[test]
+    fn failed_envelope_is_not_treated_as_http_success() {
+        assert!(matches!(
+            decode(
+                br#"{"subsonic-response":{"status":"failed","error":{"code":40,"message":"bad"}}}"#
+            ),
+            Err(WireError::ApiFailure(Some(40)))
+        ));
+    }
+
+    #[test]
+    fn server_controlled_sequences_at_their_limits_are_accepted() {
+        let songs = std::iter::repeat_n("{}", MAX_WIRE_PAGE_ROWS - 1)
+            .collect::<Vec<_>>()
+            .join(",");
+        let artists = std::iter::repeat_n(r#"{"name":"artist"}"#, MAX_WIRE_CHILD_ARTISTS)
+            .collect::<Vec<_>>()
+            .join(",");
+        let extensions = (0..MAX_WIRE_EXTENSIONS)
+            .map(|index| {
+                format!(r#"{{"name":"ext{index}","versions":[{}]}}"#, {
+                    std::iter::repeat_n("1", MAX_WIRE_EXTENSION_VERSIONS)
+                        .collect::<Vec<_>>()
+                        .join(",")
+                })
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        let payload = format!(
+            r#"{{
+                "subsonic-response": {{
+                    "status": "ok",
+                    "openSubsonicExtensions": [{extensions}],
+                    "searchResult3": {{
+                        "song": [{{"id":"kept","artists":[{artists}]}},{songs}]
+                    }}
+                }}
+            }}"#
+        );
+        let response = decode(payload.as_bytes()).unwrap();
+        assert_eq!(response.open_subsonic_extensions.len(), MAX_WIRE_EXTENSIONS);
+        assert!(
+            response
+                .open_subsonic_extensions
+                .iter()
+                .all(|extension| extension.versions.len() <= MAX_WIRE_EXTENSION_VERSIONS)
+        );
+        let songs = response.search_result3.unwrap().song;
+        assert_eq!(songs.len(), MAX_WIRE_PAGE_ROWS);
+        assert_eq!(songs[0].artists.len(), MAX_WIRE_CHILD_ARTISTS);
+    }
+
+    #[test]
+    fn bounded_vec_stops_typed_deserialization_at_limit_plus_one() {
+        static DESERIALIZED: AtomicUsize = AtomicUsize::new(0);
+
+        struct Counted;
+
+        impl<'de> Deserialize<'de> for Counted {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                DESERIALIZED.fetch_add(1, Ordering::SeqCst);
+                IgnoredAny::deserialize(deserializer)?;
+                Ok(Self)
+            }
+        }
+
+        DESERIALIZED.store(0, Ordering::SeqCst);
+        let mut decoder = serde_json::Deserializer::from_str("[{},{},{},{},{}]");
+        assert!(deserialize_bounded_vec::<_, Counted, 2>(&mut decoder).is_err());
+        assert_eq!(DESERIALIZED.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn oversized_sequences_within_response_cap_fail_closed() {
+        let payloads = [
+            format!(
+                r#"{{"subsonic-response":{{"status":"ok","searchResult3":{{"song":[{}]}}}}}}"#,
+                std::iter::repeat_n("{}", MAX_WIRE_PAGE_ROWS + 1)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
+            format!(
+                r#"{{"subsonic-response":{{"status":"ok","openSubsonicExtensions":[{}]}}}}"#,
+                std::iter::repeat_n("{}", MAX_WIRE_EXTENSIONS + 1)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
+            format!(
+                r#"{{"subsonic-response":{{"status":"ok","searchResult3":{{"song":[{{"artists":[{}]}}]}}}}}}"#,
+                std::iter::repeat_n("{}", MAX_WIRE_CHILD_ARTISTS + 1)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
+            format!(
+                r#"{{"subsonic-response":{{"status":"ok","playlists":{{"playlist":[{}]}}}}}}"#,
+                std::iter::repeat_n("{}", MAX_WIRE_NESTED_ROWS + 1)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
+        ];
+
+        for payload in payloads {
+            assert!(payload.len() < 8 * 1024 * 1024);
+            assert!(matches!(
+                decode(payload.as_bytes()),
+                Err(WireError::InvalidResponse)
+            ));
+        }
+    }
+
+    #[test]
+    fn nested_artist_indexes_accept_exact_shared_total_budget() {
+        let first = std::iter::repeat_n(r#"{"id":"a"}"#, 12_000)
+            .collect::<Vec<_>>()
+            .join(",");
+        let second = std::iter::repeat_n(r#"{"id":"b"}"#, 8_000)
+            .collect::<Vec<_>>()
+            .join(",");
+        let payload = format!(
+            r#"{{
+                "subsonic-response": {{
+                    "status": "ok",
+                    "artists": {{
+                        "index": [
+                            {{"artist":[{first}]}},
+                            {{"artist":[{second}]}}
+                        ]
+                    }}
+                }}
+            }}"#
+        );
+        let indexes = decode(payload.as_bytes()).unwrap().artists.unwrap().index;
+        assert_eq!(
+            indexes
+                .iter()
+                .map(|index| index.artist.len())
+                .sum::<usize>(),
+            MAX_WIRE_NESTED_ROWS
+        );
+    }
+
+    #[test]
+    fn nested_artist_indexes_reject_shared_total_limit_plus_one() {
+        let first = std::iter::repeat_n(r#"{"id":"a"}"#, 12_000)
+            .collect::<Vec<_>>()
+            .join(",");
+        let second = std::iter::repeat_n(r#"{"id":"b"}"#, 8_001)
+            .collect::<Vec<_>>()
+            .join(",");
+        let payload = format!(
+            r#"{{
+                "subsonic-response": {{
+                    "status": "ok",
+                    "artists": {{
+                        "index": [
+                            {{"artist":[{first}]}},
+                            {{"artist":[{second}]}}
+                        ]
+                    }}
+                }}
+            }}"#
+        );
+        assert!(payload.len() < 8 * 1024 * 1024);
+        assert!(matches!(
+            decode(payload.as_bytes()),
+            Err(WireError::InvalidResponse)
+        ));
+    }
+
+    #[test]
+    fn artist_index_count_rejects_limit_plus_one_without_typed_excess() {
+        let indexes = std::iter::repeat_n(r#"{"artist":[]}"#, MAX_WIRE_ARTIST_INDEXES + 1)
+            .collect::<Vec<_>>()
+            .join(",");
+        let payload = format!(
+            r#"{{"subsonic-response":{{"status":"ok","artists":{{"index":[{indexes}]}}}}}}"#
+        );
+        assert!(payload.len() < 8 * 1024 * 1024);
+        assert!(matches!(
+            decode(payload.as_bytes()),
+            Err(WireError::InvalidResponse)
+        ));
+    }
+}

--- a/src/personal_state/legacy.rs
+++ b/src/personal_state/legacy.rs
@@ -404,7 +404,13 @@ impl LegacyProjection {
 }
 
 pub(crate) fn portable_track(song: &crate::api::Song) -> PortableTrack {
-    let key = if let Some(youtube_id) = song.youtube_id() {
+    let key = if let Some(crate::api::PlayableRef::OpenSubsonic { item, .. }) = &song.playable {
+        PortableTrackKey::OpenSubsonic {
+            backend_id: item.backend_id().as_str().to_owned(),
+            account_scope_id: item.account_scope_id().as_str().to_owned(),
+            item_id: item.item_id().as_str().to_owned(),
+        }
+    } else if let Some(youtube_id) = song.youtube_id() {
         PortableTrackKey::Catalog {
             provider: "youtube".to_owned(),
             exact_catalog_id: youtube_id.to_owned(),
@@ -435,13 +441,14 @@ pub(crate) fn portable_track(song: &crate::api::Song) -> PortableTrack {
 }
 
 pub(crate) fn portable_track_to_song(track: PortableTrack) -> crate::api::Song {
-    let (video_id, source) = match &track.key {
+    let (video_id, source, playable) = match &track.key {
         PortableTrackKey::Catalog {
             provider,
             exact_catalog_id,
         } if provider == "youtube" || provider == "yt" => (
             exact_catalog_id.clone(),
             crate::search_source::SearchSource::Youtube,
+            None,
         ),
         PortableTrackKey::Catalog {
             provider,
@@ -449,25 +456,37 @@ pub(crate) fn portable_track_to_song(track: PortableTrack) -> crate::api::Song {
         } => (
             exact_catalog_id.clone(),
             source_from_provider(provider).unwrap_or_default(),
+            None,
         ),
         PortableTrackKey::OpenSubsonic {
             backend_id,
             account_scope_id,
             item_id,
-        } => (
-            format!(
-                "subsonic:{}",
-                stable_hash(&format!(
-                    "{backend_id}\u{0}{account_scope_id}\u{0}{item_id}"
-                ))
-            ),
-            crate::search_source::SearchSource::Youtube,
-        ),
+        } => {
+            use crate::open_subsonic::{AccountScopeId, BackendId, ItemId, OpenSubsonicItemRef};
+
+            let item = OpenSubsonicItemRef::new(
+                BackendId::new(backend_id.clone())
+                    .expect("validated portable OpenSubsonic backend id"),
+                AccountScopeId::new(account_scope_id.clone())
+                    .expect("validated portable OpenSubsonic account scope id"),
+                ItemId::new(item_id.clone()).expect("validated portable OpenSubsonic item id"),
+            );
+            (
+                item.stable_track_id(),
+                crate::search_source::SearchSource::OpenSubsonic,
+                Some(crate::api::PlayableRef::OpenSubsonic {
+                    item,
+                    cover_art_id: None,
+                }),
+            )
+        }
         PortableTrackKey::LocalPlaceholder {
             portable_placeholder_id,
         } => (
             format!("local-placeholder:{portable_placeholder_id}"),
             crate::search_source::SearchSource::Youtube,
+            None,
         ),
     };
     let duration = track.duration_secs.map_or_else(String::new, |seconds| {
@@ -475,6 +494,7 @@ pub(crate) fn portable_track_to_song(track: PortableTrack) -> crate::api::Song {
     });
     let mut song = crate::api::Song::remote(video_id, track.title, track.artist, duration);
     song.source = source;
+    song.playable = playable;
     song.album = track.album;
     song.duration_secs = track.duration_secs;
     song.isrc = track.isrc;

--- a/src/personal_state/model.rs
+++ b/src/personal_state/model.rs
@@ -202,7 +202,21 @@ impl PortableTrackKey {
             } => {
                 validate_id("backend id", backend_id, MAX_TRACK_ID_CHARS)?;
                 validate_id("account scope id", account_scope_id, MAX_TRACK_ID_CHARS)?;
-                validate_id("server item id", item_id, MAX_TRACK_ID_CHARS)
+                validate_id("server item id", item_id, MAX_TRACK_ID_CHARS)?;
+                crate::open_subsonic::BackendId::new(backend_id.as_str()).map_err(|_| {
+                    PersonalStateError::InvalidOperation("invalid OpenSubsonic backend identity")
+                })?;
+                crate::open_subsonic::AccountScopeId::new(account_scope_id.as_str()).map_err(
+                    |_| {
+                        PersonalStateError::InvalidOperation(
+                            "invalid OpenSubsonic account identity",
+                        )
+                    },
+                )?;
+                crate::open_subsonic::ItemId::new(item_id.as_str()).map_err(|_| {
+                    PersonalStateError::InvalidOperation("invalid OpenSubsonic item identity")
+                })?;
+                Ok(())
             }
             Self::LocalPlaceholder {
                 portable_placeholder_id,

--- a/src/personal_state/tests.rs
+++ b/src/personal_state/tests.rs
@@ -211,6 +211,77 @@ fn contradictory_legacy_rating_repairs_to_disliked() {
 }
 
 #[test]
+fn open_subsonic_legacy_projection_preserves_exact_server_identity() {
+    use crate::open_subsonic::{AccountScopeId, BackendId, ItemId, OpenSubsonicItemRef};
+
+    let item = OpenSubsonicItemRef::new(
+        BackendId::new("backend-a").unwrap(),
+        AccountScopeId::new("account-a").unwrap(),
+        ItemId::new("song-1").unwrap(),
+    );
+    let mut song = crate::api::Song::from_source(
+        crate::search_source::SearchSource::OpenSubsonic,
+        "song-1",
+        "Server title",
+        "Server artist",
+        "3:01",
+        crate::api::PlayableRef::OpenSubsonic {
+            item: item.clone(),
+            cover_art_id: None,
+        },
+    );
+    song.album = Some("Server album".to_owned());
+    song.duration_secs = Some(181);
+    song.isrc = Some("ISRC00000001".to_owned());
+
+    let portable = super::legacy::portable_track(&song);
+    assert_eq!(
+        portable.key,
+        PortableTrackKey::OpenSubsonic {
+            backend_id: "backend-a".to_owned(),
+            account_scope_id: "account-a".to_owned(),
+            item_id: "song-1".to_owned(),
+        }
+    );
+
+    let restored = super::legacy::portable_track_to_song(portable.clone());
+    assert_eq!(
+        restored.source,
+        crate::search_source::SearchSource::OpenSubsonic
+    );
+    assert_eq!(restored.video_id, item.stable_track_id());
+    assert_eq!(
+        restored.playable,
+        Some(crate::api::PlayableRef::OpenSubsonic {
+            item,
+            cover_art_id: None,
+        })
+    );
+    assert_eq!(restored.album.as_deref(), Some("Server album"));
+    assert_eq!(restored.duration_secs, Some(181));
+    assert_eq!(restored.isrc.as_deref(), Some("ISRC00000001"));
+    assert!(restored.local_path.is_none());
+    assert!(restored.origin_url.is_none());
+    assert_eq!(super::legacy::portable_track(&restored), portable);
+}
+
+#[test]
+fn portable_open_subsonic_identity_rejects_oversized_multibyte_ids() {
+    let key = PortableTrackKey::OpenSubsonic {
+        backend_id: "界".repeat(200),
+        account_scope_id: "account".to_owned(),
+        item_id: "song".to_owned(),
+    };
+
+    assert!(matches!(
+        key.validate(),
+        Err(PersonalStateError::InvalidOperation(
+            "invalid OpenSubsonic backend identity"
+        ))
+    ));
+}
+
+#[test]
 fn validation_rejects_private_claims_and_deserialized_identifier_bypasses() {
     let mut state = PersonalStateV2::empty("dataset".to_owned()).unwrap();
     state.metadata.filesystem_paths_included = true;

--- a/src/playback_target.rs
+++ b/src/playback_target.rs
@@ -1,6 +1,9 @@
 //! Transport-neutral validation for playback targets before they cross into a player backend.
 
+use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use reqwest::header::{LOCATION, RANGE};
@@ -9,9 +12,326 @@ use reqwest::{Method, StatusCode, Url};
 use crate::search_source::SearchSource;
 
 pub(crate) const MAX_PLAYABLE_URL_BYTES: usize = 4096;
+const MIN_ROUTE_TOKEN_BYTES: usize = 22;
+const MAX_ROUTE_TOKEN_BYTES: usize = 128;
 const DNS_TIMEOUT: Duration = Duration::from_secs(3);
 const PROBE_TIMEOUT: Duration = Duration::from_secs(4);
 const MAX_REDIRECTS: usize = 5;
+
+/// A playable destination whose credentials remain owned by an in-process provider.
+///
+/// The player transport deliberately sees only portable identifiers. It cannot construct an
+/// upstream URL or read credentials; a configured [`PlaybackRouteProvider`] must exchange this
+/// reference for one sealed loopback route after the load has passed player admission.
+#[derive(Clone, Eq, Hash, PartialEq)]
+pub enum CredentialedPlaybackRef {
+    OpenSubsonic {
+        backend_id: String,
+        account_scope_id: String,
+        item_id: String,
+    },
+}
+
+impl std::fmt::Debug for CredentialedPlaybackRef {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OpenSubsonic { .. } => formatter.write_str("OpenSubsonic(..)"),
+        }
+    }
+}
+
+/// A direct local/public target or a credential-owning provider reference.
+#[derive(Clone, Eq, PartialEq)]
+pub enum PlaybackDestination {
+    Direct(String),
+    Credentialed(CredentialedPlaybackRef),
+}
+
+impl PlaybackDestination {
+    pub fn direct(target: impl Into<String>) -> Self {
+        Self::Direct(target.into())
+    }
+
+    pub fn direct_target(&self) -> Option<&str> {
+        match self {
+            Self::Direct(target) => Some(target),
+            Self::Credentialed(_) => None,
+        }
+    }
+
+    pub fn credentialed_target(&self) -> Option<&CredentialedPlaybackRef> {
+        match self {
+            Self::Direct(_) => None,
+            Self::Credentialed(target) => Some(target),
+        }
+    }
+}
+
+impl From<String> for PlaybackDestination {
+    fn from(target: String) -> Self {
+        Self::Direct(target)
+    }
+}
+
+impl From<&str> for PlaybackDestination {
+    fn from(target: &str) -> Self {
+        Self::Direct(target.to_owned())
+    }
+}
+
+impl std::fmt::Debug for PlaybackDestination {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Direct(_) => formatter.write_str("Direct(<redacted>)"),
+            Self::Credentialed(target) => {
+                formatter.debug_tuple("Credentialed").field(target).finish()
+            }
+        }
+    }
+}
+
+/// Stable, URL-free reason returned by a route provider.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PlaybackRouteError {
+    reason: &'static str,
+}
+
+impl PlaybackRouteError {
+    pub const fn new(reason: &'static str) -> Self {
+        Self { reason }
+    }
+
+    pub const fn reason(self) -> &'static str {
+        self.reason
+    }
+}
+
+impl std::fmt::Display for PlaybackRouteError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.reason)
+    }
+}
+
+impl std::error::Error for PlaybackRouteError {}
+
+/// Immediate, idempotent revocation boundary for one local playback episode.
+pub trait PlaybackRouteRevocation: Send + Sync {
+    fn revoke(&self);
+}
+
+/// RAII ownership of one provider route. Dropping any pending or active load closes the route.
+pub struct PlaybackRouteLease {
+    revocation: Arc<dyn PlaybackRouteRevocation>,
+}
+
+impl PlaybackRouteLease {
+    pub fn new(revocation: Arc<dyn PlaybackRouteRevocation>) -> Self {
+        Self { revocation }
+    }
+
+    pub fn revoke(self) {
+        self.revocation.revoke();
+    }
+
+    pub(crate) fn revocation_handle(&self) -> PlaybackRouteRevocationHandle {
+        PlaybackRouteRevocationHandle {
+            revocation: Arc::clone(&self.revocation),
+        }
+    }
+}
+
+impl std::fmt::Debug for PlaybackRouteLease {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("PlaybackRouteLease(<redacted>)")
+    }
+}
+
+impl Drop for PlaybackRouteLease {
+    fn drop(&mut self) {
+        self.revocation.revoke();
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PlaybackRouteRevocationHandle {
+    revocation: Arc<dyn PlaybackRouteRevocation>,
+}
+
+impl PlaybackRouteRevocationHandle {
+    pub(crate) fn revoke(&self) {
+        self.revocation.revoke();
+    }
+}
+
+impl std::fmt::Debug for PlaybackRouteRevocationHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("PlaybackRouteRevocationHandle(<redacted>)")
+    }
+}
+
+/// A provider-minted route accepted only through this opaque constructor.
+pub struct RoutedPlayback {
+    port: u16,
+    token: String,
+    lease: PlaybackRouteLease,
+}
+
+impl RoutedPlayback {
+    pub fn new(
+        port: u16,
+        token: String,
+        lease: PlaybackRouteLease,
+    ) -> Result<Self, PlaybackRouteError> {
+        if port == 0
+            || !(MIN_ROUTE_TOKEN_BYTES..=MAX_ROUTE_TOKEN_BYTES).contains(&token.len())
+            || !token
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        {
+            return Err(PlaybackRouteError::new("invalid_local_route"));
+        }
+        Ok(Self { port, token, lease })
+    }
+
+    pub(crate) fn into_parts(self) -> (SealedLoopbackUrl, PlaybackRouteLease) {
+        (
+            SealedLoopbackUrl(format!(
+                "http://127.0.0.1:{}/stream/{}",
+                self.port, self.token
+            )),
+            self.lease,
+        )
+    }
+}
+
+impl std::fmt::Debug for RoutedPlayback {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("RoutedPlayback(<redacted>)")
+    }
+}
+
+/// URL accepted only after a route provider supplied validated loopback coordinates.
+pub(crate) struct SealedLoopbackUrl(String);
+
+impl SealedLoopbackUrl {
+    pub(crate) fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl std::fmt::Debug for SealedLoopbackUrl {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("SealedLoopbackUrl(<redacted>)")
+    }
+}
+
+pub type PlaybackRouteFuture =
+    Pin<Box<dyn Future<Output = Result<RoutedPlayback, PlaybackRouteError>> + Send + 'static>>;
+
+pub trait PlaybackRouteProvider: Send + Sync {
+    fn open_route(
+        &self,
+        target: CredentialedPlaybackRef,
+        file_generation: u64,
+    ) -> PlaybackRouteFuture;
+}
+
+#[derive(Clone)]
+pub struct PlaybackRouteProviderHandle {
+    provider: Arc<dyn PlaybackRouteProvider>,
+}
+
+impl PlaybackRouteProviderHandle {
+    pub fn new(provider: Arc<dyn PlaybackRouteProvider>) -> Self {
+        Self { provider }
+    }
+
+    pub fn disabled() -> Self {
+        Self::new(Arc::new(DisabledPlaybackRouteProvider))
+    }
+
+    pub(crate) fn open_route(
+        &self,
+        target: CredentialedPlaybackRef,
+        file_generation: u64,
+    ) -> PlaybackRouteFuture {
+        self.provider.open_route(target, file_generation)
+    }
+}
+
+impl std::fmt::Debug for PlaybackRouteProviderHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("PlaybackRouteProviderHandle(<redacted>)")
+    }
+}
+
+/// Stable player-facing provider whose credential-owning backend can be replaced by its owner.
+///
+/// The player keeps this forwarding handle across server setup, removal, and transport restarts.
+/// A route request snapshots exactly one provider; replacing the slot cannot splice credentials
+/// or URLs between two profiles. The retired runtime separately revokes every route it minted.
+#[derive(Clone)]
+pub(crate) struct PlaybackRouteProviderSlot {
+    provider: Arc<RwLock<PlaybackRouteProviderHandle>>,
+}
+
+impl Default for PlaybackRouteProviderSlot {
+    fn default() -> Self {
+        Self {
+            provider: Arc::new(RwLock::new(PlaybackRouteProviderHandle::disabled())),
+        }
+    }
+}
+
+impl PlaybackRouteProviderSlot {
+    pub(crate) fn handle(&self) -> PlaybackRouteProviderHandle {
+        PlaybackRouteProviderHandle::new(Arc::new(self.clone()))
+    }
+
+    pub(crate) fn install(&self, provider: PlaybackRouteProviderHandle) {
+        *self
+            .provider
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = provider;
+    }
+
+    pub(crate) fn disable(&self) {
+        self.install(PlaybackRouteProviderHandle::disabled());
+    }
+}
+
+impl PlaybackRouteProvider for PlaybackRouteProviderSlot {
+    fn open_route(
+        &self,
+        target: CredentialedPlaybackRef,
+        file_generation: u64,
+    ) -> PlaybackRouteFuture {
+        let provider = self
+            .provider
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        provider.open_route(target, file_generation)
+    }
+}
+
+impl std::fmt::Debug for PlaybackRouteProviderSlot {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("PlaybackRouteProviderSlot(<redacted>)")
+    }
+}
+
+struct DisabledPlaybackRouteProvider;
+
+impl PlaybackRouteProvider for DisabledPlaybackRouteProvider {
+    fn open_route(
+        &self,
+        _target: CredentialedPlaybackRef,
+        _file_generation: u64,
+    ) -> PlaybackRouteFuture {
+        Box::pin(async { Err(PlaybackRouteError::new("route_provider_unavailable")) })
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PlayableUrlError {
@@ -366,6 +686,99 @@ mod tests {
     use std::net::IpAddr;
 
     use super::*;
+
+    struct NoopRevocation;
+
+    impl PlaybackRouteRevocation for NoopRevocation {
+        fn revoke(&self) {}
+    }
+
+    fn lease() -> PlaybackRouteLease {
+        PlaybackRouteLease::new(Arc::new(NoopRevocation))
+    }
+
+    struct FixedRouteProvider;
+
+    impl PlaybackRouteProvider for FixedRouteProvider {
+        fn open_route(
+            &self,
+            _target: CredentialedPlaybackRef,
+            _file_generation: u64,
+        ) -> PlaybackRouteFuture {
+            Box::pin(async { RoutedPlayback::new(32123, "a".repeat(32), lease()) })
+        }
+    }
+
+    fn credentialed_target() -> CredentialedPlaybackRef {
+        CredentialedPlaybackRef::OpenSubsonic {
+            backend_id: "backend".to_owned(),
+            account_scope_id: "account".to_owned(),
+            item_id: "item".to_owned(),
+        }
+    }
+
+    #[tokio::test]
+    async fn provider_slot_switches_atomically_between_disabled_and_live() {
+        let slot = PlaybackRouteProviderSlot::default();
+        let player_handle = slot.handle();
+        assert!(
+            player_handle
+                .open_route(credentialed_target(), 1)
+                .await
+                .is_err()
+        );
+
+        slot.install(PlaybackRouteProviderHandle::new(Arc::new(
+            FixedRouteProvider,
+        )));
+        let route = player_handle
+            .open_route(credentialed_target(), 2)
+            .await
+            .expect("installed provider route");
+        let (url, _lease) = route.into_parts();
+        assert_eq!(
+            url.into_string(),
+            format!("http://127.0.0.1:32123/stream/{}", "a".repeat(32))
+        );
+
+        slot.disable();
+        assert!(
+            player_handle
+                .open_route(credentialed_target(), 3)
+                .await
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn destination_debug_never_prints_a_direct_or_credentialed_identity() {
+        let direct =
+            PlaybackDestination::Direct("https://example.test/audio?token=secret".to_owned());
+        let credentialed =
+            PlaybackDestination::Credentialed(CredentialedPlaybackRef::OpenSubsonic {
+                backend_id: "backend-secret".to_owned(),
+                account_scope_id: "account-secret".to_owned(),
+                item_id: "item-secret".to_owned(),
+            });
+        assert_eq!(format!("{direct:?}"), "Direct(<redacted>)");
+        let credentialed = format!("{credentialed:?}");
+        assert!(!credentialed.contains("backend-secret"));
+        assert!(!credentialed.contains("account-secret"));
+        assert!(!credentialed.contains("item-secret"));
+    }
+
+    #[test]
+    fn sealed_route_requires_a_high_entropy_url_safe_token() {
+        assert!(RoutedPlayback::new(1234, "too-short".to_owned(), lease()).is_err());
+        assert!(
+            RoutedPlayback::new(1234, "0123456789abcdef0123456789abcdef".to_owned(), lease())
+                .is_ok()
+        );
+        assert!(
+            RoutedPlayback::new(1234, "0123456789abcdef0123456789abcde!".to_owned(), lease())
+                .is_err()
+        );
+    }
 
     #[test]
     fn blocks_special_ipv4_ranges_beyond_std_private_helpers() {

--- a/src/player/ipc.rs
+++ b/src/player/ipc.rs
@@ -19,8 +19,8 @@ use tokio::time::{Duration, sleep};
 
 use super::proto::{self, MpvIncoming};
 use super::{
-    EventSink, MediaSourceContext, PlayerCmd, PlayerEvent, SharedLongFormSeekStatus,
-    cache_runtime::CacheRuntime, pending,
+    EventSink, MediaSourceContext, PlayerCmd, PlayerEvent, RouteRevocationRegistry,
+    SharedLongFormSeekStatus, cache_runtime::CacheRuntime, pending,
 };
 use crate::player::long_form_seek::{CacheAction, CacheEffectiveState};
 
@@ -77,6 +77,10 @@ struct DispatchState {
     /// Owner-provided semantics keyed by the exact admitted file generation. Redirect children
     /// inherit the generation, while rapid replacements can never inherit the previous source.
     media_source_contexts: HashMap<u64, MediaSourceContext>,
+    /// Credential-owning loopback routes keyed by the exact physical file generation.
+    /// Removing a lease synchronously and idempotently revokes the route.
+    playback_route_leases: HashMap<u64, crate::playback_target::PlaybackRouteLease>,
+    route_revocations: Arc<RouteRevocationRegistry>,
     /// Redirect replacement ranges may be announced before the originating load reply reaches
     /// this client. Retain the relation until the old entry's generation becomes known.
     pending_redirects: HashMap<u64, (u64, u64)>,
@@ -172,6 +176,8 @@ impl Default for DispatchState {
             uncorrelated_load_restart: false,
             entry_generations: HashMap::new(),
             media_source_contexts: HashMap::new(),
+            playback_route_leases: HashMap::new(),
+            route_revocations: Arc::new(RouteRevocationRegistry::default()),
             pending_redirects: HashMap::new(),
             failed_load_generations: HashSet::new(),
             playlist_identity_mode: PlaylistIdentityMode::Unknown,
@@ -372,18 +378,34 @@ pub async fn connect_retry(path: &str) -> io::Result<Stream> {
 /// Drive one mpv connection: subscribe to progress properties, then loop forwarding
 /// mpv events to the runtime (`emit`) and writing player commands (`cmd_rx`) to mpv.
 /// Returns when mpv closes the connection or all command senders drop.
-pub(crate) async fn run_actor(
-    conn: Stream,
-    mut cmd_rx: Receiver<PlayerCmd>,
-    emit: EventSink,
-    intentional_close: Arc<AtomicBool>,
-    file_generation_rx: watch::Receiver<u64>,
-    cache_runtime: CacheRuntime,
-    cache_status: Arc<std::sync::Mutex<SharedLongFormSeekStatus>>,
-) {
+pub(super) struct ActorInput {
+    pub(super) conn: Stream,
+    pub(super) cmd_rx: Receiver<PlayerCmd>,
+    pub(super) emit: EventSink,
+    pub(super) intentional_close: Arc<AtomicBool>,
+    pub(super) file_generation_rx: watch::Receiver<u64>,
+    pub(super) route_provider: crate::playback_target::PlaybackRouteProviderHandle,
+    pub(super) route_revocations: Arc<RouteRevocationRegistry>,
+    pub(super) cache_runtime: CacheRuntime,
+    pub(super) cache_status: Arc<std::sync::Mutex<SharedLongFormSeekStatus>>,
+}
+
+pub(super) async fn run_actor(input: ActorInput) {
+    let ActorInput {
+        conn,
+        mut cmd_rx,
+        emit,
+        intentional_close,
+        file_generation_rx,
+        route_provider,
+        route_revocations,
+        cache_runtime,
+        cache_status,
+    } = input;
     let mut state = DispatchState {
         cache: Some(cache_runtime),
         cache_status: Some(cache_status),
+        route_revocations,
         ..DispatchState::default()
     };
     publish_cache_status(&mut state);
@@ -614,6 +636,7 @@ pub(crate) async fn run_actor(
                 &mut state,
                 &mut request_id,
                 &file_generation_rx,
+                &route_provider,
                 cmd,
             )
             .await
@@ -792,246 +815,16 @@ pub(crate) async fn run_actor(
 
     let barrier_error = exit.barrier_reason();
     audio_output::fail_pending_commands(&state, &emit, &barrier_error);
+    // Revocation must win before the owner observes TransportClosed and starts a replacement
+    // player whose file generation may begin at one again.
+    revoke_all_playback_routes(&mut state);
 
     // This is deliberately the actor's final action. The owner may start a replacement only
     // after processing this event, so no event from the old actor can follow the terminal one.
     finish_actor(exit, &emit);
 }
 
-async fn begin_or_dispatch_command(
-    conn: &Stream,
-    emit: &EventSink,
-    state: &mut DispatchState,
-    request_id: &mut u64,
-    file_generation_rx: &watch::Receiver<u64>,
-    cmd: PlayerCmd,
-) -> io::Result<Option<PendingLoadValidation>> {
-    if let PlayerCmd::SetLongFormSeekOptimization(requested) = &cmd {
-        let action = state
-            .cache
-            .as_mut()
-            .and_then(|cache| cache.update_requested(*requested));
-        queue_cache_action(state, action);
-        return Ok(None);
-    }
-    let load = match cmd {
-        PlayerCmd::Load(load) => Some((load.url().to_owned(), load.source_context(), None)),
-        PlayerCmd::LoadWithResume(resume) => {
-            Some((resume.url.clone(), resume.source_context, Some(resume)))
-        }
-        cmd => {
-            if matches!(cmd, PlayerCmd::Stop) {
-                state.issued_file_generation = reserve_file_generation(state);
-            }
-            dispatch_command(conn, emit, state, request_id, cmd, None).await?;
-            None
-        }
-    };
-    if let Some((url, source_context, resume)) = load {
-        *request_id = request_id.wrapping_add(1);
-        // The public handle has already admitted this generation, but the actor does not publish
-        // it as issued until validation has succeeded and `loadfile` is actually dispatched.
-        // A seek/pause that supersedes recovery validation can therefore keep using the ready
-        // current generation instead of waiting forever for a file that was never sent to mpv.
-        let file_generation = reserve_file_generation(state);
-        let load_request_id = *request_id;
-        let task = tokio::spawn(validate_load_until_superseded(
-            url,
-            file_generation,
-            file_generation_rx.clone(),
-        ));
-        return Ok(Some(PendingLoadValidation {
-            request_id: load_request_id,
-            file_generation,
-            task,
-            resume: resume::ResumeLoad::from_request(resume),
-            source_context,
-        }));
-    }
-    Ok(None)
-}
-
-fn reserve_file_generation(state: &mut DispatchState) -> u64 {
-    state.admitted_file_generation = state
-        .admitted_file_generation
-        .max(state.issued_file_generation)
-        .wrapping_add(1);
-    state.admitted_file_generation
-}
-
-async fn validate_load_until_superseded(
-    url: String,
-    file_generation: u64,
-    mut file_generation_rx: watch::Receiver<u64>,
-) -> LoadValidationOutcome {
-    let validation = crate::playback_target::validate_playback_target_for_handoff(&url);
-    tokio::pin!(validation);
-
-    loop {
-        if *file_generation_rx.borrow_and_update() > file_generation {
-            return LoadValidationOutcome::Superseded;
-        }
-        tokio::select! {
-            changed = file_generation_rx.changed() => {
-                if changed.is_err() {
-                    return LoadValidationOutcome::Superseded;
-                }
-            }
-            result = &mut validation => {
-                // An admission can race the validation future becoming ready. Re-read the
-                // watch value at the commit boundary so unbiased select fairness cannot revive
-                // a superseded URL.
-                if *file_generation_rx.borrow_and_update() > file_generation {
-                    return LoadValidationOutcome::Superseded;
-                }
-                return match result {
-                    Ok(url) => LoadValidationOutcome::Validated(url),
-                    Err(error) => {
-                        LoadValidationOutcome::Rejected(error.handoff_reason().to_owned())
-                    }
-                };
-            }
-        }
-    }
-}
-
-fn install_resume_state(
-    state: &mut DispatchState,
-    file_generation: u64,
-    request: super::recovery::LoadWithResume,
-) {
-    state.last_confirmed_time = request.position_secs;
-    state.resume.install(file_generation, request);
-}
-
-async fn dispatch_validated_load(
-    conn: &Stream,
-    state: &mut DispatchState,
-    request_id: &mut u64,
-    load: ValidatedLoad,
-) -> io::Result<()> {
-    if load
-        .resume
-        .request()
-        .is_some_and(super::recovery::LoadWithResume::forces_ram_only)
-        && let Some(cache) = state.cache.as_mut()
-    {
-        cache.force_next_media_ram_only();
-    }
-    if state.media_source_contexts.len() >= ENTRY_GENERATION_CAPACITY {
-        let oldest = state
-            .media_source_contexts
-            .keys()
-            .filter(|generation| **generation != load.file_generation)
-            .min()
-            .copied();
-        if let Some(oldest) = oldest {
-            state.media_source_contexts.remove(&oldest);
-        }
-    }
-    state
-        .media_source_contexts
-        .insert(load.file_generation, load.source_context);
-    reset_file_state(state);
-    if state.playlist_identity_mode != PlaylistIdentityMode::EntryIds
-        && state.legacy_loads.len() >= LEGACY_LOAD_CAPACITY
-    {
-        return Err(io::Error::other(
-            "legacy mpv load correlation queue saturated",
-        ));
-    }
-    let needs_identity_query = state.playlist_identity_mode != PlaylistIdentityMode::EntryIds;
-    let load_reserved =
-        remember_pending_load(state, load.request_id, load.file_generation, "loadfile");
-    let identity_request_id = if needs_identity_query {
-        *request_id = request_id.wrapping_add(1);
-        Some(*request_id)
-    } else {
-        None
-    };
-    let identity_reserved = identity_request_id.is_none_or(|identity_request_id| {
-        remember_pending_load(
-            state,
-            identity_request_id,
-            load.file_generation,
-            "loadfile identity",
-        )
-    });
-    if !load_reserved || !identity_reserved {
-        state.pending.remove(&load.request_id);
-        if let Some(identity_request_id) = identity_request_id {
-            state.pending.remove(&identity_request_id);
-        }
-        return Err(io::Error::other(
-            "mpv load identity correlation queue saturated",
-        ));
-    }
-    if load.resume.is_some() {
-        *request_id = request_id.wrapping_add(1);
-        let pause_request_id = *request_id;
-        remember_pending_command(state, pause_request_id, "recovery pre-load pause");
-        write_json(
-            conn,
-            &proto::cmd_set_property("pause", &serde_json::Value::Bool(true), pause_request_id),
-        )
-        .await?;
-    }
-    state.issued_file_generation = load.file_generation;
-    write_json(
-        conn,
-        &proto::cmd_loadfile(&load.url, "replace", load.request_id),
-    )
-    .await?;
-    if let Some(request) = load.resume.into_request() {
-        install_resume_state(state, load.file_generation, request);
-    }
-    state.legacy_latest_playlist_filename = None;
-    state.legacy_loads.push_back(LegacyLoad {
-        generation: load.file_generation,
-        url: load.url,
-        replied: false,
-    });
-
-    // mpv 0.33+ exposes stable IDs. Legacy mpv 0.32 exposes only the selected filename, so its
-    // ordered snapshot remains the barrier that distinguishes a direct rapid replacement from
-    // a redirect child. Once stable event IDs are proven, the redundant query is omitted.
-    if let Some(identity_request_id) = identity_request_id {
-        write_json(
-            conn,
-            &proto::cmd_get_property("playlist", identity_request_id),
-        )
-        .await?;
-    }
-    Ok(())
-}
-
-fn install_rejected_load_stop_boundary(state: &mut DispatchState, file_generation: u64) {
-    reset_file_state(state);
-    state.issued_file_generation = file_generation;
-    state.admitted_file_generation = state.admitted_file_generation.max(file_generation);
-    // The old physical file may emit a final stop event, but no later uncorrelated property may
-    // be presented as the rejected owner's media while the internal Stop is in flight.
-    state.active_file_generation = None;
-}
-
-async fn dispatch_rejected_load_stop(
-    conn: &Stream,
-    emit: &EventSink,
-    state: &mut DispatchState,
-    request_id: &mut u64,
-    file_generation: u64,
-) -> io::Result<()> {
-    install_rejected_load_stop_boundary(state, file_generation);
-    dispatch_command(
-        conn,
-        emit,
-        state,
-        request_id,
-        PlayerCmd::Stop,
-        Some("rejected-load stop"),
-    )
-    .await
-}
+include!("ipc/playback_routes.rs");
 
 async fn dispatch_cache_action(
     conn: &Stream,
@@ -1161,6 +954,7 @@ async fn dispatch_command(
             unreachable!("audio-output commands are routed above")
         }
         PlayerCmd::Stop => {
+            revoke_all_playback_routes(state);
             state.legacy_loads.clear();
             state.legacy_redirect_generation = None;
             state.legacy_latest_playlist_filename = None;

--- a/src/player/ipc/command_queue.rs
+++ b/src/player/ipc/command_queue.rs
@@ -10,6 +10,7 @@ struct ValidatedLoad {
     request_id: u64,
     file_generation: u64,
     url: String,
+    route_lease: Option<crate::playback_target::PlaybackRouteLease>,
     resume: resume::ResumeLoad,
     source_context: MediaSourceContext,
     wait_for_cache_reset: bool,
@@ -61,7 +62,10 @@ impl PendingLoadBoundary {
 }
 
 enum LoadValidationOutcome {
-    Validated(String),
+    Validated {
+        url: String,
+        route_lease: Option<crate::playback_target::PlaybackRouteLease>,
+    },
     Rejected(String),
     Superseded,
 }
@@ -120,6 +124,9 @@ fn accept_actor_command(
     backlog: &mut VecDeque<PlayerCmd>,
     seek_flight: &mut Option<SeekFlight>,
 ) {
+    if cmd.invalidates_file_generation() {
+        revoke_all_playback_routes(state);
+    }
     if merge_issued_pending_resume_command(state, &cmd) {
         return;
     }
@@ -239,6 +246,10 @@ fn rebase_cancelled_recovery(
     state
         .media_source_contexts
         .insert(generation, source_context);
+    if let Some(lease) = state.playback_route_leases.remove(&previous) {
+        state.playback_route_leases.insert(generation, lease);
+    }
+    state.route_revocations.rebase(previous, generation);
     if let Some(cache) = state.cache.as_mut() {
         cache.rebase_file_generation(previous, generation);
     }
@@ -246,6 +257,16 @@ fn rebase_cancelled_recovery(
         action.rebase_file_generation(previous, generation);
     }
     publish_cache_status(state);
+}
+
+fn revoke_playback_route(state: &mut DispatchState, file_generation: u64) {
+    state.route_revocations.revoke(file_generation);
+    state.playback_route_leases.remove(&file_generation);
+}
+
+fn revoke_all_playback_routes(state: &mut DispatchState) {
+    state.route_revocations.revoke_all();
+    state.playback_route_leases.clear();
 }
 
 fn supersedes_pending_resume(cmd: &PlayerCmd) -> bool {

--- a/src/player/ipc/incoming.rs
+++ b/src/player/ipc/incoming.rs
@@ -100,12 +100,13 @@ fn finish_load_validation(
     validated: LoadValidationOutcome,
 ) -> Option<PendingLoadBoundary> {
     match validated {
-        LoadValidationOutcome::Validated(url) => {
+        LoadValidationOutcome::Validated { url, route_lease } => {
             let wait_for_cache_reset = prepare_load_replacement(state);
             Some(PendingLoadBoundary::Validated(ValidatedLoad {
                 request_id: pending.request_id,
                 file_generation: pending.file_generation,
                 url,
+                route_lease,
                 resume: pending.resume,
                 source_context: pending.source_context,
                 wait_for_cache_reset,
@@ -801,8 +802,12 @@ fn dispatch_incoming(line: &str, emit: &EventSink, state: &mut DispatchState) {
             "eof-reached" if value.as_bool() == Some(true) && !state.eof_emitted => {
                 state.eof_emitted = true;
                 if let Some(generation) = state.legacy_pending_end_generation.take() {
+                    revoke_playback_route(state, generation);
                     emit(PlayerEvent::file_scoped(generation, PlayerEvent::Eof));
                 } else {
+                    if let Some(generation) = state.active_file_generation {
+                        revoke_playback_route(state, generation);
+                    }
                     emit_file_event(emit, state, PlayerEvent::Eof);
                 }
             }
@@ -922,6 +927,9 @@ fn dispatch_incoming(line: &str, emit: &EventSink, state: &mut DispatchState) {
                 );
             }
             state.resume.cancel_pending_for_generation(generation);
+            if let Some(generation) = generation {
+                revoke_playback_route(state, generation);
+            }
             let preserve_generation = generation
                 .is_some_and(|generation| generation != state.issued_file_generation)
                 .then_some(state.issued_file_generation);
@@ -1043,6 +1051,7 @@ fn dispatch_incoming(line: &str, emit: &EventSink, state: &mut DispatchState) {
                     );
                     state.failed_load_generations.insert(file_generation);
                     state.media_source_contexts.remove(&file_generation);
+                    revoke_playback_route(state, file_generation);
                     remove_legacy_load_generation(state, file_generation);
                     emit(PlayerEvent::file_scoped(
                         file_generation,

--- a/src/player/ipc/playback_routes.rs
+++ b/src/player/ipc/playback_routes.rs
@@ -1,0 +1,271 @@
+async fn begin_or_dispatch_command(
+    conn: &Stream,
+    emit: &EventSink,
+    state: &mut DispatchState,
+    request_id: &mut u64,
+    file_generation_rx: &watch::Receiver<u64>,
+    route_provider: &crate::playback_target::PlaybackRouteProviderHandle,
+    cmd: PlayerCmd,
+) -> io::Result<Option<PendingLoadValidation>> {
+    if let PlayerCmd::SetLongFormSeekOptimization(requested) = &cmd {
+        let action = state
+            .cache
+            .as_mut()
+            .and_then(|cache| cache.update_requested(*requested));
+        queue_cache_action(state, action);
+        return Ok(None);
+    }
+    let load = match cmd {
+        PlayerCmd::Load(load) => Some((load.destination().clone(), load.source_context(), None)),
+        PlayerCmd::LoadWithResume(resume) => Some((
+            resume.destination.clone(),
+            resume.source_context,
+            Some(resume),
+        )),
+        cmd => {
+            if matches!(cmd, PlayerCmd::Stop) {
+                state.issued_file_generation = reserve_file_generation(state);
+            }
+            dispatch_command(conn, emit, state, request_id, cmd, None).await?;
+            None
+        }
+    };
+    if let Some((destination, source_context, resume)) = load {
+        *request_id = request_id.wrapping_add(1);
+        // The public handle has already admitted this generation, but the actor does not publish
+        // it as issued until validation has succeeded and `loadfile` is actually dispatched.
+        // A seek/pause that supersedes recovery validation can therefore keep using the ready
+        // current generation instead of waiting forever for a file that was never sent to mpv.
+        let file_generation = reserve_file_generation(state);
+        let load_request_id = *request_id;
+        let task = tokio::spawn(validate_load_until_superseded(
+            destination,
+            file_generation,
+            file_generation_rx.clone(),
+            route_provider.clone(),
+        ));
+        return Ok(Some(PendingLoadValidation {
+            request_id: load_request_id,
+            file_generation,
+            task,
+            resume: resume::ResumeLoad::from_request(resume),
+            source_context,
+        }));
+    }
+    Ok(None)
+}
+
+fn reserve_file_generation(state: &mut DispatchState) -> u64 {
+    state.admitted_file_generation = state
+        .admitted_file_generation
+        .max(state.issued_file_generation)
+        .wrapping_add(1);
+    state.admitted_file_generation
+}
+
+async fn validate_load_until_superseded(
+    destination: crate::playback_target::PlaybackDestination,
+    file_generation: u64,
+    mut file_generation_rx: watch::Receiver<u64>,
+    route_provider: crate::playback_target::PlaybackRouteProviderHandle,
+) -> LoadValidationOutcome {
+    let validation = async move {
+        match destination {
+            crate::playback_target::PlaybackDestination::Direct(target) => {
+                crate::playback_target::validate_playback_target_for_handoff(&target)
+                    .await
+                    .map(|url| (url, None))
+                    .map_err(|error| error.handoff_reason())
+            }
+            crate::playback_target::PlaybackDestination::Credentialed(target) => route_provider
+                .open_route(target, file_generation)
+                .await
+                .map(|route| {
+                    let (url, lease) = route.into_parts();
+                    (url.into_string(), Some(lease))
+                })
+                .map_err(|error| error.reason()),
+        }
+    };
+    tokio::pin!(validation);
+
+    loop {
+        if *file_generation_rx.borrow_and_update() > file_generation {
+            return LoadValidationOutcome::Superseded;
+        }
+        tokio::select! {
+            changed = file_generation_rx.changed() => {
+                if changed.is_err() {
+                    return LoadValidationOutcome::Superseded;
+                }
+            }
+            result = &mut validation => {
+                // An admission can race the validation future becoming ready. Re-read the
+                // watch value at the commit boundary so unbiased select fairness cannot revive
+                // a superseded URL.
+                if *file_generation_rx.borrow_and_update() > file_generation {
+                    return LoadValidationOutcome::Superseded;
+                }
+                return match result {
+                    Ok((url, route_lease)) => {
+                        LoadValidationOutcome::Validated { url, route_lease }
+                    }
+                    Err(reason) => LoadValidationOutcome::Rejected(reason.to_owned()),
+                };
+            }
+        }
+    }
+}
+
+fn install_resume_state(
+    state: &mut DispatchState,
+    file_generation: u64,
+    request: super::recovery::LoadWithResume,
+) {
+    state.last_confirmed_time = request.position_secs;
+    state.resume.install(file_generation, request);
+}
+
+async fn dispatch_validated_load(
+    conn: &Stream,
+    state: &mut DispatchState,
+    request_id: &mut u64,
+    load: ValidatedLoad,
+) -> io::Result<()> {
+    if let Some(lease) = load.route_lease {
+        let installed = state
+            .route_revocations
+            .install(load.file_generation, lease.revocation_handle());
+        if !installed {
+            record_resume_outcome(
+                load.resume.owned_request(),
+                super::diagnostics::SourceRecoveryOutcome::Superseded,
+            );
+            return Ok(());
+        }
+        state
+            .playback_route_leases
+            .insert(load.file_generation, lease);
+    }
+    if load
+        .resume
+        .request()
+        .is_some_and(super::recovery::LoadWithResume::forces_ram_only)
+        && let Some(cache) = state.cache.as_mut()
+    {
+        cache.force_next_media_ram_only();
+    }
+    if state.media_source_contexts.len() >= ENTRY_GENERATION_CAPACITY {
+        let oldest = state
+            .media_source_contexts
+            .keys()
+            .filter(|generation| **generation != load.file_generation)
+            .min()
+            .copied();
+        if let Some(oldest) = oldest {
+            state.media_source_contexts.remove(&oldest);
+        }
+    }
+    state
+        .media_source_contexts
+        .insert(load.file_generation, load.source_context);
+    reset_file_state(state);
+    if state.playlist_identity_mode != PlaylistIdentityMode::EntryIds
+        && state.legacy_loads.len() >= LEGACY_LOAD_CAPACITY
+    {
+        return Err(io::Error::other(
+            "legacy mpv load correlation queue saturated",
+        ));
+    }
+    let needs_identity_query = state.playlist_identity_mode != PlaylistIdentityMode::EntryIds;
+    let load_reserved =
+        remember_pending_load(state, load.request_id, load.file_generation, "loadfile");
+    let identity_request_id = if needs_identity_query {
+        *request_id = request_id.wrapping_add(1);
+        Some(*request_id)
+    } else {
+        None
+    };
+    let identity_reserved = identity_request_id.is_none_or(|identity_request_id| {
+        remember_pending_load(
+            state,
+            identity_request_id,
+            load.file_generation,
+            "loadfile identity",
+        )
+    });
+    if !load_reserved || !identity_reserved {
+        state.pending.remove(&load.request_id);
+        if let Some(identity_request_id) = identity_request_id {
+            state.pending.remove(&identity_request_id);
+        }
+        return Err(io::Error::other(
+            "mpv load identity correlation queue saturated",
+        ));
+    }
+    if load.resume.is_some() {
+        *request_id = request_id.wrapping_add(1);
+        let pause_request_id = *request_id;
+        remember_pending_command(state, pause_request_id, "recovery pre-load pause");
+        write_json(
+            conn,
+            &proto::cmd_set_property("pause", &serde_json::Value::Bool(true), pause_request_id),
+        )
+        .await?;
+    }
+    state.issued_file_generation = load.file_generation;
+    write_json(
+        conn,
+        &proto::cmd_loadfile(&load.url, "replace", load.request_id),
+    )
+    .await?;
+    if let Some(request) = load.resume.into_request() {
+        install_resume_state(state, load.file_generation, request);
+    }
+    state.legacy_latest_playlist_filename = None;
+    state.legacy_loads.push_back(LegacyLoad {
+        generation: load.file_generation,
+        url: load.url,
+        replied: false,
+    });
+
+    // mpv 0.33+ exposes stable IDs. Legacy mpv 0.32 exposes only the selected filename, so its
+    // ordered snapshot remains the barrier that distinguishes a direct rapid replacement from
+    // a redirect child. Once stable event IDs are proven, the redundant query is omitted.
+    if let Some(identity_request_id) = identity_request_id {
+        write_json(
+            conn,
+            &proto::cmd_get_property("playlist", identity_request_id),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+fn install_rejected_load_stop_boundary(state: &mut DispatchState, file_generation: u64) {
+    reset_file_state(state);
+    state.issued_file_generation = file_generation;
+    state.admitted_file_generation = state.admitted_file_generation.max(file_generation);
+    // The old physical file may emit a final stop event, but no later uncorrelated property may
+    // be presented as the rejected owner's media while the internal Stop is in flight.
+    state.active_file_generation = None;
+}
+
+async fn dispatch_rejected_load_stop(
+    conn: &Stream,
+    emit: &EventSink,
+    state: &mut DispatchState,
+    request_id: &mut u64,
+    file_generation: u64,
+) -> io::Result<()> {
+    install_rejected_load_stop_boundary(state, file_generation);
+    dispatch_command(
+        conn,
+        emit,
+        state,
+        request_id,
+        PlayerCmd::Stop,
+        Some("rejected-load stop"),
+    )
+    .await
+}

--- a/src/player/ipc/tests.rs
+++ b/src/player/ipc/tests.rs
@@ -3,6 +3,7 @@ use super::*;
 mod audio_output;
 mod cache_facts;
 mod cache_safety;
+mod route_lifecycle;
 mod seek_dispatch;
 
 fn recovery_request(position_secs: f64, paused: bool) -> super::super::recovery::LoadWithResume {

--- a/src/player/ipc/tests/recovery_flow.rs
+++ b/src/player/ipc/tests/recovery_flow.rs
@@ -1,10 +1,17 @@
 use super::*;
 
+fn never_validated() -> LoadValidationOutcome {
+    LoadValidationOutcome::Validated {
+        url: "never".to_owned(),
+        route_lease: None,
+    }
+}
+
 #[tokio::test]
 async fn stop_cancels_a_hung_load_validation_without_reordering_prior_commands() {
     let task = tokio::spawn(async {
         std::future::pending::<()>().await;
-        LoadValidationOutcome::Validated("never".to_owned())
+        never_validated()
     });
     let mut validation = Some(PendingLoadValidation {
         request_id: 11,
@@ -31,7 +38,7 @@ async fn stop_cancels_a_hung_load_validation_without_reordering_prior_commands()
 async fn state_free_staging_does_not_guess_that_recovery_can_alias() {
     let task = tokio::spawn(async {
         std::future::pending::<()>().await;
-        LoadValidationOutcome::Validated("never".to_owned())
+        never_validated()
     });
     let mut validation = Some(PendingLoadValidation {
         request_id: 11,
@@ -93,7 +100,7 @@ async fn superseding_seek_during_recovery_validation_keeps_current_generation_di
     assert_eq!(state.issued_file_generation, 7);
     let task = tokio::spawn(async {
         std::future::pending::<()>().await;
-        LoadValidationOutcome::Validated("never".to_owned())
+        never_validated()
     });
     let mut validation = Some(PendingLoadValidation {
         request_id: 12,
@@ -167,7 +174,7 @@ async fn emergency_recovery_validation_retains_load_and_force_ram_only_after_use
     let candidate = reserve_file_generation(&mut state);
     let task = tokio::spawn(async {
         std::future::pending::<()>().await;
-        LoadValidationOutcome::Validated("never".to_owned())
+        never_validated()
     });
     let mut validation = Some(PendingLoadValidation {
         request_id: 12,
@@ -226,6 +233,7 @@ async fn validated_recovery_wait_keeps_physical_load_and_strips_only_resume_tran
         request_id: 21,
         file_generation: 8,
         url: "https://example.invalid/fresh-source".to_owned(),
+        route_lease: None,
         resume: resume::ResumeLoad::RestoreOwned(recovery_request(900.0, true)),
         source_context: super::super::super::MediaSourceContext::OnDemand,
         wait_for_cache_reset: true,
@@ -525,9 +533,12 @@ fn end_file_atomically_drops_recovery_post_load_lane_before_new_stop() {
 async fn rejected_handoff_reports_only_a_stable_media_agnostic_reason() {
     let (_generation_tx, generation_rx) = tokio::sync::watch::channel(1u64);
     let outcome = validate_load_until_superseded(
-        "https://listener:secret@example.invalid/live?token=signed-secret".to_owned(),
+        crate::playback_target::PlaybackDestination::Direct(
+            "https://listener:secret@example.invalid/live?token=signed-secret".to_owned(),
+        ),
         1,
         generation_rx,
+        crate::playback_target::PlaybackRouteProviderHandle::disabled(),
     )
     .await;
 
@@ -746,9 +757,13 @@ fn load_invalidates_in_flight_and_unsent_interactive_targets_but_keeps_exact_bar
 #[tokio::test]
 async fn admitted_new_generation_cancels_validation_before_channel_receive() {
     let (_generation_tx, generation_rx) = watch::channel(2);
-    let result =
-        validate_load_until_superseded("https://example.com/old".to_owned(), 1, generation_rx)
-            .await;
+    let result = validate_load_until_superseded(
+        crate::playback_target::PlaybackDestination::Direct("https://example.com/old".to_owned()),
+        1,
+        generation_rx,
+        crate::playback_target::PlaybackRouteProviderHandle::disabled(),
+    )
+    .await;
 
     assert!(matches!(result, LoadValidationOutcome::Superseded));
 }

--- a/src/player/ipc/tests/route_lifecycle.rs
+++ b/src/player/ipc/tests/route_lifecycle.rs
@@ -1,0 +1,164 @@
+use super::*;
+
+#[derive(Clone)]
+struct TestRevocation(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl crate::playback_target::PlaybackRouteRevocation for TestRevocation {
+    fn revoke(&self) {
+        self.0.store(true, std::sync::atomic::Ordering::Release);
+    }
+}
+
+fn test_route_lease() -> (
+    crate::playback_target::PlaybackRouteLease,
+    std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    let revoked = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let revocation: std::sync::Arc<dyn crate::playback_target::PlaybackRouteRevocation> =
+        std::sync::Arc::new(TestRevocation(std::sync::Arc::clone(&revoked)));
+    (
+        crate::playback_target::PlaybackRouteLease::new(revocation),
+        revoked,
+    )
+}
+
+struct RecordingRouteProvider(std::sync::Arc<std::sync::atomic::AtomicU64>);
+
+impl crate::playback_target::PlaybackRouteProvider for RecordingRouteProvider {
+    fn open_route(
+        &self,
+        _target: crate::playback_target::CredentialedPlaybackRef,
+        file_generation: u64,
+    ) -> crate::playback_target::PlaybackRouteFuture {
+        self.0
+            .store(file_generation, std::sync::atomic::Ordering::Release);
+        Box::pin(async {
+            crate::playback_target::RoutedPlayback::new(32123, "a".repeat(32), test_route_lease().0)
+        })
+    }
+}
+
+#[tokio::test]
+async fn credentialed_provider_receives_the_exact_reserved_generation() {
+    let generation = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let provider = crate::playback_target::PlaybackRouteProviderHandle::new(std::sync::Arc::new(
+        RecordingRouteProvider(std::sync::Arc::clone(&generation)),
+    ));
+    let (_generation_tx, generation_rx) = watch::channel(9);
+    let outcome = validate_load_until_superseded(
+        crate::playback_target::PlaybackDestination::Credentialed(
+            crate::playback_target::CredentialedPlaybackRef::OpenSubsonic {
+                backend_id: "backend".to_owned(),
+                account_scope_id: "account".to_owned(),
+                item_id: "item".to_owned(),
+            },
+        ),
+        9,
+        generation_rx,
+        provider,
+    )
+    .await;
+
+    assert_eq!(generation.load(std::sync::atomic::Ordering::Acquire), 9);
+    assert!(matches!(
+        outcome,
+        LoadValidationOutcome::Validated {
+            route_lease: Some(_),
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn direct_loopback_target_cannot_forge_a_provider_route() {
+    let (_generation_tx, generation_rx) = watch::channel(1);
+    let outcome = validate_load_until_superseded(
+        crate::playback_target::PlaybackDestination::Direct(
+            "http://127.0.0.1:7890/stream/forged".to_owned(),
+        ),
+        1,
+        generation_rx,
+        crate::playback_target::PlaybackRouteProviderHandle::disabled(),
+    )
+    .await;
+
+    assert!(matches!(
+        outcome,
+        LoadValidationOutcome::Rejected(reason) if reason == "blocked_destination"
+    ));
+}
+
+#[test]
+fn replacing_load_revokes_the_active_route_before_validation() {
+    let (lease, revoked) = test_route_lease();
+    let mut state = DispatchState {
+        issued_file_generation: 7,
+        active_file_generation: Some(7),
+        ..DispatchState::default()
+    };
+    state.playback_route_leases.insert(7, lease);
+    let mut validation = None;
+    let mut backlog = VecDeque::new();
+    let mut flight = None;
+
+    accept_actor_command(
+        &mut state,
+        PlayerCmd::load(
+            "https://example.invalid/replacement",
+            super::super::super::MediaSourceContext::OnDemand,
+        ),
+        &mut validation,
+        &mut backlog,
+        &mut flight,
+    );
+
+    assert!(revoked.load(std::sync::atomic::Ordering::Acquire));
+    assert!(state.playback_route_leases.is_empty());
+}
+
+#[test]
+fn stale_end_file_cannot_revoke_the_newer_route() {
+    let emit: EventSink = std::sync::Arc::new(|_| {});
+    let (lease, revoked) = test_route_lease();
+    let mut state = DispatchState {
+        issued_file_generation: 2,
+        active_file_generation: Some(2),
+        active_playlist_entry_id: Some(22),
+        ..DispatchState::default()
+    };
+    state.entry_generations.insert(11, 1);
+    state.entry_generations.insert(22, 2);
+    state.playback_route_leases.insert(2, lease);
+
+    dispatch_incoming(
+        r#"{"event":"end-file","reason":"stop","playlist_entry_id":11}"#,
+        &emit,
+        &mut state,
+    );
+
+    assert!(!revoked.load(std::sync::atomic::Ordering::Acquire));
+    assert!(state.playback_route_leases.contains_key(&2));
+}
+
+#[test]
+fn correlated_end_file_revokes_its_route() {
+    let emit: EventSink = std::sync::Arc::new(|_| {});
+    let (lease, revoked) = test_route_lease();
+    let mut state = DispatchState {
+        issued_file_generation: 2,
+        active_file_generation: Some(2),
+        active_playlist_entry_id: Some(22),
+        ..DispatchState::default()
+    };
+    state.entry_generations.insert(22, 2);
+    state.playback_route_leases.insert(2, lease);
+
+    dispatch_incoming(
+        r#"{"event":"end-file","reason":"eof","playlist_entry_id":22}"#,
+        &emit,
+        &mut state,
+    );
+
+    assert!(revoked.load(std::sync::atomic::Ordering::Acquire));
+    assert!(state.playback_route_leases.is_empty());
+}

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -21,7 +21,7 @@ pub mod proto;
 pub mod recovery;
 pub mod video;
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::sync::{
     Arc, Mutex,
@@ -67,30 +67,58 @@ impl MediaSourceContext {
 }
 
 /// One playback destination and its non-inferable source semantics.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct PlaybackLoad {
-    url: String,
+    destination: crate::playback_target::PlaybackDestination,
     source_context: MediaSourceContext,
 }
 
 impl PlaybackLoad {
     pub fn new(url: impl Into<String>, source_context: MediaSourceContext) -> Self {
+        Self::from_destination(
+            crate::playback_target::PlaybackDestination::direct(url),
+            source_context,
+        )
+    }
+
+    pub fn from_destination(
+        destination: crate::playback_target::PlaybackDestination,
+        source_context: MediaSourceContext,
+    ) -> Self {
         Self {
-            url: url.into(),
+            destination,
             source_context,
         }
     }
 
+    /// Compatibility accessor for direct targets. Credentialed targets never expose an upstream
+    /// URL and return a stable marker instead.
     pub fn url(&self) -> &str {
-        &self.url
+        self.destination
+            .direct_target()
+            .unwrap_or("<credentialed-playback>")
     }
 
     pub fn as_str(&self) -> &str {
         self.url()
     }
 
+    pub const fn destination(&self) -> &crate::playback_target::PlaybackDestination {
+        &self.destination
+    }
+
     pub const fn source_context(&self) -> MediaSourceContext {
         self.source_context
+    }
+}
+
+impl std::fmt::Debug for PlaybackLoad {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PlaybackLoad")
+            .field("destination", &self.destination)
+            .field("source_context", &self.source_context)
+            .finish()
     }
 }
 
@@ -104,13 +132,13 @@ impl std::ops::Deref for PlaybackLoad {
 
 impl PartialEq<str> for PlaybackLoad {
     fn eq(&self, other: &str) -> bool {
-        self.url == other
+        self.destination.direct_target() == Some(other)
     }
 }
 
 impl PartialEq<&str> for PlaybackLoad {
     fn eq(&self, other: &&str) -> bool {
-        self.url == *other
+        self.destination.direct_target() == Some(*other)
     }
 }
 
@@ -170,6 +198,13 @@ pub struct TrackedProperty {
 impl PlayerCmd {
     pub fn load(url: impl Into<String>, source_context: MediaSourceContext) -> Self {
         Self::Load(PlaybackLoad::new(url, source_context))
+    }
+
+    pub fn load_destination(
+        destination: crate::playback_target::PlaybackDestination,
+        source_context: MediaSourceContext,
+    ) -> Self {
+        Self::Load(PlaybackLoad::from_destination(destination, source_context))
     }
 
     pub fn interactive_seek(seconds: f64) -> Self {
@@ -462,7 +497,88 @@ pub struct PlayerHandle {
     /// Generation of the latest admitted Load, or zero when the latest boundary is Stop/no-media.
     expected_media_generation: Arc<AtomicU64>,
     file_generation_tx: tokio::sync::watch::Sender<u64>,
+    route_revocations: Arc<RouteRevocationRegistry>,
     long_form_seek_status: Arc<Mutex<SharedLongFormSeekStatus>>,
+}
+
+#[derive(Default)]
+struct RouteRevocationRegistry {
+    state: Mutex<RouteRevocationState>,
+}
+
+#[derive(Default)]
+struct RouteRevocationState {
+    latest_admitted_generation: u64,
+    routes: HashMap<u64, crate::playback_target::PlaybackRouteRevocationHandle>,
+}
+
+impl RouteRevocationRegistry {
+    fn install(
+        &self,
+        file_generation: u64,
+        revocation: crate::playback_target::PlaybackRouteRevocationHandle,
+    ) -> bool {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state.latest_admitted_generation != file_generation {
+            drop(state);
+            revocation.revoke();
+            return false;
+        }
+        if let Some(previous) = state.routes.insert(file_generation, revocation) {
+            previous.revoke();
+        }
+        true
+    }
+
+    fn revoke(&self, file_generation: u64) {
+        if let Some(revocation) = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .routes
+            .remove(&file_generation)
+        {
+            revocation.revoke();
+        }
+    }
+
+    fn revoke_all(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for revocation in state.routes.values() {
+            revocation.revoke();
+        }
+        state.routes.clear();
+    }
+
+    fn advance_generation(&self, generation: u64) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.latest_admitted_generation = generation;
+        for revocation in state.routes.values() {
+            revocation.revoke();
+        }
+        state.routes.clear();
+    }
+
+    fn rebase(&self, previous: u64, generation: u64) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(revocation) = state.routes.remove(&previous)
+            && let Some(replaced) = state.routes.insert(generation, revocation)
+        {
+            replaced.revoke();
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -696,6 +812,10 @@ impl PlayerHandle {
     fn publish_file_generation(&self, admission: Option<FileAdmission>) {
         if let Some(admission) = admission {
             self.file_generation_tx.send_replace(admission.generation);
+            // Successful admission is the public lifetime boundary. Revoke an active route
+            // immediately and reject a late validation from any earlier generation.
+            self.route_revocations
+                .advance_generation(admission.generation);
         }
     }
 
@@ -709,6 +829,7 @@ impl PlayerHandle {
             admitted_file_generation: Arc::new(AtomicU64::new(0)),
             expected_media_generation: Arc::new(AtomicU64::new(0)),
             file_generation_tx,
+            route_revocations: Arc::new(RouteRevocationRegistry::default()),
             long_form_seek_status: Arc::new(Mutex::new(SharedLongFormSeekStatus::new(
                 long_form_seek::CacheStatus {
                     requested: crate::config::LongFormSeekOptimization::Off,
@@ -751,6 +872,7 @@ impl Drop for PlayerHandle {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .mark_closed();
+        self.route_revocations.revoke_all();
     }
 }
 
@@ -883,6 +1005,33 @@ pub async fn spawn<F>(
 where
     F: Fn(PlayerEvent) + Send + Sync + 'static,
 {
+    spawn_with_route_provider(
+        emit,
+        data_dir,
+        cookies_file,
+        gapless,
+        audio,
+        crate::playback_target::PlaybackRouteProviderHandle::disabled(),
+    )
+    .await
+}
+
+/// Spawn guarded mpv with a credential-owning loopback route provider.
+///
+/// Direct local/public media still passes through the unchanged public destination validator.
+/// The provider is consulted only after a typed credentialed load has been admitted by the
+/// player actor.
+pub async fn spawn_with_route_provider<F>(
+    emit: F,
+    data_dir: Option<PathBuf>,
+    cookies_file: Option<PathBuf>,
+    gapless: bool,
+    audio: crate::config::AudioRuntimeConfig,
+    route_provider: crate::playback_target::PlaybackRouteProviderHandle,
+) -> Result<(PlayerHandle, Mpv)>
+where
+    F: Fn(PlayerEvent) + Send + Sync + 'static,
+{
     let ipc_path = mpv::ipc_path()?;
     // `data_dir` is supplied only to mutation-owning player processes. Derive cache ownership
     // from that same lease so a secondary/read-only instance cannot create packet-cache state.
@@ -932,15 +1081,18 @@ where
     let admitted_file_generation = Arc::new(AtomicU64::new(0));
     let expected_media_generation = Arc::new(AtomicU64::new(0));
     let (file_generation_tx, file_generation_rx) = tokio::sync::watch::channel(0);
-    tokio::spawn(ipc::run_actor(
+    let route_revocations = Arc::new(RouteRevocationRegistry::default());
+    tokio::spawn(ipc::run_actor(ipc::ActorInput {
         conn,
-        rx,
-        Arc::new(emit),
-        Arc::clone(&intentional_close),
+        cmd_rx: rx,
+        emit: Arc::new(emit),
+        intentional_close: Arc::clone(&intentional_close),
         file_generation_rx,
+        route_provider,
+        route_revocations: Arc::clone(&route_revocations),
         cache_runtime,
-        Arc::clone(&long_form_seek_status),
-    ));
+        cache_status: Arc::clone(&long_form_seek_status),
+    }));
 
     Ok((
         PlayerHandle {
@@ -950,6 +1102,7 @@ where
             admitted_file_generation,
             expected_media_generation,
             file_generation_tx,
+            route_revocations,
             long_form_seek_status,
         },
         mpv,

--- a/src/player/recovery.rs
+++ b/src/player/recovery.rs
@@ -49,8 +49,9 @@ pub(crate) enum ResumeOrigin {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct LoadWithResume {
-    /// Freshly resolved direct URL or the provider's safe watch URL. Never log this value.
-    pub url: String,
+    /// Freshly resolved direct target or a credential-owning provider reference.
+    /// The destination's `Debug` representation is always redacted.
+    pub destination: crate::playback_target::PlaybackDestination,
     pub position_secs: f64,
     pub paused: bool,
     /// Owner-known semantics for this exact replacement; never inherited from actor state.
@@ -62,14 +63,14 @@ pub struct LoadWithResume {
 
 impl LoadWithResume {
     pub(crate) fn source_recovery(
-        url: String,
+        destination: impl Into<crate::playback_target::PlaybackDestination>,
         position_secs: f64,
         paused: bool,
         source_context: super::MediaSourceContext,
         ticket: RecoveryTicket,
     ) -> Self {
         Self {
-            url,
+            destination: destination.into(),
             position_secs,
             paused,
             source_context,
@@ -80,13 +81,13 @@ impl LoadWithResume {
     }
 
     pub(crate) fn emergency(
-        url: String,
+        destination: impl Into<crate::playback_target::PlaybackDestination>,
         position_secs: f64,
         paused: bool,
         source_context: super::MediaSourceContext,
     ) -> Self {
         Self {
-            url,
+            destination: destination.into(),
             position_secs,
             paused,
             source_context,
@@ -137,7 +138,7 @@ impl TransportRestorePlan {
     pub(crate) fn reload_if_loaded(
         loaded_video_id: Option<&str>,
         current_video_id: &str,
-        url: String,
+        destination: impl Into<crate::playback_target::PlaybackDestination>,
         paused: bool,
         source_context: super::MediaSourceContext,
     ) -> Self {
@@ -145,7 +146,7 @@ impl TransportRestorePlan {
             return Self::Idle;
         }
         Self::Reload {
-            load: super::PlaybackLoad::new(url, source_context),
+            load: super::PlaybackLoad::from_destination(destination.into(), source_context),
             paused,
         }
     }
@@ -153,7 +154,7 @@ impl TransportRestorePlan {
     pub(crate) fn resume_ram_only_if_loaded(
         loaded_video_id: Option<&str>,
         current_video_id: &str,
-        url: String,
+        destination: impl Into<crate::playback_target::PlaybackDestination>,
         position_secs: f64,
         paused: bool,
         source_context: super::MediaSourceContext,
@@ -162,7 +163,7 @@ impl TransportRestorePlan {
             return Self::Idle;
         }
         Self::ResumeRamOnly(LoadWithResume::emergency(
-            url,
+            destination,
             position_secs,
             paused,
             source_context,

--- a/src/player/tests.rs
+++ b/src/player/tests.rs
@@ -4,6 +4,53 @@ use crate::util::process::ProcessProfile;
 #[cfg(unix)]
 use crate::util::process_guard::ChildTreeGuard;
 
+struct TestRouteRevocation(Arc<AtomicBool>);
+
+impl crate::playback_target::PlaybackRouteRevocation for TestRouteRevocation {
+    fn revoke(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+}
+
+#[test]
+fn admitted_file_boundary_revokes_route_before_actor_receive() {
+    let (tx, _rx) = tokio::sync::mpsc::channel(1);
+    let handle = PlayerHandle::test_handle(tx);
+    let revoked = Arc::new(AtomicBool::new(false));
+    let revocation: Arc<dyn crate::playback_target::PlaybackRouteRevocation> =
+        Arc::new(TestRouteRevocation(Arc::clone(&revoked)));
+    let lease = crate::playback_target::PlaybackRouteLease::new(revocation);
+    handle.route_revocations.advance_generation(1);
+    assert!(
+        handle
+            .route_revocations
+            .install(1, lease.revocation_handle())
+    );
+
+    let _ = handle
+        .send(PlayerCmd::load(
+            "https://example.invalid/replacement",
+            MediaSourceContext::OnDemand,
+        ))
+        .unwrap();
+
+    assert!(revoked.load(Ordering::Acquire));
+    drop(lease);
+}
+
+#[test]
+fn late_route_install_is_rejected_after_newer_admission() {
+    let registry = RouteRevocationRegistry::default();
+    registry.advance_generation(2);
+    let revoked = Arc::new(AtomicBool::new(false));
+    let revocation: Arc<dyn crate::playback_target::PlaybackRouteRevocation> =
+        Arc::new(TestRouteRevocation(Arc::clone(&revoked)));
+    let lease = crate::playback_target::PlaybackRouteLease::new(revocation);
+
+    assert!(!registry.install(1, lease.revocation_handle()));
+    assert!(revoked.load(Ordering::Acquire));
+}
+
 #[test]
 fn file_generation_advances_only_for_admitted_load_and_stop_barriers() {
     let (tx, mut rx) = tokio::sync::mpsc::channel(4);

--- a/src/remote/client.rs
+++ b/src/remote/client.rs
@@ -758,6 +758,7 @@ fn search_source_name(source: SearchSource) -> &'static str {
         SearchSource::Audius => "audius",
         SearchSource::Jamendo => "jamendo",
         SearchSource::InternetArchive => "internet_archive",
+        SearchSource::OpenSubsonic => "open_subsonic",
         SearchSource::RadioBrowser => "radio_browser",
         SearchSource::All => "all",
     }

--- a/src/remote/client/tests.rs
+++ b/src/remote/client/tests.rs
@@ -695,7 +695,19 @@ fn capability_gate_distinguishes_old_and_capable_instances() {
 
     old.capabilities
         .push(super::super::WEB_DAV_SYNC_CAPABILITY.to_string());
-    assert!(require_capability(old, super::super::WEB_DAV_SYNC_CAPABILITY).is_ok());
+    assert!(require_capability(old.clone(), super::super::WEB_DAV_SYNC_CAPABILITY).is_ok());
+
+    let server_error =
+        require_capability(old.clone(), super::super::OPEN_SUBSONIC_CAPABILITY).unwrap_err();
+    assert_eq!(
+        server_error,
+        MissingCapability {
+            capability: super::super::OPEN_SUBSONIC_CAPABILITY.to_string()
+        }
+    );
+    old.capabilities
+        .push(super::super::OPEN_SUBSONIC_CAPABILITY.to_string());
+    assert!(require_capability(old, super::super::OPEN_SUBSONIC_CAPABILITY).is_ok());
 }
 
 #[tokio::test]

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -50,6 +50,10 @@ pub const PERSONAL_STATE_V2_CAPABILITY: &str = "personal-state-v2";
 /// Advertised when the primary owner accepts non-secret manual WebDAV sync and device-revoke
 /// commands. Credentials remain in its owner-only private store and never cross local IPC.
 pub const WEB_DAV_SYNC_CAPABILITY: &str = "webdav-sync-v1";
+/// Advertised by primary owners that can search, browse, and safely proxy playback from the
+/// configured OpenSubsonic server. Secondary TUI instances remain read-only previews and do not
+/// advertise this owner-bound integration.
+pub const OPEN_SUBSONIC_CAPABILITY: &str = "opensubsonic-v1";
 
 /// Daemon/demo capability for the managed long-form seek preference and truthful runtime status.
 /// The standalone TUI owner intentionally does not advertise daemon-only GUI mutation support.

--- a/src/remote/server.rs
+++ b/src/remote/server.rs
@@ -548,6 +548,7 @@ fn default_capabilities() -> Vec<String> {
         super::PERSONAL_EXPORT_CAPABILITY.to_string(),
         super::PERSONAL_STATE_V2_CAPABILITY.to_string(),
         super::WEB_DAV_SYNC_CAPABILITY.to_string(),
+        super::OPEN_SUBSONIC_CAPABILITY.to_string(),
         RETAINED_REQUEST_OUTCOMES_CAPABILITY.to_string(),
         // v8 sessions with live push (docs/gui/02 §10) — advertised now that subscribe
         // delivers initial snapshots through the owner-lane Publisher.
@@ -558,7 +559,10 @@ fn default_capabilities() -> Vec<String> {
 fn secondary_capabilities() -> Vec<String> {
     default_capabilities()
         .into_iter()
-        .filter(|capability| capability != super::WEB_DAV_SYNC_CAPABILITY)
+        .filter(|capability| {
+            capability != super::WEB_DAV_SYNC_CAPABILITY
+                && capability != super::OPEN_SUBSONIC_CAPABILITY
+        })
         .collect()
 }
 
@@ -574,14 +578,19 @@ fn standalone_capabilities_advertise_personal_export() {
     assert!(default_capabilities().contains(&super::PERSONAL_EXPORT_CAPABILITY.to_string()));
     assert!(default_capabilities().contains(&super::PERSONAL_STATE_V2_CAPABILITY.to_string()));
     assert!(default_capabilities().contains(&super::WEB_DAV_SYNC_CAPABILITY.to_string()));
+    assert!(default_capabilities().contains(&super::OPEN_SUBSONIC_CAPABILITY.to_string()));
 }
 
 #[cfg(test)]
 #[test]
-fn secondary_capabilities_do_not_advertise_personal_sync_mutation() {
+fn secondary_capabilities_do_not_advertise_owner_bound_integrations() {
     assert!(
         !secondary_capabilities().contains(&super::WEB_DAV_SYNC_CAPABILITY.to_string()),
         "a read-only --new-instance must not invite a WebDAV mutation"
+    );
+    assert!(
+        !secondary_capabilities().contains(&super::OPEN_SUBSONIC_CAPABILITY.to_string()),
+        "a read-only --new-instance must not advertise the primary owner's music server"
     );
     assert!(secondary_capabilities().contains(&"status".to_string()));
     assert!(secondary_capabilities().contains(&"events-v8".to_string()));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -25,6 +25,7 @@ mod dispatch;
 mod event_policy;
 pub(crate) mod ingress;
 mod local_find;
+mod open_subsonic_runtime;
 mod persist_delivery;
 mod personal_sync_commit;
 pub(crate) mod player_delivery;
@@ -78,6 +79,16 @@ pub enum RuntimeEvent {
     /// Background app-update check result (newer release available + install method).
     Update(crate::update::UpdateEvent),
     Transfer(crate::transfer::actor::TransferEvent),
+    /// Owner-only completion carrying a newly constructed credential-owning server runtime.
+    /// The runner intercepts this before reducer conversion so no secret-bearing owner can enter
+    /// retained application state.
+    OpenSubsonicReloaded {
+        generation: u64,
+        result: Result<
+            Option<crate::open_subsonic::OpenSubsonicRuntime>,
+            crate::open_subsonic::ServiceError,
+        >,
+    },
     TelemetryWake,
 }
 
@@ -160,6 +171,9 @@ impl RuntimeEvent {
                 key: Key::UpdateCheck,
             },
             RuntimeEvent::Transfer(event) => transfer_event_policy(event),
+            RuntimeEvent::OpenSubsonicReloaded { .. } => EventPolicy::MustDeliver {
+                lane: Lane::WorkResult,
+            },
             RuntimeEvent::TelemetryWake => EventPolicy::MustDeliver {
                 lane: Lane::Control,
             },
@@ -185,6 +199,7 @@ impl RuntimeEvent {
             RuntimeEvent::Tools(_) => "tools",
             RuntimeEvent::Update(_) => "update",
             RuntimeEvent::Transfer(_) => "transfer",
+            RuntimeEvent::OpenSubsonicReloaded { .. } => "open_subsonic_reloaded",
             RuntimeEvent::TelemetryWake => "telemetry_wake",
         }
     }
@@ -492,6 +507,11 @@ impl From<RuntimeEvent> for Msg {
                 Msg::UpdateChecked(status)
             }
             RuntimeEvent::Transfer(event) => Msg::Transfer(event),
+            RuntimeEvent::OpenSubsonicReloaded { .. } => {
+                unreachable!(
+                    "OpenSubsonicReloaded must be installed by the owner loop before Msg conversion"
+                )
+            }
             RuntimeEvent::TelemetryWake => {
                 unreachable!(
                     "TelemetryWake must be drained by the owner loop before Msg conversion"
@@ -581,6 +601,12 @@ pub struct RuntimeHandles {
     /// A deliberate secondary player may use playback/network actors, but every command capable
     /// of durable mutation is rejected before it reaches an actor or blocking worker.
     persistence_read_only: Option<std::sync::Arc<str>>,
+    /// Stable forwarding provider retained by every player generation.
+    open_subsonic_routes: crate::playback_target::PlaybackRouteProviderSlot,
+    /// Credential-owning actor/proxy guard; never projected into reducer state.
+    open_subsonic_runtime: Option<crate::open_subsonic::OpenSubsonicRuntime>,
+    /// Latest reload generation requested by the owner. Out-of-order candidates are dropped.
+    open_subsonic_reload_generation: u64,
 }
 
 fn settle_video_load_delivery(app: &mut App, result: DeliveryResult) -> Vec<Cmd> {
@@ -612,13 +638,16 @@ fn durable_mutation_rejection_reason(
 fn shutdown_event_is_retired(event: &RuntimeEvent) -> bool {
     matches!(
         event,
-        RuntimeEvent::TelemetryWake | RuntimeEvent::Signal(_) | RuntimeEvent::Player(_)
+        RuntimeEvent::TelemetryWake
+            | RuntimeEvent::Signal(_)
+            | RuntimeEvent::Player(_)
+            | RuntimeEvent::OpenSubsonicReloaded { .. }
     )
 }
 
 impl RuntimeHandles {
     #[allow(clippy::too_many_arguments)] // one-time construction in `run()`
-    pub fn new(
+    pub(crate) fn new(
         worker_tx: RuntimeSender,
         api_handle: crate::api::ApiHandle,
         lyrics_handle: crate::lyrics::LyricsHandle,
@@ -628,6 +657,7 @@ impl RuntimeHandles {
         ai_handle: Option<crate::ai::AiHandle>,
         scrobble_handle: crate::scrobble::ScrobbleHandle,
         persist: crate::persist::PersistHandle,
+        open_subsonic_routes: crate::playback_target::PlaybackRouteProviderSlot,
     ) -> Self {
         Self {
             worker_tx,
@@ -649,6 +679,9 @@ impl RuntimeHandles {
                 crate::persist::PersistenceAccess::Writable => None,
                 crate::persist::PersistenceAccess::ReadOnly { reason } => Some(reason),
             },
+            open_subsonic_routes,
+            open_subsonic_runtime: None,
+            open_subsonic_reload_generation: 0,
         }
     }
 

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -152,6 +152,237 @@ impl RuntimeHandles {
                     }
                 }
             },
+            Cmd::MusicServer(command) => {
+                let emitter = self.background_tasks.emitter(self.worker_tx.clone());
+                match command {
+                    crate::app::MusicServerCommand::Refresh { generation } => {
+                        self.begin_open_subsonic_reload(generation);
+                        let read_only = self.persistence_read_only.is_some();
+                        self.background_tasks.spawn_cancellable(
+                            "music_server_connection_test",
+                            async move {
+                                let (runtime_result, result) =
+                                    refresh_music_server_runtime(read_only).await;
+                                emitter
+                                    .emit_terminal(RuntimeEvent::OpenSubsonicReloaded {
+                                        generation,
+                                        result: runtime_result,
+                                    })
+                                    .await;
+                                emitter
+                                    .emit_terminal(RuntimeEvent::App(Msg::Server(
+                                        crate::app::ServerEvent::Settings(
+                                            crate::app::MusicServerEvent::Refreshed {
+                                                generation,
+                                                result,
+                                            },
+                                        ),
+                                    )))
+                                    .await;
+                            },
+                        );
+                    }
+                    crate::app::MusicServerCommand::TestAndPrepare { generation, input } => {
+                        self.background_tasks
+                            .spawn_cancellable("music_server_test", async move {
+                                let result = prepare_music_server_setup(input)
+                                    .await
+                                    .map(Box::new)
+                                    .map_err(music_server_failure);
+                                emitter
+                                    .emit_terminal(RuntimeEvent::App(Msg::Server(
+                                        crate::app::ServerEvent::Settings(
+                                            crate::app::MusicServerEvent::Prepared {
+                                                generation,
+                                                result,
+                                            },
+                                        ),
+                                    )))
+                                    .await;
+                            });
+                    }
+                    crate::app::MusicServerCommand::Commit {
+                        generation,
+                        prepared,
+                    } => {
+                        self.begin_open_subsonic_reload(generation);
+                        self.background_tasks.spawn_cancellable(
+                            "music_server_commit",
+                            async move {
+                                let committed = tokio::task::spawn_blocking(move || {
+                                    crate::open_subsonic::OpenSubsonicPaths::current()
+                                        .map_err(crate::open_subsonic::ServiceError::from)
+                                        .and_then(|paths| {
+                                            crate::open_subsonic::commit_setup(&paths, *prepared)
+                                        })
+                                })
+                                .await
+                                .map_err(|_| crate::open_subsonic::ServiceError::ActorUnavailable)
+                                .and_then(std::convert::identity);
+                                let result = match committed {
+                                    Ok(status) => {
+                                        let mut summary = music_server_summary(status);
+                                        let runtime_result =
+                                            match crate::open_subsonic::OpenSubsonicPaths::current()
+                                            {
+                                                Ok(paths) => {
+                                                    crate::open_subsonic::load_actor(&paths).await
+                                                }
+                                                Err(error) => Err(error.into()),
+                                            };
+                                        if runtime_result.is_err() {
+                                            // The durable commit already succeeded. Keep the
+                                            // configured identity visible and offer retry instead
+                                            // of reopening a first-time wizard whose Create
+                                            // intent can no longer be valid.
+                                            summary.health =
+                                                crate::app::MusicServerHealth::NeedsAttention;
+                                        }
+                                        emitter
+                                            .emit_terminal(RuntimeEvent::OpenSubsonicReloaded {
+                                                generation,
+                                                result: runtime_result,
+                                            })
+                                            .await;
+                                        Ok(summary)
+                                    }
+                                    Err(error) => Err(music_server_failure(error)),
+                                };
+                                emitter
+                                    .emit_terminal(RuntimeEvent::App(Msg::Server(
+                                        crate::app::ServerEvent::Settings(
+                                            crate::app::MusicServerEvent::Committed {
+                                                generation,
+                                                result,
+                                            },
+                                        ),
+                                    )))
+                                    .await;
+                            },
+                        );
+                    }
+                    crate::app::MusicServerCommand::Remove { generation } => {
+                        self.begin_open_subsonic_reload(generation);
+                        self.background_tasks.spawn_cancellable(
+                            "music_server_remove",
+                            async move {
+                                let removed = tokio::task::spawn_blocking(move || {
+                                    crate::open_subsonic::OpenSubsonicPaths::current()
+                                        .map_err(crate::open_subsonic::ServiceError::from)
+                                        .and_then(|paths| {
+                                            crate::open_subsonic::remove_profile(&paths)
+                                        })
+                                })
+                                .await
+                                .map_err(|_| crate::open_subsonic::ServiceError::ActorUnavailable)
+                                .and_then(std::convert::identity);
+                                let result = match removed {
+                                    Ok(_) => {
+                                        let runtime_result =
+                                            match crate::open_subsonic::OpenSubsonicPaths::current()
+                                            {
+                                                Ok(paths) => {
+                                                    crate::open_subsonic::load_actor(&paths).await
+                                                }
+                                                Err(error) => Err(error.into()),
+                                            };
+                                        emitter
+                                            .emit_terminal(RuntimeEvent::OpenSubsonicReloaded {
+                                                generation,
+                                                result: runtime_result,
+                                            })
+                                            .await;
+                                        // Removal is already durable and clears the active
+                                        // credential boundary synchronously. A follow-up reload
+                                        // failure cannot turn it back into a configured profile.
+                                        Ok(())
+                                    }
+                                    Err(error) => Err(music_server_failure(error)),
+                                };
+                                emitter
+                                    .emit_terminal(RuntimeEvent::App(Msg::Server(
+                                        crate::app::ServerEvent::Settings(
+                                            crate::app::MusicServerEvent::Removed {
+                                                generation,
+                                                result,
+                                            },
+                                        ),
+                                    )))
+                                    .await;
+                            },
+                        );
+                    }
+                }
+            }
+            Cmd::ServerLibrary(command) => {
+                let emitter = self.background_tasks.emitter(self.worker_tx.clone());
+                self.background_tasks
+                    .spawn_cancellable("music_server_library", async move {
+                        match command {
+                            crate::app::ServerLibraryCommand::LoadPage {
+                                generation,
+                                section,
+                                offset,
+                                limit,
+                            } => {
+                                let result = match crate::open_subsonic::current_handle() {
+                                    Some(handle) => handle
+                                        .library_page(crate::open_subsonic::ServerLibraryRequest {
+                                            section,
+                                            offset,
+                                            limit: limit.min(crate::open_subsonic::MAX_PAGE_SIZE),
+                                        })
+                                        .await
+                                        .map_err(server_library_failure),
+                                    None => Err(crate::app::ServerLibraryFailure::Unavailable),
+                                };
+                                emitter
+                                    .emit_terminal(RuntimeEvent::App(Msg::Server(
+                                        crate::app::ServerEvent::Library(
+                                            crate::app::ServerLibraryEvent::PageLoaded {
+                                                generation,
+                                                offset,
+                                                result,
+                                            },
+                                        ),
+                                    )))
+                                    .await;
+                            }
+                            crate::app::ServerLibraryCommand::LoadDetail { generation, target } => {
+                                let request = match target {
+                                    crate::app::ServerLibraryDetailTarget::Album(id) => {
+                                        crate::open_subsonic::ServerLibraryDetailRequest::Album(id)
+                                    }
+                                    crate::app::ServerLibraryDetailTarget::Artist(id) => {
+                                        crate::open_subsonic::ServerLibraryDetailRequest::Artist(id)
+                                    }
+                                    crate::app::ServerLibraryDetailTarget::Playlist(id) => {
+                                        crate::open_subsonic::ServerLibraryDetailRequest::Playlist(
+                                            id,
+                                        )
+                                    }
+                                };
+                                let result = match crate::open_subsonic::current_handle() {
+                                    Some(handle) => handle
+                                        .library_detail(request)
+                                        .await
+                                        .map_err(server_library_failure),
+                                    None => Err(crate::app::ServerLibraryFailure::Unavailable),
+                                };
+                                emitter
+                                    .emit_terminal(RuntimeEvent::App(Msg::Server(
+                                        crate::app::ServerEvent::Library(
+                                            crate::app::ServerLibraryEvent::DetailLoaded {
+                                                generation,
+                                                result,
+                                            },
+                                        ),
+                                    )))
+                                    .await;
+                            }
+                        }
+                    });
+            }
             // Persist: hand the persistence actor an owned snapshot (or clear one). Cloning a
             // store is a couple ms of memcpy at worst; the fsync it replaces on this task was
             // 5-50ms. The marker variants clone the live snapshot from `app` here; `Config`
@@ -797,6 +1028,224 @@ impl RuntimeHandles {
             // Handled in the main loop (the OSC path writes to the terminal this scope doesn't
             // own); never reaches here. Listed for exhaustiveness.
             Cmd::DesktopNotify { .. } => {}
+        }
+    }
+}
+
+async fn refresh_music_server_runtime(
+    read_only: bool,
+) -> (
+    Result<Option<crate::open_subsonic::OpenSubsonicRuntime>, crate::open_subsonic::ServiceError>,
+    Result<crate::app::MusicServerRefreshOutcome, crate::app::MusicServerFailure>,
+) {
+    let paths = match crate::open_subsonic::OpenSubsonicPaths::current() {
+        Ok(paths) => paths,
+        Err(error) => {
+            let error = crate::open_subsonic::ServiceError::from(error);
+            return (Err(error), Err(music_server_failure(error)));
+        }
+    };
+    let local_status = match crate::open_subsonic::read_status(&paths) {
+        Ok(status) => status,
+        Err(error) => return (Err(error), Err(music_server_failure(error))),
+    };
+    let mut local_summary = music_server_summary(local_status);
+    let runtime_result = if read_only {
+        crate::open_subsonic::load_actor_read_only(&paths).await
+    } else {
+        crate::open_subsonic::load_actor(&paths).await
+    };
+    let outcome = match &runtime_result {
+        Ok(Some(_)) => {
+            let mut summary = crate::open_subsonic::read_status(&paths)
+                .map(music_server_summary)
+                .unwrap_or(local_summary);
+            summary.health = crate::app::MusicServerHealth::UpToDate;
+            summary.configured = true;
+            crate::app::MusicServerRefreshOutcome {
+                summary,
+                failure: None,
+            }
+        }
+        Ok(None) => crate::app::MusicServerRefreshOutcome {
+            summary: crate::app::MusicServerSummary::default(),
+            failure: None,
+        },
+        Err(error) => {
+            local_summary.health = crate::app::MusicServerHealth::NeedsAttention;
+            crate::app::MusicServerRefreshOutcome {
+                summary: local_summary,
+                failure: Some(music_server_failure(*error)),
+            }
+        }
+    };
+    (runtime_result, Ok(outcome))
+}
+
+async fn prepare_music_server_setup(
+    input: crate::app::MusicServerSetupInput,
+) -> Result<crate::open_subsonic::PreparedSetup, crate::open_subsonic::ServiceError> {
+    const MAX_CUSTOM_CA_BYTES: u64 = 192 * 1024;
+
+    let crate::app::MusicServerSetupInput {
+        mut display_name,
+        mut origin,
+        mut username,
+        mut secret,
+        credential_mode,
+        mut custom_ca_path,
+        allow_lan_http,
+        identity_intent,
+    } = input;
+    let custom_ca_pem = if custom_ca_path.trim().is_empty() {
+        None
+    } else {
+        let path = std::path::PathBuf::from(custom_ca_path.as_str());
+        custom_ca_path.clear();
+        Some(
+            tokio::task::spawn_blocking(move || {
+                let bytes =
+                    crate::util::safe_fs::read_no_symlink_limited(&path, MAX_CUSTOM_CA_BYTES)
+                        .map_err(|_| crate::open_subsonic::ServiceError::InvalidSetup)?;
+                if bytes.is_empty() {
+                    return Err(crate::open_subsonic::ServiceError::InvalidSetup);
+                }
+                Ok(bytes)
+            })
+            .await
+            .map_err(|_| crate::open_subsonic::ServiceError::ActorUnavailable)??,
+        )
+    };
+    let secret_value = std::mem::take(&mut *secret);
+    let credential = match credential_mode {
+        crate::app::MusicServerCredentialMode::Password => {
+            let username_value = std::mem::take(&mut *username);
+            crate::open_subsonic::ServerCredential::password(
+                username_value,
+                age::secrecy::SecretString::from(secret_value),
+            )
+            .map_err(|_| crate::open_subsonic::ServiceError::InvalidSetup)?
+        }
+        crate::app::MusicServerCredentialMode::ApiKey => {
+            crate::open_subsonic::ServerCredential::api_key(age::secrecy::SecretString::from(
+                secret_value,
+            ))
+            .map_err(|_| crate::open_subsonic::ServiceError::InvalidSetup)?
+        }
+    };
+    let paths = crate::open_subsonic::OpenSubsonicPaths::current()?;
+    crate::open_subsonic::test_and_prepare_setup(
+        &paths,
+        crate::open_subsonic::SetupInput::new(
+            std::mem::take(&mut *display_name),
+            std::mem::take(&mut *origin),
+            allow_lan_http,
+            custom_ca_pem,
+            credential,
+            match identity_intent {
+                crate::app::MusicServerIdentityIntent::Create => {
+                    crate::open_subsonic::SetupIdentityIntent::Create
+                }
+                crate::app::MusicServerIdentityIntent::UpdateSameServerAndAccount => {
+                    crate::open_subsonic::SetupIdentityIntent::UpdateSameServerAndAccount
+                }
+                crate::app::MusicServerIdentityIntent::ReplaceServerOrAccount => {
+                    crate::open_subsonic::SetupIdentityIntent::ReplaceServerOrAccount
+                }
+            },
+        ),
+    )
+    .await
+}
+
+fn music_server_summary(
+    status: crate::open_subsonic::OpenSubsonicStatus,
+) -> crate::app::MusicServerSummary {
+    let configured = status.kind != crate::open_subsonic::OpenSubsonicStatusKind::Off;
+    let credential_label = status.credential_kind.map(|kind| match kind {
+        crate::open_subsonic::CredentialKind::Password => "Password".to_owned(),
+        crate::open_subsonic::CredentialKind::ApiKey => "API key".to_owned(),
+    });
+    crate::app::MusicServerSummary {
+        health: match status.kind {
+            crate::open_subsonic::OpenSubsonicStatusKind::Off => crate::app::MusicServerHealth::Off,
+            crate::open_subsonic::OpenSubsonicStatusKind::UpToDate => {
+                crate::app::MusicServerHealth::UpToDate
+            }
+            crate::open_subsonic::OpenSubsonicStatusKind::NeedsAttention => {
+                crate::app::MusicServerHealth::NeedsAttention
+            }
+        },
+        configured,
+        display_name: status.display_name,
+        credential_label,
+        lan_http: status.uses_lan_http,
+        custom_ca: status.uses_custom_ca,
+    }
+}
+
+fn music_server_failure(
+    error: crate::open_subsonic::ServiceError,
+) -> crate::app::MusicServerFailure {
+    match error {
+        crate::open_subsonic::ServiceError::Store(_) => crate::app::MusicServerFailure::Storage,
+        crate::open_subsonic::ServiceError::Server(error) => match error {
+            crate::open_subsonic::ServerError::AuthenticationRequired
+            | crate::open_subsonic::ServerError::PermissionDenied => {
+                crate::app::MusicServerFailure::Authentication
+            }
+            crate::open_subsonic::ServerError::CertificateFailed => {
+                crate::app::MusicServerFailure::Certificate
+            }
+            crate::open_subsonic::ServerError::OriginRejected
+            | crate::open_subsonic::ServerError::WrongAccountScope => {
+                crate::app::MusicServerFailure::InvalidInput
+            }
+            crate::open_subsonic::ServerError::Offline
+            | crate::open_subsonic::ServerError::RateLimited(_)
+            | crate::open_subsonic::ServerError::TemporarilyUnavailable => {
+                crate::app::MusicServerFailure::Connection
+            }
+            crate::open_subsonic::ServerError::UnsupportedFeature
+            | crate::open_subsonic::ServerError::NotFound
+            | crate::open_subsonic::ServerError::InvalidResponse
+            | crate::open_subsonic::ServerError::ResponseTooLarge => {
+                crate::app::MusicServerFailure::InvalidInput
+            }
+        },
+        crate::open_subsonic::ServiceError::InvalidSetup => {
+            crate::app::MusicServerFailure::InvalidInput
+        }
+        crate::open_subsonic::ServiceError::ActorUnavailable
+        | crate::open_subsonic::ServiceError::ProxyUnavailable => {
+            crate::app::MusicServerFailure::Unavailable
+        }
+    }
+}
+
+fn server_library_failure(
+    error: crate::open_subsonic::ServerError,
+) -> crate::app::ServerLibraryFailure {
+    match error {
+        crate::open_subsonic::ServerError::AuthenticationRequired
+        | crate::open_subsonic::ServerError::PermissionDenied => {
+            crate::app::ServerLibraryFailure::Authentication
+        }
+        crate::open_subsonic::ServerError::UnsupportedFeature
+        | crate::open_subsonic::ServerError::NotFound => {
+            crate::app::ServerLibraryFailure::Unsupported
+        }
+        crate::open_subsonic::ServerError::InvalidResponse
+        | crate::open_subsonic::ServerError::ResponseTooLarge
+        | crate::open_subsonic::ServerError::WrongAccountScope => {
+            crate::app::ServerLibraryFailure::InvalidResponse
+        }
+        crate::open_subsonic::ServerError::Offline
+        | crate::open_subsonic::ServerError::CertificateFailed
+        | crate::open_subsonic::ServerError::OriginRejected
+        | crate::open_subsonic::ServerError::RateLimited(_)
+        | crate::open_subsonic::ServerError::TemporarilyUnavailable => {
+            crate::app::ServerLibraryFailure::Offline
         }
     }
 }

--- a/src/runtime/event_policy.rs
+++ b/src/runtime/event_policy.rs
@@ -9,7 +9,7 @@ pub(super) fn app_msg_policy(msg: &Msg) -> EventPolicy {
         Msg::Remote(_, _) => EventPolicy::MustReplyOrBusy {
             lane: Lane::RemoteCommand,
         },
-        Msg::Data(_) => EventPolicy::MustDeliver {
+        Msg::Data(_) | Msg::Server(_) => EventPolicy::MustDeliver {
             lane: Lane::WorkResult,
         },
         Msg::Player(player) => player_msg_policy(player),

--- a/src/runtime/open_subsonic_runtime.rs
+++ b/src/runtime/open_subsonic_runtime.rs
@@ -1,0 +1,75 @@
+//! Owner-lane lifetime for the credential-owning OpenSubsonic actor and playback proxy.
+
+use super::{RuntimeEvent, RuntimeHandles};
+
+impl RuntimeHandles {
+    /// Mark a reload generation before its network work starts.
+    ///
+    /// Only the owner calls this method. A later request makes every older completion inert,
+    /// including the process-start load racing a settings save.
+    pub(crate) fn begin_open_subsonic_reload(&mut self, generation: u64) {
+        self.open_subsonic_reload_generation = generation;
+    }
+
+    /// Load the configured profile without blocking first-frame/player startup.
+    pub(crate) fn spawn_open_subsonic_reload(
+        &mut self,
+        generation: u64,
+        paths: crate::open_subsonic::OpenSubsonicPaths,
+    ) -> bool {
+        self.begin_open_subsonic_reload(generation);
+        let read_only = self.persistence_read_only.is_some();
+        let emitter = self.background_tasks.emitter(self.worker_tx.clone());
+        self.background_tasks
+            .spawn_cancellable("open_subsonic_startup", async move {
+                let result = if read_only {
+                    crate::open_subsonic::load_actor_read_only(&paths).await
+                } else {
+                    crate::open_subsonic::load_actor(&paths).await
+                };
+                emitter
+                    .emit_terminal(RuntimeEvent::OpenSubsonicReloaded { generation, result })
+                    .await;
+            })
+    }
+
+    /// Install one owner-approved load result. Returns `false` for a stale generation.
+    pub(crate) fn install_open_subsonic_runtime(
+        &mut self,
+        generation: u64,
+        result: Result<
+            Option<crate::open_subsonic::OpenSubsonicRuntime>,
+            crate::open_subsonic::ServiceError,
+        >,
+    ) -> bool {
+        if generation != self.open_subsonic_reload_generation {
+            drop(result);
+            return false;
+        }
+
+        match result {
+            Ok(Some(runtime)) => {
+                // Activation closes the previously published proxy before this stable forwarding
+                // slot can expose the new one. Dropping the old guard cannot clear the newer
+                // generation because the actor registry compares exact generations.
+                runtime.activate();
+                self.open_subsonic_routes.install(runtime.route_provider());
+                self.open_subsonic_runtime = Some(runtime);
+            }
+            Ok(None) => {
+                self.retire_open_subsonic_runtime();
+            }
+            Err(error) => {
+                self.retire_open_subsonic_runtime();
+                tracing::warn!(reason = %error, "music server runtime is unavailable");
+            }
+        }
+        true
+    }
+
+    /// Disable new routes before dropping the actor/proxy guard that revokes existing routes.
+    pub(crate) fn retire_open_subsonic_runtime(&mut self) {
+        self.open_subsonic_routes.disable();
+        self.open_subsonic_runtime = None;
+    }
+}

--- a/src/runtime/player_delivery.rs
+++ b/src/runtime/player_delivery.rs
@@ -689,6 +689,8 @@ impl super::RuntimeHandles {
         app.settle_personal_sync_shutdown();
         let follow_ups =
             begin_player_shutdown_state(&mut self.player, &mut self.pending_player_intents, app);
+        // No credential-owning loopback listener or minted route outlives the audio owner.
+        self.retire_open_subsonic_runtime();
         for follow_up in follow_ups {
             self.dispatch(app, follow_up);
         }

--- a/src/runtime/read_only.rs
+++ b/src/runtime/read_only.rs
@@ -31,6 +31,11 @@ pub(super) fn durable_mutation_component(cmd: &Cmd) -> Option<&'static str> {
         Cmd::Transfer(_) => Some("transfer state"),
         Cmd::Data(DataCmd::PersonalSync { .. }) => Some("personal sync"),
         Cmd::Data(DataCmd::SyncUi(command)) if !command.is_read_only() => Some("personal sync"),
+        Cmd::MusicServer(
+            crate::app::MusicServerCommand::TestAndPrepare { .. }
+            | crate::app::MusicServerCommand::Commit { .. }
+            | crate::app::MusicServerCommand::Remove { .. },
+        ) => Some("music server settings"),
         Cmd::PlayerControl(_)
         | Cmd::VideoConnect { .. }
         | Cmd::VideoLoad(_)
@@ -38,6 +43,8 @@ pub(super) fn durable_mutation_component(cmd: &Cmd) -> Option<&'static str> {
         | Cmd::VideoToggleFullscreen
         | Cmd::VideoToggleMute
         | Cmd::Search(_)
+        | Cmd::MusicServer(crate::app::MusicServerCommand::Refresh { .. })
+        | Cmd::ServerLibrary(_)
         | Cmd::Data(
             DataCmd::ScanDownloads(_) | DataCmd::PersonalDataExport(_) | DataCmd::SyncUi(_),
         )
@@ -134,6 +141,12 @@ pub(super) fn reject_mutation(app: &mut App, cmd: &Cmd, component: &str, reason:
             }
             app.start_pending_sync_ui_refresh()
         }
+        Cmd::MusicServer(_) => {
+            app.server.settings.busy = None;
+            app.server.settings.failure = Some(crate::app::MusicServerFailure::Storage);
+            app.dirty = true;
+            Vec::new()
+        }
         _ => Vec::new(),
     };
     app.set_status_error(match crate::i18n::current() {
@@ -174,5 +187,29 @@ mod tests {
             Some("read_only_secondary")
         );
         assert!(!app.personal_state.sync.in_progress);
+    }
+
+    #[test]
+    fn read_only_secondary_rejects_secret_bearing_server_setup_before_network_work() {
+        let setup = Cmd::MusicServer(crate::app::MusicServerCommand::TestAndPrepare {
+            generation: 1,
+            input: crate::app::MusicServerSetupInput {
+                display_name: zeroize::Zeroizing::new("Server".to_owned()),
+                origin: zeroize::Zeroizing::new("https://music.example.test".to_owned()),
+                username: zeroize::Zeroizing::new(String::new()),
+                secret: zeroize::Zeroizing::new("secret".to_owned()),
+                credential_mode: crate::app::MusicServerCredentialMode::ApiKey,
+                custom_ca_path: zeroize::Zeroizing::new(String::new()),
+                allow_lan_http: false,
+                identity_intent: crate::app::MusicServerIdentityIntent::Create,
+            },
+        });
+        let refresh = Cmd::MusicServer(crate::app::MusicServerCommand::Refresh { generation: 2 });
+
+        assert_eq!(
+            durable_mutation_component(&setup),
+            Some("music server settings")
+        );
+        assert_eq!(durable_mutation_component(&refresh), None);
     }
 }

--- a/src/search_source.rs
+++ b/src/search_source.rs
@@ -15,17 +15,19 @@ pub enum SearchSource {
     Audius,
     Jamendo,
     InternetArchive,
+    OpenSubsonic,
     RadioBrowser,
     All,
 }
 
 impl SearchSource {
-    pub const CONCRETE: [SearchSource; 6] = [
+    pub const CONCRETE: [SearchSource; 7] = [
         SearchSource::Youtube,
         SearchSource::SoundCloud,
         SearchSource::Audius,
         SearchSource::Jamendo,
         SearchSource::InternetArchive,
+        SearchSource::OpenSubsonic,
         SearchSource::RadioBrowser,
     ];
 
@@ -36,6 +38,7 @@ impl SearchSource {
             SearchSource::Audius => "AU",
             SearchSource::Jamendo => "JA",
             SearchSource::InternetArchive => "IA",
+            SearchSource::OpenSubsonic => "SUB",
             SearchSource::RadioBrowser => "RAD",
             SearchSource::All => "ALL",
         }
@@ -48,6 +51,7 @@ impl SearchSource {
             SearchSource::Audius => "Audius",
             SearchSource::Jamendo => "Jamendo",
             SearchSource::InternetArchive => "Internet Archive",
+            SearchSource::OpenSubsonic => "Music server",
             SearchSource::RadioBrowser => "Radio Browser",
             SearchSource::All => "All enabled",
         }
@@ -60,6 +64,7 @@ impl SearchSource {
             SearchSource::Audius => "au",
             SearchSource::Jamendo => "ja",
             SearchSource::InternetArchive => "ia",
+            SearchSource::OpenSubsonic => "sub",
             SearchSource::RadioBrowser => "rad",
             SearchSource::All => "all",
         }
@@ -86,6 +91,8 @@ pub struct SearchConfig {
     pub audius: bool,
     pub jamendo: bool,
     pub internet_archive: bool,
+    /// Enabled only while a complete OpenSubsonic profile is active.
+    pub open_subsonic: bool,
     pub radio_browser: bool,
     /// Audius requires an app identifier on public API calls. Not a secret.
     pub audius_app_name: Option<String>,
@@ -103,6 +110,7 @@ impl Default for SearchConfig {
             audius: true,
             jamendo: true,
             internet_archive: true,
+            open_subsonic: false,
             radio_browser: true,
             audius_app_name: None,
             jamendo_client_id: None,
@@ -118,6 +126,7 @@ impl SearchConfig {
             SearchSource::Audius => self.audius,
             SearchSource::Jamendo => self.jamendo,
             SearchSource::InternetArchive => self.internet_archive,
+            SearchSource::OpenSubsonic => self.open_subsonic,
             SearchSource::RadioBrowser => self.radio_browser,
             SearchSource::All => true,
         }
@@ -130,6 +139,7 @@ impl SearchConfig {
             SearchSource::Audius => self.audius = enabled,
             SearchSource::Jamendo => self.jamendo = enabled,
             SearchSource::InternetArchive => self.internet_archive = enabled,
+            SearchSource::OpenSubsonic => self.open_subsonic = enabled,
             SearchSource::RadioBrowser => self.radio_browser = enabled,
             SearchSource::All => {}
         }
@@ -141,6 +151,17 @@ impl SearchConfig {
         SearchSource::CONCRETE
             .into_iter()
             .filter(|&source| self.is_enabled(source))
+            .collect()
+    }
+
+    /// Sources handled by the existing public-provider search client.
+    ///
+    /// OpenSubsonic owns credentials and origin policy in a separate actor, so it must never
+    /// reach the public-provider fan-out even when it participates in the app-level `All` view.
+    pub fn enabled_public_sources(&self) -> Vec<SearchSource> {
+        self.enabled_sources()
+            .into_iter()
+            .filter(|source| *source != SearchSource::OpenSubsonic)
             .collect()
     }
 
@@ -158,7 +179,12 @@ impl SearchConfig {
     pub fn streaming_enabled_sources(&self) -> Vec<SearchSource> {
         self.enabled_sources()
             .into_iter()
-            .filter(|source| *source != SearchSource::RadioBrowser)
+            .filter(|source| {
+                !matches!(
+                    *source,
+                    SearchSource::OpenSubsonic | SearchSource::RadioBrowser
+                )
+            })
             .collect()
     }
 
@@ -205,7 +231,11 @@ impl SearchConfig {
                     .unwrap_or(SearchSource::Youtube)
             };
         }
-        if source != SearchSource::RadioBrowser && self.is_enabled(source) {
+        if !matches!(
+            source,
+            SearchSource::OpenSubsonic | SearchSource::RadioBrowser
+        ) && self.is_enabled(source)
+        {
             source
         } else {
             self.streaming_enabled_sources()
@@ -281,10 +311,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn streaming_sources_exclude_radio_browser() {
-        let cfg = SearchConfig::default();
+    fn streaming_sources_exclude_live_radio_and_open_subsonic() {
+        let cfg = SearchConfig {
+            open_subsonic: true,
+            ..SearchConfig::default()
+        };
 
         assert!(cfg.enabled_sources().contains(&SearchSource::RadioBrowser));
+        assert!(cfg.enabled_sources().contains(&SearchSource::OpenSubsonic));
+        assert!(
+            !cfg.enabled_public_sources()
+                .contains(&SearchSource::OpenSubsonic)
+        );
         assert!(
             !cfg.streaming_enabled_sources()
                 .contains(&SearchSource::RadioBrowser)
@@ -292,6 +330,14 @@ mod tests {
         assert!(
             !cfg.selectable_streaming_sources()
                 .contains(&SearchSource::RadioBrowser)
+        );
+        assert!(
+            !cfg.streaming_enabled_sources()
+                .contains(&SearchSource::OpenSubsonic)
+        );
+        assert!(
+            !cfg.selectable_streaming_sources()
+                .contains(&SearchSource::OpenSubsonic)
         );
     }
 
@@ -310,5 +356,59 @@ mod tests {
         .normalized();
 
         assert_eq!(cfg.streaming_source, SearchSource::SoundCloud);
+    }
+
+    #[test]
+    fn open_subsonic_is_disabled_by_default_and_selectable_only_when_enabled() {
+        let mut cfg = SearchConfig::default();
+        assert!(!cfg.open_subsonic);
+        assert!(
+            !cfg.selectable_sources()
+                .contains(&SearchSource::OpenSubsonic)
+        );
+
+        cfg.set_enabled(SearchSource::OpenSubsonic, true);
+        assert!(
+            cfg.selectable_sources()
+                .contains(&SearchSource::OpenSubsonic)
+        );
+
+        let before = SearchSource::InternetArchive;
+        assert_eq!(cfg.cycled_source(before, true), SearchSource::OpenSubsonic);
+        assert_eq!(cfg.cycled_source(SearchSource::OpenSubsonic, false), before);
+
+        cfg.source = SearchSource::OpenSubsonic;
+        cfg.set_enabled(SearchSource::OpenSubsonic, false);
+        assert_eq!(cfg.source, SearchSource::Youtube);
+    }
+
+    #[test]
+    fn old_search_config_defaults_open_subsonic_to_off() {
+        let cfg: SearchConfig = serde_json::from_str("{}").unwrap();
+
+        assert!(!cfg.open_subsonic);
+        assert_eq!(cfg.source, SearchSource::Youtube);
+    }
+
+    #[test]
+    fn open_subsonic_never_normalizes_as_a_streaming_source() {
+        let cfg = SearchConfig {
+            streaming_source: SearchSource::OpenSubsonic,
+            youtube: false,
+            soundcloud: true,
+            audius: false,
+            jamendo: false,
+            internet_archive: false,
+            open_subsonic: true,
+            radio_browser: false,
+            ..SearchConfig::default()
+        }
+        .normalized();
+
+        assert_eq!(cfg.streaming_source, SearchSource::SoundCloud);
+        assert!(
+            !cfg.streaming_enabled_sources()
+                .contains(&SearchSource::OpenSubsonic)
+        );
     }
 }

--- a/src/server_cli.rs
+++ b/src/server_cli.rs
@@ -1,0 +1,543 @@
+//! One-shot `ytt server` commands.
+//!
+//! Credentials are read with terminal echo disabled. Human and JSON output deliberately omit
+//! origins, custom-CA paths, usernames, and secrets.
+
+use std::io::{self, Write as _};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use age::secrecy::SecretString;
+use serde::Serialize;
+
+use yututui::open_subsonic::{
+    CredentialKind, OpenSubsonicPaths, OpenSubsonicStatus, OpenSubsonicStatusKind,
+    ServerCredential, ServerFeature, SetupIdentityIntent, SetupInput, commit_setup, read_status,
+    remove_profile, test_and_prepare_setup, test_connection_read_only,
+};
+
+const EXIT_OK: i32 = 0;
+const EXIT_RUNTIME: i32 = 1;
+const EXIT_USAGE: i32 = 2;
+const MAX_CUSTOM_CA_BYTES: u64 = 192 * 1024;
+const STATUS_PROBE_TIMEOUT: Duration = Duration::from_secs(25);
+const MAX_DISPLAY_NAME_BYTES: usize = 1_024;
+const MAX_ORIGIN_BYTES: usize = 4_096;
+const MAX_USERNAME_BYTES: usize = 1_024;
+const MAX_PASSWORD_BYTES: usize = 64 * 1_024;
+const MAX_API_KEY_BYTES: usize = 2_048;
+const MAX_CA_PATH_BYTES: usize = 16 * 1_024;
+const MAX_CHOICE_BYTES: usize = 64;
+
+const SERVER_USAGE: &str = "\
+Usage: ytt server <command>
+
+Connect one OpenSubsonic or Navidrome music server.
+
+Commands:
+  setup             Test and save a music server connection
+  status [--json]   Show the redacted connection status
+  remove            Remove the profile and credentials; keep local personal data
+
+Passwords and API keys are prompted with echo disabled and are never accepted as arguments.
+";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Command {
+    Help,
+    Setup,
+    Status { json: bool },
+    Remove,
+}
+
+#[derive(Serialize)]
+struct JsonStatus<'a> {
+    status: &'static str,
+    display_name: Option<&'a str>,
+    backend_id: Option<&'a str>,
+    account_scope_id: Option<&'a str>,
+    credential: Option<&'static str>,
+    lan_http_enabled: bool,
+    custom_ca_configured: bool,
+}
+
+pub fn run(args: &[String]) -> i32 {
+    let command = match parse(args) {
+        Ok(command) => command,
+        Err(message) => return usage_error(&message),
+    };
+    let result = match command {
+        Command::Help => {
+            print!("{SERVER_USAGE}");
+            return EXIT_OK;
+        }
+        Command::Setup => run_setup(),
+        Command::Status { json } => run_status(json),
+        Command::Remove => run_remove(),
+    };
+    match result {
+        Ok(()) => EXIT_OK,
+        Err(error) => {
+            eprintln!("ytt server: {error}");
+            EXIT_RUNTIME
+        }
+    }
+}
+
+fn parse(args: &[String]) -> Result<Command, String> {
+    let Some(command) = args.first().map(String::as_str) else {
+        return Err("missing command".to_owned());
+    };
+    match command {
+        "-h" | "--help" | "help" => no_args(&args[1..], Command::Help, "help"),
+        "setup" => no_args(&args[1..], Command::Setup, "setup"),
+        "remove" => no_args(&args[1..], Command::Remove, "remove"),
+        "status" => match &args[1..] {
+            [] => Ok(Command::Status { json: false }),
+            [flag] if flag == "--json" => Ok(Command::Status { json: true }),
+            [flag] if matches!(flag.as_str(), "-h" | "--help") => Ok(Command::Help),
+            _ => Err("status only accepts `--json`".to_owned()),
+        },
+        other => Err(format!("unknown command `{other}`")),
+    }
+}
+
+fn no_args(args: &[String], command: Command, label: &str) -> Result<Command, String> {
+    if args.is_empty() {
+        Ok(command)
+    } else if args
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "-h" | "--help"))
+    {
+        Ok(Command::Help)
+    } else {
+        Err(format!("{label} does not accept arguments"))
+    }
+}
+
+fn run_setup() -> Result<(), String> {
+    initialize_writer()?;
+    let paths = paths()?;
+    let current = read_status(&paths).map_err(|error| error.to_string())?;
+    let identity_intent = if current.kind == OpenSubsonicStatusKind::Off {
+        SetupIdentityIntent::Create
+    } else {
+        prompt_identity_intent()?
+    };
+    let display_name = prompt_required("Server name: ", MAX_DISPLAY_NAME_BYTES)?;
+    let origin = prompt_required(
+        "Server address (scheme, host, and optional port): ",
+        MAX_ORIGIN_BYTES,
+    )?;
+    let credential_kind = prompt_credential_kind()?;
+    let credential = match credential_kind {
+        CredentialKind::Password => {
+            let username = prompt_required("Username: ", MAX_USERNAME_BYTES)?;
+            let password = prompt_secret("Password: ", MAX_PASSWORD_BYTES)?;
+            ServerCredential::password(username, SecretString::from(password))
+                .map_err(|error| error.to_string())?
+        }
+        CredentialKind::ApiKey => {
+            let key = prompt_secret("API key: ", MAX_API_KEY_BYTES)?;
+            ServerCredential::api_key(SecretString::from(key)).map_err(|error| error.to_string())?
+        }
+    };
+    let custom_ca_pem = prompt_custom_ca()?;
+    let allow_lan_http =
+        confirm("Allow plain HTTP for this exact private/loopback address? [y/N]: ")?;
+    let setup = SetupInput::new(
+        display_name,
+        origin,
+        allow_lan_http,
+        custom_ca_pem,
+        credential,
+        identity_intent,
+    );
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|_| "could not start the bounded connection test".to_owned())?;
+    let prepared = runtime
+        .block_on(test_and_prepare_setup(&paths, setup))
+        .map_err(|error| error.to_string())?;
+    let api_key_supported = prepared
+        .capabilities()
+        .supports(ServerFeature::ApiKeyAuthentication);
+    let status = commit_setup(&paths, prepared).map_err(|error| error.to_string())?;
+    set_server_search_enabled(true)?;
+    let name = status.display_name.as_deref().unwrap_or("Music server");
+    println!("{name} is connected.");
+    if credential_kind == CredentialKind::Password && api_key_supported {
+        println!("This server also advertises API-key authentication.");
+    }
+    if status.uses_lan_http {
+        println!("LAN HTTP is enabled only for the exact configured address.");
+    }
+    Ok(())
+}
+
+fn run_status(json: bool) -> Result<(), String> {
+    initialize_reader()?;
+    let status = checked_status(&paths()?)?;
+    if json {
+        println!("{}", render_json_status(&status)?);
+        return Ok(());
+    }
+    print_human_status(&status);
+    Ok(())
+}
+
+fn checked_status(paths: &OpenSubsonicPaths) -> Result<OpenSubsonicStatus, String> {
+    let mut stored = read_status(paths).map_err(|error| error.to_string())?;
+    if stored.kind != OpenSubsonicStatusKind::UpToDate {
+        return Ok(stored);
+    }
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|_| "could not start the bounded connection test".to_owned())?;
+    match runtime.block_on(async {
+        tokio::time::timeout(STATUS_PROBE_TIMEOUT, test_connection_read_only(paths)).await
+    }) {
+        Ok(Ok(live)) => Ok(live),
+        Ok(Err(_)) | Err(_) => {
+            stored.kind = OpenSubsonicStatusKind::NeedsAttention;
+            Ok(stored)
+        }
+    }
+}
+
+fn render_json_status(status: &OpenSubsonicStatus) -> Result<String, String> {
+    let value = JsonStatus {
+        status: status_label(status.kind),
+        display_name: status.display_name.as_deref(),
+        backend_id: status.backend_id.as_ref().map(|id| id.as_str()),
+        account_scope_id: status.account_scope_id.as_ref().map(|id| id.as_str()),
+        credential: status.credential_kind.map(credential_label),
+        lan_http_enabled: status.uses_lan_http,
+        custom_ca_configured: status.uses_custom_ca,
+    };
+    serde_json::to_string_pretty(&value).map_err(|_| "could not encode status JSON".to_owned())
+}
+
+fn run_remove() -> Result<(), String> {
+    initialize_writer()?;
+    if !confirm("Remove the music server profile and saved credential? [y/N]: ")? {
+        println!("Music server was not removed.");
+        return Ok(());
+    }
+    remove_profile(&paths()?).map_err(|error| error.to_string())?;
+    set_server_search_enabled(false)?;
+    println!("Music server removed; local personal data was kept.");
+    Ok(())
+}
+
+fn print_human_status(status: &OpenSubsonicStatus) {
+    match status.kind {
+        OpenSubsonicStatusKind::Off => println!("Off"),
+        OpenSubsonicStatusKind::UpToDate => {
+            println!("Up to date");
+            if let Some(name) = status.display_name.as_deref() {
+                println!("Server: {name}");
+            }
+            if let Some(kind) = status.credential_kind {
+                println!("Credential: {}", credential_label(kind));
+            }
+            if status.uses_lan_http {
+                println!("LAN HTTP: enabled for the exact configured address");
+            }
+            if status.uses_custom_ca {
+                println!("Custom CA: configured");
+            }
+        }
+        OpenSubsonicStatusKind::NeedsAttention => {
+            println!("Needs attention");
+            println!("Action: update the connection settings");
+        }
+    }
+}
+
+fn status_label(kind: OpenSubsonicStatusKind) -> &'static str {
+    match kind {
+        OpenSubsonicStatusKind::Off => "off",
+        OpenSubsonicStatusKind::UpToDate => "up_to_date",
+        OpenSubsonicStatusKind::NeedsAttention => "needs_attention",
+    }
+}
+
+fn credential_label(kind: CredentialKind) -> &'static str {
+    match kind {
+        CredentialKind::ApiKey => "api_key",
+        CredentialKind::Password => "password",
+    }
+}
+
+fn initialize_reader() -> Result<(), String> {
+    yututui::persist::initialize_persistence_reader()
+        .map(|_| ())
+        .map_err(|_| "could not open a coherent local snapshot".to_owned())
+}
+
+fn initialize_writer() -> Result<(), String> {
+    match yututui::persist::initialize_persistence_writer(false) {
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+            return Err(
+                "another ytt process owns settings; use its controls or close it and retry"
+                    .to_owned(),
+            );
+        }
+        Err(_) => return Err("could not secure the settings writer".to_owned()),
+    }
+    yututui::persist::preflight_all_startup_stores()
+        .map_err(|_| "local recovery must be completed before changing the server".to_owned())
+}
+
+fn paths() -> Result<OpenSubsonicPaths, String> {
+    OpenSubsonicPaths::current().map_err(|_| "the data directory is unavailable".to_owned())
+}
+
+fn prompt_line(prompt: &str, max_bytes: usize) -> Result<String, String> {
+    print!("{prompt}");
+    io::stdout()
+        .flush()
+        .map_err(|_| "could not write the prompt".to_owned())?;
+    read_bounded_line(&mut io::stdin().lock(), max_bytes).map_err(|error| match error.kind() {
+        io::ErrorKind::InvalidData => "terminal input exceeds its byte limit".to_owned(),
+        _ => "could not read terminal input".to_owned(),
+    })
+}
+
+fn read_bounded_line(reader: &mut impl io::BufRead, max_bytes: usize) -> io::Result<String> {
+    let mut value = Vec::with_capacity(max_bytes.min(4 * 1024));
+    let mut overflow = false;
+    loop {
+        let (consumed, finished) = {
+            let available = reader.fill_buf()?;
+            if available.is_empty() {
+                break;
+            }
+            let newline = available.iter().position(|byte| *byte == b'\n');
+            let consumed = newline.map_or(available.len(), |index| index + 1);
+            let content = &available[..newline.unwrap_or(available.len())];
+            let remaining = max_bytes.saturating_sub(value.len());
+            if content.len() > remaining {
+                overflow = true;
+                value.extend_from_slice(&content[..remaining]);
+            } else {
+                value.extend_from_slice(content);
+            }
+            (consumed, newline.is_some())
+        };
+        reader.consume(consumed);
+        if finished {
+            break;
+        }
+    }
+    if overflow {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "input exceeds its byte limit",
+        ));
+    }
+    if value.last() == Some(&b'\r') {
+        value.pop();
+    }
+    String::from_utf8(value)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "input is not UTF-8"))
+}
+
+fn prompt_required(prompt: &str, max_bytes: usize) -> Result<String, String> {
+    let value = prompt_line(prompt, max_bytes)?;
+    if value.trim().is_empty() {
+        Err("a required value was left blank".to_owned())
+    } else {
+        Ok(value.trim().to_owned())
+    }
+}
+
+fn prompt_secret(prompt: &str, max_bytes: usize) -> Result<String, String> {
+    let mut value = zeroize::Zeroizing::new(
+        rpassword::prompt_password(prompt).map_err(|_| "could not read the secret".to_owned())?,
+    );
+    if value.is_empty() {
+        Err("the credential cannot be blank".to_owned())
+    } else if value.len() > max_bytes {
+        Err("the credential exceeds its byte limit".to_owned())
+    } else {
+        Ok(std::mem::take(&mut *value))
+    }
+}
+
+fn prompt_credential_kind() -> Result<CredentialKind, String> {
+    let value = prompt_required("Credential type [password/api-key]: ", MAX_CHOICE_BYTES)?;
+    match value.trim().to_ascii_lowercase().as_str() {
+        "password" | "pass" | "p" => Ok(CredentialKind::Password),
+        "api-key" | "api_key" | "apikey" | "key" | "k" => Ok(CredentialKind::ApiKey),
+        _ => Err("credential type must be `password` or `api-key`".to_owned()),
+    }
+}
+
+fn prompt_identity_intent() -> Result<SetupIdentityIntent, String> {
+    println!("Existing connection:");
+    println!("  1  Same server and account — keep existing song links");
+    println!("  2  Different server or account — start a separate identity");
+    match prompt_required("Choose 1 or 2: ", MAX_CHOICE_BYTES)?.as_str() {
+        "1" => Ok(SetupIdentityIntent::UpdateSameServerAndAccount),
+        "2" => Ok(SetupIdentityIntent::ReplaceServerOrAccount),
+        _ => Err("connection identity must be explicitly selected as `1` or `2`".to_owned()),
+    }
+}
+
+fn set_server_search_enabled(enabled: bool) -> Result<(), String> {
+    let mut config = yututui::config::Config::load();
+    config
+        .search
+        .set_enabled(yututui::search_source::SearchSource::OpenSubsonic, enabled);
+    config.search = config.search.normalized();
+    config
+        .save()
+        .map_err(|_| "music server was changed but search settings could not be saved".to_owned())
+}
+
+fn prompt_custom_ca() -> Result<Option<Vec<u8>>, String> {
+    let raw = prompt_line(
+        "Custom CA file (leave blank to use system trust): ",
+        MAX_CA_PATH_BYTES,
+    )?;
+    if raw.trim().is_empty() {
+        return Ok(None);
+    }
+    let path = std::path::absolute(PathBuf::from(raw.trim()))
+        .map_err(|_| "could not resolve the CA file".to_owned())?;
+    let bytes = yututui::util::safe_fs::read_no_symlink_limited(&path, MAX_CUSTOM_CA_BYTES)
+        .map_err(|_| {
+            "the CA file must be a readable regular non-symlink file within the size limit"
+                .to_owned()
+        })?;
+    if bytes.is_empty() {
+        return Err("the CA file is empty".to_owned());
+    }
+    Ok(Some(bytes))
+}
+
+fn confirm(prompt: &str) -> Result<bool, String> {
+    Ok(matches!(
+        prompt_line(prompt, MAX_CHOICE_BYTES)?
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "y" | "yes"
+    ))
+}
+
+fn usage_error(message: &str) -> i32 {
+    eprintln!("ytt server: {message}");
+    eprintln!("Try `ytt server --help`.");
+    EXIT_USAGE
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use age::secrecy::SecretString;
+
+    use super::*;
+    use yututui::open_subsonic::{
+        ConfiguredPrivateOrigin, OpenSubsonicBridgeState, OpenSubsonicPrivateState,
+        OpenSubsonicProfile, OpenSubsonicStoreSet, StoreRevisions, commit_store_set,
+    };
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_owned()).collect()
+    }
+
+    #[test]
+    fn parses_public_commands_without_secret_arguments() {
+        assert_eq!(parse(&args(&["setup"])), Ok(Command::Setup));
+        assert_eq!(
+            parse(&args(&["status", "--json"])),
+            Ok(Command::Status { json: true })
+        );
+        assert_eq!(parse(&args(&["remove"])), Ok(Command::Remove));
+    }
+
+    #[test]
+    fn rejects_setup_and_remove_arguments() {
+        assert!(parse(&args(&["setup", "https://secret.example"])).is_err());
+        assert!(parse(&args(&["remove", "--force"])).is_err());
+    }
+
+    #[test]
+    fn status_only_accepts_json() {
+        assert!(parse(&args(&["status", "--verbose"])).is_err());
+        assert_eq!(parse(&args(&["status", "-h"])), Ok(Command::Help));
+    }
+
+    #[test]
+    fn status_labels_are_stable() {
+        assert_eq!(status_label(OpenSubsonicStatusKind::Off), "off");
+        assert_eq!(credential_label(CredentialKind::ApiKey), "api_key");
+    }
+
+    #[test]
+    fn bounded_line_reader_drains_oversize_input_and_counts_utf8_bytes() {
+        let mut reader = Cursor::new(b"toolong\nok\n".to_vec());
+        assert_eq!(
+            read_bounded_line(&mut reader, 3).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert_eq!(read_bounded_line(&mut reader, 3).unwrap(), "ok");
+
+        let mut exact = Cursor::new("é\n".as_bytes());
+        assert_eq!(read_bounded_line(&mut exact, 2).unwrap(), "é");
+        let mut split = Cursor::new("é\n".as_bytes());
+        assert_eq!(
+            read_bounded_line(&mut split, 1).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn offline_saved_profile_is_redacted_needs_attention_in_json() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let root = std::env::temp_dir().join(format!(
+            "yututui-server-cli-status-{}-{port}",
+            std::process::id()
+        ));
+        yututui::persist::initialize_persistence_writer_for_roots([&root], false).unwrap();
+        yututui::util::safe_fs::ensure_private_dir(&root).unwrap();
+        let paths = OpenSubsonicPaths::for_data_root(root.clone());
+        let profile = OpenSubsonicProfile::new(
+            "Offline fixture",
+            ConfiguredPrivateOrigin::new(&format!("https://127.0.0.1:{port}/"), false).unwrap(),
+            None,
+        )
+        .unwrap();
+        let private_state = OpenSubsonicPrivateState::new(
+            profile.backend_id().clone(),
+            profile.account_scope_id().clone(),
+            ServerCredential::api_key(SecretString::from("json-secret-sentinel".to_owned()))
+                .unwrap(),
+        );
+        let bridge_state = OpenSubsonicBridgeState::new(
+            profile.backend_id().clone(),
+            profile.account_scope_id().clone(),
+        );
+        let mut store_set =
+            OpenSubsonicStoreSet::new(profile, private_state, bridge_state).unwrap();
+        commit_store_set(&paths, StoreRevisions::MISSING, &mut store_set).unwrap();
+
+        let status = checked_status(&paths).unwrap();
+        assert_eq!(status.kind, OpenSubsonicStatusKind::NeedsAttention);
+        let json = render_json_status(&status).unwrap();
+        assert!(json.contains(r#""status": "needs_attention""#));
+        assert!(json.contains("Offline fixture"));
+        assert!(!json.contains("json-secret-sentinel"));
+        assert!(!json.contains("https://"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/src/terminal_runtime/runner.rs
+++ b/src/terminal_runtime/runner.rs
@@ -856,13 +856,13 @@ pub async fn run(
     // found a live descriptor but nothing was accepting/answering yet. The socket itself is
     // already bound (in `bind_or_detect`), so the single-instance guard is in force from launch.
 
-    // Spawn mpv off the startup path. Until the IPC actor is ready, reducer-emitted
-    // PlayerCmds are buffered by RuntimeHandles and replayed in order.
+    let open_subsonic_routes = crate::playback_target::PlaybackRouteProviderSlot::default();
     let mut player_startup = spawn_audio_player(
         worker_tx.clone(),
         player_registry_dir.clone(),
         &player_runtime,
         shutdown.clone(),
+        open_subsonic_routes.handle(),
     );
     let mut player_ready_pending = true;
     startup.mark("mpv_spawned");
@@ -922,7 +922,14 @@ pub async fn run(
         ai_handle,
         scrobble_handle,
         persist.clone(),
+        open_subsonic_routes.clone(),
     );
+    if let Some(data_root) = data_dir.clone() {
+        let _ = handles.spawn_open_subsonic_reload(
+            0,
+            crate::open_subsonic::OpenSubsonicPaths::for_data_root(data_root),
+        );
+    }
     let network_changes = crate::sync::NetworkChangeWatch::start();
 
     let automatic_sync_active = !persistence_read_only
@@ -1359,6 +1366,14 @@ pub async fn run(
                 }
                 continue;
             }
+            OwnerTurnInput::BufferedWorker(RuntimeEvent::OpenSubsonicReloaded {
+                generation,
+                result,
+            })
+            | OwnerTurnInput::Worker(RuntimeEvent::OpenSubsonicReloaded { generation, result }) => {
+                handles.install_open_subsonic_runtime(generation, result);
+                continue;
+            }
             OwnerTurnInput::BufferedWorker(mut event) | OwnerTurnInput::Worker(mut event) => {
                 if let RuntimeEvent::Player(player_event) = &mut event {
                     handles.reconcile_cache_safety_event(player_event);
@@ -1434,6 +1449,7 @@ pub async fn run(
                 player_registry_dir.clone(),
                 &player_runtime,
                 shutdown.clone(),
+                open_subsonic_routes.handle(),
             );
             player_ready_pending = true;
         }

--- a/src/terminal_runtime/runner/player_startup.rs
+++ b/src/terminal_runtime/runner/player_startup.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 
+use crate::playback_target::PlaybackRouteProviderHandle;
 use crate::player::PlayerHandle;
 use crate::runtime::RuntimeEvent;
 use crate::{config, player, runtime};
@@ -90,6 +91,7 @@ pub(super) fn spawn_audio_player(
     data_dir: Option<std::path::PathBuf>,
     cfg: &config::PlayerRuntimeConfig,
     shutdown: player::lifetime::ShutdownLatch,
+    route_provider: PlaybackRouteProviderHandle,
 ) -> PlayerStartup {
     let cookies_file = cfg.cookies_file.clone();
     let gapless = cfg.gapless;
@@ -102,12 +104,13 @@ pub(super) fn spawn_audio_player(
         }
         match tokio::time::timeout(
             PLAYER_START_TIMEOUT,
-            player::spawn(
+            player::spawn_with_route_provider(
                 runtime::sink(worker_tx, RuntimeEvent::Player),
                 data_dir,
                 cookies_file,
                 gapless,
                 audio,
+                route_provider,
             ),
         )
         .await

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -50,11 +50,15 @@ pub fn render(frame: &mut Frame, app: &App) {
     // the overlay stack below still runs either way — modals capture keys, so they must
     // stay visible.
     let mut tier = layout::tier(area);
-    // Settings has a purpose-built narrow tab strip and list layout. Keep it reachable at the
-    // issue-114 keyboard-only acceptance width even though the playback surface still needs the
-    // 32-column Mini boundary for its transport controls.
+    // Settings and the transient Server Library have purpose-built narrow selectors. Keep those
+    // issue-114 keyboard-only surfaces reachable at 30 columns even though ordinary playback and
+    // local-library screens still need the 32-column Mini boundary for their transport controls.
+    let issue_114_narrow_surface = app.mode == Mode::Settings
+        || (app.mode == Mode::Library
+            && !app.local_dedicated_mode
+            && app.server.library.source == crate::app::LibrarySource::OpenSubsonic);
     if tier == layout::UiTier::Mini
-        && app.mode == Mode::Settings
+        && issue_114_narrow_surface
         && area.width >= 30
         && area.height >= layout::MINI_MIN_H
     {
@@ -193,6 +197,9 @@ pub fn render(frame: &mut Frame, app: &App) {
     // Draw this move-only wizard at the top level so its fields and actions always win z-order.
     if app.personal_state.sync_ui.modal_open() {
         views::settings::render_sync_wizard(frame, app, area);
+    }
+    if app.server.settings.modal_open() {
+        views::settings::render_music_server_wizard(frame, app, area);
     }
     retro::scrub_frame(frame, app);
 }

--- a/src/ui/views/help.rs
+++ b/src/ui/views/help.rs
@@ -8,7 +8,7 @@ use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use crate::app::{ActiveSearchSurface, App, Mode};
+use crate::app::{ActiveSearchSurface, App, LibrarySource, Mode};
 use crate::keymap::{self, Action, KeyContext, KeyMap};
 use crate::t;
 use crate::theme::ThemeRole as R;
@@ -261,12 +261,28 @@ fn visible_keymap(app: &App) -> &KeyMap {
 
 fn help_groups(app: &App) -> Vec<(String, Vec<(String, String)>)> {
     let keymap = visible_keymap(app);
+    let server_library_active = app.mode == Mode::Library
+        && !app.local_dedicated_mode
+        && app.server.library.source == LibrarySource::OpenSubsonic;
     let mut out = Vec::new();
     for (ctx, actions) in keymap::groups() {
         let mut rows: Vec<(String, String)> = actions
             .iter()
+            .copied()
+            .filter(|action| {
+                !server_library_active
+                    || ctx != KeyContext::Library
+                    || matches!(
+                        action,
+                        Action::Confirm
+                            | Action::Enqueue
+                            | Action::PlayAll
+                            | Action::AddToPlaylist
+                            | Action::Back
+                    )
+            })
             .map(|action| {
-                let key = keymap.chord(ctx, *action).map_or_else(
+                let key = keymap.chord(ctx, action).map_or_else(
                     || "—".to_owned(),
                     |chord| keymap::format_chord_for_display(chord, app.retro_mode()),
                 );
@@ -282,6 +298,52 @@ fn help_groups(app: &App) -> Vec<(String, Vec<(String, String)>)> {
             rows.insert(0, fixed_enter_row(Action::Confirm.human_label_for(ctx)));
         }
         out.push((ctx.title().to_owned(), rows));
+    }
+    if server_library_active {
+        let mapped = |action| {
+            keymap.chord(KeyContext::Common, action).map_or_else(
+                || "—".to_owned(),
+                |chord| keymap::format_chord_for_display(chord, app.retro_mode()),
+            )
+        };
+        out.push((
+            t!(
+                "Music server library",
+                "음악 서버 보관함",
+                "音楽サーバーライブラリ"
+            )
+            .to_owned(),
+            vec![
+                (
+                    mapped(Action::FocusPrev),
+                    t!("Previous section", "이전 섹션", "前のセクション").to_owned(),
+                ),
+                (
+                    mapped(Action::FocusNext),
+                    t!("Next section", "다음 섹션", "次のセクション").to_owned(),
+                ),
+                fixed_help_row("1–5", "Choose section", "섹션 선택", "セクションを選択"),
+                fixed_help_row(
+                    "[",
+                    "Previous server page",
+                    "이전 서버 페이지",
+                    "前のサーバーページ",
+                ),
+                fixed_help_row(
+                    "]",
+                    "Next server page",
+                    "다음 서버 페이지",
+                    "次のサーバーページ",
+                ),
+                fixed_help_row(
+                    "Left",
+                    "Return to local library",
+                    "로컬 보관함으로 돌아가기",
+                    "ローカルライブラリに戻る",
+                ),
+                fixed_help_row("Esc", "Back one level", "한 단계 뒤로", "1段階戻る"),
+            ],
+        ));
     }
     if app.mode == Mode::Search && app.active_search_surface() == ActiveSearchSurface::Local {
         out.push((
@@ -1028,6 +1090,66 @@ mod tests {
             ("a".to_owned(), "Play whole tab".to_owned()),
         ] {
             assert!(library.contains(&row), "cheat-sheet should list {row:?}");
+        }
+    }
+
+    #[test]
+    fn server_library_help_lists_only_supported_library_actions_and_fixed_navigation() {
+        let _guard = crate::i18n::lock_for_test();
+        crate::i18n::set_language(crate::i18n::Language::English);
+        let mut app = App::new(100);
+        app.mode = Mode::Library;
+        app.server.library.source = LibrarySource::OpenSubsonic;
+        let groups = help_groups(&app);
+
+        let library = groups
+            .iter()
+            .find_map(|(title, rows)| (title == "Library").then_some(rows))
+            .expect("Library group");
+        for supported in [
+            "Play selected",
+            "Add to queue",
+            "Play whole tab",
+            "Add to playlist",
+            "Close Library",
+        ] {
+            assert!(
+                library.iter().any(|(_, label)| label == supported),
+                "missing supported action {supported:?}"
+            );
+        }
+        for unsupported in [
+            "Favorite / unfavorite",
+            "Download track",
+            "Download whole list",
+            "Remove / delete",
+            "Filter library",
+        ] {
+            assert!(
+                library.iter().all(|(_, label)| label != unsupported),
+                "server Library must not advertise {unsupported:?}"
+            );
+        }
+
+        let server = groups
+            .iter()
+            .find_map(|(title, rows)| (title == "Music server library").then_some(rows))
+            .expect("contextual server group");
+        for row in [
+            ("⇧Tab", "Previous section"),
+            ("Tab", "Next section"),
+            ("1–5", "Choose section"),
+            ("[", "Previous server page"),
+            ("]", "Next server page"),
+            ("Left", "Return to local library"),
+            ("Esc", "Back one level"),
+        ] {
+            assert!(
+                server
+                    .iter()
+                    .any(|(key, label)| key == row.0 && label == row.1),
+                "missing server help row {row:?}"
+            );
         }
     }
 

--- a/src/ui/views/library.rs
+++ b/src/ui/views/library.rs
@@ -10,7 +10,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 use unicode_width::UnicodeWidthStr;
 
-use crate::app::{App, LibraryTab, MouseTarget, ScrollSurface};
+use crate::app::{App, LibrarySource, LibraryTab, MouseTarget, ScrollSurface};
 use crate::i18n::Language;
 use crate::library::FavoriteLookup;
 use crate::t;
@@ -18,6 +18,10 @@ use crate::theme::ThemeRole as R;
 use crate::ui::buttons;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+    if !app.local_dedicated_mode && app.server.library.source == LibrarySource::OpenSubsonic {
+        super::server_library::render(frame, app, area);
+        return;
+    }
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(app.theme.style(R::BorderPrimary))
@@ -87,6 +91,9 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         // Inside an opened playlist the spacer row carries a clickable breadcrumb back
         // to the playlist list.
         render_playlist_breadcrumb(frame, app, rows[1]);
+    } else {
+        // Keep the source selector visible without adding a row or reflowing the local list.
+        super::server_library::render_source_selector(frame, app, rows[1]);
     }
     if playlists_root {
         render_playlist_list(frame, app, rows[2]);

--- a/src/ui/views/mod.rs
+++ b/src/ui/views/mod.rs
@@ -19,5 +19,6 @@ mod player_layout;
 mod player_lyrics;
 mod queue_actions;
 pub mod search;
+pub mod server_library;
 pub mod settings;
 pub mod why_ai;

--- a/src/ui/views/server_library.rs
+++ b/src/ui/views/server_library.rs
@@ -1,0 +1,552 @@
+//! Read-only music-server library renderer.
+
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::app::{App, LibrarySource, MouseTarget, ScrollSurface};
+use crate::open_subsonic::model::{
+    LibraryWarning, ServerLibraryDetail, ServerLibraryRow, ServerLibrarySection,
+};
+use crate::t;
+use crate::theme::ThemeRole as R;
+use crate::ui::buttons;
+
+pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(app.theme.style(R::BorderPrimary))
+        .style(app.theme.style(R::TextPrimary));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    buttons::render_nav(
+        frame,
+        app,
+        Rect {
+            x: inner.x,
+            y: area.y,
+            width: inner.width,
+            height: 1,
+        },
+    );
+
+    let rows = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(2),
+        Constraint::Length(2),
+        Constraint::Min(0),
+        Constraint::Length(crate::ui::control_box::docked_rows(app)),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+    render_source_selector(frame, app, rows[0]);
+    render_sections(frame, app, rows[1]);
+    render_context(frame, app, rows[2]);
+    render_rows(frame, app, rows[3]);
+    crate::ui::control_box::render_docked(frame, app, rows[4]);
+    buttons::render_help_button(frame, app, rows[5]);
+}
+
+pub(super) fn render_source_selector(frame: &mut Frame, app: &App, area: Rect) {
+    if area.is_empty() {
+        return;
+    }
+    let server_name = app.server.settings.summary.display_name();
+    let local = " YuTuTui ";
+    let server = format!(" {} ", server_name);
+    let separator = "  |  ";
+    let compact = buttons::text_width(local)
+        .saturating_add(buttons::text_width(&server))
+        .saturating_add(buttons::text_width(separator))
+        > area.width;
+    let server = if compact {
+        format!(" {} ", t!("Server", "서버", "サーバー"))
+    } else {
+        server
+    };
+
+    let mut spans = Vec::new();
+    let mut x = area.x;
+    for (source, label) in [
+        (LibrarySource::Yututui, local.to_owned()),
+        (LibrarySource::OpenSubsonic, server),
+    ] {
+        if !spans.is_empty() {
+            spans.push(Span::styled(separator, app.theme.style(R::TextMuted)));
+            x = x.saturating_add(buttons::text_width(separator));
+        }
+        let width = buttons::text_width(&label).min(area.right().saturating_sub(x));
+        let selected = app.server.library.source == source;
+        let style = if selected {
+            Style::default()
+                .fg(app.theme.color(R::SelectionFg))
+                .bg(app.theme.color(R::SelectionBg))
+                .add_modifier(Modifier::BOLD)
+        } else {
+            app.theme.style(R::TextMuted)
+        };
+        spans.push(Span::styled(label, style));
+        if width > 0 {
+            app.register_mouse_button(
+                Rect {
+                    x,
+                    y: area.y,
+                    width,
+                    height: 1,
+                },
+                MouseTarget::LibrarySource(source),
+            );
+        }
+        x = x.saturating_add(width);
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn render_sections(frame: &mut Frame, app: &App, area: Rect) {
+    let section_rows = Layout::vertical([Constraint::Length(1), Constraint::Length(1)]).split(area);
+    let sections = [
+        ServerLibrarySection::RecentlyPlayed,
+        ServerLibrarySection::Albums,
+        ServerLibrarySection::Artists,
+        ServerLibrarySection::Songs,
+        ServerLibrarySection::Playlists,
+    ];
+    render_section_line(frame, app, section_rows[0], &sections[..3]);
+    render_section_line(frame, app, section_rows[1], &sections[3..]);
+}
+
+fn render_section_line(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    sections: &[ServerLibrarySection],
+) {
+    let full_width = sections
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, section)| {
+            buttons::text_width(section_label(section, false))
+                .saturating_add(2)
+                .saturating_add((index > 0) as u16 * 2)
+        })
+        .sum::<u16>();
+    // A 30-column terminal leaves 28 inner cells. Use one consistent compact vocabulary for
+    // both section rows at that tier instead of mixing a compact first row with a full second.
+    let compact = area.width <= 28 || full_width > area.width;
+    let gap = if compact { " " } else { "  " };
+    let mut spans = Vec::new();
+    let mut x = area.x;
+    for (index, section) in sections.iter().copied().enumerate() {
+        if index > 0 {
+            spans.push(Span::styled(gap, app.theme.style(R::TextMuted)));
+            x = x.saturating_add(buttons::text_width(gap));
+        }
+        let label = if compact {
+            section_label(section, true).to_owned()
+        } else {
+            format!(" {} ", section_label(section, false))
+        };
+        let width = buttons::text_width(&label).min(area.right().saturating_sub(x));
+        let active = app.server.library.section == section;
+        let style = if active {
+            Style::default()
+                .fg(app.theme.color(R::SelectionFg))
+                .bg(app.theme.color(R::SelectionBg))
+                .add_modifier(Modifier::BOLD)
+        } else {
+            app.theme.style(R::TextMuted)
+        };
+        spans.push(Span::styled(label, style));
+        if width > 0 {
+            app.register_mouse_button(
+                Rect {
+                    x,
+                    y: area.y,
+                    width,
+                    height: 1,
+                },
+                MouseTarget::ServerLibrarySection(section),
+            );
+        }
+        x = x.saturating_add(width);
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn section_label(section: ServerLibrarySection, compact: bool) -> &'static str {
+    match (section, compact) {
+        (ServerLibrarySection::RecentlyPlayed, false) => {
+            t!("Recently played", "최근 재생", "最近再生")
+        }
+        (ServerLibrarySection::RecentlyPlayed, true) => t!("Recent", "최근", "最近"),
+        (ServerLibrarySection::Albums, _) => t!("Albums", "앨범", "アルバム"),
+        (ServerLibrarySection::Artists, false) => t!("Artists", "아티스트", "アーティスト"),
+        (ServerLibrarySection::Artists, true) => t!("Artists", "아티스트", "歌手"),
+        (ServerLibrarySection::Songs, _) => t!("Songs", "노래", "曲"),
+        (ServerLibrarySection::Playlists, false) => {
+            t!("Playlists", "플레이리스트", "プレイリスト")
+        }
+        (ServerLibrarySection::Playlists, true) => t!("Lists", "목록", "リスト"),
+    }
+}
+
+fn render_context(frame: &mut Frame, app: &App, area: Rect) {
+    if area.is_empty() {
+        return;
+    }
+    let generation = app.server.library.generation;
+    if let Some(failure) = app.server.library.failure {
+        frame.render_widget(
+            Paragraph::new(failure.label())
+                .style(app.theme.style(R::Error))
+                .wrap(ratatui::widgets::Wrap { trim: true }),
+            area,
+        );
+        return;
+    }
+    if app.server.library.busy.is_some() {
+        frame.render_widget(
+            Paragraph::new(t!("Loading…", "불러오는 중…", "読み込み中…"))
+                .style(app.theme.style(R::Accent)),
+            area,
+        );
+        return;
+    }
+    if let Some(detail) = app.server.library.detail.as_ref() {
+        let title = match detail {
+            ServerLibraryDetail::AlbumSongs { album, .. } => {
+                format!("← {}", album.name)
+            }
+            ServerLibraryDetail::ArtistAlbums { artist, .. } => {
+                format!("← {}", artist.name)
+            }
+            ServerLibraryDetail::PlaylistEntries(playlist) => {
+                format!("← {}", playlist.summary.name)
+            }
+        };
+        let text = crate::ui::text::truncate_owned_to_width(title, area.width as usize);
+        frame.render_widget(
+            Paragraph::new(text).style(app.theme.style(R::SettingsGroup)),
+            Rect { height: 1, ..area },
+        );
+        app.register_mouse_button(
+            Rect {
+                height: 1,
+                width: area.width,
+                ..area
+            },
+            MouseTarget::ServerLibraryBack { generation },
+        );
+        return;
+    }
+
+    let previous = if app.server.library.previous_offsets.is_empty() {
+        t!("Previous", "이전", "前へ")
+    } else {
+        t!("← Previous", "← 이전", "← 前へ")
+    };
+    let next = if app.server.library.next_offset().is_some() {
+        t!("Next →", "다음 →", "次へ →")
+    } else {
+        t!("Next", "다음", "次へ")
+    };
+    let page = app.server.library.offset / crate::app::SERVER_LIBRARY_PAGE_LIMIT + 1;
+    let line = format!("{previous}  ·  {page}  ·  {next}");
+    frame.render_widget(
+        Paragraph::new(line)
+            .style(app.theme.style(R::TextMuted))
+            .alignment(Alignment::Center),
+        Rect { height: 1, ..area },
+    );
+    let half = area.width / 2;
+    app.register_mouse_button(
+        Rect {
+            width: half,
+            height: 1,
+            ..area
+        },
+        MouseTarget::ServerLibraryPreviousPage { generation },
+    );
+    app.register_mouse_button(
+        Rect {
+            x: area.x.saturating_add(half),
+            width: area.width.saturating_sub(half),
+            height: 1,
+            ..area
+        },
+        MouseTarget::ServerLibraryNextPage { generation },
+    );
+    if let Some(warning) = app
+        .server
+        .library
+        .page
+        .as_ref()
+        .and_then(|page| page.warning)
+    {
+        let text = match warning {
+            LibraryWarning::FeatureUnsupported => t!(
+                "Some server features are unavailable.",
+                "일부 서버 기능을 사용할 수 없어요.",
+                "一部のサーバー機能を利用できません。"
+            ),
+            LibraryWarning::PartialResults => t!(
+                "Showing partial results.",
+                "일부 결과만 표시하고 있어요.",
+                "一部の結果を表示しています。"
+            ),
+        };
+        frame.render_widget(
+            Paragraph::new(text).style(app.theme.style(R::Warning)),
+            Rect {
+                y: area.y.saturating_add(1),
+                height: 1,
+                ..area
+            },
+        );
+    }
+}
+
+fn render_rows(frame: &mut Frame, app: &App, area: Rect) {
+    app.bridges.list_viewport_rows.set(area.height);
+    let len = app.server.library.rows_len();
+    if area.is_empty() {
+        return;
+    }
+    if len == 0 {
+        frame.render_widget(
+            Paragraph::new(t!(
+                "Nothing to show in this section.",
+                "이 섹션에 표시할 항목이 없어요.",
+                "このセクションに表示する項目はありません。"
+            ))
+            .style(app.theme.style(R::TextMuted)),
+            area,
+        );
+        return;
+    }
+
+    let cursor = app.server.library.selected.min(len - 1);
+    let visible = area.height as usize;
+    let start =
+        app.bridges
+            .library_scroll
+            .resolve(cursor, area.height, len, crate::ui::scroll::SCROLLOFF);
+    for visible_index in 0..visible {
+        let index = start + visible_index;
+        if index >= len {
+            break;
+        }
+        let selected = index == cursor;
+        let marker = if selected { "▶ " } else { "  " };
+        let text = server_row_text(app, index);
+        let text = crate::ui::text::truncate_owned_to_width(
+            format!("{marker}{text}"),
+            area.width.saturating_sub(1) as usize,
+        );
+        let style = if selected {
+            Style::default()
+                .fg(app.theme.color(R::SelectionFg))
+                .bg(app.theme.color(R::SelectionBg))
+                .add_modifier(Modifier::BOLD)
+        } else {
+            app.theme.style(R::TextPrimary)
+        };
+        let rect = Rect {
+            x: area.x,
+            y: area.y + visible_index as u16,
+            width: area.width,
+            height: 1,
+        };
+        frame.render_widget(Paragraph::new(text).style(style), rect);
+        app.register_mouse_button(
+            rect,
+            MouseTarget::ServerLibraryRow {
+                generation: app.server.library.generation,
+                index,
+            },
+        );
+    }
+    buttons::render_list_scrollbar(
+        frame,
+        app,
+        Rect {
+            x: area.right(),
+            y: area.y,
+            width: 1,
+            height: area.height,
+        },
+        ScrollSurface::Library,
+        len,
+        start,
+        visible,
+    );
+}
+
+fn server_row_text(app: &App, index: usize) -> String {
+    match app.server.library.detail.as_ref() {
+        Some(ServerLibraryDetail::AlbumSongs { songs, .. }) => {
+            songs.get(index).map_or_else(String::new, song_text)
+        }
+        Some(ServerLibraryDetail::ArtistAlbums { albums, .. }) => {
+            albums.get(index).map_or_else(String::new, album_text)
+        }
+        Some(ServerLibraryDetail::PlaylistEntries(playlist)) => playlist
+            .entries
+            .get(index)
+            .map_or_else(String::new, song_text),
+        None => app
+            .server
+            .library
+            .page
+            .as_ref()
+            .and_then(|page| page.rows.get(index))
+            .map_or_else(String::new, |row| match row {
+                ServerLibraryRow::Song(song) => song_text(song),
+                ServerLibraryRow::Album(album) => album_text(album),
+                ServerLibraryRow::Artist(artist) => {
+                    let count = artist.album_count.map_or_else(String::new, |count| {
+                        format!("  ·  {count} {}", t!("albums", "앨범", "アルバム"))
+                    });
+                    format!("♬ {}{count}", artist.name)
+                }
+                ServerLibraryRow::Playlist(playlist) => {
+                    let count = playlist.song_count.map_or_else(String::new, |count| {
+                        format!("  ·  {count} {}", t!("songs", "곡", "曲"))
+                    });
+                    format!("☷ {}{count}", playlist.name)
+                }
+            }),
+    }
+}
+
+fn song_text(song: &crate::open_subsonic::ServerSong) -> String {
+    let duration = song.duration_secs.map_or_else(String::new, |seconds| {
+        format!("  ({}:{:02})", seconds / 60, seconds % 60)
+    });
+    format!("♪ {} — {}{duration}", song.title, song.artist)
+}
+
+fn album_text(album: &crate::open_subsonic::ServerAlbum) -> String {
+    let count = album.song_count.map_or_else(String::new, |count| {
+        format!("  ·  {count} {}", t!("songs", "곡", "曲"))
+    });
+    format!("▣ {} — {}{count}", album.name, album.artist)
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+
+    fn draw_server_library(app: &App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app, frame.area()))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn section_labels_exist_in_all_languages() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for language in [
+            crate::i18n::Language::English,
+            crate::i18n::Language::Korean,
+            crate::i18n::Language::Japanese,
+        ] {
+            crate::i18n::set_language(language);
+            for section in [
+                ServerLibrarySection::RecentlyPlayed,
+                ServerLibrarySection::Albums,
+                ServerLibrarySection::Artists,
+                ServerLibrarySection::Songs,
+                ServerLibrarySection::Playlists,
+            ] {
+                assert!(!section_label(section, false).is_empty());
+                assert!(!section_label(section, true).is_empty());
+            }
+        }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn thirty_column_selector_shows_every_section_in_all_languages() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        let mut app = App::new(50);
+        app.mode = crate::app::Mode::Library;
+        app.server.library.source = LibrarySource::OpenSubsonic;
+
+        for (language, labels) in [
+            (
+                crate::i18n::Language::English,
+                ["Recent", "Albums", "Artists", "Songs", "Lists"],
+            ),
+            (
+                crate::i18n::Language::Korean,
+                ["최근", "앨범", "아티스트", "노래", "목록"],
+            ),
+            (
+                crate::i18n::Language::Japanese,
+                ["最近", "アルバム", "歌手", "曲", "リスト"],
+            ),
+        ] {
+            crate::i18n::set_language(language);
+            let text = draw_server_library(&app, 30, 30);
+            // TestBackend retains the continuation cell after each double-width glyph as a
+            // space. Compare whitespace-free text so CJK labels are checked as words.
+            let comparable: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
+            for label in labels {
+                let label: String = label.chars().filter(|ch| !ch.is_whitespace()).collect();
+                assert!(
+                    comparable.contains(&label),
+                    "{language:?} selector should contain {label:?}: {text:?}"
+                );
+            }
+        }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn compact_section_rows_fit_the_twenty_eight_cell_inner_width() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for language in [
+            crate::i18n::Language::English,
+            crate::i18n::Language::Korean,
+            crate::i18n::Language::Japanese,
+        ] {
+            crate::i18n::set_language(language);
+            for sections in [
+                &[
+                    ServerLibrarySection::RecentlyPlayed,
+                    ServerLibrarySection::Albums,
+                    ServerLibrarySection::Artists,
+                ][..],
+                &[ServerLibrarySection::Songs, ServerLibrarySection::Playlists][..],
+            ] {
+                let width = sections
+                    .iter()
+                    .copied()
+                    .map(|section| buttons::text_width(section_label(section, true)))
+                    .sum::<u16>()
+                    .saturating_add(sections.len().saturating_sub(1) as u16);
+                assert!(width <= 28, "{language:?} compact row is {width} cells");
+            }
+        }
+        crate::i18n::set_language(original);
+    }
+}

--- a/src/ui/views/settings.rs
+++ b/src/ui/views/settings.rs
@@ -3,6 +3,7 @@
 //! that highlights the focused row is rebuilt fresh each frame from a `usize` index.
 
 mod dialogs;
+mod music_server;
 mod recording;
 mod spotify;
 mod sync;
@@ -10,6 +11,7 @@ mod sync_wizard;
 mod tabs;
 
 pub use dialogs::{render_confirm, render_conflict};
+pub(crate) use music_server::render_music_server_wizard;
 pub use recording::{render_recording_settings, render_recordings_browser};
 pub(super) use spotify::render_spotify_import_mode_dropdown_popup;
 pub use spotify::render_spotify_picker;
@@ -73,11 +75,24 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     .split(inner);
 
     render_tabs(frame, app, st, rows[0]);
+    if st.tab == SettingsTab::Sync {
+        music_server::render_sync_area_selector(frame, app, st, rows[1]);
+    }
     if st.tab == SettingsTab::Keys {
         render_keys(frame, app, st, rows[2]);
     } else if st.tab == SettingsTab::Sync {
-        let model = app.sync_settings_model();
-        render_sync(frame, app, st, &model, rows[2]);
+        match app.server.settings.area {
+            crate::app::SyncArea::Status => {
+                music_server::render_status(frame, app, st, rows[2]);
+            }
+            crate::app::SyncArea::PersonalState | crate::app::SyncArea::DevicesRecovery => {
+                let model = app.sync_settings_model();
+                render_sync(frame, app, st, &model, rows[2]);
+            }
+            crate::app::SyncArea::MusicServer => {
+                music_server::render_music_server(frame, app, st, rows[2]);
+            }
+        }
     } else {
         render_fields(frame, app, st, rows[2]);
     }

--- a/src/ui/views/settings/music_server.rs
+++ b/src/ui/views/settings/music_server.rs
@@ -1,0 +1,658 @@
+//! Plain-language Sync area selector and music-server settings/wizard rendering.
+
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+use zeroize::Zeroizing;
+
+use crate::app::{
+    App, MouseTarget, MusicServerBusy, MusicServerHealth, MusicServerSetupField, MusicServerWizard,
+    SyncArea,
+};
+use crate::settings::SettingsState;
+use crate::settings::sync::health_label;
+use crate::t;
+use crate::theme::ThemeRole as R;
+use crate::ui::buttons;
+
+pub(crate) fn render_sync_area_selector(
+    frame: &mut Frame,
+    app: &App,
+    settings: &SettingsState,
+    area: Rect,
+) {
+    if area.is_empty() {
+        return;
+    }
+    let theme = &settings.draft.theme;
+    let mut x = area.x;
+    let mut spans = Vec::new();
+    for (index, sync_area) in SyncArea::ALL.iter().copied().enumerate() {
+        if index > 0 {
+            spans.push(Span::styled(" | ", theme.style(R::TextMuted)));
+            x = x.saturating_add(3);
+        }
+        let label = compact_area_label(sync_area);
+        let width = buttons::text_width(label).min(area.right().saturating_sub(x));
+        let selected = app.server.settings.area == sync_area;
+        spans.push(Span::styled(
+            label,
+            if selected {
+                Style::default()
+                    .fg(theme.color(R::SelectionFg))
+                    .bg(theme.color(R::SelectionBg))
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                theme.style(R::TextMuted)
+            },
+        ));
+        if width > 0 {
+            app.register_mouse_button(
+                Rect {
+                    x,
+                    y: area.y,
+                    width,
+                    height: 1,
+                },
+                MouseTarget::SettingsSyncArea(sync_area),
+            );
+        }
+        x = x.saturating_add(width);
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn compact_area_label(area: SyncArea) -> &'static str {
+    match area {
+        SyncArea::Status => t!("Status", "상태", "状態"),
+        SyncArea::PersonalState => t!("Data", "개인", "個人"),
+        SyncArea::MusicServer => t!("Server", "서버", "音楽"),
+        SyncArea::DevicesRecovery => t!("Dev", "기기", "機器"),
+    }
+}
+
+pub(crate) fn render_status(frame: &mut Frame, app: &App, settings: &SettingsState, area: Rect) {
+    let theme = &settings.draft.theme;
+    let personal = app.sync_settings_model();
+    let server = &app.server.settings.summary;
+    let rows = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(2),
+        Constraint::Length(1),
+        Constraint::Length(2),
+        Constraint::Min(0),
+    ])
+    .split(area);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                t!("Personal state", "개인 상태", "個人データ"),
+                theme.style(R::SettingsGroup).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  ", theme.style(R::TextMuted)),
+            Span::styled(health_label(personal.health), theme.style(R::SettingsValue)),
+        ])),
+        rows[0],
+    );
+    frame.render_widget(
+        Paragraph::new(t!(
+            "Encrypted changes stay local when the network is unavailable.",
+            "네트워크를 사용할 수 없어도 암호화된 변경 사항은 로컬에 보관돼요.",
+            "ネットワークが使えない間も暗号化された変更はローカルに保持されます。"
+        ))
+        .style(theme.style(R::TextMuted))
+        .wrap(Wrap { trim: true }),
+        rows[1],
+    );
+    let server_health = match server.health {
+        MusicServerHealth::Off => t!("Off", "꺼짐", "オフ"),
+        MusicServerHealth::UpToDate => t!("Up to date", "최신 상태", "最新"),
+        MusicServerHealth::NeedsAttention => {
+            t!("Needs attention", "확인 필요", "要確認")
+        }
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                t!("Music server", "음악 서버", "音楽サーバー"),
+                theme.style(R::SettingsGroup).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  ", theme.style(R::TextMuted)),
+            Span::styled(server_health, theme.style(R::SettingsValue)),
+        ])),
+        rows[2],
+    );
+    frame.render_widget(
+        Paragraph::new(if server.configured {
+            t!(
+                "Server browsing is optional; local search and playback stay independent.",
+                "서버 탐색은 선택 사항이며 로컬 검색과 재생은 독립적으로 동작해요.",
+                "サーバー閲覧は任意で、ローカル検索と再生は独立して動作します。"
+            )
+        } else {
+            t!(
+                "No music server is connected.",
+                "연결된 음악 서버가 없어요.",
+                "音楽サーバーは接続されていません。"
+            )
+        })
+        .style(theme.style(R::TextMuted))
+        .wrap(Wrap { trim: true }),
+        rows[3],
+    );
+}
+
+pub(crate) fn render_music_server(
+    frame: &mut Frame,
+    app: &App,
+    settings: &SettingsState,
+    area: Rect,
+) {
+    let theme = &settings.draft.theme;
+    let rows = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(2),
+        Constraint::Min(0),
+    ])
+    .split(area);
+    let summary = &app.server.settings.summary;
+    let state = if app.server.settings.busy.is_some() {
+        t!("Working…", "처리 중…", "処理中…")
+    } else {
+        match summary.health {
+            MusicServerHealth::Off => t!("Off", "꺼짐", "オフ"),
+            MusicServerHealth::UpToDate => t!("Up to date", "최신 상태", "最新"),
+            MusicServerHealth::NeedsAttention => {
+                t!("Needs attention", "확인 필요", "要確認")
+            }
+        }
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                summary.display_name(),
+                theme.style(R::SettingsGroup).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  ", theme.style(R::TextMuted)),
+            Span::styled(state, theme.style(R::SettingsValue)),
+        ])),
+        rows[0],
+    );
+    let detail = app.server.settings.failure.map_or_else(
+        || {
+            if summary.configured {
+                let auth = summary.credential_label.as_deref().unwrap_or("—");
+                format!(
+                    "{}  ·  {}",
+                    auth,
+                    if summary.lan_http {
+                        t!("LAN HTTP allowed", "LAN HTTP 허용", "LAN HTTP 許可")
+                    } else {
+                        "HTTPS"
+                    }
+                )
+            } else {
+                t!(
+                    "Connect one OpenSubsonic or Navidrome server.",
+                    "OpenSubsonic 또는 Navidrome 서버 하나를 연결하세요.",
+                    "OpenSubsonic または Navidrome サーバーを1台接続します。"
+                )
+                .to_owned()
+            }
+        },
+        |failure| format!("{}  ·  {}", failure.label(), failure.recovery_label()),
+    );
+    frame.render_widget(
+        Paragraph::new(detail)
+            .style(theme.style(if app.server.settings.failure.is_some() {
+                R::Error
+            } else {
+                R::TextMuted
+            }))
+            .wrap(Wrap { trim: true }),
+        rows[1],
+    );
+
+    let labels: Vec<&str> = if summary.configured {
+        vec![
+            t!("Test connection", "연결 테스트", "接続テスト"),
+            t!("Edit connection", "연결 정보 수정", "接続情報を編集"),
+            t!("Remove server", "서버 제거", "サーバーを削除"),
+        ]
+    } else {
+        vec![
+            t!(
+                "Set up music server",
+                "음악 서버 설정",
+                "音楽サーバーを設定"
+            ),
+            t!("Check again", "다시 확인", "再確認"),
+        ]
+    };
+    for (index, label) in labels.iter().enumerate().take(rows[2].height as usize) {
+        let selected = index == app.server.settings.selected;
+        let rect = Rect {
+            x: rows[2].x,
+            y: rows[2].y + index as u16,
+            width: rows[2].width,
+            height: 1,
+        };
+        frame.render_widget(
+            Paragraph::new(format!("{}↵ {label}", if selected { "▶ " } else { "  " })).style(
+                if selected {
+                    theme
+                        .style(R::SettingsValueFocused)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    theme.style(R::SettingsValue)
+                },
+            ),
+            rect,
+        );
+        app.register_mouse_button(rect, MouseTarget::SettingsMusicServerRow(index));
+    }
+}
+
+pub(crate) fn render_music_server_wizard(frame: &mut Frame, app: &App, area: Rect) {
+    let Some(wizard) = app.server.settings.wizard.as_ref() else {
+        return;
+    };
+    let popup = centered(
+        area,
+        64,
+        match wizard {
+            MusicServerWizard::Setup(_) => 16,
+            MusicServerWizard::Waiting | MusicServerWizard::RemoveConfirm => 8,
+        },
+    );
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(t!(" Music server ", " 음악 서버 ", " 音楽サーバー "))
+        .borders(Borders::ALL)
+        .border_style(app.theme.style(R::Accent))
+        .style(app.theme.style(R::TextPrimary));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    match wizard {
+        MusicServerWizard::Setup(form) => render_setup_form(frame, app, form, inner),
+        MusicServerWizard::Waiting => {
+            let (message, cancel_allowed) = match app.server.settings.busy {
+                Some(MusicServerBusy::Testing) => (
+                    t!(
+                        "Testing the connection…",
+                        "연결을 테스트하는 중…",
+                        "接続をテストしています…"
+                    ),
+                    true,
+                ),
+                Some(MusicServerBusy::Saving) => {
+                    (t!("Saving…", "저장하는 중…", "保存しています…"), false)
+                }
+                Some(MusicServerBusy::Removing) => {
+                    (t!("Removing…", "제거하는 중…", "削除しています…"), false)
+                }
+                _ => (t!("Working…", "처리 중…", "処理中…"), true),
+            };
+            let detail = if cancel_allowed {
+                t!(
+                    "Esc or q cancels this screen; a late test result will be ignored.",
+                    "Esc 또는 q로 취소할 수 있으며 늦게 도착한 테스트 결과는 무시돼요.",
+                    "Esc または q でキャンセルできます。遅れて届いた結果は無視されます。"
+                )
+            } else {
+                t!(
+                    "This storage step cannot be cancelled safely.",
+                    "이 저장 단계는 안전하게 취소할 수 없어요.",
+                    "この保存処理は安全にキャンセルできません。"
+                )
+            };
+            frame.render_widget(
+                Paragraph::new(format!("{message}\n\n{detail}"))
+                    .alignment(Alignment::Center)
+                    .wrap(Wrap { trim: true }),
+                inner,
+            );
+            if cancel_allowed {
+                app.register_mouse_button(inner, MouseTarget::MusicServerWizardSecondary);
+            }
+        }
+        MusicServerWizard::RemoveConfirm => {
+            frame.render_widget(
+                Paragraph::new(t!(
+                    "Remove this connection?\nLocal music and personal data will be kept.\n\nEnter: Remove  ·  Esc: Cancel",
+                    "이 연결을 제거할까요?\n로컬 음악과 개인 데이터는 그대로 유지돼요.\n\nEnter: 제거  ·  Esc: 취소",
+                    "この接続を削除しますか？\nローカル音楽と個人データは保持されます。\n\nEnter: 削除  ·  Esc: キャンセル"
+                ))
+                .alignment(Alignment::Center)
+                .wrap(Wrap { trim: true }),
+                inner,
+            );
+            let half = inner.width / 2;
+            app.register_mouse_button(
+                Rect {
+                    width: half,
+                    ..inner
+                },
+                MouseTarget::MusicServerWizardPrimary,
+            );
+            app.register_mouse_button(
+                Rect {
+                    x: inner.x + half,
+                    width: inner.width - half,
+                    ..inner
+                },
+                MouseTarget::MusicServerWizardSecondary,
+            );
+        }
+    }
+}
+
+fn render_setup_form(
+    frame: &mut Frame,
+    app: &App,
+    form: &crate::app::MusicServerSetupForm,
+    area: Rect,
+) {
+    let fields = MusicServerSetupField::ALL;
+    for (index, field) in fields.iter().copied().enumerate() {
+        if index >= area.height.saturating_sub(2) as usize {
+            break;
+        }
+        let selected = form.selected == index;
+        let label = setup_field_label(field);
+        let rect = Rect {
+            x: area.x,
+            y: area.y + index as u16,
+            width: area.width,
+            height: 1,
+        };
+        let reveal_width =
+            u16::from(field == MusicServerSetupField::Secret && rect.width >= 12).saturating_mul(8);
+        let field_rect = Rect {
+            width: rect.width.saturating_sub(reveal_width),
+            ..rect
+        };
+        let text = setup_field_text(form, field, label, selected, field_rect.width as usize);
+        frame.render_widget(
+            Paragraph::new(text.as_str()).style(if selected {
+                app.theme
+                    .style(R::SettingsValueFocused)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                app.theme.style(R::TextPrimary)
+            }),
+            field_rect,
+        );
+        app.register_mouse_button(field_rect, MouseTarget::MusicServerWizardField(index));
+        if reveal_width > 0 {
+            let reveal_rect = Rect {
+                x: field_rect.right(),
+                width: reveal_width,
+                ..rect
+            };
+            frame.render_widget(
+                Paragraph::new(if form.reveal_secret {
+                    t!(" Hide ", " 숨김 ", " 隠す ")
+                } else {
+                    t!(" Show ", " 보기 ", " 表示 ")
+                })
+                .alignment(Alignment::Center)
+                .style(app.theme.style(R::TextMuted)),
+                reveal_rect,
+            );
+            app.register_mouse_button(reveal_rect, MouseTarget::MusicServerWizardReveal);
+        }
+    }
+    let hint = t!(
+        "↑/↓ fields  ·  Enter reveal/action  ·  Esc cancel",
+        "↑/↓ 필드  ·  Enter 표시/실행  ·  Esc 취소",
+        "↑/↓ 項目  ·  Enter 表示/実行  ·  Esc キャンセル"
+    );
+    frame.render_widget(
+        Paragraph::new(hint)
+            .style(app.theme.style(R::TextMuted))
+            .wrap(Wrap { trim: true }),
+        Rect {
+            y: area.bottom().saturating_sub(2),
+            height: 2,
+            ..area
+        },
+    );
+}
+
+fn setup_field_text(
+    form: &crate::app::MusicServerSetupForm,
+    field: MusicServerSetupField,
+    label: &str,
+    selected: bool,
+    width: usize,
+) -> Zeroizing<String> {
+    if selected && let Some(raw) = form.text_value(field) {
+        let full_prefix = format!("▶ {label}: ");
+        let full_prefix_width = usize::from(buttons::text_width(&full_prefix));
+        let prefix = if full_prefix_width.saturating_add(8) <= width {
+            full_prefix
+        } else {
+            "▶ ".to_owned()
+        };
+        let prefix_width = usize::from(buttons::text_width(&prefix));
+        let shown = Zeroizing::new(crate::ui::text::editable_value(
+            raw,
+            form.cursor.byte_index(raw),
+            width.saturating_sub(prefix_width),
+            '│',
+            field == MusicServerSetupField::Secret && !form.reveal_secret,
+        ));
+        let mut text = Zeroizing::new(format!("{prefix}{}", shown.as_str()));
+        return Zeroizing::new(crate::ui::text::truncate_owned_to_width(
+            std::mem::take(&mut *text),
+            width,
+        ));
+    }
+
+    let value = Zeroizing::new(match field {
+        MusicServerSetupField::DisplayName
+        | MusicServerSetupField::Origin
+        | MusicServerSetupField::Username
+        | MusicServerSetupField::CustomCa => form.text_value(field).unwrap_or_default().to_owned(),
+        MusicServerSetupField::Secret if form.reveal_secret => {
+            form.text_value(field).unwrap_or_default().to_owned()
+        }
+        MusicServerSetupField::Secret => "•".repeat(
+            form.text_value(field)
+                .unwrap_or_default()
+                .chars()
+                .count()
+                .min(24),
+        ),
+        MusicServerSetupField::CredentialMode => form.credential_mode.label().to_owned(),
+        MusicServerSetupField::Identity => match form.identity_intent {
+            Some(crate::app::MusicServerIdentityIntent::Create) => {
+                t!("New connection", "새 연결", "新しい接続").to_owned()
+            }
+            Some(crate::app::MusicServerIdentityIntent::UpdateSameServerAndAccount) => t!(
+                "Same server and account",
+                "같은 서버와 계정",
+                "同じサーバーとアカウント"
+            )
+            .to_owned(),
+            Some(crate::app::MusicServerIdentityIntent::ReplaceServerOrAccount) => t!(
+                "Different server or account",
+                "다른 서버 또는 계정",
+                "別のサーバーまたはアカウント"
+            )
+            .to_owned(),
+            None => t!("Choose before saving", "저장 전에 선택", "保存前に選択").to_owned(),
+        },
+        MusicServerSetupField::AllowLanHttp => if form.allow_lan_http {
+            t!("Yes", "예", "はい")
+        } else {
+            t!("No", "아니요", "いいえ")
+        }
+        .to_owned(),
+        MusicServerSetupField::SaveAndTest | MusicServerSetupField::Cancel => String::new(),
+    });
+    let mut text = Zeroizing::new(if value.is_empty() {
+        format!("{}{}", if selected { "▶ " } else { "  " }, label)
+    } else {
+        format!(
+            "{}{}: {}",
+            if selected { "▶ " } else { "  " },
+            label,
+            value.as_str()
+        )
+    });
+    Zeroizing::new(crate::ui::text::truncate_owned_to_width(
+        std::mem::take(&mut *text),
+        width,
+    ))
+}
+
+fn setup_field_label(field: MusicServerSetupField) -> &'static str {
+    match field {
+        MusicServerSetupField::DisplayName => t!("Name", "이름", "名前"),
+        MusicServerSetupField::Origin => t!("Server address", "서버 주소", "サーバーアドレス"),
+        MusicServerSetupField::Identity => t!("Connection identity", "연결 식별", "接続の識別"),
+        MusicServerSetupField::CredentialMode => {
+            t!("Sign-in method", "로그인 방식", "ログイン方法")
+        }
+        MusicServerSetupField::Username => t!("Username", "사용자 이름", "ユーザー名"),
+        MusicServerSetupField::Secret => t!(
+            "Password / API key",
+            "비밀번호 / API 키",
+            "パスワード / APIキー"
+        ),
+        MusicServerSetupField::CustomCa => {
+            t!("CA file (optional)", "CA 파일 (선택)", "CAファイル（任意）")
+        }
+        MusicServerSetupField::AllowLanHttp => t!(
+            "Allow exact LAN HTTP",
+            "정확한 LAN HTTP 허용",
+            "指定LAN HTTPを許可"
+        ),
+        MusicServerSetupField::SaveAndTest => t!("Save & test", "저장 및 테스트", "保存してテスト"),
+        MusicServerSetupField::Cancel => t!("Cancel", "취소", "キャンセル"),
+    }
+}
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let width = width.min(area.width);
+    let height = height.min(area.height);
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+
+    fn draw_wizard(app: &App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_music_server_wizard(frame, app, frame.area()))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn compact_area_labels_cover_three_languages() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for language in [
+            crate::i18n::Language::English,
+            crate::i18n::Language::Korean,
+            crate::i18n::Language::Japanese,
+        ] {
+            crate::i18n::set_language(language);
+            assert!(
+                SyncArea::ALL
+                    .iter()
+                    .all(|area| !compact_area_label(*area).is_empty())
+            );
+        }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn compact_area_labels_fit_one_inner_row_in_every_language() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for language in [
+            crate::i18n::Language::English,
+            crate::i18n::Language::Korean,
+            crate::i18n::Language::Japanese,
+        ] {
+            crate::i18n::set_language(language);
+            let labels = SyncArea::ALL
+                .iter()
+                .map(|area| usize::from(buttons::text_width(compact_area_label(*area))))
+                .sum::<usize>();
+            assert!(labels + 3 * (SyncArea::ALL.len() - 1) <= 28);
+        }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn removal_progress_does_not_render_a_cancel_action() {
+        let mut app = App::new(50);
+        app.server.settings.wizard = Some(MusicServerWizard::Waiting);
+        app.server.settings.busy = Some(MusicServerBusy::Removing);
+
+        let text = draw_wizard(&app, 80, 24);
+        assert!(
+            ["Removing", "제거하는 중", "削除しています"]
+                .iter()
+                .any(|message| text.contains(message))
+        );
+        assert!(
+            !["Cancel", "취소", "キャンセル"]
+                .iter()
+                .any(|message| text.contains(message))
+        );
+    }
+
+    #[test]
+    fn thirty_column_editor_keeps_origin_and_ca_carets_visible() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        crate::i18n::set_language(crate::i18n::Language::English);
+
+        let mut form = crate::app::MusicServerSetupForm::default();
+        form.origin
+            .push_str("https://music.example.test:4533/rest/endpoint");
+        form.selected = MusicServerSetupField::Origin as usize;
+        form.cursor = crate::util::text_edit::TextCursor::at_end(&form.origin);
+        let mut app = App::new(50);
+        app.server.settings.wizard = Some(MusicServerWizard::Setup(form));
+        let origin = draw_wizard(&app, 30, 30);
+        assert!(origin.contains("endpoint│"));
+
+        let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_mut() else {
+            panic!("setup form");
+        };
+        form.custom_ca_path
+            .push_str("/private/certificates/custom.pem");
+        form.selected = MusicServerSetupField::CustomCa as usize;
+        form.cursor = crate::util::text_edit::TextCursor::at_end(&form.custom_ca_path);
+        let ca = draw_wizard(&app, 30, 30);
+        assert!(ca.contains("custom.pem│"));
+        crate::i18n::set_language(original);
+    }
+}

--- a/src/util/safe_fs/owner_only.rs
+++ b/src/util/safe_fs/owner_only.rs
@@ -104,6 +104,18 @@ pub fn read_owner_only_limited(path: &Path, max_bytes: u64) -> io::Result<Vec<u8
     Ok(bytes)
 }
 
+/// Validate an existing current-user-only regular file without reading its contents.
+///
+/// This is used before an explicit reset inventories exact private-state artifacts. The later
+/// removal still repeats the identity check, so a path replacement between the two operations
+/// fails closed.
+pub fn validate_owner_only_file(path: &Path) -> io::Result<()> {
+    let file = platform::open(path)?;
+    platform::validate(&file)?;
+    let expected = platform::identity(&file)?;
+    platform::require_path_identity(path, &expected)
+}
+
 fn too_large() -> io::Error {
     io::Error::new(
         io::ErrorKind::InvalidData,


### PR DESCRIPTION
## Summary

- add one active OpenSubsonic/Navidrome profile with owner-only, crash-consistent credential storage and an exact-origin network policy
- integrate OpenSubsonic into unified search and add a dedicated Server Library for recent tracks, albums, artists, songs, playlists, pagination, metadata, and cover art
- route authenticated streams through a short-lived credential-owning loopback proxy, with matching App/daemon playback lifecycle behavior
- add TUI and CLI setup/status/remove flows, read-only secondary behavior, and offline isolation so local and YouTube features remain available

## Security

- credentials are never passed to mpv; playback uses one-shot loopback routes that are revoked on completion or failure
- setup commits fail closed across ambiguous durable commits and invalidate the previous runtime before installing replacement credentials
- response sizes are bounded, redirects remain same-origin, and LAN HTTP requires an exact explicit opt-in

## Validation

- `~/.fable-harness/bin/run-gates .`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cd gui && npm ci && npm run check && npm run test && npm run build`
- `scripts/check-gui-types.sh`
- isolated TUI verification with a fake OpenSubsonic server at normal and 30×30 terminal sizes, including setup, search, Server Library, offline fallback, and clean shutdown without playback

Part of #114