### PR TITLE
feat: bridge OpenSubsonic ratings and playback history

### DIFF
--- a/src/api/domain.rs
+++ b/src/api/domain.rs
@@ -252,6 +252,13 @@ pub enum PlayableRef {
 }
 
 impl Song {
+    pub fn open_subsonic_item(&self) -> Option<&OpenSubsonicItemRef> {
+        match &self.playable {
+            Some(PlayableRef::OpenSubsonic { item, .. }) => Some(item),
+            _ => None,
+        }
+    }
+
     pub fn remote(
         video_id: impl Into<String>,
         title: impl Into<String>,

--- a/src/app/artist.rs
+++ b/src/app/artist.rs
@@ -142,11 +142,7 @@ impl App {
             },
             Some(Action::Favorite) => match self.artist_selected_row() {
                 Some(row) if row.youtube_playlist_id().is_some() => self.playlist_row_hint(),
-                Some(row) => {
-                    self.library_mut().toggle_favorite(&row);
-                    self.dirty = true;
-                    vec![Cmd::Persist(PersistCmd::Library)]
-                }
+                Some(row) => self.toggle_song_favorite_rating(&row),
                 None => Vec::new(),
             },
             Some(Action::Download) => match self.artist_selected_row() {

--- a/src/app/context_menu.rs
+++ b/src/app/context_menu.rs
@@ -849,7 +849,7 @@ impl App {
                 C::Remove,
             ],
             ContextTarget::ServerLibrary { identity, .. } if identity.is_song() => {
-                vec![C::PlayNow, C::Enqueue, C::AddToPlaylist]
+                vec![C::PlayNow, C::Enqueue, C::ToggleFavorite, C::AddToPlaylist]
             }
             ContextTarget::ServerLibrary { .. } => vec![C::Activate],
             ContextTarget::Queue { .. } => vec![C::PlayFromHere, C::Remove],
@@ -1046,8 +1046,7 @@ impl App {
                 None => self.enqueue(song),
             },
             ContextCommand::ToggleFavorite if is_song_row => {
-                self.library_mut().toggle_favorite(&song);
-                vec![Cmd::Persist(PersistCmd::Library)]
+                self.toggle_song_favorite_rating(&song)
             }
             ContextCommand::AddToPlaylist if is_song_row => {
                 self.open_playlist_picker(vec![song]);
@@ -1101,13 +1100,13 @@ impl App {
             ContextCommand::Enqueue => self.enqueue_many(selected),
             ContextCommand::ToggleFavorite if selected.len() == 1 => {
                 let rows_before = self.library_len();
-                self.library_mut().toggle_favorite(&selected[0]);
+                let commands = self.toggle_song_favorite_rating(&selected[0]);
                 // Un-favoriting can remove the row (Favorites/All tab): re-clamp
                 // and drop the now-stale picks; unchanged tabs keep the selection.
                 if self.library_len() != rows_before {
                     self.clamp_library_selection();
                 }
-                vec![Cmd::Persist(PersistCmd::Library)]
+                commands
             }
             ContextCommand::AddToPlaylist => {
                 self.open_playlist_picker(selected);
@@ -1186,6 +1185,13 @@ impl App {
                 .cloned()
                 .map(crate::api::Song::from_open_subsonic)
                 .map_or_else(Vec::new, |song| self.enqueue_many(vec![song])),
+            ContextCommand::ToggleFavorite if identity.is_song() => self
+                .server
+                .library
+                .row_song(index)
+                .cloned()
+                .map(crate::api::Song::from_open_subsonic)
+                .map_or_else(Vec::new, |song| self.toggle_song_favorite_rating(&song)),
             ContextCommand::AddToPlaylist if identity.is_song() => {
                 if let Some(song) = self
                     .server
@@ -1336,6 +1342,8 @@ mod tests {
             suffix: None,
             starred: false,
             user_rating: None,
+            play_count: None,
+            played_at: None,
         }
     }
 
@@ -1392,14 +1400,18 @@ mod tests {
             .iter()
             .map(|item| item.label(menu.target_count()))
             .collect();
-        assert_eq!(labels, vec!["Play now", "Add to queue", "Add to playlist"]);
-        assert!(
-            labels
-                .iter()
-                .all(|label| !label.contains("Download") && !label.contains("Favorite"))
+        assert_eq!(
+            labels,
+            vec![
+                "Play now",
+                "Add to queue",
+                "Favorite / unfavorite",
+                "Add to playlist"
+            ]
         );
+        assert!(labels.iter().all(|label| !label.contains("Download")));
 
-        assert!(app.activate_context_menu_item(2).is_empty());
+        assert!(app.activate_context_menu_item(3).is_empty());
         assert_eq!(
             app.playlist_picker
                 .as_ref()

--- a/src/app/library.rs
+++ b/src/app/library.rs
@@ -418,15 +418,14 @@ impl App {
             Some(Action::Favorite) => {
                 if let Some(song) = self.selected_library_song() {
                     let rows_before = self.library_len();
-                    self.library_mut().toggle_favorite(&song);
+                    let commands = self.toggle_song_favorite_rating(&song);
                     // Un-favoriting can remove the row (Favorites/All tab): re-clamp and
                     // drop the now-stale picks. Tabs where the row list is unchanged
                     // (e.g. History) keep the selection.
                     if self.library_len() != rows_before {
                         self.clamp_library_selection();
                     }
-                    self.dirty = true;
-                    return vec![Cmd::Persist(PersistCmd::Library)];
+                    return commands;
                 }
                 Vec::new()
             }

--- a/src/app/library_reducer.rs
+++ b/src/app/library_reducer.rs
@@ -477,19 +477,11 @@ impl App {
             // ambiguous. Manage tracks from their own tab instead.
             LibraryTab::All => Vec::new(),
             LibraryTab::Favorites => {
-                for song in targets {
-                    if let Some(pos) = self
-                        .library
-                        .favorites
-                        .iter()
-                        .position(|s| s.video_id == song.video_id)
-                    {
-                        self.library_mut().remove_favorite_at(pos);
-                    }
+                let commands = self.neutralize_song_ratings(targets);
+                if !commands.is_empty() {
+                    self.clamp_library_selection();
                 }
-                self.clamp_library_selection();
-                self.dirty = true;
-                vec![Cmd::Persist(PersistCmd::Library)]
+                commands
             }
             LibraryTab::History => {
                 for song in targets {
@@ -659,3 +651,47 @@ pub(in crate::app) struct LibraryRowsCache {
 /// (library_rev, downloaded_rev, favorites len, history len, downloaded len) — the All-tab
 /// count reads nothing else.
 pub(in crate::app) type AllCountKey = (u64, u64, usize, usize, usize);
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[test]
+    fn favorites_delete_neutralizes_rating_and_persists_one_personal_state_snapshot() {
+        let song = Song::remote("favorite", "Favorite", "Artist", "3:00");
+        let artist_key = crate::signals::normalize_artist(&song.artist);
+        let mut app = App::new(50);
+        crate::rating::set(
+            Arc::make_mut(&mut app.library),
+            Arc::make_mut(&mut app.signals),
+            &song,
+            crate::personal_state::Rating::Liked,
+            1,
+        );
+        app.mode = Mode::Library;
+        app.library_ui.tab = LibraryTab::Favorites;
+
+        let commands = app.library_delete_rows(0, 0);
+
+        assert_eq!(
+            crate::rating::current(&app.library, &app.signals, &song.video_id),
+            crate::personal_state::Rating::Neutral
+        );
+        assert_eq!(app.signals.artist_weight(&artist_key), 0.0);
+        assert_eq!(
+            commands
+                .iter()
+                .filter(|command| matches!(command, Cmd::Persist(PersistCmd::Library)))
+                .count(),
+            1
+        );
+        assert!(
+            commands
+                .iter()
+                .all(|command| !matches!(command, Cmd::Persist(PersistCmd::Signals))),
+            "the Library marker persists the whole personal-state snapshot atomically"
+        );
+    }
+}

--- a/src/app/media_reducer.rs
+++ b/src/app/media_reducer.rs
@@ -353,54 +353,52 @@ impl App {
         };
         if song.is_radio_station() {
             // Stations only have favorite membership; a dislike has no meaning.
-            if like {
-                self.library_mut().toggle_favorite(&song);
-                self.dirty = true;
-                return vec![Cmd::Persist(PersistCmd::Library)];
-            }
-            return Vec::new();
-        }
-        let artist_key = signals::normalize_artist(&song.artist);
-        let now = signals::unix_now();
-        let current = crate::rating::current(&self.library, &self.signals, &song.video_id);
-        let target = if like {
-            if current == crate::personal_state::Rating::Liked {
-                crate::personal_state::Rating::Neutral
+            let change = if like {
+                crate::rating::toggle_liked(
+                    Arc::make_mut(&mut self.library),
+                    Arc::make_mut(&mut self.signals),
+                    &song,
+                    signals::unix_now(),
+                )
             } else {
-                crate::personal_state::Rating::Liked
-            }
-        } else if current == crate::personal_state::Rating::Disliked {
-            crate::personal_state::Rating::Neutral
+                crate::rating::toggle_disliked(
+                    Arc::make_mut(&mut self.library),
+                    Arc::make_mut(&mut self.signals),
+                    &song,
+                    signals::unix_now(),
+                )
+            };
+            self.record_rating_session_event(&song, change);
+            self.dirty |= change.changed();
+            return change
+                .changed()
+                .then_some(Cmd::Persist(PersistCmd::Library))
+                .into_iter()
+                .collect();
+        }
+        let now = signals::unix_now();
+        let change = if like {
+            crate::rating::toggle_liked(
+                Arc::make_mut(&mut self.library),
+                Arc::make_mut(&mut self.signals),
+                &song,
+                now,
+            )
         } else {
-            crate::personal_state::Rating::Disliked
+            crate::rating::toggle_disliked(
+                Arc::make_mut(&mut self.library),
+                Arc::make_mut(&mut self.signals),
+                &song,
+                now,
+            )
         };
-        let change = crate::rating::set(
-            Arc::make_mut(&mut self.library),
-            Arc::make_mut(&mut self.signals),
-            &song,
-            target,
-            now,
-        );
         self.dirty = true;
-        match change.after {
-            crate::personal_state::Rating::Liked => {
-                let comp = self.playback_completion();
-                self.record_session_event(&artist_key, Outcome::Like, comp);
-            }
-            crate::personal_state::Rating::Disliked => {
-                let comp = self.playback_completion();
-                self.record_session_event(&artist_key, Outcome::Dislike, comp);
-            }
-            crate::personal_state::Rating::Neutral => {}
-        }
-        let mut persist = Vec::with_capacity(2);
-        if change.library_changed {
-            persist.push(Cmd::Persist(PersistCmd::Library));
-        }
-        if change.signals_changed {
-            persist.push(Cmd::Persist(PersistCmd::Signals));
-        }
-        persist
+        self.record_rating_session_event(&song, change);
+        change
+            .changed()
+            .then_some(Cmd::Persist(PersistCmd::Library))
+            .into_iter()
+            .collect()
     }
 
     /// MPRIS `OpenUri`: parse a YouTube / YouTube Music URL and play it now (inserted
@@ -471,6 +469,7 @@ impl App {
             };
             MediaTrack {
                 key: song.video_id.clone(),
+                open_subsonic_item: song.open_subsonic_item().cloned(),
                 title,
                 artist,
                 album: if is_live { None } else { song.album.clone() },

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -88,12 +88,13 @@ pub use server_library::{
     LibrarySource, SERVER_LIBRARY_PAGE_LIMIT, ServerLibraryCommand, ServerLibraryDetailTarget,
     ServerLibraryEvent, ServerLibraryFailure, ServerLibraryState,
 };
+mod server_history_settings;
 mod server_settings;
 pub use server_settings::{
     MusicServerBusy, MusicServerCommand, MusicServerCredentialMode, MusicServerEvent,
-    MusicServerFailure, MusicServerHealth, MusicServerIdentityIntent, MusicServerRefreshOutcome,
-    MusicServerSettingsState, MusicServerSetupField, MusicServerSetupForm, MusicServerSetupInput,
-    MusicServerSummary, MusicServerWizard, SyncArea,
+    MusicServerFailure, MusicServerHealth, MusicServerHistoryHealth, MusicServerIdentityIntent,
+    MusicServerRefreshOutcome, MusicServerSettingsState, MusicServerSetupField,
+    MusicServerSetupForm, MusicServerSetupInput, MusicServerSummary, MusicServerWizard, SyncArea,
 };
 mod server;
 pub use server::{ServerEvent, ServerUiState};
@@ -103,7 +104,9 @@ mod bootstrap;
 mod data_export;
 mod feedback;
 mod helpers;
+mod open_subsonic_bridge;
 mod personal_sync;
+mod rating_action;
 pub(crate) use helpers::open_in_browser;
 pub(in crate::app) use helpers::{
     fetch_lyrics_cmd, rect_contains, song_label, spawn_video_overlay,

--- a/src/app/now_playing_reducer.rs
+++ b/src/app/now_playing_reducer.rs
@@ -215,14 +215,12 @@ impl App {
     }
 
     /// Add a resolved YouTube track to the music-mode favorites, idempotently.
-    /// `toggle_favorite` is a toggle — the `is_favorite` precheck keeps a repeat press
-    /// from *removing* the song. A Youtube-source track routes to the music favorites
-    /// (not `radio_favorites`) by `Library`'s own rules. The toast names exactly what
-    /// was saved, which library it went to, and doubles as the wrong-song tripwire.
     fn add_resolved_favorite(&mut self, song: Song) -> Vec<Cmd> {
         self.status.kind = StatusKind::Info;
         self.dirty = true;
-        if self.library.is_favorite(&song.video_id) {
+        if crate::rating::current(&self.library, &self.signals, &song.video_id)
+            == crate::personal_state::Rating::Liked
+        {
             self.status.text = t!(
                 "Already in music favorites",
                 "이미 음악 즐겨찾기에 있어요",
@@ -231,7 +229,7 @@ impl App {
             .to_owned();
             return Vec::new();
         }
-        self.library_mut().toggle_favorite(&song);
+        let commands = self.ensure_song_liked_rating(&song);
         self.status.text = match crate::i18n::current() {
             crate::i18n::Language::Korean => {
                 format!("음악 즐겨찾기에 저장: {} — {}", song.title, song.artist)
@@ -241,7 +239,7 @@ impl App {
             }
             _ => format!("Saved to music favorites: {} — {}", song.title, song.artist),
         };
-        vec![Cmd::Persist(PersistCmd::Library)]
+        commands
     }
 
     /// "Tell me more": close the card and hand off to the DJ Gem view, seeding the normal

--- a/src/app/open_subsonic_bridge.rs
+++ b/src/app/open_subsonic_bridge.rs
@@ -1,0 +1,114 @@
+//! Owner-lane installation of durable OpenSubsonic observations.
+
+use super::App;
+
+impl App {
+    /// Merge an exactly-once server observation into the canonical ledger and refresh all runtime
+    /// projections. The runtime persists the resulting snapshot before acknowledging the bridge.
+    pub(crate) fn apply_open_subsonic_bridge_import(
+        &mut self,
+        import: &crate::open_subsonic::OpenSubsonicBridgeImport,
+    ) -> Result<String, crate::personal_state::PersonalStateError> {
+        let current = self.reconcile_personal_state(&self.playlists)?;
+        let operation = import.operation();
+        let origin = import.origin()?;
+        let (candidate, envelope_id) = match &self.personal_state.device_id {
+            Some(device_id) => {
+                let envelope_id = crate::personal_state::external_operation_envelope_id(
+                    device_id,
+                    import.operation_id(),
+                )?;
+                let candidate = crate::personal_state::append_external_operation_as(
+                    &current,
+                    device_id,
+                    import.operation_id().to_owned(),
+                    origin,
+                    operation,
+                    import.observed_at_unix(),
+                )?;
+                (candidate, envelope_id)
+            }
+            None => {
+                let envelope_id = crate::personal_state::external_operation_envelope_id_for_state(
+                    &current,
+                    import.operation_id(),
+                )?;
+                let candidate = crate::personal_state::append_external_operation(
+                    &current,
+                    import.operation_id().to_owned(),
+                    origin,
+                    operation,
+                    import.observed_at_unix(),
+                )?;
+                (candidate, envelope_id)
+            }
+        };
+        self.install_personal_state_runtime(candidate)?;
+        Ok(envelope_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::open_subsonic::OpenSubsonicBridgeImport;
+    use crate::personal_state::{PortableTrack, PortableTrackKey, Rating};
+
+    fn portable() -> PortableTrack {
+        PortableTrack {
+            key: PortableTrackKey::OpenSubsonic {
+                backend_id: "backend".to_owned(),
+                account_scope_id: "account".to_owned(),
+                item_id: "song".to_owned(),
+            },
+            title: "Server title".to_owned(),
+            artist: "Server artist".to_owned(),
+            album: Some("Server album".to_owned()),
+            duration_secs: Some(180),
+            isrc: None,
+        }
+    }
+
+    fn app_with_legacy_state() -> App {
+        let mut app = App::new(50);
+        let state = crate::personal_state::legacy_state(
+            &app.library,
+            &app.playlists,
+            &app.signals,
+            &app.station,
+        )
+        .unwrap();
+        app.install_personal_state_runtime(state).unwrap();
+        app
+    }
+
+    #[test]
+    fn unsynced_owner_imports_and_replays_one_server_rating_exactly_once() {
+        let mut app = app_with_legacy_state();
+        let import = OpenSubsonicBridgeImport::Rating {
+            operation_id: "server-rating-observation".to_owned(),
+            track: portable(),
+            rating: Rating::Liked,
+            observed_at_unix: 100,
+        };
+
+        let envelope_id = app.apply_open_subsonic_bridge_import(&import).unwrap();
+        assert_eq!(
+            app.apply_open_subsonic_bridge_import(&import).unwrap(),
+            envelope_id
+        );
+
+        assert_eq!(
+            app.personal_state
+                .ledger
+                .operations
+                .iter()
+                .filter(|operation| operation.operation_id == envelope_id)
+                .count(),
+            1
+        );
+        assert_ne!(envelope_id, import.operation_id());
+        assert_eq!(app.library.favorites.len(), 1);
+        assert_eq!(app.library.favorites[0].title, "Server title");
+    }
+}

--- a/src/app/personal_sync.rs
+++ b/src/app/personal_sync.rs
@@ -530,11 +530,18 @@ impl App {
         &mut self,
         state: crate::personal_state::PersonalStateV2,
     ) -> Result<(), SyncServiceError> {
+        self.install_personal_state_runtime(state)
+            .map_err(SyncServiceError::from)
+    }
+
+    pub(crate) fn install_personal_state_runtime(
+        &mut self,
+        state: crate::personal_state::PersonalStateV2,
+    ) -> Result<(), crate::personal_state::PersonalStateError> {
         let prepared = crate::personal_state::PersonalStateCommit::prepare_for_runtime(
             state,
             self.playlists.revision(),
-        )
-        .map_err(SyncServiceError::from)?;
+        )?;
         let (library, mut playlists, signals, station) = prepared.runtime_stores();
         playlists.inherit_revision_from(&self.playlists);
         self.personal_state.replace_ledger(prepared.state().clone());

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -632,7 +632,13 @@ impl App {
             Action::CycleRating => {
                 if let Some(song) = self.queue.current().cloned() {
                     if song.is_radio_station() {
-                        self.library_mut().toggle_favorite(&song);
+                        let change = crate::rating::toggle_liked(
+                            Arc::make_mut(&mut self.library),
+                            Arc::make_mut(&mut self.signals),
+                            &song,
+                            signals::unix_now(),
+                        );
+                        self.record_rating_session_event(&song, change);
                         self.dirty = true;
                         return vec![Cmd::Persist(PersistCmd::Library)];
                     }
@@ -643,17 +649,7 @@ impl App {
                         &song,
                         now,
                     );
-                    let artist_key = signals::normalize_artist(&song.artist);
-                    let comp = self.playback_completion();
-                    match change.after {
-                        crate::personal_state::Rating::Liked => {
-                            self.record_session_event(&artist_key, Outcome::Like, comp);
-                        }
-                        crate::personal_state::Rating::Disliked => {
-                            self.record_session_event(&artist_key, Outcome::Dislike, comp);
-                        }
-                        crate::personal_state::Rating::Neutral => {}
-                    }
+                    self.record_rating_session_event(&song, change);
                     self.dirty = true;
                     let mut persist = Vec::with_capacity(2);
                     if change.library_changed {
@@ -1041,6 +1037,25 @@ impl App {
         while buf.len() > SESSION_EVENTS_CAP {
             buf.pop_front();
         }
+    }
+
+    pub(in crate::app) fn record_rating_session_event(
+        &mut self,
+        song: &Song,
+        change: crate::rating::RatingChange,
+    ) {
+        let Some(signal) = crate::rating::session_signal(song, change) else {
+            return;
+        };
+        let outcome = match signal {
+            crate::rating::SessionRatingSignal::Like => Outcome::Like,
+            crate::rating::SessionRatingSignal::Dislike => Outcome::Dislike,
+        };
+        self.record_session_event(
+            &signals::normalize_artist(&song.artist),
+            outcome,
+            self.playback_completion(),
+        );
     }
 
     /// How much to trust a skip as a dislike signal: lower early in / in short sessions

--- a/src/app/rating_action.rs
+++ b/src/app/rating_action.rs
@@ -1,0 +1,121 @@
+//! Shared App entry point for explicit favorite/unfavorite actions.
+
+use std::sync::Arc;
+
+use super::{App, Cmd, PersistCmd};
+use crate::api::Song;
+use crate::personal_state::Rating;
+
+impl App {
+    /// Treat the legacy "favorite" gesture as an explicit two-state choice inside the canonical
+    /// tri-state register. One personal-state transaction persists both projections atomically.
+    pub(in crate::app) fn toggle_song_favorite_rating(&mut self, song: &Song) -> Vec<Cmd> {
+        let change = crate::rating::toggle_liked(
+            Arc::make_mut(&mut self.library),
+            Arc::make_mut(&mut self.signals),
+            song,
+            crate::signals::unix_now(),
+        );
+        self.persist_song_rating_change(change)
+    }
+
+    pub(in crate::app) fn ensure_song_liked_rating(&mut self, song: &Song) -> Vec<Cmd> {
+        let change = crate::rating::set(
+            Arc::make_mut(&mut self.library),
+            Arc::make_mut(&mut self.signals),
+            song,
+            Rating::Liked,
+            crate::signals::unix_now(),
+        );
+        self.persist_song_rating_change(change)
+    }
+
+    /// Remove selected music favorites as explicit `Liked -> Neutral` operations.
+    ///
+    /// The collection view may delete several rows at once, so all rating mutations share one
+    /// timestamp and one personal-state persistence marker.
+    pub(in crate::app) fn neutralize_song_ratings(&mut self, songs: &[Song]) -> Vec<Cmd> {
+        let now = crate::signals::unix_now();
+        let mut changed = false;
+        for song in songs {
+            changed |= crate::rating::set(
+                Arc::make_mut(&mut self.library),
+                Arc::make_mut(&mut self.signals),
+                song,
+                Rating::Neutral,
+                now,
+            )
+            .changed();
+        }
+        self.persist_any_song_rating_change(changed)
+    }
+
+    fn persist_song_rating_change(&mut self, change: crate::rating::RatingChange) -> Vec<Cmd> {
+        self.persist_any_song_rating_change(change.changed())
+    }
+
+    fn persist_any_song_rating_change(&mut self, changed: bool) -> Vec<Cmd> {
+        if changed {
+            self.dirty = true;
+            // Every personal-state marker snapshots the ledger and all projections together.
+            vec![Cmd::Persist(PersistCmd::Library)]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn favorite_action_repairs_dislike_then_clears_to_neutral_in_daemon_parity() {
+        let song = Song::remote("server-song", "Song", "Artist", "3:00");
+        let mut app = App::new(50);
+        let mut daemon_library = crate::library::Library::default();
+        let mut daemon_signals = crate::signals::Signals::default();
+
+        crate::rating::set(
+            Arc::make_mut(&mut app.library),
+            Arc::make_mut(&mut app.signals),
+            &song,
+            Rating::Disliked,
+            1,
+        );
+        crate::rating::set(
+            &mut daemon_library,
+            &mut daemon_signals,
+            &song,
+            Rating::Disliked,
+            1,
+        );
+
+        assert_eq!(app.toggle_song_favorite_rating(&song).len(), 1);
+        crate::rating::toggle_liked(&mut daemon_library, &mut daemon_signals, &song, 2);
+        assert_eq!(
+            crate::rating::current(&app.library, &app.signals, &song.video_id),
+            Rating::Liked
+        );
+        assert_eq!(
+            crate::rating::current(&daemon_library, &daemon_signals, &song.video_id),
+            Rating::Liked
+        );
+        assert_eq!(
+            app.signals
+                .artist_weight(&crate::signals::normalize_artist(&song.artist)),
+            daemon_signals.artist_weight(&crate::signals::normalize_artist(&song.artist))
+        );
+
+        assert_eq!(app.toggle_song_favorite_rating(&song).len(), 1);
+        crate::rating::toggle_liked(&mut daemon_library, &mut daemon_signals, &song, 3);
+        assert_eq!(
+            crate::rating::current(&app.library, &app.signals, &song.video_id),
+            Rating::Neutral
+        );
+        assert_eq!(
+            crate::rating::current(&daemon_library, &daemon_signals, &song.video_id),
+            Rating::Neutral
+        );
+    }
+}

--- a/src/app/scrobble_reducer.rs
+++ b/src/app/scrobble_reducer.rs
@@ -11,6 +11,10 @@ impl App {
         use crate::scrobble::ScrobbleEvent;
         self.dirty = true;
         match event {
+            ScrobbleEvent::OpenSubsonic { .. } => {
+                // The runtime owner intercepts this durable work item before App reduction.
+                Vec::new()
+            }
             ScrobbleEvent::AuthUrl(url) => {
                 let opened = crate::util::browser::open_in_browser_checked(&url);
                 // Also copy the URL: xdg-open can fail silently (e.g. a Flatpak

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -375,9 +375,7 @@ impl App {
                         if song.youtube_playlist_id().is_some() {
                             return self.playlist_row_hint();
                         }
-                        self.library_mut().toggle_favorite(&song);
-                        self.dirty = true;
-                        return vec![Cmd::Persist(PersistCmd::Library)];
+                        return self.toggle_song_favorite_rating(&song);
                     }
                     Vec::new()
                 }

--- a/src/app/server_history_settings.rs
+++ b/src/app/server_history_settings.rs
@@ -1,0 +1,33 @@
+//! Minimal TUI controls for the experimental detailed-history credential.
+
+use super::{App, Cmd, MusicServerBusy, MusicServerCommand, MusicServerHistoryHealth, StatusKind};
+
+impl App {
+    pub(in crate::app) fn activate_music_server_history(&mut self) -> Vec<Cmd> {
+        match self.server.settings.summary.history {
+            MusicServerHistoryHealth::Off => {
+                self.status.kind = StatusKind::Info;
+                self.status.text = crate::t!(
+                    "Enable detailed history with: ytt server history enable --experimental",
+                    "다음 명령으로 상세 이력을 켜세요: ytt server history enable --experimental",
+                    "次のコマンドで詳細履歴を有効にします: ytt server history enable --experimental"
+                )
+                .to_owned();
+                self.dirty = true;
+                Vec::new()
+            }
+            MusicServerHistoryHealth::Probing
+            | MusicServerHistoryHealth::Detailed
+            | MusicServerHistoryHealth::PlayCountsOnly
+            | MusicServerHistoryHealth::UpdatePassword => {
+                let generation = self.server.settings.next_generation();
+                self.server.settings.busy = Some(MusicServerBusy::History);
+                self.server.settings.failure = None;
+                self.dirty = true;
+                vec![Cmd::MusicServer(MusicServerCommand::DisableHistory {
+                    generation,
+                })]
+            }
+        }
+    }
+}

--- a/src/app/server_library.rs
+++ b/src/app/server_library.rs
@@ -489,6 +489,15 @@ impl App {
         Vec::new()
     }
 
+    fn toggle_selected_server_library_song_rating(&mut self) -> Vec<Cmd> {
+        self.server
+            .library
+            .row_song(self.server.library.selected)
+            .cloned()
+            .map(Song::from_open_subsonic)
+            .map_or_else(Vec::new, |song| self.toggle_song_favorite_rating(&song))
+    }
+
     fn handle_server_library_action(&mut self, action: Action) -> Option<Vec<Cmd>> {
         let commands = match action {
             Action::Back => {
@@ -539,15 +548,15 @@ impl App {
             Action::Enqueue => self.enqueue_selected_server_library_song(),
             Action::PlayAll => self.play_now_many(self.server.library.visible_songs()),
             Action::AddToPlaylist => self.add_selected_server_library_song_to_playlist(),
+            Action::Favorite => self.toggle_selected_server_library_song_rating(),
             _ => return None,
         };
         Some(commands)
     }
 
     pub(in crate::app) fn on_key_server_library(&mut self, key: KeyEvent) -> Vec<Cmd> {
-        // Resolve the same semantic Library/Common actions as the local Library. Unsupported
-        // local mutations (favorite, remove, filter, download) deliberately fall through to a
-        // no-op on this read-only surface.
+        // Resolve the same semantic Library/Common actions as the local Library. Rating is a
+        // personal-state mutation; server catalog mutation (remove/filter/download) stays absent.
         let action = self.keymap.action(KeyContext::Library, Chord::from(key));
         if let Some(commands) = action.and_then(|action| self.handle_server_library_action(action))
         {
@@ -668,6 +677,8 @@ mod tests {
             suffix: None,
             starred: false,
             user_rating: None,
+            play_count: None,
+            played_at: None,
         }
     }
 
@@ -822,6 +833,27 @@ mod tests {
             app.server.library.failure,
             Some(ServerLibraryFailure::Offline)
         );
+    }
+
+    #[test]
+    fn server_favorite_repairs_a_local_dislike() {
+        let mut app = server_library_app(&["one"]);
+        let selected = Song::from_open_subsonic(song("one"));
+        crate::rating::set(
+            std::sync::Arc::make_mut(&mut app.library),
+            std::sync::Arc::make_mut(&mut app.signals),
+            &selected,
+            crate::personal_state::Rating::Disliked,
+            1,
+        );
+
+        let commands = app.handle_server_library_action(Action::Favorite).unwrap();
+        assert!(app.library.is_favorite(&selected.video_id));
+        assert!(!app.signals.is_disliked(&selected.video_id));
+        assert!(matches!(
+            commands.as_slice(),
+            [Cmd::Persist(crate::app::PersistCmd::Library)]
+        ));
     }
 
     #[test]

--- a/src/app/server_settings.rs
+++ b/src/app/server_settings.rs
@@ -71,14 +71,27 @@ pub enum MusicServerHealth {
     NeedsAttention,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MusicServerHistoryHealth {
+    #[default]
+    Off,
+    Probing,
+    Detailed,
+    PlayCountsOnly,
+    UpdatePassword,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct MusicServerSummary {
     pub health: MusicServerHealth,
     pub configured: bool,
     pub display_name: Option<String>,
-    pub credential_label: Option<String>,
+    pub credential_kind: Option<MusicServerCredentialMode>,
     pub lan_http: bool,
     pub custom_ca: bool,
+    pub history: MusicServerHistoryHealth,
+    /// Ambiguously delivered playback reports awaiting an explicit user decision.
+    pub playback_reports_needing_decision: usize,
 }
 
 impl MusicServerSummary {
@@ -211,6 +224,9 @@ pub enum MusicServerCommand {
         generation: u64,
         prepared: Box<PreparedSetup>,
     },
+    DisableHistory {
+        generation: u64,
+    },
     Remove {
         generation: u64,
     },
@@ -226,6 +242,10 @@ pub enum MusicServerEvent {
         result: Result<Box<PreparedSetup>, MusicServerFailure>,
     },
     Committed {
+        generation: u64,
+        result: Result<MusicServerSummary, MusicServerFailure>,
+    },
+    HistoryDisabled {
         generation: u64,
         result: Result<MusicServerSummary, MusicServerFailure>,
     },
@@ -246,6 +266,7 @@ pub enum MusicServerBusy {
     Refresh,
     Testing,
     Saving,
+    History,
     Removing,
 }
 
@@ -439,14 +460,14 @@ impl Default for MusicServerSettingsState {
 
 impl MusicServerSettingsState {
     pub fn row_count(&self) -> usize {
-        if self.summary.configured { 3 } else { 2 }
+        if self.summary.configured { 4 } else { 2 }
     }
 
     pub fn modal_open(&self) -> bool {
         self.wizard.is_some()
     }
 
-    fn next_generation(&mut self) -> u64 {
+    pub(in crate::app) fn next_generation(&mut self) -> u64 {
         self.generation = self.generation.wrapping_add(1).max(1);
         self.generation
     }
@@ -594,7 +615,8 @@ impl App {
                     self.open_music_server_setup();
                     Vec::new()
                 }
-                2 => {
+                2 => self.activate_music_server_history(),
+                3 => {
                     self.server.settings.wizard = Some(MusicServerWizard::RemoveConfirm);
                     self.dirty = true;
                     Vec::new()
@@ -890,6 +912,7 @@ impl App {
             MusicServerEvent::Refreshed { generation, .. }
             | MusicServerEvent::Prepared { generation, .. }
             | MusicServerEvent::Committed { generation, .. }
+            | MusicServerEvent::HistoryDisabled { generation, .. }
             | MusicServerEvent::Removed { generation, .. } => *generation,
         };
         if event_generation != self.server.settings.generation {
@@ -981,6 +1004,42 @@ impl App {
                 self.dirty = true;
                 commands
             }
+            MusicServerEvent::HistoryDisabled { result, .. } => {
+                self.server.settings.busy = None;
+                match result {
+                    Ok(summary) => {
+                        let runtime_ready = summary.health == MusicServerHealth::UpToDate;
+                        self.server.settings.summary = summary;
+                        self.server.settings.failure =
+                            (!runtime_ready).then_some(MusicServerFailure::Connection);
+                        if runtime_ready {
+                            self.status.kind = StatusKind::Info;
+                            self.status.text = crate::t!(
+                                "Detailed history is off; standard server access was kept",
+                                "상세 이력을 껐어요. 일반 서버 연결은 그대로예요",
+                                "詳細履歴をオフにしました。通常のサーバー接続は保持されます"
+                            )
+                            .to_owned();
+                        } else {
+                            self.status.kind = StatusKind::Error;
+                            self.status.text = crate::t!(
+                                "Detailed history is off; the server needs attention",
+                                "상세 이력은 껐지만 서버 확인이 필요해요",
+                                "詳細履歴はオフですが、サーバーの確認が必要です"
+                            )
+                            .to_owned();
+                        }
+                    }
+                    Err(failure) => {
+                        self.server.settings.failure = Some(failure);
+                        self.server.settings.summary.health = MusicServerHealth::NeedsAttention;
+                        self.status.kind = StatusKind::Error;
+                        self.status.text = failure.label().to_owned();
+                    }
+                }
+                self.dirty = true;
+                Vec::new()
+            }
             MusicServerEvent::Removed { result, .. } => {
                 self.server.settings.busy = None;
                 let commands = match result {
@@ -1000,6 +1059,8 @@ impl App {
                     }
                     Err(failure) => {
                         self.server.settings.failure = Some(failure);
+                        self.server.settings.summary.health = MusicServerHealth::NeedsAttention;
+                        self.server.settings.wizard = None;
                         self.status.kind = StatusKind::Error;
                         self.status.text = failure.label().to_owned();
                         Vec::new()
@@ -1091,7 +1152,13 @@ mod tests {
     fn confirmed_remove_switches_to_non_cancellable_waiting_state() {
         let mut app = App::new(50);
         app.server.settings.summary.configured = true;
-        assert!(app.activate_music_server_row(2).is_empty());
+        app.server.settings.summary.history = MusicServerHistoryHealth::Detailed;
+        assert!(matches!(
+            app.activate_music_server_row(2).as_slice(),
+            [Cmd::MusicServer(MusicServerCommand::DisableHistory { .. })]
+        ));
+        app.server.settings.busy = None;
+        assert!(app.activate_music_server_row(3).is_empty());
         let commands = app.on_key_music_server_settings(key(KeyCode::Enter));
 
         assert_eq!(commands.len(), 1);
@@ -1237,9 +1304,11 @@ mod tests {
                 health: MusicServerHealth::UpToDate,
                 configured: true,
                 display_name: Some("Home server".to_owned()),
-                credential_label: Some("Password".to_owned()),
+                credential_kind: Some(MusicServerCredentialMode::Password),
                 lan_http: false,
                 custom_ca: false,
+                history: MusicServerHistoryHealth::Off,
+                playback_reports_needing_decision: 0,
             }),
         });
 
@@ -1269,9 +1338,11 @@ mod tests {
                 health: MusicServerHealth::UpToDate,
                 configured: true,
                 display_name: Some("Replacement".to_owned()),
-                credential_label: Some("API key".to_owned()),
+                credential_kind: Some(MusicServerCredentialMode::ApiKey),
                 lan_http: false,
                 custom_ca: false,
+                history: MusicServerHistoryHealth::Off,
+                playback_reports_needing_decision: 0,
             }),
         });
 
@@ -1293,9 +1364,11 @@ mod tests {
                 health: MusicServerHealth::NeedsAttention,
                 configured: true,
                 display_name: Some("Saved server".to_owned()),
-                credential_label: Some("Password".to_owned()),
+                credential_kind: Some(MusicServerCredentialMode::Password),
                 lan_http: false,
                 custom_ca: false,
+                history: MusicServerHistoryHealth::Off,
+                playback_reports_needing_decision: 0,
             }),
         });
 
@@ -1329,16 +1402,18 @@ mod tests {
                         health: MusicServerHealth::NeedsAttention,
                         configured: true,
                         display_name: Some("Saved server".to_owned()),
-                        credential_label: Some("Password".to_owned()),
+                        credential_kind: Some(MusicServerCredentialMode::Password),
                         lan_http: false,
                         custom_ca: false,
+                        history: MusicServerHistoryHealth::Off,
+                        playback_reports_needing_decision: 0,
                     },
                     failure: Some(failure),
                 }),
             });
 
             assert!(app.server.settings.summary.configured);
-            assert_eq!(app.server.settings.row_count(), 3);
+            assert_eq!(app.server.settings.row_count(), 4);
             assert_eq!(app.server.settings.failure, Some(failure));
             app.open_music_server_setup();
             let Some(MusicServerWizard::Setup(form)) = app.server.settings.wizard.as_ref() else {
@@ -1346,6 +1421,18 @@ mod tests {
             };
             assert_eq!(form.identity_intent, None);
         }
+    }
+
+    #[test]
+    fn playback_report_attention_keeps_the_configured_action_rows_stable() {
+        let mut state = MusicServerSettingsState::default();
+        state.summary.configured = true;
+        state.summary.health = MusicServerHealth::NeedsAttention;
+        state.summary.playback_reports_needing_decision = 3;
+
+        assert_eq!(state.row_count(), 4);
+        state.selected = state.row_count() - 1;
+        assert_eq!(state.selected, 3);
     }
 
     #[test]
@@ -1374,6 +1461,18 @@ mod tests {
                 if !config.search.open_subsonic
                     && config.search.source != SearchSource::OpenSubsonic
         ));
+
+        app.server.settings.summary.configured = true;
+        app.server.settings.wizard = Some(MusicServerWizard::Waiting);
+        app.finish_music_server_event(MusicServerEvent::Removed {
+            generation: 9,
+            result: Err(MusicServerFailure::Storage),
+        });
+        assert!(app.server.settings.wizard.is_none());
+        assert_eq!(
+            app.server.settings.summary.health,
+            MusicServerHealth::NeedsAttention
+        );
     }
 
     #[test]

--- a/src/app/streaming_reducer.rs
+++ b/src/app/streaming_reducer.rs
@@ -1049,15 +1049,23 @@ impl App {
         for event in self.streaming.session_events.iter().rev().take(8) {
             let delta = match event.outcome {
                 Outcome::FullPlay => 0.05,
-                Outcome::Like => 0.15,
+                Outcome::Like => crate::rating::SessionRatingSignal::Like.affinity_delta(),
                 Outcome::Skip => -0.10,
                 Outcome::QuickSkip => -0.20,
-                Outcome::Dislike => -0.40,
+                Outcome::Dislike => crate::rating::SessionRatingSignal::Dislike.affinity_delta(),
             };
             let entry = out.entry(event.artist_key.clone()).or_insert(0.0);
             *entry = (*entry + delta).clamp(-0.50, 0.35);
         }
         out
+    }
+
+    #[cfg(test)]
+    pub(crate) fn recommendation_station_state_for_test(
+        &self,
+        seed_video_id: &str,
+    ) -> StationState {
+        self.build_station_state(seed_video_id)
     }
 
     /// Sync the active station profile's adventurousness onto the live engine mode. The avoid

--- a/src/app/tests/downloads.rs
+++ b/src/app/tests/downloads.rs
@@ -252,6 +252,8 @@ fn open_subsonic_download_fixture() -> Song {
         suffix: Some("flac".to_owned()),
         starred: false,
         user_rating: None,
+        play_count: None,
+        played_at: None,
     })
 }
 

--- a/src/app/tests/library_core.rs
+++ b/src/app/tests/library_core.rs
@@ -195,8 +195,17 @@ fn favorite_from_search_results() {
     app.search.selected = 1;
     app.search.focus = SearchFocus::Results;
     app.mode = Mode::Search;
+    let selected = app.search.results[1].clone();
+    crate::rating::set(
+        std::sync::Arc::make_mut(&mut app.library),
+        std::sync::Arc::make_mut(&mut app.signals),
+        &selected,
+        crate::personal_state::Rating::Disliked,
+        1,
+    );
     let cmds = app.update(Msg::Key(key(KeyCode::Char('f'))));
     assert!(app.library.is_favorite("id1"));
+    assert!(!app.signals.is_disliked("id1"));
     assert!(
         cmds.iter()
             .any(|c| matches!(c, Cmd::Persist(PersistCmd::Library)))

--- a/src/daemon/engine.rs
+++ b/src/daemon/engine.rs
@@ -35,6 +35,7 @@ mod gui_search;
 mod gui_settings;
 mod keymap_theme;
 mod media_session;
+mod open_subsonic_bridge;
 mod open_subsonic_runtime;
 mod persistence_gate;
 mod personal_export;
@@ -51,7 +52,9 @@ mod engine_session;
 
 pub use delivery::EngineError;
 use delivery::{record_player_delivery, require_player_delivery};
-use engine_session::data_dir;
+#[cfg(test)]
+use engine_session::SESSION_EVENTS_CAP;
+use engine_session::{DaemonOutcome, DaemonSessionEvent, data_dir};
 pub(super) use gui_search::RequesterKey;
 use gui_search::{GuiSearchAdmission, GuiSearchIndex};
 #[cfg(test)]
@@ -69,8 +72,6 @@ use crate::playback_policy::{
 use crate::streaming::CandidateSource;
 
 mod media_projection;
-
-const SESSION_EVENTS_CAP: usize = 20;
 
 pub struct EngineOptions {
     pub resume: bool,
@@ -133,6 +134,9 @@ pub struct DaemonEngine {
     maintainer: crate::util::background_task::BackgroundTask,
     player: Option<PlayerRuntime>,
     open_subsonic: open_subsonic_runtime::OpenSubsonicOwner,
+    open_subsonic_rating_identity: Option<String>,
+    open_subsonic_pending_rating: Option<open_subsonic_bridge::PendingOpenSubsonicRatingProjection>,
+    open_subsonic_pending_scrobbles: VecDeque<open_subsonic_bridge::PendingOpenSubsonicScrobble>,
     player_emit: Arc<dyn Fn(PlayerEvent) + Send + Sync>,
     queue: Queue,
     playback: DaemonPlayback,
@@ -234,24 +238,16 @@ enum PositionEpochReason {
     IdleReset,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DaemonOutcome {
-    FullPlay,
-    Skip,
-    QuickSkip,
-}
-
-#[derive(Debug, Clone)]
-struct DaemonSessionEvent {
-    artist_key: String,
-    outcome: DaemonOutcome,
-    completion: f32,
-}
-
 impl DaemonEngine {
-    pub async fn start<F>(options: EngineOptions, emit: F) -> Result<Self, EngineError>
+    pub async fn start<F, B>(
+        options: EngineOptions,
+        emit: F,
+        bridge_emit: B,
+        ready_emit: open_subsonic_runtime::OpenSubsonicReadySink,
+    ) -> Result<Self, EngineError>
     where
         F: Fn(PlayerEvent) + Send + Sync + 'static,
+        B: Fn(crate::open_subsonic::OpenSubsonicBridgeImport) + Send + Sync + 'static,
     {
         let (config, startup) =
             crate::persist::load_verified_startup_state().map_err(EngineError::from)?;
@@ -281,7 +277,7 @@ impl DaemonEngine {
         engine.install_personal_state(personal_state);
         engine.personal_state_device_id = personal_state_device_id;
         // Optional server discovery must not hold local restore or player startup hostage.
-        open_subsonic_runtime::initialize(&mut engine);
+        open_subsonic_runtime::initialize(&mut engine, Arc::new(bridge_emit), ready_emit);
         // External tool discovery remains required for ordinary YouTube/local playback.
         crate::tools::init(&engine.config.tools).await;
         // Keep the managed copy fresh; the daemon has no status-line emitter.
@@ -324,6 +320,9 @@ impl DaemonEngine {
             maintainer: crate::util::background_task::BackgroundTask::disabled("yt-dlp maintainer"),
             player: None,
             open_subsonic: Default::default(),
+            open_subsonic_rating_identity: None,
+            open_subsonic_pending_rating: None,
+            open_subsonic_pending_scrobbles: VecDeque::new(),
             player_emit,
             queue,
             playback: DaemonPlayback {
@@ -463,19 +462,6 @@ impl DaemonEngine {
     pub async fn shutdown_background(&mut self) {
         self.open_subsonic.shutdown().await;
         self.maintainer.shutdown().await;
-    }
-
-    /// Retire every daemon-owned media process at the start of owner shutdown.
-    ///
-    /// The remaining remote, effect, and durability barriers can legitimately take longer than
-    /// player teardown. Keeping audio or an overlay alive through those barriers would make a
-    /// normal daemon stop appear stuck and would leave later termination signals with nothing
-    /// useful to coordinate. Recovery is suppressed before this method is called, so closing the
-    /// IPC actor cannot start a replacement player.
-    pub(crate) fn shutdown_media_owners(&mut self) {
-        self.video_overlay = None;
-        self.player = None;
-        self.open_subsonic.retire();
     }
 
     pub fn initial_effects(&mut self) -> Vec<EngineEffect> {

--- a/src/daemon/engine/gui_library.rs
+++ b/src/daemon/engine/gui_library.rs
@@ -141,16 +141,23 @@ impl DaemonEngine {
     pub(super) fn gui_library_remove(&mut self, scope: &str, video_id: &str) -> RemoteResponse {
         let removed = match scope {
             "favorites" => {
-                let mut removed = false;
-                while let Some(index) = self
+                let Some(song) = self
                     .library
                     .favorites
                     .iter()
-                    .position(|song| song.video_id == video_id)
-                {
-                    removed |= self.library.remove_favorite_at(index);
-                }
-                removed
+                    .find(|song| song.video_id == video_id)
+                    .cloned()
+                else {
+                    return RemoteResponse::err("unknown_track");
+                };
+                crate::rating::set(
+                    &mut self.library,
+                    &mut self.signals,
+                    &song,
+                    crate::personal_state::Rating::Neutral,
+                    crate::signals::unix_now(),
+                )
+                .changed()
             }
             "history" => {
                 let mut removed = false;
@@ -284,9 +291,8 @@ impl DaemonEngine {
     /// accepted (its sole sender binds the player model's current track); the cycle
     /// transitions mirror the TUI's `Action::CycleRating` (src/app/player.rs) lockstep —
     /// neutral → like → dislike → neutral over library favorites + dislike signals.
-    /// The daemon skips only the App-local DJ session event, matching its OS-media
-    /// rating path (`media_set_rating`). Persistent recommendation affinity is updated
-    /// by the shared rating reducer on both owners.
+    /// Persistent affinity and immediate session recommendation feedback are both shared with
+    /// the App owner; radio favorites remain outside track recommendation feedback.
     pub(super) fn gui_rate(
         &mut self,
         video_id: &str,
@@ -301,20 +307,14 @@ impl DaemonEngine {
         if song.video_id != video_id {
             return RemoteResponse::err("unknown_track");
         }
-        if song.is_radio_station() {
-            self.library.toggle_favorite(&song);
-            self.save_library("daemon GUI radio rating");
-            self.library_invalidations = self.library_invalidations.wrapping_add(1);
-            return RemoteResponse::ok("rating cycled".to_string());
-        }
         let now = crate::signals::unix_now();
         let change = crate::rating::cycle(&mut self.library, &mut self.signals, &song, now);
-        if change.library_changed {
+        self.record_rating_session_event(&song, change);
+        if change.changed() {
             self.save_library("daemon GUI rating library");
-            self.library_invalidations = self.library_invalidations.wrapping_add(1);
         }
-        if change.signals_changed {
-            self.save_signals("daemon GUI rating signals");
+        if change.library_changed {
+            self.library_invalidations = self.library_invalidations.wrapping_add(1);
         }
         RemoteResponse::ok("rating cycled".to_string())
     }
@@ -506,6 +506,52 @@ mod tests {
         let unknown = engine.gui_library_remove("nonsense", "fav");
         assert_eq!(reason(&unknown), Some("bad_request"));
         assert_eq!(engine.library_invalidations(), before + 3);
+    }
+
+    #[test]
+    fn favorite_removal_neutralizes_rating_and_commits_all_personal_state_projections() {
+        let mut engine = super::super::tests::engine_with_queue(&[]);
+        let song = song("fav", "Favorite Song", "Artist");
+        let artist_key = crate::signals::normalize_artist(&song.artist);
+        crate::rating::set(
+            &mut engine.library,
+            &mut engine.signals,
+            &song,
+            crate::personal_state::Rating::Liked,
+            1,
+        );
+        engine.save_library("seed liked rating");
+        let liked_revision = engine.personal_state_revision();
+
+        assert!(engine.gui_library_remove("favorites", "fav").ok);
+
+        assert_eq!(
+            crate::rating::current(engine.library(), engine.signals(), "fav"),
+            crate::personal_state::Rating::Neutral
+        );
+        assert_eq!(engine.signals().artist_weight(&artist_key), 0.0);
+        assert!(engine.personal_state_revision() > liked_revision);
+        let projection = crate::personal_state::project(&engine.personal_state).unwrap();
+        assert!(projection.legacy.favorites.is_empty());
+        assert!(
+            projection
+                .legacy
+                .signals
+                .tracks
+                .values()
+                .all(|signal| !signal.disliked)
+        );
+        assert!(
+            projection
+                .legacy
+                .signals
+                .artist_affinity
+                .get(&artist_key)
+                .copied()
+                .unwrap_or(0.0)
+                .abs()
+                < f32::EPSILON
+        );
     }
 
     #[test]

--- a/src/daemon/engine/media_session.rs
+++ b/src/daemon/engine/media_session.rs
@@ -14,6 +14,12 @@ use crate::player::PlayerCmd;
 use crate::signals;
 
 impl DaemonEngine {
+    /// Retire every daemon-owned media process before slower shutdown durability barriers.
+    pub(crate) fn shutdown_media_owners(&mut self) {
+        self.video_overlay = None;
+        self.player = None;
+    }
+
     pub fn set_media_art(&mut self, ready: crate::media::artwork::MediaArtworkReady) {
         self.media_art = Some(ready);
     }
@@ -201,40 +207,19 @@ impl DaemonEngine {
         let Some(song) = self.queue.current().cloned() else {
             return;
         };
-        if song.is_radio_station() {
-            if like {
-                self.library.toggle_favorite(&song);
-                self.save_library("daemon radio favorite");
-                self.library_invalidations = self.library_invalidations.wrapping_add(1);
-            }
-            return;
-        }
         let now = signals::unix_now();
-        let target = if like {
-            if crate::rating::current(&self.library, &self.signals, &song.video_id)
-                == crate::personal_state::Rating::Liked
-            {
-                crate::personal_state::Rating::Neutral
-            } else {
-                crate::personal_state::Rating::Liked
-            }
+        let change = if like {
+            crate::rating::toggle_liked(&mut self.library, &mut self.signals, &song, now)
         } else {
-            if crate::rating::current(&self.library, &self.signals, &song.video_id)
-                == crate::personal_state::Rating::Disliked
-            {
-                crate::personal_state::Rating::Neutral
-            } else {
-                crate::personal_state::Rating::Disliked
-            }
+            crate::rating::toggle_disliked(&mut self.library, &mut self.signals, &song, now)
         };
-        let change = crate::rating::set(&mut self.library, &mut self.signals, &song, target, now);
-        if change.library_changed {
+        self.record_rating_session_event(&song, change);
+        if change.changed() {
             self.save_library("daemon media rating library");
+        }
+        if change.library_changed {
             // Favorites membership changed: a subscribed GUI's paged library view is stale.
             self.library_invalidations = self.library_invalidations.wrapping_add(1);
-        }
-        if change.signals_changed {
-            self.save_signals("daemon media rating signals");
         }
     }
 
@@ -262,6 +247,7 @@ impl DaemonEngine {
             };
             MediaTrack {
                 key: song.video_id.clone(),
+                open_subsonic_item: song.open_subsonic_item().cloned(),
                 title: song.title.clone(),
                 artist: song.artist.clone(),
                 album: if is_live { None } else { song.album.clone() },

--- a/src/daemon/engine/open_subsonic_bridge.rs
+++ b/src/daemon/engine/open_subsonic_bridge.rs
@@ -1,0 +1,965 @@
+//! Daemon owner commit for exactly-once OpenSubsonic observations.
+
+use super::DaemonEngine;
+
+pub(super) struct PendingOpenSubsonicScrobble {
+    event_id: String,
+    kind: crate::open_subsonic::OpenSubsonicScrobbleKind,
+    track: crate::scrobble::ScrobbleTrack,
+    confirmation: Option<crate::scrobble::OpenSubsonicSubmissionAck>,
+    receipt: Option<crate::open_subsonic::OpenSubsonicScrobbleReceipt>,
+    source_receipt: Option<crate::open_subsonic::OpenSubsonicScrobbleReceipt>,
+    bridge_durable: bool,
+    source_ack_durable: bool,
+}
+
+pub(super) struct PendingOpenSubsonicRatingProjection {
+    identity: String,
+    receipt: crate::open_subsonic::OpenSubsonicRatingReceipt,
+}
+
+fn same_server_track(
+    left: &crate::scrobble::ScrobbleTrack,
+    right: &crate::scrobble::ScrobbleTrack,
+) -> bool {
+    match (&left.open_subsonic_item, &right.open_subsonic_item) {
+        (Some(left), Some(right)) => left == right,
+        _ => left.key == right.key,
+    }
+}
+
+fn wrong_account_scope(error: &crate::open_subsonic::ServiceError) -> bool {
+    matches!(
+        error,
+        crate::open_subsonic::ServiceError::Server(
+            crate::open_subsonic::ServerError::WrongAccountScope
+        )
+    )
+}
+
+fn request_scope_retirement(pending: &PendingOpenSubsonicScrobble) {
+    if let Some(confirmation) = pending.confirmation.as_ref()
+        && let Err(error) = confirmation.retire_account_scope()
+    {
+        tracing::debug!(
+            %error,
+            "retired daemon music-server account marker waits for source-journal durability"
+        );
+    }
+}
+
+fn admit_pending_scrobble(
+    queue: &mut std::collections::VecDeque<PendingOpenSubsonicScrobble>,
+    pending: PendingOpenSubsonicScrobble,
+) -> bool {
+    use crate::open_subsonic::{OWNER_PLAYBACK_REPORT_QUEUE_MAX, OpenSubsonicScrobbleKind as Kind};
+
+    if queue
+        .iter()
+        .any(|queued| queued.event_id == pending.event_id)
+    {
+        return false;
+    }
+
+    if pending.kind == Kind::NowPlaying {
+        let mut index = 0;
+        while index < queue.len() {
+            let duplicate = queue.get(index).is_some_and(|queued| {
+                queued.kind == Kind::NowPlaying && same_server_track(&queued.track, &pending.track)
+            });
+            if duplicate {
+                queue.remove(index);
+            } else {
+                index += 1;
+            }
+        }
+    }
+
+    while queue.len() >= OWNER_PLAYBACK_REPORT_QUEUE_MAX {
+        if let Some(index) = queue
+            .iter()
+            .position(|queued| queued.kind == Kind::NowPlaying)
+        {
+            queue.remove(index);
+            continue;
+        }
+        if pending.kind == Kind::NowPlaying {
+            tracing::debug!(
+                capacity = OWNER_PLAYBACK_REPORT_QUEUE_MAX,
+                "ephemeral daemon music server now-playing report coalesced at capacity"
+            );
+            return false;
+        }
+        // All retained submissions may be between two durable acknowledgement boundaries. Keep
+        // them stable and defer this newly announced marker to restart replay.
+        tracing::warn!(
+            capacity = OWNER_PLAYBACK_REPORT_QUEUE_MAX,
+            "daemon music server submission queue full; newest journaled report deferred"
+        );
+        if let Some(confirmation) = pending.confirmation.as_ref() {
+            confirmation.defer_submission();
+        }
+        return false;
+    }
+    queue.push_back(pending);
+    true
+}
+
+impl DaemonEngine {
+    /// Persist a server observation before exposing its projection or acknowledging the bridge.
+    pub(in crate::daemon) fn apply_open_subsonic_bridge_import(
+        &mut self,
+        import: &crate::open_subsonic::OpenSubsonicBridgeImport,
+    ) -> Result<String, crate::personal_state::PersonalStateError> {
+        let current = match &self.personal_state_device_id {
+            Some(device_id) => crate::personal_state::reconcile_runtime_as(
+                &self.personal_state,
+                device_id,
+                &self.library,
+                &self.playlists,
+                &self.signals,
+                &self.station,
+            )?,
+            None => crate::personal_state::reconcile_runtime(
+                &self.personal_state,
+                &self.library,
+                &self.playlists,
+                &self.signals,
+                &self.station,
+            )?,
+        };
+        let (candidate, envelope_id) = match &self.personal_state_device_id {
+            Some(device_id) => {
+                let envelope_id = crate::personal_state::external_operation_envelope_id(
+                    device_id,
+                    import.operation_id(),
+                )?;
+                let candidate = crate::personal_state::append_external_operation_as(
+                    &current,
+                    device_id,
+                    import.operation_id().to_owned(),
+                    import.origin()?,
+                    import.operation(),
+                    import.observed_at_unix(),
+                )?;
+                (candidate, envelope_id)
+            }
+            None => {
+                let envelope_id = crate::personal_state::external_operation_envelope_id_for_state(
+                    &current,
+                    import.operation_id(),
+                )?;
+                let candidate = crate::personal_state::append_external_operation(
+                    &current,
+                    import.operation_id().to_owned(),
+                    import.origin()?,
+                    import.operation(),
+                    import.observed_at_unix(),
+                )?;
+                (candidate, envelope_id)
+            }
+        };
+        let commit = crate::personal_state::PersonalStateCommit::prepare_for_runtime(
+            candidate,
+            self.playlists.revision(),
+        )?;
+        let paths = self.personal_state_paths()?;
+        let installed = commit.commit(&paths)?;
+        if installed != *commit.state() {
+            return Err(crate::personal_state::PersonalStateError::ProjectionMismatch);
+        }
+
+        let (library, mut playlists, signals, station) = commit.runtime_stores();
+        let playlists_changed = playlists.inherit_revision_from(&self.playlists);
+        self.install_personal_state(installed);
+        self.library = library;
+        self.playlists = playlists;
+        self.signals = signals;
+        self.station = station;
+        if playlists_changed {
+            self.bump_playlists_rev();
+        }
+        self.library_invalidations = self.library_invalidations.wrapping_add(1);
+        Ok(envelope_id)
+    }
+
+    pub(in crate::daemon) fn accept_open_subsonic_bridge_import(
+        &mut self,
+        import: &crate::open_subsonic::OpenSubsonicBridgeImport,
+    ) {
+        if let Err(error) = self.apply_open_subsonic_bridge_import(import) {
+            tracing::warn!(%error, "music server observation could not be committed");
+            return;
+        }
+        if let Some(handle) = crate::open_subsonic::current_handle()
+            && let Err(error) = handle.acknowledge_bridge_import(import.operation_id())
+        {
+            tracing::debug!(%error, "music server observation acknowledgement will retry");
+        }
+    }
+
+    pub(in crate::daemon) fn queue_open_subsonic_scrobble(
+        &mut self,
+        event_id: String,
+        kind: crate::open_subsonic::OpenSubsonicScrobbleKind,
+        track: crate::scrobble::ScrobbleTrack,
+        confirmation: Option<crate::scrobble::OpenSubsonicSubmissionAck>,
+    ) {
+        let bridge_durable = confirmation
+            .as_ref()
+            .is_some_and(crate::scrobble::OpenSubsonicSubmissionAck::bridge_marker_is_durable);
+        let _admitted = admit_pending_scrobble(
+            &mut self.open_subsonic_pending_scrobbles,
+            PendingOpenSubsonicScrobble {
+                event_id,
+                kind,
+                track,
+                confirmation,
+                receipt: None,
+                source_receipt: None,
+                bridge_durable,
+                source_ack_durable: false,
+            },
+        );
+        self.drive_open_subsonic_scrobbles();
+    }
+
+    pub(in crate::daemon) fn maintain_open_subsonic_bridge(&mut self) {
+        self.drive_open_subsonic_scrobbles();
+        if let Some(pending) = self.open_subsonic_pending_rating.as_mut() {
+            match pending.receipt.try_recv() {
+                Ok(Ok(())) => {
+                    let pending = self
+                        .open_subsonic_pending_rating
+                        .take()
+                        .expect("rating receipt was present");
+                    self.open_subsonic_rating_identity = Some(pending.identity);
+                }
+                Ok(Err(error)) => {
+                    tracing::warn!(
+                        reason = %error,
+                        "music server ratings are waiting for local durability"
+                    );
+                    self.open_subsonic_pending_rating = None;
+                }
+                Err(tokio::sync::oneshot::error::TryRecvError::Empty) => return,
+                Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                    self.open_subsonic_pending_rating = None;
+                }
+            }
+        }
+        let Some(handle) = crate::open_subsonic::current_handle() else {
+            return;
+        };
+
+        let Ok(identity) = self.personal_state.identity() else {
+            return;
+        };
+        if self.open_subsonic_rating_identity.as_deref() == Some(identity.as_str()) {
+            return;
+        }
+        let winners =
+            match crate::personal_state::open_subsonic_rating_winners(&self.personal_state) {
+                Ok(winners) => winners,
+                Err(error) => {
+                    tracing::warn!(%error, "music server rating projection could not be prepared");
+                    return;
+                }
+            };
+        if let Ok(receipt) = handle.reconcile_ratings(winners) {
+            self.open_subsonic_pending_rating =
+                Some(PendingOpenSubsonicRatingProjection { identity, receipt });
+        }
+    }
+
+    /// Poll only receipts which are already ready. An unresolved Submission remains protected by
+    /// the scrobble JSONL marker; NowPlaying is intentionally ephemeral.
+    pub(in crate::daemon) fn pump_open_subsonic_scrobbles_for_shutdown(
+        &mut self,
+    ) -> Result<(), crate::open_subsonic::ServiceError> {
+        loop {
+            let Some(pending) = self.open_subsonic_pending_scrobbles.front_mut() else {
+                return Ok(());
+            };
+            if pending
+                .confirmation
+                .as_ref()
+                .is_some_and(crate::scrobble::OpenSubsonicSubmissionAck::account_scope_is_retired)
+            {
+                self.open_subsonic_pending_scrobbles.pop_front();
+                continue;
+            }
+            if pending.confirmation.as_ref().is_some_and(
+                crate::scrobble::OpenSubsonicSubmissionAck::account_scope_retirement_is_pending,
+            ) {
+                return Ok(());
+            }
+            if pending.bridge_durable {
+                if pending.kind == crate::open_subsonic::OpenSubsonicScrobbleKind::Submission
+                    && let Some(confirmation) = pending.confirmation.as_ref()
+                {
+                    if !confirmation.bridge_marker_is_durable() {
+                        let _ = confirmation.confirm_bridge_durable();
+                    } else if pending.source_ack_durable {
+                        let _ = confirmation.confirm_source_acknowledged();
+                    } else if let Some(receipt) = pending.source_receipt.as_mut() {
+                        match receipt.try_recv() {
+                            Ok(Ok(())) => {
+                                let _ = confirmation.confirm_source_acknowledged();
+                            }
+                            Ok(Err(error)) if wrong_account_scope(&error) => {
+                                pending.source_receipt = None;
+                                request_scope_retirement(pending);
+                                return Ok(());
+                            }
+                            Ok(Err(error)) => return Err(error),
+                            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+                            | Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {}
+                        }
+                    } else if let Some(handle) = crate::open_subsonic::current_handle() {
+                        let _ = handle.acknowledge_scrobble_source(
+                            pending.event_id.clone(),
+                            pending.track.clone(),
+                        );
+                    }
+                }
+                self.open_subsonic_pending_scrobbles.pop_front();
+                continue;
+            }
+            if let Some(receipt) = pending.receipt.as_mut() {
+                match receipt.try_recv() {
+                    Ok(Ok(())) => {
+                        pending.receipt = None;
+                        pending.bridge_durable = true;
+                        continue;
+                    }
+                    Ok(Err(error)) if wrong_account_scope(&error) => {
+                        pending.receipt = None;
+                        if pending.kind
+                            == crate::open_subsonic::OpenSubsonicScrobbleKind::NowPlaying
+                        {
+                            self.open_subsonic_pending_scrobbles.pop_front();
+                            continue;
+                        }
+                        request_scope_retirement(pending);
+                        return Ok(());
+                    }
+                    Ok(Err(error))
+                        if pending.kind
+                            == crate::open_subsonic::OpenSubsonicScrobbleKind::NowPlaying =>
+                    {
+                        tracing::debug!(
+                            reason = %error,
+                            "ephemeral music server now-playing report retired during shutdown"
+                        );
+                        self.open_subsonic_pending_scrobbles.pop_front();
+                        continue;
+                    }
+                    Ok(Err(error)) => return Err(error),
+                    Err(tokio::sync::oneshot::error::TryRecvError::Empty) => return Ok(()),
+                    Err(tokio::sync::oneshot::error::TryRecvError::Closed) => return Ok(()),
+                }
+            }
+            let Some(handle) = crate::open_subsonic::current_handle() else {
+                return Ok(());
+            };
+            match handle.queue_scrobble(
+                pending.event_id.clone(),
+                pending.kind,
+                pending.track.clone(),
+            ) {
+                Ok(receipt) => {
+                    pending.receipt = Some(receipt);
+                }
+                Err(error) => {
+                    tracing::debug!(
+                        reason = %error,
+                        "music server playback report remains journaled for restart replay"
+                    );
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    fn drive_open_subsonic_scrobbles(&mut self) {
+        loop {
+            let Some(pending) = self.open_subsonic_pending_scrobbles.front_mut() else {
+                return;
+            };
+            if pending
+                .confirmation
+                .as_ref()
+                .is_some_and(crate::scrobble::OpenSubsonicSubmissionAck::account_scope_is_retired)
+            {
+                self.open_subsonic_pending_scrobbles.pop_front();
+                continue;
+            }
+            if pending.confirmation.as_ref().is_some_and(
+                crate::scrobble::OpenSubsonicSubmissionAck::account_scope_retirement_is_pending,
+            ) {
+                return;
+            }
+            if pending.kind == crate::open_subsonic::OpenSubsonicScrobbleKind::NowPlaying
+                && pending.bridge_durable
+            {
+                self.open_subsonic_pending_scrobbles.pop_front();
+                continue;
+            }
+            if !pending.bridge_durable {
+                if let Some(receipt) = pending.receipt.as_mut() {
+                    match receipt.try_recv() {
+                        Ok(Ok(())) => {
+                            pending.receipt = None;
+                            pending.bridge_durable = true;
+                            continue;
+                        }
+                        Ok(Err(error)) if wrong_account_scope(&error) => {
+                            pending.receipt = None;
+                            if pending.kind
+                                == crate::open_subsonic::OpenSubsonicScrobbleKind::NowPlaying
+                            {
+                                self.open_subsonic_pending_scrobbles.pop_front();
+                                continue;
+                            }
+                            request_scope_retirement(pending);
+                            return;
+                        }
+                        Ok(Err(error)) => {
+                            tracing::warn!(
+                                reason = %error,
+                                "music server playback report is waiting for local durability"
+                            );
+                            pending.receipt = None;
+                            return;
+                        }
+                        Err(tokio::sync::oneshot::error::TryRecvError::Empty) => return,
+                        Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                            pending.receipt = None;
+                            return;
+                        }
+                    }
+                }
+                let Some(handle) = crate::open_subsonic::current_handle() else {
+                    return;
+                };
+                match handle.queue_scrobble(
+                    pending.event_id.clone(),
+                    pending.kind,
+                    pending.track.clone(),
+                ) {
+                    Ok(receipt) => {
+                        pending.receipt = Some(receipt);
+                        return;
+                    }
+                    Err(_) => return,
+                }
+            }
+
+            let Some(confirmation) = pending.confirmation.as_ref() else {
+                self.open_subsonic_pending_scrobbles.pop_front();
+                continue;
+            };
+            if !confirmation.bridge_marker_is_durable() {
+                match confirmation.confirm_bridge_durable() {
+                    Ok(()) | Err(crate::util::delivery::DeliveryError::Busy) => return,
+                    Err(crate::util::delivery::DeliveryError::Closed) => {
+                        self.open_subsonic_pending_scrobbles.pop_front();
+                        continue;
+                    }
+                    Err(_) => return,
+                }
+            }
+            if !pending.source_ack_durable {
+                if let Some(receipt) = pending.source_receipt.as_mut() {
+                    match receipt.try_recv() {
+                        Ok(Ok(())) => {
+                            pending.source_receipt = None;
+                            pending.source_ack_durable = true;
+                            continue;
+                        }
+                        Ok(Err(error)) if wrong_account_scope(&error) => {
+                            pending.source_receipt = None;
+                            request_scope_retirement(pending);
+                            return;
+                        }
+                        Ok(Err(error)) => {
+                            tracing::warn!(
+                                reason = %error,
+                                "music server source acknowledgement is waiting for durability"
+                            );
+                            pending.source_receipt = None;
+                            return;
+                        }
+                        Err(tokio::sync::oneshot::error::TryRecvError::Empty) => return,
+                        Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                            pending.source_receipt = None;
+                            return;
+                        }
+                    }
+                }
+                let Some(handle) = crate::open_subsonic::current_handle() else {
+                    return;
+                };
+                match handle
+                    .acknowledge_scrobble_source(pending.event_id.clone(), pending.track.clone())
+                {
+                    Ok(receipt) => {
+                        pending.source_receipt = Some(receipt);
+                        return;
+                    }
+                    Err(_) => return,
+                }
+            }
+            if confirmation.source_marker_is_removed() {
+                self.open_subsonic_pending_scrobbles.pop_front();
+                continue;
+            }
+            match confirmation.confirm_source_acknowledged() {
+                Ok(()) | Err(crate::util::delivery::DeliveryError::Busy) => return,
+                Err(crate::util::delivery::DeliveryError::Closed) => {
+                    self.open_subsonic_pending_scrobbles.pop_front();
+                    continue;
+                }
+                Err(_) => return,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::personal_state::{EngagementKind, PortableTrack, PortableTrackKey, Rating};
+
+    fn scrobble_track() -> crate::scrobble::ScrobbleTrack {
+        crate::scrobble::ScrobbleTrack {
+            key: "server-song".to_owned(),
+            open_subsonic_item: None,
+            artist: "Artist".to_owned(),
+            title: "Song".to_owned(),
+            album: None,
+            duration_secs: Some(180),
+            origin_url: None,
+            started_unix: 100,
+        }
+    }
+
+    fn pending(
+        event_id: impl Into<String>,
+        kind: crate::open_subsonic::OpenSubsonicScrobbleKind,
+        confirmation: Option<crate::scrobble::OpenSubsonicSubmissionAck>,
+    ) -> super::PendingOpenSubsonicScrobble {
+        super::PendingOpenSubsonicScrobble {
+            event_id: event_id.into(),
+            kind,
+            track: scrobble_track(),
+            confirmation,
+            receipt: None,
+            source_receipt: None,
+            bridge_durable: false,
+            source_ack_durable: false,
+        }
+    }
+
+    fn track() -> PortableTrack {
+        PortableTrack {
+            key: PortableTrackKey::OpenSubsonic {
+                backend_id: "backend".to_owned(),
+                account_scope_id: "account".to_owned(),
+                item_id: "song".to_owned(),
+            },
+            title: "Song".to_owned(),
+            artist: "Artist".to_owned(),
+            album: None,
+            duration_secs: Some(180),
+            isrc: None,
+        }
+    }
+
+    #[test]
+    fn daemon_commits_replayed_server_observation_once() {
+        let mut engine = super::super::tests::engine_with_queue(&[]);
+        let import = crate::open_subsonic::OpenSubsonicBridgeImport::Rating {
+            operation_id: "daemon-server-rating".to_owned(),
+            track: track(),
+            rating: Rating::Liked,
+            observed_at_unix: 100,
+        };
+
+        let envelope_id = engine.apply_open_subsonic_bridge_import(&import).unwrap();
+        assert_eq!(
+            engine.apply_open_subsonic_bridge_import(&import).unwrap(),
+            envelope_id
+        );
+
+        assert_eq!(
+            engine
+                .personal_state
+                .operations
+                .iter()
+                .filter(|operation| operation.operation_id == envelope_id)
+                .count(),
+            1
+        );
+        assert_ne!(envelope_id, import.operation_id());
+        assert_eq!(engine.library.favorites.len(), 1);
+    }
+
+    #[test]
+    fn app_and_daemon_reduce_server_rating_and_history_in_lockstep() {
+        let mut app = crate::app::App::new(50);
+        let initial = crate::personal_state::legacy_state(
+            &app.library,
+            &app.playlists,
+            &app.signals,
+            &app.station,
+        )
+        .unwrap();
+        app.install_personal_state_runtime(initial).unwrap();
+        let mut engine = super::super::tests::engine_with_queue(&[]);
+        let imports = [
+            crate::open_subsonic::OpenSubsonicBridgeImport::Rating {
+                operation_id: "shared-rating".to_owned(),
+                track: track(),
+                rating: Rating::Disliked,
+                observed_at_unix: 100,
+            },
+            crate::open_subsonic::OpenSubsonicBridgeImport::Engagement {
+                operation_id: "shared-play".to_owned(),
+                track: track(),
+                engagement: EngagementKind::Play,
+                played_duration_ms: None,
+                total_duration_ms: Some(180_000),
+                artist_key: "artist".to_owned(),
+                observed_at_unix: 101,
+            },
+        ];
+        for import in &imports {
+            app.apply_open_subsonic_bridge_import(import).unwrap();
+            engine.apply_open_subsonic_bridge_import(import).unwrap();
+        }
+
+        let app_projection = crate::personal_state::project(&app.personal_state.ledger).unwrap();
+        let daemon_projection = crate::personal_state::project(&engine.personal_state).unwrap();
+        assert_eq!(
+            app_projection.legacy.favorites,
+            daemon_projection.legacy.favorites
+        );
+        assert_eq!(
+            app_projection.legacy.signals,
+            daemon_projection.legacy.signals
+        );
+    }
+
+    #[test]
+    fn daemon_keeps_scrobble_buffered_until_durability_receipt() {
+        let mut engine = super::super::tests::engine_with_queue(&[]);
+        let (reply, receipt) = tokio::sync::oneshot::channel();
+        let (confirmation_tx, mut confirmation_rx) = tokio::sync::mpsc::channel(2);
+        engine
+            .open_subsonic_pending_scrobbles
+            .push_back(super::PendingOpenSubsonicScrobble {
+                event_id: "server-play-1".to_owned(),
+                kind: crate::open_subsonic::OpenSubsonicScrobbleKind::Submission,
+                track: scrobble_track(),
+                confirmation: Some(crate::scrobble::OpenSubsonicSubmissionAck::new(
+                    "server-play-1".to_owned(),
+                    confirmation_tx,
+                )),
+                receipt: Some(receipt),
+                source_receipt: None,
+                bridge_durable: false,
+                source_ack_durable: false,
+            });
+
+        engine.drive_open_subsonic_scrobbles();
+        assert_eq!(engine.open_subsonic_pending_scrobbles.len(), 1);
+        assert!(matches!(
+            confirmation_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+
+        reply.send(Ok(())).unwrap();
+        engine.drive_open_subsonic_scrobbles();
+        assert_eq!(engine.open_subsonic_pending_scrobbles.len(), 1);
+        assert!(
+            confirmation_rx.try_recv().is_ok(),
+            "the intermediate marker rewrite starts only after bridge-store durability"
+        );
+    }
+
+    #[test]
+    fn daemon_retires_only_wrong_scope_then_advances_the_valid_fifo_tail() {
+        use crate::open_subsonic::{OpenSubsonicScrobbleKind as Kind, ServerError, ServiceError};
+
+        let mut engine = super::super::tests::engine_with_queue(&[]);
+        let (ack_tx, mut ack_rx) = tokio::sync::mpsc::channel(4);
+        let old_confirmation =
+            crate::scrobble::OpenSubsonicSubmissionAck::new("old-a".to_owned(), ack_tx.clone());
+        let (old_reply, old_receipt) = tokio::sync::oneshot::channel();
+        old_reply
+            .send(Err(ServiceError::Server(ServerError::WrongAccountScope)))
+            .unwrap();
+        let mut old = pending("old-a", Kind::Submission, Some(old_confirmation.clone()));
+        old.receipt = Some(old_receipt);
+
+        let new_confirmation =
+            crate::scrobble::OpenSubsonicSubmissionAck::new("valid-b".to_owned(), ack_tx);
+        let (new_reply, new_receipt) = tokio::sync::oneshot::channel();
+        new_reply.send(Ok(())).unwrap();
+        let mut valid = pending("valid-b", Kind::Submission, Some(new_confirmation.clone()));
+        valid.receipt = Some(new_receipt);
+        engine.open_subsonic_pending_scrobbles.push_back(old);
+        engine.open_subsonic_pending_scrobbles.push_back(valid);
+
+        engine.drive_open_subsonic_scrobbles();
+        assert!(old_confirmation.account_scope_retirement_is_pending());
+        assert_eq!(
+            engine
+                .open_subsonic_pending_scrobbles
+                .front()
+                .unwrap()
+                .event_id,
+            "old-a"
+        );
+        assert!(ack_rx.try_recv().is_ok());
+
+        old_confirmation.mark_account_scope_retired();
+        engine.drive_open_subsonic_scrobbles();
+        let current = engine.open_subsonic_pending_scrobbles.front().unwrap();
+        assert_eq!(current.event_id, "valid-b");
+        assert!(current.bridge_durable);
+        assert!(
+            ack_rx.try_recv().is_ok(),
+            "the valid profile-B submission reaches its bridge acknowledgement in the same run"
+        );
+        assert!(!new_confirmation.account_scope_retirement_is_pending());
+    }
+
+    #[test]
+    fn daemon_retires_awaiting_wrong_scope_and_never_retires_transient_setup_failure() {
+        use crate::open_subsonic::{OpenSubsonicScrobbleKind as Kind, ServerError, ServiceError};
+
+        let mut engine = super::super::tests::engine_with_queue(&[]);
+        let (ack_tx, mut ack_rx) = tokio::sync::mpsc::channel(4);
+        let awaiting_confirmation =
+            crate::scrobble::OpenSubsonicSubmissionAck::new_with_bridge_marker(
+                "awaiting-a".to_owned(),
+                ack_tx.clone(),
+            );
+        let (source_reply, source_receipt) = tokio::sync::oneshot::channel();
+        source_reply
+            .send(Err(ServiceError::Server(ServerError::WrongAccountScope)))
+            .unwrap();
+        let mut awaiting = pending(
+            "awaiting-a",
+            Kind::Submission,
+            Some(awaiting_confirmation.clone()),
+        );
+        awaiting.bridge_durable = true;
+        awaiting.source_receipt = Some(source_receipt);
+        engine.open_subsonic_pending_scrobbles.push_back(awaiting);
+
+        engine.drive_open_subsonic_scrobbles();
+        assert!(awaiting_confirmation.account_scope_retirement_is_pending());
+        assert!(ack_rx.try_recv().is_ok());
+
+        engine.open_subsonic_pending_scrobbles.clear();
+        let transient_confirmation =
+            crate::scrobble::OpenSubsonicSubmissionAck::new("offline".to_owned(), ack_tx);
+        let (reply, receipt) = tokio::sync::oneshot::channel();
+        reply.send(Err(ServiceError::InvalidSetup)).unwrap();
+        let mut transient = pending(
+            "offline",
+            Kind::Submission,
+            Some(transient_confirmation.clone()),
+        );
+        transient.receipt = Some(receipt);
+        engine.open_subsonic_pending_scrobbles.push_back(transient);
+
+        engine.drive_open_subsonic_scrobbles();
+        assert!(!transient_confirmation.account_scope_retirement_is_pending());
+        assert_eq!(engine.open_subsonic_pending_scrobbles.len(), 1);
+    }
+
+    #[test]
+    fn daemon_wrong_scope_now_playing_never_blocks_a_valid_submission() {
+        use crate::open_subsonic::{OpenSubsonicScrobbleKind as Kind, ServerError, ServiceError};
+
+        let mut engine = super::super::tests::engine_with_queue(&[]);
+        let (old_reply, old_receipt) = tokio::sync::oneshot::channel();
+        old_reply
+            .send(Err(ServiceError::Server(ServerError::WrongAccountScope)))
+            .unwrap();
+        let mut old = pending("now-a", Kind::NowPlaying, None);
+        old.receipt = Some(old_receipt);
+        let (valid_reply, valid_receipt) = tokio::sync::oneshot::channel();
+        valid_reply.send(Ok(())).unwrap();
+        let mut valid = pending("valid-b", Kind::NowPlaying, None);
+        valid.receipt = Some(valid_receipt);
+        engine.open_subsonic_pending_scrobbles.push_back(old);
+        engine.open_subsonic_pending_scrobbles.push_back(valid);
+
+        engine.drive_open_subsonic_scrobbles();
+        assert!(
+            engine.open_subsonic_pending_scrobbles.is_empty(),
+            "the stale ephemeral report is removed and the valid tail progresses immediately"
+        );
+    }
+
+    #[test]
+    fn daemon_shutdown_pump_never_waits_for_an_unresolved_bridge_receipt() {
+        let mut engine = super::super::tests::engine_with_queue(&[]);
+        let (_reply, receipt) = tokio::sync::oneshot::channel();
+        engine
+            .open_subsonic_pending_scrobbles
+            .push_back(super::PendingOpenSubsonicScrobble {
+                event_id: "server-play-in-flight".to_owned(),
+                kind: crate::open_subsonic::OpenSubsonicScrobbleKind::Submission,
+                track: scrobble_track(),
+                confirmation: None,
+                receipt: Some(receipt),
+                source_receipt: None,
+                bridge_durable: false,
+                source_ack_durable: false,
+            });
+
+        assert!(engine.pump_open_subsonic_scrobbles_for_shutdown().is_ok());
+        assert_eq!(
+            engine.open_subsonic_pending_scrobbles.len(),
+            1,
+            "the JSONL journal, not shutdown waiting, owns unresolved submission recovery"
+        );
+    }
+
+    #[test]
+    fn daemon_advances_rating_identity_only_after_durability_receipt() {
+        let mut engine = super::super::tests::engine_with_queue(&[]);
+        let (reply, receipt) = tokio::sync::oneshot::channel();
+        engine.open_subsonic_pending_rating = Some(super::PendingOpenSubsonicRatingProjection {
+            identity: "durable-ledger".to_owned(),
+            receipt,
+        });
+
+        engine.maintain_open_subsonic_bridge();
+        assert_eq!(engine.open_subsonic_rating_identity, None);
+        assert!(engine.open_subsonic_pending_rating.is_some());
+
+        reply.send(Ok(())).unwrap();
+        engine.maintain_open_subsonic_bridge();
+        assert_eq!(
+            engine.open_subsonic_rating_identity.as_deref(),
+            Some("durable-ledger")
+        );
+        assert!(engine.open_subsonic_pending_rating.is_none());
+    }
+
+    #[test]
+    fn daemon_owner_scrobble_queue_is_bounded_and_ephemeral_reports_yield_first() {
+        use crate::open_subsonic::{
+            OWNER_PLAYBACK_REPORT_QUEUE_MAX, OpenSubsonicScrobbleKind as Kind,
+        };
+
+        let mut queue = std::collections::VecDeque::new();
+        for index in 0..OWNER_PLAYBACK_REPORT_QUEUE_MAX {
+            queue.push_back(pending(format!("now-{index}"), Kind::NowPlaying, None));
+        }
+        assert!(super::admit_pending_scrobble(
+            &mut queue,
+            pending("submission", Kind::Submission, None)
+        ));
+        assert_eq!(queue.len(), OWNER_PLAYBACK_REPORT_QUEUE_MAX);
+        assert!(queue.iter().any(|queued| queued.kind == Kind::Submission));
+
+        queue.clear();
+        for index in 0..OWNER_PLAYBACK_REPORT_QUEUE_MAX {
+            queue.push_back(pending(
+                format!("submission-{index}"),
+                Kind::Submission,
+                None,
+            ));
+        }
+        assert!(!super::admit_pending_scrobble(
+            &mut queue,
+            pending("now-at-cap", Kind::NowPlaying, None)
+        ));
+        assert_eq!(queue.len(), OWNER_PLAYBACK_REPORT_QUEUE_MAX);
+    }
+
+    #[test]
+    fn daemon_submission_backpressure_retries_after_same_run_capacity_release() {
+        use crate::open_subsonic::{
+            OWNER_PLAYBACK_REPORT_QUEUE_MAX, OpenSubsonicScrobbleKind as Kind,
+        };
+
+        let (confirmation_tx, mut confirmation_rx) = tokio::sync::mpsc::channel(2);
+        let _keepalive = confirmation_tx.clone();
+        let oldest_confirmation =
+            crate::scrobble::OpenSubsonicSubmissionAck::new("oldest".to_owned(), confirmation_tx);
+        let mut queue = std::collections::VecDeque::new();
+        queue.push_back(pending(
+            "oldest",
+            Kind::Submission,
+            Some(oldest_confirmation),
+        ));
+        for index in 1..OWNER_PLAYBACK_REPORT_QUEUE_MAX {
+            queue.push_back(pending(
+                format!("submission-{index}"),
+                Kind::Submission,
+                None,
+            ));
+        }
+
+        let newest_confirmation = crate::scrobble::OpenSubsonicSubmissionAck::new(
+            "newest".to_owned(),
+            _keepalive.clone(),
+        );
+        assert!(!super::admit_pending_scrobble(
+            &mut queue,
+            pending(
+                "newest",
+                Kind::Submission,
+                Some(newest_confirmation.clone())
+            )
+        ));
+        assert!(queue.iter().any(|queued| queued.event_id == "oldest"));
+        assert!(!queue.iter().any(|queued| queued.event_id == "newest"));
+        assert!(newest_confirmation.submission_is_deferred());
+        assert!(matches!(
+            confirmation_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+
+        queue.pop_front();
+        assert!(newest_confirmation.take_deferred_submission());
+        assert!(super::admit_pending_scrobble(
+            &mut queue,
+            pending(
+                "newest",
+                Kind::Submission,
+                Some(newest_confirmation.clone())
+            )
+        ));
+        assert_eq!(queue.len(), OWNER_PLAYBACK_REPORT_QUEUE_MAX);
+        assert_eq!(
+            queue
+                .iter()
+                .filter(|queued| queued.event_id == "newest")
+                .count(),
+            1
+        );
+
+        let duplicate_confirmation =
+            crate::scrobble::OpenSubsonicSubmissionAck::new("newest".to_owned(), _keepalive);
+        assert!(!super::admit_pending_scrobble(
+            &mut queue,
+            pending(
+                "newest",
+                Kind::Submission,
+                Some(duplicate_confirmation.clone())
+            )
+        ));
+        assert!(!duplicate_confirmation.submission_is_deferred());
+        assert_eq!(queue.len(), OWNER_PLAYBACK_REPORT_QUEUE_MAX);
+    }
+}

--- a/src/daemon/engine/open_subsonic_runtime.rs
+++ b/src/daemon/engine/open_subsonic_runtime.rs
@@ -1,11 +1,14 @@
 //! Daemon ownership for the OpenSubsonic actor and loopback playback proxy.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use super::{DaemonEngine, data_dir};
 
 const RETRY_MIN: Duration = Duration::from_secs(2);
 const RETRY_MAX: Duration = Duration::from_secs(15 * 60);
+
+pub(super) type OpenSubsonicReadySink = Arc<dyn Fn() + Send + Sync>;
 
 fn next_retry(delay: Duration) -> Duration {
     delay.saturating_mul(2).min(RETRY_MAX)
@@ -28,7 +31,12 @@ impl Default for OpenSubsonicOwner {
 }
 
 impl OpenSubsonicOwner {
-    fn start(&mut self, paths: Option<crate::open_subsonic::OpenSubsonicPaths>) {
+    fn start(
+        &mut self,
+        paths: Option<crate::open_subsonic::OpenSubsonicPaths>,
+        sink: crate::open_subsonic::OpenSubsonicBridgeSink,
+        ready: OpenSubsonicReadySink,
+    ) {
         self.retire();
         let Some(paths) = paths else {
             return;
@@ -42,10 +50,16 @@ impl OpenSubsonicOwner {
                     // The loader already runs off the daemon owner path, and every DNS/API step
                     // inside `load_actor` has its own bound. Do not impose a shorter aggregate
                     // deadline that can permanently reject a valid but slower server.
-                    match crate::open_subsonic::load_actor(&paths).await {
+                    match crate::open_subsonic::load_actor_with_bridge_sink(
+                        &paths,
+                        Some(sink.clone()),
+                    )
+                    .await
+                    {
                         Ok(Some(runtime)) => {
                             runtime.activate();
                             routes.install(runtime.route_provider());
+                            ready();
                             // This task owns the actor and proxy until daemon shutdown.
                             std::future::pending::<()>().await;
                             drop(runtime);
@@ -82,9 +96,13 @@ impl OpenSubsonicOwner {
     }
 }
 
-pub(super) fn initialize(engine: &mut DaemonEngine) {
+pub(super) fn initialize(
+    engine: &mut DaemonEngine,
+    sink: crate::open_subsonic::OpenSubsonicBridgeSink,
+    ready: OpenSubsonicReadySink,
+) {
     let paths = data_dir().map(crate::open_subsonic::OpenSubsonicPaths::for_data_root);
-    engine.open_subsonic.start(paths);
+    engine.open_subsonic.start(paths, sink, ready);
 }
 
 #[cfg(test)]

--- a/src/daemon/engine/streaming.rs
+++ b/src/daemon/engine/streaming.rs
@@ -505,11 +505,23 @@ impl DaemonEngine {
                 DaemonOutcome::FullPlay => 0.05 * completion.max(0.5),
                 DaemonOutcome::Skip => -0.10 * (1.0 - completion).max(0.25),
                 DaemonOutcome::QuickSkip => -0.20 * (1.0 - completion).max(0.5),
+                DaemonOutcome::Like => crate::rating::SessionRatingSignal::Like.affinity_delta(),
+                DaemonOutcome::Dislike => {
+                    crate::rating::SessionRatingSignal::Dislike.affinity_delta()
+                }
             };
             let entry = out.entry(event.artist_key.clone()).or_insert(0.0);
             *entry = (*entry + delta).clamp(-0.50, 0.35);
         }
         out
+    }
+
+    #[cfg(test)]
+    pub(crate) fn recommendation_station_state_for_test(
+        &self,
+        seed_video_id: &str,
+    ) -> StationState {
+        self.build_station_state(seed_video_id)
     }
 
     pub(super) fn streaming_skip_streak(&self) -> usize {

--- a/src/daemon/engine/tests.rs
+++ b/src/daemon/engine/tests.rs
@@ -44,6 +44,9 @@ pub(in crate::daemon) fn engine_with_queue(ids: &[&str]) -> DaemonEngine {
         maintainer: crate::util::background_task::BackgroundTask::disabled("yt-dlp maintainer"),
         player: None,
         open_subsonic: Default::default(),
+        open_subsonic_rating_identity: None,
+        open_subsonic_pending_rating: None,
+        open_subsonic_pending_scrobbles: VecDeque::new(),
         player_emit: Arc::new(|_| {}),
         queue,
         playback: DaemonPlayback {

--- a/src/daemon/engine_session.rs
+++ b/src/daemon/engine_session.rs
@@ -2,6 +2,24 @@
 
 use super::*;
 
+pub(super) const SESSION_EVENTS_CAP: usize = 20;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DaemonOutcome {
+    FullPlay,
+    Skip,
+    QuickSkip,
+    Like,
+    Dislike,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct DaemonSessionEvent {
+    pub(super) artist_key: String,
+    pub(super) outcome: DaemonOutcome,
+    pub(super) completion: f32,
+}
+
 impl DaemonEngine {
     pub(super) fn record_session_event(
         &mut self,
@@ -17,6 +35,25 @@ impl DaemonEngine {
         while self.session_events.len() > SESSION_EVENTS_CAP {
             self.session_events.pop_front();
         }
+    }
+
+    pub(super) fn record_rating_session_event(
+        &mut self,
+        song: &Song,
+        change: crate::rating::RatingChange,
+    ) {
+        let Some(signal) = crate::rating::session_signal(song, change) else {
+            return;
+        };
+        let outcome = match signal {
+            crate::rating::SessionRatingSignal::Like => DaemonOutcome::Like,
+            crate::rating::SessionRatingSignal::Dislike => DaemonOutcome::Dislike,
+        };
+        self.record_session_event(
+            &crate::signals::normalize_artist(&song.artist),
+            outcome,
+            self.playback_completion(),
+        );
     }
 
     pub(super) fn session_cache_snapshot(&self) -> SessionCache {

--- a/src/daemon/events.rs
+++ b/src/daemon/events.rs
@@ -26,6 +26,10 @@ pub(super) enum DaemonEvent {
     /// Scrobble-actor notices. The daemon has no UI and never runs the interactive auth
     /// flow (`ytt auth lastfm` does), so these only reach the log.
     Scrobble(crate::scrobble::ScrobbleEvent),
+    /// A durable, secret-free server observation waiting for the daemon personal-state owner.
+    OpenSubsonicBridge(crate::open_subsonic::OpenSubsonicBridgeImport),
+    /// The credential owner is active and initial local projections may now be submitted.
+    OpenSubsonicReady,
     /// The lyrics actor resolved (or failed to find) lines for a track. Fetches are
     /// gated on a live `lyrics` subscriber; see [`super::lyrics_host::LyricsHost`].
     Lyrics(crate::lyrics::LyricsEvent),
@@ -70,6 +74,11 @@ impl DaemonEvent {
                 key: Key::MediaArtVideo,
             },
             DaemonEvent::Scrobble(event) => scrobble_event_policy(event),
+            DaemonEvent::OpenSubsonicBridge(_) | DaemonEvent::OpenSubsonicReady => {
+                EventPolicy::MustDeliver {
+                    lane: Lane::WorkResult,
+                }
+            }
             // The daemon lyrics host already gates fetches by subscriber and track generation.
             DaemonEvent::Lyrics(_) => EventPolicy::MustDeliver {
                 lane: Lane::WorkResult,
@@ -118,6 +127,8 @@ impl DaemonEvent {
             DaemonEvent::Media(_) => "media",
             DaemonEvent::MediaArt(_) => "media_art",
             DaemonEvent::Scrobble(_) => "scrobble",
+            DaemonEvent::OpenSubsonicBridge(_) => "open_subsonic_bridge",
+            DaemonEvent::OpenSubsonicReady => "open_subsonic_ready",
             DaemonEvent::Lyrics(_) => "lyrics",
             DaemonEvent::Download(_) => "download",
             DaemonEvent::Transfer(_) => "transfer",

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -19,7 +19,6 @@ use crate::remote::{
     PERSONAL_STATE_V2_CAPABILITY, WEB_DAV_SYNC_CAPABILITY,
 };
 use crate::util::process::{self, ProcessProfile};
-
 mod accounts_host;
 mod ai_host;
 mod capabilities;
@@ -49,7 +48,7 @@ use events::{DaemonEvent, DaemonEventSender, emit_daemon_event, record_daemon_ev
 use events::{DaemonTelemetrySlot, emit_daemon_callback_result};
 use gui_search_pending::{GuiSearchPending, PendingGuiSearch};
 use serve_setup::transport_or_return;
-use shutdown_drain::drain_daemon_shutdown_ingress;
+use shutdown_drain::{drain_playback_report_frontier, playback_report_frontier_succeeded};
 
 const EXIT_OK: i32 = 0;
 const EXIT_TRANSPORT: i32 = 1;
@@ -713,6 +712,18 @@ async fn run_owner_loop(
             DaemonEvent::PersonalSyncFinished(finished) => {
                 personal_sync.finish(*finished, &mut engine, &event_tx, &shutdown)
             }
+            DaemonEvent::OpenSubsonicBridge(import) => {
+                engine.accept_open_subsonic_bridge_import(&import);
+            }
+            DaemonEvent::OpenSubsonicReady => {}
+            DaemonEvent::Scrobble(crate::scrobble::ScrobbleEvent::OpenSubsonic {
+                event_id,
+                kind,
+                track,
+                confirmation,
+            }) => {
+                engine.queue_open_subsonic_scrobble(event_id, kind, track, confirmation);
+            }
             DaemonEvent::Scrobble(event) => {
                 accounts_host::on_scrobble_event(event, &mut engine, &mut publisher);
             }
@@ -737,6 +748,7 @@ async fn run_owner_loop(
             engine.suppress_transport_recovery_for_shutdown();
             break;
         }
+        engine.maintain_open_subsonic_bridge();
         personal_sync.observe(&mut engine, &event_tx, &shutdown);
         // Queue/session/settings mutations can invalidate an in-flight autoplay request even
         // when the seed id still exists. Settle that owner generation before publishing this
@@ -840,37 +852,30 @@ async fn run_owner_loop(
     // admission before the generic owner ingress so no accepted request can appear without a
     // wire-settlement token beyond the drain frontier.
     publisher.quiesce_owner_admission();
-    // Reject callback producers before awaiting any task that may itself be inside a callback.
-    // This breaks the owner-waits-producer / producer-waits-owner shutdown cycle under saturation.
-    event_tx.close_admission();
-    // Audio and overlay ownership ends before any slower remote/durability barrier. Keep the OS
-    // signal consumer alive until later teardown, but do not make normal daemon stop latency part
-    // of an mpv lifetime.
+    // Seal playback time while the projection and credential owner are still live.
+    shutdown_drain::seal_final_playback_observation(&mut scrobble, &engine);
     engine.shutdown_media_owners();
     // Remove the OS media surface before the slower task barrier. Its callbacks now see a closed
     // ingress, and a fast successor must not compete with a stale Now Playing/MPRIS/SMTC target.
     let _ = media.set_enabled(false);
-    let drain = drain_daemon_shutdown_ingress(
+    // The scrobble actor may discover a final threshold while draining observations which were
+    // accepted before shutdown. Keep pumping its owner events until the actor joins; closing the
+    // ingress first would reject the exact OpenSubsonic submission before bridge persistence.
+    let (scrobble_outcome, open_subsonic_outcome, drain) = drain_playback_report_frontier(
+        &mut scrobble,
         &event_tx,
         &mut event_rx,
         &mut pending_events,
         &publisher,
         &mut personal_export,
+        &mut engine,
     )
     .await;
     // A worker that completed before the admission frontier was settled by the drain above.
     // Anything still retained cannot re-enter now, so release its wire settlement explicitly.
     personal_export.shutdown();
     personal_sync.shutdown();
-    tracing::debug!(
-        remote_requests = drain.remote_requests,
-        subscribe_requests = drain.subscribe_requests,
-        terminal_events = drain.terminal_events,
-        personal_export_completions = drain.personal_export_completions,
-        coalesced_events = drain.coalesced_events,
-        retired_events = drain.retired_events,
-        "daemon shutdown ingress drained"
-    );
+    drain.log_summary();
     if !publisher.wait_for_wire_settlements().await {
         // Only a last scheduler margin after the structural writer budget timed out (and logged).
         crate::remote::await_shutdown_reply_grace().await;
@@ -885,17 +890,10 @@ async fn run_owner_loop(
     signal_handlers.shutdown().await;
     engine.shutdown_background().await;
     effect_tasks.shutdown().await;
-    // The deadline reports slow shutdown but never cancels accepted local durability. A failed
-    // final frontier is a transport failure, not a clean daemon exit.
-    match scrobble
-        .shutdown_and_join(Duration::from_millis(1500))
-        .await
-    {
-        Ok(()) => EXIT_OK,
-        Err(error) => {
-            tracing::warn!(%error, "scrobble shutdown durability was not confirmed");
-            EXIT_TRANSPORT
-        }
+    if playback_report_frontier_succeeded(scrobble_outcome, open_subsonic_outcome) {
+        EXIT_OK
+    } else {
+        EXIT_TRANSPORT
     }
 }
 
@@ -936,6 +934,9 @@ fn route_gui_search_completion(
 fn log_scrobble_event(event: crate::scrobble::ScrobbleEvent) {
     use crate::scrobble::ScrobbleEvent;
     match event {
+        ScrobbleEvent::OpenSubsonic { .. } => {
+            tracing::warn!("music server playback report missed its owner route");
+        }
         ScrobbleEvent::SessionInvalid(kind) => {
             tracing::warn!(
                 service = kind.label(),

--- a/src/daemon/parity_tests.rs
+++ b/src/daemon/parity_tests.rs
@@ -17,6 +17,7 @@
 //!   vs `true` with nothing loaded). The script then must keep them equal.
 
 mod harness;
+mod rating_recommendation;
 
 use std::sync::Arc;
 
@@ -887,7 +888,7 @@ async fn track_rating_cycle_and_recommendation_projection_stay_in_parity() {
 
     for step in ["liked", "disliked", "neutral"] {
         let command = RemoteCommand::Rate {
-            video_id: "v1".to_owned(),
+            video_id: "b".to_owned(),
             rating: RateChange::Cycle,
         };
         let app_response = app_apply(&mut app, command.clone());
@@ -908,10 +909,30 @@ async fn track_rating_cycle_and_recommendation_projection_stay_in_parity() {
 }
 
 #[tokio::test]
+async fn media_like_repairs_dislike_and_clears_like_in_parity() {
+    let (mut app, mut engine) = hermetic_pair();
+    for _ in 0..2 {
+        let command = RemoteCommand::Rate {
+            video_id: "b".to_owned(),
+            rating: RateChange::Cycle,
+        };
+        app_apply(&mut app, command.clone());
+        engine.handle_remote(command).await;
+    }
+    assert!(app.signals.is_disliked("b"));
+
+    for step in ["liked", "neutral"] {
+        app.update(Msg::Media(MediaCommand::Like));
+        let (shutdown, effects) = engine.handle_media(MediaCommand::Like).await;
+        assert!(!shutdown);
+        assert!(effects.is_empty());
+        assert_parity(&format!("media like {step}"), &app, &engine);
+    }
+}
+
+#[tokio::test]
 async fn radio_station_rating_cycle_stays_in_parity() {
-    // The radio branch of the rating cycle is dual-implemented by hand (App
-    // player.rs vs daemon gui_rate) — pin it: the cycle toggles radio-favorite
-    // membership, which projects through TrackModel.favorite on both owners.
+    // The shared reducer keeps binary station favorites out of track-rating signals.
     let (mut app, mut engine) = hermetic_pair();
     let mut station = Song::remote("st1", "station-st1", "", "");
     station.playable = Some(crate::api::PlayableRef::RadioStream {

--- a/src/daemon/parity_tests/rating_recommendation.rs
+++ b/src/daemon/parity_tests/rating_recommendation.rs
@@ -1,0 +1,128 @@
+use super::*;
+use crate::streaming::{self, CandidateSource, Cooc, StationState};
+
+fn rerank_snapshot(state: &StationState, signals: &Signals) -> Vec<(String, f32)> {
+    let candidates = vec![
+        Song::remote(
+            "rated-artist-candidate",
+            "Rated Artist Song",
+            "artist-b",
+            "3:45",
+        ),
+        Song::remote("other-candidate", "Other Song", "artist-other", "3:45"),
+        Song::remote("third-candidate", "Third Song", "artist-third", "3:45"),
+    ];
+    let config = Config::default().streaming;
+    let pool = streaming::pool_from_songs(candidates, CandidateSource::YtdlpStreaming);
+    streaming::shortlist_for_ai(pool, state, signals, &Cooc::default(), &config, 3, 1)
+        .into_iter()
+        .map(|candidate| (candidate.video_id().to_owned(), candidate.base_score))
+        .collect()
+}
+
+fn assert_recommendation_parity(
+    step: &str,
+    app: &App,
+    engine: &DaemonEngine,
+    expected_artist_bias: f32,
+) {
+    assert_eq!(
+        serde_json::to_value(&*app.signals).unwrap(),
+        serde_json::to_value(engine.signals()).unwrap(),
+        "{step}: persistent recommendation projections diverged"
+    );
+
+    let app_state = app.recommendation_station_state_for_test("b");
+    let daemon_state = engine.recommendation_station_state_for_test("b");
+    assert_eq!(
+        app_state.session_artist_bias, daemon_state.session_artist_bias,
+        "{step}: session recommendation snapshots diverged"
+    );
+    assert_eq!(
+        app_state.session_artist_bias.get("artist-b").copied(),
+        Some(expected_artist_bias),
+        "{step}: rating feedback was missing or recorded more than once"
+    );
+    assert_eq!(
+        rerank_snapshot(&app_state, &app.signals),
+        rerank_snapshot(&daemon_state, engine.signals()),
+        "{step}: production rerank results diverged"
+    );
+}
+
+#[tokio::test]
+async fn gui_and_os_rating_feedback_keep_session_reranking_in_parity() {
+    let (mut app, mut engine) = hermetic_pair();
+
+    for (step, expected_bias) in [("liked", 0.15), ("disliked", -0.25), ("neutral", -0.25)] {
+        let command = RemoteCommand::Rate {
+            video_id: "b".to_owned(),
+            rating: RateChange::Cycle,
+        };
+        let app_response = app_apply(&mut app, command.clone());
+        let (engine_response, shutdown, effects) = engine.handle_remote(command).await;
+        assert!(!shutdown);
+        assert!(effects.is_empty());
+        assert_eq!(app_response.reason, engine_response.reason);
+        assert_recommendation_parity(step, &app, &engine, expected_bias);
+    }
+
+    let (mut app, mut engine) = hermetic_pair();
+    for (step, command, expected_bias) in [
+        ("OS like", MediaCommand::Like, 0.15),
+        ("OS neutral from like", MediaCommand::Like, 0.15),
+        ("OS dislike", MediaCommand::Dislike, -0.25),
+        ("OS neutral from dislike", MediaCommand::Dislike, -0.25),
+    ] {
+        app.update(Msg::Media(command.clone()));
+        let (shutdown, effects) = engine.handle_media(command).await;
+        assert!(!shutdown);
+        assert!(effects.is_empty());
+        assert_recommendation_parity(step, &app, &engine, expected_bias);
+    }
+}
+
+#[tokio::test]
+async fn radio_favorites_never_enter_track_session_reranking() {
+    let (mut app, mut engine) = hermetic_pair();
+    let mut station = Song::remote("station", "Station", "Radio", "");
+    station.playable = Some(crate::api::PlayableRef::RadioStream {
+        url: "https://radio.example/station.mp3".to_owned(),
+    });
+    let mut queue = Queue::default();
+    queue.set(vec![station], 0);
+    let snapshot = queue.snapshot();
+    engine.restore_queue_snapshot(snapshot.clone(), RNG_SEED);
+    app.queue.restore_snapshot(snapshot);
+
+    let command = RemoteCommand::Rate {
+        video_id: "station".to_owned(),
+        rating: RateChange::Cycle,
+    };
+    let app_response = app_apply(&mut app, command.clone());
+    let (engine_response, shutdown, effects) = engine.handle_remote(command).await;
+    assert!(!shutdown);
+    assert!(effects.is_empty());
+    assert_eq!(app_response.reason, engine_response.reason);
+    let app_effects = app.update(Msg::Media(MediaCommand::Like));
+    let (shutdown, engine_effects) = engine.handle_media(MediaCommand::Like).await;
+    assert!(!shutdown);
+    assert!(
+        app_effects
+            .iter()
+            .all(|effect| matches!(effect, Cmd::Persist(_)))
+    );
+    assert!(engine_effects.is_empty());
+
+    let app_state = app.recommendation_station_state_for_test("station");
+    let daemon_state = engine.recommendation_station_state_for_test("station");
+    assert_eq!(
+        serde_json::to_value(&*app.signals).unwrap(),
+        serde_json::to_value(engine.signals()).unwrap()
+    );
+    assert!(app_state.session_artist_bias.is_empty());
+    assert_eq!(
+        app_state.session_artist_bias,
+        daemon_state.session_artist_bias
+    );
+}

--- a/src/daemon/serve_setup.rs
+++ b/src/daemon/serve_setup.rs
@@ -70,14 +70,26 @@ pub(super) fn spawn_signals(
 
 pub(super) async fn start_engine(
     resume: bool,
-    player_event_tx: DaemonEventSender,
+    event_tx: DaemonEventSender,
     shutdown: &crate::player::lifetime::ShutdownLatch,
 ) -> Option<Result<engine::DaemonEngine, engine::EngineError>> {
+    let player_event_tx = event_tx.clone();
+    let bridge_event_tx = event_tx.clone();
+    let ready_event_tx = event_tx;
     await_owner_handler(
         shutdown,
-        engine::DaemonEngine::start(engine::EngineOptions { resume }, move |event| {
-            record_daemon_event(&player_event_tx, DaemonEvent::Player(event));
-        }),
+        engine::DaemonEngine::start(
+            engine::EngineOptions { resume },
+            move |event| {
+                record_daemon_event(&player_event_tx, DaemonEvent::Player(event));
+            },
+            move |event| {
+                record_daemon_event(&bridge_event_tx, DaemonEvent::OpenSubsonicBridge(event));
+            },
+            std::sync::Arc::new(move || {
+                record_daemon_event(&ready_event_tx, DaemonEvent::OpenSubsonicReady);
+            }),
+        ),
     )
     .await
 }

--- a/src/daemon/shutdown_drain.rs
+++ b/src/daemon/shutdown_drain.rs
@@ -4,7 +4,9 @@ use std::collections::VecDeque;
 
 use tokio::sync::mpsc;
 
-use super::{DaemonEvent, DaemonEventSender, personal_export::PersonalExport};
+use super::{
+    DaemonEvent, DaemonEventSender, engine::DaemonEngine, personal_export::PersonalExport,
+};
 use crate::remote::proto::RemoteResponse;
 use crate::remote::publish::Publisher;
 use crate::remote::server::RemoteEvent;
@@ -15,8 +17,155 @@ pub(super) struct DaemonShutdownDrain {
     pub(super) subscribe_requests: usize,
     pub(super) terminal_events: usize,
     pub(super) personal_export_completions: usize,
+    pub(super) open_subsonic_events: usize,
     pub(super) coalesced_events: usize,
     pub(super) retired_events: usize,
+}
+
+impl DaemonShutdownDrain {
+    pub(super) fn absorb(&mut self, other: Self) {
+        self.remote_requests += other.remote_requests;
+        self.subscribe_requests += other.subscribe_requests;
+        self.terminal_events += other.terminal_events;
+        self.personal_export_completions += other.personal_export_completions;
+        self.open_subsonic_events += other.open_subsonic_events;
+        self.coalesced_events += other.coalesced_events;
+        self.retired_events += other.retired_events;
+    }
+
+    pub(super) fn log_summary(self) {
+        tracing::debug!(
+            remote_requests = self.remote_requests,
+            subscribe_requests = self.subscribe_requests,
+            terminal_events = self.terminal_events,
+            personal_export_completions = self.personal_export_completions,
+            open_subsonic_events = self.open_subsonic_events,
+            coalesced_events = self.coalesced_events,
+            retired_events = self.retired_events,
+            "daemon shutdown ingress drained"
+        );
+    }
+}
+
+pub(super) fn playback_report_frontier_succeeded(
+    scrobble: Result<(), crate::util::delivery::DeliveryError>,
+    open_subsonic: Result<(), crate::open_subsonic::ServiceError>,
+) -> bool {
+    match (scrobble, open_subsonic) {
+        (Ok(()), Ok(())) => true,
+        (Err(error), _) => {
+            tracing::warn!(%error, "scrobble shutdown durability was not confirmed");
+            false
+        }
+        (Ok(()), Err(error)) => {
+            tracing::warn!(%error, "music server playback report durability was not confirmed");
+            false
+        }
+    }
+}
+
+/// Capture one fresh monotonic tail before retiring audio ownership. A saturated terminal lane
+/// retains this observation in the scrobble handle's shutdown-only retry slot.
+pub(super) fn seal_final_playback_observation(
+    scrobble: &mut crate::scrobble::ScrobbleHandle,
+    engine: &DaemonEngine,
+) {
+    if let Err(error) = scrobble.observe_shutdown(&engine.media_snapshot()) {
+        tracing::debug!(
+            delivery_outcome = error.reason(),
+            "final daemon scrobble observation will settle at the shutdown frontier"
+        );
+    }
+}
+
+/// Join the final playback-threshold producer while its owner lane remains live, then close
+/// admission and pump already-ready credential-owner receipts. Unresolved submissions stay in
+/// the scrobble journal instead of extending shutdown behind a network request.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn drain_playback_report_frontier(
+    scrobble: &mut crate::scrobble::ScrobbleHandle,
+    event_tx: &DaemonEventSender,
+    event_rx: &mut mpsc::Receiver<DaemonEvent>,
+    pending_events: &mut VecDeque<DaemonEvent>,
+    publisher: &Publisher,
+    personal_export: &mut PersonalExport,
+    engine: &mut DaemonEngine,
+) -> (
+    Result<(), crate::util::delivery::DeliveryError>,
+    Result<(), crate::open_subsonic::ServiceError>,
+    DaemonShutdownDrain,
+) {
+    let (scrobble_outcome, mut drain) = shutdown_scrobble_with_owner_pump(
+        scrobble,
+        event_tx,
+        event_rx,
+        pending_events,
+        publisher,
+        personal_export,
+        engine,
+    )
+    .await;
+    event_tx.close_admission();
+    drain.absorb(
+        drain_daemon_shutdown_ingress(
+            event_tx,
+            event_rx,
+            pending_events,
+            publisher,
+            personal_export,
+            engine,
+        )
+        .await,
+    );
+    let open_subsonic_outcome = engine.pump_open_subsonic_scrobbles_for_shutdown();
+    (scrobble_outcome, open_subsonic_outcome, drain)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn shutdown_scrobble_with_owner_pump(
+    scrobble: &mut crate::scrobble::ScrobbleHandle,
+    event_tx: &DaemonEventSender,
+    event_rx: &mut mpsc::Receiver<DaemonEvent>,
+    pending_events: &mut VecDeque<DaemonEvent>,
+    publisher: &Publisher,
+    personal_export: &mut PersonalExport,
+    engine: &mut DaemonEngine,
+) -> (
+    Result<(), crate::util::delivery::DeliveryError>,
+    DaemonShutdownDrain,
+) {
+    let mut drain = DaemonShutdownDrain::default();
+    while let Some(event) = pending_events.pop_front() {
+        settle_daemon_shutdown_event(
+            event_tx,
+            publisher,
+            personal_export,
+            engine,
+            event,
+            &mut drain,
+        );
+    }
+
+    let shutdown = scrobble.shutdown_and_join(std::time::Duration::from_millis(1500));
+    tokio::pin!(shutdown);
+    let mut ingress_open = true;
+    loop {
+        tokio::select! {
+            biased;
+            outcome = shutdown.as_mut() => return (outcome, drain),
+            event = event_rx.recv(), if ingress_open => match event {
+                Some(event) => settle_daemon_shutdown_event(
+                    event_tx,
+                    publisher,
+                    personal_export,
+                    engine,
+                    event,
+                    &mut drain,
+                ),
+                None => ingress_open = false,
+            },
+        }
+    }
 }
 
 /// Drain every event whose admission linearized before shutdown. The receiver deliberately stays
@@ -28,22 +177,44 @@ pub(super) async fn drain_daemon_shutdown_ingress(
     pending_events: &mut VecDeque<DaemonEvent>,
     publisher: &Publisher,
     personal_export: &mut PersonalExport,
+    engine: &mut DaemonEngine,
 ) -> DaemonShutdownDrain {
     let mut drain = DaemonShutdownDrain::default();
 
     while let Some(event) = pending_events.pop_front() {
-        settle_event(event_tx, publisher, personal_export, event, &mut drain);
+        settle_daemon_shutdown_event(
+            event_tx,
+            publisher,
+            personal_export,
+            engine,
+            event,
+            &mut drain,
+        );
     }
 
     loop {
         while let Ok(event) = event_rx.try_recv() {
-            settle_event(event_tx, publisher, personal_export, event, &mut drain);
+            settle_daemon_shutdown_event(
+                event_tx,
+                publisher,
+                personal_export,
+                engine,
+                event,
+                &mut drain,
+            );
         }
 
         if event_tx.deferred_is_idle() {
             match event_rx.try_recv() {
                 Ok(event) => {
-                    settle_event(event_tx, publisher, personal_export, event, &mut drain);
+                    settle_daemon_shutdown_event(
+                        event_tx,
+                        publisher,
+                        personal_export,
+                        engine,
+                        event,
+                        &mut drain,
+                    );
                     continue;
                 }
                 Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected) => {
@@ -58,32 +229,34 @@ pub(super) async fn drain_daemon_shutdown_ingress(
     // admission is closed, so this final generation is stable and can be retired exactly once.
     for event in event_tx.drain_coalesced() {
         drain.coalesced_events += 1;
-        settle_non_wake(publisher, personal_export, event, &mut drain);
+        settle_non_wake(publisher, personal_export, engine, event, &mut drain);
     }
     event_rx.close();
     drain
 }
 
-fn settle_event(
+pub(super) fn settle_daemon_shutdown_event(
     event_tx: &DaemonEventSender,
     publisher: &Publisher,
     personal_export: &mut PersonalExport,
+    engine: &mut DaemonEngine,
     event: DaemonEvent,
     drain: &mut DaemonShutdownDrain,
 ) {
     if matches!(event, DaemonEvent::TelemetryWake) {
         for event in event_tx.drain_coalesced() {
             drain.coalesced_events += 1;
-            settle_non_wake(publisher, personal_export, event, drain);
+            settle_non_wake(publisher, personal_export, engine, event, drain);
         }
     } else {
-        settle_non_wake(publisher, personal_export, event, drain);
+        settle_non_wake(publisher, personal_export, engine, event, drain);
     }
 }
 
 fn settle_non_wake(
     publisher: &Publisher,
     personal_export: &mut PersonalExport,
+    engine: &mut DaemonEngine,
     event: DaemonEvent,
     drain: &mut DaemonShutdownDrain,
 ) {
@@ -135,6 +308,23 @@ fn settle_non_wake(
         DaemonEvent::PersonalExportFinished(finished) => {
             drain.personal_export_completions += 1;
             personal_export.finish(finished);
+        }
+        DaemonEvent::OpenSubsonicBridge(import) => {
+            drain.open_subsonic_events += 1;
+            engine.accept_open_subsonic_bridge_import(&import);
+        }
+        DaemonEvent::OpenSubsonicReady => {
+            drain.open_subsonic_events += 1;
+            engine.maintain_open_subsonic_bridge();
+        }
+        DaemonEvent::Scrobble(crate::scrobble::ScrobbleEvent::OpenSubsonic {
+            event_id,
+            kind,
+            track,
+            confirmation,
+        }) => {
+            drain.open_subsonic_events += 1;
+            engine.queue_open_subsonic_scrobble(event_id, kind, track, confirmation);
         }
         event => {
             drain.retired_events += 1;

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -325,6 +325,12 @@ fn daemon_event_policy_covers_representative_events() {
         }
     );
     assert_eq!(
+        DaemonEvent::OpenSubsonicReady.policy(),
+        EventPolicy::MustDeliver {
+            lane: EventLane::WorkResult,
+        }
+    );
+    assert_eq!(
         DaemonEvent::MediaArt(crate::media::artwork::MediaArtworkReady {
             key: "track".to_owned(),
             path: "art.jpg".into(),
@@ -489,6 +495,7 @@ fn daemon_event_kind_and_telemetry_slots_are_stable() {
         DaemonEvent::Scrobble(crate::scrobble::ScrobbleEvent::QueueStalled { pending: 3 }).kind(),
         "scrobble"
     );
+    assert_eq!(DaemonEvent::OpenSubsonicReady.kind(), "open_subsonic_ready");
     assert_eq!(
         DaemonEvent::Download(crate::download::DownloadEvent::Error {
             video_id: "v".to_owned(),
@@ -1040,18 +1047,40 @@ async fn shutdown_drain_settles_pending_main_deferred_and_coalesced_events() {
             origin: crate::remote::RemoteSessionScope::for_test(9, Some("page")),
             reply: pending_reply.into(),
         }),
+        DaemonEvent::OpenSubsonicReady,
+        DaemonEvent::Scrobble(crate::scrobble::ScrobbleEvent::OpenSubsonic {
+            event_id: "shutdown-server-play-1".to_owned(),
+            kind: crate::open_subsonic::OpenSubsonicScrobbleKind::Submission,
+            track: crate::scrobble::ScrobbleTrack {
+                key: "server-song".to_owned(),
+                open_subsonic_item: Some(crate::open_subsonic::OpenSubsonicItemRef::new(
+                    crate::open_subsonic::BackendId::new("shutdown-backend").unwrap(),
+                    crate::open_subsonic::AccountScopeId::new("shutdown-account").unwrap(),
+                    crate::open_subsonic::ItemId::new("shutdown-song").unwrap(),
+                )),
+                artist: "Artist".to_owned(),
+                title: "Song".to_owned(),
+                album: None,
+                duration_secs: Some(180),
+                origin_url: None,
+                started_unix: 100,
+            },
+            confirmation: None,
+        }),
     ]);
     assert!(event_tx.close_admission());
 
     let (hub, _session, _line_rx) = crate::remote::test_register(Default::default());
     let publisher = crate::remote::publish::Publisher::new(hub);
     let mut personal_export = personal_export::PersonalExport::default();
+    let mut engine = engine::tests::engine_with_queue(&[]);
     let drain = crate::daemon::shutdown_drain::drain_daemon_shutdown_ingress(
         &event_tx,
         &mut event_rx,
         &mut pending_events,
         &publisher,
         &mut personal_export,
+        &mut engine,
     )
     .await;
 
@@ -1071,6 +1100,10 @@ async fn shutdown_drain_settles_pending_main_deferred_and_coalesced_events() {
     );
     assert_eq!(drain.coalesced_events, 1);
     assert_eq!(drain.personal_export_completions, 1);
+    assert_eq!(
+        drain.open_subsonic_events, 2,
+        "server readiness and threshold events must settle during shutdown"
+    );
     assert_eq!(
         drain.retired_events, 2,
         "Signal plus the coalesced time tick"

--- a/src/download/server_download_tests.rs
+++ b/src/download/server_download_tests.rs
@@ -26,6 +26,8 @@ async fn rejects_music_server_tracks_before_spawning_ytdlp() {
         suffix: Some("flac".to_owned()),
         starred: false,
         user_rating: None,
+        play_count: None,
+        played_at: None,
     });
     let emit: EventSink = Arc::new(|_| Ok(DeliveryReceipt::Enqueued));
     let root =

--- a/src/media/delivery.rs
+++ b/src/media/delivery.rs
@@ -321,6 +321,7 @@ mod tests {
         MediaSnapshot {
             track: Some(MediaTrack {
                 key: format!("track-{title}"),
+                open_subsonic_item: None,
                 title: title.to_owned(),
                 artist: format!("artist-{title}"),
                 album: Some(format!("album-{title}")),

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -101,6 +101,9 @@ pub struct MediaCaps {
 pub struct MediaTrack {
     /// Stable per-track key (the queue `video_id`; also keys the artwork cache).
     pub key: String,
+    /// Exact credential-owning server identity, when this queue entry came from OpenSubsonic.
+    /// It contains no URL or secret and lets the shared playback observer submit exact scrobbles.
+    pub open_subsonic_item: Option<crate::open_subsonic::OpenSubsonicItemRef>,
     pub title: String,
     /// Display artist; empty when unknown (adapters omit the field then).
     pub artist: String,
@@ -741,6 +744,7 @@ mod tests {
         MediaSnapshot {
             track: Some(MediaTrack {
                 key: key.to_owned(),
+                open_subsonic_item: None,
                 title: "t".to_owned(),
                 artist: "a".to_owned(),
                 album: None,
@@ -902,6 +906,7 @@ mod tests {
     fn track(key: &str) -> MediaTrack {
         MediaTrack {
             key: key.to_owned(),
+            open_subsonic_item: None,
             title: format!("title-{key}"),
             artist: "artist".to_owned(),
             album: None,

--- a/src/media/mpris.rs
+++ b/src/media/mpris.rs
@@ -696,6 +696,7 @@ mod tests {
         let mut snapshot = MediaSnapshot::idle();
         snapshot.track = Some(MediaTrack {
             key: "track-key".to_owned(),
+            open_subsonic_item: None,
             title: "Title".to_owned(),
             artist: "Artist".to_owned(),
             album: Some("Album".to_owned()),

--- a/src/open_subsonic/actor.rs
+++ b/src/open_subsonic/actor.rs
@@ -1,13 +1,15 @@
 //! Long-lived credential owner plus setup/status lifecycle facade.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
 
-use tokio::sync::{mpsc, oneshot};
-use tokio::task::JoinHandle;
+use tokio::sync::{Notify, mpsc, oneshot};
+use tokio::task::{JoinHandle, JoinSet};
 use zeroize::Zeroize;
 
-use super::OpenSubsonicBridgeState;
+use super::bridge_event::{OpenSubsonicBridgeSink, OpenSubsonicScrobbleKind};
+use super::bridge_runtime::BridgeRuntime;
+pub use super::bridge_runtime::OutboundScrobbleResolution;
 use super::capabilities::ServerCapabilities;
 use super::catalog::OpenSubsonicCatalog;
 use super::client::{BinaryPayload, OpenSubsonicClient, ServerError};
@@ -26,8 +28,13 @@ use super::transaction::{
     OpenSubsonicStoreSet, StoreRevisions, commit_store_set, load_store_set,
     load_store_set_read_only, remove_store_set, reset_store_set,
 };
+use super::{NativeHistoryHealth, OpenSubsonicBridgeState};
+use crate::personal_state::OpenSubsonicRatingWinner;
 
 const ACTOR_CAPACITY: usize = 32;
+const BRIDGE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+const NATIVE_HISTORY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+const HISTORY_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ServiceError {
@@ -144,6 +151,12 @@ pub struct OpenSubsonicStatus {
     /// This deliberately exposes only the redacted presence bit, never certificate bytes,
     /// fingerprints, paths, or the configured origin.
     pub uses_custom_ca: bool,
+    /// Experimental exact Navidrome history is enabled. No username/password is exposed.
+    pub native_history_enabled: bool,
+    /// Actual redacted native-history capability/health; standard play-count history is separate.
+    pub native_history_health: NativeHistoryHealth,
+    /// Bounded count of opaque outbound reports requiring an explicit delivery decision.
+    pub outbound_scrobbles_needing_attention: usize,
 }
 
 impl OpenSubsonicStatus {
@@ -156,6 +169,9 @@ impl OpenSubsonicStatus {
             credential_kind: None,
             uses_lan_http: false,
             uses_custom_ca: false,
+            native_history_enabled: false,
+            native_history_health: NativeHistoryHealth::Off,
+            outbound_scrobbles_needing_attention: 0,
         }
     }
 
@@ -168,6 +184,9 @@ impl OpenSubsonicStatus {
             credential_kind: None,
             uses_lan_http: false,
             uses_custom_ca: false,
+            native_history_enabled: false,
+            native_history_health: NativeHistoryHealth::Off,
+            outbound_scrobbles_needing_attention: 0,
         }
     }
 }
@@ -235,9 +254,28 @@ pub async fn test_and_prepare_setup(
         origin,
         custom_ca_pem,
     )?;
-    let private_state =
+    let mut private_state =
         OpenSubsonicPrivateState::new(backend_id.clone(), account_scope_id.clone(), credential);
-    let bridge_state = OpenSubsonicBridgeState::new(backend_id, account_scope_id);
+    if input.identity_intent == SetupIdentityIntent::UpdateSameServerAndAccount {
+        private_state.preserve_native_history_from(
+            &current
+                .as_ref()
+                .ok_or(ServiceError::InvalidSetup)?
+                .private_state,
+        )?;
+    }
+    let mut bridge_state =
+        if input.identity_intent == SetupIdentityIntent::UpdateSameServerAndAccount {
+            current
+                .as_ref()
+                .map(|state| state.bridge_state.clone())
+                .ok_or(ServiceError::InvalidSetup)?
+        } else {
+            OpenSubsonicBridgeState::new(backend_id, account_scope_id)
+        };
+    // Candidates are identity-coherent at revision zero; commit assigns the next shared store
+    // revision after its optimistic check.
+    bridge_state.set_revision(0);
     let store_set = OpenSubsonicStoreSet::new(profile, private_state, bridge_state)?;
     let client = OpenSubsonicClient::connect(&store_set.profile).await?;
     let capabilities =
@@ -322,15 +360,54 @@ pub fn remove_profile(paths: &OpenSubsonicPaths) -> Result<OpenSubsonicStatus, S
     Ok(OpenSubsonicStatus::off())
 }
 
+/// Disable the experimental native-history credential as one coherent private/bridge commit.
+///
+/// The caller must retire any live credential owner before invoking this mutation, then load a
+/// fresh actor from the returned durable state. Standard OpenSubsonic credentials are retained.
+pub fn disable_native_history(
+    paths: &OpenSubsonicPaths,
+) -> Result<OpenSubsonicStatus, ServiceError> {
+    let Some(mut store_set) = load_store_set(paths)? else {
+        return Err(ServiceError::InvalidSetup);
+    };
+    let expected = store_set.revisions();
+    store_set.private_state.disable_native_history();
+    store_set
+        .bridge_state
+        .set_native_history_health(NativeHistoryHealth::Off);
+    commit_store_set(paths, expected, &mut store_set)?;
+    Ok(status_from_store_set(&store_set))
+}
+
 fn status_from_store_set(store_set: &OpenSubsonicStoreSet) -> OpenSubsonicStatus {
+    let native_history_enabled = store_set.private_state.native_history_enabled();
+    let native_history_health = if native_history_enabled {
+        match store_set.bridge_state.native_history_health() {
+            NativeHistoryHealth::Off => NativeHistoryHealth::Probing,
+            health => health,
+        }
+    } else {
+        NativeHistoryHealth::Off
+    };
+    let outbound_scrobbles_needing_attention = store_set
+        .bridge_state
+        .outbound_scrobble_attention_ids()
+        .len();
     OpenSubsonicStatus {
-        kind: OpenSubsonicStatusKind::UpToDate,
+        kind: if outbound_scrobbles_needing_attention == 0 {
+            OpenSubsonicStatusKind::UpToDate
+        } else {
+            OpenSubsonicStatusKind::NeedsAttention
+        },
         display_name: Some(store_set.profile.display_name().to_owned()),
         backend_id: Some(store_set.profile.backend_id().clone()),
         account_scope_id: Some(store_set.profile.account_scope_id().clone()),
         credential_kind: Some(store_set.private_state.credential_kind()),
         uses_lan_http: store_set.profile.uses_lan_http(),
         uses_custom_ca: store_set.profile.custom_ca_fingerprint().is_some(),
+        native_history_enabled,
+        native_history_health,
+        outbound_scrobbles_needing_attention,
     }
 }
 
@@ -389,6 +466,92 @@ impl OpenSubsonicHandle {
             .await
     }
 
+    /// Queue the current personal-state winners for canonical server projection.
+    ///
+    /// This never contains a credential and does not wait for the network. The credential owner
+    /// persists each projection before attempting it and retries partial writes.
+    pub fn reconcile_ratings(
+        &self,
+        winners: Vec<OpenSubsonicRatingWinner>,
+    ) -> Result<OpenSubsonicRatingReceipt, ServerError> {
+        let (reply, receipt) = oneshot::channel();
+        self.try_send(ActorCommand::ReconcileRatings { winners, reply })?;
+        Ok(receipt)
+    }
+
+    /// Confirm that the personal-state owner durably committed one bridge import.
+    pub fn acknowledge_bridge_import(
+        &self,
+        operation_id: impl Into<String>,
+    ) -> Result<(), ServerError> {
+        self.try_send(ActorCommand::AcknowledgeBridgeImport {
+            operation_id: operation_id.into(),
+        })
+    }
+
+    /// Queue an exact OpenSubsonic playback action without exposing upstream authentication.
+    ///
+    /// The returned receipt resolves only after the credential owner has committed the report to
+    /// its bridge store. Channel admission alone is not a durability acknowledgement.
+    pub fn queue_scrobble(
+        &self,
+        event_id: String,
+        kind: OpenSubsonicScrobbleKind,
+        track: crate::scrobble::ScrobbleTrack,
+    ) -> Result<OpenSubsonicScrobbleReceipt, ServerError> {
+        let (reply, receipt) = oneshot::channel();
+        self.try_send(ActorCommand::QueueScrobble {
+            event_id,
+            kind,
+            track,
+            reply,
+        })?;
+        Ok(receipt)
+    }
+
+    /// Confirm that the exact source journal durably entered its non-submitting acknowledgement
+    /// state.
+    ///
+    /// This second receipt closes the cross-store crash window: the bridge retains its replay
+    /// receipt until this command itself has crossed the bridge-store durability boundary.
+    pub fn acknowledge_scrobble_source(
+        &self,
+        event_id: String,
+        track: crate::scrobble::ScrobbleTrack,
+    ) -> Result<OpenSubsonicScrobbleReceipt, ServerError> {
+        let (reply, receipt) = oneshot::channel();
+        self.try_send(ActorCommand::AcknowledgeScrobbleSource {
+            event_id,
+            track,
+            reply,
+        })?;
+        Ok(receipt)
+    }
+
+    /// Return only opaque event IDs for reports requiring an explicit delivery decision.
+    pub async fn scrobble_attention_ids(&self) -> Result<Vec<String>, ServerError> {
+        self.request(|reply| ActorCommand::ScrobbleAttentionIds { reply })
+            .await
+    }
+
+    /// Explicitly retry or mark one ambiguously delivered report as sent.
+    ///
+    /// The command accepts only its opaque event ID; track metadata, server addresses, and
+    /// credentials never cross this API.
+    pub fn resolve_scrobble(
+        &self,
+        event_id: String,
+        resolution: OutboundScrobbleResolution,
+    ) -> Result<OpenSubsonicScrobbleReceipt, ServerError> {
+        let (reply, receipt) = oneshot::channel();
+        self.try_send(ActorCommand::ResolveScrobble {
+            event_id,
+            resolution,
+            reply,
+        })?;
+        Ok(receipt)
+    }
+
     async fn open_stream_response(
         &self,
         item: OpenSubsonicItemRef,
@@ -413,6 +576,12 @@ impl OpenSubsonicHandle {
             .map_err(|_| ServerError::Offline)?;
         response.await.map_err(|_| ServerError::Offline)?
     }
+
+    fn try_send(&self, command: ActorCommand) -> Result<(), ServerError> {
+        self.tx
+            .try_send(command)
+            .map_err(|_| ServerError::TemporarilyUnavailable)
+    }
 }
 
 impl StreamSource for OpenSubsonicHandle {
@@ -431,8 +600,29 @@ pub struct OpenSubsonicRuntime {
     generation: u64,
     handle: OpenSubsonicHandle,
     proxy_handle: OpenSubsonicProxyHandle,
+    bridge_activation: Arc<BridgeActivation>,
     proxy_guard: Option<OpenSubsonicProxyGuard>,
     actor_task: Option<JoinHandle<()>>,
+}
+
+#[derive(Default)]
+struct BridgeActivation {
+    active: AtomicBool,
+    changed: Notify,
+}
+
+impl BridgeActivation {
+    fn activate(&self) -> bool {
+        if self.active.swap(true, Ordering::AcqRel) {
+            return false;
+        }
+        self.changed.notify_waiters();
+        true
+    }
+
+    fn is_active(&self) -> bool {
+        self.active.load(Ordering::Acquire)
+    }
 }
 
 impl OpenSubsonicRuntime {
@@ -454,6 +644,9 @@ impl OpenSubsonicRuntime {
     /// out of order, and only the owner lane may decide which result is current. A discarded
     /// candidate therefore never replaces or revokes the active profile.
     pub(crate) fn activate(&self) {
+        if !self.bridge_activation.activate() {
+            return;
+        }
         install_current(
             self.generation,
             self.handle.clone(),
@@ -489,10 +682,20 @@ impl Drop for OpenSubsonicRuntime {
 pub async fn load_actor(
     paths: &OpenSubsonicPaths,
 ) -> Result<Option<OpenSubsonicRuntime>, ServiceError> {
+    load_actor_with_bridge_sink(paths, None).await
+}
+
+/// Load the primary credential owner and deliver durable server observations to its state owner.
+pub async fn load_actor_with_bridge_sink(
+    paths: &OpenSubsonicPaths,
+    sink: Option<OpenSubsonicBridgeSink>,
+) -> Result<Option<OpenSubsonicRuntime>, ServiceError> {
     let Some(store_set) = load_store_set(paths)? else {
         return Ok(None);
     };
-    start_actor(store_set).await.map(Some)
+    start_actor(store_set, BridgeRuntime::writable(paths.clone(), sink))
+        .await
+        .map(Some)
 }
 
 /// Start a credential owner from a coherent snapshot without creating storage, locking for
@@ -503,10 +706,15 @@ pub async fn load_actor_read_only(
     let Some(store_set) = load_store_set_read_only(paths)? else {
         return Ok(None);
     };
-    start_actor(store_set).await.map(Some)
+    start_actor(store_set, BridgeRuntime::read_only())
+        .await
+        .map(Some)
 }
 
-async fn start_actor(store_set: OpenSubsonicStoreSet) -> Result<OpenSubsonicRuntime, ServiceError> {
+async fn start_actor(
+    store_set: OpenSubsonicStoreSet,
+    bridge: BridgeRuntime,
+) -> Result<OpenSubsonicRuntime, ServiceError> {
     let client = OpenSubsonicClient::connect(&store_set.profile).await?;
     let capabilities =
         ServerCapabilities::probe(&client, store_set.private_state.credential()).await?;
@@ -520,7 +728,15 @@ async fn start_actor(store_set: OpenSubsonicStoreSet) -> Result<OpenSubsonicRunt
     };
     let (tx, rx) = mpsc::channel(ACTOR_CAPACITY);
     let handle = OpenSubsonicHandle { tx };
-    let actor_task = tokio::spawn(run_actor(rx, store_set, client, summary));
+    let bridge_activation = Arc::new(BridgeActivation::default());
+    let actor_task = tokio::spawn(run_actor(
+        rx,
+        store_set,
+        client,
+        summary,
+        bridge,
+        bridge_activation.clone(),
+    ));
     let (proxy_handle, proxy_guard) = match super::proxy::start(Arc::new(handle.clone())).await {
         Ok(proxy) => proxy,
         Err(_) => {
@@ -533,6 +749,7 @@ async fn start_actor(store_set: OpenSubsonicStoreSet) -> Result<OpenSubsonicRunt
         generation,
         handle,
         proxy_handle,
+        bridge_activation,
         proxy_guard: Some(proxy_guard),
         actor_task: Some(actor_task),
     })
@@ -556,96 +773,423 @@ pub fn current_proxy_handle() -> Option<OpenSubsonicProxyHandle> {
 
 async fn run_actor(
     mut rx: mpsc::Receiver<ActorCommand>,
-    store_set: OpenSubsonicStoreSet,
+    mut store_set: OpenSubsonicStoreSet,
     client: OpenSubsonicClient,
     summary: OpenSubsonicProfileSummary,
+    bridge: BridgeRuntime,
+    bridge_activation: Arc<BridgeActivation>,
 ) {
-    while let Some(command) = rx.recv().await {
-        let catalog = OpenSubsonicCatalog::new(
-            &client,
-            store_set.private_state.credential(),
-            store_set.profile.backend_id(),
-            store_set.profile.account_scope_id(),
-        );
-        match command {
-            ActorCommand::Search {
-                query,
-                limit,
-                mut reply,
-            } => {
-                let result = tokio::select! {
-                    _ = reply.closed() => continue,
-                    result = catalog.search(&query, limit) => result,
+    let now = tokio::time::Instant::now();
+    let mut retry = tokio::time::interval_at(
+        now + std::time::Duration::from_secs(2),
+        BRIDGE_RETRY_INTERVAL,
+    );
+    retry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut native_history = tokio::time::interval_at(
+        now + std::time::Duration::from_secs(5),
+        NATIVE_HISTORY_INTERVAL,
+    );
+    native_history.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut history_jobs = JoinSet::new();
+    let mut bridge_active = false;
+    let mut last_native_history_error = None;
+    let mut native_history_was_truncated = false;
+
+    loop {
+        if let Err(error) = activate_bridge_if_needed(
+            &bridge,
+            &bridge_activation,
+            &mut bridge_active,
+            &mut store_set,
+        ) {
+            tracing::warn!(
+                reason = %error,
+                "music server candidate could not rebase its durable bridge snapshot"
+            );
+            break;
+        }
+        tokio::select! {
+            command = rx.recv() => {
+                let Some(command) = command else {
+                    break;
                 };
-                let _ = reply.send(result);
+                // Activation and the first owner command can become ready on the same scheduler
+                // turn. Rebase in this branch too so that command cannot mutate a stale revision.
+                if let Err(error) = activate_bridge_if_needed(
+                    &bridge,
+                    &bridge_activation,
+                    &mut bridge_active,
+                    &mut store_set,
+                ) {
+                    tracing::warn!(
+                        reason = %error,
+                        "music server candidate could not rebase its durable bridge snapshot"
+                    );
+                    break;
+                }
+                handle_actor_command(
+                    command,
+                    &mut store_set,
+                    &client,
+                    &summary,
+                    &bridge,
+                )
+                .await;
             }
-            ActorCommand::LibraryPage { request, mut reply } => {
-                let result = tokio::select! {
-                    _ = reply.closed() => continue,
-                    result = catalog.library_page(
-                        request.section,
-                        request.offset,
-                        request.limit,
-                    ) => result,
-                };
-                let _ = reply.send(result);
+            _ = bridge_activation.changed.notified(), if !bridge_active => {}
+            _ = retry.tick(), if bridge.is_writable() && bridge_active => {
+                if let Err(error) = bridge.retry_network(&mut store_set, &client).await {
+                    tracing::warn!(reason = %error, "music server bridge will retry");
+                }
             }
-            ActorCommand::LibraryDetail { request, mut reply } => {
-                let operation = async {
-                    match request {
-                        ServerLibraryDetailRequest::Album(id) => catalog.album_detail(&id).await,
-                        ServerLibraryDetailRequest::Artist(id) => catalog.artist_detail(&id).await,
-                        ServerLibraryDetailRequest::Playlist(id) => {
-                            catalog.playlist_detail(&id).await
+            _ = native_history.tick(),
+                if bridge.is_writable() && bridge_active && history_jobs.is_empty() =>
+            {
+                if let Some(worker) = bridge.history_worker() {
+                    history_jobs.spawn(worker.fetch());
+                }
+            }
+            completed = history_jobs.join_next(), if !history_jobs.is_empty() => {
+                let mut retry_soon = false;
+                match completed {
+                    Some(Ok(Ok(result))) => match bridge.apply_history_refresh(
+                        &mut store_set,
+                        result,
+                    ) {
+                        Ok(outcome) => {
+                            let health = native_history_health_after(
+                                store_set.private_state.native_history_enabled(),
+                                outcome.native_error,
+                            );
+                            if let Err(error) =
+                                bridge.set_native_history_health(&mut store_set, health)
+                            {
+                                retry_soon = true;
+                                tracing::warn!(
+                                    reason = %error,
+                                    "detailed music server history status could not be persisted"
+                                );
+                            }
+                            if let Some(error) = outcome.native_error {
+                                retry_soon |= native_history_error_retries_soon(error);
+                                if last_native_history_error != Some(error) {
+                                    tracing::warn!(
+                                        reason = %error,
+                                        "detailed music server history is unavailable; standard history remains active"
+                                    );
+                                }
+                            } else if last_native_history_error.take().is_some() {
+                                tracing::info!(
+                                    "detailed music server history is available again"
+                                );
+                            }
+                            last_native_history_error = outcome.native_error;
+                            if let Some(error) = outcome.standard_error {
+                                retry_soon = true;
+                                tracing::warn!(
+                                    reason = %error,
+                                    "music server play-count history is temporarily unavailable"
+                                );
+                            }
+                            if outcome.native_stale {
+                                retry_soon = true;
+                                tracing::debug!(
+                                    "stale detailed-history result was discarded and will retry"
+                                );
+                            }
+                            if outcome.native_truncated {
+                                retry_soon = true;
+                                if !native_history_was_truncated {
+                                    tracing::warn!(
+                                        "detailed music server history reached its bounded scan limit; continuing from its durable cursor"
+                                    );
+                                }
+                            }
+                            native_history_was_truncated = outcome.native_truncated;
                         }
+                        Err(error) => {
+                            retry_soon = true;
+                            let health = if store_set.private_state.native_history_enabled() {
+                                NativeHistoryHealth::Probing
+                            } else {
+                                NativeHistoryHealth::Off
+                            };
+                            if let Err(status_error) =
+                                bridge.set_native_history_health(&mut store_set, health)
+                            {
+                                tracing::warn!(
+                                    reason = %status_error,
+                                    "detailed music server history status could not be persisted"
+                                );
+                            }
+                            tracing::warn!(
+                                reason = %error,
+                                "music server history could not be persisted"
+                            );
+                        }
+                    },
+                    Some(Ok(Err(error))) => {
+                        retry_soon = true;
+                        if store_set.private_state.native_history_enabled()
+                            && let Err(status_error) = bridge.set_native_history_health(
+                                &mut store_set,
+                                NativeHistoryHealth::Probing,
+                            )
+                        {
+                            tracing::warn!(
+                                reason = %status_error,
+                                "detailed music server history status could not be persisted"
+                            );
+                        }
+                        tracing::warn!(
+                            reason = %error,
+                            "music server history worker is temporarily unavailable"
+                        );
                     }
-                };
-                let result = tokio::select! {
-                    _ = reply.closed() => continue,
-                    result = operation => result,
-                };
-                let _ = reply.send(result);
-            }
-            ActorCommand::CoverArt {
-                item,
-                id,
-                mut reply,
-            } => {
-                let operation = async {
-                    match client.validate_item_scope(&item) {
-                        Ok(()) => catalog.cover_art(&id).await,
-                        Err(error) => Err(error),
+                    Some(Err(error)) => {
+                        retry_soon = true;
+                        if store_set.private_state.native_history_enabled()
+                            && let Err(status_error) = bridge.set_native_history_health(
+                                &mut store_set,
+                                NativeHistoryHealth::Probing,
+                            )
+                        {
+                            tracing::warn!(
+                                reason = %status_error,
+                                "detailed music server history status could not be persisted"
+                            );
+                        }
+                        tracing::warn!(
+                            cancelled = error.is_cancelled(),
+                            "music server history worker stopped unexpectedly"
+                        );
                     }
-                };
-                let result = tokio::select! {
-                    _ = reply.closed() => continue,
-                    result = operation => result,
-                };
-                let _ = reply.send(result);
-            }
-            ActorCommand::ProfileSummary { reply } => {
-                let _ = reply.send(Ok(summary.clone()));
-            }
-            ActorCommand::OpenStream {
-                item,
-                request,
-                mut reply,
-            } => {
-                let operation = async {
-                    let origin = client.proxy_origin()?;
-                    let response = client
-                        .open_stream(store_set.private_state.credential(), &item, request)
-                        .await?;
-                    Ok(UpstreamStream::new(response, origin))
-                };
-                let result = tokio::select! {
-                    _ = reply.closed() => continue,
-                    result = operation => result,
-                };
-                let _ = reply.send(result);
+                    None => {}
+                }
+                if retry_soon {
+                    native_history.reset_after(HISTORY_RETRY_INTERVAL);
+                }
             }
         }
     }
+}
+
+fn activate_bridge_if_needed(
+    bridge: &BridgeRuntime,
+    activation: &BridgeActivation,
+    bridge_active: &mut bool,
+    store_set: &mut OpenSubsonicStoreSet,
+) -> Result<(), ServiceError> {
+    if !*bridge_active && activation.is_active() {
+        bridge.refresh_snapshot_for_activation(store_set)?;
+        *bridge_active = true;
+        bridge.emit_pending(store_set);
+    }
+    Ok(())
+}
+
+fn native_history_error_retries_soon(error: super::native_history::NativeHistoryError) -> bool {
+    matches!(
+        error,
+        super::native_history::NativeHistoryError::Offline
+            | super::native_history::NativeHistoryError::TemporarilyUnavailable
+    )
+}
+
+fn native_history_health_after(
+    enabled: bool,
+    error: Option<super::native_history::NativeHistoryError>,
+) -> NativeHistoryHealth {
+    use super::native_history::NativeHistoryError;
+
+    if !enabled {
+        return NativeHistoryHealth::Off;
+    }
+    match error {
+        None => NativeHistoryHealth::Detailed,
+        Some(
+            NativeHistoryError::InvalidCredential
+            | NativeHistoryError::AuthenticationRequired
+            | NativeHistoryError::PermissionDenied,
+        ) => NativeHistoryHealth::UpdatePassword,
+        Some(NativeHistoryError::UnsupportedFeature) => NativeHistoryHealth::PlayCountsOnly,
+        Some(_) => NativeHistoryHealth::Probing,
+    }
+}
+
+async fn handle_actor_command(
+    command: ActorCommand,
+    store_set: &mut OpenSubsonicStoreSet,
+    client: &OpenSubsonicClient,
+    summary: &OpenSubsonicProfileSummary,
+    bridge: &BridgeRuntime,
+) {
+    match command {
+        ActorCommand::Search {
+            query,
+            limit,
+            mut reply,
+        } => {
+            let catalog = catalog(store_set, client);
+            let result = tokio::select! {
+                _ = reply.closed() => return,
+                result = catalog.search(&query, limit) => result,
+            };
+            if let Ok(songs) = &result
+                && let Err(error) = bridge.observe_songs(store_set, songs)
+            {
+                tracing::warn!(reason = %error, "music server observations were not persisted");
+            }
+            let _ = reply.send(result);
+        }
+        ActorCommand::LibraryPage { request, mut reply } => {
+            let catalog = catalog(store_set, client);
+            let result = tokio::select! {
+                _ = reply.closed() => return,
+                result = catalog.library_page(
+                    request.section,
+                    request.offset,
+                    request.limit,
+                ) => result,
+            };
+            if let Ok(page) = &result
+                && let Err(error) = bridge.observe_page(store_set, page)
+            {
+                tracing::warn!(reason = %error, "music server observations were not persisted");
+            }
+            let _ = reply.send(result);
+        }
+        ActorCommand::LibraryDetail { request, mut reply } => {
+            let catalog = catalog(store_set, client);
+            let operation = async {
+                match request {
+                    ServerLibraryDetailRequest::Album(id) => catalog.album_detail(&id).await,
+                    ServerLibraryDetailRequest::Artist(id) => catalog.artist_detail(&id).await,
+                    ServerLibraryDetailRequest::Playlist(id) => catalog.playlist_detail(&id).await,
+                }
+            };
+            let result = tokio::select! {
+                _ = reply.closed() => return,
+                result = operation => result,
+            };
+            if let Ok(detail) = &result
+                && let Err(error) = bridge.observe_detail(store_set, detail)
+            {
+                tracing::warn!(reason = %error, "music server observations were not persisted");
+            }
+            let _ = reply.send(result);
+        }
+        ActorCommand::CoverArt {
+            item,
+            id,
+            mut reply,
+        } => {
+            let catalog = catalog(store_set, client);
+            let operation = async {
+                match client.validate_item_scope(&item) {
+                    Ok(()) => catalog.cover_art(&id).await,
+                    Err(error) => Err(error),
+                }
+            };
+            let result = tokio::select! {
+                _ = reply.closed() => return,
+                result = operation => result,
+            };
+            let _ = reply.send(result);
+        }
+        ActorCommand::ProfileSummary { reply } => {
+            let _ = reply.send(Ok(summary.clone()));
+        }
+        ActorCommand::OpenStream {
+            item,
+            request,
+            mut reply,
+        } => {
+            let operation = async {
+                let origin = client.proxy_origin()?;
+                let response = client
+                    .open_stream(store_set.private_state.credential(), &item, request)
+                    .await?;
+                Ok(UpstreamStream::new(response, origin))
+            };
+            let result = tokio::select! {
+                _ = reply.closed() => return,
+                result = operation => result,
+            };
+            let _ = reply.send(result);
+        }
+        ActorCommand::ReconcileRatings { winners, reply } => {
+            let result = bridge.reconcile_ratings(store_set, winners);
+            let failed = result.err();
+            let _ = reply.send(failed.map_or(Ok(()), Err));
+            if let Some(error) = failed {
+                tracing::warn!(reason = %error, "music server ratings will retry");
+            }
+        }
+        ActorCommand::AcknowledgeBridgeImport { operation_id } => {
+            if let Err(error) = bridge.acknowledge_import(store_set, &operation_id) {
+                tracing::warn!(reason = %error, "music server import acknowledgement will retry");
+            }
+        }
+        ActorCommand::QueueScrobble {
+            event_id,
+            kind,
+            track,
+            reply,
+        } => {
+            let result = bridge.queue_scrobble(store_set, &event_id, kind, track);
+            let failed = result.err();
+            let _ = reply.send(failed.map_or(Ok(()), Err));
+            if let Some(error) = failed {
+                tracing::warn!(reason = %error, "music server playback report will retry");
+            }
+        }
+        ActorCommand::AcknowledgeScrobbleSource {
+            event_id,
+            track,
+            reply,
+        } => {
+            let result = bridge.acknowledge_scrobble_source(store_set, &event_id, track);
+            let failed = result.err();
+            let _ = reply.send(failed.map_or(Ok(()), Err));
+            if let Some(error) = failed {
+                tracing::warn!(
+                    reason = %error,
+                    "music server source acknowledgement will retry"
+                );
+            }
+        }
+        ActorCommand::ScrobbleAttentionIds { reply } => {
+            let _ = reply.send(Ok(bridge.outbound_scrobble_attention_ids(store_set)));
+        }
+        ActorCommand::ResolveScrobble {
+            event_id,
+            resolution,
+            reply,
+        } => {
+            let result = bridge.resolve_outbound_scrobble(store_set, &event_id, resolution);
+            let failed = result.err();
+            let _ = reply.send(failed.map_or(Ok(()), Err));
+            if let Some(error) = failed {
+                tracing::warn!(
+                    reason = %error,
+                    "music server playback report decision was not persisted"
+                );
+            }
+        }
+    }
+}
+
+fn catalog<'a>(
+    store_set: &'a OpenSubsonicStoreSet,
+    client: &'a OpenSubsonicClient,
+) -> OpenSubsonicCatalog<'a> {
+    OpenSubsonicCatalog::new(
+        client,
+        store_set.private_state.credential(),
+        store_set.profile.backend_id(),
+        store_set.profile.account_scope_id(),
+    )
 }
 
 enum ActorCommand {
@@ -675,7 +1219,39 @@ enum ActorCommand {
         request: StreamRequest,
         reply: oneshot::Sender<Result<UpstreamStream, ServerError>>,
     },
+    ReconcileRatings {
+        winners: Vec<OpenSubsonicRatingWinner>,
+        reply: oneshot::Sender<Result<(), ServiceError>>,
+    },
+    AcknowledgeBridgeImport {
+        operation_id: String,
+    },
+    QueueScrobble {
+        event_id: String,
+        kind: OpenSubsonicScrobbleKind,
+        track: crate::scrobble::ScrobbleTrack,
+        reply: oneshot::Sender<Result<(), ServiceError>>,
+    },
+    AcknowledgeScrobbleSource {
+        event_id: String,
+        track: crate::scrobble::ScrobbleTrack,
+        reply: oneshot::Sender<Result<(), ServiceError>>,
+    },
+    ScrobbleAttentionIds {
+        reply: oneshot::Sender<Result<Vec<String>, ServerError>>,
+    },
+    ResolveScrobble {
+        event_id: String,
+        resolution: OutboundScrobbleResolution,
+        reply: oneshot::Sender<Result<(), ServiceError>>,
+    },
 }
+
+/// Correlated proof that an outbound playback report crossed the bridge-store fsync boundary.
+pub type OpenSubsonicScrobbleReceipt = oneshot::Receiver<Result<(), ServiceError>>;
+
+/// Correlated proof that a rating projection crossed the bridge-store fsync boundary.
+pub type OpenSubsonicRatingReceipt = oneshot::Receiver<Result<(), ServiceError>>;
 
 fn proxy_error(error: ServerError) -> ProxyUpstreamError {
     let reason = match error {
@@ -755,248 +1331,4 @@ fn clear_current_generation(generation: u64) {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
-
-    use age::secrecy::SecretString;
-    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
-
-    use super::*;
-
-    static NEXT_ROOT: AtomicU64 = AtomicU64::new(0);
-
-    #[test]
-    fn status_never_contains_origin_or_credentials() {
-        let status = OpenSubsonicStatus {
-            kind: OpenSubsonicStatusKind::UpToDate,
-            display_name: Some("Server".to_owned()),
-            backend_id: Some(BackendId::new("backend").unwrap()),
-            account_scope_id: Some(AccountScopeId::new("account").unwrap()),
-            credential_kind: Some(CredentialKind::ApiKey),
-            uses_lan_http: false,
-            uses_custom_ca: false,
-        };
-        let rendered = format!("{status:?}");
-        assert!(!rendered.contains("https://"));
-        assert!(!rendered.contains("sentinel-secret"));
-    }
-
-    #[test]
-    fn confirmed_remove_resets_corrupt_partial_and_oversized_stores() {
-        for (case, bytes) in [
-            ("corrupt", b"not-json".to_vec()),
-            (
-                "oversized",
-                vec![b'x'; crate::open_subsonic::profile::MAX_PROFILE_BYTES as usize + 1],
-            ),
-        ] {
-            let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
-            let root = std::env::temp_dir().join(format!(
-                "yututui-open-subsonic-reset-{case}-{}-{id}",
-                std::process::id()
-            ));
-            let paths = OpenSubsonicPaths::for_data_root(root.clone());
-            crate::util::safe_fs::write_owner_only_atomic(paths.profile(), &bytes).unwrap();
-
-            assert_eq!(
-                read_status(&paths).unwrap().kind,
-                OpenSubsonicStatusKind::NeedsAttention
-            );
-            assert_eq!(
-                remove_profile(&paths).unwrap().kind,
-                OpenSubsonicStatusKind::Off
-            );
-            assert_eq!(
-                read_status(&paths).unwrap().kind,
-                OpenSubsonicStatusKind::Off
-            );
-            let _ = std::fs::remove_dir_all(root);
-        }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn confirmed_remove_rejects_a_symlink_without_touching_its_target() {
-        use std::os::unix::fs::symlink;
-
-        let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
-        let root = std::env::temp_dir().join(format!(
-            "yututui-open-subsonic-reset-link-{}-{id}",
-            std::process::id()
-        ));
-        let paths = OpenSubsonicPaths::for_data_root(root.clone());
-        crate::util::safe_fs::ensure_private_dir(paths.root()).unwrap();
-        let external = root.join("outside-secret");
-        std::fs::write(&external, b"must-stay").unwrap();
-        symlink(&external, paths.profile()).unwrap();
-
-        assert!(remove_profile(&paths).is_err());
-        assert_eq!(std::fs::read(&external).unwrap(), b"must-stay");
-        assert!(paths.profile().is_symlink());
-        let _ = std::fs::remove_dir_all(root);
-    }
-
-    #[test]
-    fn setup_input_is_move_only_and_accepts_secret_credential() {
-        let input = SetupInput::new(
-            "Server",
-            "https://music.example.test/",
-            false,
-            None,
-            ServerCredential::api_key(SecretString::from("secret".to_owned())).unwrap(),
-            SetupIdentityIntent::Create,
-        );
-        assert_eq!(input.identity_intent, SetupIdentityIntent::Create);
-    }
-
-    #[tokio::test]
-    async fn tested_setup_commits_all_stores_and_remove_is_local_only() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let server = tokio::spawn(async move {
-            let replies = [
-                r#"{"subsonic-response":{"status":"ok","openSubsonicExtensions":[]}}"#,
-                r#"{"subsonic-response":{"status":"ok","version":"1.16.1"}}"#,
-            ];
-            for body in replies.into_iter().cycle().take(12) {
-                let (mut stream, _) = listener.accept().await.unwrap();
-                let mut request = Vec::new();
-                let mut byte = [0_u8; 1];
-                while request.len() < 16 * 1024 {
-                    if stream.read(&mut byte).await.unwrap() == 0 {
-                        break;
-                    }
-                    request.push(byte[0]);
-                    if request.ends_with(b"\r\n\r\n") {
-                        break;
-                    }
-                }
-                let response = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{body}"
-                );
-                stream.write_all(response.as_bytes()).await.unwrap();
-            }
-        });
-        let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
-        let root = std::env::temp_dir().join(format!(
-            "yututui-open-subsonic-service-{}-{id}",
-            std::process::id()
-        ));
-        crate::util::safe_fs::ensure_private_dir(&root).unwrap();
-        let paths = OpenSubsonicPaths::for_data_root(root.clone());
-        let input = SetupInput::new(
-            "Test server",
-            format!("http://127.0.0.1:{port}/"),
-            true,
-            None,
-            ServerCredential::api_key(SecretString::from("secret".to_owned())).unwrap(),
-            SetupIdentityIntent::Create,
-        );
-        let prepared = test_and_prepare_setup(&paths, input).await.unwrap();
-        let status = commit_setup(&paths, prepared).unwrap();
-        assert_eq!(status.kind, OpenSubsonicStatusKind::UpToDate);
-        let original_backend = status.backend_id.clone().unwrap();
-        let original_account = status.account_scope_id.clone().unwrap();
-        assert_eq!(read_status(&paths).unwrap().kind, status.kind);
-        assert_eq!(
-            test_connection(&paths).await.unwrap().kind,
-            OpenSubsonicStatusKind::UpToDate
-        );
-        let old_runtime = load_actor(&paths).await.unwrap().unwrap();
-        let old_handle = old_runtime.handle();
-        let old_provider = old_runtime.route_provider();
-        old_runtime.activate();
-        let old_target = crate::playback_target::CredentialedPlaybackRef::OpenSubsonic {
-            backend_id: original_backend.as_str().to_owned(),
-            account_scope_id: original_account.as_str().to_owned(),
-            item_id: "old-route-item".to_owned(),
-        };
-        let old_route = old_provider
-            .open_route(old_target.clone(), 1)
-            .await
-            .unwrap();
-        let (old_route_url, _old_route_lease) = old_route.into_parts();
-        let old_route_url = old_route_url.into_string();
-
-        let update = SetupInput::new(
-            "Renamed server",
-            format!("http://127.0.0.1:{port}/"),
-            true,
-            None,
-            ServerCredential::api_key(SecretString::from("updated-secret".to_owned())).unwrap(),
-            SetupIdentityIntent::UpdateSameServerAndAccount,
-        );
-        crate::open_subsonic::transaction::fail_after_commit_marker_once_for_test();
-        assert_eq!(
-            commit_setup(
-                &paths,
-                test_and_prepare_setup(&paths, update).await.unwrap(),
-            ),
-            Err(ServiceError::Store(StoreError::StorageUnavailable))
-        );
-        assert_eq!(
-            old_handle.profile_summary().await.unwrap_err(),
-            ServerError::Offline
-        );
-        assert_eq!(
-            old_provider
-                .open_route(old_target, 2)
-                .await
-                .unwrap_err()
-                .reason(),
-            "route_provider_unavailable"
-        );
-        assert_eq!(
-            reqwest::get(old_route_url).await.unwrap().status(),
-            reqwest::StatusCode::NOT_FOUND
-        );
-
-        // The next owner load rolls the committed candidate forward, but never revives the old
-        // handle or route.
-        load_store_set(&paths).unwrap().unwrap();
-        let updated = read_status(&paths).unwrap();
-        assert_eq!(updated.kind, OpenSubsonicStatusKind::UpToDate);
-        assert_eq!(updated.display_name.as_deref(), Some("Renamed server"));
-        assert_eq!(updated.backend_id.as_ref(), Some(&original_backend));
-        assert_eq!(updated.account_scope_id.as_ref(), Some(&original_account));
-        assert_eq!(
-            old_handle.profile_summary().await.unwrap_err(),
-            ServerError::Offline
-        );
-        drop(old_runtime);
-
-        let replacement = SetupInput::new(
-            "Replacement server",
-            format!("http://127.0.0.1:{port}/"),
-            true,
-            None,
-            ServerCredential::api_key(SecretString::from("replacement-secret".to_owned())).unwrap(),
-            SetupIdentityIntent::ReplaceServerOrAccount,
-        );
-        let replaced = commit_setup(
-            &paths,
-            test_and_prepare_setup(&paths, replacement).await.unwrap(),
-        )
-        .unwrap();
-        assert_ne!(replaced.backend_id.as_ref(), Some(&original_backend));
-        assert_ne!(replaced.account_scope_id.as_ref(), Some(&original_account));
-        let removal_runtime = load_actor(&paths).await.unwrap().unwrap();
-        let removal_handle = removal_runtime.handle();
-        removal_runtime.activate();
-        assert_eq!(
-            remove_profile(&paths).unwrap().kind,
-            OpenSubsonicStatusKind::Off
-        );
-        assert_eq!(
-            removal_handle.profile_summary().await.unwrap_err(),
-            ServerError::Offline
-        );
-        drop(removal_runtime);
-        assert_eq!(
-            read_status(&paths).unwrap().kind,
-            OpenSubsonicStatusKind::Off
-        );
-        server.await.unwrap();
-        let _ = std::fs::remove_dir_all(root);
-    }
-}
+mod tests;

--- a/src/open_subsonic/actor/tests.rs
+++ b/src/open_subsonic/actor/tests.rs
@@ -1,0 +1,654 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use age::secrecy::SecretString;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+use super::*;
+use crate::open_subsonic::bridge_store::RatingShadow;
+use crate::open_subsonic::rating::RawServerRating;
+
+static NEXT_ROOT: AtomicU64 = AtomicU64::new(0);
+static LIFECYCLE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[test]
+fn status_never_contains_origin_or_credentials() {
+    let status = OpenSubsonicStatus {
+        kind: OpenSubsonicStatusKind::UpToDate,
+        display_name: Some("Server".to_owned()),
+        backend_id: Some(BackendId::new("backend").unwrap()),
+        account_scope_id: Some(AccountScopeId::new("account").unwrap()),
+        credential_kind: Some(CredentialKind::ApiKey),
+        uses_lan_http: false,
+        uses_custom_ca: false,
+        native_history_enabled: false,
+        native_history_health: NativeHistoryHealth::Off,
+        outbound_scrobbles_needing_attention: 0,
+    };
+    let rendered = format!("{status:?}");
+    assert!(!rendered.contains("https://"));
+    assert!(!rendered.contains("sentinel-secret"));
+}
+
+#[test]
+fn only_transient_native_history_failures_use_the_short_retry_window() {
+    use crate::open_subsonic::NativeHistoryError;
+
+    assert!(native_history_error_retries_soon(
+        NativeHistoryError::Offline
+    ));
+    assert!(native_history_error_retries_soon(
+        NativeHistoryError::TemporarilyUnavailable
+    ));
+    for error in [
+        NativeHistoryError::InvalidCredential,
+        NativeHistoryError::AuthenticationRequired,
+        NativeHistoryError::PermissionDenied,
+        NativeHistoryError::UnsupportedFeature,
+        NativeHistoryError::InvalidResponse,
+        NativeHistoryError::ResponseTooLarge,
+    ] {
+        assert!(!native_history_error_retries_soon(error));
+    }
+    assert_eq!(
+        native_history_health_after(false, None),
+        NativeHistoryHealth::Off
+    );
+    assert_eq!(
+        native_history_health_after(true, None),
+        NativeHistoryHealth::Detailed
+    );
+    assert_eq!(
+        native_history_health_after(true, Some(NativeHistoryError::UnsupportedFeature)),
+        NativeHistoryHealth::PlayCountsOnly
+    );
+    assert_eq!(
+        native_history_health_after(true, Some(NativeHistoryError::InvalidCredential)),
+        NativeHistoryHealth::UpdatePassword
+    );
+    assert_eq!(
+        native_history_health_after(true, Some(NativeHistoryError::Offline)),
+        NativeHistoryHealth::Probing
+    );
+}
+
+#[test]
+fn disabling_native_history_removes_only_its_credential() {
+    let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
+    let root = std::env::temp_dir().join(format!(
+        "yututui-open-subsonic-disable-history-{}-{id}",
+        std::process::id()
+    ));
+    let paths = OpenSubsonicPaths::for_data_root(root.clone());
+    let profile = OpenSubsonicProfile::new(
+        "History server",
+        ConfiguredPrivateOrigin::new("http://127.0.0.1:4533/", true).unwrap(),
+        None,
+    )
+    .unwrap();
+    let mut private_state = OpenSubsonicPrivateState::new(
+        profile.backend_id().clone(),
+        profile.account_scope_id().clone(),
+        ServerCredential::password("alice", SecretString::from("server-password".to_owned()))
+            .unwrap(),
+    );
+    private_state
+        .enable_native_history_reusing_server_password()
+        .unwrap();
+    let mut bridge_state = OpenSubsonicBridgeState::new(
+        profile.backend_id().clone(),
+        profile.account_scope_id().clone(),
+    );
+    bridge_state.set_native_history_health(NativeHistoryHealth::Detailed);
+    let mut store_set = OpenSubsonicStoreSet::new(profile, private_state, bridge_state).unwrap();
+    commit_store_set(&paths, StoreRevisions::MISSING, &mut store_set).unwrap();
+
+    let status = disable_native_history(&paths).unwrap();
+    assert!(!status.native_history_enabled);
+    assert_eq!(status.native_history_health, NativeHistoryHealth::Off);
+    let stored = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        stored.private_state.credential_kind(),
+        CredentialKind::Password
+    );
+    assert!(!stored.private_state.native_history_enabled());
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn confirmed_remove_resets_corrupt_partial_and_oversized_stores() {
+    let _lifecycle = LIFECYCLE_LOCK.lock().await;
+    for (case, bytes) in [
+        ("corrupt", b"not-json".to_vec()),
+        (
+            "oversized",
+            vec![b'x'; crate::open_subsonic::profile::MAX_PROFILE_BYTES as usize + 1],
+        ),
+    ] {
+        let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "yututui-open-subsonic-reset-{case}-{}-{id}",
+            std::process::id()
+        ));
+        let paths = OpenSubsonicPaths::for_data_root(root.clone());
+        crate::util::safe_fs::write_owner_only_atomic(paths.profile(), &bytes).unwrap();
+
+        assert_eq!(
+            read_status(&paths).unwrap().kind,
+            OpenSubsonicStatusKind::NeedsAttention
+        );
+        assert_eq!(
+            remove_profile(&paths).unwrap().kind,
+            OpenSubsonicStatusKind::Off
+        );
+        assert_eq!(
+            read_status(&paths).unwrap().kind,
+            OpenSubsonicStatusKind::Off
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn confirmed_remove_rejects_a_symlink_without_touching_its_target() {
+    use std::os::unix::fs::symlink;
+
+    let _lifecycle = LIFECYCLE_LOCK.lock().await;
+    let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
+    let root = std::env::temp_dir().join(format!(
+        "yututui-open-subsonic-reset-link-{}-{id}",
+        std::process::id()
+    ));
+    let paths = OpenSubsonicPaths::for_data_root(root.clone());
+    crate::util::safe_fs::ensure_private_dir(paths.root()).unwrap();
+    let external = root.join("outside-secret");
+    std::fs::write(&external, b"must-stay").unwrap();
+    symlink(&external, paths.profile()).unwrap();
+
+    assert!(remove_profile(&paths).is_err());
+    assert_eq!(std::fs::read(&external).unwrap(), b"must-stay");
+    assert!(paths.profile().is_symlink());
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn setup_input_is_move_only_and_accepts_secret_credential() {
+    let input = SetupInput::new(
+        "Server",
+        "https://music.example.test/",
+        false,
+        None,
+        ServerCredential::api_key(SecretString::from("secret".to_owned())).unwrap(),
+        SetupIdentityIntent::Create,
+    );
+    assert_eq!(input.identity_intent, SetupIdentityIntent::Create);
+}
+
+struct LifecycleFixture {
+    root: std::path::PathBuf,
+    paths: OpenSubsonicPaths,
+    server: tokio::task::JoinHandle<()>,
+    active: Option<OpenSubsonicRuntime>,
+    backend_id: BackendId,
+    account_scope_id: AccountScopeId,
+}
+
+impl Drop for LifecycleFixture {
+    fn drop(&mut self) {
+        self.active.take();
+        self.server.abort();
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+async fn lifecycle_fixture(label: &str) -> LifecycleFixture {
+    clear_current_runtime();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let request = read_request_head(&mut stream).await;
+            let (content_type, body): (&str, &[u8]) =
+                if request.contains("/rest/getOpenSubsonicExtensions") {
+                    (
+                        "application/json",
+                        br#"{"subsonic-response":{"status":"ok","openSubsonicExtensions":[]}}"#,
+                    )
+                } else if request.contains("/rest/stream") {
+                    ("audio/mpeg", b"fake-audio")
+                } else {
+                    (
+                        "application/json",
+                        br#"{"subsonic-response":{"status":"ok","version":"1.16.1"}}"#,
+                    )
+                };
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            if stream.write_all(response.as_bytes()).await.is_ok() {
+                let _ = stream.write_all(body).await;
+            }
+        }
+    });
+
+    let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
+    let root = std::env::temp_dir().join(format!(
+        "yututui-open-subsonic-lifecycle-{label}-{}-{id}",
+        std::process::id()
+    ));
+    let paths = OpenSubsonicPaths::for_data_root(root.clone());
+    let backend_id = BackendId::new(format!("lifecycle-backend-{id}")).unwrap();
+    let account_scope_id = AccountScopeId::new(format!("lifecycle-account-{id}")).unwrap();
+    let profile = OpenSubsonicProfile::with_ids(
+        0,
+        backend_id.clone(),
+        account_scope_id.clone(),
+        "Lifecycle server",
+        ConfiguredPrivateOrigin::new(&format!("http://127.0.0.1:{port}/"), true).unwrap(),
+        None,
+    )
+    .unwrap();
+    let private_state = OpenSubsonicPrivateState::new(
+        backend_id.clone(),
+        account_scope_id.clone(),
+        ServerCredential::api_key(SecretString::from("lifecycle-secret".to_owned())).unwrap(),
+    );
+    let bridge_state = OpenSubsonicBridgeState::new(backend_id.clone(), account_scope_id.clone());
+    let mut store_set = OpenSubsonicStoreSet::new(profile, private_state, bridge_state).unwrap();
+    commit_store_set(&paths, StoreRevisions::MISSING, &mut store_set).unwrap();
+    let active = load_actor(&paths).await.unwrap().unwrap();
+    active.activate();
+    LifecycleFixture {
+        root,
+        paths,
+        server,
+        active: Some(active),
+        backend_id,
+        account_scope_id,
+    }
+}
+
+async fn read_request_head(stream: &mut tokio::net::TcpStream) -> String {
+    let mut request = Vec::new();
+    let mut byte = [0_u8; 1];
+    while request.len() < 32 * 1024 {
+        if stream.read(&mut byte).await.unwrap_or(0) == 0 {
+            break;
+        }
+        request.push(byte[0]);
+        if request.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    String::from_utf8(request).unwrap()
+}
+
+fn lifecycle_target(
+    fixture: &LifecycleFixture,
+    item_id: &str,
+) -> crate::playback_target::CredentialedPlaybackRef {
+    crate::playback_target::CredentialedPlaybackRef::OpenSubsonic {
+        backend_id: fixture.backend_id.as_str().to_owned(),
+        account_scope_id: fixture.account_scope_id.as_str().to_owned(),
+        item_id: item_id.to_owned(),
+    }
+}
+
+fn lifecycle_track(
+    fixture: &LifecycleFixture,
+    item_id: &str,
+    started_unix: i64,
+) -> crate::scrobble::ScrobbleTrack {
+    crate::scrobble::ScrobbleTrack {
+        key: item_id.to_owned(),
+        open_subsonic_item: Some(OpenSubsonicItemRef::new(
+            fixture.backend_id.clone(),
+            fixture.account_scope_id.clone(),
+            crate::open_subsonic::ItemId::new(item_id).unwrap(),
+        )),
+        artist: "Lifecycle artist".to_owned(),
+        title: "Lifecycle song".to_owned(),
+        album: None,
+        duration_secs: Some(180),
+        origin_url: None,
+        started_unix,
+    }
+}
+
+#[tokio::test]
+async fn dormant_and_discarded_candidates_leave_the_active_runtime_usable() {
+    let _lifecycle = LIFECYCLE_LOCK.lock().await;
+    let fixture = lifecycle_fixture("discard").await;
+    let active = fixture.active.as_ref().unwrap();
+    let active_handle = active.handle();
+    let active_provider = active.route_provider();
+    let route = active_provider
+        .open_route(lifecycle_target(&fixture, "before-candidate"), 1)
+        .await
+        .unwrap();
+    let (route_url, _route_lease) = route.into_parts();
+    let route_url = route_url.into_string();
+
+    let candidate = load_actor(&fixture.paths).await.unwrap().unwrap();
+    assert_eq!(
+        current_handle()
+            .unwrap()
+            .profile_summary()
+            .await
+            .unwrap()
+            .display_name,
+        "Lifecycle server"
+    );
+    assert_eq!(
+        active_handle.profile_summary().await.unwrap().display_name,
+        "Lifecycle server"
+    );
+    assert_eq!(
+        reqwest::get(&route_url).await.unwrap().status(),
+        reqwest::StatusCode::OK
+    );
+    let route_after_load = active_provider
+        .open_route(lifecycle_target(&fixture, "after-candidate"), 2)
+        .await
+        .unwrap();
+    let (route_after_load_url, _route_after_load_lease) = route_after_load.into_parts();
+    let route_after_load_url = route_after_load_url.into_string();
+
+    drop(candidate);
+    assert!(active_handle.profile_summary().await.is_ok());
+    assert_eq!(
+        reqwest::get(&route_after_load_url).await.unwrap().status(),
+        reqwest::StatusCode::OK
+    );
+    assert!(
+        active_provider
+            .open_route(lifecycle_target(&fixture, "after-discard"), 3)
+            .await
+            .is_ok()
+    );
+}
+
+#[tokio::test]
+async fn activation_rebases_then_replaces_the_active_runtime_once() {
+    let _lifecycle = LIFECYCLE_LOCK.lock().await;
+    let fixture = lifecycle_fixture("activate").await;
+    let active = fixture.active.as_ref().unwrap();
+    let old_handle = active.handle();
+    let old_provider = active.route_provider();
+    let usable_route = old_provider
+        .open_route(lifecycle_target(&fixture, "usable-before-activation"), 10)
+        .await
+        .unwrap();
+    let (usable_url, _usable_lease) = usable_route.into_parts();
+    let usable_url = usable_url.into_string();
+    assert_eq!(
+        reqwest::get(&usable_url).await.unwrap().status(),
+        reqwest::StatusCode::OK
+    );
+    let revoked_route = old_provider
+        .open_route(lifecycle_target(&fixture, "revoked-on-activation"), 11)
+        .await
+        .unwrap();
+    let (revoked_url, _revoked_lease) = revoked_route.into_parts();
+    let revoked_url = revoked_url.into_string();
+
+    let candidate = load_actor(&fixture.paths).await.unwrap().unwrap();
+    let candidate_handle = candidate.handle();
+    let first_receipt = old_handle
+        .queue_scrobble(
+            "old-owner-advanced-store".to_owned(),
+            OpenSubsonicScrobbleKind::Submission,
+            lifecycle_track(&fixture, "history-song", 100),
+        )
+        .unwrap();
+    first_receipt.await.unwrap().unwrap();
+
+    candidate.activate();
+    candidate.activate();
+    let second_receipt = candidate_handle
+        .queue_scrobble(
+            "candidate-after-rebase".to_owned(),
+            OpenSubsonicScrobbleKind::Submission,
+            lifecycle_track(&fixture, "history-song", 101),
+        )
+        .unwrap();
+    second_receipt.await.unwrap().unwrap();
+
+    assert_eq!(
+        old_handle.profile_summary().await.unwrap_err(),
+        ServerError::Offline
+    );
+    assert_eq!(
+        old_provider
+            .open_route(lifecycle_target(&fixture, "old-provider"), 12)
+            .await
+            .unwrap_err()
+            .reason(),
+        "route_provider_unavailable"
+    );
+    assert_eq!(
+        reqwest::get(&revoked_url).await.unwrap().status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+
+    let durable = load_store_set(&fixture.paths).unwrap().unwrap();
+    assert_eq!(
+        durable.bridge_state.outbound_scrobbles().len(),
+        2,
+        "activation rebase must preserve the old actor's durable bridge mutation"
+    );
+    assert!(candidate_handle.profile_summary().await.is_ok());
+    let candidate_route = candidate
+        .route_provider()
+        .open_route(lifecycle_target(&fixture, "candidate-route"), 13)
+        .await
+        .unwrap();
+    let (candidate_url, _candidate_lease) = candidate_route.into_parts();
+    let candidate_url = candidate_url.into_string();
+    assert_eq!(
+        reqwest::get(&candidate_url).await.unwrap().status(),
+        reqwest::StatusCode::OK,
+        "a repeated activation must not revoke the already-current candidate"
+    );
+    drop(candidate);
+}
+
+#[tokio::test]
+async fn tested_setup_commits_all_stores_and_remove_is_local_only() {
+    let _lifecycle = LIFECYCLE_LOCK.lock().await;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let replies = [
+            r#"{"subsonic-response":{"status":"ok","openSubsonicExtensions":[]}}"#,
+            r#"{"subsonic-response":{"status":"ok","version":"1.16.1"}}"#,
+        ];
+        for body in replies.into_iter().cycle().take(12) {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut byte = [0_u8; 1];
+            while request.len() < 16 * 1024 {
+                if stream.read(&mut byte).await.unwrap() == 0 {
+                    break;
+                }
+                request.push(byte[0]);
+                if request.ends_with(b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{body}"
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+    let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
+    let root = std::env::temp_dir().join(format!(
+        "yututui-open-subsonic-service-{}-{id}",
+        std::process::id()
+    ));
+    crate::util::safe_fs::ensure_private_dir(&root).unwrap();
+    let paths = OpenSubsonicPaths::for_data_root(root.clone());
+    let input = SetupInput::new(
+        "Test server",
+        format!("http://127.0.0.1:{port}/"),
+        true,
+        None,
+        ServerCredential::api_key(SecretString::from("secret".to_owned())).unwrap(),
+        SetupIdentityIntent::Create,
+    );
+    let prepared = test_and_prepare_setup(&paths, input).await.unwrap();
+    let status = commit_setup(&paths, prepared).unwrap();
+    assert_eq!(status.kind, OpenSubsonicStatusKind::UpToDate);
+    let original_backend = status.backend_id.clone().unwrap();
+    let original_account = status.account_scope_id.clone().unwrap();
+    assert_eq!(read_status(&paths).unwrap().kind, status.kind);
+    assert_eq!(
+        test_connection(&paths).await.unwrap().kind,
+        OpenSubsonicStatusKind::UpToDate
+    );
+    let retained_item = crate::open_subsonic::ItemId::new("retained-rating").unwrap();
+    let mut store_with_observation = load_store_set(&paths).unwrap().unwrap();
+    let expected = store_with_observation.revisions();
+    store_with_observation
+        .bridge_state
+        .upsert_rating_shadow(
+            retained_item.clone(),
+            RatingShadow {
+                raw: RawServerRating {
+                    user_rating: Some(3),
+                    starred: true,
+                },
+                observed_at_unix: 10,
+                confirmed_operation_id: None,
+            },
+        )
+        .unwrap();
+    commit_store_set(&paths, expected, &mut store_with_observation).unwrap();
+    let old_runtime = load_actor(&paths).await.unwrap().unwrap();
+    let old_handle = old_runtime.handle();
+    let old_provider = old_runtime.route_provider();
+    old_runtime.activate();
+    let old_target = crate::playback_target::CredentialedPlaybackRef::OpenSubsonic {
+        backend_id: original_backend.as_str().to_owned(),
+        account_scope_id: original_account.as_str().to_owned(),
+        item_id: "old-route-item".to_owned(),
+    };
+    let old_route = old_provider
+        .open_route(old_target.clone(), 1)
+        .await
+        .unwrap();
+    let (old_route_url, _old_route_lease) = old_route.into_parts();
+    let old_route_url = old_route_url.into_string();
+
+    let update = SetupInput::new(
+        "Renamed server",
+        format!("http://127.0.0.1:{port}/"),
+        true,
+        None,
+        ServerCredential::api_key(SecretString::from("updated-secret".to_owned())).unwrap(),
+        SetupIdentityIntent::UpdateSameServerAndAccount,
+    );
+    crate::open_subsonic::transaction::fail_after_commit_marker_once_for_test();
+    let prepared_update = test_and_prepare_setup(&paths, update).await.unwrap();
+    assert_eq!(
+        prepared_update
+            .store_set
+            .as_ref()
+            .unwrap()
+            .bridge_state
+            .rating_shadow(&retained_item)
+            .unwrap()
+            .raw,
+        RawServerRating {
+            user_rating: Some(3),
+            starred: true,
+        }
+    );
+    assert_eq!(
+        commit_setup(&paths, prepared_update),
+        Err(ServiceError::Store(StoreError::StorageUnavailable))
+    );
+    assert_eq!(
+        old_handle.profile_summary().await.unwrap_err(),
+        ServerError::Offline
+    );
+    assert_eq!(
+        old_provider
+            .open_route(old_target, 2)
+            .await
+            .unwrap_err()
+            .reason(),
+        "route_provider_unavailable"
+    );
+    assert_eq!(
+        reqwest::get(old_route_url).await.unwrap().status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+
+    // The next owner load rolls the committed candidate forward, but never revives the old
+    // handle or route.
+    let recovered_store = load_store_set(&paths).unwrap().unwrap();
+    assert!(
+        recovered_store
+            .bridge_state
+            .rating_shadow(&retained_item)
+            .is_some()
+    );
+    let updated = read_status(&paths).unwrap();
+    assert_eq!(updated.kind, OpenSubsonicStatusKind::UpToDate);
+    assert_eq!(updated.display_name.as_deref(), Some("Renamed server"));
+    assert_eq!(updated.backend_id.as_ref(), Some(&original_backend));
+    assert_eq!(updated.account_scope_id.as_ref(), Some(&original_account));
+    assert_eq!(
+        old_handle.profile_summary().await.unwrap_err(),
+        ServerError::Offline
+    );
+    drop(old_runtime);
+
+    let replacement = SetupInput::new(
+        "Replacement server",
+        format!("http://127.0.0.1:{port}/"),
+        true,
+        None,
+        ServerCredential::api_key(SecretString::from("replacement-secret".to_owned())).unwrap(),
+        SetupIdentityIntent::ReplaceServerOrAccount,
+    );
+    let replaced = commit_setup(
+        &paths,
+        test_and_prepare_setup(&paths, replacement).await.unwrap(),
+    )
+    .unwrap();
+    assert_ne!(replaced.backend_id.as_ref(), Some(&original_backend));
+    assert_ne!(replaced.account_scope_id.as_ref(), Some(&original_account));
+    assert!(
+        load_store_set(&paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .rating_shadow(&retained_item)
+            .is_none()
+    );
+    let removal_runtime = load_actor(&paths).await.unwrap().unwrap();
+    let removal_handle = removal_runtime.handle();
+    removal_runtime.activate();
+    assert_eq!(
+        remove_profile(&paths).unwrap().kind,
+        OpenSubsonicStatusKind::Off
+    );
+    assert_eq!(
+        removal_handle.profile_summary().await.unwrap_err(),
+        ServerError::Offline
+    );
+    drop(removal_runtime);
+    assert_eq!(
+        read_status(&paths).unwrap().kind,
+        OpenSubsonicStatusKind::Off
+    );
+    server.await.unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/src/open_subsonic/bridge_event.rs
+++ b/src/open_subsonic/bridge_event.rs
@@ -1,0 +1,200 @@
+//! Secret-free messages crossing from the server bridge into a playback owner.
+
+use std::sync::Arc;
+
+use crate::personal_state::{
+    EngagementKind, Operation, OperationOrigin, PortableTrack, PortableTrackKey, Rating,
+};
+
+use super::model::{BackendId, ServerSong};
+
+pub type OpenSubsonicBridgeSink = Arc<dyn Fn(OpenSubsonicBridgeImport) + Send + Sync + 'static>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenSubsonicScrobbleKind {
+    NowPlaying,
+    Submission,
+}
+
+/// One durable server observation waiting for the App or daemon personal-state owner.
+///
+/// The bridge keeps this record on disk until the owner confirms its personal-state transaction.
+/// Re-delivery is therefore expected and safe: `operation_id` is the portable acknowledgement
+/// key. The personal-state owner derives a device-scoped ledger envelope from it, while an
+/// engagement keeps this value as its cross-device event dedupe key.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OpenSubsonicBridgeImport {
+    Rating {
+        operation_id: String,
+        track: PortableTrack,
+        rating: Rating,
+        observed_at_unix: i64,
+    },
+    Engagement {
+        operation_id: String,
+        track: PortableTrack,
+        engagement: EngagementKind,
+        played_duration_ms: Option<u64>,
+        total_duration_ms: Option<u64>,
+        artist_key: String,
+        observed_at_unix: i64,
+    },
+}
+
+impl OpenSubsonicBridgeImport {
+    pub fn operation_id(&self) -> &str {
+        match self {
+            Self::Rating { operation_id, .. } | Self::Engagement { operation_id, .. } => {
+                operation_id
+            }
+        }
+    }
+
+    pub fn track(&self) -> &PortableTrack {
+        match self {
+            Self::Rating { track, .. } | Self::Engagement { track, .. } => track,
+        }
+    }
+
+    pub fn observed_at_unix(&self) -> i64 {
+        match self {
+            Self::Rating {
+                observed_at_unix, ..
+            }
+            | Self::Engagement {
+                observed_at_unix, ..
+            } => *observed_at_unix,
+        }
+    }
+
+    pub fn backend_id(&self) -> Result<BackendId, crate::personal_state::PersonalStateError> {
+        let PortableTrackKey::OpenSubsonic { backend_id, .. } = &self.track().key else {
+            return Err(crate::personal_state::PersonalStateError::InvalidOperation(
+                "server bridge import is not an OpenSubsonic track",
+            ));
+        };
+        BackendId::new(backend_id.clone()).map_err(|_| {
+            crate::personal_state::PersonalStateError::InvalidOperation(
+                "server bridge import has an invalid backend",
+            )
+        })
+    }
+
+    pub fn origin(&self) -> Result<OperationOrigin, crate::personal_state::PersonalStateError> {
+        Ok(OperationOrigin::OpenSubsonic {
+            backend_id: self.backend_id()?.into_string(),
+        })
+    }
+
+    pub fn operation(&self) -> Operation {
+        match self {
+            Self::Rating { track, rating, .. } => Operation::SetRating {
+                track: track.clone(),
+                rating: *rating,
+            },
+            Self::Engagement {
+                operation_id,
+                track,
+                engagement,
+                played_duration_ms,
+                total_duration_ms,
+                artist_key,
+                ..
+            } => Operation::RecordEngagement {
+                event_id: operation_id.clone(),
+                track: track.clone(),
+                engagement: *engagement,
+                played_duration_ms: *played_duration_ms,
+                total_duration_ms: *total_duration_ms,
+                artist_key: artist_key.clone(),
+            },
+        }
+    }
+}
+
+pub(crate) fn portable_server_track(song: &ServerSong) -> PortableTrack {
+    PortableTrack {
+        key: PortableTrackKey::OpenSubsonic {
+            backend_id: song.item.backend_id().as_str().to_owned(),
+            account_scope_id: song.item.account_scope_id().as_str().to_owned(),
+            item_id: song.item.item_id().as_str().to_owned(),
+        },
+        title: song.title.clone(),
+        artist: song.artist.clone(),
+        album: song.album.clone(),
+        duration_secs: song.duration_secs,
+        isrc: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::open_subsonic::{
+        AccountScopeId, BackendId, ItemId, OpenSubsonicItemRef, ServerSong,
+    };
+
+    fn song() -> ServerSong {
+        ServerSong {
+            item: OpenSubsonicItemRef::new(
+                BackendId::new("backend").unwrap(),
+                AccountScopeId::new("account").unwrap(),
+                ItemId::new("song").unwrap(),
+            ),
+            title: "Title".to_owned(),
+            artist: "Artist".to_owned(),
+            artists: Vec::new(),
+            album: Some("Album".to_owned()),
+            album_id: None,
+            album_artist: None,
+            duration_secs: Some(180),
+            track_number: None,
+            disc_number: None,
+            year: None,
+            cover_art_id: None,
+            content_type: None,
+            suffix: None,
+            starred: true,
+            user_rating: Some(5),
+            play_count: Some(3),
+            played_at: None,
+        }
+    }
+
+    #[test]
+    fn server_song_becomes_path_and_url_free_portable_identity() {
+        let track = portable_server_track(&song());
+        assert_eq!(
+            track.key,
+            PortableTrackKey::OpenSubsonic {
+                backend_id: "backend".to_owned(),
+                account_scope_id: "account".to_owned(),
+                item_id: "song".to_owned(),
+            }
+        );
+        track.validate().unwrap();
+    }
+
+    #[test]
+    fn engagement_uses_the_import_id_as_event_dedupe_key() {
+        let import = OpenSubsonicBridgeImport::Engagement {
+            operation_id: "native-row-7".to_owned(),
+            track: portable_server_track(&song()),
+            engagement: EngagementKind::Play,
+            played_duration_ms: None,
+            total_duration_ms: Some(180_000),
+            artist_key: "artist".to_owned(),
+            observed_at_unix: 10,
+        };
+        assert!(matches!(
+            import.operation(),
+            Operation::RecordEngagement { event_id, .. } if event_id == "native-row-7"
+        ));
+        assert_eq!(
+            import.origin().unwrap(),
+            OperationOrigin::OpenSubsonic {
+                backend_id: "backend".to_owned()
+            }
+        );
+    }
+}

--- a/src/open_subsonic/bridge_runtime.rs
+++ b/src/open_subsonic/bridge_runtime.rs
@@ -1,0 +1,1488 @@
+//! Durable rating, history, and scrobble bridge driven by the credential-owning actor.
+
+use std::collections::BTreeMap;
+use std::ops::Bound::{Excluded, Unbounded};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use data_encoding::HEXLOWER;
+use futures::StreamExt as _;
+use sha2::{Digest as _, Sha256};
+
+use super::actor::ServiceError;
+use super::bridge_event::{
+    OpenSubsonicBridgeImport, OpenSubsonicBridgeSink, OpenSubsonicScrobbleKind,
+    portable_server_track,
+};
+use super::bridge_store::{
+    AggregatePlayShadow, BridgeMutationError, HistoryCursor, MAX_UNCERTAIN_SCROBBLE_READBACKS,
+    NativeHistoryHealth, OutboundScrobbleDelivery, OutboundScrobbleEcho, OutboundScrobbleKind,
+    PendingEngagementImport, PendingNativeMetadataRow, PendingOutboundScrobble,
+    PendingRatingImport, PendingRatingProjection, PendingRatingProjectionStage, RatingShadow,
+};
+use super::catalog::OpenSubsonicCatalog;
+use super::client::MutationDeliveryError;
+use super::client::OpenSubsonicClient;
+use super::history::parse_rfc3339_unix;
+use super::model::{
+    AccountScopeId, BackendId, ItemId, OpenSubsonicItemRef, ServerLibraryDetail, ServerLibraryPage,
+    ServerLibraryRow, ServerSong,
+};
+use super::native_history::{NativeHistoryError, NavidromeNativeClient};
+use super::profile::{OpenSubsonicPaths, StoreError};
+use super::rating::{RawServerRating, canonical_server_rating, map_server_rating};
+use super::transaction::{
+    OpenSubsonicStoreSet, commit_store_set, load_store_set, load_store_set_read_only,
+};
+use crate::personal_state::{
+    EngagementKind, OpenSubsonicRatingWinner, OperationOrigin, PortableTrack, PortableTrackKey,
+};
+
+const NATIVE_CURSOR: &str = "navidrome-native";
+const MAX_NETWORK_FLUSH_PER_TURN: usize = 1;
+const STANDARD_RECENT_ALBUMS: u32 = 20;
+const STANDARD_RECENT_SONGS: usize = 2_000;
+const STANDARD_ALBUM_CONCURRENCY: usize = 4;
+const NATIVE_HISTORY_TOTAL_TIMEOUT: Duration = Duration::from_secs(60);
+const STANDARD_HISTORY_TOTAL_TIMEOUT: Duration = Duration::from_secs(30);
+
+mod history_metadata;
+mod history_support;
+mod outbound_resolution;
+
+pub(super) use history_support::completed_history_overlap;
+use history_support::{
+    history_continuation, native_cursor, native_scan_continuation, next_counter_epoch,
+    observe_aggregate,
+};
+
+/// A credential-owning, read-only network worker. It never mutates the live bridge snapshot.
+///
+/// The worker is deliberately not `Debug` or `Clone`: one actor tick creates one single-flight
+/// value and moves it into an owned, abortable task.
+pub(crate) struct HistoryWorker {
+    paths: OpenSubsonicPaths,
+}
+
+pub(crate) struct HistoryRefreshResult {
+    pub(super) backend_id: BackendId,
+    pub(super) account_scope_id: AccountScopeId,
+    pub(super) base_cursor: Option<HistoryCursor>,
+    pub(super) native: Result<Option<NativeHistoryBatch>, NativeHistoryError>,
+    pub(super) standard: Result<Vec<ServerSong>, ServiceError>,
+}
+
+pub(super) struct NativeHistoryBatch {
+    pub(super) rows: Vec<NativeHistoryObservation>,
+    pub(super) aggregate_baselines: BTreeMap<ItemId, (u64, Option<String>)>,
+    pub(super) next_cursor: Option<HistoryCursor>,
+    pub(super) truncated: bool,
+    pub(super) metadata_retry_pending: bool,
+}
+
+pub(super) struct NativeHistoryObservation {
+    pub(super) row_id: u64,
+    pub(super) item_id: ItemId,
+    pub(super) track: PortableTrack,
+    pub(super) observed_at_unix: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HistoryApplyOutcome {
+    pub native_error: Option<NativeHistoryError>,
+    pub standard_error: Option<ServiceError>,
+    pub native_stale: bool,
+    pub native_truncated: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutboundScrobbleResolution {
+    Retry,
+    MarkSent,
+}
+
+pub(crate) struct BridgeRuntime {
+    paths: Option<OpenSubsonicPaths>,
+    sink: Option<OpenSubsonicBridgeSink>,
+    retry_cursors: Mutex<RetryCursors>,
+}
+
+#[derive(Default)]
+struct RetryCursors {
+    lane_after: Option<RetryLane>,
+    rating_after: Option<ItemId>,
+    outbound_after: Option<String>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RetryLane {
+    Rating,
+    Outbound,
+}
+
+impl HistoryWorker {
+    /// Load a coherent owner-only credential snapshot, then fetch both history sources without
+    /// holding the live actor. Each source has a whole-operation deadline; native failure never
+    /// prevents the standard aggregate fallback from completing.
+    pub(crate) async fn fetch(self) -> Result<HistoryRefreshResult, ServiceError> {
+        let paths = self.paths;
+        let store_set = tokio::task::spawn_blocking(move || load_store_set_read_only(&paths))
+            .await
+            .map_err(|_| ServiceError::Store(StoreError::StorageUnavailable))??
+            .ok_or(ServiceError::InvalidSetup)?;
+        let client = OpenSubsonicClient::connect(&store_set.profile).await?;
+        fetch_history_sources(
+            &store_set,
+            &client,
+            NATIVE_HISTORY_TOTAL_TIMEOUT,
+            STANDARD_HISTORY_TOTAL_TIMEOUT,
+        )
+        .await
+    }
+}
+
+impl BridgeRuntime {
+    pub(crate) fn writable(paths: OpenSubsonicPaths, sink: Option<OpenSubsonicBridgeSink>) -> Self {
+        Self {
+            paths: Some(paths),
+            sink,
+            retry_cursors: Mutex::new(RetryCursors::default()),
+        }
+    }
+
+    pub(crate) fn read_only() -> Self {
+        Self {
+            paths: None,
+            sink: None,
+            retry_cursors: Mutex::new(RetryCursors::default()),
+        }
+    }
+
+    pub(crate) fn is_writable(&self) -> bool {
+        self.paths.is_some()
+    }
+
+    pub(crate) fn history_worker(&self) -> Option<HistoryWorker> {
+        self.paths
+            .as_ref()
+            .cloned()
+            .map(|paths| HistoryWorker { paths })
+    }
+
+    /// Rebase a dormant candidate on the latest coherent owner snapshot immediately before the
+    /// owner publishes it. The previous active actor may have advanced bridge state while this
+    /// candidate probed the server; carrying that stale revision into activation would otherwise
+    /// make its first durable bridge mutation fail. Ephemeral now-playing work never crosses an
+    /// activation boundary, while exact submissions remain durable.
+    pub(crate) fn refresh_snapshot_for_activation(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+    ) -> Result<(), ServiceError> {
+        let Some(paths) = &self.paths else {
+            return Ok(());
+        };
+        let latest = load_store_set(paths)?.ok_or(ServiceError::InvalidSetup)?;
+        if latest.profile.backend_id() != store_set.profile.backend_id()
+            || latest.profile.account_scope_id() != store_set.profile.account_scope_id()
+        {
+            return Err(ServiceError::Store(StoreError::RevisionConflict));
+        }
+        *store_set = latest;
+        let before = store_set.bridge_state.clone();
+        if store_set.bridge_state.discard_stale_now_playing() > 0 {
+            self.persist_or_restore(store_set, before)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn set_native_history_health(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        health: NativeHistoryHealth,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() || store_set.bridge_state.native_history_health() == health {
+            return Ok(());
+        }
+        let before = store_set.bridge_state.clone();
+        store_set.bridge_state.set_native_history_health(health);
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    /// Merge a completed read-only fetch into the current owner snapshot.
+    ///
+    /// Identity and cursor checks are intentionally independent of the store revision: unrelated
+    /// rating/scrobble work is expected to commit while the network job is running and must not be
+    /// overwritten. Native rows are idempotent by row ID; a changed cursor rejects only that stale
+    /// native batch, while still allowing current-account aggregate observations to merge.
+    pub(crate) fn apply_history_refresh(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        result: HistoryRefreshResult,
+    ) -> Result<HistoryApplyOutcome, ServiceError> {
+        let HistoryRefreshResult {
+            backend_id,
+            account_scope_id,
+            base_cursor,
+            native,
+            standard,
+        } = result;
+        if &backend_id != store_set.profile.backend_id()
+            || &account_scope_id != store_set.profile.account_scope_id()
+        {
+            return Ok(HistoryApplyOutcome {
+                native_error: None,
+                standard_error: None,
+                native_stale: true,
+                native_truncated: false,
+            });
+        }
+
+        let mut native_error = native.as_ref().err().copied();
+        let standard_error = standard.as_ref().err().copied();
+        let mut native_stale = false;
+        let mut native_truncated = false;
+        if let Ok(Some(batch)) = native {
+            native_truncated = batch.truncated;
+            if batch.metadata_retry_pending {
+                native_error = Some(NativeHistoryError::TemporarilyUnavailable);
+            }
+            if native_cursor(store_set) == base_cursor.as_ref() {
+                self.apply_native_history_batch(store_set, batch)?;
+            } else {
+                native_stale = true;
+            }
+        }
+        if let Ok(songs) = standard {
+            self.observe_songs(store_set, &songs)?;
+        }
+        Ok(HistoryApplyOutcome {
+            native_error,
+            standard_error,
+            native_stale,
+            native_truncated,
+        })
+    }
+
+    pub(crate) fn observe_page(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        page: &ServerLibraryPage,
+    ) -> Result<(), ServiceError> {
+        let songs = page
+            .rows
+            .iter()
+            .filter_map(|row| match row {
+                ServerLibraryRow::Song(song) => Some(song.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        self.observe_songs(store_set, &songs)
+    }
+
+    pub(crate) fn observe_detail(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        detail: &ServerLibraryDetail,
+    ) -> Result<(), ServiceError> {
+        let songs = match detail {
+            ServerLibraryDetail::AlbumSongs { songs, .. } => songs.as_slice(),
+            ServerLibraryDetail::PlaylistEntries(playlist) => playlist.entries.as_slice(),
+            ServerLibraryDetail::ArtistAlbums { .. } => &[],
+        };
+        self.observe_songs(store_set, songs)
+    }
+
+    pub(crate) fn observe_songs(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        songs: &[ServerSong],
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() || songs.is_empty() {
+            return Ok(());
+        }
+        let before = store_set.bridge_state.clone();
+        let observed_at_unix = crate::signals::unix_now();
+        let nonce = store_set.bridge_state.revision().saturating_add(1);
+        let result = songs.iter().enumerate().try_for_each(|(index, song)| {
+            if song.item.backend_id() != store_set.profile.backend_id()
+                || song.item.account_scope_id() != store_set.profile.account_scope_id()
+            {
+                return Err(BridgeMutationError::InvalidEntry);
+            }
+            observe_rating(
+                store_set,
+                song,
+                observed_at_unix,
+                nonce.saturating_add(index as u64),
+            )?;
+            observe_aggregate(store_set, song, observed_at_unix)
+        });
+        if let Err(error) = result {
+            store_set.bridge_state = before;
+            return Err(mutation_error(error));
+        }
+        self.persist_or_restore(store_set, before)?;
+        self.emit_pending(store_set);
+        Ok(())
+    }
+
+    pub(crate) fn reconcile_ratings(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        winners: Vec<OpenSubsonicRatingWinner>,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Ok(());
+        }
+        let before = store_set.bridge_state.clone();
+        let queued_at_unix = crate::signals::unix_now();
+        for winner in winners {
+            let Some(item_id) = matching_item_id(store_set, &winner.track) else {
+                continue;
+            };
+            if matches!(
+                &winner.origin,
+                OperationOrigin::OpenSubsonic { backend_id }
+                    if backend_id == store_set.profile.backend_id().as_str()
+            ) {
+                // The canonical ledger has already accepted this server observation as the
+                // effective winner. Any older local projection for the same exact item is now
+                // superseded and must not keep rewriting the server behind the owner's back.
+                store_set.bridge_state.remove_rating_projection(&item_id);
+                continue;
+            }
+            if store_set
+                .bridge_state
+                .rating_shadow(&item_id)
+                .and_then(|shadow| shadow.confirmed_operation_id.as_deref())
+                == Some(winner.operation_id.as_str())
+            {
+                continue;
+            }
+            if store_set
+                .bridge_state
+                .pending_rating_projections()
+                .get(&item_id)
+                .is_some_and(|pending| {
+                    pending.operation_id == winner.operation_id && pending.target == winner.rating
+                })
+            {
+                continue;
+            }
+            if let Err(error) = store_set.bridge_state.queue_rating_projection(
+                item_id,
+                PendingRatingProjection {
+                    operation_id: winner.operation_id,
+                    target: winner.rating,
+                    stage: PendingRatingProjectionStage::SetRating,
+                    last_readback: None,
+                    queued_at_unix,
+                },
+            ) {
+                store_set.bridge_state = before;
+                return Err(mutation_error(error));
+            }
+        }
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    /// Persist one outbound playback report before the caller releases its in-memory ownership.
+    ///
+    /// Network delivery deliberately stays on [`Self::retry_network`]. A successful return is a
+    /// local durability receipt and never waits for an unavailable server during owner shutdown.
+    pub(crate) fn queue_scrobble(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        owner_event_id: &str,
+        kind: OpenSubsonicScrobbleKind,
+        track: crate::scrobble::service::ScrobbleTrack,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Err(ServiceError::InvalidSetup);
+        }
+        let item = track.open_subsonic_item.ok_or(ServiceError::InvalidSetup)?;
+        if item.backend_id() != store_set.profile.backend_id()
+            || item.account_scope_id() != store_set.profile.account_scope_id()
+        {
+            return Err(ServiceError::Server(super::ServerError::WrongAccountScope));
+        }
+        let before = store_set.bridge_state.clone();
+        let baseline = store_set
+            .bridge_state
+            .aggregate_play_shadows()
+            .get(item.item_id())
+            .cloned();
+        store_set
+            .bridge_state
+            .queue_outbound_scrobble(PendingOutboundScrobble {
+                event_id: scrobble_event_id(&item, owner_event_id),
+                item_id: item.item_id().clone(),
+                played_at_unix: track.started_unix,
+                kind: match kind {
+                    OpenSubsonicScrobbleKind::NowPlaying => OutboundScrobbleKind::NowPlaying,
+                    OpenSubsonicScrobbleKind::Submission => OutboundScrobbleKind::Submission,
+                },
+                delivery: OutboundScrobbleDelivery::Queued,
+                baseline_captured: baseline.is_some(),
+                baseline_play_count: baseline.as_ref().map(|shadow| shadow.play_count),
+                baseline_played_at: baseline.and_then(|shadow| shadow.played_at),
+                exact_credit_recorded: false,
+                exact_credit_epoch: None,
+                uncertain_readbacks: 0,
+                source_marker_acknowledged: kind == OpenSubsonicScrobbleKind::NowPlaying,
+            })?;
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    /// Persist proof that the source journal entered its non-submitting acknowledgement state.
+    pub(crate) fn acknowledge_scrobble_source(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        owner_event_id: &str,
+        track: crate::scrobble::service::ScrobbleTrack,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Err(ServiceError::InvalidSetup);
+        }
+        let item = track.open_subsonic_item.ok_or(ServiceError::InvalidSetup)?;
+        if item.backend_id() != store_set.profile.backend_id()
+            || item.account_scope_id() != store_set.profile.account_scope_id()
+        {
+            return Err(ServiceError::Server(super::ServerError::WrongAccountScope));
+        }
+        let before = store_set.bridge_state.clone();
+        store_set
+            .bridge_state
+            .acknowledge_outbound_source(&scrobble_event_id(&item, owner_event_id))?;
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    pub(crate) fn acknowledge_import(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        operation_id: &str,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Ok(());
+        }
+        let before = store_set.bridge_state.clone();
+        store_set.bridge_state.remove_rating_import(operation_id);
+        store_set
+            .bridge_state
+            .remove_engagement_import(operation_id);
+        if let Err(error) = store_set
+            .bridge_state
+            .materialize_pending_aggregate_ranges()
+        {
+            store_set.bridge_state = before;
+            return Err(mutation_error(error));
+        }
+        self.persist_or_restore(store_set, before)?;
+        self.emit_pending(store_set);
+        Ok(())
+    }
+
+    pub(crate) async fn retry_network(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        client: &OpenSubsonicClient,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Ok(());
+        }
+        self.emit_pending(store_set);
+        match self.next_retry_lane(store_set) {
+            Some(RetryLane::Rating) => self.flush_rating_projections(store_set, client).await,
+            Some(RetryLane::Outbound) => self.flush_outbound_scrobbles(store_set, client).await,
+            None => Ok(()),
+        }
+    }
+
+    fn apply_native_history_batch(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        batch: NativeHistoryBatch,
+    ) -> Result<(), ServiceError> {
+        let before = store_set.bridge_state.clone();
+        let mutation = (|| {
+            let mut exact_rows_by_item = BTreeMap::<ItemId, u64>::new();
+            let mut baseline_covered_rows = BTreeMap::<ItemId, u64>::new();
+            for row in batch.rows.iter().rev() {
+                let count = exact_rows_by_item.entry(row.item_id.clone()).or_default();
+                *count = count.saturating_add(1);
+                let aggregate_shadow = store_set
+                    .bridge_state
+                    .aggregate_play_shadows()
+                    .get(&row.item_id);
+                let counter_epoch = aggregate_shadow.map_or(0, |shadow| shadow.counter_epoch);
+                let covered_by_previous_baseline = aggregate_shadow
+                    .and_then(|shadow| shadow.played_at.as_deref())
+                    .and_then(parse_rfc3339_unix)
+                    .is_some_and(|covered_through| row.observed_at_unix <= covered_through);
+                if let Some(pending) = store_set
+                    .bridge_state
+                    .outbound_scrobbles()
+                    .iter()
+                    .find(|pending| {
+                        matches!(
+                            pending.delivery,
+                            OutboundScrobbleDelivery::Uncertain
+                                | OutboundScrobbleDelivery::NeedsAttention
+                        ) && pending.kind == OutboundScrobbleKind::Submission
+                            && pending.item_id == row.item_id
+                            && pending.played_at_unix == row.observed_at_unix
+                    })
+                    .cloned()
+                {
+                    if !pending.exact_credit_recorded {
+                        store_set
+                            .bridge_state
+                            .reserve_outbound_exact_history_credit(
+                                row.item_id.clone(),
+                                counter_epoch,
+                            )?;
+                    }
+                    if covered_by_previous_baseline {
+                        let covered = baseline_covered_rows
+                            .entry(row.item_id.clone())
+                            .or_default();
+                        *covered = covered.saturating_add(1);
+                    }
+                    store_set
+                        .bridge_state
+                        .complete_outbound_scrobble(&pending.event_id)?;
+                    continue;
+                }
+                if store_set
+                    .bridge_state
+                    .consume_outbound_echo(&row.item_id, row.observed_at_unix)
+                    .is_some()
+                {
+                    continue;
+                }
+                let should_import = store_set
+                    .bridge_state
+                    .record_exact_history_evidence(row.item_id.clone(), counter_epoch)?;
+                if !should_import {
+                    continue;
+                }
+                if covered_by_previous_baseline {
+                    let covered = baseline_covered_rows
+                        .entry(row.item_id.clone())
+                        .or_default();
+                    *covered = covered.saturating_add(1);
+                }
+                let operation_id = native_event_id(store_set, row.row_id);
+                store_set.bridge_state.queue_engagement_import(
+                    operation_id,
+                    PendingEngagementImport {
+                        track: row.track.clone(),
+                        engagement: EngagementKind::Play,
+                        played_duration_ms: None,
+                        total_duration_ms: row
+                            .track
+                            .duration_secs
+                            .map(|seconds| u64::from(seconds).saturating_mul(1_000)),
+                        artist_key: crate::signals::normalize_artist(&row.track.artist),
+                        observed_at_unix: row.observed_at_unix,
+                    },
+                )?;
+            }
+            // Rows at or before the previous server `played` watermark were already represented by
+            // that aggregate baseline. Retaining their exact credits would make a later, genuinely
+            // new playCount increment disappear. A row newer than the watermark deliberately keeps
+            // its credit until the count catches up, preventing an aggregate echo from duplicating
+            // the exact event.
+            for (item_id, covered) in &baseline_covered_rows {
+                let counter_epoch = store_set
+                    .bridge_state
+                    .aggregate_play_shadows()
+                    .get(item_id)
+                    .map_or(0, |shadow| shadow.counter_epoch);
+                store_set.bridge_state.reconcile_native_aggregate_baseline(
+                    item_id.clone(),
+                    counter_epoch,
+                    *covered,
+                )?;
+            }
+            let aggregate_observed_at = crate::signals::unix_now();
+            for (item_id, (play_count, played_at)) in &batch.aggregate_baselines {
+                if store_set
+                    .bridge_state
+                    .has_unresolved_outbound_submission(item_id)
+                {
+                    // Exact rows above may resolve an ambiguous submission in this transaction.
+                    // If any remain, preserve the old raw shadow so a later refresh can reconsider
+                    // every aggregate increment without consuming speculative exact evidence.
+                    continue;
+                }
+                let previous = store_set
+                    .bridge_state
+                    .aggregate_play_shadows()
+                    .get(item_id)
+                    .cloned();
+                let counter_epoch = next_counter_epoch(previous.as_ref(), *play_count);
+                let exact_rows = exact_rows_by_item.get(item_id).copied().unwrap_or(0);
+                let already_covered = baseline_covered_rows.get(item_id).copied().unwrap_or(0);
+                let newly_exact = exact_rows.saturating_sub(already_covered);
+                let covered_delta = previous.as_ref().map_or_else(
+                    || newly_exact.min(*play_count),
+                    |shadow| {
+                        if counter_epoch == shadow.counter_epoch {
+                            newly_exact.min(play_count.saturating_sub(shadow.play_count))
+                        } else {
+                            newly_exact.min(*play_count)
+                        }
+                    },
+                );
+                store_set.bridge_state.reconcile_native_aggregate_baseline(
+                    item_id.clone(),
+                    counter_epoch,
+                    covered_delta,
+                )?;
+                store_set.bridge_state.upsert_aggregate_play_shadow(
+                    item_id.clone(),
+                    AggregatePlayShadow {
+                        play_count: *play_count,
+                        played_at: played_at.clone(),
+                        observed_at_unix: aggregate_observed_at,
+                        counter_epoch,
+                    },
+                )?;
+            }
+            store_set
+                .bridge_state
+                .materialize_pending_aggregate_ranges()?;
+            if let Some(cursor) = batch.next_cursor {
+                store_set
+                    .bridge_state
+                    .set_history_cursor(NATIVE_CURSOR.to_owned(), cursor)?;
+            }
+            Ok::<(), BridgeMutationError>(())
+        })();
+        if let Err(error) = mutation {
+            store_set.bridge_state = before;
+            return Err(mutation_error(error));
+        }
+        self.persist_or_restore(store_set, before)?;
+        self.emit_pending(store_set);
+        Ok(())
+    }
+
+    fn next_retry_lane(&self, store_set: &OpenSubsonicStoreSet) -> Option<RetryLane> {
+        let has_rating = !store_set
+            .bridge_state
+            .pending_rating_projections()
+            .is_empty();
+        let has_outbound = store_set
+            .bridge_state
+            .outbound_scrobbles()
+            .iter()
+            .any(|pending| pending.delivery != OutboundScrobbleDelivery::NeedsAttention);
+        let mut cursors = self
+            .retry_cursors
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let order = if cursors.lane_after == Some(RetryLane::Rating) {
+            [RetryLane::Outbound, RetryLane::Rating]
+        } else {
+            [RetryLane::Rating, RetryLane::Outbound]
+        };
+        let selected = order.into_iter().find(|lane| match lane {
+            RetryLane::Rating => has_rating,
+            RetryLane::Outbound => has_outbound,
+        });
+        if let Some(lane) = selected {
+            cursors.lane_after = Some(lane);
+        }
+        selected
+    }
+
+    fn next_rating_projection(
+        &self,
+        store_set: &OpenSubsonicStoreSet,
+    ) -> Option<(ItemId, PendingRatingProjection)> {
+        let pending = store_set.bridge_state.pending_rating_projections();
+        let mut cursors = self
+            .retry_cursors
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let selected = cursors
+            .rating_after
+            .as_ref()
+            .and_then(|last| pending.range((Excluded(last.clone()), Unbounded)).next())
+            .or_else(|| pending.iter().next())
+            .map(|(item_id, projection)| (item_id.clone(), projection.clone()));
+        if let Some((item_id, _)) = &selected {
+            cursors.rating_after = Some(item_id.clone());
+        }
+        selected
+    }
+
+    fn next_outbound_scrobble(
+        &self,
+        store_set: &OpenSubsonicStoreSet,
+    ) -> Option<PendingOutboundScrobble> {
+        let pending = store_set.bridge_state.outbound_scrobbles();
+        let mut cursors = self
+            .retry_cursors
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let after = cursors.outbound_after.as_deref();
+        let selected = pending
+            .iter()
+            .filter(|entry| entry.delivery != OutboundScrobbleDelivery::NeedsAttention)
+            .filter(|entry| after.is_none_or(|last| entry.event_id.as_str() > last))
+            .min_by(|left, right| left.event_id.cmp(&right.event_id))
+            .or_else(|| {
+                pending
+                    .iter()
+                    .filter(|entry| entry.delivery != OutboundScrobbleDelivery::NeedsAttention)
+                    .min_by(|left, right| left.event_id.cmp(&right.event_id))
+            })
+            .cloned();
+        if let Some(entry) = &selected {
+            cursors.outbound_after = Some(entry.event_id.clone());
+        }
+        selected
+    }
+
+    async fn flush_rating_projections(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        client: &OpenSubsonicClient,
+    ) -> Result<(), ServiceError> {
+        for _ in 0..MAX_NETWORK_FLUSH_PER_TURN {
+            let Some((item_id, pending)) = self.next_rating_projection(store_set) else {
+                break;
+            };
+            let item = scoped_item(store_set, item_id.clone());
+            let target = canonical_server_rating(pending.target);
+            match pending.stage {
+                PendingRatingProjectionStage::SetRating => {
+                    let rating = target
+                        .user_rating
+                        .and_then(|value| u8::try_from(value).ok())
+                        .ok_or(ServiceError::InvalidSetup)?;
+                    catalog(store_set, client).set_rating(&item, rating).await?;
+                    self.update_projection_stage(
+                        store_set,
+                        item_id,
+                        PendingRatingProjectionStage::SetStarred,
+                        None,
+                    )?;
+                }
+                PendingRatingProjectionStage::SetStarred => {
+                    if target.starred {
+                        catalog(store_set, client).star(&item).await?;
+                    } else {
+                        catalog(store_set, client).unstar(&item).await?;
+                    }
+                    self.update_projection_stage(
+                        store_set,
+                        item_id,
+                        PendingRatingProjectionStage::Readback,
+                        None,
+                    )?;
+                }
+                PendingRatingProjectionStage::Readback => {
+                    let song = catalog(store_set, client).get_song(&item).await?;
+                    let readback = raw_rating(&song);
+                    if readback != target {
+                        if pending.last_readback == Some(readback) {
+                            self.accept_stable_rating_mismatch(
+                                store_set, item_id, pending, &song, readback,
+                            )?;
+                        } else {
+                            // A first (or changing) mismatch can be a delayed read-after-write.
+                            // Persist it and re-read once without issuing another mutation. Only a
+                            // stable repeat becomes an external causal observation.
+                            self.update_projection_stage(
+                                store_set,
+                                item_id,
+                                PendingRatingProjectionStage::Readback,
+                                Some(readback),
+                            )?;
+                        }
+                        break;
+                    }
+                    let before = store_set.bridge_state.clone();
+                    store_set
+                        .bridge_state
+                        .remove_rating_projection(item.item_id());
+                    store_set.bridge_state.upsert_rating_shadow(
+                        item.item_id().clone(),
+                        RatingShadow {
+                            raw: readback,
+                            observed_at_unix: crate::signals::unix_now(),
+                            confirmed_operation_id: Some(pending.operation_id),
+                        },
+                    )?;
+                    self.persist_or_restore(store_set, before)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn update_projection_stage(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        item_id: ItemId,
+        stage: PendingRatingProjectionStage,
+        last_readback: Option<RawServerRating>,
+    ) -> Result<(), ServiceError> {
+        let before = store_set.bridge_state.clone();
+        let mut pending = store_set
+            .bridge_state
+            .pending_rating_projections()
+            .get(&item_id)
+            .cloned()
+            .ok_or(ServiceError::InvalidSetup)?;
+        pending.stage = stage;
+        pending.last_readback = last_readback;
+        store_set
+            .bridge_state
+            .queue_rating_projection(item_id, pending)?;
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    fn accept_stable_rating_mismatch(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        item_id: ItemId,
+        pending: PendingRatingProjection,
+        song: &ServerSong,
+        readback: RawServerRating,
+    ) -> Result<(), ServiceError> {
+        let before = store_set.bridge_state.clone();
+        let observed_at_unix = crate::signals::unix_now();
+        let operation_id =
+            rating_projection_mismatch_id(store_set, &item_id, &pending.operation_id, readback);
+        let mutation = (|| {
+            store_set.bridge_state.queue_rating_import(
+                operation_id,
+                PendingRatingImport {
+                    item_id: item_id.clone(),
+                    track: portable_server_track(song),
+                    raw: readback,
+                    mapped: map_server_rating(readback),
+                    observed_at_unix,
+                },
+            )?;
+            store_set.bridge_state.upsert_rating_shadow(
+                item_id.clone(),
+                RatingShadow {
+                    raw: readback,
+                    observed_at_unix,
+                    confirmed_operation_id: None,
+                },
+            )?;
+            store_set.bridge_state.remove_rating_projection(&item_id);
+            Ok::<(), BridgeMutationError>(())
+        })();
+        if let Err(error) = mutation {
+            store_set.bridge_state = before;
+            return Err(mutation_error(error));
+        }
+        self.persist_or_restore(store_set, before)?;
+        self.emit_pending(store_set);
+        Ok(())
+    }
+
+    async fn flush_outbound_scrobbles(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        client: &OpenSubsonicClient,
+    ) -> Result<(), ServiceError> {
+        for _ in 0..MAX_NETWORK_FLUSH_PER_TURN {
+            let Some(mut pending) = self.next_outbound_scrobble(store_set) else {
+                break;
+            };
+            if pending.delivery == OutboundScrobbleDelivery::Uncertain {
+                if pending.kind == OutboundScrobbleKind::NowPlaying {
+                    self.complete_outbound(store_set, &pending, false)?;
+                    continue;
+                }
+                if !pending.exact_credit_recorded {
+                    let before = store_set.bridge_state.clone();
+                    let mut credited = pending.clone();
+                    record_pending_exact_credit(store_set, &mut credited)?;
+                    store_set.bridge_state.replace_outbound_scrobble(credited)?;
+                    self.persist_or_restore(store_set, before)?;
+                    continue;
+                }
+                let item = scoped_item(store_set, pending.item_id.clone());
+                let song = catalog(store_set, client).get_song(&item).await?;
+                let confirmed = outbound_readback_confirms(&pending, &song);
+                let before = store_set.bridge_state.clone();
+                let mutation = (|| {
+                    if confirmed {
+                        store_set
+                            .bridge_state
+                            .complete_outbound_scrobble(&pending.event_id)?;
+                        store_set
+                            .bridge_state
+                            .record_outbound_echo(outbound_echo(&pending))?;
+                        observe_aggregate(store_set, &song, crate::signals::unix_now())?;
+                    } else {
+                        observe_aggregate(store_set, &song, crate::signals::unix_now())?;
+                        pending.uncertain_readbacks = pending.uncertain_readbacks.saturating_add(1);
+                        if pending.uncertain_readbacks >= MAX_UNCERTAIN_SCROBBLE_READBACKS {
+                            pending.uncertain_readbacks = MAX_UNCERTAIN_SCROBBLE_READBACKS;
+                            pending.delivery = OutboundScrobbleDelivery::NeedsAttention;
+                            tracing::warn!(
+                                "music server playback report needs an explicit retry or sent decision"
+                            );
+                        }
+                        store_set.bridge_state.replace_outbound_scrobble(pending)?;
+                    }
+                    Ok::<(), BridgeMutationError>(())
+                })();
+                if let Err(error) = mutation {
+                    store_set.bridge_state = before;
+                    return Err(mutation_error(error));
+                }
+                self.persist_or_restore(store_set, before)?;
+                self.emit_pending(store_set);
+                continue;
+            }
+
+            let item = scoped_item(store_set, pending.item_id.clone());
+            let submission = pending.kind == OutboundScrobbleKind::Submission;
+            if submission && !pending.baseline_captured {
+                let song = catalog(store_set, client).get_song(&item).await?;
+                let before = store_set.bridge_state.clone();
+                if let Err(error) = observe_aggregate(store_set, &song, crate::signals::unix_now())
+                {
+                    store_set.bridge_state = before;
+                    return Err(mutation_error(error));
+                }
+                pending.baseline_captured = true;
+                pending.baseline_play_count = song.play_count;
+                pending.baseline_played_at = song.played_at;
+                store_set.bridge_state.replace_outbound_scrobble(pending)?;
+                self.persist_or_restore(store_set, before)?;
+                self.emit_pending(store_set);
+                continue;
+            }
+
+            let queued_before_attempt = store_set.bridge_state.clone();
+            pending.delivery = OutboundScrobbleDelivery::Uncertain;
+            pending.uncertain_readbacks = 0;
+            if submission {
+                record_pending_exact_credit(store_set, &mut pending)?;
+            }
+            store_set
+                .bridge_state
+                .replace_outbound_scrobble(pending.clone())?;
+            self.persist_or_restore(store_set, queued_before_attempt.clone())?;
+
+            let time = u64::try_from(pending.played_at_unix)
+                .ok()
+                .and_then(|seconds| seconds.checked_mul(1_000));
+            let delivery = catalog(store_set, client)
+                .scrobble(&item, submission, time)
+                .await;
+            match delivery {
+                Ok(()) => self.complete_outbound(store_set, &pending, submission)?,
+                Err(MutationDeliveryError::DefinitelyNotApplied(error)) => {
+                    let uncertain = store_set.bridge_state.clone();
+                    let mut queued = queued_before_attempt;
+                    queued.set_revision(uncertain.revision());
+                    store_set.bridge_state = queued;
+                    self.persist_or_restore(store_set, uncertain)?;
+                    return Err(error.into());
+                }
+                Err(MutationDeliveryError::Ambiguous(error)) => return Err(error.into()),
+            }
+        }
+        Ok(())
+    }
+
+    fn complete_outbound(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        pending: &PendingOutboundScrobble,
+        retain_echo: bool,
+    ) -> Result<(), ServiceError> {
+        let before = store_set.bridge_state.clone();
+        let mutation = (|| {
+            store_set
+                .bridge_state
+                .complete_outbound_scrobble(&pending.event_id)?;
+            if retain_echo {
+                store_set
+                    .bridge_state
+                    .record_outbound_echo(outbound_echo(pending))?;
+            }
+            Ok::<(), BridgeMutationError>(())
+        })();
+        if let Err(error) = mutation {
+            store_set.bridge_state = before;
+            return Err(mutation_error(error));
+        }
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    fn persist_or_restore(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        before: super::OpenSubsonicBridgeState,
+    ) -> Result<bool, ServiceError> {
+        if before == store_set.bridge_state {
+            return Ok(false);
+        }
+        let Some(paths) = self.paths.as_ref() else {
+            store_set.bridge_state = before;
+            return Err(ServiceError::InvalidSetup);
+        };
+        let expected = store_set.revisions();
+        let desired = store_set.bridge_state.clone();
+        let Err(error) = commit_store_set(paths, expected, store_set) else {
+            return Ok(true);
+        };
+
+        // A store-set install may report an error after its commit marker became durable. Reloading
+        // both rolls that transaction forward and distinguishes "committed, response lost" from a
+        // genuine rejected write. Revision conflicts also rebase this actor onto the current owner
+        // snapshot so a later replay can make progress instead of repeatedly presenting stale
+        // revisions.
+        if let Ok(Some(recovered)) = load_store_set(paths)
+            && recovered.profile.backend_id() == store_set.profile.backend_id()
+            && recovered.profile.account_scope_id() == store_set.profile.account_scope_id()
+        {
+            let mut desired_at_recovered_revision = desired;
+            desired_at_recovered_revision.set_revision(recovered.bridge_state.revision());
+            let desired_is_durable = recovered.bridge_state == desired_at_recovered_revision;
+            *store_set = recovered;
+            return if desired_is_durable {
+                Ok(true)
+            } else {
+                Err(error.into())
+            };
+        }
+
+        store_set.bridge_state = before;
+        Err(error.into())
+    }
+
+    pub(crate) fn emit_pending(&self, store_set: &OpenSubsonicStoreSet) {
+        let Some(sink) = &self.sink else {
+            return;
+        };
+        let ratings = store_set.bridge_state.pending_rating_imports().iter().map(
+            |(operation_id, pending)| OpenSubsonicBridgeImport::Rating {
+                operation_id: operation_id.clone(),
+                track: pending.track.clone(),
+                rating: pending.mapped,
+                observed_at_unix: pending.observed_at_unix,
+            },
+        );
+        let engagements = store_set
+            .bridge_state
+            .pending_engagement_imports()
+            .iter()
+            .map(
+                |(operation_id, pending)| OpenSubsonicBridgeImport::Engagement {
+                    operation_id: operation_id.clone(),
+                    track: pending.track.clone(),
+                    engagement: pending.engagement,
+                    played_duration_ms: pending.played_duration_ms,
+                    total_duration_ms: pending.total_duration_ms,
+                    artist_key: pending.artist_key.clone(),
+                    observed_at_unix: pending.observed_at_unix,
+                },
+            );
+        for event in ratings.chain(engagements) {
+            sink(event);
+        }
+    }
+}
+
+async fn fetch_history_sources(
+    store_set: &OpenSubsonicStoreSet,
+    client: &OpenSubsonicClient,
+    native_budget: Duration,
+    standard_budget: Duration,
+) -> Result<HistoryRefreshResult, ServiceError> {
+    let base_cursor = native_cursor(store_set).cloned();
+    let native = tokio::time::timeout(native_budget, fetch_native_history_batch(store_set, client));
+    let standard = tokio::time::timeout(standard_budget, fetch_standard_history(store_set, client));
+    let (native, standard) = tokio::join!(native, standard);
+    Ok(HistoryRefreshResult {
+        backend_id: store_set.profile.backend_id().clone(),
+        account_scope_id: store_set.profile.account_scope_id().clone(),
+        base_cursor,
+        native: native.unwrap_or(Err(NativeHistoryError::TemporarilyUnavailable)),
+        standard: standard.unwrap_or(Err(ServiceError::Server(
+            super::ServerError::TemporarilyUnavailable,
+        ))),
+    })
+}
+
+async fn fetch_native_history_batch(
+    store_set: &OpenSubsonicStoreSet,
+    client: &OpenSubsonicClient,
+) -> Result<Option<NativeHistoryBatch>, NativeHistoryError> {
+    let Some(credential) = store_set
+        .private_state
+        .native_history_credential()
+        .map_err(|_| NativeHistoryError::InvalidCredential)?
+    else {
+        return Ok(None);
+    };
+    let cursor = native_cursor(store_set);
+    if let Some(cursor) = cursor.filter(|cursor| !cursor.pending_metadata_rows.is_empty()) {
+        let previous_len = cursor.pending_metadata_rows.len();
+        let resolution =
+            history_metadata::resolve(store_set, client, cursor.pending_metadata_rows.clone())
+                .await;
+        let mut next_cursor = cursor.clone();
+        next_cursor.pending_metadata_rows = resolution.pending;
+        if next_cursor.pending_metadata_rows.len() != previous_len {
+            next_cursor.updated_at_unix = crate::signals::unix_now();
+        }
+        let truncated =
+            !next_cursor.pending_metadata_rows.is_empty() || next_cursor.continuation.is_some();
+        return Ok(Some(NativeHistoryBatch {
+            rows: resolution.observations,
+            aggregate_baselines: resolution.aggregate_baselines,
+            next_cursor: Some(next_cursor),
+            truncated,
+            metadata_retry_pending: resolution.transient_failure,
+        }));
+    }
+    let high_water = cursor
+        .and_then(|cursor| cursor.high_water_id.as_deref())
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .map_err(|_| NativeHistoryError::InvalidResponse)
+        })
+        .transpose()?;
+    let continuation = cursor
+        .and_then(|cursor| cursor.continuation.as_ref())
+        .map(native_scan_continuation)
+        .transpose()?;
+    let overlap_from_unix = cursor
+        .and_then(|cursor| cursor.overlap_started_at_unix)
+        .and_then(|value| u64::try_from(value).ok());
+    let native = NavidromeNativeClient::connect(&store_set.profile).await?;
+    let mut session = native.login(&credential).await?;
+    native.probe(&mut session).await?;
+    let scan = native
+        .scan_recent_from_window(&mut session, high_water, overlap_from_unix, continuation)
+        .await?;
+
+    let pending = scan
+        .rows
+        .iter()
+        .map(|row| {
+            Ok(PendingNativeMetadataRow {
+                row_id: row.id,
+                item_id: row.media_file_id.clone(),
+                observed_at_unix: i64::try_from(row.submission_time_unix)
+                    .map_err(|_| NativeHistoryError::InvalidResponse)?,
+            })
+        })
+        .collect::<Result<Vec<_>, NativeHistoryError>>()?;
+    let resolution = history_metadata::resolve(store_set, client, pending).await;
+    let mut next_cursor = if let Some(continuation) = scan.continuation.as_ref() {
+        Some(HistoryCursor {
+            high_water_id: high_water.map(|id| id.to_string()),
+            overlap_started_at_unix: continuation
+                .through_unix
+                .and_then(|value| i64::try_from(value).ok()),
+            updated_at_unix: crate::signals::unix_now(),
+            continuation: Some(history_continuation(continuation)?),
+            pending_metadata_rows: Vec::new(),
+        })
+    } else {
+        scan.next_high_water_id.map(|high_water_id| HistoryCursor {
+            high_water_id: Some(high_water_id.to_string()),
+            overlap_started_at_unix: completed_history_overlap(cursor, &scan.rows),
+            updated_at_unix: crate::signals::unix_now(),
+            continuation: None,
+            pending_metadata_rows: Vec::new(),
+        })
+    };
+    if !resolution.pending.is_empty() {
+        next_cursor
+            .as_mut()
+            .ok_or(NativeHistoryError::InvalidResponse)?
+            .pending_metadata_rows = resolution.pending;
+    }
+    let truncated = scan.truncated
+        || next_cursor
+            .as_ref()
+            .is_some_and(|cursor| !cursor.pending_metadata_rows.is_empty());
+    Ok(Some(NativeHistoryBatch {
+        rows: resolution.observations,
+        aggregate_baselines: resolution.aggregate_baselines,
+        next_cursor,
+        truncated,
+        metadata_retry_pending: resolution.transient_failure,
+    }))
+}
+
+async fn fetch_standard_history(
+    store_set: &OpenSubsonicStoreSet,
+    client: &OpenSubsonicClient,
+) -> Result<Vec<ServerSong>, ServiceError> {
+    let page = catalog(store_set, client)
+        .library_page(
+            super::model::ServerLibrarySection::RecentlyPlayed,
+            0,
+            STANDARD_RECENT_ALBUMS,
+        )
+        .await?;
+    let mut songs = page
+        .rows
+        .iter()
+        .filter_map(|row| match row {
+            ServerLibraryRow::Song(song) => Some(song.clone()),
+            _ => None,
+        })
+        .take(STANDARD_RECENT_SONGS)
+        .collect::<Vec<_>>();
+    let album_ids = page
+        .rows
+        .iter()
+        .filter_map(|row| match row {
+            ServerLibraryRow::Album(album) => Some(album.id.clone()),
+            _ => None,
+        })
+        .take(STANDARD_RECENT_ALBUMS as usize)
+        .collect::<Vec<_>>();
+    let details =
+        futures::stream::iter(album_ids.into_iter().map(|album_id| async move {
+            catalog(store_set, client).album_detail(&album_id).await
+        }))
+        .buffered(STANDARD_ALBUM_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+    for detail in details {
+        if songs.len() >= STANDARD_RECENT_SONGS {
+            break;
+        }
+        let Ok(ServerLibraryDetail::AlbumSongs {
+            songs: album_songs, ..
+        }) = detail
+        else {
+            continue;
+        };
+        songs.extend(
+            album_songs
+                .into_iter()
+                .take(STANDARD_RECENT_SONGS.saturating_sub(songs.len())),
+        );
+    }
+    Ok(songs)
+}
+
+fn observe_rating(
+    store_set: &mut OpenSubsonicStoreSet,
+    song: &ServerSong,
+    observed_at_unix: i64,
+    nonce: u64,
+) -> Result<(), BridgeMutationError> {
+    let item_id = song.item.item_id();
+    if store_set
+        .bridge_state
+        .pending_rating_projections()
+        .contains_key(item_id)
+    {
+        return Ok(());
+    }
+    let raw = raw_rating(song);
+    if store_set
+        .bridge_state
+        .rating_shadow(item_id)
+        .is_some_and(|shadow| shadow.raw == raw)
+    {
+        return Ok(());
+    }
+    let operation_id = rating_observation_id(store_set, item_id, raw, nonce);
+    store_set.bridge_state.queue_rating_import(
+        operation_id,
+        PendingRatingImport {
+            item_id: item_id.clone(),
+            track: portable_server_track(song),
+            raw,
+            mapped: map_server_rating(raw),
+            observed_at_unix,
+        },
+    )?;
+    store_set.bridge_state.upsert_rating_shadow(
+        item_id.clone(),
+        RatingShadow {
+            raw,
+            observed_at_unix,
+            confirmed_operation_id: None,
+        },
+    )
+}
+
+fn record_pending_exact_credit(
+    store_set: &mut OpenSubsonicStoreSet,
+    pending: &mut PendingOutboundScrobble,
+) -> Result<(), BridgeMutationError> {
+    if pending.exact_credit_recorded {
+        return Ok(());
+    }
+    let counter_epoch = store_set
+        .bridge_state
+        .aggregate_play_shadows()
+        .get(&pending.item_id)
+        .map_or(0, |shadow| shadow.counter_epoch);
+    store_set
+        .bridge_state
+        .reserve_outbound_exact_history_credit(pending.item_id.clone(), counter_epoch)?;
+    pending.exact_credit_recorded = true;
+    pending.exact_credit_epoch = Some(counter_epoch);
+    Ok(())
+}
+
+fn outbound_echo(pending: &PendingOutboundScrobble) -> OutboundScrobbleEcho {
+    OutboundScrobbleEcho {
+        event_id: pending.event_id.clone(),
+        item_id: pending.item_id.clone(),
+        played_at_unix: pending.played_at_unix,
+    }
+}
+
+fn outbound_readback_confirms(pending: &PendingOutboundScrobble, song: &ServerSong) -> bool {
+    if !pending.baseline_captured {
+        return false;
+    }
+    song.played_at != pending.baseline_played_at
+        && song.played_at.as_deref().and_then(parse_rfc3339_unix) == Some(pending.played_at_unix)
+}
+
+fn matching_item_id(store_set: &OpenSubsonicStoreSet, track: &PortableTrack) -> Option<ItemId> {
+    match &track.key {
+        PortableTrackKey::OpenSubsonic {
+            backend_id,
+            account_scope_id,
+            item_id,
+        } if backend_id == store_set.profile.backend_id().as_str()
+            && account_scope_id == store_set.profile.account_scope_id().as_str() =>
+        {
+            ItemId::new(item_id.clone()).ok()
+        }
+        _ => None,
+    }
+}
+
+fn scoped_item(store_set: &OpenSubsonicStoreSet, item_id: ItemId) -> OpenSubsonicItemRef {
+    OpenSubsonicItemRef::new(
+        store_set.profile.backend_id().clone(),
+        store_set.profile.account_scope_id().clone(),
+        item_id,
+    )
+}
+
+fn catalog<'a>(
+    store_set: &'a OpenSubsonicStoreSet,
+    client: &'a OpenSubsonicClient,
+) -> OpenSubsonicCatalog<'a> {
+    OpenSubsonicCatalog::new(
+        client,
+        store_set.private_state.credential(),
+        store_set.profile.backend_id(),
+        store_set.profile.account_scope_id(),
+    )
+}
+
+fn raw_rating(song: &ServerSong) -> RawServerRating {
+    RawServerRating {
+        user_rating: song.user_rating,
+        starred: song.starred,
+    }
+}
+
+fn rating_observation_id(
+    store_set: &OpenSubsonicStoreSet,
+    item_id: &ItemId,
+    raw: RawServerRating,
+    nonce: u64,
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"yututui-open-subsonic-rating-observation-v1\0");
+    hash_text(&mut digest, store_set.profile.backend_id().as_str());
+    hash_text(&mut digest, store_set.profile.account_scope_id().as_str());
+    hash_text(&mut digest, item_id.as_str());
+    digest.update(nonce.to_be_bytes());
+    hash_raw_rating(&mut digest, raw);
+    format!("sub-rating-{}", HEXLOWER.encode(&digest.finalize()))
+}
+
+fn rating_projection_mismatch_id(
+    store_set: &OpenSubsonicStoreSet,
+    item_id: &ItemId,
+    projected_operation_id: &str,
+    raw: RawServerRating,
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"yututui-open-subsonic-rating-projection-mismatch-v1\0");
+    hash_text(&mut digest, store_set.profile.backend_id().as_str());
+    hash_text(&mut digest, store_set.profile.account_scope_id().as_str());
+    hash_text(&mut digest, item_id.as_str());
+    hash_text(&mut digest, projected_operation_id);
+    hash_raw_rating(&mut digest, raw);
+    format!(
+        "sub-rating-mismatch-{}",
+        HEXLOWER.encode(&digest.finalize())
+    )
+}
+
+fn hash_raw_rating(digest: &mut Sha256, raw: RawServerRating) {
+    match raw.user_rating {
+        Some(value) => {
+            digest.update([1]);
+            digest.update(value.to_be_bytes());
+        }
+        None => digest.update([0]),
+    }
+    digest.update([u8::from(raw.starred)]);
+}
+
+fn native_event_id(store_set: &OpenSubsonicStoreSet, row_id: u64) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"yututui-open-subsonic-native-history-v1\0");
+    hash_text(&mut digest, store_set.profile.backend_id().as_str());
+    hash_text(&mut digest, store_set.profile.account_scope_id().as_str());
+    digest.update(row_id.to_be_bytes());
+    format!("sub-native-{}", HEXLOWER.encode(&digest.finalize()))
+}
+
+fn scrobble_event_id(item: &OpenSubsonicItemRef, owner_event_id: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"yututui-open-subsonic-outbound-scrobble-v2\0");
+    hash_text(&mut digest, item.backend_id().as_str());
+    hash_text(&mut digest, item.account_scope_id().as_str());
+    hash_text(&mut digest, owner_event_id);
+    format!("sub-scrobble-{}", HEXLOWER.encode(&digest.finalize()))
+}
+
+fn hash_text(digest: &mut Sha256, value: &str) {
+    digest.update((value.len() as u64).to_be_bytes());
+    digest.update(value.as_bytes());
+}
+
+fn mutation_error(_error: BridgeMutationError) -> ServiceError {
+    ServiceError::Store(StoreError::InvalidState)
+}
+
+impl From<BridgeMutationError> for ServiceError {
+    fn from(error: BridgeMutationError) -> Self {
+        mutation_error(error)
+    }
+}

--- a/src/open_subsonic/bridge_runtime/history_metadata.rs
+++ b/src/open_subsonic/bridge_runtime/history_metadata.rs
@@ -1,0 +1,247 @@
+//! Bounded, durable metadata enrichment for exact native-history rows.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use futures::StreamExt as _;
+
+use super::*;
+
+const METADATA_ITEMS_PER_REFRESH: usize = 64;
+const METADATA_CONCURRENCY: usize = 8;
+
+pub(super) struct MetadataResolution {
+    pub observations: Vec<NativeHistoryObservation>,
+    pub aggregate_baselines: BTreeMap<ItemId, (u64, Option<String>)>,
+    pub pending: Vec<PendingNativeMetadataRow>,
+    pub transient_failure: bool,
+}
+
+pub(super) async fn resolve(
+    store_set: &OpenSubsonicStoreSet,
+    client: &OpenSubsonicClient,
+    pending: Vec<PendingNativeMetadataRow>,
+) -> MetadataResolution {
+    let metadata_ids = oldest_metadata_ids(&pending);
+    let fetched = futures::stream::iter(metadata_ids.into_iter().map(|item_id| {
+        let item = scoped_item(store_set, item_id.clone());
+        async move {
+            let result = catalog(store_set, client).get_song(&item).await;
+            (item_id, result)
+        }
+    }))
+    .buffer_unordered(METADATA_CONCURRENCY)
+    .collect::<Vec<_>>()
+    .await;
+    let metadata = fetched.into_iter().collect();
+    resolve_fetched(store_set, pending, &metadata)
+}
+
+fn oldest_metadata_ids(pending: &[PendingNativeMetadataRow]) -> Vec<ItemId> {
+    let mut seen = BTreeSet::new();
+    let mut ids = Vec::new();
+    for row in pending.iter().rev() {
+        if seen.insert(row.item_id.clone()) {
+            ids.push(row.item_id.clone());
+            if ids.len() == METADATA_ITEMS_PER_REFRESH {
+                break;
+            }
+        }
+    }
+    ids
+}
+
+fn resolve_fetched(
+    store_set: &OpenSubsonicStoreSet,
+    mut pending: Vec<PendingNativeMetadataRow>,
+    metadata: &BTreeMap<ItemId, Result<ServerSong, super::super::ServerError>>,
+) -> MetadataResolution {
+    let mut observations = Vec::new();
+    let mut aggregate_baselines = BTreeMap::new();
+    let mut resolved = 0;
+    let mut transient_failure = false;
+    for row in pending.iter().rev() {
+        let Some(result) = metadata.get(&row.item_id) else {
+            break;
+        };
+        let track = match result {
+            Ok(song) => {
+                if song.play_count.is_some() || song.played_at.is_some() {
+                    aggregate_baselines.insert(
+                        row.item_id.clone(),
+                        (song.play_count.unwrap_or(0), song.played_at.clone()),
+                    );
+                }
+                portable_server_track(song)
+            }
+            Err(super::super::ServerError::NotFound) => {
+                placeholder_track(&scoped_item(store_set, row.item_id.clone()))
+            }
+            Err(_) => {
+                transient_failure = true;
+                break;
+            }
+        };
+        observations.push(NativeHistoryObservation {
+            row_id: row.row_id,
+            item_id: row.item_id.clone(),
+            track,
+            observed_at_unix: row.observed_at_unix,
+        });
+        resolved += 1;
+    }
+    pending.truncate(pending.len().saturating_sub(resolved));
+    observations.reverse();
+    MetadataResolution {
+        observations,
+        aggregate_baselines,
+        pending,
+        transient_failure,
+    }
+}
+
+fn placeholder_track(item: &OpenSubsonicItemRef) -> PortableTrack {
+    PortableTrack {
+        key: PortableTrackKey::OpenSubsonic {
+            backend_id: item.backend_id().as_str().to_owned(),
+            account_scope_id: item.account_scope_id().as_str().to_owned(),
+            item_id: item.item_id().as_str().to_owned(),
+        },
+        title: "Server track".to_owned(),
+        artist: "Unknown artist".to_owned(),
+        album: None,
+        duration_secs: None,
+        isrc: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::open_subsonic::model::OpenSubsonicItemRef;
+    use crate::open_subsonic::private_store::{OpenSubsonicPrivateState, ServerCredential};
+    use crate::open_subsonic::profile::OpenSubsonicProfile;
+    use crate::open_subsonic::{ConfiguredPrivateOrigin, OpenSubsonicBridgeState};
+    use age::secrecy::SecretString;
+
+    fn store_set() -> OpenSubsonicStoreSet {
+        let backend = BackendId::new("backend-history-metadata").unwrap();
+        let account = AccountScopeId::new("account-history-metadata").unwrap();
+        let profile = OpenSubsonicProfile::with_ids(
+            0,
+            backend.clone(),
+            account.clone(),
+            "Server",
+            ConfiguredPrivateOrigin::new("http://127.0.0.1:4040/", true).unwrap(),
+            None,
+        )
+        .unwrap();
+        let private = OpenSubsonicPrivateState::new(
+            backend.clone(),
+            account.clone(),
+            ServerCredential::api_key(SecretString::from("test-key".to_owned())).unwrap(),
+        );
+        OpenSubsonicStoreSet::new(
+            profile,
+            private,
+            OpenSubsonicBridgeState::new(backend, account),
+        )
+        .unwrap()
+    }
+
+    fn pending_rows(count: u64) -> Vec<PendingNativeMetadataRow> {
+        (1..=count)
+            .rev()
+            .map(|id| PendingNativeMetadataRow {
+                row_id: id,
+                item_id: ItemId::new(format!("song-{id}")).unwrap(),
+                observed_at_unix: i64::try_from(id).unwrap(),
+            })
+            .collect()
+    }
+
+    fn song(store_set: &OpenSubsonicStoreSet, item_id: ItemId) -> ServerSong {
+        ServerSong {
+            item: OpenSubsonicItemRef::new(
+                store_set.profile.backend_id().clone(),
+                store_set.profile.account_scope_id().clone(),
+                item_id,
+            ),
+            title: "Resolved song".to_owned(),
+            artist: "Resolved artist".to_owned(),
+            artists: Vec::new(),
+            album: None,
+            album_id: None,
+            album_artist: None,
+            duration_secs: Some(180),
+            track_number: None,
+            disc_number: None,
+            year: None,
+            cover_art_id: None,
+            content_type: None,
+            suffix: None,
+            starred: false,
+            user_rating: None,
+            play_count: Some(1),
+            played_at: None,
+        }
+    }
+
+    #[test]
+    fn more_than_sixty_four_unique_items_continue_without_unknown_metadata() {
+        let store_set = store_set();
+        let pending = pending_rows(65);
+        let mut metadata = BTreeMap::new();
+        for id in 1..=64 {
+            let item_id = ItemId::new(format!("song-{id}")).unwrap();
+            metadata.insert(item_id.clone(), Ok(song(&store_set, item_id)));
+        }
+
+        let resolution = resolve_fetched(&store_set, pending, &metadata);
+
+        assert_eq!(resolution.observations.len(), 64);
+        assert_eq!(resolution.pending.len(), 1);
+        assert_eq!(resolution.pending[0].row_id, 65);
+        assert!(resolution.observations.iter().all(|observation| {
+            observation.track.title == "Resolved song"
+                && observation.track.artist == "Resolved artist"
+        }));
+    }
+
+    #[test]
+    fn transient_metadata_failure_keeps_the_row_and_every_newer_row_pending() {
+        let store_set = store_set();
+        let pending = pending_rows(3);
+        let mut metadata = BTreeMap::new();
+        metadata.insert(
+            ItemId::new("song-1").unwrap(),
+            Err(super::super::super::ServerError::TemporarilyUnavailable),
+        );
+        for id in 2..=3 {
+            let item_id = ItemId::new(format!("song-{id}")).unwrap();
+            metadata.insert(item_id.clone(), Ok(song(&store_set, item_id)));
+        }
+
+        let resolution = resolve_fetched(&store_set, pending.clone(), &metadata);
+
+        assert!(resolution.observations.is_empty());
+        assert_eq!(resolution.pending, pending);
+        assert!(resolution.transient_failure);
+    }
+
+    #[test]
+    fn only_definitive_not_found_uses_placeholder_metadata() {
+        let store_set = store_set();
+        let pending = pending_rows(1);
+        let metadata = BTreeMap::from([(
+            ItemId::new("song-1").unwrap(),
+            Err(super::super::super::ServerError::NotFound),
+        )]);
+
+        let resolution = resolve_fetched(&store_set, pending, &metadata);
+
+        assert!(resolution.pending.is_empty());
+        assert!(!resolution.transient_failure);
+        assert_eq!(resolution.observations[0].track.title, "Server track");
+        assert_eq!(resolution.observations[0].track.artist, "Unknown artist");
+    }
+}

--- a/src/open_subsonic/bridge_runtime/history_support.rs
+++ b/src/open_subsonic/bridge_runtime/history_support.rs
@@ -1,0 +1,179 @@
+//! Standard/native history bookkeeping kept out of the credential-owning actor core.
+
+use super::NATIVE_CURSOR;
+use crate::open_subsonic::bridge_event::portable_server_track;
+use crate::open_subsonic::bridge_store::{
+    AggregatePlayShadow, BridgeMutationError, HistoryContinuation, HistoryCursor,
+    PendingAggregateRange,
+};
+use crate::open_subsonic::history::{
+    AggregateHistoryShadow, parse_rfc3339_unix, plan_aggregate_history,
+};
+use crate::open_subsonic::model::ServerSong;
+use crate::open_subsonic::native_history::{
+    NativeHistoryError, NativeScrobbleRow, NativeScrobbleScanContinuation,
+};
+use crate::open_subsonic::transaction::OpenSubsonicStoreSet;
+
+pub(super) fn native_cursor(store_set: &OpenSubsonicStoreSet) -> Option<&HistoryCursor> {
+    store_set.bridge_state.history_cursors().get(NATIVE_CURSOR)
+}
+
+pub(in crate::open_subsonic) fn completed_history_overlap(
+    prior: Option<&HistoryCursor>,
+    rows: &[NativeScrobbleRow],
+) -> Option<i64> {
+    prior
+        .filter(|cursor| cursor.continuation.is_some())
+        .and_then(|cursor| cursor.overlap_started_at_unix)
+        .or_else(|| {
+            rows.last()
+                .and_then(|row| i64::try_from(row.submission_time_unix).ok())
+        })
+}
+
+pub(super) fn native_scan_continuation(
+    continuation: &HistoryContinuation,
+) -> Result<NativeScrobbleScanContinuation, NativeHistoryError> {
+    Ok(NativeScrobbleScanContinuation {
+        candidate_high_water_id: continuation
+            .candidate_high_water_id
+            .as_deref()
+            .map(str::parse)
+            .transpose()
+            .map_err(|_| NativeHistoryError::InvalidResponse)?,
+        next_start: usize::try_from(continuation.next_start)
+            .map_err(|_| NativeHistoryError::InvalidResponse)?,
+        through_unix: continuation.through_unix,
+        reached_high_water: continuation.reached_high_water,
+        overlap_row_ids: continuation.overlap_row_ids.clone(),
+        backlog_complete: continuation.backlog_complete,
+        head_anchor_high_water_id: continuation
+            .head_anchor_high_water_id
+            .as_deref()
+            .map(str::parse)
+            .transpose()
+            .map_err(|_| NativeHistoryError::InvalidResponse)?,
+        head_next_start: continuation
+            .head_next_start
+            .map(usize::try_from)
+            .transpose()
+            .map_err(|_| NativeHistoryError::InvalidResponse)?,
+        head_from_unix: continuation.head_from_unix,
+        head_through_unix: continuation.head_through_unix,
+        head_overlap_row_ids: continuation.head_overlap_row_ids.clone(),
+    })
+}
+
+pub(super) fn history_continuation(
+    continuation: &NativeScrobbleScanContinuation,
+) -> Result<HistoryContinuation, NativeHistoryError> {
+    Ok(HistoryContinuation {
+        candidate_high_water_id: continuation
+            .candidate_high_water_id
+            .map(|id| id.to_string()),
+        next_start: u32::try_from(continuation.next_start)
+            .map_err(|_| NativeHistoryError::InvalidResponse)?,
+        through_unix: continuation.through_unix,
+        reached_high_water: continuation.reached_high_water,
+        overlap_row_ids: continuation.overlap_row_ids.clone(),
+        backlog_complete: continuation.backlog_complete,
+        head_anchor_high_water_id: continuation
+            .head_anchor_high_water_id
+            .map(|id| id.to_string()),
+        head_next_start: continuation
+            .head_next_start
+            .map(u32::try_from)
+            .transpose()
+            .map_err(|_| NativeHistoryError::InvalidResponse)?,
+        head_from_unix: continuation.head_from_unix,
+        head_through_unix: continuation.head_through_unix,
+        head_overlap_row_ids: continuation.head_overlap_row_ids.clone(),
+    })
+}
+
+pub(super) fn observe_aggregate(
+    store_set: &mut OpenSubsonicStoreSet,
+    song: &ServerSong,
+    observed_at_unix: i64,
+) -> Result<(), BridgeMutationError> {
+    if song.play_count.is_none() && song.played_at.is_none() {
+        return Ok(());
+    }
+    if store_set
+        .bridge_state
+        .has_unresolved_outbound_submission(song.item.item_id())
+    {
+        // An ambiguous local submission owns speculative exact evidence. Advancing the raw
+        // aggregate shadow here could consume an unrelated mobile increment and make it
+        // unrecoverable. Keep the prior shadow so the same server value is retried after explicit
+        // resolution or an exact native echo.
+        return Ok(());
+    }
+    let previous_shadow = store_set
+        .bridge_state
+        .aggregate_play_shadows()
+        .get(song.item.item_id())
+        .cloned();
+    let previous = previous_shadow
+        .as_ref()
+        .map(|shadow| AggregateHistoryShadow {
+            play_count: shadow.play_count,
+            played_at_unix: shadow.played_at.as_deref().and_then(parse_rfc3339_unix),
+            observed_at_unix: shadow.observed_at_unix,
+            counter_epoch: shadow.counter_epoch,
+        });
+    let plan = plan_aggregate_history(previous.as_ref(), song, observed_at_unix);
+    let track = portable_server_track(song);
+    let artist_key = crate::signals::normalize_artist(&track.artist);
+    let played_at = song
+        .played_at
+        .as_ref()
+        .filter(|value| parse_rfc3339_unix(value).is_some())
+        .cloned()
+        .or_else(|| {
+            previous_shadow
+                .as_ref()
+                .and_then(|shadow| shadow.played_at.clone())
+                .filter(|value| parse_rfc3339_unix(value).is_some())
+        });
+    store_set.bridge_state.upsert_aggregate_play_shadow(
+        song.item.item_id().clone(),
+        AggregatePlayShadow {
+            play_count: plan.next_shadow.play_count,
+            // Missing/malformed values create count-only evidence but never erase a stronger time.
+            played_at,
+            observed_at_unix,
+            counter_epoch: plan.next_shadow.counter_epoch,
+        },
+    )?;
+    if plan.baseline_only_delta > 0 {
+        store_set.bridge_state.reconcile_native_aggregate_baseline(
+            song.item.item_id().clone(),
+            plan.next_shadow.counter_epoch,
+            plan.baseline_only_delta,
+        )?;
+    }
+    if let Some(range) = plan.range {
+        store_set
+            .bridge_state
+            .queue_aggregate_range(PendingAggregateRange {
+                track,
+                artist_key,
+                counter_epoch: plan.next_shadow.counter_epoch,
+                range,
+            })?;
+        store_set
+            .bridge_state
+            .materialize_pending_aggregate_ranges()?;
+    }
+    Ok(())
+}
+
+pub(super) fn next_counter_epoch(previous: Option<&AggregatePlayShadow>, play_count: u64) -> u64 {
+    previous.map_or(0, |shadow| {
+        shadow
+            .counter_epoch
+            .saturating_add(u64::from(play_count < shadow.play_count))
+    })
+}

--- a/src/open_subsonic/bridge_runtime/outbound_resolution.rs
+++ b/src/open_subsonic/bridge_runtime/outbound_resolution.rs
@@ -1,0 +1,80 @@
+//! Explicit recovery for outbound reports whose delivery cannot be proven.
+
+use super::{BridgeRuntime, OutboundScrobbleResolution, mutation_error, outbound_echo};
+use crate::open_subsonic::actor::ServiceError;
+use crate::open_subsonic::bridge_store::{BridgeMutationError, OutboundScrobbleDelivery};
+use crate::open_subsonic::transaction::OpenSubsonicStoreSet;
+
+impl BridgeRuntime {
+    pub(crate) fn outbound_scrobble_attention_ids(
+        &self,
+        store_set: &OpenSubsonicStoreSet,
+    ) -> Vec<String> {
+        store_set.bridge_state.outbound_scrobble_attention_ids()
+    }
+
+    pub(crate) fn resolve_outbound_scrobble(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        event_id: &str,
+        resolution: OutboundScrobbleResolution,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Err(ServiceError::InvalidSetup);
+        }
+        let Some(mut pending) = store_set
+            .bridge_state
+            .outbound_scrobbles()
+            .iter()
+            .find(|pending| pending.event_id == event_id)
+            .cloned()
+        else {
+            return Err(ServiceError::InvalidSetup);
+        };
+        if pending.delivery != OutboundScrobbleDelivery::NeedsAttention {
+            return Err(ServiceError::InvalidSetup);
+        }
+
+        let before = store_set.bridge_state.clone();
+        let mutation = (|| {
+            match resolution {
+                OutboundScrobbleResolution::Retry => {
+                    if pending.exact_credit_recorded {
+                        store_set.bridge_state.discard_exact_history_evidence(
+                            &pending.item_id,
+                            pending
+                                .exact_credit_epoch
+                                .ok_or(BridgeMutationError::InvalidEntry)?,
+                        );
+                    }
+                    pending.delivery = OutboundScrobbleDelivery::Queued;
+                    pending.baseline_captured = false;
+                    pending.baseline_play_count = None;
+                    pending.baseline_played_at = None;
+                    pending.exact_credit_recorded = false;
+                    pending.exact_credit_epoch = None;
+                    pending.uncertain_readbacks = 0;
+                    store_set.bridge_state.replace_outbound_scrobble(pending)?;
+                }
+                OutboundScrobbleResolution::MarkSent => {
+                    store_set
+                        .bridge_state
+                        .record_outbound_echo(outbound_echo(&pending))?;
+                    store_set
+                        .bridge_state
+                        .complete_outbound_scrobble(&pending.event_id)?;
+                }
+            }
+            store_set
+                .bridge_state
+                .materialize_pending_aggregate_ranges()?;
+            Ok::<(), BridgeMutationError>(())
+        })();
+        if let Err(error) = mutation {
+            store_set.bridge_state = before;
+            return Err(mutation_error(error));
+        }
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+}

--- a/src/open_subsonic/bridge_runtime_tests.rs
+++ b/src/open_subsonic/bridge_runtime_tests.rs
@@ -1,0 +1,1487 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use age::secrecy::SecretString;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+use super::bridge_event::portable_server_track;
+use super::bridge_runtime::{
+    BridgeRuntime, HistoryRefreshResult, NativeHistoryBatch, NativeHistoryObservation,
+    completed_history_overlap,
+};
+use super::bridge_store::{
+    HistoryContinuation, HistoryCursor, OutboundScrobbleDelivery, OutboundScrobbleKind,
+    PendingNativeMetadataRow, PendingRatingProjectionStage,
+};
+use super::*;
+use crate::personal_state::{
+    OpenSubsonicRatingWinner, OperationOrigin, PortableTrack, PortableTrackKey, Rating,
+};
+
+static NEXT_ROOT: AtomicU64 = AtomicU64::new(1);
+
+mod aggregate_continuation;
+mod rating_projection;
+mod scrobble_delivery;
+
+async fn fixture(
+    port: u16,
+    sink: Option<OpenSubsonicBridgeSink>,
+) -> (
+    std::path::PathBuf,
+    OpenSubsonicPaths,
+    OpenSubsonicStoreSet,
+    OpenSubsonicClient,
+    BridgeRuntime,
+) {
+    let backend_id = BackendId::new("bridge-backend").unwrap();
+    let account_scope_id = AccountScopeId::new("bridge-account").unwrap();
+    let profile = OpenSubsonicProfile::with_ids(
+        0,
+        backend_id.clone(),
+        account_scope_id.clone(),
+        "Bridge server",
+        ConfiguredPrivateOrigin::new(&format!("http://127.0.0.1:{port}/"), true).unwrap(),
+        None,
+    )
+    .unwrap();
+    let private_state = OpenSubsonicPrivateState::new(
+        backend_id.clone(),
+        account_scope_id.clone(),
+        ServerCredential::api_key(SecretString::from("test-api-key".to_owned())).unwrap(),
+    );
+    let bridge_state = OpenSubsonicBridgeState::new(backend_id, account_scope_id);
+    let mut store_set = OpenSubsonicStoreSet::new(profile, private_state, bridge_state).unwrap();
+    let root = std::env::temp_dir().join(format!(
+        "yututui-bridge-runtime-{}-{}",
+        std::process::id(),
+        NEXT_ROOT.fetch_add(1, Ordering::Relaxed)
+    ));
+    let paths = OpenSubsonicPaths::for_data_root(root.clone());
+    commit_store_set(&paths, StoreRevisions::MISSING, &mut store_set).unwrap();
+    let client = OpenSubsonicClient::connect(&store_set.profile)
+        .await
+        .unwrap();
+    let runtime = BridgeRuntime::writable(paths.clone(), sink);
+    (root, paths, store_set, client, runtime)
+}
+
+fn song(store_set: &OpenSubsonicStoreSet, rating: i64, play_count: u64) -> ServerSong {
+    ServerSong {
+        item: OpenSubsonicItemRef::new(
+            store_set.profile.backend_id().clone(),
+            store_set.profile.account_scope_id().clone(),
+            ItemId::new("song-1").unwrap(),
+        ),
+        title: "Server song".to_owned(),
+        artist: "Server artist".to_owned(),
+        artists: Vec::new(),
+        album: Some("Server album".to_owned()),
+        album_id: None,
+        album_artist: None,
+        duration_secs: Some(180),
+        track_number: None,
+        disc_number: None,
+        year: None,
+        cover_art_id: None,
+        content_type: None,
+        suffix: None,
+        starred: rating == 5,
+        user_rating: Some(rating),
+        play_count: Some(play_count),
+        played_at: Some("2026-07-26T00:00:00Z".to_owned()),
+    }
+}
+
+fn scrobble_track(store_set: &OpenSubsonicStoreSet) -> crate::scrobble::ScrobbleTrack {
+    scrobble_track_for(store_set, "song-1", 1_774_483_200)
+}
+
+fn scrobble_track_for(
+    store_set: &OpenSubsonicStoreSet,
+    item_id: &str,
+    started_unix: i64,
+) -> crate::scrobble::ScrobbleTrack {
+    crate::scrobble::ScrobbleTrack {
+        key: item_id.to_owned(),
+        open_subsonic_item: Some(OpenSubsonicItemRef::new(
+            store_set.profile.backend_id().clone(),
+            store_set.profile.account_scope_id().clone(),
+            ItemId::new(item_id).unwrap(),
+        )),
+        artist: "Server artist".to_owned(),
+        title: if item_id == "song-1" {
+            "Server song".to_owned()
+        } else {
+            format!("Server song {item_id}")
+        },
+        album: Some("Server album".to_owned()),
+        duration_secs: Some(180),
+        origin_url: None,
+        started_unix,
+    }
+}
+
+fn rating_winner(
+    store_set: &OpenSubsonicStoreSet,
+    item_id: &str,
+    operation_id: &str,
+) -> OpenSubsonicRatingWinner {
+    OpenSubsonicRatingWinner {
+        operation_id: operation_id.to_owned(),
+        track: PortableTrack {
+            key: PortableTrackKey::OpenSubsonic {
+                backend_id: store_set.profile.backend_id().as_str().to_owned(),
+                account_scope_id: store_set.profile.account_scope_id().as_str().to_owned(),
+                item_id: item_id.to_owned(),
+            },
+            title: format!("Server song {item_id}"),
+            artist: "Server artist".to_owned(),
+            album: None,
+            duration_secs: Some(180),
+            isrc: None,
+        },
+        rating: Rating::Liked,
+        origin: OperationOrigin::Local,
+    }
+}
+
+#[tokio::test]
+async fn outbound_scrobble_acknowledges_local_durability_without_network() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let track = scrobble_track(&store_set);
+
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "same-second-owner-event-1",
+            OpenSubsonicScrobbleKind::Submission,
+            track.clone(),
+        )
+        .unwrap();
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "same-second-owner-event-2",
+            OpenSubsonicScrobbleKind::Submission,
+            track,
+        )
+        .unwrap();
+
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(durable.bridge_state.outbound_scrobbles().len(), 2);
+    assert_ne!(
+        durable.bridge_state.outbound_scrobbles()[0].event_id,
+        durable.bridge_state.outbound_scrobbles()[1].event_id,
+        "distinct owner events in the same second must not collapse"
+    );
+    assert_eq!(
+        durable
+            .bridge_state
+            .outbound_scrobbles()
+            .front()
+            .unwrap()
+            .item_id
+            .as_str(),
+        "song-1"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn activation_discards_stale_now_playing_but_preserves_exact_submission() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let track = scrobble_track(&store_set);
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "stale-now-playing",
+            OpenSubsonicScrobbleKind::NowPlaying,
+            track.clone(),
+        )
+        .unwrap();
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "durable-submission",
+            OpenSubsonicScrobbleKind::Submission,
+            track,
+        )
+        .unwrap();
+
+    runtime
+        .refresh_snapshot_for_activation(&mut store_set)
+        .unwrap();
+
+    assert_eq!(store_set.bridge_state.outbound_scrobbles().len(), 1);
+    assert_eq!(
+        store_set.bridge_state.outbound_scrobbles()[0].kind,
+        OutboundScrobbleKind::Submission
+    );
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(durable.bridge_state.outbound_scrobbles().len(), 1);
+    assert_eq!(
+        durable.bridge_state.outbound_scrobbles()[0].kind,
+        OutboundScrobbleKind::Submission
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn outbound_scrobble_rejects_read_only_missing_and_foreign_scope_without_acknowledgement() {
+    let (root, _paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let track = scrobble_track(&store_set);
+
+    assert_eq!(
+        BridgeRuntime::read_only().queue_scrobble(
+            &mut store_set,
+            "read-only",
+            OpenSubsonicScrobbleKind::Submission,
+            track.clone(),
+        ),
+        Err(ServiceError::InvalidSetup)
+    );
+    let mut missing_item = track.clone();
+    missing_item.open_subsonic_item = None;
+    assert_eq!(
+        runtime.queue_scrobble(
+            &mut store_set,
+            "missing-item",
+            OpenSubsonicScrobbleKind::Submission,
+            missing_item,
+        ),
+        Err(ServiceError::InvalidSetup)
+    );
+
+    for (event_id, backend_id, account_scope_id) in [
+        (
+            "foreign-profile",
+            BackendId::new("other-backend").unwrap(),
+            store_set.profile.account_scope_id().clone(),
+        ),
+        (
+            "foreign-account",
+            store_set.profile.backend_id().clone(),
+            AccountScopeId::new("other-account").unwrap(),
+        ),
+    ] {
+        let mut foreign = track.clone();
+        foreign.open_subsonic_item = Some(OpenSubsonicItemRef::new(
+            backend_id,
+            account_scope_id,
+            ItemId::new("song-1").unwrap(),
+        ));
+        assert_eq!(
+            runtime.queue_scrobble(
+                &mut store_set,
+                event_id,
+                OpenSubsonicScrobbleKind::Submission,
+                foreign,
+            ),
+            Err(ServiceError::Server(ServerError::WrongAccountScope))
+        );
+    }
+    assert!(store_set.bridge_state.outbound_scrobbles().is_empty());
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn rating_projection_receipt_is_durable_without_contacting_the_server() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let winner = OpenSubsonicRatingWinner {
+        operation_id: "offline-rating-op".to_owned(),
+        track: PortableTrack {
+            key: PortableTrackKey::OpenSubsonic {
+                backend_id: store_set.profile.backend_id().as_str().to_owned(),
+                account_scope_id: store_set.profile.account_scope_id().as_str().to_owned(),
+                item_id: "song-1".to_owned(),
+            },
+            title: "Server song".to_owned(),
+            artist: "Server artist".to_owned(),
+            album: None,
+            duration_secs: Some(180),
+            isrc: None,
+        },
+        rating: Rating::Liked,
+        origin: OperationOrigin::Local,
+    };
+
+    runtime
+        .reconcile_ratings(&mut store_set, vec![winner])
+        .unwrap();
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(durable.bridge_state.pending_rating_projections().len(), 1);
+    assert_eq!(
+        durable
+            .bridge_state
+            .pending_rating_projections()
+            .values()
+            .next()
+            .unwrap()
+            .stage,
+        PendingRatingProjectionStage::SetRating
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn native_history_health_transition_is_durable_and_redacted() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    runtime
+        .set_native_history_health(&mut store_set, NativeHistoryHealth::Detailed)
+        .unwrap();
+    assert_eq!(
+        load_store_set(&paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .native_history_health(),
+        NativeHistoryHealth::Detailed
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn revision_conflict_rebases_memory_before_a_retry() {
+    let (root, paths, mut stale, _client, runtime) = fixture(9, None).await;
+    let mut concurrent = load_store_set(&paths).unwrap().unwrap();
+    concurrent
+        .bridge_state
+        .set_native_history_health(NativeHistoryHealth::Probing);
+    let expected = concurrent.revisions();
+    commit_store_set(&paths, expected, &mut concurrent).unwrap();
+
+    assert_eq!(
+        runtime.set_native_history_health(&mut stale, NativeHistoryHealth::Detailed),
+        Err(ServiceError::Store(StoreError::RevisionConflict))
+    );
+    assert_eq!(
+        stale.bridge_state.native_history_health(),
+        NativeHistoryHealth::Probing,
+        "a rejected mutation must leave the actor on the latest coherent snapshot"
+    );
+    assert_eq!(stale.revisions(), concurrent.revisions());
+
+    runtime
+        .set_native_history_health(&mut stale, NativeHistoryHealth::Detailed)
+        .unwrap();
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        durable.bridge_state.native_history_health(),
+        NativeHistoryHealth::Detailed
+    );
+    assert_eq!(stale.revisions(), durable.revisions());
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn response_lost_after_commit_marker_recovers_as_durable_success() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    super::transaction::fail_after_commit_marker_once_for_test();
+
+    runtime
+        .set_native_history_health(&mut store_set, NativeHistoryHealth::Detailed)
+        .unwrap();
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(store_set.revisions(), durable.revisions());
+    assert_eq!(
+        durable.bridge_state.native_history_health(),
+        NativeHistoryHealth::Detailed
+    );
+
+    let committed_revision = store_set.bridge_state.revision();
+    runtime
+        .set_native_history_health(&mut store_set, NativeHistoryHealth::Detailed)
+        .unwrap();
+    assert_eq!(
+        store_set.bridge_state.revision(),
+        committed_revision,
+        "replaying the acknowledged mutation must not create a second commit"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn progressive_history_cursor_survives_restart_and_rejects_stale_results() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let initial = HistoryCursor {
+        high_water_id: Some("100".to_owned()),
+        overlap_started_at_unix: Some(1_000),
+        updated_at_unix: 10,
+        continuation: None,
+        pending_metadata_rows: Vec::new(),
+    };
+    store_set
+        .bridge_state
+        .set_history_cursor("navidrome-native".to_owned(), initial.clone())
+        .unwrap();
+    let expected = store_set.revisions();
+    commit_store_set(&paths, expected, &mut store_set).unwrap();
+
+    let progress = HistoryCursor {
+        high_water_id: initial.high_water_id.clone(),
+        overlap_started_at_unix: Some(800),
+        updated_at_unix: 20,
+        continuation: Some(HistoryContinuation {
+            candidate_high_water_id: Some("300".to_owned()),
+            next_start: 400,
+            through_unix: Some(800),
+            reached_high_water: false,
+            overlap_row_ids: vec![250, 249],
+            backlog_complete: false,
+            head_anchor_high_water_id: None,
+            head_next_start: None,
+            head_from_unix: None,
+            head_through_unix: None,
+            head_overlap_row_ids: Vec::new(),
+        }),
+        pending_metadata_rows: (1..=65)
+            .rev()
+            .map(|id| PendingNativeMetadataRow {
+                row_id: id,
+                item_id: ItemId::new(format!("pending-song-{id}")).unwrap(),
+                observed_at_unix: i64::try_from(id).unwrap(),
+            })
+            .collect(),
+    };
+    let mut result = history_result(
+        &store_set,
+        Some(initial.clone()),
+        Some(progress.clone()),
+        true,
+    );
+    if let Ok(Some(batch)) = &mut result.native {
+        batch.metadata_retry_pending = true;
+    }
+    let outcome = runtime
+        .apply_history_refresh(&mut store_set, result)
+        .unwrap();
+    assert!(outcome.native_truncated);
+    assert!(!outcome.native_stale);
+    assert_eq!(
+        outcome.native_error,
+        Some(NativeHistoryError::TemporarilyUnavailable),
+        "a metadata retry must not silently report detailed history as healthy"
+    );
+    assert_eq!(
+        store_set
+            .bridge_state
+            .history_cursors()
+            .get("navidrome-native"),
+        Some(&progress),
+        "a partial refresh must retain the old committed high-water"
+    );
+
+    let mut restarted = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        restarted
+            .bridge_state
+            .history_cursors()
+            .get("navidrome-native"),
+        Some(&progress),
+        "page/time progress must survive an owner restart"
+    );
+
+    let stale_cursor = HistoryCursor {
+        high_water_id: Some("999".to_owned()),
+        overlap_started_at_unix: None,
+        updated_at_unix: 30,
+        continuation: None,
+        pending_metadata_rows: Vec::new(),
+    };
+    let stale = runtime
+        .apply_history_refresh(
+            &mut restarted,
+            history_result(&store_set, Some(initial), Some(stale_cursor), false),
+        )
+        .unwrap();
+    assert!(stale.native_stale);
+    assert_eq!(
+        restarted
+            .bridge_state
+            .history_cursors()
+            .get("navidrome-native"),
+        Some(&progress),
+        "same high-water but an older continuation generation must not overwrite progress"
+    );
+
+    let completed = HistoryCursor {
+        high_water_id: Some("300".to_owned()),
+        overlap_started_at_unix: Some(100),
+        updated_at_unix: 40,
+        continuation: None,
+        pending_metadata_rows: Vec::new(),
+    };
+    let completed_result =
+        history_result(&restarted, Some(progress), Some(completed.clone()), false);
+    let outcome = runtime
+        .apply_history_refresh(&mut restarted, completed_result)
+        .unwrap();
+    assert!(!outcome.native_stale);
+    assert_eq!(
+        restarted
+            .bridge_state
+            .history_cursors()
+            .get("navidrome-native"),
+        Some(&completed),
+        "only a completed continuation commits the accumulated candidate high-water"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn failed_cursor_commit_does_not_advance_past_unresolved_metadata() {
+    let (root, _paths, mut store_set, _client, _runtime) = fixture(9, None).await;
+    let unresolved = HistoryCursor {
+        high_water_id: Some("2".to_owned()),
+        overlap_started_at_unix: Some(1),
+        updated_at_unix: 2,
+        continuation: None,
+        pending_metadata_rows: vec![PendingNativeMetadataRow {
+            row_id: 2,
+            item_id: ItemId::new("pending-song-2").unwrap(),
+            observed_at_unix: 2,
+        }],
+    };
+    let result = history_result(&store_set, None, Some(unresolved), true);
+
+    let error = BridgeRuntime::read_only()
+        .apply_history_refresh(&mut store_set, result)
+        .unwrap_err();
+
+    assert!(matches!(error, ServiceError::InvalidSetup));
+    assert!(
+        store_set
+            .bridge_state
+            .history_cursors()
+            .get("navidrome-native")
+            .is_none(),
+        "a rejected apply must retain the old cursor so the upstream row is scanned again"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn continuation_completion_without_new_rows_preserves_the_bounded_overlap() {
+    let cursor = HistoryCursor {
+        high_water_id: Some("100".to_owned()),
+        overlap_started_at_unix: Some(800),
+        updated_at_unix: 20,
+        continuation: Some(HistoryContinuation {
+            candidate_high_water_id: Some("300".to_owned()),
+            next_start: 400,
+            through_unix: Some(800),
+            reached_high_water: true,
+            overlap_row_ids: vec![250, 249],
+            backlog_complete: true,
+            head_anchor_high_water_id: Some("100".to_owned()),
+            head_next_start: Some(200),
+            head_from_unix: Some(800),
+            head_through_unix: Some(900),
+            head_overlap_row_ids: vec![300, 299],
+        }),
+        pending_metadata_rows: Vec::new(),
+    };
+    assert_eq!(completed_history_overlap(Some(&cursor), &[]), Some(800));
+}
+
+fn history_result(
+    store_set: &OpenSubsonicStoreSet,
+    base_cursor: Option<HistoryCursor>,
+    next_cursor: Option<HistoryCursor>,
+    truncated: bool,
+) -> HistoryRefreshResult {
+    HistoryRefreshResult {
+        backend_id: store_set.profile.backend_id().clone(),
+        account_scope_id: store_set.profile.account_scope_id().clone(),
+        base_cursor,
+        native: Ok(Some(NativeHistoryBatch {
+            rows: Vec::new(),
+            aggregate_baselines: std::collections::BTreeMap::new(),
+            next_cursor,
+            truncated,
+            metadata_retry_pending: false,
+        })),
+        standard: Ok(Vec::new()),
+    }
+}
+
+fn native_history_result(
+    store_set: &OpenSubsonicStoreSet,
+    row_time: i64,
+    play_count: u64,
+    played_at: &str,
+) -> HistoryRefreshResult {
+    let item_id = ItemId::new("song-1").unwrap();
+    HistoryRefreshResult {
+        backend_id: store_set.profile.backend_id().clone(),
+        account_scope_id: store_set.profile.account_scope_id().clone(),
+        base_cursor: None,
+        native: Ok(Some(NativeHistoryBatch {
+            rows: vec![NativeHistoryObservation {
+                row_id: 77,
+                item_id: item_id.clone(),
+                track: portable_server_track(&song(store_set, 5, play_count)),
+                observed_at_unix: row_time,
+            }],
+            aggregate_baselines: std::iter::once((
+                item_id,
+                (play_count, Some(played_at.to_owned())),
+            ))
+            .collect(),
+            next_cursor: None,
+            truncated: false,
+            metadata_retry_pending: false,
+        })),
+        standard: Ok(Vec::new()),
+    }
+}
+
+#[tokio::test]
+async fn exact_history_credits_distinguish_covered_backfill_from_aggregate_lag() {
+    let (root, _paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let mut baseline = song(&store_set, 5, 10);
+    baseline.played_at = Some("1970-01-01T00:01:40Z".to_owned());
+    runtime.observe_songs(&mut store_set, &[baseline]).unwrap();
+
+    let covered_backfill = native_history_result(&store_set, 90, 10, "1970-01-01T00:01:40Z");
+    runtime
+        .apply_history_refresh(&mut store_set, covered_backfill)
+        .unwrap();
+    assert_eq!(store_set.bridge_state.pending_engagement_imports().len(), 1);
+    assert!(
+        store_set.bridge_state.history_dedupe_credits().is_empty(),
+        "an exact backfill at or before the established played watermark is already in the baseline"
+    );
+
+    let mut next_play = song(&store_set, 5, 11);
+    next_play.played_at = Some("1970-01-01T00:01:50Z".to_owned());
+    runtime.observe_songs(&mut store_set, &[next_play]).unwrap();
+    assert_eq!(
+        store_set.bridge_state.pending_engagement_imports().len(),
+        2,
+        "the next distinct aggregate play must not be consumed by an old exact credit"
+    );
+
+    let (lag_root, _paths, mut lag, _client, lag_runtime) = fixture(9, None).await;
+    let mut lag_baseline = song(&lag, 5, 10);
+    lag_baseline.played_at = Some("1970-01-01T00:01:40Z".to_owned());
+    lag_runtime
+        .observe_songs(&mut lag, &[lag_baseline])
+        .unwrap();
+    let aggregate_lag = native_history_result(&lag, 110, 10, "1970-01-01T00:01:40Z");
+    lag_runtime
+        .apply_history_refresh(&mut lag, aggregate_lag)
+        .unwrap();
+    assert_eq!(lag.bridge_state.history_dedupe_credits().len(), 1);
+    let mut caught_up = song(&lag, 5, 11);
+    caught_up.played_at = Some("1970-01-01T00:01:50Z".to_owned());
+    lag_runtime.observe_songs(&mut lag, &[caught_up]).unwrap();
+    assert_eq!(
+        lag.bridge_state.pending_engagement_imports().len(),
+        1,
+        "a count that catches up to the newer exact row must be suppressed as its aggregate echo"
+    );
+    assert!(lag.bridge_state.history_dedupe_credits().is_empty());
+
+    let _ = std::fs::remove_dir_all(root);
+    let _ = std::fs::remove_dir_all(lag_root);
+}
+
+#[tokio::test]
+async fn response_lost_submission_is_not_resent_and_readback_completes_replay_safely() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let (mut baseline, _) = listener.accept().await.unwrap();
+        assert!(
+            read_request(&mut baseline)
+                .await
+                .contains("/rest/getSong.view?")
+        );
+        write_json(
+            &mut baseline,
+            r#"{"subsonic-response":{"status":"ok","song":{"id":"song-1","title":"Server song","artist":"Server artist","playCount":10,"played":"2026-03-25T00:00:00Z"}}}"#,
+        )
+        .await;
+
+        let (mut lost_response, _) = listener.accept().await.unwrap();
+        assert!(
+            read_request(&mut lost_response)
+                .await
+                .contains("/rest/scrobble.view?")
+        );
+        drop(lost_response);
+
+        let (mut readback, _) = listener.accept().await.unwrap();
+        assert!(
+            read_request(&mut readback)
+                .await
+                .contains("/rest/getSong.view?")
+        );
+        write_json(
+            &mut readback,
+            r#"{"subsonic-response":{"status":"ok","song":{"id":"song-1","title":"Server song","artist":"Server artist","playCount":11,"played":"2026-03-26T00:00:00Z"}}}"#,
+        )
+        .await;
+    });
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let track = scrobble_track(&store_set);
+
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "stable-response-lost-event",
+            OpenSubsonicScrobbleKind::Submission,
+            track.clone(),
+        )
+        .unwrap();
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    assert!(
+        runtime
+            .retry_network(&mut store_set, &client)
+            .await
+            .is_err()
+    );
+    let uncertain = load_store_set(&paths).unwrap().unwrap();
+    let pending = uncertain.bridge_state.outbound_scrobbles().front().unwrap();
+    assert_eq!(pending.delivery, OutboundScrobbleDelivery::Uncertain);
+    assert!(pending.exact_credit_recorded);
+
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    let completed = load_store_set(&paths).unwrap().unwrap();
+    assert!(completed.bridge_state.outbound_scrobbles().is_empty());
+    assert!(
+        completed
+            .bridge_state
+            .pending_engagement_imports()
+            .is_empty(),
+        "aggregate readback must consume the local exact credit"
+    );
+
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "stable-response-lost-event",
+            OpenSubsonicScrobbleKind::Submission,
+            track,
+        )
+        .unwrap();
+    assert!(
+        load_store_set(&paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .outbound_scrobbles()
+            .is_empty(),
+        "owner replay after acknowledgement must remain a durable no-op"
+    );
+
+    server.await.unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn definite_rejection_restores_a_retriable_queue_without_exact_credit() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let (mut baseline, _) = listener.accept().await.unwrap();
+        assert!(
+            read_request(&mut baseline)
+                .await
+                .contains("/rest/getSong.view?")
+        );
+        write_json(
+            &mut baseline,
+            r#"{"subsonic-response":{"status":"ok","song":{"id":"song-1","title":"Server song","artist":"Server artist","playCount":10}}}"#,
+        )
+        .await;
+
+        let (mut rejected, _) = listener.accept().await.unwrap();
+        assert!(
+            read_request(&mut rejected)
+                .await
+                .contains("/rest/scrobble.view?")
+        );
+        rejected
+            .write_all(
+                b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            )
+            .await
+            .unwrap();
+    });
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let track = scrobble_track(&store_set);
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "definitely-rejected-event",
+            OpenSubsonicScrobbleKind::Submission,
+            track,
+        )
+        .unwrap();
+
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    assert!(
+        runtime
+            .retry_network(&mut store_set, &client)
+            .await
+            .is_err()
+    );
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    let pending = durable.bridge_state.outbound_scrobbles().front().unwrap();
+    assert_eq!(pending.delivery, OutboundScrobbleDelivery::Queued);
+    assert!(!pending.exact_credit_recorded);
+    assert!(durable.bridge_state.history_dedupe_credits().is_empty());
+
+    server.await.unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn observations_are_durable_until_owner_ack_and_aggregate_is_delta_only() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    let sink: OpenSubsonicBridgeSink = Arc::new(move |event| {
+        captured.lock().unwrap().push(event);
+    });
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, Some(sink)).await;
+
+    let first_song = song(&store_set, 5, 10);
+    runtime
+        .observe_songs(&mut store_set, &[first_song])
+        .unwrap();
+    let first = events.lock().unwrap().clone();
+    assert_eq!(first.len(), 1);
+    assert!(matches!(
+        &first[0],
+        OpenSubsonicBridgeImport::Rating {
+            rating: Rating::Liked,
+            ..
+        }
+    ));
+    let operation_id = first[0].operation_id().to_owned();
+    assert_eq!(
+        load_store_set(&paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .pending_rating_imports()
+            .len(),
+        1
+    );
+
+    runtime
+        .acknowledge_import(&mut store_set, &operation_id)
+        .unwrap();
+    events.lock().unwrap().clear();
+    let changed_song = song(&store_set, 1, 12);
+    runtime
+        .observe_songs(&mut store_set, &[changed_song])
+        .unwrap();
+    let second = events.lock().unwrap().clone();
+    assert_eq!(
+        second
+            .iter()
+            .filter(|event| matches!(event, OpenSubsonicBridgeImport::Rating { .. }))
+            .count(),
+        1
+    );
+    assert_eq!(
+        second
+            .iter()
+            .filter(|event| matches!(event, OpenSubsonicBridgeImport::Engagement { .. }))
+            .count(),
+        2
+    );
+    assert!(second.iter().any(|event| matches!(
+        event,
+        OpenSubsonicBridgeImport::Rating {
+            rating: Rating::Disliked,
+            ..
+        }
+    )));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn count_only_aggregate_growth_consumes_exact_credit_before_importing() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    let sink: OpenSubsonicBridgeSink = Arc::new(move |event| {
+        captured.lock().unwrap().push(event);
+    });
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, Some(sink)).await;
+
+    let baseline = song(&store_set, 5, 10);
+    runtime.observe_songs(&mut store_set, &[baseline]).unwrap();
+    events.lock().unwrap().clear();
+
+    let item_id = ItemId::new("song-1").unwrap();
+    let counter_epoch = store_set
+        .bridge_state
+        .aggregate_play_shadows()
+        .get(&item_id)
+        .unwrap()
+        .counter_epoch;
+    assert!(
+        store_set
+            .bridge_state
+            .record_exact_history_evidence(item_id.clone(), counter_epoch)
+            .unwrap()
+    );
+
+    let mut count_only = song(&store_set, 5, 11);
+    count_only.played_at = None;
+    runtime
+        .observe_songs(&mut store_set, &[count_only])
+        .unwrap();
+    assert!(
+        events
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|event| !matches!(event, OpenSubsonicBridgeImport::Engagement { .. }))
+    );
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert!(durable.bridge_state.pending_engagement_imports().is_empty());
+    assert!(durable.bridge_state.history_dedupe_credits().is_empty());
+
+    events.lock().unwrap().clear();
+    let mut verified = song(&store_set, 5, 12);
+    verified.played_at = Some("2026-07-26T00:01:00Z".to_owned());
+    runtime.observe_songs(&mut store_set, &[verified]).unwrap();
+    assert_eq!(
+        events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|event| matches!(event, OpenSubsonicBridgeImport::Engagement { .. }))
+            .count(),
+        1,
+        "the count-only delta consumes only the matching exact credit"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn count_only_growth_is_durable_retry_stable_and_accepts_invalid_played() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let baseline = song(&store_set, 5, 10);
+    let baseline_played = baseline.played_at.clone();
+    runtime.observe_songs(&mut store_set, &[baseline]).unwrap();
+
+    let mut missing = song(&store_set, 5, 12);
+    missing.played_at = None;
+    runtime
+        .observe_songs(&mut store_set, &[missing.clone()])
+        .unwrap();
+    let ids = store_set
+        .bridge_state
+        .pending_engagement_imports()
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(ids.len(), 2);
+    assert!(
+        store_set
+            .bridge_state
+            .pending_engagement_imports()
+            .values()
+            .all(|pending| {
+                pending.engagement == crate::personal_state::EngagementKind::Play
+                    && pending.played_duration_ms.is_none()
+            })
+    );
+    assert_eq!(
+        store_set
+            .bridge_state
+            .aggregate_play_shadows()
+            .get(missing.item.item_id())
+            .unwrap()
+            .played_at,
+        baseline_played
+    );
+
+    runtime
+        .observe_songs(&mut store_set, &[missing.clone()])
+        .unwrap();
+    assert_eq!(
+        store_set
+            .bridge_state
+            .pending_engagement_imports()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>(),
+        ids,
+        "retrying the same counter observation must not mint new events"
+    );
+
+    let mut restarted = load_store_set(&paths).unwrap().unwrap();
+    runtime.observe_songs(&mut restarted, &[missing]).unwrap();
+    assert_eq!(
+        restarted
+            .bridge_state
+            .pending_engagement_imports()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>(),
+        ids,
+        "restart replay must preserve the same durable event identities"
+    );
+
+    let mut invalid = song(&restarted, 5, 14);
+    invalid.played_at = Some("not-a-timestamp".to_owned());
+    runtime.observe_songs(&mut restarted, &[invalid]).unwrap();
+    assert_eq!(
+        restarted.bridge_state.pending_engagement_imports().len(),
+        4,
+        "invalid played is the same low-confidence count-only fallback as missing played"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn rating_partial_failure_resumes_from_durable_stage_and_requires_readback() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        for (endpoint, body) in [
+            (
+                "/rest/setRating.view?",
+                r#"{"subsonic-response":{"status":"ok"}}"#,
+            ),
+            (
+                "/rest/star.view?",
+                r#"{"subsonic-response":{"status":"failed","error":{"code":50}}}"#,
+            ),
+            (
+                "/rest/star.view?",
+                r#"{"subsonic-response":{"status":"ok"}}"#,
+            ),
+            (
+                "/rest/getSong.view?",
+                r#"{"subsonic-response":{"status":"ok","song":{"id":"song-1","title":"Server song","artist":"Server artist","userRating":5,"starred":"2026-07-26T00:00:00Z"}}}"#,
+            ),
+        ] {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut stream).await;
+            assert!(
+                request
+                    .lines()
+                    .next()
+                    .unwrap_or_default()
+                    .contains(endpoint),
+                "{request}"
+            );
+            write_json(&mut stream, body).await;
+        }
+    });
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let track = PortableTrack {
+        key: PortableTrackKey::OpenSubsonic {
+            backend_id: store_set.profile.backend_id().as_str().to_owned(),
+            account_scope_id: store_set.profile.account_scope_id().as_str().to_owned(),
+            item_id: "song-1".to_owned(),
+        },
+        title: "Server song".to_owned(),
+        artist: "Server artist".to_owned(),
+        album: None,
+        duration_secs: Some(180),
+        isrc: None,
+    };
+    let winner = OpenSubsonicRatingWinner {
+        operation_id: "local-rating-op".to_owned(),
+        track,
+        rating: Rating::Liked,
+        origin: OperationOrigin::Local,
+    };
+
+    runtime
+        .reconcile_ratings(&mut store_set, vec![winner])
+        .unwrap();
+    let queued = load_store_set(&paths)
+        .unwrap()
+        .unwrap()
+        .bridge_state
+        .pending_rating_projections()
+        .values()
+        .next()
+        .unwrap()
+        .clone();
+    assert_eq!(queued.stage, PendingRatingProjectionStage::SetRating);
+
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    let pending = load_store_set(&paths)
+        .unwrap()
+        .unwrap()
+        .bridge_state
+        .pending_rating_projections()
+        .values()
+        .next()
+        .unwrap()
+        .clone();
+    assert_eq!(pending.stage, PendingRatingProjectionStage::SetStarred);
+
+    assert!(
+        runtime
+            .retry_network(&mut store_set, &client)
+            .await
+            .is_err()
+    );
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    assert_eq!(
+        load_store_set(&paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .pending_rating_projections()
+            .values()
+            .next()
+            .unwrap()
+            .stage,
+        PendingRatingProjectionStage::Readback
+    );
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert!(durable.bridge_state.pending_rating_projections().is_empty());
+    assert_eq!(
+        durable
+            .bridge_state
+            .rating_shadow(&ItemId::new("song-1").unwrap())
+            .and_then(|shadow| shadow.confirmed_operation_id.as_deref()),
+        Some("local-rating-op")
+    );
+    server.await.unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn failing_rating_does_not_head_of_line_block_later_items() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let failed =
+            r#"{"subsonic-response":{"status":"failed","error":{"code":50,"message":"failed"}}}"#;
+        let ok = r#"{"subsonic-response":{"status":"ok"}}"#;
+        let readback = r#"{"subsonic-response":{"status":"ok","song":{"id":"item-b","title":"Server song item-b","artist":"Server artist","userRating":5,"starred":"2026-07-26T00:00:00Z"}}}"#;
+        for (endpoint, item_id, body) in [
+            ("/rest/setRating.view?", "item-a", failed),
+            ("/rest/setRating.view?", "item-b", ok),
+            ("/rest/setRating.view?", "item-a", failed),
+            ("/rest/star.view?", "item-b", ok),
+            ("/rest/setRating.view?", "item-a", failed),
+            ("/rest/getSong.view?", "item-b", readback),
+        ] {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut stream).await;
+            let request_line = request.lines().next().unwrap_or_default();
+            assert!(request_line.contains(endpoint), "{request_line}");
+            assert!(
+                request_line.contains(&format!("id={item_id}")),
+                "{request_line}"
+            );
+            write_json(&mut stream, body).await;
+        }
+    });
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let rating_a = rating_winner(&store_set, "item-a", "rating-a");
+    let rating_b = rating_winner(&store_set, "item-b", "rating-b");
+    runtime
+        .reconcile_ratings(&mut store_set, vec![rating_a, rating_b])
+        .unwrap();
+
+    for attempt in 0..6 {
+        let result = runtime.retry_network(&mut store_set, &client).await;
+        if attempt % 2 == 0 {
+            assert!(result.is_err(), "item-a must remain a permanent failure");
+        } else {
+            result.unwrap();
+        }
+    }
+
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(durable.bridge_state.pending_rating_projections().len(), 1);
+    assert_eq!(
+        durable
+            .bridge_state
+            .pending_rating_projections()
+            .keys()
+            .next()
+            .unwrap()
+            .as_str(),
+        "item-a"
+    );
+    assert_eq!(
+        durable
+            .bridge_state
+            .pending_rating_projections()
+            .values()
+            .next()
+            .unwrap()
+            .stage,
+        PendingRatingProjectionStage::SetRating
+    );
+    server.await.unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn failing_rating_lane_does_not_block_outbound_lane() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        for (endpoint, item_id, body) in [
+            (
+                "/rest/setRating.view?",
+                "item-a",
+                r#"{"subsonic-response":{"status":"failed","error":{"code":50,"message":"failed"}}}"#,
+            ),
+            (
+                "/rest/getSong.view?",
+                "item-b",
+                r#"{"subsonic-response":{"status":"ok","song":{"id":"item-b","title":"Server song item-b","artist":"Server artist","playCount":10,"played":"2026-03-25T00:00:00Z"}}}"#,
+            ),
+            (
+                "/rest/setRating.view?",
+                "item-a",
+                r#"{"subsonic-response":{"status":"failed","error":{"code":50,"message":"failed"}}}"#,
+            ),
+            (
+                "/rest/scrobble.view?",
+                "item-b",
+                r#"{"subsonic-response":{"status":"ok"}}"#,
+            ),
+        ] {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut stream).await;
+            let request_line = request.lines().next().unwrap_or_default();
+            assert!(request_line.contains(endpoint), "{request_line}");
+            assert!(
+                request_line.contains(&format!("id={item_id}")),
+                "{request_line}"
+            );
+            write_json(&mut stream, body).await;
+        }
+    });
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let rating = rating_winner(&store_set, "item-a", "rating-a");
+    runtime
+        .reconcile_ratings(&mut store_set, vec![rating])
+        .unwrap();
+    let track = scrobble_track_for(&store_set, "item-b", 1_774_483_200);
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "owner-event-b",
+            OpenSubsonicScrobbleKind::Submission,
+            track,
+        )
+        .unwrap();
+
+    assert!(
+        runtime
+            .retry_network(&mut store_set, &client)
+            .await
+            .is_err()
+    );
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    assert!(
+        runtime
+            .retry_network(&mut store_set, &client)
+            .await
+            .is_err()
+    );
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(durable.bridge_state.pending_rating_projections().len(), 1);
+    assert!(durable.bridge_state.outbound_scrobbles().is_empty());
+    server.await.unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn uncertain_scrobble_does_not_head_of_line_block_queued_reports() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let track_a = scrobble_track_for(&store_set, "item-a", 1_774_483_200);
+    let track_b = scrobble_track_for(&store_set, "item-b", 1_774_483_201);
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "owner-event-a",
+            OpenSubsonicScrobbleKind::Submission,
+            track_a,
+        )
+        .unwrap();
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "owner-event-b",
+            OpenSubsonicScrobbleKind::Submission,
+            track_b,
+        )
+        .unwrap();
+    let mut ordered = store_set
+        .bridge_state
+        .outbound_scrobbles()
+        .iter()
+        .map(|pending| (pending.event_id.clone(), pending.item_id.clone()))
+        .collect::<Vec<_>>();
+    ordered.sort_by(|left, right| left.0.cmp(&right.0));
+    let failing_event_id = ordered[0].0.clone();
+    let failing_item_id = ordered[0].1.clone();
+    let succeeding_event_id = ordered[1].0.clone();
+    let succeeding_item_id = ordered[1].1.clone();
+
+    let server_failing_item = failing_item_id.clone();
+    let server_succeeding_item = succeeding_item_id.clone();
+    let server = tokio::spawn(async move {
+        for item_id in [&server_failing_item, &server_succeeding_item] {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut stream).await;
+            let request_line = request.lines().next().unwrap_or_default();
+            assert!(
+                request_line.contains("/rest/getSong.view?"),
+                "{request_line}"
+            );
+            assert!(
+                request_line.contains(&format!("id={}", item_id.as_str())),
+                "{request_line}"
+            );
+            let body = format!(
+                r#"{{"subsonic-response":{{"status":"ok","song":{{"id":"{}","title":"Server song","artist":"Server artist","playCount":10,"played":"2026-03-25T00:00:00Z"}}}}}}"#,
+                item_id.as_str()
+            );
+            write_json(&mut stream, &body).await;
+        }
+
+        let (mut lost_response, _) = listener.accept().await.unwrap();
+        let request = read_request(&mut lost_response).await;
+        let request_line = request.lines().next().unwrap_or_default();
+        assert!(
+            request_line.contains("/rest/scrobble.view?"),
+            "{request_line}"
+        );
+        assert!(
+            request_line.contains(&format!("id={}", server_failing_item.as_str())),
+            "{request_line}"
+        );
+        drop(lost_response);
+
+        let (mut succeeding, _) = listener.accept().await.unwrap();
+        let request = read_request(&mut succeeding).await;
+        let request_line = request.lines().next().unwrap_or_default();
+        assert!(
+            request_line.contains("/rest/scrobble.view?"),
+            "{request_line}"
+        );
+        assert!(
+            request_line.contains(&format!("id={}", server_succeeding_item.as_str())),
+            "{request_line}"
+        );
+        write_json(&mut succeeding, r#"{"subsonic-response":{"status":"ok"}}"#).await;
+    });
+
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    assert!(
+        runtime
+            .retry_network(&mut store_set, &client)
+            .await
+            .is_err(),
+        "the first submission loses its response and becomes uncertain"
+    );
+    let after_loss = load_store_set(&paths).unwrap().unwrap();
+    let uncertain = after_loss
+        .bridge_state
+        .outbound_scrobbles()
+        .iter()
+        .find(|pending| pending.event_id == failing_event_id)
+        .unwrap();
+    assert_eq!(uncertain.delivery, OutboundScrobbleDelivery::Uncertain);
+    assert!(uncertain.exact_credit_recorded);
+    assert_eq!(
+        after_loss
+            .bridge_state
+            .outbound_scrobbles()
+            .iter()
+            .find(|pending| pending.event_id == succeeding_event_id)
+            .unwrap()
+            .delivery,
+        OutboundScrobbleDelivery::Queued
+    );
+
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(durable.bridge_state.outbound_scrobbles().len(), 1);
+    assert_eq!(
+        durable.bridge_state.outbound_scrobbles()[0].event_id,
+        failing_event_id
+    );
+    assert_eq!(
+        durable.bridge_state.outbound_scrobbles()[0].delivery,
+        OutboundScrobbleDelivery::Uncertain
+    );
+    server.await.unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+async fn read_request(stream: &mut tokio::net::TcpStream) -> String {
+    let mut request = Vec::new();
+    let mut byte = [0_u8; 1];
+    while request.len() < 32 * 1024 {
+        if stream.read(&mut byte).await.unwrap() == 0 {
+            break;
+        }
+        request.push(byte[0]);
+        if request.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    String::from_utf8(request).unwrap()
+}
+
+async fn write_json(stream: &mut tokio::net::TcpStream, body: &str) {
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(response.as_bytes()).await.unwrap();
+}

--- a/src/open_subsonic/bridge_runtime_tests/aggregate_continuation.rs
+++ b/src/open_subsonic/bridge_runtime_tests/aggregate_continuation.rs
@@ -1,0 +1,428 @@
+use super::*;
+use crate::open_subsonic::bridge_store::{
+    MAX_UNCERTAIN_SCROBBLE_READBACKS, PendingOutboundScrobble,
+};
+
+fn mark_speculative_exact(
+    store_set: &mut OpenSubsonicStoreSet,
+    event_id: &str,
+    delivery: OutboundScrobbleDelivery,
+) {
+    let mut pending: PendingOutboundScrobble = store_set
+        .bridge_state
+        .outbound_scrobbles()
+        .iter()
+        .find(|pending| pending.event_id == event_id)
+        .cloned()
+        .unwrap();
+    let epoch = store_set
+        .bridge_state
+        .aggregate_play_shadows()
+        .get(&pending.item_id)
+        .unwrap()
+        .counter_epoch;
+    store_set
+        .bridge_state
+        .reserve_outbound_exact_history_credit(pending.item_id.clone(), epoch)
+        .unwrap();
+    pending.delivery = delivery;
+    pending.exact_credit_recorded = true;
+    pending.exact_credit_epoch = Some(epoch);
+    pending.uncertain_readbacks = if delivery == OutboundScrobbleDelivery::NeedsAttention {
+        MAX_UNCERTAIN_SCROBBLE_READBACKS
+    } else {
+        0
+    };
+    store_set
+        .bridge_state
+        .replace_outbound_scrobble(pending)
+        .unwrap();
+}
+
+#[tokio::test]
+async fn baseline_ten_to_one_hundred_eleven_is_lossless_and_retry_stable() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let baseline = song(&store_set, 5, 10);
+    runtime.observe_songs(&mut store_set, &[baseline]).unwrap();
+
+    let growth = song(&store_set, 5, 111);
+    runtime
+        .observe_songs(&mut store_set, std::slice::from_ref(&growth))
+        .unwrap();
+    let ids = store_set
+        .bridge_state
+        .pending_engagement_imports()
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(ids.len(), 101);
+    assert!(store_set.bridge_state.pending_aggregate_ranges().is_empty());
+
+    runtime
+        .observe_songs(&mut store_set, std::slice::from_ref(&growth))
+        .unwrap();
+    assert_eq!(
+        store_set
+            .bridge_state
+            .pending_engagement_imports()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>(),
+        ids
+    );
+    let mut restarted = load_store_set(&paths).unwrap().unwrap();
+    runtime.observe_songs(&mut restarted, &[growth]).unwrap();
+    assert_eq!(
+        restarted
+            .bridge_state
+            .pending_engagement_imports()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>(),
+        ids
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn twenty_thousand_boundary_and_acknowledged_tail_survive_restart() {
+    let (root, _paths, mut exact_capacity, _client, runtime) = fixture(9, None).await;
+    let baseline = song(&exact_capacity, 5, 0);
+    runtime
+        .observe_songs(&mut exact_capacity, &[baseline])
+        .unwrap();
+    let growth = song(&exact_capacity, 5, 20_000);
+    runtime
+        .observe_songs(&mut exact_capacity, &[growth])
+        .unwrap();
+    assert_eq!(
+        exact_capacity
+            .bridge_state
+            .pending_engagement_imports()
+            .len(),
+        20_000
+    );
+    assert!(
+        exact_capacity
+            .bridge_state
+            .pending_aggregate_ranges()
+            .is_empty()
+    );
+    let _ = std::fs::remove_dir_all(root);
+
+    let (tail_root, paths, mut with_tail, _client, tail_runtime) = fixture(9, None).await;
+    let baseline = song(&with_tail, 5, 0);
+    tail_runtime
+        .observe_songs(&mut with_tail, &[baseline])
+        .unwrap();
+    let growth = song(&with_tail, 5, 20_001);
+    tail_runtime
+        .observe_songs(&mut with_tail, &[growth])
+        .unwrap();
+    assert_eq!(
+        with_tail.bridge_state.pending_engagement_imports().len(),
+        20_000
+    );
+    assert_eq!(
+        with_tail
+            .bridge_state
+            .pending_aggregate_ranges()
+            .front()
+            .unwrap()
+            .range
+            .first_ordinal,
+        20_001
+    );
+
+    let mut restarted = load_store_set(&paths).unwrap().unwrap();
+    let acknowledged = restarted
+        .bridge_state
+        .pending_engagement_imports()
+        .keys()
+        .next()
+        .cloned()
+        .unwrap();
+    tail_runtime
+        .acknowledge_import(&mut restarted, &acknowledged)
+        .unwrap();
+    assert_eq!(
+        restarted.bridge_state.pending_engagement_imports().len(),
+        20_000
+    );
+    assert!(restarted.bridge_state.pending_aggregate_ranges().is_empty());
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(durable.bridge_state, restarted.bridge_state);
+    let _ = std::fs::remove_dir_all(tail_root);
+}
+
+#[tokio::test]
+async fn exact_first_and_reset_generations_do_not_consume_each_other() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let baseline = song(&store_set, 5, 0);
+    runtime.observe_songs(&mut store_set, &[baseline]).unwrap();
+    let item_id = ItemId::new("song-1").unwrap();
+    assert!(
+        store_set
+            .bridge_state
+            .record_exact_history_evidence(item_id.clone(), 0)
+            .unwrap()
+    );
+    let growth = song(&store_set, 5, 20_002);
+    runtime.observe_songs(&mut store_set, &[growth]).unwrap();
+    assert_eq!(
+        store_set.bridge_state.pending_engagement_imports().len(),
+        20_000
+    );
+    assert_eq!(
+        store_set
+            .bridge_state
+            .pending_aggregate_ranges()
+            .front()
+            .unwrap()
+            .range
+            .first_ordinal,
+        20_002,
+        "the epoch-zero exact credit suppresses only the first logical ordinal"
+    );
+
+    let mut reset = song(&store_set, 5, 0);
+    reset.played_at = Some("2026-07-26T00:01:00Z".to_owned());
+    runtime.observe_songs(&mut store_set, &[reset]).unwrap();
+    assert_eq!(
+        store_set
+            .bridge_state
+            .aggregate_play_shadows()
+            .get(&item_id)
+            .unwrap()
+            .counter_epoch,
+        1
+    );
+    assert!(
+        store_set
+            .bridge_state
+            .record_exact_history_evidence(item_id.clone(), 1)
+            .unwrap()
+    );
+
+    let acknowledged = store_set
+        .bridge_state
+        .pending_engagement_imports()
+        .keys()
+        .next()
+        .cloned()
+        .unwrap();
+    runtime
+        .acknowledge_import(&mut store_set, &acknowledged)
+        .unwrap();
+    assert!(store_set.bridge_state.pending_aggregate_ranges().is_empty());
+    let epochs = store_set
+        .bridge_state
+        .history_dedupe_credits()
+        .get(&item_id)
+        .unwrap();
+    assert_eq!(epochs.get(&0).unwrap().aggregate_unmatched, 20_001);
+    assert_eq!(epochs.get(&1).unwrap().exact_unmatched, 1);
+
+    let mut post_reset = song(&store_set, 5, 1);
+    post_reset.played_at = Some("2026-07-26T00:02:00Z".to_owned());
+    runtime
+        .observe_songs(&mut store_set, &[post_reset])
+        .unwrap();
+    assert!(store_set.bridge_state.pending_aggregate_ranges().is_empty());
+    let epochs = store_set
+        .bridge_state
+        .history_dedupe_credits()
+        .get(&item_id)
+        .unwrap();
+    assert_eq!(epochs.get(&0).unwrap().aggregate_unmatched, 20_001);
+    assert!(epochs.get(&1).is_none());
+    assert_eq!(
+        load_store_set(&paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .history_dedupe_credits(),
+        store_set.bridge_state.history_dedupe_credits()
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn ambiguous_aggregate_observation_freezes_until_retry_or_mark_sent() {
+    for resolution in [
+        OutboundScrobbleResolution::Retry,
+        OutboundScrobbleResolution::MarkSent,
+    ] {
+        let (root, _paths, mut store_set, _client, runtime) = fixture(9, None).await;
+        let baseline = song(&store_set, 5, 10);
+        runtime.observe_songs(&mut store_set, &[baseline]).unwrap();
+        let track = scrobble_track(&store_set);
+        runtime
+            .queue_scrobble(
+                &mut store_set,
+                "freeze-owner-event",
+                OpenSubsonicScrobbleKind::Submission,
+                track,
+            )
+            .unwrap();
+        let event_id = store_set
+            .bridge_state
+            .outbound_scrobbles()
+            .front()
+            .unwrap()
+            .event_id
+            .clone();
+        mark_speculative_exact(
+            &mut store_set,
+            &event_id,
+            OutboundScrobbleDelivery::NeedsAttention,
+        );
+
+        let mobile_growth = song(&store_set, 1, 12);
+        runtime
+            .observe_songs(&mut store_set, std::slice::from_ref(&mobile_growth))
+            .unwrap();
+        assert_eq!(
+            store_set
+                .bridge_state
+                .aggregate_play_shadows()
+                .get(mobile_growth.item.item_id())
+                .unwrap()
+                .play_count,
+            10
+        );
+        assert!(
+            store_set
+                .bridge_state
+                .pending_engagement_imports()
+                .is_empty()
+        );
+        assert!(store_set.bridge_state.pending_aggregate_ranges().is_empty());
+        assert_eq!(
+            store_set
+                .bridge_state
+                .rating_shadow(mobile_growth.item.item_id())
+                .unwrap()
+                .raw
+                .user_rating,
+            Some(1),
+            "rating observations stay live while aggregate history is frozen"
+        );
+
+        runtime
+            .resolve_outbound_scrobble(&mut store_set, &event_id, resolution)
+            .unwrap();
+        runtime
+            .observe_songs(&mut store_set, &[mobile_growth])
+            .unwrap();
+        assert_eq!(
+            store_set
+                .bridge_state
+                .aggregate_play_shadows()
+                .get(&ItemId::new("song-1").unwrap())
+                .unwrap()
+                .play_count,
+            12
+        );
+        let expected_imports = if resolution == OutboundScrobbleResolution::Retry {
+            2
+        } else {
+            1
+        };
+        assert_eq!(
+            store_set.bridge_state.pending_engagement_imports().len(),
+            expected_imports,
+            "mark-sent reserves one aggregate increment for the local event"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+}
+
+#[tokio::test]
+async fn native_aggregate_baseline_stays_frozen_until_exact_echo_resolves_uncertainty() {
+    let (root, _paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let initial = song(&store_set, 5, 10);
+    runtime.observe_songs(&mut store_set, &[initial]).unwrap();
+    let track = scrobble_track(&store_set);
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "native-freeze-owner-event",
+            OpenSubsonicScrobbleKind::Submission,
+            track.clone(),
+        )
+        .unwrap();
+    let event_id = store_set
+        .bridge_state
+        .outbound_scrobbles()
+        .front()
+        .unwrap()
+        .event_id
+        .clone();
+    mark_speculative_exact(
+        &mut store_set,
+        &event_id,
+        OutboundScrobbleDelivery::Uncertain,
+    );
+    let item_id = ItemId::new("song-1").unwrap();
+    let backend_id = store_set.profile.backend_id().clone();
+    let account_scope_id = store_set.profile.account_scope_id().clone();
+    let baseline = |rows| HistoryRefreshResult {
+        backend_id: backend_id.clone(),
+        account_scope_id: account_scope_id.clone(),
+        base_cursor: None,
+        native: Ok(Some(NativeHistoryBatch {
+            rows,
+            aggregate_baselines: std::iter::once((
+                item_id.clone(),
+                (11, Some("2026-07-26T00:01:00Z".to_owned())),
+            ))
+            .collect(),
+            next_cursor: None,
+            truncated: false,
+            metadata_retry_pending: false,
+        })),
+        standard: Ok(Vec::new()),
+    };
+
+    runtime
+        .apply_history_refresh(&mut store_set, baseline(Vec::new()))
+        .unwrap();
+    assert_eq!(
+        store_set
+            .bridge_state
+            .aggregate_play_shadows()
+            .get(&item_id)
+            .unwrap()
+            .play_count,
+        10
+    );
+
+    let exact_track = portable_server_track(&song(&store_set, 5, 11));
+    runtime
+        .apply_history_refresh(
+            &mut store_set,
+            baseline(vec![NativeHistoryObservation {
+                row_id: 9001,
+                item_id: item_id.clone(),
+                track: exact_track,
+                observed_at_unix: track.started_unix,
+            }]),
+        )
+        .unwrap();
+    assert!(
+        !store_set
+            .bridge_state
+            .has_unresolved_outbound_submission(&item_id)
+    );
+    assert_eq!(
+        store_set
+            .bridge_state
+            .aggregate_play_shadows()
+            .get(&item_id)
+            .unwrap()
+            .play_count,
+        11
+    );
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/src/open_subsonic/bridge_runtime_tests/rating_projection.rs
+++ b/src/open_subsonic/bridge_runtime_tests/rating_projection.rs
@@ -1,0 +1,401 @@
+use super::*;
+use crate::open_subsonic::bridge_store::PendingRatingProjectionStage;
+use crate::open_subsonic::rating::{RawServerRating, canonical_server_rating};
+
+type ExpectedRequest = (&'static str, Option<String>, String);
+
+async fn rating_server(expected: Vec<ExpectedRequest>) -> (u16, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        for (endpoint, query, body) in expected {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut stream).await;
+            let request_line = request.lines().next().unwrap_or_default();
+            assert!(request_line.contains(endpoint), "{request_line}");
+            if let Some(query) = query {
+                assert!(request_line.contains(&query), "{request_line}");
+            }
+            write_json(&mut stream, &body).await;
+        }
+    });
+    (port, server)
+}
+
+fn ok() -> String {
+    r#"{"subsonic-response":{"status":"ok"}}"#.to_owned()
+}
+
+fn failed() -> String {
+    r#"{"subsonic-response":{"status":"failed","error":{"code":50,"message":"failed"}}}"#.to_owned()
+}
+
+fn song_readback(item_id: &str, raw: RawServerRating) -> String {
+    let mut song = serde_json::json!({
+        "id": item_id,
+        "title": format!("Server song {item_id}"),
+        "artist": "Server artist"
+    });
+    if let Some(rating) = raw.user_rating {
+        song["userRating"] = serde_json::json!(rating);
+    }
+    if raw.starred {
+        song["starred"] = serde_json::json!("2026-07-26T00:00:00Z");
+    }
+    serde_json::json!({
+        "subsonic-response": {
+            "status": "ok",
+            "song": song
+        }
+    })
+    .to_string()
+}
+
+fn local_winner(
+    store_set: &OpenSubsonicStoreSet,
+    operation_id: &str,
+    rating: Rating,
+) -> OpenSubsonicRatingWinner {
+    let mut winner = rating_winner(store_set, "song-1", operation_id);
+    winner.rating = rating;
+    winner
+}
+
+async fn assert_unstar_failure_survives_restart(target: Rating) {
+    let raw = canonical_server_rating(target);
+    assert!(!raw.starred);
+    let rating = raw.user_rating.unwrap();
+    let (port, server) = rating_server(vec![
+        (
+            "/rest/setRating.view?",
+            Some(format!("rating={rating}")),
+            ok(),
+        ),
+        ("/rest/unstar.view?", None, failed()),
+        ("/rest/unstar.view?", None, ok()),
+        ("/rest/getSong.view?", None, song_readback("song-1", raw)),
+    ])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let winner = local_winner(&store_set, "local-rating", target);
+    runtime
+        .reconcile_ratings(&mut store_set, vec![winner])
+        .unwrap();
+
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    assert!(
+        runtime
+            .retry_network(&mut store_set, &client)
+            .await
+            .is_err()
+    );
+    let failed_stage = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        failed_stage
+            .bridge_state
+            .pending_rating_projections()
+            .values()
+            .next()
+            .unwrap()
+            .stage,
+        PendingRatingProjectionStage::SetStarred
+    );
+
+    let mut restarted_store = load_store_set(&paths).unwrap().unwrap();
+    let restarted_client = OpenSubsonicClient::connect(&restarted_store.profile)
+        .await
+        .unwrap();
+    let restarted = BridgeRuntime::writable(paths.clone(), None);
+    restarted
+        .retry_network(&mut restarted_store, &restarted_client)
+        .await
+        .unwrap();
+    assert_eq!(
+        restarted_store
+            .bridge_state
+            .pending_rating_projections()
+            .values()
+            .next()
+            .unwrap()
+            .stage,
+        PendingRatingProjectionStage::Readback
+    );
+    restarted
+        .retry_network(&mut restarted_store, &restarted_client)
+        .await
+        .unwrap();
+
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert!(durable.bridge_state.pending_rating_projections().is_empty());
+    let shadow = durable
+        .bridge_state
+        .rating_shadow(&ItemId::new("song-1").unwrap())
+        .unwrap();
+    assert_eq!(shadow.raw, raw);
+    assert_eq!(
+        shadow.confirmed_operation_id.as_deref(),
+        Some("local-rating")
+    );
+    server.await.unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn disliked_and_neutral_unstar_failures_resume_after_restart() {
+    assert_unstar_failure_survives_restart(Rating::Disliked).await;
+    assert_unstar_failure_survives_restart(Rating::Neutral).await;
+}
+
+#[tokio::test]
+async fn stable_mismatch_becomes_one_external_observation_and_stops_local_rewrites() {
+    let mismatch = RawServerRating {
+        user_rating: Some(1),
+        starred: false,
+    };
+    let (port, server) = rating_server(vec![
+        ("/rest/setRating.view?", Some("rating=5".to_owned()), ok()),
+        ("/rest/star.view?", None, ok()),
+        (
+            "/rest/getSong.view?",
+            None,
+            song_readback("song-1", mismatch),
+        ),
+        (
+            "/rest/getSong.view?",
+            None,
+            song_readback("song-1", mismatch),
+        ),
+    ])
+    .await;
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    let sink: OpenSubsonicBridgeSink = Arc::new(move |event| {
+        captured.lock().unwrap().push(event);
+    });
+    let (root, paths, mut store_set, client, runtime) = fixture(port, Some(sink)).await;
+    let winner = local_winner(&store_set, "local-liked", Rating::Liked);
+    runtime
+        .reconcile_ratings(&mut store_set, vec![winner])
+        .unwrap();
+
+    for _ in 0..4 {
+        runtime
+            .retry_network(&mut store_set, &client)
+            .await
+            .unwrap();
+    }
+
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert!(durable.bridge_state.pending_rating_projections().is_empty());
+    assert_eq!(durable.bridge_state.pending_rating_imports().len(), 1);
+    let (operation_id, pending) = durable
+        .bridge_state
+        .pending_rating_imports()
+        .first_key_value()
+        .unwrap();
+    assert_eq!(pending.raw, mismatch);
+    assert_eq!(pending.mapped, Rating::Disliked);
+    assert_eq!(
+        durable
+            .bridge_state
+            .rating_shadow(&ItemId::new("song-1").unwrap())
+            .unwrap()
+            .raw,
+        mismatch
+    );
+    let operation_id = operation_id.clone();
+    let imported = events.lock().unwrap().clone();
+    assert_eq!(imported.len(), 1);
+    assert!(matches!(
+        &imported[0],
+        OpenSubsonicBridgeImport::Rating {
+            operation_id: emitted,
+            rating: Rating::Disliked,
+            ..
+        } if emitted == &operation_id
+    ));
+
+    runtime
+        .acknowledge_import(&mut store_set, &operation_id)
+        .unwrap();
+    let repeated_observation = song(&store_set, 1, 0);
+    runtime
+        .observe_songs(&mut store_set, &[repeated_observation])
+        .unwrap();
+    assert!(store_set.bridge_state.pending_rating_imports().is_empty());
+    assert_eq!(events.lock().unwrap().len(), 1);
+
+    let older_local = local_winner(&store_set, "older-local-retry", Rating::Liked);
+    runtime
+        .reconcile_ratings(&mut store_set, vec![older_local])
+        .unwrap();
+    assert_eq!(store_set.bridge_state.pending_rating_projections().len(), 1);
+    let mut server_winner = local_winner(&store_set, "server-ledger-winner", Rating::Disliked);
+    server_winner.origin = OperationOrigin::OpenSubsonic {
+        backend_id: store_set.profile.backend_id().as_str().to_owned(),
+    };
+    runtime
+        .reconcile_ratings(&mut store_set, vec![server_winner])
+        .unwrap();
+    assert!(
+        store_set
+            .bridge_state
+            .pending_rating_projections()
+            .is_empty()
+    );
+
+    server.await.unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn changing_mismatch_must_repeat_before_it_becomes_external() {
+    let first = RawServerRating {
+        user_rating: Some(1),
+        starred: false,
+    };
+    let second = RawServerRating {
+        user_rating: Some(0),
+        starred: false,
+    };
+    let (port, server) = rating_server(vec![
+        ("/rest/setRating.view?", Some("rating=5".to_owned()), ok()),
+        ("/rest/star.view?", None, ok()),
+        ("/rest/getSong.view?", None, song_readback("song-1", first)),
+        ("/rest/getSong.view?", None, song_readback("song-1", second)),
+        ("/rest/getSong.view?", None, song_readback("song-1", second)),
+    ])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let winner = local_winner(&store_set, "local-liked", Rating::Liked);
+    runtime
+        .reconcile_ratings(&mut store_set, vec![winner])
+        .unwrap();
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    let after_first = load_store_set(&paths).unwrap().unwrap();
+    let pending = after_first
+        .bridge_state
+        .pending_rating_projections()
+        .values()
+        .next()
+        .unwrap();
+    assert_eq!(pending.stage, PendingRatingProjectionStage::Readback);
+    assert_eq!(pending.last_readback, Some(first));
+    assert!(after_first.bridge_state.pending_rating_imports().is_empty());
+
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    let after_change = load_store_set(&paths).unwrap().unwrap();
+    let pending = after_change
+        .bridge_state
+        .pending_rating_projections()
+        .values()
+        .next()
+        .unwrap();
+    assert_eq!(pending.stage, PendingRatingProjectionStage::Readback);
+    assert_eq!(pending.last_readback, Some(second));
+    assert!(
+        after_change
+            .bridge_state
+            .pending_rating_imports()
+            .is_empty()
+    );
+
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    let stable = load_store_set(&paths).unwrap().unwrap();
+    assert!(stable.bridge_state.pending_rating_projections().is_empty());
+    let imported = stable
+        .bridge_state
+        .pending_rating_imports()
+        .values()
+        .next()
+        .unwrap();
+    assert_eq!(imported.raw, second);
+    assert_eq!(imported.mapped, Rating::Neutral);
+    server.await.unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn stable_noncanonical_readback_with_same_mapping_is_preserved_without_normalizing_loop() {
+    let noncanonical_like = RawServerRating {
+        user_rating: Some(3),
+        starred: true,
+    };
+    let (port, server) = rating_server(vec![
+        ("/rest/setRating.view?", Some("rating=5".to_owned()), ok()),
+        ("/rest/star.view?", None, ok()),
+        (
+            "/rest/getSong.view?",
+            None,
+            song_readback("song-1", noncanonical_like),
+        ),
+        (
+            "/rest/getSong.view?",
+            None,
+            song_readback("song-1", noncanonical_like),
+        ),
+    ])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let winner = local_winner(&store_set, "local-liked", Rating::Liked);
+    runtime
+        .reconcile_ratings(&mut store_set, vec![winner])
+        .unwrap();
+    for _ in 0..4 {
+        runtime
+            .retry_network(&mut store_set, &client)
+            .await
+            .unwrap();
+    }
+
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert!(durable.bridge_state.pending_rating_projections().is_empty());
+    let (operation_id, imported) = durable
+        .bridge_state
+        .pending_rating_imports()
+        .first_key_value()
+        .unwrap();
+    assert_eq!(imported.raw, noncanonical_like);
+    assert_eq!(imported.mapped, Rating::Liked);
+    let operation_id = operation_id.clone();
+
+    let mut repeated_observation = song(&store_set, 3, 0);
+    repeated_observation.starred = true;
+    runtime
+        .observe_songs(&mut store_set, &[repeated_observation])
+        .unwrap();
+    let repeated = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(repeated.bridge_state.pending_rating_imports().len(), 1);
+    assert_eq!(
+        repeated
+            .bridge_state
+            .pending_rating_imports()
+            .first_key_value()
+            .unwrap()
+            .0,
+        &operation_id
+    );
+    server.await.unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/src/open_subsonic/bridge_runtime_tests/scrobble_delivery.rs
+++ b/src/open_subsonic/bridge_runtime_tests/scrobble_delivery.rs
@@ -1,0 +1,417 @@
+use super::*;
+use crate::open_subsonic::bridge_store::MAX_UNCERTAIN_SCROBBLE_READBACKS;
+
+fn unchanged_song_body(count: u64, played: &str) -> String {
+    format!(
+        r#"{{"subsonic-response":{{"status":"ok","song":{{"id":"song-1","title":"Server song","artist":"Server artist","playCount":{count},"played":"{played}"}}}}}}"#
+    )
+}
+
+#[tokio::test]
+async fn redirected_submission_uses_bounded_attention_never_false_confirmation() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let (mut baseline, _) = listener.accept().await.unwrap();
+        assert!(
+            read_request(&mut baseline)
+                .await
+                .contains("/rest/getSong.view?")
+        );
+        write_json(
+            &mut baseline,
+            &unchanged_song_body(10, "2026-03-25T00:00:00Z"),
+        )
+        .await;
+
+        let (mut lost, _) = listener.accept().await.unwrap();
+        assert!(
+            read_request(&mut lost)
+                .await
+                .contains("/rest/scrobble.view?")
+        );
+        lost.write_all(
+            b"HTTP/1.1 302 Found\r\nLocation: /rest/scrobble-again\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        for (count, played) in [
+            (10, "2026-03-25T00:00:00Z"),
+            (11, "2026-03-27T00:00:00Z"),
+            (12, "2026-03-28T00:00:00Z"),
+        ] {
+            let (mut readback, _) = listener.accept().await.unwrap();
+            assert!(
+                read_request(&mut readback)
+                    .await
+                    .contains("/rest/getSong.view?")
+            );
+            write_json(&mut readback, &unchanged_song_body(count, played)).await;
+        }
+    });
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let track = scrobble_track(&store_set);
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "count-only-ambiguous",
+            OpenSubsonicScrobbleKind::Submission,
+            track,
+        )
+        .unwrap();
+
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    assert!(
+        runtime
+            .retry_network(&mut store_set, &client)
+            .await
+            .is_err()
+    );
+    for _ in 0..MAX_UNCERTAIN_SCROBBLE_READBACKS {
+        runtime
+            .retry_network(&mut store_set, &client)
+            .await
+            .unwrap();
+    }
+    // No active lane remains, so another automatic retry neither GETs nor resubmits.
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    let pending = durable.bridge_state.outbound_scrobbles().front().unwrap();
+    assert_eq!(pending.delivery, OutboundScrobbleDelivery::NeedsAttention);
+    assert_eq!(
+        pending.uncertain_readbacks,
+        MAX_UNCERTAIN_SCROBBLE_READBACKS
+    );
+    assert_eq!(
+        read_status(&paths).unwrap().kind,
+        OpenSubsonicStatusKind::NeedsAttention
+    );
+    assert_eq!(
+        read_status(&paths)
+            .unwrap()
+            .outbound_scrobbles_needing_attention,
+        1
+    );
+    let attention_ids = runtime.outbound_scrobble_attention_ids(&durable);
+    assert_eq!(attention_ids.len(), 1);
+    assert!(attention_ids[0].starts_with("sub-scrobble-"));
+    for forbidden in ["count-only-ambiguous", "song-1", "test-api-key", "http://"] {
+        assert!(!attention_ids[0].contains(forbidden));
+    }
+
+    let item_id = ItemId::new("song-1").unwrap();
+    let exact_echo = HistoryRefreshResult {
+        backend_id: store_set.profile.backend_id().clone(),
+        account_scope_id: store_set.profile.account_scope_id().clone(),
+        base_cursor: None,
+        native: Ok(Some(NativeHistoryBatch {
+            rows: vec![NativeHistoryObservation {
+                row_id: 999,
+                item_id: item_id.clone(),
+                track: portable_server_track(&song(&store_set, 5, 12)),
+                observed_at_unix: 1_774_483_200,
+            }],
+            aggregate_baselines: std::collections::BTreeMap::new(),
+            next_cursor: None,
+            truncated: false,
+            metadata_retry_pending: false,
+        })),
+        standard: Ok(Vec::new()),
+    };
+    runtime
+        .apply_history_refresh(&mut store_set, exact_echo)
+        .unwrap();
+    assert!(store_set.bridge_state.outbound_scrobbles().is_empty());
+    assert_eq!(
+        read_status(&paths).unwrap().kind,
+        OpenSubsonicStatusKind::UpToDate
+    );
+    server.await.unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn definite_connect_failure_restores_queue_and_credit_before_restart() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let (mut baseline, _) = listener.accept().await.unwrap();
+        assert!(
+            read_request(&mut baseline)
+                .await
+                .contains("/rest/getSong.view?")
+        );
+        write_json(
+            &mut baseline,
+            &unchanged_song_body(10, "2026-03-25T00:00:00Z"),
+        )
+        .await;
+        // Dropping the listener makes the following connection fail before request bytes exist.
+    });
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let track = scrobble_track(&store_set);
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "connect-failed-before-send",
+            OpenSubsonicScrobbleKind::Submission,
+            track,
+        )
+        .unwrap();
+    runtime
+        .retry_network(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+    let item_id = ItemId::new("song-1").unwrap();
+    let counter_epoch = store_set
+        .bridge_state
+        .aggregate_play_shadows()
+        .get(&item_id)
+        .unwrap()
+        .counter_epoch;
+    assert_eq!(
+        store_set
+            .bridge_state
+            .record_aggregate_history_evidence(item_id.clone(), counter_epoch, 1)
+            .unwrap(),
+        1
+    );
+    let expected = store_set.revisions();
+    commit_store_set(&paths, expected, &mut store_set).unwrap();
+    assert!(
+        runtime
+            .retry_network(&mut store_set, &client)
+            .await
+            .is_err()
+    );
+
+    let mut restarted = load_store_set(&paths).unwrap().unwrap();
+    let pending = restarted.bridge_state.outbound_scrobbles().front().unwrap();
+    assert_eq!(pending.delivery, OutboundScrobbleDelivery::Queued);
+    assert!(!pending.exact_credit_recorded);
+    assert_eq!(pending.uncertain_readbacks, 0);
+    let credits = restarted
+        .bridge_state
+        .history_dedupe_credits()
+        .get(&item_id)
+        .unwrap()
+        .get(&counter_epoch)
+        .unwrap();
+    assert_eq!(credits.aggregate_unmatched, 1);
+    assert_eq!(credits.exact_unmatched, 0);
+
+    let retry_listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+        .await
+        .unwrap();
+    let retry_server = tokio::spawn(async move {
+        let (mut stream, _) = retry_listener.accept().await.unwrap();
+        assert!(
+            read_request(&mut stream)
+                .await
+                .contains("/rest/scrobble.view?")
+        );
+        write_json(&mut stream, r#"{"subsonic-response":{"status":"ok"}}"#).await;
+    });
+    let retry_client = OpenSubsonicClient::connect(&restarted.profile)
+        .await
+        .unwrap();
+    let restarted_runtime = BridgeRuntime::writable(paths.clone(), None);
+    restarted_runtime
+        .retry_network(&mut restarted, &retry_client)
+        .await
+        .unwrap();
+    assert!(restarted.bridge_state.outbound_scrobbles().is_empty());
+    let credits = restarted
+        .bridge_state
+        .history_dedupe_credits()
+        .get(&item_id)
+        .unwrap()
+        .get(&counter_epoch)
+        .unwrap();
+    assert_eq!(credits.aggregate_unmatched, 1);
+    assert_eq!(
+        credits.exact_unmatched, 1,
+        "a successful outbound report must reserve future aggregate growth without consuming older evidence"
+    );
+    retry_server.await.unwrap();
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn pre_wire_crash_boundary_is_ambiguous_bounded_and_explicitly_resolvable() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (root, paths, mut store_set, _client, runtime) = fixture(port, None).await;
+    let mut initial = song(&store_set, 5, 10);
+    initial.played_at = Some("2026-03-25T00:00:00Z".to_owned());
+    runtime.observe_songs(&mut store_set, &[initial]).unwrap();
+    let track = scrobble_track(&store_set);
+    runtime
+        .queue_scrobble(
+            &mut store_set,
+            "irreducible-pre-wire-crash-boundary",
+            OpenSubsonicScrobbleKind::Submission,
+            track,
+        )
+        .unwrap();
+    // The fsync-to-wire boundary cannot atomically prove whether request bytes escaped before a
+    // process crash. Recovery must therefore preserve ambiguity, never infer a safe resend.
+    let mut pending = store_set.bridge_state.outbound_scrobbles()[0].clone();
+    pending.delivery = OutboundScrobbleDelivery::Uncertain;
+    pending.baseline_captured = true;
+    pending.baseline_play_count = Some(10);
+    pending.baseline_played_at = Some("2026-03-25T00:00:00Z".to_owned());
+    store_set
+        .bridge_state
+        .reserve_outbound_exact_history_credit(pending.item_id.clone(), 0)
+        .unwrap();
+    pending.exact_credit_recorded = true;
+    pending.exact_credit_epoch = Some(0);
+    store_set
+        .bridge_state
+        .replace_outbound_scrobble(pending)
+        .unwrap();
+    let expected = store_set.revisions();
+    commit_store_set(&paths, expected, &mut store_set).unwrap();
+    drop(store_set);
+
+    let server = tokio::spawn(async move {
+        for _ in 0..MAX_UNCERTAIN_SCROBBLE_READBACKS {
+            let (mut readback, _) = listener.accept().await.unwrap();
+            assert!(
+                read_request(&mut readback)
+                    .await
+                    .contains("/rest/getSong.view?"),
+                "restart recovery must never blindly resubmit an ambiguous marker"
+            );
+            write_json(
+                &mut readback,
+                &unchanged_song_body(10, "2026-03-25T00:00:00Z"),
+            )
+            .await;
+        }
+    });
+    let mut restarted = load_store_set(&paths).unwrap().unwrap();
+    let client = OpenSubsonicClient::connect(&restarted.profile)
+        .await
+        .unwrap();
+    let restarted_runtime = BridgeRuntime::writable(paths.clone(), None);
+    for _ in 0..MAX_UNCERTAIN_SCROBBLE_READBACKS {
+        restarted_runtime
+            .retry_network(&mut restarted, &client)
+            .await
+            .unwrap();
+    }
+    server.await.unwrap();
+
+    let event_id = restarted_runtime
+        .outbound_scrobble_attention_ids(&restarted)
+        .into_iter()
+        .next()
+        .unwrap();
+    restarted_runtime
+        .resolve_outbound_scrobble(&mut restarted, &event_id, OutboundScrobbleResolution::Retry)
+        .unwrap();
+    let queued = restarted
+        .bridge_state
+        .outbound_scrobbles()
+        .front()
+        .unwrap()
+        .clone();
+    assert_eq!(queued.delivery, OutboundScrobbleDelivery::Queued);
+    assert!(!queued.exact_credit_recorded);
+    assert!(!queued.baseline_captured);
+    assert!(restarted.bridge_state.history_dedupe_credits().is_empty());
+
+    // Recreate a bounded attention marker to exercise the explicit "treat as sent" choice.
+    restarted
+        .bridge_state
+        .reserve_outbound_exact_history_credit(queued.item_id.clone(), 0)
+        .unwrap();
+    let mut attention = queued;
+    attention.delivery = OutboundScrobbleDelivery::NeedsAttention;
+    attention.baseline_captured = true;
+    attention.exact_credit_recorded = true;
+    attention.exact_credit_epoch = Some(0);
+    attention.uncertain_readbacks = MAX_UNCERTAIN_SCROBBLE_READBACKS;
+    restarted
+        .bridge_state
+        .replace_outbound_scrobble(attention)
+        .unwrap();
+    let expected = restarted.revisions();
+    commit_store_set(&paths, expected, &mut restarted).unwrap();
+    restarted_runtime
+        .resolve_outbound_scrobble(
+            &mut restarted,
+            &event_id,
+            OutboundScrobbleResolution::MarkSent,
+        )
+        .unwrap();
+    assert!(restarted.bridge_state.outbound_scrobbles().is_empty());
+    assert_eq!(restarted.bridge_state.outbound_echoes().len(), 1);
+    assert_eq!(
+        restarted
+            .bridge_state
+            .history_dedupe_credits()
+            .get(&ItemId::new("song-1").unwrap())
+            .unwrap()
+            .get(&0)
+            .unwrap()
+            .exact_unmatched,
+        1
+    );
+
+    let exact_echo = HistoryRefreshResult {
+        backend_id: restarted.profile.backend_id().clone(),
+        account_scope_id: restarted.profile.account_scope_id().clone(),
+        base_cursor: None,
+        native: Ok(Some(NativeHistoryBatch {
+            rows: vec![NativeHistoryObservation {
+                row_id: 777,
+                item_id: ItemId::new("song-1").unwrap(),
+                track: portable_server_track(&song(&restarted, 5, 11)),
+                observed_at_unix: 1_774_483_200,
+            }],
+            aggregate_baselines: std::collections::BTreeMap::new(),
+            next_cursor: None,
+            truncated: false,
+            metadata_retry_pending: false,
+        })),
+        standard: Ok(Vec::new()),
+    };
+    restarted_runtime
+        .apply_history_refresh(&mut restarted, exact_echo)
+        .unwrap();
+    assert!(
+        restarted
+            .bridge_state
+            .pending_engagement_imports()
+            .is_empty(),
+        "a late exact echo must link to the marked-sent local event"
+    );
+    assert!(restarted.bridge_state.outbound_echoes().is_empty());
+
+    let mut aggregate_echo = song(&restarted, 5, 11);
+    aggregate_echo.played_at = Some("2026-03-26T00:00:00Z".to_owned());
+    restarted_runtime
+        .observe_songs(&mut restarted, &[aggregate_echo])
+        .unwrap();
+    assert!(
+        restarted
+            .bridge_state
+            .pending_engagement_imports()
+            .is_empty(),
+        "the reserved outbound credit must suppress the late aggregate echo"
+    );
+    assert!(restarted.bridge_state.history_dedupe_credits().is_empty());
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/src/open_subsonic/bridge_store.rs
+++ b/src/open_subsonic/bridge_store.rs
@@ -1,29 +1,243 @@
-//! Owner-only foundation for exact server observations and later projection bridges.
+//! Owner-only durable observations and work queues for server bridges.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
 
-use super::model::{AccountScopeId, BackendId};
+use super::model::{AccountScopeId, BackendId, ItemId};
 use super::profile::StoreError;
+use super::rating::{RawServerRating, map_server_rating};
+use crate::personal_state::{EngagementKind, PortableTrack, PortableTrackKey, Rating};
+
+mod aggregate_ranges;
+mod history_credits;
+mod history_cursor;
+mod outbound_lifecycle;
+
+pub(crate) use aggregate_ranges::PendingAggregateRange;
+pub use history_cursor::NativeHistoryHealth;
+pub(crate) use history_cursor::{HistoryContinuation, HistoryCursor, PendingNativeMetadataRow};
+use outbound_lifecycle::{
+    completed_matches_pending, same_outbound_identity, validate_outbound_scrobble,
+};
 
 pub(crate) const BRIDGE_KIND: &str = "yututui_open_subsonic_bridge";
-pub(crate) const BRIDGE_SCHEMA_VERSION: u32 = 1;
+pub(crate) const BRIDGE_SCHEMA_VERSION: u32 = 2;
 pub(crate) const MAX_BRIDGE_BYTES: u64 = 16 * 1024 * 1024;
 
-/// The PR 6 bridge is deliberately empty: later rating/history work can add versioned observations
-/// without coupling the profile or credentials to portable personal state.
+const MAX_RATING_SHADOWS: usize = 20_000;
+const MAX_PENDING_RATING_PROJECTIONS: usize = 20_000;
+const MAX_PENDING_RATING_IMPORTS: usize = 20_000;
+const MAX_PENDING_ENGAGEMENT_IMPORTS: usize = 20_000;
+const MAX_PENDING_AGGREGATE_RANGES: usize = 20_000;
+const MAX_AGGREGATE_PLAY_SHADOWS: usize = 20_000;
+const MAX_HISTORY_DEDUPE_CREDITS: usize = 20_000;
+const MAX_HISTORY_CURSORS: usize = 32;
+const MAX_OUTBOUND_SCROBBLES: usize = 20_000;
+const MAX_OUTBOUND_ECHOES: usize = 20_000;
+const MAX_COMPLETED_OUTBOUND_SCROBBLES: usize = 20_000;
+pub(crate) const MAX_UNCERTAIN_SCROBBLE_READBACKS: u8 = 3;
+const MAX_EVENT_ID_BYTES: usize = 512;
+const MAX_CURSOR_KEY_BYTES: usize = 128;
+const MAX_PLAYED_AT_BYTES: usize = 256;
+const MAX_PORTABLE_TEXT_CHARS: usize = 1_024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BridgeMutationError {
+    InvalidEntry,
+    CapacityExceeded,
+    ConflictingEntry,
+}
+
+/// Exact last rating observation for one server item.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RatingShadow {
+    pub raw: RawServerRating,
+    pub observed_at_unix: i64,
+    /// The local operation whose server echo produced this observation, when known.
+    pub confirmed_operation_id: Option<String>,
+}
+
+/// Durable two-call projection state. A projection is complete only after `Readback`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PendingRatingProjectionStage {
+    SetRating,
+    SetStarred,
+    Readback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PendingRatingProjection {
+    pub operation_id: String,
+    pub target: Rating,
+    pub stage: PendingRatingProjectionStage,
+    /// First non-canonical readback candidate. A consecutive identical readback is treated as a
+    /// stable external observation; a changing value replaces this candidate without another write.
+    pub last_readback: Option<RawServerRating>,
+    pub queued_at_unix: i64,
+}
+
+/// A server observation waiting to become one external personal-state operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PendingRatingImport {
+    pub item_id: ItemId,
+    /// Sanitized portable metadata makes a committed observation replayable while offline.
+    pub track: PortableTrack,
+    pub raw: RawServerRating,
+    pub mapped: Rating,
+    pub observed_at_unix: i64,
+}
+
+/// Exact or aggregate server evidence waiting to become one engagement operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PendingEngagementImport {
+    pub track: PortableTrack,
+    pub engagement: EngagementKind,
+    pub played_duration_ms: Option<u64>,
+    pub total_duration_ms: Option<u64>,
+    pub artist_key: String,
+    pub observed_at_unix: i64,
+}
+
+/// Standard OpenSubsonic aggregate history evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AggregatePlayShadow {
+    pub play_count: u64,
+    pub played_at: Option<String>,
+    pub observed_at_unix: i64,
+    /// Local generation used to keep counter ordinals unique after a server reset.
+    #[serde(default)]
+    pub counter_epoch: u64,
+}
+
+/// Durable two-way evidence credits prevent exact and aggregate history from counting one play
+/// twice regardless of which source arrives first.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct HistoryDedupeCredits {
+    pub exact_unmatched: u64,
+    pub aggregate_unmatched: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum OutboundScrobbleKind {
+    NowPlaying,
+    Submission,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum OutboundScrobbleDelivery {
+    #[default]
+    Queued,
+    /// The request may have reached the server and must never be blindly resent.
+    Uncertain,
+    /// Bounded readback could not prove delivery. Only an exact echo or an explicit user
+    /// resolution may release this report.
+    NeedsAttention,
+}
+
+/// One exact local event waiting for standard OpenSubsonic scrobble acknowledgement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PendingOutboundScrobble {
+    pub event_id: String,
+    pub item_id: ItemId,
+    pub played_at_unix: i64,
+    pub kind: OutboundScrobbleKind,
+    #[serde(default)]
+    pub delivery: OutboundScrobbleDelivery,
+    #[serde(default)]
+    pub baseline_captured: bool,
+    #[serde(default)]
+    pub baseline_play_count: Option<u64>,
+    #[serde(default)]
+    pub baseline_played_at: Option<String>,
+    #[serde(default)]
+    pub exact_credit_recorded: bool,
+    /// Counter generation in which `exact_credit_recorded` was registered.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exact_credit_epoch: Option<u64>,
+    /// Successful, unchanged aggregate readbacks after an ambiguous response.
+    #[serde(default)]
+    pub uncertain_readbacks: u8,
+    /// The source journal durably entered `AwaitingSourceAck` and the bridge accepted that proof.
+    ///
+    /// The intermediate marker may still exist, but restart will replay only this acknowledgement,
+    /// never the server submission. Until this bit crosses the bridge-store durability boundary, a
+    /// successful submission must retain a completion receipt.
+    #[serde(default)]
+    pub source_marker_acknowledged: bool,
+}
+
+/// Successful local submission retained until the native-history importer observes its echo.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct OutboundScrobbleEcho {
+    pub event_id: String,
+    pub item_id: ItemId,
+    pub played_at_unix: i64,
+}
+
+/// A bounded completion receipt makes owner-event replay a durable no-op after acknowledgement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CompletedOutboundScrobble {
+    pub event_id: String,
+    pub item_id: ItemId,
+    pub played_at_unix: i64,
+    pub kind: OutboundScrobbleKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OpenSubsonicBridgeState {
     revision: u64,
     backend_id: BackendId,
     account_scope_id: AccountScopeId,
+    rating_shadows: BTreeMap<ItemId, RatingShadow>,
+    pending_rating_projections: BTreeMap<ItemId, PendingRatingProjection>,
+    pending_rating_imports: BTreeMap<String, PendingRatingImport>,
+    pending_engagement_imports: BTreeMap<String, PendingEngagementImport>,
+    pending_aggregate_ranges: VecDeque<PendingAggregateRange>,
+    aggregate_play_shadows: BTreeMap<ItemId, AggregatePlayShadow>,
+    history_dedupe_credits: BTreeMap<ItemId, BTreeMap<u64, HistoryDedupeCredits>>,
+    history_cursors: BTreeMap<String, HistoryCursor>,
+    native_history_health: NativeHistoryHealth,
+    outbound_scrobbles: VecDeque<PendingOutboundScrobble>,
+    outbound_echoes: VecDeque<OutboundScrobbleEcho>,
+    completed_outbound_scrobbles: VecDeque<CompletedOutboundScrobble>,
 }
 
+#[allow(
+    dead_code,
+    reason = "bounded durable bridge APIs are consumed incrementally by the PR 7 owner runtime"
+)]
 impl OpenSubsonicBridgeState {
     pub fn new(backend_id: BackendId, account_scope_id: AccountScopeId) -> Self {
         Self {
             revision: 0,
             backend_id,
             account_scope_id,
+            rating_shadows: BTreeMap::new(),
+            pending_rating_projections: BTreeMap::new(),
+            pending_rating_imports: BTreeMap::new(),
+            pending_engagement_imports: BTreeMap::new(),
+            pending_aggregate_ranges: VecDeque::new(),
+            aggregate_play_shadows: BTreeMap::new(),
+            history_dedupe_credits: BTreeMap::new(),
+            history_cursors: BTreeMap::new(),
+            native_history_health: NativeHistoryHealth::Off,
+            outbound_scrobbles: VecDeque::new(),
+            outbound_echoes: VecDeque::new(),
+            completed_outbound_scrobbles: VecDeque::new(),
         }
     }
 
@@ -39,14 +253,647 @@ impl OpenSubsonicBridgeState {
         &self.account_scope_id
     }
 
+    pub(crate) fn rating_shadows(&self) -> &BTreeMap<ItemId, RatingShadow> {
+        &self.rating_shadows
+    }
+
+    pub(crate) fn rating_shadow(&self, item_id: &ItemId) -> Option<&RatingShadow> {
+        self.rating_shadows.get(item_id)
+    }
+
+    pub(crate) fn upsert_rating_shadow(
+        &mut self,
+        item_id: ItemId,
+        shadow: RatingShadow,
+    ) -> Result<(), BridgeMutationError> {
+        self.upsert_rating_shadow_with_limit(item_id, shadow, MAX_RATING_SHADOWS)
+    }
+
+    fn upsert_rating_shadow_with_limit(
+        &mut self,
+        item_id: ItemId,
+        shadow: RatingShadow,
+        limit: usize,
+    ) -> Result<(), BridgeMutationError> {
+        validate_rating_shadow(&shadow)?;
+        if self.rating_shadows.contains_key(&item_id) || self.rating_shadows.len() < limit {
+            self.rating_shadows.insert(item_id, shadow);
+            return Ok(());
+        }
+
+        let incoming_is_protected = self.pending_rating_projections.contains_key(&item_id)
+            || self
+                .pending_rating_imports
+                .values()
+                .any(|pending| pending.item_id == item_id);
+        let mut victim = (!incoming_is_protected).then(|| {
+            (
+                shadow.observed_at_unix,
+                item_id.as_str().to_owned(),
+                item_id.clone(),
+            )
+        });
+        for (candidate_id, candidate) in &self.rating_shadows {
+            let protected = self.pending_rating_projections.contains_key(candidate_id)
+                || self
+                    .pending_rating_imports
+                    .values()
+                    .any(|pending| pending.item_id == *candidate_id);
+            if protected {
+                continue;
+            }
+            let key = (
+                candidate.observed_at_unix,
+                candidate_id.as_str().to_owned(),
+                candidate_id.clone(),
+            );
+            if victim.as_ref().is_none_or(|current| key < *current) {
+                victim = Some(key);
+            }
+        }
+        let Some((_, _, victim_id)) = victim else {
+            return Err(BridgeMutationError::CapacityExceeded);
+        };
+        if victim_id != item_id {
+            self.rating_shadows.remove(&victim_id);
+            self.rating_shadows.insert(item_id, shadow);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn pending_rating_projections(&self) -> &BTreeMap<ItemId, PendingRatingProjection> {
+        &self.pending_rating_projections
+    }
+
+    pub(crate) fn queue_rating_projection(
+        &mut self,
+        item_id: ItemId,
+        pending: PendingRatingProjection,
+    ) -> Result<(), BridgeMutationError> {
+        validate_pending_projection(&pending)?;
+        if !self.pending_rating_projections.contains_key(&item_id)
+            && self.pending_rating_projections.len() >= MAX_PENDING_RATING_PROJECTIONS
+        {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        self.pending_rating_projections.insert(item_id, pending);
+        Ok(())
+    }
+
+    pub(crate) fn remove_rating_projection(
+        &mut self,
+        item_id: &ItemId,
+    ) -> Option<PendingRatingProjection> {
+        self.pending_rating_projections.remove(item_id)
+    }
+
+    pub(crate) fn pending_rating_imports(&self) -> &BTreeMap<String, PendingRatingImport> {
+        &self.pending_rating_imports
+    }
+
+    pub(crate) fn queue_rating_import(
+        &mut self,
+        observation_id: String,
+        pending: PendingRatingImport,
+    ) -> Result<(), BridgeMutationError> {
+        validate_identifier(&observation_id, MAX_EVENT_ID_BYTES)?;
+        self.validate_pending_import(&pending)?;
+        if let Some(existing) = self.pending_rating_imports.get(&observation_id) {
+            return if existing == &pending {
+                Ok(())
+            } else {
+                Err(BridgeMutationError::ConflictingEntry)
+            };
+        }
+        let replaces_same_item = self
+            .pending_rating_imports
+            .values()
+            .any(|existing| existing.item_id == pending.item_id);
+        if !replaces_same_item && self.pending_rating_imports.len() >= MAX_PENDING_RATING_IMPORTS {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        // A rating is a register, not an event stream. Only the most recently observed value for
+        // one exact server item needs to cross the owner boundary. Coalescing here also preserves
+        // that order across a crash: replay must not depend on the lexical order of hashed
+        // observation IDs in the map.
+        self.pending_rating_imports
+            .retain(|_, existing| existing.item_id != pending.item_id);
+        self.pending_rating_imports.insert(observation_id, pending);
+        Ok(())
+    }
+
+    pub(crate) fn remove_rating_import(
+        &mut self,
+        observation_id: &str,
+    ) -> Option<PendingRatingImport> {
+        self.pending_rating_imports.remove(observation_id)
+    }
+
+    pub(crate) fn pending_engagement_imports(&self) -> &BTreeMap<String, PendingEngagementImport> {
+        &self.pending_engagement_imports
+    }
+
+    pub(crate) fn queue_engagement_import(
+        &mut self,
+        observation_id: String,
+        pending: PendingEngagementImport,
+    ) -> Result<(), BridgeMutationError> {
+        self.queue_engagement_import_with_limit(
+            observation_id,
+            pending,
+            MAX_PENDING_ENGAGEMENT_IMPORTS,
+        )
+    }
+
+    fn queue_engagement_import_with_limit(
+        &mut self,
+        observation_id: String,
+        pending: PendingEngagementImport,
+        limit: usize,
+    ) -> Result<(), BridgeMutationError> {
+        validate_identifier(&observation_id, MAX_EVENT_ID_BYTES)?;
+        self.validate_pending_engagement_import(&pending)?;
+        if let Some(existing) = self.pending_engagement_imports.get(&observation_id) {
+            return if existing == &pending {
+                Ok(())
+            } else {
+                Err(BridgeMutationError::ConflictingEntry)
+            };
+        }
+        if self.pending_engagement_imports.len() >= limit {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        self.pending_engagement_imports
+            .insert(observation_id, pending);
+        Ok(())
+    }
+
+    pub(crate) fn remove_engagement_import(
+        &mut self,
+        observation_id: &str,
+    ) -> Option<PendingEngagementImport> {
+        self.pending_engagement_imports.remove(observation_id)
+    }
+
+    pub(crate) fn aggregate_play_shadows(&self) -> &BTreeMap<ItemId, AggregatePlayShadow> {
+        &self.aggregate_play_shadows
+    }
+
+    pub(crate) fn upsert_aggregate_play_shadow(
+        &mut self,
+        item_id: ItemId,
+        shadow: AggregatePlayShadow,
+    ) -> Result<(), BridgeMutationError> {
+        validate_aggregate_shadow(&shadow)?;
+        if !self.aggregate_play_shadows.contains_key(&item_id)
+            && self.aggregate_play_shadows.len() >= MAX_AGGREGATE_PLAY_SHADOWS
+        {
+            let victim = self
+                .aggregate_play_shadows
+                .iter()
+                .filter(|(candidate_id, _)| !self.aggregate_item_is_protected(candidate_id))
+                .map(|(candidate_id, candidate)| {
+                    (
+                        candidate.observed_at_unix,
+                        candidate_id.as_str(),
+                        candidate_id,
+                    )
+                })
+                .min_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(right.1)))
+                .map(|(_, _, candidate_id)| candidate_id.clone())
+                .ok_or(BridgeMutationError::CapacityExceeded)?;
+            self.aggregate_play_shadows.remove(&victim);
+        }
+        self.aggregate_play_shadows.insert(item_id, shadow);
+        Ok(())
+    }
+
+    pub fn native_history_health(&self) -> NativeHistoryHealth {
+        self.native_history_health
+    }
+
+    pub fn set_native_history_health(&mut self, health: NativeHistoryHealth) {
+        self.native_history_health = health;
+    }
+
+    pub(crate) fn queue_outbound_scrobble(
+        &mut self,
+        pending: PendingOutboundScrobble,
+    ) -> Result<(), BridgeMutationError> {
+        validate_outbound_scrobble(&pending)?;
+        if let Some(existing) = self
+            .outbound_scrobbles
+            .iter()
+            .find(|existing| existing.event_id == pending.event_id)
+        {
+            return if same_outbound_identity(existing, &pending) {
+                Ok(())
+            } else {
+                Err(BridgeMutationError::ConflictingEntry)
+            };
+        }
+        if let Some(existing) = self
+            .outbound_echoes
+            .iter()
+            .find(|existing| existing.event_id == pending.event_id)
+        {
+            return if pending.kind == OutboundScrobbleKind::Submission
+                && existing.item_id == pending.item_id
+                && existing.played_at_unix == pending.played_at_unix
+            {
+                Ok(())
+            } else {
+                Err(BridgeMutationError::ConflictingEntry)
+            };
+        }
+        if let Some(existing) = self
+            .completed_outbound_scrobbles
+            .iter()
+            .find(|existing| existing.event_id == pending.event_id)
+        {
+            return if completed_matches_pending(existing, &pending) {
+                Ok(())
+            } else {
+                Err(BridgeMutationError::ConflictingEntry)
+            };
+        }
+        if self.outbound_scrobbles.len() >= MAX_OUTBOUND_SCROBBLES {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        self.outbound_scrobbles.push_back(pending);
+        Ok(())
+    }
+
+    /// Accept a durable `AwaitingSourceAck` marker from the source JSONL journal.
+    ///
+    /// A pending report carries the acknowledgement into completion. A completed report no longer
+    /// needs its replay tombstone and can release that bounded slot immediately. Missing entries
+    /// are an idempotent success: either the acknowledgement was already applied or the source had
+    /// no durable marker (for example, an ephemeral now-playing report).
+    pub(crate) fn acknowledge_outbound_source(
+        &mut self,
+        event_id: &str,
+    ) -> Result<(), BridgeMutationError> {
+        validate_identifier(event_id, MAX_EVENT_ID_BYTES)?;
+        if let Some(pending) = self
+            .outbound_scrobbles
+            .iter_mut()
+            .find(|pending| pending.event_id == event_id)
+        {
+            pending.source_marker_acknowledged = true;
+            return Ok(());
+        }
+        if let Some(position) = self
+            .completed_outbound_scrobbles
+            .iter()
+            .position(|completed| completed.event_id == event_id)
+        {
+            self.completed_outbound_scrobbles.remove(position);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn replace_outbound_scrobble(
+        &mut self,
+        pending: PendingOutboundScrobble,
+    ) -> Result<(), BridgeMutationError> {
+        validate_outbound_scrobble(&pending)?;
+        let Some(position) = self
+            .outbound_scrobbles
+            .iter()
+            .position(|existing| existing.event_id == pending.event_id)
+        else {
+            return Err(BridgeMutationError::ConflictingEntry);
+        };
+        if !same_outbound_identity(&self.outbound_scrobbles[position], &pending) {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+        self.outbound_scrobbles[position] = pending;
+        Ok(())
+    }
+
+    pub(crate) fn acknowledge_outbound_scrobble(
+        &mut self,
+        event_id: &str,
+    ) -> Result<Option<PendingOutboundScrobble>, BridgeMutationError> {
+        validate_identifier(event_id, MAX_EVENT_ID_BYTES)?;
+        if self
+            .outbound_scrobbles
+            .front()
+            .is_some_and(|pending| pending.event_id == event_id)
+        {
+            return Ok(self.outbound_scrobbles.pop_front());
+        }
+        if self
+            .outbound_scrobbles
+            .iter()
+            .any(|pending| pending.event_id == event_id)
+        {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+        Ok(None)
+    }
+
+    pub(crate) fn complete_outbound_scrobble(
+        &mut self,
+        event_id: &str,
+    ) -> Result<Option<PendingOutboundScrobble>, BridgeMutationError> {
+        validate_identifier(event_id, MAX_EVENT_ID_BYTES)?;
+        let Some(position) = self
+            .outbound_scrobbles
+            .iter()
+            .position(|pending| pending.event_id == event_id)
+        else {
+            return Ok(None);
+        };
+        let retain_completion = !self.outbound_scrobbles[position].source_marker_acknowledged;
+        if retain_completion
+            && self.completed_outbound_scrobbles.len() >= MAX_COMPLETED_OUTBOUND_SCROBBLES
+        {
+            // Every retained receipt protects a source marker whose durable removal has not been
+            // observed. Evicting one would permit a duplicate after restart, so apply backpressure
+            // and leave the uncertain/pending report intact.
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        let pending = self
+            .outbound_scrobbles
+            .remove(position)
+            .ok_or(BridgeMutationError::ConflictingEntry)?;
+        if !retain_completion {
+            return Ok(Some(pending));
+        }
+        let completed = CompletedOutboundScrobble {
+            event_id: pending.event_id.clone(),
+            item_id: pending.item_id.clone(),
+            played_at_unix: pending.played_at_unix,
+            kind: pending.kind,
+        };
+        self.completed_outbound_scrobbles.push_back(completed);
+        Ok(Some(pending))
+    }
+
+    pub(crate) fn record_outbound_echo(
+        &mut self,
+        echo: OutboundScrobbleEcho,
+    ) -> Result<(), BridgeMutationError> {
+        validate_identifier(&echo.event_id, MAX_EVENT_ID_BYTES)?;
+        if let Some(existing) = self
+            .outbound_echoes
+            .iter()
+            .find(|existing| existing.event_id == echo.event_id)
+        {
+            return if existing == &echo {
+                Ok(())
+            } else {
+                Err(BridgeMutationError::ConflictingEntry)
+            };
+        }
+        if self.outbound_echoes.len() == MAX_OUTBOUND_ECHOES {
+            self.outbound_echoes.pop_front();
+        }
+        self.outbound_echoes.push_back(echo);
+        Ok(())
+    }
+
+    pub(crate) fn consume_outbound_echo(
+        &mut self,
+        item_id: &ItemId,
+        played_at_unix: i64,
+    ) -> Option<OutboundScrobbleEcho> {
+        let position = self
+            .outbound_echoes
+            .iter()
+            .position(|echo| echo.item_id == *item_id && echo.played_at_unix == played_at_unix)?;
+        self.outbound_echoes.remove(position)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn outbound_echoes(&self) -> &VecDeque<OutboundScrobbleEcho> {
+        &self.outbound_echoes
+    }
+
+    #[cfg(test)]
+    pub(crate) fn completed_outbound_scrobbles(&self) -> &VecDeque<CompletedOutboundScrobble> {
+        &self.completed_outbound_scrobbles
+    }
+
     pub(crate) fn set_revision(&mut self, revision: u64) {
         self.revision = revision;
     }
+
+    fn validate(&self) -> Result<(), BridgeMutationError> {
+        if self.rating_shadows.len() > MAX_RATING_SHADOWS
+            || self.pending_rating_projections.len() > MAX_PENDING_RATING_PROJECTIONS
+            || self.pending_rating_imports.len() > MAX_PENDING_RATING_IMPORTS
+            || self.pending_engagement_imports.len() > MAX_PENDING_ENGAGEMENT_IMPORTS
+            || self.pending_aggregate_ranges.len() > MAX_PENDING_AGGREGATE_RANGES
+            || self.aggregate_play_shadows.len() > MAX_AGGREGATE_PLAY_SHADOWS
+            || self.history_credit_entry_count()? > MAX_HISTORY_DEDUPE_CREDITS
+            || self.history_cursors.len() > MAX_HISTORY_CURSORS
+            || self.outbound_scrobbles.len() > MAX_OUTBOUND_SCROBBLES
+            || self.outbound_echoes.len() > MAX_OUTBOUND_ECHOES
+            || self.completed_outbound_scrobbles.len() > MAX_COMPLETED_OUTBOUND_SCROBBLES
+        {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        for shadow in self.rating_shadows.values() {
+            validate_rating_shadow(shadow)?;
+        }
+        for pending in self.pending_rating_projections.values() {
+            validate_pending_projection(pending)?;
+        }
+        for (observation_id, pending) in &self.pending_rating_imports {
+            validate_identifier(observation_id, MAX_EVENT_ID_BYTES)?;
+            self.validate_pending_import(pending)?;
+        }
+        let mut pending_rating_items = BTreeSet::new();
+        if self
+            .pending_rating_imports
+            .values()
+            .any(|pending| !pending_rating_items.insert(&pending.item_id))
+        {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+        for (observation_id, pending) in &self.pending_engagement_imports {
+            validate_identifier(observation_id, MAX_EVENT_ID_BYTES)?;
+            self.validate_pending_engagement_import(pending)?;
+        }
+        self.validate_pending_aggregate_ranges()?;
+        for shadow in self.aggregate_play_shadows.values() {
+            validate_aggregate_shadow(shadow)?;
+        }
+        for (item_id, credits_by_epoch) in &self.history_dedupe_credits {
+            if credits_by_epoch.is_empty() {
+                return Err(BridgeMutationError::InvalidEntry);
+            }
+            for (epoch, credits) in credits_by_epoch {
+                let epoch_is_valid = self
+                    .aggregate_play_shadows
+                    .get(item_id)
+                    .map_or(*epoch == 0, |shadow| *epoch <= shadow.counter_epoch);
+                if !epoch_is_valid
+                    || (credits.exact_unmatched == 0 && credits.aggregate_unmatched == 0)
+                {
+                    return Err(BridgeMutationError::InvalidEntry);
+                }
+            }
+        }
+        for (source, cursor) in &self.history_cursors {
+            validate_identifier(source, MAX_CURSOR_KEY_BYTES)?;
+            history_cursor::validate(cursor)?;
+        }
+        let mut event_ids = BTreeSet::new();
+        for pending in &self.outbound_scrobbles {
+            validate_outbound_scrobble(pending)?;
+            if !event_ids.insert(pending.event_id.as_str()) {
+                return Err(BridgeMutationError::ConflictingEntry);
+            }
+        }
+        for echo in &self.outbound_echoes {
+            validate_identifier(&echo.event_id, MAX_EVENT_ID_BYTES)?;
+            if !event_ids.insert(echo.event_id.as_str()) {
+                return Err(BridgeMutationError::ConflictingEntry);
+            }
+        }
+        let mut completed_ids = BTreeSet::new();
+        for completed in &self.completed_outbound_scrobbles {
+            validate_identifier(&completed.event_id, MAX_EVENT_ID_BYTES)?;
+            if !completed_ids.insert(completed.event_id.as_str())
+                || self
+                    .outbound_scrobbles
+                    .iter()
+                    .any(|pending| pending.event_id == completed.event_id)
+            {
+                return Err(BridgeMutationError::ConflictingEntry);
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_pending_import(
+        &self,
+        pending: &PendingRatingImport,
+    ) -> Result<(), BridgeMutationError> {
+        pending
+            .track
+            .validate()
+            .map_err(|_| BridgeMutationError::InvalidEntry)?;
+        if pending.mapped != map_server_rating(pending.raw) {
+            return Err(BridgeMutationError::InvalidEntry);
+        }
+        match &pending.track.key {
+            PortableTrackKey::OpenSubsonic {
+                backend_id,
+                account_scope_id,
+                item_id,
+            } if backend_id == self.backend_id.as_str()
+                && account_scope_id == self.account_scope_id.as_str()
+                && item_id == pending.item_id.as_str() =>
+            {
+                Ok(())
+            }
+            _ => Err(BridgeMutationError::InvalidEntry),
+        }
+    }
+
+    fn validate_pending_engagement_import(
+        &self,
+        pending: &PendingEngagementImport,
+    ) -> Result<(), BridgeMutationError> {
+        pending
+            .track
+            .validate()
+            .map_err(|_| BridgeMutationError::InvalidEntry)?;
+        validate_portable_text(&pending.artist_key)?;
+        if let (Some(played), Some(total)) = (pending.played_duration_ms, pending.total_duration_ms)
+            && total > 0
+            && played > total.saturating_mul(4)
+        {
+            return Err(BridgeMutationError::InvalidEntry);
+        }
+        match &pending.track.key {
+            PortableTrackKey::OpenSubsonic {
+                backend_id,
+                account_scope_id,
+                ..
+            } if backend_id == self.backend_id.as_str()
+                && account_scope_id == self.account_scope_id.as_str() =>
+            {
+                Ok(())
+            }
+            _ => Err(BridgeMutationError::InvalidEntry),
+        }
+    }
 }
 
-#[derive(Serialize, Deserialize)]
+fn validate_rating_shadow(shadow: &RatingShadow) -> Result<(), BridgeMutationError> {
+    if let Some(operation_id) = &shadow.confirmed_operation_id {
+        validate_identifier(operation_id, MAX_EVENT_ID_BYTES)?;
+    }
+    Ok(())
+}
+
+fn validate_pending_projection(
+    pending: &PendingRatingProjection,
+) -> Result<(), BridgeMutationError> {
+    validate_identifier(&pending.operation_id, MAX_EVENT_ID_BYTES)
+}
+
+fn validate_aggregate_shadow(shadow: &AggregatePlayShadow) -> Result<(), BridgeMutationError> {
+    if let Some(played_at) = &shadow.played_at {
+        validate_text(played_at, MAX_PLAYED_AT_BYTES)?;
+    }
+    Ok(())
+}
+
+fn validate_identifier(value: &str, max_bytes: usize) -> Result<(), BridgeMutationError> {
+    if value.is_empty()
+        || value.len() > max_bytes
+        || value.chars().any(|character| character.is_control())
+    {
+        return Err(BridgeMutationError::InvalidEntry);
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, max_bytes: usize) -> Result<(), BridgeMutationError> {
+    if value.len() > max_bytes || value.chars().any(|character| character.is_control()) {
+        return Err(BridgeMutationError::InvalidEntry);
+    }
+    Ok(())
+}
+
+fn validate_portable_text(value: &str) -> Result<(), BridgeMutationError> {
+    let forbidden = |character: char| {
+        character.is_control()
+            || matches!(
+                character,
+                '\u{061c}'
+                    | '\u{200b}'
+                    | '\u{200c}'
+                    | '\u{200d}'
+                    | '\u{200e}'
+                    | '\u{200f}'
+                    | '\u{202a}'..='\u{202e}'
+                    | '\u{2066}'..='\u{2069}'
+                    | '\u{feff}'
+            )
+    };
+    if value.chars().count() > MAX_PORTABLE_TEXT_CHARS || value.chars().any(forbidden) {
+        return Err(BridgeMutationError::InvalidEntry);
+    }
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct DiskBridgeHeader {
+    kind: String,
+    schema_version: u32,
+}
+
+#[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct DiskBridgeState {
+struct DiskBridgeStateV1 {
     kind: String,
     schema_version: u32,
     revision: u64,
@@ -54,15 +901,55 @@ struct DiskBridgeState {
     account_scope_id: AccountScopeId,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DiskBridgeStateV2 {
+    kind: String,
+    schema_version: u32,
+    revision: u64,
+    backend_id: BackendId,
+    account_scope_id: AccountScopeId,
+    rating_shadows: BTreeMap<ItemId, RatingShadow>,
+    pending_rating_projections: BTreeMap<ItemId, PendingRatingProjection>,
+    pending_rating_imports: BTreeMap<String, PendingRatingImport>,
+    pending_engagement_imports: BTreeMap<String, PendingEngagementImport>,
+    #[serde(default)]
+    pending_aggregate_ranges: VecDeque<PendingAggregateRange>,
+    aggregate_play_shadows: BTreeMap<ItemId, AggregatePlayShadow>,
+    #[serde(default)]
+    history_dedupe_credits: BTreeMap<ItemId, BTreeMap<u64, HistoryDedupeCredits>>,
+    history_cursors: BTreeMap<String, HistoryCursor>,
+    #[serde(default)]
+    native_history_health: NativeHistoryHealth,
+    outbound_scrobbles: VecDeque<PendingOutboundScrobble>,
+    #[serde(default)]
+    outbound_echoes: VecDeque<OutboundScrobbleEcho>,
+    #[serde(default)]
+    completed_outbound_scrobbles: VecDeque<CompletedOutboundScrobble>,
+}
+
 pub(crate) fn encode_bridge(
     state: &OpenSubsonicBridgeState,
 ) -> Result<Zeroizing<Vec<u8>>, StoreError> {
-    let disk = DiskBridgeState {
+    state.validate().map_err(|_| StoreError::InvalidState)?;
+    let disk = DiskBridgeStateV2 {
         kind: BRIDGE_KIND.to_owned(),
         schema_version: BRIDGE_SCHEMA_VERSION,
         revision: state.revision,
         backend_id: state.backend_id.clone(),
         account_scope_id: state.account_scope_id.clone(),
+        rating_shadows: state.rating_shadows.clone(),
+        pending_rating_projections: state.pending_rating_projections.clone(),
+        pending_rating_imports: state.pending_rating_imports.clone(),
+        pending_engagement_imports: state.pending_engagement_imports.clone(),
+        pending_aggregate_ranges: state.pending_aggregate_ranges.clone(),
+        aggregate_play_shadows: state.aggregate_play_shadows.clone(),
+        history_dedupe_credits: state.history_dedupe_credits.clone(),
+        history_cursors: state.history_cursors.clone(),
+        native_history_health: state.native_history_health,
+        outbound_scrobbles: state.outbound_scrobbles.clone(),
+        outbound_echoes: state.outbound_echoes.clone(),
+        completed_outbound_scrobbles: state.completed_outbound_scrobbles.clone(),
     };
     let bytes =
         Zeroizing::new(serde_json::to_vec(&disk).map_err(|_| StoreError::SerializationFailed)?);
@@ -76,30 +963,555 @@ pub(crate) fn decode_bridge(bytes: &[u8]) -> Result<OpenSubsonicBridgeState, Sto
     if bytes.len() as u64 > MAX_BRIDGE_BYTES {
         return Err(StoreError::PayloadTooLarge);
     }
-    let disk: DiskBridgeState =
+    let header: DiskBridgeHeader =
         serde_json::from_slice(bytes).map_err(|_| StoreError::InvalidState)?;
-    if disk.kind != BRIDGE_KIND || disk.schema_version != BRIDGE_SCHEMA_VERSION {
+    if header.kind != BRIDGE_KIND {
         return Err(StoreError::InvalidState);
     }
-    Ok(OpenSubsonicBridgeState {
-        revision: disk.revision,
-        backend_id: disk.backend_id,
-        account_scope_id: disk.account_scope_id,
-    })
+    let state = match header.schema_version {
+        1 => {
+            let disk: DiskBridgeStateV1 =
+                serde_json::from_slice(bytes).map_err(|_| StoreError::InvalidState)?;
+            if disk.kind != BRIDGE_KIND || disk.schema_version != 1 {
+                return Err(StoreError::InvalidState);
+            }
+            let mut state = OpenSubsonicBridgeState::new(disk.backend_id, disk.account_scope_id);
+            state.revision = disk.revision;
+            state
+        }
+        BRIDGE_SCHEMA_VERSION => {
+            let disk: DiskBridgeStateV2 =
+                serde_json::from_slice(bytes).map_err(|_| StoreError::InvalidState)?;
+            if disk.kind != BRIDGE_KIND || disk.schema_version != BRIDGE_SCHEMA_VERSION {
+                return Err(StoreError::InvalidState);
+            }
+            OpenSubsonicBridgeState {
+                revision: disk.revision,
+                backend_id: disk.backend_id,
+                account_scope_id: disk.account_scope_id,
+                rating_shadows: disk.rating_shadows,
+                pending_rating_projections: disk.pending_rating_projections,
+                pending_rating_imports: disk.pending_rating_imports,
+                pending_engagement_imports: disk.pending_engagement_imports,
+                pending_aggregate_ranges: disk.pending_aggregate_ranges,
+                aggregate_play_shadows: disk.aggregate_play_shadows,
+                history_dedupe_credits: disk.history_dedupe_credits,
+                history_cursors: disk.history_cursors,
+                native_history_health: disk.native_history_health,
+                outbound_scrobbles: disk.outbound_scrobbles,
+                outbound_echoes: disk.outbound_echoes,
+                completed_outbound_scrobbles: disk.completed_outbound_scrobbles,
+            }
+        }
+        _ => return Err(StoreError::InvalidState),
+    };
+    state.validate().map_err(|_| StoreError::InvalidState)?;
+    Ok(state)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn bridge_round_trip_preserves_scope() {
-        let bridge = OpenSubsonicBridgeState::new(
+    mod aggregate_continuation;
+    mod outbound_scrobble;
+    mod rating_coalescing;
+
+    fn bridge() -> OpenSubsonicBridgeState {
+        OpenSubsonicBridgeState::new(
             BackendId::new("backend").unwrap(),
             AccountScopeId::new("account").unwrap(),
-        );
+        )
+    }
+
+    fn shadow(rating: Option<i64>, starred: bool, observed_at_unix: i64) -> RatingShadow {
+        RatingShadow {
+            raw: RawServerRating {
+                user_rating: rating,
+                starred,
+            },
+            observed_at_unix,
+            confirmed_operation_id: None,
+        }
+    }
+
+    fn portable(item_id: &str) -> PortableTrack {
+        PortableTrack {
+            key: PortableTrackKey::OpenSubsonic {
+                backend_id: "backend".to_owned(),
+                account_scope_id: "account".to_owned(),
+                item_id: item_id.to_owned(),
+            },
+            title: "Title".to_owned(),
+            artist: "Artist".to_owned(),
+            album: Some("Album".to_owned()),
+            duration_secs: Some(180),
+            isrc: None,
+        }
+    }
+
+    fn engagement(item_id: &str) -> PendingEngagementImport {
+        PendingEngagementImport {
+            track: portable(item_id),
+            engagement: EngagementKind::Play,
+            played_duration_ms: None,
+            total_duration_ms: None,
+            artist_key: "artist".to_owned(),
+            observed_at_unix: 12,
+        }
+    }
+
+    #[test]
+    fn bridge_round_trip_preserves_every_queue_and_invalid_raw_rating() {
+        let mut bridge = bridge();
+        bridge.set_native_history_health(NativeHistoryHealth::Detailed);
+        let item = ItemId::new("song").unwrap();
+        bridge
+            .upsert_rating_shadow(item.clone(), shadow(Some(99), true, 10))
+            .unwrap();
+        bridge
+            .queue_rating_projection(
+                item.clone(),
+                PendingRatingProjection {
+                    operation_id: "local-op".to_owned(),
+                    target: Rating::Disliked,
+                    stage: PendingRatingProjectionStage::SetStarred,
+                    last_readback: Some(RawServerRating {
+                        user_rating: Some(99),
+                        starred: true,
+                    }),
+                    queued_at_unix: 11,
+                },
+            )
+            .unwrap();
+        bridge
+            .queue_rating_import(
+                "server-observation".to_owned(),
+                PendingRatingImport {
+                    item_id: item.clone(),
+                    track: portable("song"),
+                    raw: RawServerRating {
+                        user_rating: Some(-9),
+                        starred: false,
+                    },
+                    mapped: Rating::Neutral,
+                    observed_at_unix: 12,
+                },
+            )
+            .unwrap();
+        bridge
+            .queue_engagement_import("history-row".to_owned(), engagement("song"))
+            .unwrap();
+        bridge
+            .upsert_aggregate_play_shadow(
+                item.clone(),
+                AggregatePlayShadow {
+                    play_count: 7,
+                    played_at: Some("2026-07-26T10:00:00Z".to_owned()),
+                    observed_at_unix: 13,
+                    counter_epoch: 2,
+                },
+            )
+            .unwrap();
+        bridge
+            .set_history_cursor(
+                "navidrome-native".to_owned(),
+                HistoryCursor {
+                    high_water_id: Some("row-7".to_owned()),
+                    overlap_started_at_unix: Some(14),
+                    updated_at_unix: 15,
+                    continuation: None,
+                    pending_metadata_rows: Vec::new(),
+                },
+            )
+            .unwrap();
+        bridge
+            .queue_outbound_scrobble(PendingOutboundScrobble {
+                event_id: "engagement-1".to_owned(),
+                item_id: item,
+                played_at_unix: 16,
+                kind: OutboundScrobbleKind::Submission,
+                delivery: OutboundScrobbleDelivery::Queued,
+                baseline_captured: false,
+                baseline_play_count: None,
+                baseline_played_at: None,
+                exact_credit_recorded: false,
+                exact_credit_epoch: None,
+                uncertain_readbacks: 0,
+                source_marker_acknowledged: false,
+            })
+            .unwrap();
+        bridge
+            .record_outbound_echo(OutboundScrobbleEcho {
+                event_id: "echo-1".to_owned(),
+                item_id: ItemId::new("song").unwrap(),
+                played_at_unix: 17,
+            })
+            .unwrap();
+
         let decoded = decode_bridge(&encode_bridge(&bridge).unwrap()).unwrap();
-        assert_eq!(decoded.backend_id().as_str(), "backend");
-        assert_eq!(decoded.account_scope_id().as_str(), "account");
+        assert_eq!(decoded, bridge);
+        assert_eq!(
+            decoded
+                .rating_shadow(&ItemId::new("song").unwrap())
+                .unwrap()
+                .raw
+                .user_rating,
+            Some(99)
+        );
+    }
+
+    #[test]
+    fn schema_one_empty_bridge_migrates_explicitly_to_schema_two() {
+        let legacy = br#"{
+            "kind":"yututui_open_subsonic_bridge",
+            "schema_version":1,
+            "revision":8,
+            "backend_id":"backend",
+            "account_scope_id":"account"
+        }"#;
+        let migrated = decode_bridge(legacy).unwrap();
+        assert_eq!(migrated.revision(), 8);
+        assert!(migrated.rating_shadows().is_empty());
+        assert!(migrated.pending_rating_projections().is_empty());
+        assert!(migrated.pending_rating_imports().is_empty());
+        assert!(migrated.pending_engagement_imports().is_empty());
+        assert!(migrated.aggregate_play_shadows().is_empty());
+        assert!(migrated.history_dedupe_credits().is_empty());
+        assert!(migrated.history_cursors().is_empty());
+        assert!(migrated.outbound_scrobbles().is_empty());
+        assert!(migrated.outbound_echoes().is_empty());
+        assert!(migrated.completed_outbound_scrobbles().is_empty());
+        assert_eq!(migrated.native_history_health(), NativeHistoryHealth::Off);
+        let encoded: serde_json::Value =
+            serde_json::from_slice(&encode_bridge(&migrated).unwrap()).unwrap();
+        assert_eq!(
+            encoded["schema_version"],
+            serde_json::Value::from(BRIDGE_SCHEMA_VERSION)
+        );
+    }
+
+    #[test]
+    fn schema_two_aggregate_shadow_without_counter_epoch_defaults_to_legacy_ids() {
+        let mut state = bridge();
+        state
+            .upsert_aggregate_play_shadow(
+                ItemId::new("song").unwrap(),
+                AggregatePlayShadow {
+                    play_count: 4,
+                    played_at: None,
+                    observed_at_unix: 12,
+                    counter_epoch: 3,
+                },
+            )
+            .unwrap();
+        let mut encoded: serde_json::Value =
+            serde_json::from_slice(&encode_bridge(&state).unwrap()).unwrap();
+        encoded["aggregate_play_shadows"]["song"]
+            .as_object_mut()
+            .unwrap()
+            .remove("counter_epoch");
+        encoded
+            .as_object_mut()
+            .unwrap()
+            .remove("native_history_health");
+
+        let decoded = decode_bridge(&serde_json::to_vec(&encoded).unwrap()).unwrap();
+        assert_eq!(
+            decoded
+                .aggregate_play_shadows()
+                .get(&ItemId::new("song").unwrap())
+                .unwrap()
+                .counter_epoch,
+            0
+        );
+        assert_eq!(decoded.native_history_health(), NativeHistoryHealth::Off);
+    }
+
+    #[test]
+    fn ordinary_shadows_have_deterministic_eviction_and_pending_are_protected() {
+        let mut bridge = bridge();
+        let protected = ItemId::new("protected").unwrap();
+        bridge
+            .upsert_rating_shadow_with_limit(protected.clone(), shadow(Some(5), true, 1), 2)
+            .unwrap();
+        bridge
+            .queue_rating_projection(
+                protected.clone(),
+                PendingRatingProjection {
+                    operation_id: "op".to_owned(),
+                    target: Rating::Liked,
+                    stage: PendingRatingProjectionStage::Readback,
+                    last_readback: None,
+                    queued_at_unix: 1,
+                },
+            )
+            .unwrap();
+        let tie_loser = ItemId::new("a").unwrap();
+        bridge
+            .upsert_rating_shadow_with_limit(tie_loser.clone(), shadow(None, false, 2), 2)
+            .unwrap();
+        let kept = ItemId::new("z").unwrap();
+        bridge
+            .upsert_rating_shadow_with_limit(kept.clone(), shadow(None, false, 2), 2)
+            .unwrap();
+
+        assert!(bridge.rating_shadow(&protected).is_some());
+        assert!(bridge.rating_shadow(&tie_loser).is_none());
+        assert!(bridge.rating_shadow(&kept).is_some());
+    }
+
+    #[test]
+    fn pending_work_is_idempotent_but_never_evicted_or_reordered() {
+        let mut bridge = bridge();
+        let item = ItemId::new("song").unwrap();
+        let import = PendingRatingImport {
+            item_id: item.clone(),
+            track: portable("song"),
+            raw: RawServerRating {
+                user_rating: Some(1),
+                starred: true,
+            },
+            mapped: Rating::Disliked,
+            observed_at_unix: 1,
+        };
+        bridge
+            .queue_rating_import("observation".to_owned(), import.clone())
+            .unwrap();
+        bridge
+            .queue_rating_import("observation".to_owned(), import)
+            .unwrap();
+        assert_eq!(bridge.pending_rating_imports().len(), 1);
+
+        let pending_engagement = engagement("song");
+        bridge
+            .queue_engagement_import("history".to_owned(), pending_engagement.clone())
+            .unwrap();
+        bridge
+            .queue_engagement_import("history".to_owned(), pending_engagement.clone())
+            .unwrap();
+        assert_eq!(bridge.pending_engagement_imports().len(), 1);
+        let mut conflicting_engagement = pending_engagement;
+        conflicting_engagement.engagement = EngagementKind::Completion;
+        assert_eq!(
+            bridge.queue_engagement_import("history".to_owned(), conflicting_engagement),
+            Err(BridgeMutationError::ConflictingEntry)
+        );
+        assert_eq!(
+            bridge.queue_engagement_import_with_limit(
+                "history-2".to_owned(),
+                engagement("song"),
+                1,
+            ),
+            Err(BridgeMutationError::CapacityExceeded)
+        );
+
+        let first = PendingOutboundScrobble {
+            event_id: "event-1".to_owned(),
+            item_id: item.clone(),
+            played_at_unix: 2,
+            kind: OutboundScrobbleKind::NowPlaying,
+            delivery: OutboundScrobbleDelivery::Queued,
+            baseline_captured: false,
+            baseline_play_count: None,
+            baseline_played_at: None,
+            exact_credit_recorded: false,
+            exact_credit_epoch: None,
+            uncertain_readbacks: 0,
+            source_marker_acknowledged: false,
+        };
+        let second = PendingOutboundScrobble {
+            event_id: "event-2".to_owned(),
+            item_id: item,
+            played_at_unix: 3,
+            kind: OutboundScrobbleKind::Submission,
+            delivery: OutboundScrobbleDelivery::Queued,
+            baseline_captured: false,
+            baseline_play_count: None,
+            baseline_played_at: None,
+            exact_credit_recorded: false,
+            exact_credit_epoch: None,
+            uncertain_readbacks: 0,
+            source_marker_acknowledged: false,
+        };
+        bridge.queue_outbound_scrobble(first.clone()).unwrap();
+        bridge.queue_outbound_scrobble(first.clone()).unwrap();
+        bridge.queue_outbound_scrobble(second).unwrap();
+        assert_eq!(bridge.outbound_scrobbles().len(), 2);
+        assert_eq!(
+            bridge.acknowledge_outbound_scrobble("event-2"),
+            Err(BridgeMutationError::ConflictingEntry)
+        );
+        assert_eq!(
+            bridge.acknowledge_outbound_scrobble("event-1").unwrap(),
+            Some(first)
+        );
+    }
+
+    #[test]
+    fn native_echo_marker_is_exact_idempotent_and_consumed_once() {
+        let mut bridge = bridge();
+        let item = ItemId::new("song").unwrap();
+        let echo = OutboundScrobbleEcho {
+            event_id: "local-submission".to_owned(),
+            item_id: item.clone(),
+            played_at_unix: 42,
+        };
+        bridge.record_outbound_echo(echo.clone()).unwrap();
+        bridge.record_outbound_echo(echo.clone()).unwrap();
+        assert!(bridge.consume_outbound_echo(&item, 41).is_none());
+        assert_eq!(bridge.consume_outbound_echo(&item, 42), Some(echo));
+        assert!(bridge.consume_outbound_echo(&item, 42).is_none());
+    }
+
+    #[test]
+    fn exact_and_aggregate_history_credits_cancel_in_either_arrival_order() {
+        let item = ItemId::new("song").unwrap();
+
+        let mut zero_baseline = bridge();
+        assert_eq!(
+            zero_baseline
+                .record_aggregate_history_evidence(item.clone(), 0, 0)
+                .unwrap(),
+            0
+        );
+        zero_baseline
+            .reconcile_native_aggregate_baseline(item.clone(), 0, 0)
+            .unwrap();
+        assert!(zero_baseline.history_dedupe_credits().is_empty());
+
+        let mut exact_first = bridge();
+        assert!(
+            exact_first
+                .record_exact_history_evidence(item.clone(), 0)
+                .unwrap()
+        );
+        assert_eq!(
+            exact_first
+                .record_aggregate_history_evidence(item.clone(), 0, 1)
+                .unwrap(),
+            0
+        );
+        assert!(exact_first.history_dedupe_credits().is_empty());
+
+        let mut aggregate_first = bridge();
+        assert_eq!(
+            aggregate_first
+                .record_aggregate_history_evidence(item.clone(), 0, 1)
+                .unwrap(),
+            1
+        );
+        assert!(
+            !aggregate_first
+                .record_exact_history_evidence(item, 0)
+                .unwrap()
+        );
+        assert!(aggregate_first.history_dedupe_credits().is_empty());
+    }
+
+    #[test]
+    fn counter_epochs_keep_exact_and_aggregate_credits_isolated() {
+        let mut bridge = bridge();
+        let item = ItemId::new("song").unwrap();
+        assert_eq!(
+            bridge
+                .record_aggregate_history_evidence(item.clone(), 0, 1)
+                .unwrap(),
+            1
+        );
+        assert!(
+            bridge
+                .record_exact_history_evidence(item.clone(), 1)
+                .unwrap()
+        );
+        let epochs = bridge.history_dedupe_credits().get(&item).unwrap();
+        assert_eq!(epochs.get(&0).unwrap().aggregate_unmatched, 1);
+        assert_eq!(epochs.get(&0).unwrap().exact_unmatched, 0);
+        assert_eq!(epochs.get(&1).unwrap().aggregate_unmatched, 0);
+        assert_eq!(epochs.get(&1).unwrap().exact_unmatched, 1);
+
+        bridge
+            .reconcile_native_aggregate_baseline(item.clone(), 1, 1)
+            .unwrap();
+        let epochs = bridge.history_dedupe_credits().get(&item).unwrap();
+        assert!(epochs.get(&1).is_none());
+        assert_eq!(epochs.get(&0).unwrap().aggregate_unmatched, 1);
+        assert!(
+            !bridge
+                .record_exact_history_evidence(item.clone(), 0)
+                .unwrap()
+        );
+        assert!(bridge.history_dedupe_credits().get(&item).is_none());
+    }
+
+    #[test]
+    fn pending_engagement_rejects_wrong_scope_and_impossible_duration() {
+        let mut bridge = bridge();
+        let mut pending = engagement("song");
+        pending.track.key = PortableTrackKey::OpenSubsonic {
+            backend_id: "different-backend".to_owned(),
+            account_scope_id: "account".to_owned(),
+            item_id: "song".to_owned(),
+        };
+        assert_eq!(
+            bridge.queue_engagement_import("history".to_owned(), pending),
+            Err(BridgeMutationError::InvalidEntry)
+        );
+
+        let mut pending = engagement("song");
+        pending.played_duration_ms = Some(401);
+        pending.total_duration_ms = Some(100);
+        assert_eq!(
+            bridge.queue_engagement_import("history".to_owned(), pending),
+            Err(BridgeMutationError::InvalidEntry)
+        );
+    }
+
+    #[test]
+    fn pending_import_requires_matching_scope_item_and_fixed_mapping() {
+        let mut bridge = bridge();
+        let item = ItemId::new("song").unwrap();
+        let mut pending = PendingRatingImport {
+            item_id: item,
+            track: portable("song"),
+            raw: RawServerRating {
+                user_rating: Some(1),
+                starred: true,
+            },
+            mapped: Rating::Liked,
+            observed_at_unix: 1,
+        };
+        assert_eq!(
+            bridge.queue_rating_import("observation".to_owned(), pending.clone()),
+            Err(BridgeMutationError::InvalidEntry)
+        );
+
+        pending.mapped = Rating::Disliked;
+        pending.track.key = PortableTrackKey::OpenSubsonic {
+            backend_id: "different-backend".to_owned(),
+            account_scope_id: "account".to_owned(),
+            item_id: "song".to_owned(),
+        };
+        assert_eq!(
+            bridge.queue_rating_import("observation".to_owned(), pending),
+            Err(BridgeMutationError::InvalidEntry)
+        );
+    }
+
+    #[test]
+    fn corrupt_or_oversized_v2_collections_are_rejected() {
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&encode_bridge(&bridge()).unwrap()).unwrap();
+        value["pending_rating_imports"] = serde_json::json!({
+            "": {
+                "item_id": "song",
+                "raw": {"user_rating": null, "starred": false},
+                "observed_at_unix": 0
+            }
+        });
+        assert_eq!(
+            decode_bridge(&serde_json::to_vec(&value).unwrap()),
+            Err(StoreError::InvalidState)
+        );
     }
 }

--- a/src/open_subsonic/bridge_store/aggregate_ranges.rs
+++ b/src/open_subsonic/bridge_store/aggregate_ranges.rs
@@ -1,0 +1,205 @@
+//! Compact, durable continuation for standard aggregate play-count growth.
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    BridgeMutationError, MAX_PENDING_AGGREGATE_RANGES, MAX_PENDING_ENGAGEMENT_IMPORTS,
+    OpenSubsonicBridgeState, PendingEngagementImport,
+};
+use crate::open_subsonic::history::AggregatePlayRange;
+use crate::open_subsonic::model::ItemId;
+use crate::personal_state::{EngagementKind, PortableTrack, PortableTrackKey};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PendingAggregateRange {
+    pub track: PortableTrack,
+    pub artist_key: String,
+    pub counter_epoch: u64,
+    pub range: AggregatePlayRange,
+}
+
+impl OpenSubsonicBridgeState {
+    #[cfg(test)]
+    pub(crate) fn pending_aggregate_ranges(
+        &self,
+    ) -> &std::collections::VecDeque<PendingAggregateRange> {
+        &self.pending_aggregate_ranges
+    }
+
+    pub(crate) fn queue_aggregate_range(
+        &mut self,
+        pending: PendingAggregateRange,
+    ) -> Result<(), BridgeMutationError> {
+        self.validate_pending_aggregate_range(&pending)?;
+        if self
+            .pending_aggregate_ranges
+            .iter()
+            .any(|existing| existing == &pending)
+        {
+            return Ok(());
+        }
+        if self.pending_aggregate_ranges.len() >= MAX_PENDING_AGGREGATE_RANGES {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        let overlaps = self.pending_aggregate_ranges.iter().any(|existing| {
+            existing.range.item == pending.range.item
+                && existing.counter_epoch == pending.counter_epoch
+                && existing.range.first_ordinal <= pending.range.last_ordinal
+                && pending.range.first_ordinal <= existing.range.last_ordinal
+        });
+        if overlaps {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+        self.pending_aggregate_ranges.push_back(pending);
+        Ok(())
+    }
+
+    /// Fill the bounded import queue without expanding the unprocessed ordinal tail.
+    ///
+    /// Exact-first evidence consumes a prefix arithmetically, so even an enormous suppressed range
+    /// does not allocate or loop once per server play.
+    pub(crate) fn materialize_pending_aggregate_ranges(
+        &mut self,
+    ) -> Result<(), BridgeMutationError> {
+        loop {
+            let available = MAX_PENDING_ENGAGEMENT_IMPORTS
+                .saturating_sub(self.pending_engagement_imports.len());
+            let Some((position, pending)) = self
+                .pending_aggregate_ranges
+                .iter()
+                .enumerate()
+                .find(|(_, pending)| {
+                    let item_id = pending.range.item.item_id();
+                    !self.has_unresolved_outbound_submission(item_id)
+                        && (available > 0
+                            || self.exact_history_credit_count(item_id, pending.counter_epoch) > 0)
+                })
+                .map(|(position, pending)| (position, pending.clone()))
+            else {
+                return Ok(());
+            };
+            let item_id = pending.range.item.item_id().clone();
+            let exact = self.exact_history_credit_count(&item_id, pending.counter_epoch);
+            let logical_count = pending
+                .range
+                .logical_len()
+                .min(exact.saturating_add(available as u64));
+            let import_count = self.record_aggregate_history_evidence(
+                item_id,
+                pending.counter_epoch,
+                logical_count,
+            )?;
+            let suppressed = logical_count.saturating_sub(import_count);
+            let first_import = pending
+                .range
+                .first_ordinal
+                .checked_add(suppressed)
+                .ok_or(BridgeMutationError::CapacityExceeded)?;
+            let consumed_through = pending
+                .range
+                .first_ordinal
+                .checked_add(logical_count.saturating_sub(1))
+                .ok_or(BridgeMutationError::CapacityExceeded)?;
+            for ordinal in first_import..=consumed_through {
+                let play = pending
+                    .range
+                    .play(ordinal)
+                    .ok_or(BridgeMutationError::InvalidEntry)?;
+                self.queue_engagement_import(
+                    play.event_id,
+                    PendingEngagementImport {
+                        track: pending.track.clone(),
+                        engagement: EngagementKind::Play,
+                        played_duration_ms: None,
+                        total_duration_ms: pending
+                            .track
+                            .duration_secs
+                            .map(|seconds| u64::from(seconds).saturating_mul(1_000)),
+                        artist_key: pending.artist_key.clone(),
+                        observed_at_unix: play.played_at_unix,
+                    },
+                )?;
+            }
+            if consumed_through == pending.range.last_ordinal {
+                self.pending_aggregate_ranges.remove(position);
+            } else {
+                self.pending_aggregate_ranges
+                    .get_mut(position)
+                    .ok_or(BridgeMutationError::ConflictingEntry)?
+                    .range
+                    .first_ordinal = consumed_through
+                    .checked_add(1)
+                    .ok_or(BridgeMutationError::CapacityExceeded)?;
+            }
+        }
+    }
+
+    pub(super) fn aggregate_item_is_protected(&self, item_id: &ItemId) -> bool {
+        self.history_dedupe_credits.contains_key(item_id)
+            || self
+                .pending_aggregate_ranges
+                .iter()
+                .any(|pending| pending.range.item.item_id() == item_id)
+    }
+
+    pub(super) fn validate_pending_aggregate_range(
+        &self,
+        pending: &PendingAggregateRange,
+    ) -> Result<(), BridgeMutationError> {
+        pending
+            .track
+            .validate()
+            .map_err(|_| BridgeMutationError::InvalidEntry)?;
+        super::validate_portable_text(&pending.artist_key)?;
+        if pending.range.first_ordinal == 0
+            || pending.range.first_ordinal > pending.range.last_ordinal
+            || (!pending.range.has_server_time && !pending.range.has_server_ordinal)
+            || (!pending.range.has_server_ordinal && pending.range.logical_len() != 1)
+        {
+            return Err(BridgeMutationError::InvalidEntry);
+        }
+        let PortableTrackKey::OpenSubsonic {
+            backend_id,
+            account_scope_id,
+            item_id,
+        } = &pending.track.key
+        else {
+            return Err(BridgeMutationError::InvalidEntry);
+        };
+        if backend_id != self.backend_id.as_str()
+            || account_scope_id != self.account_scope_id.as_str()
+            || item_id != pending.range.item.item_id().as_str()
+            || pending.range.item.backend_id() != &self.backend_id
+            || pending.range.item.account_scope_id() != &self.account_scope_id
+        {
+            return Err(BridgeMutationError::InvalidEntry);
+        }
+        let shadow = self
+            .aggregate_play_shadows
+            .get(pending.range.item.item_id())
+            .ok_or(BridgeMutationError::InvalidEntry)?;
+        if pending.counter_epoch > shadow.counter_epoch
+            || (pending.counter_epoch == shadow.counter_epoch
+                && pending.range.last_ordinal > shadow.play_count)
+        {
+            return Err(BridgeMutationError::InvalidEntry);
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_pending_aggregate_ranges(&self) -> Result<(), BridgeMutationError> {
+        let mut last_by_generation = std::collections::BTreeMap::<(&ItemId, u64), u64>::new();
+        for pending in &self.pending_aggregate_ranges {
+            self.validate_pending_aggregate_range(pending)?;
+            let key = (pending.range.item.item_id(), pending.counter_epoch);
+            if last_by_generation
+                .insert(key, pending.range.last_ordinal)
+                .is_some_and(|last| last >= pending.range.first_ordinal)
+            {
+                return Err(BridgeMutationError::ConflictingEntry);
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/open_subsonic/bridge_store/history_credits.rs
+++ b/src/open_subsonic/bridge_store/history_credits.rs
@@ -1,0 +1,185 @@
+//! Durable reconciliation between exact scrobble rows and aggregate play counters.
+
+use super::{
+    BridgeMutationError, HistoryDedupeCredits, ItemId, MAX_HISTORY_DEDUPE_CREDITS,
+    OpenSubsonicBridgeState,
+};
+
+impl OpenSubsonicBridgeState {
+    #[cfg(test)]
+    pub(crate) fn history_dedupe_credits(
+        &self,
+    ) -> &std::collections::BTreeMap<ItemId, std::collections::BTreeMap<u64, HistoryDedupeCredits>>
+    {
+        &self.history_dedupe_credits
+    }
+
+    /// Record one exact event. `true` means it is new evidence that should be imported; `false`
+    /// means an earlier aggregate fallback in the same counter generation already represented it.
+    pub(crate) fn record_exact_history_evidence(
+        &mut self,
+        item_id: ItemId,
+        counter_epoch: u64,
+    ) -> Result<bool, BridgeMutationError> {
+        self.ensure_credit_slot(&item_id, counter_epoch)?;
+        let credits = self
+            .history_dedupe_credits
+            .entry(item_id.clone())
+            .or_default()
+            .entry(counter_epoch)
+            .or_insert(HistoryDedupeCredits {
+                exact_unmatched: 0,
+                aggregate_unmatched: 0,
+            });
+        let should_import = if credits.aggregate_unmatched > 0 {
+            credits.aggregate_unmatched -= 1;
+            false
+        } else {
+            credits.exact_unmatched = credits
+                .exact_unmatched
+                .checked_add(1)
+                .ok_or(BridgeMutationError::CapacityExceeded)?;
+            true
+        };
+        self.remove_empty_credits(&item_id, counter_epoch);
+        Ok(should_import)
+    }
+
+    /// Reserve one future aggregate increment for an outbound local event already present in the
+    /// personal-state ledger.
+    ///
+    /// Unlike an imported exact history row, this must never pair with older aggregate evidence:
+    /// doing so would silently relabel an unrelated mobile play as the local outbound report.
+    pub(crate) fn reserve_outbound_exact_history_credit(
+        &mut self,
+        item_id: ItemId,
+        counter_epoch: u64,
+    ) -> Result<(), BridgeMutationError> {
+        self.ensure_credit_slot(&item_id, counter_epoch)?;
+        let credits = self
+            .history_dedupe_credits
+            .entry(item_id)
+            .or_default()
+            .entry(counter_epoch)
+            .or_insert(HistoryDedupeCredits {
+                exact_unmatched: 0,
+                aggregate_unmatched: 0,
+            });
+        credits.exact_unmatched = credits
+            .exact_unmatched
+            .checked_add(1)
+            .ok_or(BridgeMutationError::CapacityExceeded)?;
+        Ok(())
+    }
+
+    /// Discard one speculative exact credit in the generation where it was registered.
+    pub(crate) fn discard_exact_history_evidence(&mut self, item_id: &ItemId, counter_epoch: u64) {
+        if let Some(credits) = self
+            .history_dedupe_credits
+            .get_mut(item_id)
+            .and_then(|epochs| epochs.get_mut(&counter_epoch))
+        {
+            credits.exact_unmatched = credits.exact_unmatched.saturating_sub(1);
+        }
+        self.remove_empty_credits(item_id, counter_epoch);
+    }
+
+    pub(super) fn exact_history_credit_count(&self, item_id: &ItemId, counter_epoch: u64) -> u64 {
+        self.history_dedupe_credits
+            .get(item_id)
+            .and_then(|epochs| epochs.get(&counter_epoch))
+            .map_or(0, |credits| credits.exact_unmatched)
+    }
+
+    /// Reconcile aggregate counter growth against exact events. The returned suffix length is the
+    /// number of aggregate operations that still need importing.
+    pub(crate) fn record_aggregate_history_evidence(
+        &mut self,
+        item_id: ItemId,
+        counter_epoch: u64,
+        delta: u64,
+    ) -> Result<u64, BridgeMutationError> {
+        if delta == 0 {
+            return Ok(0);
+        }
+        self.ensure_credit_slot(&item_id, counter_epoch)?;
+        let credits = self
+            .history_dedupe_credits
+            .entry(item_id.clone())
+            .or_default()
+            .entry(counter_epoch)
+            .or_insert(HistoryDedupeCredits {
+                exact_unmatched: 0,
+                aggregate_unmatched: 0,
+            });
+        let consumed = delta.min(credits.exact_unmatched);
+        credits.exact_unmatched -= consumed;
+        let remaining = delta - consumed;
+        credits.aggregate_unmatched = credits
+            .aggregate_unmatched
+            .checked_add(remaining)
+            .ok_or(BridgeMutationError::CapacityExceeded)?;
+        self.remove_empty_credits(&item_id, counter_epoch);
+        Ok(remaining)
+    }
+
+    /// Advance an aggregate baseline observed alongside exact rows without creating fallback
+    /// operations. This consumes only exact credits from the matching counter generation.
+    pub(crate) fn reconcile_native_aggregate_baseline(
+        &mut self,
+        item_id: ItemId,
+        counter_epoch: u64,
+        delta: u64,
+    ) -> Result<(), BridgeMutationError> {
+        if let Some(credits) = self
+            .history_dedupe_credits
+            .get_mut(&item_id)
+            .and_then(|epochs| epochs.get_mut(&counter_epoch))
+        {
+            credits.exact_unmatched -= delta.min(credits.exact_unmatched);
+        }
+        self.remove_empty_credits(&item_id, counter_epoch);
+        Ok(())
+    }
+
+    pub(super) fn history_credit_entry_count(&self) -> Result<usize, BridgeMutationError> {
+        self.history_dedupe_credits
+            .values()
+            .try_fold(0_usize, |total, epochs| {
+                total
+                    .checked_add(epochs.len())
+                    .ok_or(BridgeMutationError::CapacityExceeded)
+            })
+    }
+
+    fn ensure_credit_slot(
+        &self,
+        item_id: &ItemId,
+        counter_epoch: u64,
+    ) -> Result<(), BridgeMutationError> {
+        if self
+            .history_dedupe_credits
+            .get(item_id)
+            .is_some_and(|epochs| epochs.contains_key(&counter_epoch))
+        {
+            return Ok(());
+        }
+        if self.history_credit_entry_count()? >= MAX_HISTORY_DEDUPE_CREDITS {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        Ok(())
+    }
+
+    fn remove_empty_credits(&mut self, item_id: &ItemId, counter_epoch: u64) {
+        if let Some(epochs) = self.history_dedupe_credits.get_mut(item_id) {
+            if epochs.get(&counter_epoch).is_some_and(|credits| {
+                credits.exact_unmatched == 0 && credits.aggregate_unmatched == 0
+            }) {
+                epochs.remove(&counter_epoch);
+            }
+            if epochs.is_empty() {
+                self.history_dedupe_credits.remove(item_id);
+            }
+        }
+    }
+}

--- a/src/open_subsonic/bridge_store/history_cursor.rs
+++ b/src/open_subsonic/bridge_store/history_cursor.rs
@@ -1,0 +1,202 @@
+//! Durable bounded progress for exact server-history imports.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    BridgeMutationError, MAX_CURSOR_KEY_BYTES, MAX_EVENT_ID_BYTES, MAX_HISTORY_CURSORS,
+    OpenSubsonicBridgeState, validate_identifier,
+};
+
+/// Resume point for a bounded exact-history importer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct HistoryCursor {
+    pub high_water_id: Option<String>,
+    pub overlap_started_at_unix: Option<i64>,
+    pub updated_at_unix: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub continuation: Option<HistoryContinuation>,
+    /// Exact rows whose metadata must be resolved before scanning advances again.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pending_metadata_rows: Vec<PendingNativeMetadataRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PendingNativeMetadataRow {
+    pub row_id: u64,
+    pub item_id: super::ItemId,
+    pub observed_at_unix: i64,
+}
+
+/// Durable progress for a scan that exhausted one bounded refresh.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct HistoryContinuation {
+    pub candidate_high_water_id: Option<String>,
+    pub next_start: u32,
+    pub through_unix: Option<u64>,
+    #[serde(default)]
+    pub reached_high_water: bool,
+    /// IDs from the preceding page that an inclusive timestamp boundary can return again.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub overlap_row_ids: Vec<u64>,
+    #[serde(default)]
+    pub backlog_complete: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_anchor_high_water_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_next_start: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_from_unix: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_through_unix: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub head_overlap_row_ids: Vec<u64>,
+}
+
+/// Redacted capability/health for the optional native-history bridge.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeHistoryHealth {
+    #[default]
+    Off,
+    Probing,
+    Detailed,
+    PlayCountsOnly,
+    UpdatePassword,
+}
+
+impl OpenSubsonicBridgeState {
+    pub(crate) fn history_cursors(&self) -> &std::collections::BTreeMap<String, HistoryCursor> {
+        &self.history_cursors
+    }
+
+    pub(crate) fn set_history_cursor(
+        &mut self,
+        source: String,
+        cursor: HistoryCursor,
+    ) -> Result<(), BridgeMutationError> {
+        validate_identifier(&source, MAX_CURSOR_KEY_BYTES)?;
+        validate(&cursor)?;
+        if !self.history_cursors.contains_key(&source)
+            && self.history_cursors.len() >= MAX_HISTORY_CURSORS
+        {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        self.history_cursors.insert(source, cursor);
+        Ok(())
+    }
+}
+
+pub(super) fn validate(cursor: &HistoryCursor) -> Result<(), BridgeMutationError> {
+    if let Some(high_water_id) = &cursor.high_water_id {
+        validate_identifier(high_water_id, MAX_EVENT_ID_BYTES)?;
+    }
+    if let Some(continuation) = &cursor.continuation {
+        if let Some(candidate) = &continuation.candidate_high_water_id {
+            validate_identifier(candidate, MAX_EVENT_ID_BYTES)?;
+        }
+        if let Some(anchor) = &continuation.head_anchor_high_water_id {
+            validate_identifier(anchor, MAX_EVENT_ID_BYTES)?;
+        }
+        if continuation.next_start as usize
+            >= super::super::native_history::MAX_NATIVE_HISTORY_OFFSET
+        {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        if continuation.head_next_start.is_some_and(|next_start| {
+            next_start as usize >= super::super::native_history::MAX_NATIVE_HISTORY_OFFSET
+        }) {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        validate_overlap(&continuation.overlap_row_ids)?;
+        validate_overlap(&continuation.head_overlap_row_ids)?;
+        if continuation.head_next_start.is_none()
+            && (continuation.head_anchor_high_water_id.is_some()
+                || continuation.head_from_unix.is_some()
+                || continuation.head_through_unix.is_some()
+                || !continuation.head_overlap_row_ids.is_empty())
+        {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+        if matches!(
+            (
+                continuation.head_from_unix,
+                continuation.head_through_unix
+            ),
+            (Some(from), Some(through)) if from > through
+        ) {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+    }
+    if cursor.pending_metadata_rows.len() > super::super::native_history::MAX_NATIVE_HISTORY_ROWS {
+        return Err(BridgeMutationError::CapacityExceeded);
+    }
+    let mut row_ids = BTreeSet::new();
+    if cursor
+        .pending_metadata_rows
+        .iter()
+        .any(|row| !row_ids.insert(row.row_id))
+    {
+        return Err(BridgeMutationError::ConflictingEntry);
+    }
+    Ok(())
+}
+
+fn validate_overlap(ids: &[u64]) -> Result<(), BridgeMutationError> {
+    if ids.len() > super::super::native_history::NATIVE_HISTORY_PAGE_SIZE {
+        return Err(BridgeMutationError::CapacityExceeded);
+    }
+    let mut unique = BTreeSet::new();
+    if ids.iter().any(|id| !unique.insert(id)) {
+        return Err(BridgeMutationError::ConflictingEntry);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_metadata_rows_survive_a_restart_round_trip() {
+        let cursor = HistoryCursor {
+            high_water_id: Some("65".to_owned()),
+            overlap_started_at_unix: Some(1),
+            updated_at_unix: 2,
+            continuation: None,
+            pending_metadata_rows: (1..=65)
+                .rev()
+                .map(|id| PendingNativeMetadataRow {
+                    row_id: id,
+                    item_id: super::super::ItemId::new(format!("song-{id}")).unwrap(),
+                    observed_at_unix: i64::try_from(id).unwrap(),
+                })
+                .collect(),
+        };
+
+        let encoded = serde_json::to_vec(&cursor).unwrap();
+        let restored: HistoryCursor = serde_json::from_slice(&encoded).unwrap();
+
+        assert_eq!(restored, cursor);
+        validate(&restored).unwrap();
+    }
+
+    #[test]
+    fn older_cursor_json_defaults_to_no_pending_metadata() {
+        let restored: HistoryCursor = serde_json::from_str(
+            r#"{
+                "high_water_id":"7",
+                "overlap_started_at_unix":1,
+                "updated_at_unix":2,
+                "continuation":null
+            }"#,
+        )
+        .unwrap();
+
+        assert!(restored.pending_metadata_rows.is_empty());
+    }
+}

--- a/src/open_subsonic/bridge_store/outbound_lifecycle.rs
+++ b/src/open_subsonic/bridge_store/outbound_lifecycle.rs
@@ -1,0 +1,84 @@
+//! Small read and startup helpers for the durable outbound report lifecycle.
+
+use super::{
+    BridgeMutationError, CompletedOutboundScrobble, MAX_EVENT_ID_BYTES, MAX_PLAYED_AT_BYTES,
+    MAX_UNCERTAIN_SCROBBLE_READBACKS, OpenSubsonicBridgeState, OutboundScrobbleDelivery,
+    OutboundScrobbleKind, PendingOutboundScrobble, validate_identifier, validate_text,
+};
+
+pub(super) fn validate_outbound_scrobble(
+    pending: &PendingOutboundScrobble,
+) -> Result<(), BridgeMutationError> {
+    validate_identifier(&pending.event_id, MAX_EVENT_ID_BYTES)?;
+    if let Some(played_at) = &pending.baseline_played_at {
+        validate_text(played_at, MAX_PLAYED_AT_BYTES)?;
+    }
+    if (pending.delivery == OutboundScrobbleDelivery::Queued && pending.exact_credit_recorded)
+        || pending.exact_credit_recorded != pending.exact_credit_epoch.is_some()
+        || pending.uncertain_readbacks > MAX_UNCERTAIN_SCROBBLE_READBACKS
+        || (pending.delivery == OutboundScrobbleDelivery::Queued
+            && pending.uncertain_readbacks != 0)
+        || (pending.delivery == OutboundScrobbleDelivery::NeedsAttention
+            && (pending.kind != OutboundScrobbleKind::Submission
+                || !pending.baseline_captured
+                || !pending.exact_credit_recorded
+                || pending.uncertain_readbacks != MAX_UNCERTAIN_SCROBBLE_READBACKS))
+    {
+        return Err(BridgeMutationError::InvalidEntry);
+    }
+    Ok(())
+}
+
+pub(super) fn same_outbound_identity(
+    left: &PendingOutboundScrobble,
+    right: &PendingOutboundScrobble,
+) -> bool {
+    left.event_id == right.event_id
+        && left.item_id == right.item_id
+        && left.played_at_unix == right.played_at_unix
+        && left.kind == right.kind
+}
+
+pub(super) fn completed_matches_pending(
+    completed: &CompletedOutboundScrobble,
+    pending: &PendingOutboundScrobble,
+) -> bool {
+    completed.event_id == pending.event_id
+        && completed.item_id == pending.item_id
+        && completed.played_at_unix == pending.played_at_unix
+        && completed.kind == pending.kind
+}
+
+impl OpenSubsonicBridgeState {
+    pub(crate) fn outbound_scrobbles(
+        &self,
+    ) -> &std::collections::VecDeque<PendingOutboundScrobble> {
+        &self.outbound_scrobbles
+    }
+
+    pub(crate) fn outbound_scrobble_attention_ids(&self) -> Vec<String> {
+        self.outbound_scrobbles
+            .iter()
+            .filter(|pending| pending.delivery == OutboundScrobbleDelivery::NeedsAttention)
+            .map(|pending| pending.event_id.clone())
+            .collect()
+    }
+
+    pub(crate) fn has_unresolved_outbound_submission(&self, item_id: &super::ItemId) -> bool {
+        self.outbound_scrobbles.iter().any(|pending| {
+            pending.item_id == *item_id
+                && pending.kind == OutboundScrobbleKind::Submission
+                && matches!(
+                    pending.delivery,
+                    OutboundScrobbleDelivery::Uncertain | OutboundScrobbleDelivery::NeedsAttention
+                )
+        })
+    }
+
+    pub(crate) fn discard_stale_now_playing(&mut self) -> usize {
+        let before = self.outbound_scrobbles.len();
+        self.outbound_scrobbles
+            .retain(|pending| pending.kind != OutboundScrobbleKind::NowPlaying);
+        before.saturating_sub(self.outbound_scrobbles.len())
+    }
+}

--- a/src/open_subsonic/bridge_store/tests/aggregate_continuation.rs
+++ b/src/open_subsonic/bridge_store/tests/aggregate_continuation.rs
@@ -1,0 +1,134 @@
+use super::*;
+use crate::open_subsonic::history::AggregatePlayRange;
+use crate::open_subsonic::model::OpenSubsonicItemRef;
+
+fn range(first: u64, last: u64, counter_epoch: u64) -> PendingAggregateRange {
+    PendingAggregateRange {
+        track: portable("song"),
+        artist_key: "artist".to_owned(),
+        counter_epoch,
+        range: AggregatePlayRange {
+            item: OpenSubsonicItemRef::new(
+                BackendId::new("backend").unwrap(),
+                AccountScopeId::new("account").unwrap(),
+                ItemId::new("song").unwrap(),
+            ),
+            first_ordinal: first,
+            last_ordinal: last,
+            played_at_unix: 42,
+            has_server_time: true,
+            has_server_ordinal: true,
+        },
+    }
+}
+
+fn bridge_with_shadow(play_count: u64, counter_epoch: u64) -> OpenSubsonicBridgeState {
+    let mut state = bridge();
+    state
+        .upsert_aggregate_play_shadow(
+            ItemId::new("song").unwrap(),
+            AggregatePlayShadow {
+                play_count,
+                played_at: Some("1970-01-01T00:00:42Z".to_owned()),
+                observed_at_unix: 42,
+                counter_epoch,
+            },
+        )
+        .unwrap();
+    state
+}
+
+#[test]
+fn twenty_thousand_plus_one_is_compact_durable_and_refills_after_ack() {
+    let mut state = bridge_with_shadow(20_001, 0);
+    state.queue_aggregate_range(range(1, 20_001, 0)).unwrap();
+    state.materialize_pending_aggregate_ranges().unwrap();
+
+    assert_eq!(state.pending_engagement_imports().len(), 20_000);
+    let tail = state.pending_aggregate_ranges().front().unwrap();
+    assert_eq!(tail.range.first_ordinal, 20_001);
+    assert_eq!(tail.range.last_ordinal, 20_001);
+
+    let encoded = encode_bridge(&state).unwrap();
+    assert!((encoded.len() as u64) < MAX_BRIDGE_BYTES);
+    let mut restarted = decode_bridge(&encoded).unwrap();
+    assert_eq!(restarted, state);
+    let mut frozen = restarted.clone();
+    let item_id = ItemId::new("song").unwrap();
+    frozen
+        .reserve_outbound_exact_history_credit(item_id.clone(), 0)
+        .unwrap();
+    frozen
+        .queue_outbound_scrobble(PendingOutboundScrobble {
+            event_id: "uncertain".to_owned(),
+            item_id: item_id.clone(),
+            played_at_unix: 42,
+            kind: OutboundScrobbleKind::Submission,
+            delivery: OutboundScrobbleDelivery::Uncertain,
+            baseline_captured: true,
+            baseline_play_count: Some(20_000),
+            baseline_played_at: Some("1970-01-01T00:00:42Z".to_owned()),
+            exact_credit_recorded: true,
+            exact_credit_epoch: Some(0),
+            uncertain_readbacks: 0,
+            source_marker_acknowledged: false,
+        })
+        .unwrap();
+    let frozen_ack = frozen
+        .pending_engagement_imports()
+        .keys()
+        .next()
+        .cloned()
+        .unwrap();
+    frozen.remove_engagement_import(&frozen_ack);
+    frozen.materialize_pending_aggregate_ranges().unwrap();
+    assert_eq!(frozen.pending_engagement_imports().len(), 19_999);
+    assert_eq!(
+        frozen
+            .pending_aggregate_ranges()
+            .front()
+            .unwrap()
+            .range
+            .first_ordinal,
+        20_001
+    );
+
+    let acknowledged = restarted
+        .pending_engagement_imports()
+        .keys()
+        .next()
+        .cloned()
+        .unwrap();
+    restarted.remove_engagement_import(&acknowledged);
+    restarted.materialize_pending_aggregate_ranges().unwrap();
+    assert_eq!(restarted.pending_engagement_imports().len(), 20_000);
+    assert!(restarted.pending_aggregate_ranges().is_empty());
+    assert_eq!(
+        restarted
+            .history_dedupe_credits()
+            .get(&ItemId::new("song").unwrap())
+            .unwrap()
+            .get(&0)
+            .unwrap()
+            .aggregate_unmatched,
+        20_001
+    );
+}
+
+#[test]
+fn corrupt_ranges_and_payloads_over_sixteen_mib_are_rejected() {
+    let mut state = bridge_with_shadow(20_001, 0);
+    state.queue_aggregate_range(range(1, 20_001, 0)).unwrap();
+    state.materialize_pending_aggregate_ranges().unwrap();
+    let mut value: serde_json::Value =
+        serde_json::from_slice(&encode_bridge(&state).unwrap()).unwrap();
+
+    value["pending_aggregate_ranges"][0]["counter_epoch"] = serde_json::Value::from(1);
+    assert_eq!(
+        decode_bridge(&serde_json::to_vec(&value).unwrap()),
+        Err(StoreError::InvalidState)
+    );
+
+    let oversized = vec![b' '; usize::try_from(MAX_BRIDGE_BYTES).unwrap() + 1];
+    assert_eq!(decode_bridge(&oversized), Err(StoreError::PayloadTooLarge));
+}

--- a/src/open_subsonic/bridge_store/tests/outbound_scrobble.rs
+++ b/src/open_subsonic/bridge_store/tests/outbound_scrobble.rs
@@ -1,0 +1,135 @@
+use super::*;
+
+#[test]
+fn completed_or_echoed_owner_event_replay_is_a_no_op() {
+    let mut bridge = bridge();
+    let item = ItemId::new("song").unwrap();
+    let pending = PendingOutboundScrobble {
+        event_id: "stable-owner-event".to_owned(),
+        item_id: item.clone(),
+        played_at_unix: 42,
+        kind: OutboundScrobbleKind::Submission,
+        delivery: OutboundScrobbleDelivery::Queued,
+        baseline_captured: false,
+        baseline_play_count: None,
+        baseline_played_at: None,
+        exact_credit_recorded: false,
+        exact_credit_epoch: None,
+        uncertain_readbacks: 0,
+        source_marker_acknowledged: false,
+    };
+    bridge.queue_outbound_scrobble(pending.clone()).unwrap();
+    bridge
+        .complete_outbound_scrobble(&pending.event_id)
+        .unwrap();
+    bridge
+        .record_outbound_echo(OutboundScrobbleEcho {
+            event_id: pending.event_id.clone(),
+            item_id: item,
+            played_at_unix: 42,
+        })
+        .unwrap();
+
+    bridge.queue_outbound_scrobble(pending.clone()).unwrap();
+    assert!(bridge.outbound_scrobbles().is_empty());
+    assert_eq!(bridge.completed_outbound_scrobbles().len(), 1);
+
+    let mut conflicting = pending;
+    conflicting.played_at_unix += 1;
+    assert_eq!(
+        bridge.queue_outbound_scrobble(conflicting),
+        Err(BridgeMutationError::ConflictingEntry)
+    );
+}
+
+#[test]
+fn unacknowledged_completion_window_backpressures_and_survives_restart() {
+    let mut bridge = bridge();
+    let item = ItemId::new("song").unwrap();
+    let pending = |index: usize| PendingOutboundScrobble {
+        event_id: format!("event-{index}"),
+        item_id: item.clone(),
+        played_at_unix: index as i64,
+        kind: OutboundScrobbleKind::Submission,
+        delivery: OutboundScrobbleDelivery::Uncertain,
+        baseline_captured: true,
+        baseline_play_count: Some(index as u64),
+        baseline_played_at: None,
+        exact_credit_recorded: true,
+        exact_credit_epoch: Some(0),
+        uncertain_readbacks: 0,
+        source_marker_acknowledged: false,
+    };
+    for index in 0..MAX_COMPLETED_OUTBOUND_SCROBBLES {
+        let event = pending(index);
+        bridge.queue_outbound_scrobble(event.clone()).unwrap();
+        bridge.complete_outbound_scrobble(&event.event_id).unwrap();
+    }
+
+    let mut restarted = decode_bridge(&encode_bridge(&bridge).unwrap()).unwrap();
+    let oldest = pending(0);
+    restarted.queue_outbound_scrobble(oldest.clone()).unwrap();
+    assert!(restarted.outbound_scrobbles().is_empty());
+    assert_eq!(
+        restarted.completed_outbound_scrobbles().len(),
+        MAX_COMPLETED_OUTBOUND_SCROBBLES
+    );
+
+    let overflow = pending(MAX_COMPLETED_OUTBOUND_SCROBBLES);
+    restarted.queue_outbound_scrobble(overflow.clone()).unwrap();
+    assert_eq!(
+        restarted.complete_outbound_scrobble(&overflow.event_id),
+        Err(BridgeMutationError::CapacityExceeded)
+    );
+    assert!(
+        restarted
+            .outbound_scrobbles()
+            .iter()
+            .any(|event| event.event_id == overflow.event_id)
+    );
+
+    restarted
+        .acknowledge_outbound_source(&oldest.event_id)
+        .unwrap();
+    restarted
+        .complete_outbound_scrobble(&overflow.event_id)
+        .unwrap();
+    assert_eq!(
+        restarted.completed_outbound_scrobbles().len(),
+        MAX_COMPLETED_OUTBOUND_SCROBBLES
+    );
+}
+
+#[test]
+fn outbound_reserve_never_consumes_preexisting_aggregate_evidence() {
+    let mut bridge = bridge();
+    let item = ItemId::new("song").unwrap();
+    assert_eq!(
+        bridge
+            .record_aggregate_history_evidence(item.clone(), 0, 1)
+            .unwrap(),
+        1
+    );
+
+    bridge
+        .reserve_outbound_exact_history_credit(item.clone(), 0)
+        .unwrap();
+    let credits = bridge
+        .history_dedupe_credits()
+        .get(&item)
+        .unwrap()
+        .get(&0)
+        .unwrap();
+    assert_eq!(credits.aggregate_unmatched, 1);
+    assert_eq!(credits.exact_unmatched, 1);
+
+    bridge.discard_exact_history_evidence(&item, 0);
+    let credits = bridge
+        .history_dedupe_credits()
+        .get(&item)
+        .unwrap()
+        .get(&0)
+        .unwrap();
+    assert_eq!(credits.aggregate_unmatched, 1);
+    assert_eq!(credits.exact_unmatched, 0);
+}

--- a/src/open_subsonic/bridge_store/tests/rating_coalescing.rs
+++ b/src/open_subsonic/bridge_store/tests/rating_coalescing.rs
@@ -1,0 +1,49 @@
+use super::*;
+
+#[test]
+fn newest_rating_observation_coalesces_by_item_and_survives_restart() {
+    let mut bridge = bridge();
+    let item = ItemId::new("song").unwrap();
+    let pending = |raw, mapped, observed_at_unix| PendingRatingImport {
+        item_id: item.clone(),
+        track: portable("song"),
+        raw,
+        mapped,
+        observed_at_unix,
+    };
+    bridge
+        .queue_rating_import(
+            "zz-older-lexically-later".to_owned(),
+            pending(
+                RawServerRating {
+                    user_rating: Some(5),
+                    starred: true,
+                },
+                Rating::Liked,
+                10,
+            ),
+        )
+        .unwrap();
+    bridge
+        .queue_rating_import(
+            "aa-newer-lexically-earlier".to_owned(),
+            pending(
+                RawServerRating {
+                    user_rating: Some(1),
+                    starred: false,
+                },
+                Rating::Disliked,
+                11,
+            ),
+        )
+        .unwrap();
+
+    let restarted = decode_bridge(&encode_bridge(&bridge).unwrap()).unwrap();
+    assert_eq!(restarted.pending_rating_imports().len(), 1);
+    let (operation_id, pending) = restarted
+        .pending_rating_imports()
+        .first_key_value()
+        .unwrap();
+    assert_eq!(operation_id, "aa-newer-lexically-earlier");
+    assert_eq!(pending.mapped, Rating::Disliked);
+}

--- a/src/open_subsonic/catalog.rs
+++ b/src/open_subsonic/catalog.rs
@@ -168,6 +168,51 @@ impl<'a> OpenSubsonicCatalog<'a> {
         }))
     }
 
+    pub async fn get_song(&self, item: &OpenSubsonicItemRef) -> Result<ServerSong, ServerError> {
+        self.validate_item_scope(item)?;
+        let song = self
+            .client
+            .get_song_raw(self.credential, item)
+            .await
+            .and_then(|raw| self.song(raw).ok_or(ServerError::InvalidResponse))?;
+        if &song.item != item {
+            return Err(ServerError::InvalidResponse);
+        }
+        Ok(song)
+    }
+
+    pub async fn set_rating(
+        &self,
+        item: &OpenSubsonicItemRef,
+        rating: u8,
+    ) -> Result<(), ServerError> {
+        self.validate_item_scope(item)?;
+        self.client.set_rating(self.credential, item, rating).await
+    }
+
+    pub async fn star(&self, item: &OpenSubsonicItemRef) -> Result<(), ServerError> {
+        self.validate_item_scope(item)?;
+        self.client.star(self.credential, item).await
+    }
+
+    pub async fn unstar(&self, item: &OpenSubsonicItemRef) -> Result<(), ServerError> {
+        self.validate_item_scope(item)?;
+        self.client.unstar(self.credential, item).await
+    }
+
+    pub(crate) async fn scrobble(
+        &self,
+        item: &OpenSubsonicItemRef,
+        submission: bool,
+        time_unix_ms: Option<u64>,
+    ) -> Result<(), super::client::MutationDeliveryError> {
+        self.validate_item_scope(item)
+            .map_err(super::client::MutationDeliveryError::DefinitelyNotApplied)?;
+        self.client
+            .scrobble(self.credential, item, submission, time_unix_ms)
+            .await
+    }
+
     /// Artwork is independently optional. Unsupported or unsafe images return `Ok(None)`.
     pub async fn cover_art(&self, id: &CoverArtId) -> Result<Option<BinaryPayload>, ServerError> {
         let payload = match self.client.get_cover_art(self.credential, id).await {
@@ -197,6 +242,14 @@ impl<'a> OpenSubsonicCatalog<'a> {
             bytes,
             content_type: Some(content_type),
         }))
+    }
+
+    fn validate_item_scope(&self, item: &OpenSubsonicItemRef) -> Result<(), ServerError> {
+        if item.backend_id() != self.backend_id || item.account_scope_id() != self.account_scope_id
+        {
+            return Err(ServerError::WrongAccountScope);
+        }
+        self.client.validate_item_scope(item)
     }
 
     async fn album_page(
@@ -366,10 +419,12 @@ impl<'a> OpenSubsonicCatalog<'a> {
             content_type: raw.content_type.and_then(safe_short_value),
             suffix: raw.suffix.and_then(safe_short_value),
             starred: raw.starred.is_some(),
-            user_rating: raw
-                .user_rating
-                .and_then(|rating| u8::try_from(rating).ok())
-                .filter(|rating| *rating <= 5),
+            user_rating: raw.user_rating,
+            play_count: raw.play_count,
+            played_at: raw
+                .played
+                .map(|value| crate::api::sanitize_metadata_text(&value, 64))
+                .filter(|value| !value.is_empty()),
         })
     }
 }

--- a/src/open_subsonic/client.rs
+++ b/src/open_subsonic/client.rs
@@ -14,6 +14,10 @@ use super::profile::OpenSubsonicProfile;
 use super::proxy::{ProxyOrigin, StreamMethod, StreamRequest};
 use super::wire::{RawResponse, WireError};
 
+#[path = "endpoint.rs"]
+mod endpoint;
+pub(crate) use endpoint::Endpoint;
+
 const MAX_REDIRECTS: usize = 3;
 const MAX_JSON_BYTES: usize = 8 * 1024 * 1024;
 const MAX_COVER_ART_BYTES: usize = 32 * 1024 * 1024;
@@ -34,6 +38,25 @@ pub enum ServerError {
     ResponseTooLarge,
     TemporarilyUnavailable,
     WrongAccountScope,
+}
+
+/// Delivery evidence for a non-idempotent server mutation.
+///
+/// Only failures which prove that the server did not apply the mutation may be retried
+/// automatically. Every other transport failure is ambiguous, even when its redacted public
+/// error is merely `Offline`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MutationDeliveryError {
+    DefinitelyNotApplied(ServerError),
+    Ambiguous(ServerError),
+}
+
+impl MutationDeliveryError {
+    pub(crate) const fn server_error(self) -> ServerError {
+        match self {
+            Self::DefinitelyNotApplied(error) | Self::Ambiguous(error) => error,
+        }
+    }
 }
 
 impl std::fmt::Display for ServerError {
@@ -70,39 +93,6 @@ pub struct ServerInfo {
 pub struct BinaryPayload {
     pub bytes: Vec<u8>,
     pub content_type: Option<String>,
-}
-
-#[derive(Clone, Copy)]
-pub(crate) enum Endpoint {
-    Ping,
-    Extensions,
-    Search3,
-    AlbumList2,
-    Artists,
-    Playlists,
-    Playlist,
-    Album,
-    Artist,
-    CoverArt,
-    Stream,
-}
-
-impl Endpoint {
-    fn method_name(self) -> &'static str {
-        match self {
-            Self::Ping => "ping",
-            Self::Extensions => "getOpenSubsonicExtensions",
-            Self::Search3 => "search3",
-            Self::AlbumList2 => "getAlbumList2",
-            Self::Artists => "getArtists",
-            Self::Playlists => "getPlaylists",
-            Self::Playlist => "getPlaylist",
-            Self::Album => "getAlbum",
-            Self::Artist => "getArtist",
-            Self::CoverArt => "getCoverArt",
-            Self::Stream => "stream",
-        }
-    }
 }
 
 /// DNS-pinned transport. Credentials remain in the caller/actor.
@@ -261,11 +251,25 @@ impl OpenSubsonicClient {
         method: Method,
         range: Option<String>,
     ) -> Result<Response, ServerError> {
+        self.request_response_with_delivery(credential, endpoint, parameters, method, range)
+            .await
+            .map_err(MutationDeliveryError::server_error)
+    }
+
+    pub(super) async fn request_response_with_delivery(
+        &self,
+        credential: Option<&ServerCredential>,
+        endpoint: Endpoint,
+        parameters: &[(&str, String)],
+        method: Method,
+        range: Option<String>,
+    ) -> Result<Response, MutationDeliveryError> {
         let mut target = self
             .transport
             .origin()
             .endpoint(endpoint.method_name())
-            .map_err(map_origin_error)?;
+            .map_err(map_origin_error)
+            .map_err(MutationDeliveryError::DefinitelyNotApplied)?;
         for redirects in 0..=MAX_REDIRECTS {
             let mut request = self
                 .transport
@@ -278,7 +282,7 @@ impl OpenSubsonicClient {
             let auth = credential
                 .map(AuthParameters::fresh)
                 .transpose()
-                .map_err(|_| ServerError::Offline)?;
+                .map_err(|_| MutationDeliveryError::DefinitelyNotApplied(ServerError::Offline))?;
             if let Some(auth) = &auth {
                 request = request.query(auth.fields());
             }
@@ -289,26 +293,40 @@ impl OpenSubsonicClient {
             let response = request
                 .send()
                 .await
-                .map_err(|error| classify_request_error(&error))?;
+                .map_err(classify_mutation_request_error)?;
             if !response.status().is_redirection() {
                 return Ok(response);
             }
+            if endpoint == Endpoint::Scrobble {
+                // A non-conforming server could commit this GET-style mutation before returning
+                // its redirect. Following even a same-origin Location could submit it twice.
+                return Err(MutationDeliveryError::Ambiguous(
+                    ServerError::OriginRejected,
+                ));
+            }
             if redirects == MAX_REDIRECTS {
-                return Err(ServerError::OriginRejected);
+                return Err(MutationDeliveryError::DefinitelyNotApplied(
+                    ServerError::OriginRejected,
+                ));
             }
             let location = response
                 .headers()
                 .get(LOCATION)
                 .and_then(|value| value.to_str().ok())
                 .filter(|value| value.len() <= MAX_LOCATION_BYTES)
-                .ok_or(ServerError::OriginRejected)?;
+                .ok_or(MutationDeliveryError::DefinitelyNotApplied(
+                    ServerError::OriginRejected,
+                ))?;
             target = self
                 .transport
                 .origin()
                 .validate_redirect(response.url(), location)
-                .map_err(map_origin_error)?;
+                .map_err(map_origin_error)
+                .map_err(MutationDeliveryError::DefinitelyNotApplied)?;
         }
-        Err(ServerError::OriginRejected)
+        Err(MutationDeliveryError::DefinitelyNotApplied(
+            ServerError::OriginRejected,
+        ))
     }
 
     pub(crate) fn validate_item_scope(
@@ -349,6 +367,17 @@ fn classify_request_error(error: &reqwest::Error) -> ServerError {
         source = current.source();
     }
     ServerError::Offline
+}
+
+fn classify_mutation_request_error(error: reqwest::Error) -> MutationDeliveryError {
+    let classified = classify_request_error(&error);
+    if error.is_connect() || error.is_builder() || classified == ServerError::CertificateFailed {
+        MutationDeliveryError::DefinitelyNotApplied(classified)
+    } else {
+        // A timeout, request-body failure, or response-header loss can happen after the server
+        // committed a GET-style OpenSubsonic mutation.
+        MutationDeliveryError::Ambiguous(classified)
+    }
 }
 
 fn status_error_for(endpoint: Endpoint, response: &Response) -> ServerError {

--- a/src/open_subsonic/endpoint.rs
+++ b/src/open_subsonic/endpoint.rs
@@ -1,0 +1,571 @@
+//! Typed standard OpenSubsonic endpoint calls.
+//!
+//! All item mutations take a fully scoped identity. Query serialization remains owned by
+//! `reqwest`; opaque server IDs are never interpolated into URLs.
+
+use super::super::model::OpenSubsonicItemRef;
+use super::super::private_store::ServerCredential;
+use super::super::wire::RawChild;
+use super::{MutationDeliveryError, OpenSubsonicClient, ServerError};
+
+const MAX_SCROBBLE_TIME_UNIX_MS: u64 = i64::MAX as u64;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Endpoint {
+    Ping,
+    Extensions,
+    Search3,
+    AlbumList2,
+    Artists,
+    Playlists,
+    Playlist,
+    Album,
+    Artist,
+    GetSong,
+    SetRating,
+    Star,
+    Unstar,
+    Scrobble,
+    CoverArt,
+    Stream,
+}
+
+impl Endpoint {
+    pub(super) const fn method_name(self) -> &'static str {
+        match self {
+            Self::Ping => "ping",
+            Self::Extensions => "getOpenSubsonicExtensions",
+            Self::Search3 => "search3",
+            Self::AlbumList2 => "getAlbumList2",
+            Self::Artists => "getArtists",
+            Self::Playlists => "getPlaylists",
+            Self::Playlist => "getPlaylist",
+            Self::Album => "getAlbum",
+            Self::Artist => "getArtist",
+            Self::GetSong => "getSong",
+            Self::SetRating => "setRating",
+            Self::Star => "star",
+            Self::Unstar => "unstar",
+            Self::Scrobble => "scrobble",
+            Self::CoverArt => "getCoverArt",
+            Self::Stream => "stream",
+        }
+    }
+}
+
+impl OpenSubsonicClient {
+    pub(crate) async fn get_song_raw(
+        &self,
+        credential: &ServerCredential,
+        item: &OpenSubsonicItemRef,
+    ) -> Result<RawChild, ServerError> {
+        self.validate_item_scope(item)?;
+        let response = self
+            .request_json(
+                credential,
+                Endpoint::GetSong,
+                &[("id", item.item_id().as_str().to_owned())],
+            )
+            .await?;
+        let song = response.song.ok_or(ServerError::InvalidResponse)?;
+        if song.id.as_deref() != Some(item.item_id().as_str()) {
+            return Err(ServerError::InvalidResponse);
+        }
+        Ok(song)
+    }
+
+    pub(crate) async fn set_rating(
+        &self,
+        credential: &ServerCredential,
+        item: &OpenSubsonicItemRef,
+        rating: u8,
+    ) -> Result<(), ServerError> {
+        self.validate_item_scope(item)?;
+        if rating > 5 {
+            return Err(ServerError::InvalidResponse);
+        }
+        self.request_mutation(
+            credential,
+            Endpoint::SetRating,
+            &[
+                ("id", item.item_id().as_str().to_owned()),
+                ("rating", rating.to_string()),
+            ],
+        )
+        .await
+    }
+
+    pub(crate) async fn star(
+        &self,
+        credential: &ServerCredential,
+        item: &OpenSubsonicItemRef,
+    ) -> Result<(), ServerError> {
+        self.item_mutation(credential, Endpoint::Star, item).await
+    }
+
+    pub(crate) async fn unstar(
+        &self,
+        credential: &ServerCredential,
+        item: &OpenSubsonicItemRef,
+    ) -> Result<(), ServerError> {
+        self.item_mutation(credential, Endpoint::Unstar, item).await
+    }
+
+    pub(crate) async fn scrobble(
+        &self,
+        credential: &ServerCredential,
+        item: &OpenSubsonicItemRef,
+        submission: bool,
+        time_unix_ms: Option<u64>,
+    ) -> Result<(), MutationDeliveryError> {
+        self.validate_item_scope(item)
+            .map_err(MutationDeliveryError::DefinitelyNotApplied)?;
+        if time_unix_ms.is_some_and(|time| time > MAX_SCROBBLE_TIME_UNIX_MS) {
+            return Err(MutationDeliveryError::DefinitelyNotApplied(
+                ServerError::InvalidResponse,
+            ));
+        }
+        let mut parameters = vec![
+            ("id", item.item_id().as_str().to_owned()),
+            ("submission", submission.to_string()),
+        ];
+        if let Some(time) = time_unix_ms {
+            parameters.push(("time", time.to_string()));
+        }
+        self.request_scrobble_mutation(credential, &parameters)
+            .await
+    }
+
+    async fn item_mutation(
+        &self,
+        credential: &ServerCredential,
+        endpoint: Endpoint,
+        item: &OpenSubsonicItemRef,
+    ) -> Result<(), ServerError> {
+        self.validate_item_scope(item)?;
+        self.request_mutation(
+            credential,
+            endpoint,
+            &[("id", item.item_id().as_str().to_owned())],
+        )
+        .await
+    }
+
+    async fn request_mutation(
+        &self,
+        credential: &ServerCredential,
+        endpoint: Endpoint,
+        parameters: &[(&str, String)],
+    ) -> Result<(), ServerError> {
+        // Standard mutations return an otherwise-empty envelope. `request_json` is intentional:
+        // accepting an HTTP success without checking `subsonic-response.status` would silently
+        // acknowledge rejected writes.
+        self.request_json(credential, endpoint, parameters)
+            .await
+            .map(drop)
+    }
+
+    async fn request_scrobble_mutation(
+        &self,
+        credential: &ServerCredential,
+        parameters: &[(&str, String)],
+    ) -> Result<(), MutationDeliveryError> {
+        let response = self
+            .request_response_with_delivery(
+                Some(credential),
+                Endpoint::Scrobble,
+                parameters,
+                reqwest::Method::GET,
+                None,
+            )
+            .await?;
+        if !response.status().is_success() {
+            let error = super::status_error_for(Endpoint::Scrobble, &response);
+            return if response.status().is_server_error() {
+                Err(MutationDeliveryError::Ambiguous(error))
+            } else {
+                Err(MutationDeliveryError::DefinitelyNotApplied(error))
+            };
+        }
+        let bytes = super::read_limited(response, super::MAX_JSON_BYTES)
+            .await
+            .map_err(MutationDeliveryError::Ambiguous)?;
+        match super::super::wire::decode(&bytes) {
+            Ok(_) => Ok(()),
+            Err(super::super::wire::WireError::ApiFailure(error)) => {
+                Err(MutationDeliveryError::DefinitelyNotApplied(
+                    super::map_wire_error(super::super::wire::WireError::ApiFailure(error)),
+                ))
+            }
+            Err(error) => Err(MutationDeliveryError::Ambiguous(super::map_wire_error(
+                error,
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use age::secrecy::SecretString;
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    use super::*;
+    use crate::open_subsonic::{
+        AccountScopeId, BackendId, ConfiguredPrivateOrigin, ItemId, OpenSubsonicProfile,
+        ServerCredential,
+    };
+
+    struct TestClient {
+        client: OpenSubsonicClient,
+        credential: ServerCredential,
+        backend_id: BackendId,
+        account_scope_id: AccountScopeId,
+    }
+
+    impl TestClient {
+        fn item(&self, item_id: &str) -> OpenSubsonicItemRef {
+            OpenSubsonicItemRef::new(
+                self.backend_id.clone(),
+                self.account_scope_id.clone(),
+                ItemId::new(item_id).unwrap(),
+            )
+        }
+    }
+
+    async fn test_client(port: u16) -> TestClient {
+        let profile = OpenSubsonicProfile::new(
+            "Test server",
+            ConfiguredPrivateOrigin::new(&format!("http://127.0.0.1:{port}/"), true).unwrap(),
+            None,
+        )
+        .unwrap();
+        let backend_id = profile.backend_id().clone();
+        let account_scope_id = profile.account_scope_id().clone();
+        let client = OpenSubsonicClient::connect(&profile).await.unwrap();
+        let credential =
+            ServerCredential::api_key(SecretString::from("sentinel-api-key".to_owned())).unwrap();
+        TestClient {
+            client,
+            credential,
+            backend_id,
+            account_scope_id,
+        }
+    }
+
+    async fn read_request(stream: &mut tokio::net::TcpStream) -> String {
+        let mut request = Vec::new();
+        let mut byte = [0_u8; 1];
+        while request.len() < 32 * 1024 {
+            if stream.read(&mut byte).await.unwrap() == 0 {
+                break;
+            }
+            request.push(byte[0]);
+            if request.ends_with(b"\r\n\r\n") {
+                break;
+            }
+        }
+        String::from_utf8(request).unwrap()
+    }
+
+    async fn write_json(stream: &mut tokio::net::TcpStream, body: &str) {
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+    }
+
+    fn request_target(request: &str) -> &str {
+        request
+            .lines()
+            .next()
+            .and_then(|line| line.split_ascii_whitespace().nth(1))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn get_song_serializes_opaque_id_and_preserves_exact_server_fields() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut stream).await;
+            let target = request_target(&request);
+            assert!(target.starts_with("/rest/getSong.view?"));
+            assert!(target.contains("id=song+id%26admin%3Dtrue"));
+            assert!(!target.contains("&admin=true"));
+            write_json(
+                &mut stream,
+                r#"{"subsonic-response":{"status":"ok","song":{"id":"song id&admin=true","title":"Song","userRating":3,"starred":"2026-07-26T00:00:00Z","playCount":7,"played":"2026-07-26T00:00:00Z"}}}"#,
+            )
+            .await;
+        });
+        let fixture = test_client(port).await;
+        let song = fixture
+            .client
+            .get_song_raw(&fixture.credential, &fixture.item("song id&admin=true"))
+            .await
+            .unwrap();
+        assert_eq!(song.user_rating, Some(3));
+        assert_eq!(song.play_count, Some(7));
+        assert!(song.starred.is_some());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn mutations_use_exact_standard_parameters_and_validate_status() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let expected = [
+                ("/rest/setRating.view?", &["id=song-1", "rating=5"][..]),
+                ("/rest/star.view?", &["id=song-1"][..]),
+                ("/rest/unstar.view?", &["id=song-1"][..]),
+                (
+                    "/rest/scrobble.view?",
+                    &["id=song-1", "submission=false"][..],
+                ),
+                (
+                    "/rest/scrobble.view?",
+                    &["id=song-1", "submission=true", "time=1785024000123"][..],
+                ),
+            ];
+            for (index, (endpoint, parameters)) in expected.into_iter().enumerate() {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let request = read_request(&mut stream).await;
+                let target = request_target(&request);
+                assert!(target.starts_with(endpoint), "{target}");
+                for parameter in parameters {
+                    assert!(target.contains(parameter), "{target}");
+                }
+                if index == 3 {
+                    assert!(!target.contains("&time="), "{target}");
+                }
+                let body = if index == 4 {
+                    r#"{"subsonic-response":{"status":"failed","error":{"code":50}}}"#
+                } else {
+                    r#"{"subsonic-response":{"status":"ok"}}"#
+                };
+                write_json(&mut stream, body).await;
+            }
+        });
+        let fixture = test_client(port).await;
+        let item = fixture.item("song-1");
+        fixture
+            .client
+            .set_rating(&fixture.credential, &item, 5)
+            .await
+            .unwrap();
+        fixture
+            .client
+            .star(&fixture.credential, &item)
+            .await
+            .unwrap();
+        fixture
+            .client
+            .unstar(&fixture.credential, &item)
+            .await
+            .unwrap();
+        fixture
+            .client
+            .scrobble(&fixture.credential, &item, false, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            fixture
+                .client
+                .scrobble(&fixture.credential, &item, true, Some(1_785_024_000_123),)
+                .await,
+            Err(MutationDeliveryError::DefinitelyNotApplied(
+                ServerError::PermissionDenied
+            ))
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn item_scope_invalid_rating_and_time_fail_before_network() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let fixture = test_client(port).await;
+        let wrong_backend = OpenSubsonicItemRef::new(
+            BackendId::new("another-backend").unwrap(),
+            fixture.account_scope_id.clone(),
+            ItemId::new("song").unwrap(),
+        );
+        let wrong_account = OpenSubsonicItemRef::new(
+            fixture.backend_id.clone(),
+            AccountScopeId::new("another-account").unwrap(),
+            ItemId::new("song").unwrap(),
+        );
+        assert!(matches!(
+            fixture
+                .client
+                .get_song_raw(&fixture.credential, &wrong_backend)
+                .await,
+            Err(ServerError::WrongAccountScope)
+        ));
+        assert_eq!(
+            fixture
+                .client
+                .star(&fixture.credential, &wrong_account)
+                .await,
+            Err(ServerError::WrongAccountScope)
+        );
+        let item = fixture.item("song");
+        assert_eq!(
+            fixture
+                .client
+                .set_rating(&fixture.credential, &item, 6)
+                .await,
+            Err(ServerError::InvalidResponse)
+        );
+        assert_eq!(
+            fixture
+                .client
+                .scrobble(&fixture.credential, &item, true, Some(u64::MAX))
+                .await,
+            Err(MutationDeliveryError::DefinitelyNotApplied(
+                ServerError::InvalidResponse
+            ))
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), listener.accept())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn scrobble_connect_failure_is_definitely_not_applied() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let fixture = test_client(port).await;
+        assert_eq!(
+            fixture
+                .client
+                .scrobble(&fixture.credential, &fixture.item("song"), true, None)
+                .await,
+            Err(MutationDeliveryError::DefinitelyNotApplied(
+                ServerError::Offline
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn scrobble_response_loss_and_server_errors_are_ambiguous() {
+        for response in [
+            None,
+            Some(
+                b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    .as_slice(),
+            ),
+            Some(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx"
+                    .as_slice(),
+            ),
+        ] {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let server = tokio::spawn(async move {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let request = read_request(&mut stream).await;
+                assert!(request_target(&request).starts_with("/rest/scrobble.view?"));
+                if let Some(response) = response {
+                    stream.write_all(response).await.unwrap();
+                }
+            });
+            let fixture = test_client(port).await;
+            let error = fixture
+                .client
+                .scrobble(&fixture.credential, &fixture.item("song"), true, None)
+                .await
+                .unwrap_err();
+            assert!(matches!(error, MutationDeliveryError::Ambiguous(_)));
+            server.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn scrobble_redirects_are_ambiguous_and_never_followed() {
+        for redirect_kind in ["same-origin", "loop", "cross-origin"] {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let cross_target = if redirect_kind == "cross-origin" {
+                Some(tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap())
+            } else {
+                None
+            };
+            let location = match (&cross_target, redirect_kind) {
+                (Some(target), _) => format!(
+                    "http://127.0.0.1:{}/rest/scrobble.view",
+                    target.local_addr().unwrap().port()
+                ),
+                (None, "loop") => "/rest/scrobble.view".to_owned(),
+                _ => "/rest/scrobble-again".to_owned(),
+            };
+            let fixture = test_client(port).await;
+            let server = tokio::spawn(async move {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let request = read_request(&mut stream).await;
+                assert!(request_target(&request).starts_with("/rest/scrobble.view?"));
+                let response = format!(
+                    "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                );
+                stream.write_all(response.as_bytes()).await.unwrap();
+                drop(stream);
+                assert!(
+                    tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                        .await
+                        .is_err(),
+                    "redirected scrobble must issue exactly one request"
+                );
+            });
+            assert_eq!(
+                fixture
+                    .client
+                    .scrobble(&fixture.credential, &fixture.item("song"), true, None)
+                    .await,
+                Err(MutationDeliveryError::Ambiguous(
+                    ServerError::OriginRejected
+                ))
+            );
+            server.await.unwrap();
+            if let Some(target) = cross_target {
+                assert!(
+                    tokio::time::timeout(Duration::from_millis(100), target.accept())
+                        .await
+                        .is_err(),
+                    "cross-origin redirect must not receive a credentialed request"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn get_song_rejects_a_different_returned_item_id() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _ = read_request(&mut stream).await;
+            write_json(
+                &mut stream,
+                r#"{"subsonic-response":{"status":"ok","song":{"id":"different","title":"Song"}}}"#,
+            )
+            .await;
+        });
+        let fixture = test_client(port).await;
+        assert!(matches!(
+            fixture
+                .client
+                .get_song_raw(&fixture.credential, &fixture.item("requested"))
+                .await,
+            Err(ServerError::InvalidResponse)
+        ));
+        server.await.unwrap();
+    }
+}

--- a/src/open_subsonic/history.rs
+++ b/src/open_subsonic/history.rs
@@ -1,0 +1,668 @@
+//! Pure standard aggregate-history planning and timestamp normalization.
+
+use data_encoding::HEXLOWER;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use super::model::{OpenSubsonicItemRef, ServerSong};
+
+/// Maximum number of low-confidence plays expanded by the pure planner.
+///
+/// The complete logical ordinal range remains in [`AggregatePlan::range`]. Durable bridge
+/// bookkeeping expands the rest incrementally instead of allocating an unbounded event vector.
+pub const MAX_AGGREGATE_DELTA: u64 = 100;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregateHistoryShadow {
+    pub play_count: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub played_at_unix: Option<i64>,
+    pub observed_at_unix: i64,
+    /// Monotonic local generation for a server counter that moved backwards.
+    ///
+    /// This is local bookkeeping for exact-versus-aggregate reconciliation only. It must
+    /// never participate in a portable event ID because devices can observe resets at
+    /// different times.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub counter_epoch: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AggregatePlay {
+    pub event_id: String,
+    pub item: OpenSubsonicItemRef,
+    pub played_at_unix: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AggregatePlayRange {
+    pub item: OpenSubsonicItemRef,
+    pub first_ordinal: u64,
+    pub last_ordinal: u64,
+    pub played_at_unix: i64,
+    pub has_server_time: bool,
+    pub has_server_ordinal: bool,
+}
+
+impl AggregatePlayRange {
+    pub(crate) fn logical_len(&self) -> u64 {
+        self.last_ordinal
+            .saturating_sub(self.first_ordinal)
+            .saturating_add(1)
+    }
+
+    pub(crate) fn play(&self, ordinal: u64) -> Option<AggregatePlay> {
+        if !(self.first_ordinal..=self.last_ordinal).contains(&ordinal) {
+            return None;
+        }
+        let event_id = if self.has_server_time {
+            aggregate_event_id(
+                &self.item,
+                self.played_at_unix,
+                self.has_server_ordinal.then_some(ordinal),
+            )
+        } else {
+            timeless_aggregate_event_id(&self.item, ordinal)
+        };
+        Some(AggregatePlay {
+            event_id,
+            item: self.item.clone(),
+            played_at_unix: self.played_at_unix,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AggregatePlan {
+    pub next_shadow: AggregateHistoryShadow,
+    /// Complete compact logical range, including ordinals not expanded in `plays`.
+    pub(crate) range: Option<AggregatePlayRange>,
+    /// Bounded first chunk for callers that only need a preview.
+    pub plays: Vec<AggregatePlay>,
+    pub baseline_reset: bool,
+    /// Counter growth deliberately consumed as baseline-only evidence.
+    ///
+    /// Once a server counter has reset, a count-only ordinal can be indistinguishable from an
+    /// ordinal emitted before the reset. The caller still consumes matching exact credits, but
+    /// conservatively avoids creating a duplicate aggregate event.
+    pub baseline_only_delta: u64,
+}
+
+/// First observation and counter decreases establish a baseline only. Increases use the exact
+/// item and each server counter ordinal as a deterministic dedupe identity. A valid server
+/// `playedAt` strengthens that identity and supplies the event time. Without one, the local
+/// observation time is display/retention metadata only and never participates in the event ID.
+pub fn plan_aggregate_history(
+    previous: Option<&AggregateHistoryShadow>,
+    song: &ServerSong,
+    observed_at_unix: i64,
+) -> AggregatePlan {
+    let played_at_unix = song.played_at.as_deref().and_then(parse_rfc3339_unix);
+    let Some(previous) = previous else {
+        return AggregatePlan {
+            next_shadow: AggregateHistoryShadow {
+                play_count: song.play_count.unwrap_or(0),
+                played_at_unix,
+                observed_at_unix,
+                counter_epoch: 0,
+            },
+            range: None,
+            plays: Vec::new(),
+            baseline_reset: false,
+            baseline_only_delta: 0,
+        };
+    };
+    let mut counter_epoch = previous.counter_epoch;
+    let (play_count, baseline_reset) = match song.play_count {
+        Some(play_count) if play_count < previous.play_count => {
+            counter_epoch = counter_epoch.saturating_add(1);
+            (play_count, true)
+        }
+        Some(play_count) => (play_count, false),
+        None if played_at_unix.is_some_and(|played_at| {
+            previous
+                .played_at_unix
+                .is_none_or(|prior| played_at > prior)
+        }) =>
+        {
+            // A changed last-played timestamp is the only standard evidence available.
+            // Advance a synthetic ordinal so a later playCount readback of the same play
+            // does not create a second event.
+            (previous.play_count.saturating_add(1), false)
+        }
+        None => (previous.play_count, false),
+    };
+    let next_shadow = AggregateHistoryShadow {
+        play_count,
+        played_at_unix: played_at_unix.or(previous.played_at_unix),
+        observed_at_unix,
+        counter_epoch,
+    };
+    if baseline_reset || play_count <= previous.play_count {
+        return AggregatePlan {
+            next_shadow,
+            range: None,
+            plays: Vec::new(),
+            baseline_reset,
+            baseline_only_delta: 0,
+        };
+    }
+
+    let observed_delta = play_count.saturating_sub(previous.play_count);
+    if played_at_unix.is_none() && counter_epoch > 0 {
+        return AggregatePlan {
+            next_shadow,
+            range: None,
+            plays: Vec::new(),
+            baseline_reset: false,
+            baseline_only_delta: observed_delta,
+        };
+    }
+    let first = previous.play_count.saturating_add(1);
+    let has_server_ordinal = song.play_count.is_some();
+    let range = AggregatePlayRange {
+        item: song.item.clone(),
+        first_ordinal: first,
+        last_ordinal: play_count,
+        played_at_unix: played_at_unix.unwrap_or(observed_at_unix),
+        has_server_time: played_at_unix.is_some(),
+        has_server_ordinal,
+    };
+    let plays = (first..=play_count)
+        .take(MAX_AGGREGATE_DELTA as usize)
+        .filter_map(|ordinal| range.play(ordinal))
+        .collect();
+    AggregatePlan {
+        next_shadow,
+        range: Some(range),
+        plays,
+        baseline_reset: false,
+        baseline_only_delta: 0,
+    }
+}
+
+fn aggregate_event_id(
+    item: &OpenSubsonicItemRef,
+    played_at_unix: i64,
+    server_ordinal: Option<u64>,
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"yututui-open-subsonic-aggregate-play-v3\0");
+    update_hash(&mut digest, item.backend_id().as_str());
+    update_hash(&mut digest, item.account_scope_id().as_str());
+    update_hash(&mut digest, item.item_id().as_str());
+    digest.update(played_at_unix.to_be_bytes());
+    match server_ordinal {
+        Some(ordinal) => {
+            digest.update([1]);
+            digest.update(ordinal.to_be_bytes());
+        }
+        None => digest.update([0]),
+    }
+    format!("sub-aggregate-{}", HEXLOWER.encode(&digest.finalize()))
+}
+
+fn timeless_aggregate_event_id(item: &OpenSubsonicItemRef, server_ordinal: u64) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"yututui-open-subsonic-aggregate-count-only-v1\0");
+    update_hash(&mut digest, item.backend_id().as_str());
+    update_hash(&mut digest, item.account_scope_id().as_str());
+    update_hash(&mut digest, item.item_id().as_str());
+    digest.update(server_ordinal.to_be_bytes());
+    format!("sub-aggregate-{}", HEXLOWER.encode(&digest.finalize()))
+}
+
+const fn is_zero(value: &u64) -> bool {
+    *value == 0
+}
+
+fn update_hash(digest: &mut Sha256, value: &str) {
+    digest.update((value.len() as u64).to_be_bytes());
+    digest.update(value.as_bytes());
+}
+
+/// Strict RFC3339 parser for display/retention timestamps. It accepts UTC `Z` and numeric
+/// offsets with optional fractional seconds. Malformed timestamps simply provide no evidence.
+pub fn parse_rfc3339_unix(value: &str) -> Option<i64> {
+    let bytes = value.as_bytes();
+    if bytes.len() < 20
+        || bytes.get(4) != Some(&b'-')
+        || bytes.get(7) != Some(&b'-')
+        || !matches!(bytes.get(10), Some(b'T' | b't' | b' '))
+        || bytes.get(13) != Some(&b':')
+        || bytes.get(16) != Some(&b':')
+    {
+        return None;
+    }
+    let year = decimal(&bytes[0..4])?;
+    let month = decimal(&bytes[5..7])?;
+    let day = decimal(&bytes[8..10])?;
+    let hour = decimal(&bytes[11..13])?;
+    let minute = decimal(&bytes[14..16])?;
+    let second = decimal(&bytes[17..19])?;
+    if year < 1970
+        || !(1..=12).contains(&month)
+        || day == 0
+        || day > days_in_month(year, month)
+        || hour > 23
+        || minute > 59
+        || second > 59
+    {
+        return None;
+    }
+
+    let mut cursor = 19;
+    if bytes.get(cursor) == Some(&b'.') {
+        cursor += 1;
+        let start = cursor;
+        while bytes.get(cursor).is_some_and(u8::is_ascii_digit) {
+            cursor += 1;
+        }
+        if cursor == start {
+            return None;
+        }
+    }
+    let offset_seconds = match bytes.get(cursor) {
+        Some(b'Z' | b'z') if cursor + 1 == bytes.len() => 0_i64,
+        Some(sign @ (b'+' | b'-'))
+            if cursor + 6 == bytes.len() && bytes.get(cursor + 3) == Some(&b':') =>
+        {
+            let offset_hour = decimal(&bytes[cursor + 1..cursor + 3])?;
+            let offset_minute = decimal(&bytes[cursor + 4..cursor + 6])?;
+            if offset_hour > 23 || offset_minute > 59 {
+                return None;
+            }
+            let offset = i64::from(offset_hour * 3_600 + offset_minute * 60);
+            if *sign == b'+' { offset } else { -offset }
+        }
+        _ => return None,
+    };
+
+    let years = year.checked_sub(1970)?;
+    let leap_days = leap_years_before(year).checked_sub(leap_years_before(1970))?;
+    let mut days = years.checked_mul(365)?.checked_add(leap_days)?;
+    for prior_month in 1..month {
+        days = days.checked_add(days_in_month(year, prior_month))?;
+    }
+    days = days.checked_add(day.checked_sub(1)?)?;
+    let local = i64::from(
+        days.checked_mul(86_400)?
+            .checked_add(hour.checked_mul(3_600)?)?
+            .checked_add(minute.checked_mul(60)?)?
+            .checked_add(second)?,
+    );
+    local.checked_sub(offset_seconds)
+}
+
+fn decimal(bytes: &[u8]) -> Option<u32> {
+    bytes.iter().try_fold(0_u32, |value, byte| {
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+        value.checked_mul(10)?.checked_add(u32::from(byte - b'0'))
+    })
+}
+
+fn days_in_month(year: u32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: u32) -> bool {
+    year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400))
+}
+
+fn leap_years_before(year: u32) -> u32 {
+    let prior = year.saturating_sub(1);
+    prior / 4 - prior / 100 + prior / 400
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::open_subsonic::{AccountScopeId, BackendId, ItemId};
+
+    fn song(play_count: u64, played_at: Option<&str>) -> ServerSong {
+        ServerSong {
+            item: OpenSubsonicItemRef::new(
+                BackendId::new("backend").unwrap(),
+                AccountScopeId::new("account").unwrap(),
+                ItemId::new("item").unwrap(),
+            ),
+            title: "Track".to_owned(),
+            artist: "Artist".to_owned(),
+            artists: Vec::new(),
+            album: None,
+            album_id: None,
+            album_artist: None,
+            duration_secs: Some(180),
+            track_number: None,
+            disc_number: None,
+            year: None,
+            cover_art_id: None,
+            content_type: None,
+            suffix: None,
+            starred: false,
+            user_rating: None,
+            play_count: Some(play_count),
+            played_at: played_at.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn timestamp_parser_handles_offsets_fraction_and_invalid_dates() {
+        assert_eq!(parse_rfc3339_unix("1970-01-01T00:00:00Z"), Some(0));
+        assert_eq!(parse_rfc3339_unix("1970-01-01T09:00:00.123+09:00"), Some(0));
+        assert_eq!(
+            parse_rfc3339_unix("2024-02-29T00:00:00-01:00"),
+            Some(1_709_168_400)
+        );
+        assert_eq!(parse_rfc3339_unix("2023-02-29T00:00:00Z"), None);
+        assert_eq!(parse_rfc3339_unix("1970-01-01T00:00:60Z"), None);
+    }
+
+    #[test]
+    fn baseline_reset_and_bounded_stable_increases() {
+        let first = plan_aggregate_history(None, &song(10, None), 100);
+        assert!(first.plays.is_empty());
+        assert_eq!(first.baseline_only_delta, 0);
+        let reset = plan_aggregate_history(Some(&first.next_shadow), &song(2, None), 200);
+        assert!(reset.baseline_reset);
+        assert!(reset.plays.is_empty());
+        assert_eq!(reset.baseline_only_delta, 0);
+
+        let previous = AggregateHistoryShadow {
+            play_count: 1,
+            played_at_unix: None,
+            observed_at_unix: 1,
+            counter_epoch: 0,
+        };
+        let plan = plan_aggregate_history(
+            Some(&previous),
+            &song(102, Some("1970-01-01T00:01:40Z")),
+            200,
+        );
+        assert_eq!(plan.plays.len(), MAX_AGGREGATE_DELTA as usize);
+        let range = plan.range.as_ref().unwrap();
+        assert_eq!(range.first_ordinal, 2);
+        assert_eq!(range.last_ordinal, 102);
+        assert_eq!(range.logical_len(), 101);
+        assert_eq!(
+            plan.plays.last().unwrap().event_id,
+            range.play(101).unwrap().event_id
+        );
+        assert_ne!(
+            plan.plays.last().unwrap().event_id,
+            range.play(102).unwrap().event_id,
+            "the unexpanded logical tail must retain its own stable identity"
+        );
+        assert_eq!(plan.plays[0].played_at_unix, 100);
+        assert_eq!(plan.baseline_only_delta, 0);
+        let retry = plan_aggregate_history(
+            Some(&previous),
+            &song(102, Some("1970-01-01T00:01:40Z")),
+            999,
+        );
+        assert_eq!(
+            plan.plays
+                .iter()
+                .map(|play| &play.event_id)
+                .collect::<Vec<_>>(),
+            retry
+                .plays
+                .iter()
+                .map(|play| &play.event_id)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn counter_reset_keeps_local_epoch_but_changes_identity_with_server_time() {
+        let baseline = plan_aggregate_history(None, &song(0, Some("1970-01-01T00:00:10Z")), 10);
+        let original = plan_aggregate_history(
+            Some(&baseline.next_shadow),
+            &song(1, Some("1970-01-01T00:00:20Z")),
+            20,
+        );
+        assert_eq!(original.plays.len(), 1);
+
+        let reset = plan_aggregate_history(
+            Some(&original.next_shadow),
+            &song(0, Some("1970-01-01T00:00:30Z")),
+            30,
+        );
+        assert!(reset.baseline_reset);
+        assert_eq!(reset.next_shadow.counter_epoch, 1);
+        let after_reset = plan_aggregate_history(
+            Some(&reset.next_shadow),
+            &song(1, Some("1970-01-01T00:00:40Z")),
+            40,
+        );
+        assert_eq!(after_reset.plays.len(), 1);
+        assert_ne!(original.plays[0].event_id, after_reset.plays[0].event_id);
+
+        let retry = plan_aggregate_history(
+            Some(&reset.next_shadow),
+            &song(1, Some("1970-01-01T00:00:40Z")),
+            99,
+        );
+        assert_eq!(after_reset.plays[0].event_id, retry.plays[0].event_id);
+    }
+
+    #[test]
+    fn missing_or_invalid_played_at_imports_portable_low_confidence_plays() {
+        let previous = AggregateHistoryShadow {
+            play_count: 5,
+            played_at_unix: Some(100),
+            observed_at_unix: 100,
+            counter_epoch: 0,
+        };
+        let missing = plan_aggregate_history(Some(&previous), &song(7, None), 200);
+        assert_eq!(missing.plays.len(), 2);
+        assert_eq!(missing.baseline_only_delta, 0);
+        assert!(missing.plays.iter().all(|play| play.played_at_unix == 200));
+        assert_eq!(missing.next_shadow.play_count, 7);
+        assert_eq!(missing.next_shadow.played_at_unix, Some(100));
+
+        let invalid = plan_aggregate_history(
+            Some(&missing.next_shadow),
+            &song(9, Some("not-a-timestamp")),
+            300,
+        );
+        assert_eq!(invalid.plays.len(), 2);
+        assert_eq!(invalid.baseline_only_delta, 0);
+        assert!(invalid.plays.iter().all(|play| play.played_at_unix == 300));
+        assert_eq!(invalid.next_shadow.play_count, 9);
+        assert_eq!(invalid.next_shadow.played_at_unix, Some(100));
+
+        let verified = plan_aggregate_history(
+            Some(&invalid.next_shadow),
+            &song(10, Some("1970-01-01T00:06:40Z")),
+            400,
+        );
+        assert_eq!(verified.plays.len(), 1);
+        assert_eq!(verified.plays[0].played_at_unix, 400);
+        assert_eq!(verified.baseline_only_delta, 0);
+    }
+
+    #[test]
+    fn count_only_ids_are_retry_stable_and_post_reset_growth_is_conservative() {
+        let previous = AggregateHistoryShadow {
+            play_count: 1,
+            played_at_unix: None,
+            observed_at_unix: 100,
+            counter_epoch: 0,
+        };
+        let observation = song(2, None);
+        let first = plan_aggregate_history(Some(&previous), &observation, 200);
+        let retry = plan_aggregate_history(Some(&previous), &observation, 999);
+        assert_eq!(first.plays.len(), 1);
+        assert_eq!(first.plays[0].event_id, retry.plays[0].event_id);
+        assert_ne!(
+            first.plays[0].played_at_unix, retry.plays[0].played_at_unix,
+            "local observation time is display/retention metadata, not portable identity"
+        );
+
+        let reset = plan_aggregate_history(Some(&first.next_shadow), &song(0, None), 300);
+        assert!(reset.baseline_reset);
+        assert_eq!(reset.next_shadow.counter_epoch, 1);
+        let reused_ordinals = plan_aggregate_history(Some(&reset.next_shadow), &song(2, None), 400);
+        assert!(reused_ordinals.plays.is_empty());
+        assert_eq!(reused_ordinals.baseline_only_delta, 2);
+        let reset_retry = plan_aggregate_history(Some(&reset.next_shadow), &song(2, None), 999);
+        assert!(reset_retry.plays.is_empty());
+        assert_eq!(
+            reset_retry.baseline_only_delta,
+            reused_ordinals.baseline_only_delta
+        );
+        assert_eq!(
+            reset_retry.next_shadow.play_count,
+            reused_ordinals.next_shadow.play_count
+        );
+        assert_eq!(
+            reset_retry.next_shadow.counter_epoch,
+            reused_ordinals.next_shadow.counter_epoch
+        );
+    }
+
+    #[test]
+    fn two_devices_with_different_local_epochs_emit_the_same_ids() {
+        let first_device = AggregateHistoryShadow {
+            play_count: 7,
+            played_at_unix: Some(100),
+            observed_at_unix: 100,
+            counter_epoch: 0,
+        };
+        let second_device = AggregateHistoryShadow {
+            counter_epoch: 42,
+            ..first_device.clone()
+        };
+        let observation = song(9, Some("1970-01-01T00:03:20Z"));
+        let first = plan_aggregate_history(Some(&first_device), &observation, 200);
+        let second = plan_aggregate_history(Some(&second_device), &observation, 201);
+
+        assert_eq!(first.plays.len(), 2);
+        assert_eq!(
+            first
+                .plays
+                .iter()
+                .map(|play| &play.event_id)
+                .collect::<Vec<_>>(),
+            second
+                .plays
+                .iter()
+                .map(|play| &play.event_id)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn reset_observers_converge_despite_different_local_epochs() {
+        let before_reset = AggregateHistoryShadow {
+            play_count: 3,
+            played_at_unix: Some(100),
+            observed_at_unix: 100,
+            counter_epoch: 0,
+        };
+        let other_before_reset = AggregateHistoryShadow {
+            counter_epoch: 17,
+            ..before_reset.clone()
+        };
+        let reset_observation = song(0, Some("1970-01-01T00:03:20Z"));
+        let first_reset = plan_aggregate_history(Some(&before_reset), &reset_observation, 200);
+        let second_reset =
+            plan_aggregate_history(Some(&other_before_reset), &reset_observation, 201);
+        assert_eq!(first_reset.next_shadow.counter_epoch, 1);
+        assert_eq!(second_reset.next_shadow.counter_epoch, 18);
+
+        let next_play = song(1, Some("1970-01-01T00:05:00Z"));
+        let first = plan_aggregate_history(Some(&first_reset.next_shadow), &next_play, 300);
+        let second = plan_aggregate_history(Some(&second_reset.next_shadow), &next_play, 301);
+        assert_eq!(first.plays.len(), 1);
+        assert_eq!(first.plays[0].event_id, second.plays[0].event_id);
+    }
+
+    #[test]
+    fn established_and_new_devices_share_the_overlapping_server_ordinal() {
+        let established_shadow = AggregateHistoryShadow {
+            play_count: 10,
+            played_at_unix: Some(100),
+            observed_at_unix: 100,
+            counter_epoch: 8,
+        };
+        let latest = song(12, Some("1970-01-01T00:03:20Z"));
+        let established = plan_aggregate_history(Some(&established_shadow), &latest, 200);
+        assert_eq!(established.plays.len(), 2);
+
+        let new_device_baseline =
+            plan_aggregate_history(None, &song(11, Some("1970-01-01T00:02:30Z")), 150);
+        let new_device =
+            plan_aggregate_history(Some(&new_device_baseline.next_shadow), &latest, 201);
+        assert_eq!(new_device.plays.len(), 1);
+        assert_eq!(established.plays[1].event_id, new_device.plays[0].event_id);
+    }
+
+    #[test]
+    fn legacy_shadow_without_counter_epoch_migrates_to_convergent_ids() {
+        let legacy: AggregateHistoryShadow = serde_json::from_value(serde_json::json!({
+            "play_count": 7,
+            "played_at_unix": 100,
+            "observed_at_unix": 100
+        }))
+        .unwrap();
+        assert_eq!(legacy.counter_epoch, 0);
+
+        let migrated_elsewhere = AggregateHistoryShadow {
+            counter_epoch: 99,
+            ..legacy.clone()
+        };
+        let observation = song(8, Some("1970-01-01T00:03:20Z"));
+        let legacy_plan = plan_aggregate_history(Some(&legacy), &observation, 200);
+        let migrated_plan = plan_aggregate_history(Some(&migrated_elsewhere), &observation, 201);
+        assert_eq!(
+            legacy_plan.plays[0].event_id,
+            migrated_plan.plays[0].event_id
+        );
+    }
+
+    #[test]
+    fn changed_played_timestamp_without_count_has_a_portable_identity() {
+        let mut initial_song = song(0, Some("1970-01-01T00:01:40Z"));
+        initial_song.play_count = None;
+        let baseline = plan_aggregate_history(None, &initial_song, 100);
+        assert!(baseline.plays.is_empty());
+
+        let mut changed_song = song(0, Some("1970-01-01T00:03:20Z"));
+        changed_song.play_count = None;
+        let changed = plan_aggregate_history(Some(&baseline.next_shadow), &changed_song, 200);
+        assert_eq!(changed.plays.len(), 1);
+        assert_eq!(changed.plays[0].played_at_unix, 200);
+        assert_eq!(changed.next_shadow.play_count, 1);
+
+        let other_device_shadow = AggregateHistoryShadow {
+            play_count: 50,
+            played_at_unix: Some(100),
+            observed_at_unix: 150,
+            counter_epoch: 23,
+        };
+        let other_device = plan_aggregate_history(Some(&other_device_shadow), &changed_song, 201);
+        assert_eq!(other_device.plays.len(), 1);
+        assert_eq!(changed.plays[0].event_id, other_device.plays[0].event_id);
+
+        let same = plan_aggregate_history(Some(&changed.next_shadow), &changed_song, 300);
+        assert!(same.plays.is_empty());
+        let count_readback =
+            plan_aggregate_history(Some(&changed.next_shadow), &song(1, None), 301);
+        assert!(
+            count_readback.plays.is_empty(),
+            "the later count echo must not duplicate the timestamp-only evidence"
+        );
+    }
+}

--- a/src/open_subsonic/mod.rs
+++ b/src/open_subsonic/mod.rs
@@ -2,39 +2,67 @@
 
 pub mod actor;
 pub mod auth;
+mod bridge_event;
+mod bridge_runtime;
+#[cfg(test)]
+mod bridge_runtime_tests;
 pub mod bridge_store;
 pub mod capabilities;
 pub mod catalog;
 pub mod client;
+pub mod history;
 pub mod model;
+pub mod native_history;
 pub mod origin;
+mod outbound_recovery;
 pub mod private_store;
 pub mod profile;
 pub mod proxy;
+pub mod rating;
 pub mod transaction;
 mod wire;
 
 pub use actor::{
-    OpenSubsonicHandle, OpenSubsonicProfileSummary, OpenSubsonicRuntime, OpenSubsonicStatus,
-    OpenSubsonicStatusKind, PreparedSetup, ServerLibraryDetailRequest, ServerLibraryRequest,
+    OpenSubsonicHandle, OpenSubsonicProfileSummary, OpenSubsonicRatingReceipt, OpenSubsonicRuntime,
+    OpenSubsonicScrobbleReceipt, OpenSubsonicStatus, OpenSubsonicStatusKind,
+    OutboundScrobbleResolution, PreparedSetup, ServerLibraryDetailRequest, ServerLibraryRequest,
     ServiceError, SetupIdentityIntent, SetupInput, commit_setup, current_handle,
-    current_proxy_handle, load_actor, load_actor_read_only, read_status, remove_profile,
-    test_and_prepare_setup, test_connection, test_connection_read_only,
+    current_proxy_handle, disable_native_history, load_actor, load_actor_read_only,
+    load_actor_with_bridge_sink, read_status, remove_profile, test_and_prepare_setup,
+    test_connection, test_connection_read_only,
 };
-pub use bridge_store::OpenSubsonicBridgeState;
+pub use bridge_event::{
+    OpenSubsonicBridgeImport, OpenSubsonicBridgeSink, OpenSubsonicScrobbleKind,
+};
+pub use bridge_store::{NativeHistoryHealth, OpenSubsonicBridgeState};
 pub use capabilities::{ServerCapabilities, ServerFeature};
 pub use catalog::{MAX_PAGE_SIZE, OpenSubsonicCatalog};
 pub use client::{BinaryPayload, OpenSubsonicClient, ServerError, ServerInfo};
+pub use history::{
+    AggregateHistoryShadow, AggregatePlan, AggregatePlay, MAX_AGGREGATE_DELTA, parse_rfc3339_unix,
+    plan_aggregate_history,
+};
 pub use model::{
     AccountScopeId, AlbumId, ArtistId, BackendId, CoverArtId, ItemId, LibraryWarning, ModelError,
     OpenSubsonicItemRef, Page, ServerAlbum, ServerArtist, ServerLibraryDetail, ServerLibraryPage,
     ServerLibraryRow, ServerLibrarySection, ServerPlaylist, ServerPlaylistId,
     ServerPlaylistSummary, ServerSong,
 };
+pub use native_history::{
+    MAX_NATIVE_HISTORY_PAGES, MAX_NATIVE_HISTORY_ROWS, NATIVE_HISTORY_PAGE_SIZE,
+    NativeHistoryCredential, NativeHistoryError, NativeHistorySession, NativeScrobblePage,
+    NativeScrobblePageRequest, NativeScrobbleRow, NativeScrobbleScan, NavidromeNativeClient,
+};
 pub use origin::{ConfiguredPrivateOrigin, OriginError};
+pub use outbound_recovery::{list_scrobble_attention_ids, resolve_scrobble_attention};
 pub use private_store::{CredentialKind, OpenSubsonicPrivateState, ServerCredential};
 pub use profile::{OpenSubsonicPaths, OpenSubsonicProfile, StoreError};
+pub use rating::{RawServerRating, canonical_server_rating, map_server_rating};
 pub use transaction::{
     OpenSubsonicStoreSet, StoreRevisions, commit_store_set, load_store_set, recover_store_set,
     remove_store_set, reset_store_set,
 };
+
+/// Bounded owner-lane handoff. Durable submissions exceeding this transient window remain in the
+/// scrobble JSONL source journal and replay after restart; ephemeral now-playing reports yield first.
+pub(crate) const OWNER_PLAYBACK_REPORT_QUEUE_MAX: usize = 1024;

--- a/src/open_subsonic/model.rs
+++ b/src/open_subsonic/model.rs
@@ -163,7 +163,14 @@ pub struct ServerSong {
     pub content_type: Option<String>,
     pub suffix: Option<String>,
     pub starred: bool,
-    pub user_rating: Option<u8>,
+    /// Exact server value. Values outside `0..=5` remain available to the bridge shadow so a
+    /// malformed/mobile-written value is never silently normalized.
+    pub user_rating: Option<i64>,
+    /// Aggregate fallback evidence from the standard Child response.
+    pub play_count: Option<u64>,
+    /// Sanitized RFC3339-ish server value. Parsing is deferred to the history bridge; malformed
+    /// values cannot make an otherwise playable catalog row disappear.
+    pub played_at: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -219,6 +226,10 @@ pub enum ServerLibrarySection {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(
+    clippy::large_enum_variant,
+    reason = "library rows stay inline because pages are bounded and consumers borrow every variant"
+)]
 pub enum ServerLibraryRow {
     Song(ServerSong),
     Album(ServerAlbum),

--- a/src/open_subsonic/native_history.rs
+++ b/src/open_subsonic/native_history.rs
@@ -1,0 +1,1378 @@
+//! Bounded, credential-owning access to Navidrome's experimental native history API.
+
+use std::collections::BTreeSet;
+use std::error::Error as _;
+use std::time::Duration;
+
+use age::secrecy::{ExposeSecret as _, SecretString};
+use reqwest::header::{ACCEPT, CONTENT_TYPE, LOCATION};
+use reqwest::{Response, StatusCode};
+use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, Zeroizing};
+
+use super::model::ItemId;
+use super::origin::{OriginError, PinnedOriginClient};
+use super::profile::OpenSubsonicProfile;
+
+pub const NATIVE_HISTORY_PAGE_SIZE: usize = 200;
+pub const MAX_NATIVE_HISTORY_PAGES: usize = 100;
+pub const MAX_NATIVE_HISTORY_ROWS: usize = NATIVE_HISTORY_PAGE_SIZE * MAX_NATIVE_HISTORY_PAGES;
+const NATIVE_HISTORY_HEAD_PAGE_BUDGET: usize = MAX_NATIVE_HISTORY_PAGES / 2;
+/// Offset remains bounded independently from the per-refresh row budget so a large same-second
+/// slice can make progress over several refreshes without relaxing that budget.
+pub(crate) const MAX_NATIVE_HISTORY_OFFSET: usize = 20_000_000;
+
+const MAX_LOGIN_RESPONSE_BYTES: usize = 64 * 1024;
+const MAX_PAGE_RESPONSE_BYTES: usize = 512 * 1024;
+const MAX_LOCATION_BYTES: usize = 4_096;
+const MAX_USERNAME_BYTES: usize = 1_024;
+const MAX_PASSWORD_BYTES: usize = 64 * 1024;
+const MAX_TOKEN_BYTES: usize = 16 * 1024;
+const MAX_REDIRECTS: usize = 3;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+const AUTHORIZATION_HEADER: &str = "x-nd-authorization";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeHistoryError {
+    InvalidCredential,
+    InvalidRequest,
+    Offline,
+    CertificateFailed,
+    OriginRejected,
+    AuthenticationRequired,
+    PermissionDenied,
+    UnsupportedFeature,
+    InvalidResponse,
+    ResponseTooLarge,
+    TemporarilyUnavailable,
+}
+
+impl std::fmt::Display for NativeHistoryError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::InvalidCredential => "native history credentials are invalid",
+            Self::InvalidRequest => "native history request is invalid",
+            Self::Offline => "music server is offline",
+            Self::CertificateFailed => "music server certificate could not be verified",
+            Self::OriginRejected => "music server address was rejected",
+            Self::AuthenticationRequired => "native history password needs updating",
+            Self::PermissionDenied => "music server denied native history access",
+            Self::UnsupportedFeature => "music server does not support detailed history",
+            Self::InvalidResponse => "music server returned invalid detailed history",
+            Self::ResponseTooLarge => "music server history exceeded the safety limit",
+            Self::TemporarilyUnavailable => "detailed history is temporarily unavailable",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for NativeHistoryError {}
+
+/// Password authentication for Navidrome's native API. Deliberately not `Debug` or `Clone`.
+pub struct NativeHistoryCredential {
+    username: SecretString,
+    password: SecretString,
+}
+
+impl NativeHistoryCredential {
+    pub fn new(
+        username: impl Into<String>,
+        password: SecretString,
+    ) -> Result<Self, NativeHistoryError> {
+        let username = username.into();
+        validate_secret_part(&username, MAX_USERNAME_BYTES)?;
+        validate_secret_part(password.expose_secret(), MAX_PASSWORD_BYTES)?;
+        Ok(Self {
+            username: SecretString::from(username),
+            password,
+        })
+    }
+}
+
+/// An in-memory native API session. The JWT is never serialized and the type is not `Debug`.
+pub struct NativeHistorySession {
+    token: Zeroizing<String>,
+}
+
+impl NativeHistorySession {
+    fn new(token: String) -> Result<Self, NativeHistoryError> {
+        validate_token(&token)?;
+        Ok(Self {
+            token: Zeroizing::new(token),
+        })
+    }
+
+    fn authorization(&self) -> Result<Zeroizing<String>, NativeHistoryError> {
+        let value = Zeroizing::new(format!("Bearer {}", self.token.as_str()));
+        reqwest::header::HeaderValue::from_str(&value)
+            .map_err(|_| NativeHistoryError::InvalidResponse)?;
+        Ok(value)
+    }
+
+    fn replace_token(&mut self, token: &str) -> Result<(), NativeHistoryError> {
+        validate_token(token)?;
+        self.token.zeroize();
+        self.token.push_str(token);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeScrobbleRow {
+    pub id: u64,
+    pub media_file_id: ItemId,
+    /// Seconds since the Unix epoch, as supplied by Navidrome's native API.
+    pub submission_time_unix: u64,
+}
+
+impl NativeScrobbleRow {
+    pub fn submission_time_unix_millis(&self) -> u64 {
+        self.submission_time_unix * 1_000
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NativeScrobblePageRequest {
+    start: usize,
+    limit: usize,
+    from_unix: Option<u64>,
+    through_unix: Option<u64>,
+}
+
+impl NativeScrobblePageRequest {
+    pub fn new(start: usize, limit: usize) -> Result<Self, NativeHistoryError> {
+        if limit == 0
+            || limit > NATIVE_HISTORY_PAGE_SIZE
+            || start >= MAX_NATIVE_HISTORY_OFFSET
+            || start.saturating_add(limit) > MAX_NATIVE_HISTORY_OFFSET
+        {
+            return Err(NativeHistoryError::InvalidRequest);
+        }
+        Ok(Self {
+            start,
+            limit,
+            from_unix: None,
+            through_unix: None,
+        })
+    }
+
+    pub fn with_time_window(
+        mut self,
+        from_unix: Option<u64>,
+        through_unix: Option<u64>,
+    ) -> Result<Self, NativeHistoryError> {
+        if matches!((from_unix, through_unix), (Some(from), Some(through)) if from > through) {
+            return Err(NativeHistoryError::InvalidRequest);
+        }
+        self.from_unix = from_unix;
+        self.through_unix = through_unix;
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeScrobblePage {
+    pub rows: Vec<NativeScrobbleRow>,
+    pub next_start: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeScrobbleScan {
+    pub rows: Vec<NativeScrobbleRow>,
+    /// Largest immutable row ID observed during the scan. Submission timestamps are
+    /// client-supplied, so the first timestamp-sorted row is not necessarily the newest ID.
+    pub next_high_water_id: Option<u64>,
+    pub reached_high_water: bool,
+    pub truncated: bool,
+    pub continuation: Option<NativeScrobbleScanContinuation>,
+}
+
+/// Resume point for a scan that used its bounded page/row budget.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeScrobbleScanContinuation {
+    pub candidate_high_water_id: Option<u64>,
+    pub next_start: usize,
+    pub through_unix: Option<u64>,
+    pub reached_high_water: bool,
+    /// The next inclusive time window can repeat these preceding-page rows.
+    pub overlap_row_ids: Vec<u64>,
+    /// The original backlog may finish while a newer head sweep is still in progress.
+    pub backlog_complete: bool,
+    /// Stable insertion-ID threshold for a durable head sweep. The candidate high-water is not
+    /// promoted into this threshold until the entire bounded overlap has been scanned.
+    pub head_anchor_high_water_id: Option<u64>,
+    /// `Some` means a head sweep is active; zero is therefore distinct from no sweep.
+    pub head_next_start: Option<usize>,
+    /// Fixed lower time bound captured when the head sweep started.
+    pub head_from_unix: Option<u64>,
+    pub head_through_unix: Option<u64>,
+    pub head_overlap_row_ids: Vec<u64>,
+}
+
+fn valid_continuation(
+    continuation: &NativeScrobbleScanContinuation,
+    high_water_id: Option<u64>,
+) -> bool {
+    let valid_overlap = |ids: &[u64]| {
+        ids.len() <= NATIVE_HISTORY_PAGE_SIZE
+            && ids.iter().copied().collect::<BTreeSet<_>>().len() == ids.len()
+    };
+    if continuation.next_start >= MAX_NATIVE_HISTORY_OFFSET
+        || !valid_overlap(&continuation.overlap_row_ids)
+        || matches!(
+            (continuation.candidate_high_water_id, high_water_id),
+            (Some(candidate), Some(high_water)) if candidate < high_water
+        )
+    {
+        return false;
+    }
+    let head_active = continuation.head_next_start.is_some();
+    if !head_active
+        && (continuation.head_anchor_high_water_id.is_some()
+            || continuation.head_from_unix.is_some()
+            || continuation.head_through_unix.is_some()
+            || !continuation.head_overlap_row_ids.is_empty())
+    {
+        return false;
+    }
+    if let Some(head_next_start) = continuation.head_next_start
+        && (head_next_start >= MAX_NATIVE_HISTORY_OFFSET
+            || !valid_overlap(&continuation.head_overlap_row_ids)
+            || matches!(
+                (
+                    continuation.head_anchor_high_water_id,
+                    continuation.candidate_high_water_id,
+                ),
+                (Some(anchor), Some(candidate)) if anchor > candidate
+            )
+            || matches!(
+                (
+                    continuation.head_anchor_high_water_id,
+                    continuation.candidate_high_water_id,
+                ),
+                (Some(_), None)
+            )
+            || matches!(
+                (continuation.head_from_unix, continuation.head_through_unix),
+                (Some(from), Some(through)) if from > through
+            ))
+    {
+        return false;
+    }
+    true
+}
+
+fn collect_scan_row(
+    row: NativeScrobbleRow,
+    new_after_id: Option<u64>,
+    high_water_id: Option<u64>,
+    next_high_water_id: &mut Option<u64>,
+    reached_high_water: &mut bool,
+    seen: &mut BTreeSet<u64>,
+    rows: &mut Vec<NativeScrobbleRow>,
+) {
+    *next_high_water_id = Some(next_high_water_id.map_or(row.id, |current| current.max(row.id)));
+    if high_water_id == Some(row.id) {
+        *reached_high_water = true;
+    }
+    if new_after_id.is_none_or(|known| row.id > known)
+        && seen.insert(row.id)
+        && rows.len() < MAX_NATIVE_HISTORY_ROWS
+    {
+        rows.push(row);
+    }
+}
+
+fn advance_scan_lane(
+    start: &mut usize,
+    through_unix: &mut Option<u64>,
+    oldest_timestamp: Option<u64>,
+) -> Result<(), NativeHistoryError> {
+    let oldest_timestamp = oldest_timestamp.ok_or(NativeHistoryError::InvalidResponse)?;
+    if through_unix.is_none_or(|through| oldest_timestamp < through) {
+        // Re-anchor at the oldest timestamp from the preceding page. Inclusive overlap makes
+        // head insertions unable to shift unseen older rows past the next offset.
+        *through_unix = Some(oldest_timestamp);
+        *start = 0;
+    } else {
+        // More than one page may share the same second. Advance inside that stable slice.
+        *start = start
+            .checked_add(NATIVE_HISTORY_PAGE_SIZE)
+            .ok_or(NativeHistoryError::InvalidRequest)?;
+    }
+    Ok(())
+}
+
+/// DNS-pinned Navidrome native transport. It owns no long-lived password or JWT.
+pub struct NavidromeNativeClient {
+    transport: PinnedOriginClient,
+}
+
+impl NavidromeNativeClient {
+    pub async fn connect(profile: &OpenSubsonicProfile) -> Result<Self, NativeHistoryError> {
+        let transport = profile
+            .origin()
+            .build_pinned_client(profile.custom_ca_pem())
+            .await
+            .map_err(map_origin_error)?;
+        Ok(Self { transport })
+    }
+
+    pub async fn login(
+        &self,
+        credential: &NativeHistoryCredential,
+    ) -> Result<NativeHistorySession, NativeHistoryError> {
+        let mut target = self
+            .transport
+            .origin()
+            .native_endpoint("auth/login")
+            .map_err(map_origin_error)?;
+        for redirects in 0..=MAX_REDIRECTS {
+            let body = LoginRequest {
+                username: credential.username.expose_secret(),
+                password: credential.password.expose_secret(),
+            };
+            let response = self
+                .transport
+                .client()
+                .post(target.clone())
+                .timeout(REQUEST_TIMEOUT)
+                .header(ACCEPT, "application/json")
+                .header(CONTENT_TYPE, "application/json")
+                .json(&body)
+                .send()
+                .await
+                .map_err(|error| classify_request_error(&error))?;
+            if response.status().is_redirection() {
+                if redirects == MAX_REDIRECTS {
+                    return Err(NativeHistoryError::OriginRejected);
+                }
+                target = redirect_target(&self.transport, &response)?;
+                continue;
+            }
+            if !response.status().is_success() {
+                return Err(status_error(response.status()));
+            }
+            let bytes = read_limited_secret(response, MAX_LOGIN_RESPONSE_BYTES).await?;
+            let mut decoded: LoginResponse =
+                serde_json::from_slice(&bytes).map_err(|_| NativeHistoryError::InvalidResponse)?;
+            let token = std::mem::take(&mut decoded.token);
+            return NativeHistorySession::new(token);
+        }
+        Err(NativeHistoryError::OriginRejected)
+    }
+
+    /// A bounded capability probe. Status errors deliberately do not affect standard API use.
+    pub async fn probe(
+        &self,
+        session: &mut NativeHistorySession,
+    ) -> Result<(), NativeHistoryError> {
+        let request = NativeScrobblePageRequest::new(0, 1)?;
+        self.fetch_page(session, request).await.map(|_| ())
+    }
+
+    pub async fn fetch_page(
+        &self,
+        session: &mut NativeHistorySession,
+        request: NativeScrobblePageRequest,
+    ) -> Result<NativeScrobblePage, NativeHistoryError> {
+        let mut parameters = vec![
+            ("_sort", "submission_time".to_owned()),
+            ("_order", "DESC".to_owned()),
+            ("_start", request.start.to_string()),
+            (
+                "_end",
+                request.start.saturating_add(request.limit).to_string(),
+            ),
+        ];
+        if let Some(from) = request.from_unix {
+            parameters.push(("from", from.to_string()));
+        }
+        if let Some(through) = request.through_unix {
+            parameters.push(("to", through.to_string()));
+        }
+        let response = self
+            .authorized_get(session, "api/scrobble", &parameters)
+            .await?;
+        if !response.status().is_success() {
+            return Err(status_error(response.status()));
+        }
+        let bytes = read_limited(response, MAX_PAGE_RESPONSE_BYTES).await?;
+        let raw: Vec<RawScrobbleRow> =
+            serde_json::from_slice(&bytes).map_err(|_| NativeHistoryError::InvalidResponse)?;
+        if raw.len() > request.limit {
+            return Err(NativeHistoryError::InvalidResponse);
+        }
+        let mut rows = Vec::with_capacity(raw.len());
+        for row in raw {
+            if row.submission_time > u64::MAX / 1_000 {
+                return Err(NativeHistoryError::InvalidResponse);
+            }
+            rows.push(NativeScrobbleRow {
+                id: row.id,
+                media_file_id: row.media_file_id,
+                submission_time_unix: row.submission_time,
+            });
+        }
+        if rows
+            .windows(2)
+            .any(|pair| pair[0].submission_time_unix < pair[1].submission_time_unix)
+        {
+            return Err(NativeHistoryError::InvalidResponse);
+        }
+        let next_start = (rows.len() == request.limit
+            && request.start.saturating_add(request.limit) < MAX_NATIVE_HISTORY_ROWS)
+            .then_some(request.start.saturating_add(request.limit));
+        Ok(NativeScrobblePage { rows, next_start })
+    }
+
+    /// Fetches at most 20,000 newest rows and stops as soon as the known row is observed.
+    pub async fn scan_recent(
+        &self,
+        session: &mut NativeHistorySession,
+        high_water_id: Option<u64>,
+    ) -> Result<NativeScrobbleScan, NativeHistoryError> {
+        self.scan_recent_from(session, high_water_id, None).await
+    }
+
+    /// Continue a timestamp-stable scan while keeping each invocation below the public
+    /// 100-page/20,000-row limit. The committed high-water remains external to this cursor.
+    pub async fn scan_recent_from(
+        &self,
+        session: &mut NativeHistorySession,
+        high_water_id: Option<u64>,
+        continuation: Option<NativeScrobbleScanContinuation>,
+    ) -> Result<NativeScrobbleScan, NativeHistoryError> {
+        self.scan_recent_from_window(session, high_water_id, None, continuation)
+            .await
+    }
+
+    /// Scan a bounded overlap window. While an older continuation is active, half of every
+    /// refresh remains available to a durable current-head sweep and half to the old backlog.
+    /// The two lanes share the public 100-page/20,000-row budget.
+    pub(crate) async fn scan_recent_from_window(
+        &self,
+        session: &mut NativeHistorySession,
+        high_water_id: Option<u64>,
+        overlap_from_unix: Option<u64>,
+        continuation: Option<NativeScrobbleScanContinuation>,
+    ) -> Result<NativeScrobbleScan, NativeHistoryError> {
+        if continuation
+            .as_ref()
+            .is_some_and(|continuation| !valid_continuation(continuation, high_water_id))
+        {
+            return Err(NativeHistoryError::InvalidRequest);
+        }
+        let resuming = continuation.is_some();
+        let mut start = continuation.as_ref().map_or(0, |continuation| {
+            continuation
+                .next_start
+                .saturating_sub(NATIVE_HISTORY_PAGE_SIZE)
+        });
+        let mut through_unix = continuation
+            .as_ref()
+            .and_then(|continuation| continuation.through_unix);
+        let mut pages = 0;
+        let mut rows = Vec::new();
+        let mut seen = BTreeSet::new();
+        if let Some(continuation) = &continuation {
+            seen.extend(continuation.overlap_row_ids.iter().copied());
+            seen.extend(
+                continuation
+                    .head_overlap_row_ids
+                    .iter()
+                    .copied()
+                    .filter(|id| {
+                        continuation
+                            .head_anchor_high_water_id
+                            .is_none_or(|anchor| *id > anchor)
+                    }),
+            );
+        }
+        let mut next_high_water_id = continuation
+            .as_ref()
+            .and_then(|continuation| continuation.candidate_high_water_id)
+            .or(high_water_id);
+        let mut reached_high_water = continuation
+            .as_ref()
+            .is_some_and(|continuation| continuation.reached_high_water);
+        let mut overlap_row_ids = continuation
+            .as_ref()
+            .map(|continuation| continuation.overlap_row_ids.clone())
+            .unwrap_or_default();
+        let mut backlog_complete = continuation
+            .as_ref()
+            .is_some_and(|continuation| continuation.backlog_complete);
+
+        let mut head_complete = !resuming;
+        let mut head_anchor_high_water_id = None;
+        let mut head_start = 0;
+        let mut head_from_unix = None;
+        let mut head_through_unix = None;
+        let mut head_overlap_row_ids = Vec::new();
+        if let Some(progress) = continuation.as_ref() {
+            head_complete = false;
+            head_anchor_high_water_id = progress
+                .head_next_start
+                .is_some()
+                .then_some(progress.head_anchor_high_water_id)
+                .flatten()
+                .or(progress.candidate_high_water_id)
+                .or(high_water_id);
+            head_start = progress.head_next_start.map_or(0, |next_start| {
+                next_start.saturating_sub(NATIVE_HISTORY_PAGE_SIZE)
+            });
+            head_from_unix = progress
+                .head_next_start
+                .is_some()
+                .then_some(progress.head_from_unix)
+                .flatten()
+                .or(overlap_from_unix);
+            head_through_unix = progress.head_next_start.and(progress.head_through_unix);
+            if progress.head_next_start.is_some() {
+                head_overlap_row_ids = progress.head_overlap_row_ids.clone();
+            }
+        }
+
+        let mut head_pages = 0;
+        while !head_complete
+            && head_pages < NATIVE_HISTORY_HEAD_PAGE_BUDGET
+            && pages < MAX_NATIVE_HISTORY_PAGES
+            && rows.len() < MAX_NATIVE_HISTORY_ROWS
+        {
+            let request = NativeScrobblePageRequest::new(head_start, NATIVE_HISTORY_PAGE_SIZE)?
+                .with_time_window(head_from_unix, head_through_unix)?;
+            let page = self.fetch_page(session, request).await?;
+            pages += 1;
+            head_pages += 1;
+            let page_was_full = page.rows.len() == NATIVE_HISTORY_PAGE_SIZE;
+            let oldest_timestamp = page.rows.last().map(|row| row.submission_time_unix);
+            head_overlap_row_ids = page.rows.iter().map(|row| row.id).collect();
+            for row in page.rows {
+                collect_scan_row(
+                    row,
+                    head_anchor_high_water_id,
+                    high_water_id,
+                    &mut next_high_water_id,
+                    &mut reached_high_water,
+                    &mut seen,
+                    &mut rows,
+                );
+            }
+            if !page_was_full {
+                head_complete = true;
+                break;
+            }
+            advance_scan_lane(&mut head_start, &mut head_through_unix, oldest_timestamp)?;
+        }
+
+        while !backlog_complete
+            && pages < MAX_NATIVE_HISTORY_PAGES
+            && rows.len() < MAX_NATIVE_HISTORY_ROWS
+        {
+            let from_unix = if resuming { None } else { overlap_from_unix };
+            let request = NativeScrobblePageRequest::new(start, NATIVE_HISTORY_PAGE_SIZE)?
+                .with_time_window(from_unix, through_unix)?;
+            let page = self.fetch_page(session, request).await?;
+            pages += 1;
+            let page_was_full = page.rows.len() == NATIVE_HISTORY_PAGE_SIZE;
+            let oldest_timestamp = page.rows.last().map(|row| row.submission_time_unix);
+            overlap_row_ids = page.rows.iter().map(|row| row.id).collect();
+            for row in page.rows {
+                // Row IDs are immutable insertion identities, but submission time is supplied by
+                // the client. A newly inserted offline scrobble can therefore sort well below the
+                // prior high-water row. Scan the bounded timestamp window to completion and use
+                // the ID only as the newness predicate; stopping at the known row would lose that
+                // legitimate backfill.
+                collect_scan_row(
+                    row,
+                    high_water_id,
+                    high_water_id,
+                    &mut next_high_water_id,
+                    &mut reached_high_water,
+                    &mut seen,
+                    &mut rows,
+                );
+            }
+            if !page_was_full {
+                backlog_complete = true;
+                break;
+            }
+            advance_scan_lane(&mut start, &mut through_unix, oldest_timestamp)?;
+        }
+        rows.sort_by(|left, right| {
+            right
+                .submission_time_unix
+                .cmp(&left.submission_time_unix)
+                .then_with(|| right.id.cmp(&left.id))
+        });
+        let complete = backlog_complete && head_complete;
+        let continuation = (!complete).then_some(NativeScrobbleScanContinuation {
+            candidate_high_water_id: next_high_water_id,
+            next_start: start,
+            through_unix,
+            reached_high_water,
+            overlap_row_ids,
+            backlog_complete,
+            head_anchor_high_water_id: (!head_complete)
+                .then_some(head_anchor_high_water_id)
+                .flatten(),
+            head_next_start: (!head_complete).then_some(head_start),
+            head_from_unix: (!head_complete).then_some(head_from_unix).flatten(),
+            head_through_unix: (!head_complete).then_some(head_through_unix).flatten(),
+            head_overlap_row_ids: if head_complete {
+                Vec::new()
+            } else {
+                head_overlap_row_ids
+            },
+        });
+        Ok(NativeScrobbleScan {
+            rows,
+            next_high_water_id,
+            reached_high_water,
+            truncated: !complete,
+            continuation,
+        })
+    }
+
+    async fn authorized_get(
+        &self,
+        session: &mut NativeHistorySession,
+        path: &str,
+        parameters: &[(&str, String)],
+    ) -> Result<Response, NativeHistoryError> {
+        let mut target = self
+            .transport
+            .origin()
+            .native_endpoint(path)
+            .map_err(map_origin_error)?;
+        for redirects in 0..=MAX_REDIRECTS {
+            let authorization = session.authorization()?;
+            let response = self
+                .transport
+                .client()
+                .get(target.clone())
+                .timeout(REQUEST_TIMEOUT)
+                .header(ACCEPT, "application/json")
+                .header(AUTHORIZATION_HEADER, authorization.as_str())
+                .query(parameters)
+                .send()
+                .await
+                .map_err(|error| classify_request_error(&error))?;
+            refresh_session(session, &response)?;
+            if !response.status().is_redirection() {
+                return Ok(response);
+            }
+            if redirects == MAX_REDIRECTS {
+                return Err(NativeHistoryError::OriginRejected);
+            }
+            target = redirect_target(&self.transport, &response)?;
+        }
+        Err(NativeHistoryError::OriginRejected)
+    }
+}
+
+#[derive(Serialize)]
+struct LoginRequest<'a> {
+    username: &'a str,
+    password: &'a str,
+}
+
+#[derive(Deserialize)]
+struct LoginResponse {
+    token: String,
+}
+
+impl Drop for LoginResponse {
+    fn drop(&mut self) {
+        self.token.zeroize();
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawScrobbleRow {
+    id: u64,
+    media_file_id: ItemId,
+    submission_time: u64,
+}
+
+fn refresh_session(
+    session: &mut NativeHistorySession,
+    response: &Response,
+) -> Result<(), NativeHistoryError> {
+    let Some(value) = response.headers().get(AUTHORIZATION_HEADER) else {
+        return Ok(());
+    };
+    let token = value
+        .to_str()
+        .map_err(|_| NativeHistoryError::InvalidResponse)?;
+    session.replace_token(token)
+}
+
+fn redirect_target(
+    transport: &PinnedOriginClient,
+    response: &Response,
+) -> Result<reqwest::Url, NativeHistoryError> {
+    let location = response
+        .headers()
+        .get(LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| value.len() <= MAX_LOCATION_BYTES)
+        .ok_or(NativeHistoryError::OriginRejected)?;
+    transport
+        .origin()
+        .validate_redirect(response.url(), location)
+        .map_err(map_origin_error)
+}
+
+fn validate_secret_part(value: &str, max_bytes: usize) -> Result<(), NativeHistoryError> {
+    if value.is_empty()
+        || value.len() > max_bytes
+        || value.chars().any(|character| {
+            character.is_control()
+                || matches!(
+                    character,
+                    '\u{200b}'
+                        | '\u{200c}'
+                        | '\u{200d}'
+                        | '\u{200e}'
+                        | '\u{200f}'
+                        | '\u{202a}'..='\u{202e}'
+                        | '\u{2066}'..='\u{2069}'
+                        | '\u{feff}'
+                )
+        })
+    {
+        return Err(NativeHistoryError::InvalidCredential);
+    }
+    Ok(())
+}
+
+fn validate_token(token: &str) -> Result<(), NativeHistoryError> {
+    if token.is_empty()
+        || token.len() > MAX_TOKEN_BYTES
+        || !token
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'='))
+    {
+        return Err(NativeHistoryError::InvalidResponse);
+    }
+    Ok(())
+}
+
+fn status_error(status: StatusCode) -> NativeHistoryError {
+    match status {
+        StatusCode::UNAUTHORIZED => NativeHistoryError::AuthenticationRequired,
+        StatusCode::FORBIDDEN => NativeHistoryError::PermissionDenied,
+        StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED | StatusCode::NOT_IMPLEMENTED => {
+            NativeHistoryError::UnsupportedFeature
+        }
+        status if status.is_server_error() || status == StatusCode::TOO_MANY_REQUESTS => {
+            NativeHistoryError::TemporarilyUnavailable
+        }
+        _ => NativeHistoryError::InvalidResponse,
+    }
+}
+
+fn map_origin_error(error: OriginError) -> NativeHistoryError {
+    match error {
+        OriginError::InvalidCertificate => NativeHistoryError::CertificateFailed,
+        OriginError::ResolutionFailed | OriginError::ClientBuildFailed => {
+            NativeHistoryError::Offline
+        }
+        OriginError::InvalidOrigin
+        | OriginError::InsecureOrigin
+        | OriginError::DestinationRejected
+        | OriginError::RedirectRejected => NativeHistoryError::OriginRejected,
+    }
+}
+
+fn classify_request_error(error: &reqwest::Error) -> NativeHistoryError {
+    let mut source = error.source();
+    while let Some(current) = source {
+        if current.is::<native_tls::Error>() {
+            return NativeHistoryError::CertificateFailed;
+        }
+        source = current.source();
+    }
+    NativeHistoryError::Offline
+}
+
+async fn read_limited(
+    mut response: Response,
+    max_bytes: usize,
+) -> Result<Vec<u8>, NativeHistoryError> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > max_bytes as u64)
+    {
+        return Err(NativeHistoryError::ResponseTooLarge);
+    }
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| classify_request_error(&error))?
+    {
+        if bytes.len().saturating_add(chunk.len()) > max_bytes {
+            return Err(NativeHistoryError::ResponseTooLarge);
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+async fn read_limited_secret(
+    mut response: Response,
+    max_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, NativeHistoryError> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > max_bytes as u64)
+    {
+        return Err(NativeHistoryError::ResponseTooLarge);
+    }
+    let mut bytes = Zeroizing::new(Vec::new());
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| classify_request_error(&error))?
+    {
+        if bytes.len().saturating_add(chunk.len()) > max_bytes {
+            return Err(NativeHistoryError::ResponseTooLarge);
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    use super::*;
+    use crate::open_subsonic::ConfiguredPrivateOrigin;
+
+    struct HttpRequest {
+        head: String,
+        body: Vec<u8>,
+    }
+
+    async fn read_request(stream: &mut tokio::net::TcpStream) -> HttpRequest {
+        let mut head = Vec::new();
+        let mut byte = [0_u8; 1];
+        while head.len() < 32 * 1024 {
+            assert_ne!(stream.read(&mut byte).await.unwrap(), 0);
+            head.push(byte[0]);
+            if head.ends_with(b"\r\n\r\n") {
+                break;
+            }
+        }
+        let head = String::from_utf8(head).unwrap();
+        let content_length = head
+            .lines()
+            .find_map(|line| {
+                line.to_ascii_lowercase()
+                    .strip_prefix("content-length:")
+                    .and_then(|value| value.trim().parse::<usize>().ok())
+            })
+            .unwrap_or(0);
+        let mut body = vec![0; content_length];
+        stream.read_exact(&mut body).await.unwrap();
+        HttpRequest { head, body }
+    }
+
+    async fn write_json(
+        stream: &mut tokio::net::TcpStream,
+        status: &str,
+        headers: &str,
+        body: &[u8],
+    ) {
+        let head = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{headers}Connection: close\r\n\r\n",
+            body.len()
+        );
+        stream.write_all(head.as_bytes()).await.unwrap();
+        stream.write_all(body).await.unwrap();
+    }
+
+    async fn test_client(port: u16, base: &str) -> NavidromeNativeClient {
+        let profile = OpenSubsonicProfile::new(
+            "Test server",
+            ConfiguredPrivateOrigin::new(&format!("http://127.0.0.1:{port}/{base}"), true).unwrap(),
+            None,
+        )
+        .unwrap();
+        NavidromeNativeClient::connect(&profile).await.unwrap()
+    }
+
+    fn test_session() -> NativeHistorySession {
+        NativeHistorySession::new("test.jwt-token".to_owned()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn login_body_and_history_authorization_are_kept_out_of_urls() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut login, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut login).await;
+            assert!(request.head.starts_with("POST /base/auth/login HTTP/1.1"));
+            assert!(!request.head.contains("sentinel-password"));
+            assert!(!request.head.contains("sentinel-user"));
+            let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+            assert_eq!(body["username"], "sentinel-user");
+            assert_eq!(body["password"], "sentinel-password");
+            write_json(
+                &mut login,
+                "200 OK",
+                "",
+                br#"{"token":"first.jwt-token","ignored":"safe"}"#,
+            )
+            .await;
+
+            let (mut history, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut history).await;
+            assert!(request.head.starts_with("GET /base/api/scrobble?"));
+            assert!(request.head.contains("_sort=submission_time"));
+            assert!(request.head.contains("_order=DESC"));
+            assert!(request.head.contains("_start=0"));
+            assert!(request.head.contains("_end=2"));
+            assert!(
+                request
+                    .head
+                    .to_ascii_lowercase()
+                    .contains("x-nd-authorization: bearer first.jwt-token")
+            );
+            assert!(!request.head.contains("sentinel-password"));
+            write_json(
+                &mut history,
+                "200 OK",
+                "X-ND-Authorization: refreshed.jwt-token\r\n",
+                br#"[{"id":9,"mediaFileId":"song-9","submissionTime":1720000000},{"id":8,"mediaFileId":"song-8","submissionTime":1719999999}]"#,
+            )
+            .await;
+        });
+
+        let client = test_client(port, "base/").await;
+        let credential = NativeHistoryCredential::new(
+            "sentinel-user",
+            SecretString::from("sentinel-password".to_owned()),
+        )
+        .unwrap();
+        let mut session = client.login(&credential).await.unwrap();
+        let page = client
+            .fetch_page(&mut session, NativeScrobblePageRequest::new(0, 2).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(page.rows.len(), 2);
+        assert_eq!(page.rows[0].media_file_id.as_str(), "song-9");
+        assert_eq!(
+            page.rows[0].submission_time_unix_millis(),
+            1_720_000_000_000
+        );
+        assert_eq!(session.token.as_str(), "refreshed.jwt-token");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn status_schema_and_size_failures_are_classified() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            for status in [
+                "404 Not Found",
+                "405 Method Not Allowed",
+                "401 Unauthorized",
+                "403 Forbidden",
+                "500 Internal Server Error",
+            ] {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let _ = read_request(&mut stream).await;
+                write_json(&mut stream, status, "", b"").await;
+            }
+            let (mut invalid, _) = listener.accept().await.unwrap();
+            let _ = read_request(&mut invalid).await;
+            write_json(&mut invalid, "200 OK", "", br#"{"not":"a list"}"#).await;
+
+            let (mut oversized, _) = listener.accept().await.unwrap();
+            let _ = read_request(&mut oversized).await;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                MAX_PAGE_RESPONSE_BYTES + 1
+            );
+            oversized.write_all(response.as_bytes()).await.unwrap();
+        });
+        let client = test_client(port, "").await;
+        let mut session = test_session();
+        let request = NativeScrobblePageRequest::new(0, 1).unwrap();
+        for expected in [
+            NativeHistoryError::UnsupportedFeature,
+            NativeHistoryError::UnsupportedFeature,
+            NativeHistoryError::AuthenticationRequired,
+            NativeHistoryError::PermissionDenied,
+            NativeHistoryError::TemporarilyUnavailable,
+            NativeHistoryError::InvalidResponse,
+            NativeHistoryError::ResponseTooLarge,
+        ] {
+            assert_eq!(
+                client.fetch_page(&mut session, request).await,
+                Err(expected)
+            );
+        }
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn redirects_are_same_origin_and_bounded() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            for _ in 0..=MAX_REDIRECTS {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let request = read_request(&mut stream).await;
+                assert!(
+                    request
+                        .head
+                        .to_ascii_lowercase()
+                        .contains("x-nd-authorization: bearer test.jwt-token")
+                );
+                write_json(
+                    &mut stream,
+                    "307 Temporary Redirect",
+                    "Location: /base/api/scrobble-loop\r\n",
+                    b"",
+                )
+                .await;
+            }
+        });
+        let client = test_client(port, "base/").await;
+        let mut session = test_session();
+        assert_eq!(
+            client.probe(&mut session).await,
+            Err(NativeHistoryError::OriginRejected)
+        );
+        server.await.unwrap();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _ = read_request(&mut stream).await;
+            write_json(
+                &mut stream,
+                "307 Temporary Redirect",
+                "Location: http://127.0.0.1:9/steal\r\n",
+                b"",
+            )
+            .await;
+        });
+        let client = test_client(port, "").await;
+        let mut session = test_session();
+        assert_eq!(
+            client.probe(&mut session).await,
+            Err(NativeHistoryError::OriginRejected)
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn timestamp_sorted_scan_accepts_backfilled_id_inversion_across_pages() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let first_rows = (101_u64..=300)
+                .rev()
+                .map(|id| {
+                    serde_json::json!({
+                        "id": id,
+                        "mediaFileId": format!("song-{id}"),
+                        "submissionTime": 1_720_000_000_u64 + id,
+                    })
+                })
+                .collect::<Vec<_>>();
+            let second_rows = (95_u64..=101)
+                .rev()
+                .map(|id| {
+                    // An offline submission is inserted later (ID 500) with the older
+                    // client-supplied timestamp that row 100 would have occupied.
+                    let inserted_id = if id == 100 { 500 } else { id };
+                    serde_json::json!({
+                        "id": inserted_id,
+                        "mediaFileId": format!("song-{inserted_id}"),
+                        "submissionTime": 1_720_000_000_u64 + id,
+                    })
+                })
+                .collect::<Vec<_>>();
+            for (index, rows) in [first_rows, second_rows].into_iter().enumerate() {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let request = read_request(&mut stream).await;
+                assert!(request.head.contains("_start=0"));
+                if index == 1 {
+                    assert!(request.head.contains("to=1720000101"));
+                }
+                let body = serde_json::to_vec(&rows).unwrap();
+                write_json(&mut stream, "200 OK", "", &body).await;
+            }
+        });
+        let client = test_client(port, "").await;
+        let mut session = test_session();
+        let scan = client.scan_recent(&mut session, Some(98)).await.unwrap();
+        assert!(scan.reached_high_water);
+        assert!(!scan.truncated);
+        assert_eq!(scan.rows.len(), 202);
+        assert_eq!(scan.rows.first().unwrap().id, 300);
+        assert_eq!(scan.rows.last().unwrap().id, 99);
+        assert!(scan.rows.iter().any(|row| row.id == 500));
+        assert_eq!(scan.next_high_water_id, Some(500));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn same_second_rows_advance_inside_the_timestamp_overlap() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let page = |first: u64, last: u64| {
+            (last..=first)
+                .rev()
+                .map(|id| {
+                    serde_json::json!({
+                        "id": id,
+                        "mediaFileId": format!("song-{id}"),
+                        "submissionTime": 1_720_000_000_u64,
+                    })
+                })
+                .collect::<Vec<_>>()
+        };
+        let first = page(400, 201);
+        let duplicate = first.clone();
+        let third = page(200, 190);
+        let server = tokio::spawn(async move {
+            for (expected_start, rows) in [(0, first), (0, duplicate), (200, third)] {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let request = read_request(&mut stream).await;
+                assert!(request.head.contains(&format!("_start={expected_start}")));
+                let body = serde_json::to_vec(&rows).unwrap();
+                write_json(&mut stream, "200 OK", "", &body).await;
+            }
+        });
+        let client = test_client(port, "").await;
+        let mut session = test_session();
+        let scan = client.scan_recent(&mut session, Some(198)).await.unwrap();
+        assert!(scan.reached_high_water);
+        assert_eq!(scan.rows.len(), 202);
+        assert_eq!(scan.rows.first().unwrap().id, 400);
+        assert_eq!(scan.rows.last().unwrap().id, 199);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn resumed_same_second_scan_overlaps_page_to_absorb_head_insert_race() {
+        const SUBMITTED_AT: u64 = 1_720_000_000;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let all_rows = (1_u64..=650).rev().collect::<Vec<_>>();
+            // A durable head sweep completes before the old backlog resumes. Both lanes overlap
+            // their preceding page at the inclusive same-second boundary.
+            for (index, expected_start) in [0, 0, 200, 400, 600, 0, 200, 400, 600]
+                .into_iter()
+                .enumerate()
+            {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let request = read_request(&mut stream).await;
+                assert_eq!(query_number(&request.head, "_start"), Some(expected_start));
+                assert_eq!(
+                    query_number(&request.head, "to"),
+                    (index != 0).then_some(SUBMITTED_AT)
+                );
+                let rows = all_rows
+                    .iter()
+                    .skip(expected_start as usize)
+                    .take(NATIVE_HISTORY_PAGE_SIZE)
+                    .map(|id| {
+                        serde_json::json!({
+                            "id": id,
+                            "mediaFileId": format!("song-{id}"),
+                            "submissionTime": SUBMITTED_AT,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                let body = serde_json::to_vec(&rows).unwrap();
+                write_json(&mut stream, "200 OK", "", &body).await;
+            }
+        });
+        let client = test_client(port, "").await;
+        let mut session = test_session();
+        let continuation = NativeScrobbleScanContinuation {
+            candidate_high_water_id: Some(400),
+            next_start: 200,
+            through_unix: Some(SUBMITTED_AT),
+            reached_high_water: false,
+            overlap_row_ids: (201..=400).rev().collect(),
+            backlog_complete: false,
+            head_anchor_high_water_id: None,
+            head_next_start: None,
+            head_from_unix: None,
+            head_through_unix: None,
+            head_overlap_row_ids: Vec::new(),
+        };
+        let scan = client
+            .scan_recent_from(&mut session, None, Some(continuation))
+            .await
+            .unwrap();
+        assert!(!scan.truncated);
+        assert_eq!(scan.next_high_water_id, Some(650));
+        let ids = scan.rows.iter().map(|row| row.id).collect::<BTreeSet<_>>();
+        assert_eq!(ids.len(), 450);
+        assert!((1..=200).all(|id| ids.contains(&id)));
+        assert!((401..=650).all(|id| ids.contains(&id)));
+        assert!((201..=400).all(|id| !ids.contains(&id)));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn durable_head_and_backlog_both_progress_across_a_twenty_thousand_row_burst() {
+        const BASE_TIME: u64 = 1_720_000_000;
+        const PRIOR_CANDIDATE: u64 = 20_250;
+        const TOTAL_ROWS: u64 = 40_300;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let requests = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let server_requests = requests.clone();
+        let (shutdown, mut stop) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            loop {
+                let accepted = tokio::select! {
+                    _ = &mut stop => break,
+                    accepted = listener.accept() => accepted,
+                };
+                let (mut stream, _) = accepted.unwrap();
+                server_requests.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let request = read_request(&mut stream).await;
+                let start = query_number(&request.head, "_start").unwrap_or(0) as usize;
+                let newest = query_number(&request.head, "to")
+                    .map(|through| through.saturating_sub(BASE_TIME).min(TOTAL_ROWS))
+                    .unwrap_or(TOTAL_ROWS);
+                let rows = (1..=newest)
+                    .rev()
+                    .skip(start)
+                    .take(NATIVE_HISTORY_PAGE_SIZE)
+                    .map(|id| {
+                        serde_json::json!({
+                            "id": id,
+                            "mediaFileId": format!("song-{id}"),
+                            "submissionTime": BASE_TIME + id,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                let body = serde_json::to_vec(&rows).unwrap();
+                write_json(&mut stream, "200 OK", "", &body).await;
+            }
+        });
+
+        let client = test_client(port, "").await;
+        let mut session = test_session();
+        let persisted = NativeScrobbleScanContinuation {
+            candidate_high_water_id: Some(PRIOR_CANDIDATE),
+            next_start: 0,
+            through_unix: Some(BASE_TIME + 500),
+            reached_high_water: false,
+            overlap_row_ids: Vec::new(),
+            backlog_complete: false,
+            head_anchor_high_water_id: None,
+            head_next_start: None,
+            head_from_unix: None,
+            head_through_unix: None,
+            head_overlap_row_ids: Vec::new(),
+        };
+        let before = requests.load(std::sync::atomic::Ordering::Relaxed);
+        let mut scan = client
+            .scan_recent_from(&mut session, Some(1), Some(persisted))
+            .await
+            .unwrap();
+        let used = requests
+            .load(std::sync::atomic::Ordering::Relaxed)
+            .saturating_sub(before);
+        assert!(used <= MAX_NATIVE_HISTORY_PAGES);
+        assert!(scan.truncated);
+        let progress = scan.continuation.as_ref().unwrap();
+        assert!(
+            progress.backlog_complete,
+            "the old backlog must progress while the new head exceeds one refresh"
+        );
+        assert!(progress.head_next_start.is_some());
+        assert!(
+            scan.rows.iter().any(|row| row.id == 2)
+                && scan.rows.iter().any(|row| row.id > PRIOR_CANDIDATE),
+            "one refresh must advance both the old tail and the newly inserted head"
+        );
+
+        // IDs 501..=20,250 model rows returned before the serialized crash point. Every later
+        // invocation receives only a cloned cursor; no in-memory seen set survives the restart.
+        let mut ids = (501..=PRIOR_CANDIDATE).collect::<BTreeSet<_>>();
+        for row in &scan.rows {
+            assert!(ids.insert(row.id), "a resumed scan replayed row {}", row.id);
+        }
+        for _ in 0..8 {
+            let Some(continuation) = scan.continuation.clone() else {
+                break;
+            };
+            let before = requests.load(std::sync::atomic::Ordering::Relaxed);
+            scan = client
+                .scan_recent_from(&mut session, Some(1), Some(continuation))
+                .await
+                .unwrap();
+            let used = requests
+                .load(std::sync::atomic::Ordering::Relaxed)
+                .saturating_sub(before);
+            assert!(used <= MAX_NATIVE_HISTORY_PAGES);
+            for row in &scan.rows {
+                assert!(ids.insert(row.id), "a resumed scan replayed row {}", row.id);
+            }
+        }
+        assert!(!scan.truncated);
+        assert!(scan.reached_high_water);
+        assert_eq!(scan.next_high_water_id, Some(TOTAL_ROWS));
+        assert_eq!(ids.len(), (TOTAL_ROWS - 1) as usize);
+        assert_eq!(ids.first(), Some(&2));
+        assert_eq!(ids.last(), Some(&TOTAL_ROWS));
+        shutdown.send(()).unwrap();
+        server.await.unwrap();
+    }
+
+    fn query_number(head: &str, key: &str) -> Option<u64> {
+        let target = head.lines().next()?.split_whitespace().nth(1)?;
+        let query = target.split_once('?')?.1;
+        query.split('&').find_map(|pair| {
+            let (name, value) = pair.split_once('=')?;
+            (name == key).then(|| value.parse().ok()).flatten()
+        })
+    }
+
+    #[test]
+    fn credential_page_and_token_validation_fail_closed() {
+        assert!(
+            NativeHistoryCredential::new("", SecretString::from("password".to_owned())).is_err()
+        );
+        assert!(NativeHistoryCredential::new("user", SecretString::from(String::new())).is_err());
+        assert_eq!(
+            NativeScrobblePageRequest::new(0, 0),
+            Err(NativeHistoryError::InvalidRequest)
+        );
+        assert_eq!(
+            NativeScrobblePageRequest::new(0, NATIVE_HISTORY_PAGE_SIZE + 1),
+            Err(NativeHistoryError::InvalidRequest)
+        );
+        assert!(NativeHistorySession::new("unsafe token".to_owned()).is_err());
+        let rendered = format!(
+            "{:?} {}",
+            NativeHistoryError::AuthenticationRequired,
+            NativeHistoryError::AuthenticationRequired
+        );
+        assert!(!rendered.contains("sentinel-password"));
+        assert!(!rendered.contains("http://"));
+    }
+}

--- a/src/open_subsonic/origin.rs
+++ b/src/open_subsonic/origin.rs
@@ -100,6 +100,24 @@ impl ConfiguredPrivateOrigin {
             .map_err(|_| OriginError::InvalidOrigin)
     }
 
+    pub(crate) fn native_endpoint(&self, path: &str) -> Result<Url, OriginError> {
+        if path.is_empty()
+            || path.len() > MAX_ORIGIN_BYTES
+            || path.starts_with('/')
+            || !path.split('/').all(|segment| {
+                !segment.is_empty()
+                    && segment
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+            })
+        {
+            return Err(OriginError::InvalidOrigin);
+        }
+        self.base_url
+            .join(path)
+            .map_err(|_| OriginError::InvalidOrigin)
+    }
+
     pub async fn build_pinned_client(
         &self,
         custom_ca_pem: Option<&[u8]>,
@@ -276,6 +294,26 @@ mod tests {
             origin.endpoint("search3").unwrap().as_str(),
             "https://music.example.test/navidrome/rest/search3.view"
         );
+        assert_eq!(
+            origin.native_endpoint("auth/login").unwrap().as_str(),
+            "https://music.example.test/navidrome/auth/login"
+        );
+        assert_eq!(
+            origin.native_endpoint("api/scrobble").unwrap().as_str(),
+            "https://music.example.test/navidrome/api/scrobble"
+        );
+        for unsafe_path in [
+            "",
+            "/auth/login",
+            "../auth/login",
+            "api//scrobble",
+            "api/scrobble?token=secret",
+        ] {
+            assert!(
+                origin.native_endpoint(unsafe_path).is_err(),
+                "{unsafe_path}"
+            );
+        }
     }
 
     #[test]

--- a/src/open_subsonic/outbound_recovery.rs
+++ b/src/open_subsonic/outbound_recovery.rs
@@ -1,0 +1,205 @@
+//! Offline owner-store recovery for ambiguously delivered playback reports.
+//!
+//! These functions never start an actor or perform network I/O. Mutating callers must already own
+//! the process-wide persistence writer lease.
+
+use super::actor::{OutboundScrobbleResolution, ServiceError};
+use super::bridge_runtime::BridgeRuntime;
+use super::profile::OpenSubsonicPaths;
+use super::transaction::{load_store_set, load_store_set_read_only};
+
+const OPAQUE_EVENT_ID_PREFIX: &str = "sub-scrobble-";
+const OPAQUE_EVENT_ID_HEX_LEN: usize = 64;
+
+/// Return only opaque report IDs from one coherent read-only snapshot.
+pub fn list_scrobble_attention_ids(paths: &OpenSubsonicPaths) -> Result<Vec<String>, ServiceError> {
+    let store_set = load_store_set_read_only(paths)?.ok_or(ServiceError::InvalidSetup)?;
+    let ids = store_set.bridge_state.outbound_scrobble_attention_ids();
+    if ids.iter().all(|id| is_opaque_event_id(id)) {
+        Ok(ids)
+    } else {
+        Err(ServiceError::InvalidSetup)
+    }
+}
+
+/// Persist one explicit delivery decision without contacting the configured server.
+pub fn resolve_scrobble_attention(
+    paths: &OpenSubsonicPaths,
+    event_id: &str,
+    resolution: OutboundScrobbleResolution,
+) -> Result<(), ServiceError> {
+    if !is_opaque_event_id(event_id) {
+        return Err(ServiceError::InvalidSetup);
+    }
+    let mut store_set = load_store_set(paths)?.ok_or(ServiceError::InvalidSetup)?;
+    BridgeRuntime::writable(paths.clone(), None).resolve_outbound_scrobble(
+        &mut store_set,
+        event_id,
+        resolution,
+    )
+}
+
+fn is_opaque_event_id(value: &str) -> bool {
+    value
+        .strip_prefix(OPAQUE_EVENT_ID_PREFIX)
+        .is_some_and(|digest| {
+            digest.len() == OPAQUE_EVENT_ID_HEX_LEN
+                && digest
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use age::secrecy::SecretString;
+
+    use super::*;
+    use crate::open_subsonic::bridge_store::{
+        AggregatePlayShadow, MAX_UNCERTAIN_SCROBBLE_READBACKS, OutboundScrobbleDelivery,
+        OutboundScrobbleKind, PendingOutboundScrobble,
+    };
+    use crate::open_subsonic::{
+        ConfiguredPrivateOrigin, ItemId, OpenSubsonicBridgeState, OpenSubsonicPrivateState,
+        OpenSubsonicProfile, OpenSubsonicStoreSet, ServerCredential, StoreRevisions,
+        commit_store_set,
+    };
+
+    fn fixture(label: &str) -> (std::path::PathBuf, OpenSubsonicPaths, String) {
+        let root = std::env::temp_dir().join(format!(
+            "yututui-outbound-recovery-{label}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        crate::persist::initialize_persistence_writer_for_roots([&root], false).unwrap();
+        crate::util::safe_fs::ensure_private_dir(&root).unwrap();
+        let paths = OpenSubsonicPaths::for_data_root(root.clone());
+        let profile = OpenSubsonicProfile::new(
+            "Recovery fixture",
+            ConfiguredPrivateOrigin::new("http://127.0.0.1:9/", true).unwrap(),
+            None,
+        )
+        .unwrap();
+        let private_state = OpenSubsonicPrivateState::new(
+            profile.backend_id().clone(),
+            profile.account_scope_id().clone(),
+            ServerCredential::api_key(SecretString::from("recovery-secret".to_owned())).unwrap(),
+        );
+        let mut bridge_state = OpenSubsonicBridgeState::new(
+            profile.backend_id().clone(),
+            profile.account_scope_id().clone(),
+        );
+        let item_id = ItemId::new("song").unwrap();
+        bridge_state
+            .reserve_outbound_exact_history_credit(item_id.clone(), 0)
+            .unwrap();
+        let event_id = format!("sub-scrobble-{}", "a".repeat(64));
+        bridge_state
+            .queue_outbound_scrobble(PendingOutboundScrobble {
+                event_id: event_id.clone(),
+                item_id,
+                played_at_unix: 42,
+                kind: OutboundScrobbleKind::Submission,
+                delivery: OutboundScrobbleDelivery::NeedsAttention,
+                baseline_captured: true,
+                baseline_play_count: Some(7),
+                baseline_played_at: None,
+                exact_credit_recorded: true,
+                exact_credit_epoch: Some(0),
+                uncertain_readbacks: MAX_UNCERTAIN_SCROBBLE_READBACKS,
+                source_marker_acknowledged: false,
+            })
+            .unwrap();
+        let mut store_set =
+            OpenSubsonicStoreSet::new(profile, private_state, bridge_state).unwrap();
+        commit_store_set(&paths, StoreRevisions::MISSING, &mut store_set).unwrap();
+        (root, paths, event_id)
+    }
+
+    #[test]
+    fn offline_list_and_mark_sent_return_only_opaque_identity_and_preserve_credit() {
+        let (root, paths, event_id) = fixture("mark-sent");
+        assert_eq!(
+            list_scrobble_attention_ids(&paths).unwrap(),
+            vec![event_id.clone()]
+        );
+
+        resolve_scrobble_attention(&paths, &event_id, OutboundScrobbleResolution::MarkSent)
+            .unwrap();
+        let durable = load_store_set(&paths).unwrap().unwrap();
+        assert!(durable.bridge_state.outbound_scrobbles().is_empty());
+        assert_eq!(durable.bridge_state.completed_outbound_scrobbles().len(), 1);
+        assert_eq!(durable.bridge_state.outbound_echoes().len(), 1);
+        assert_eq!(
+            durable
+                .bridge_state
+                .history_dedupe_credits()
+                .get(&ItemId::new("song").unwrap())
+                .unwrap()
+                .get(&0)
+                .unwrap()
+                .exact_unmatched,
+            1
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn recovery_boundary_rejects_non_opaque_identifiers() {
+        for id in [
+            "owner-event-with-metadata",
+            "sub-scrobble-short",
+            "sub-scrobble-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        ] {
+            assert!(!is_opaque_event_id(id));
+        }
+    }
+
+    #[test]
+    fn offline_retry_resets_delivery_evidence_and_discards_only_its_credit() {
+        let (root, paths, event_id) = fixture("retry");
+        let item_id = ItemId::new("song").unwrap();
+        let mut before = load_store_set(&paths).unwrap().unwrap();
+        before
+            .bridge_state
+            .upsert_aggregate_play_shadow(
+                item_id.clone(),
+                AggregatePlayShadow {
+                    play_count: 0,
+                    played_at: None,
+                    observed_at_unix: 43,
+                    counter_epoch: 1,
+                },
+            )
+            .unwrap();
+        before
+            .bridge_state
+            .reserve_outbound_exact_history_credit(item_id.clone(), 1)
+            .unwrap();
+        let expected = before.revisions();
+        commit_store_set(&paths, expected, &mut before).unwrap();
+
+        resolve_scrobble_attention(&paths, &event_id, OutboundScrobbleResolution::Retry).unwrap();
+
+        let durable = load_store_set(&paths).unwrap().unwrap();
+        let pending = durable.bridge_state.outbound_scrobbles().front().unwrap();
+        assert_eq!(pending.delivery, OutboundScrobbleDelivery::Queued);
+        assert!(!pending.baseline_captured);
+        assert_eq!(pending.baseline_play_count, None);
+        assert_eq!(pending.baseline_played_at, None);
+        assert!(!pending.exact_credit_recorded);
+        assert_eq!(pending.exact_credit_epoch, None);
+        assert_eq!(pending.uncertain_readbacks, 0);
+        let credits = durable
+            .bridge_state
+            .history_dedupe_credits()
+            .get(&item_id)
+            .unwrap();
+        assert!(
+            credits.get(&0).is_none(),
+            "retry must discard the reserve from its saved counter epoch"
+        );
+        assert_eq!(credits.get(&1).unwrap().exact_unmatched, 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/src/open_subsonic/private_store.rs
+++ b/src/open_subsonic/private_store.rs
@@ -5,10 +5,11 @@ use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, Zeroizing};
 
 use super::model::{AccountScopeId, BackendId};
+use super::native_history::NativeHistoryCredential;
 use super::profile::StoreError;
 
 pub(crate) const PRIVATE_KIND: &str = "yututui_open_subsonic_private";
-pub(crate) const PRIVATE_SCHEMA_VERSION: u32 = 1;
+pub(crate) const PRIVATE_SCHEMA_VERSION: u32 = 2;
 pub(crate) const MAX_PRIVATE_BYTES: u64 = 256 * 1024;
 const MAX_USERNAME_BYTES: usize = 1_024;
 const MAX_PASSWORD_BYTES: usize = 64 * 1024;
@@ -73,6 +74,16 @@ pub struct OpenSubsonicPrivateState {
     backend_id: BackendId,
     account_scope_id: AccountScopeId,
     credential: ServerCredential,
+    native_history: NativeHistorySetting,
+}
+
+enum NativeHistorySetting {
+    Off,
+    ReuseServerPassword,
+    DedicatedPassword {
+        username: SecretString,
+        password: SecretString,
+    },
 }
 
 impl OpenSubsonicPrivateState {
@@ -86,6 +97,7 @@ impl OpenSubsonicPrivateState {
             backend_id,
             account_scope_id,
             credential,
+            native_history: NativeHistorySetting::Off,
         }
     }
 
@@ -105,6 +117,93 @@ impl OpenSubsonicPrivateState {
         self.credential.kind()
     }
 
+    pub fn native_history_enabled(&self) -> bool {
+        !matches!(self.native_history, NativeHistorySetting::Off)
+    }
+
+    pub fn enable_native_history_reusing_server_password(&mut self) -> Result<(), StoreError> {
+        if self.credential.kind() != CredentialKind::Password {
+            return Err(StoreError::InvalidState);
+        }
+        self.native_history = NativeHistorySetting::ReuseServerPassword;
+        Ok(())
+    }
+
+    pub fn enable_native_history_with_password(
+        &mut self,
+        username: impl Into<String>,
+        password: SecretString,
+    ) -> Result<(), StoreError> {
+        if self.credential.kind() != CredentialKind::ApiKey {
+            return Err(StoreError::InvalidState);
+        }
+        let username = username.into();
+        validate_credential_part(&username, MAX_USERNAME_BYTES)?;
+        validate_credential_part(password.expose_secret(), MAX_PASSWORD_BYTES)?;
+        self.native_history = NativeHistorySetting::DedicatedPassword {
+            username: SecretString::from(username),
+            password,
+        };
+        Ok(())
+    }
+
+    pub fn disable_native_history(&mut self) {
+        self.native_history = NativeHistorySetting::Off;
+    }
+
+    pub(crate) fn preserve_native_history_from(
+        &mut self,
+        previous: &Self,
+    ) -> Result<(), StoreError> {
+        if self.backend_id != previous.backend_id
+            || self.account_scope_id != previous.account_scope_id
+        {
+            return Err(StoreError::InvalidState);
+        }
+        match (self.credential.kind(), &previous.native_history) {
+            (_, NativeHistorySetting::Off) => {
+                self.disable_native_history();
+                Ok(())
+            }
+            (CredentialKind::Password, _) => self.enable_native_history_reusing_server_password(),
+            (CredentialKind::ApiKey, NativeHistorySetting::ReuseServerPassword) => self
+                .enable_native_history_with_password(
+                    previous
+                        .credential
+                        .username()
+                        .ok_or(StoreError::InvalidState)?
+                        .expose_secret()
+                        .to_owned(),
+                    SecretString::from(previous.credential.secret().expose_secret().to_owned()),
+                ),
+            (
+                CredentialKind::ApiKey,
+                NativeHistorySetting::DedicatedPassword { username, password },
+            ) => self.enable_native_history_with_password(
+                username.expose_secret().to_owned(),
+                SecretString::from(password.expose_secret().to_owned()),
+            ),
+        }
+    }
+
+    /// Copies the selected password into an ephemeral, non-serializable login value.
+    pub fn native_history_credential(&self) -> Result<Option<NativeHistoryCredential>, StoreError> {
+        let (username, password) = match &self.native_history {
+            NativeHistorySetting::Off => return Ok(None),
+            NativeHistorySetting::ReuseServerPassword => (
+                self.credential.username().ok_or(StoreError::InvalidState)?,
+                self.credential.secret(),
+            ),
+            NativeHistorySetting::DedicatedPassword { username, password } => (username, password),
+        };
+        NativeHistoryCredential::new(
+            username.expose_secret().to_owned(),
+            SecretString::from(password.expose_secret().to_owned()),
+        )
+        .map(Some)
+        .map_err(|_| StoreError::InvalidState)
+    }
+
     pub(crate) fn credential(&self) -> &ServerCredential {
         &self.credential
     }
@@ -114,7 +213,7 @@ impl OpenSubsonicPrivateState {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum DiskCredentialKind {
     ApiKey,
@@ -132,6 +231,12 @@ struct DiskPrivateState {
     credential_kind: DiskCredentialKind,
     username: Option<String>,
     secret: String,
+    #[serde(default)]
+    native_history_enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    native_history_username: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    native_history_password: Option<String>,
 }
 
 impl Drop for DiskPrivateState {
@@ -140,12 +245,28 @@ impl Drop for DiskPrivateState {
             username.zeroize();
         }
         self.secret.zeroize();
+        if let Some(username) = &mut self.native_history_username {
+            username.zeroize();
+        }
+        if let Some(password) = &mut self.native_history_password {
+            password.zeroize();
+        }
     }
 }
 
 pub(crate) fn encode_private(
     state: &OpenSubsonicPrivateState,
 ) -> Result<Zeroizing<Vec<u8>>, StoreError> {
+    let (native_history_enabled, native_history_username, native_history_password) =
+        match &state.native_history {
+            NativeHistorySetting::Off => (false, None, None),
+            NativeHistorySetting::ReuseServerPassword => (true, None, None),
+            NativeHistorySetting::DedicatedPassword { username, password } => (
+                true,
+                Some(username.expose_secret().to_owned()),
+                Some(password.expose_secret().to_owned()),
+            ),
+        };
     let disk = DiskPrivateState {
         kind: PRIVATE_KIND.to_owned(),
         schema_version: PRIVATE_SCHEMA_VERSION,
@@ -161,6 +282,9 @@ pub(crate) fn encode_private(
             .username()
             .map(|username| username.expose_secret().to_owned()),
         secret: state.credential.secret().expose_secret().to_owned(),
+        native_history_enabled,
+        native_history_username,
+        native_history_password,
     };
     let bytes =
         Zeroizing::new(serde_json::to_vec(&disk).map_err(|_| StoreError::SerializationFailed)?);
@@ -176,7 +300,14 @@ pub(crate) fn decode_private(bytes: &[u8]) -> Result<OpenSubsonicPrivateState, S
     }
     let disk: DiskPrivateState =
         serde_json::from_slice(bytes).map_err(|_| StoreError::InvalidState)?;
-    if disk.kind != PRIVATE_KIND || disk.schema_version != PRIVATE_SCHEMA_VERSION {
+    if disk.kind != PRIVATE_KIND || !matches!(disk.schema_version, 1 | PRIVATE_SCHEMA_VERSION) {
+        return Err(StoreError::InvalidState);
+    }
+    if disk.schema_version == 1
+        && (disk.native_history_enabled
+            || disk.native_history_username.is_some()
+            || disk.native_history_password.is_some())
+    {
         return Err(StoreError::InvalidState);
     }
     let credential = match disk.credential_kind {
@@ -189,11 +320,32 @@ pub(crate) fn decode_private(bytes: &[u8]) -> Result<OpenSubsonicPrivateState, S
         }
         DiskCredentialKind::ApiKey => return Err(StoreError::InvalidState),
     };
+    let native_history = match (
+        disk.credential_kind,
+        disk.native_history_enabled,
+        disk.native_history_username.as_deref(),
+        disk.native_history_password.as_deref(),
+    ) {
+        (_, false, None, None) => NativeHistorySetting::Off,
+        (DiskCredentialKind::Password, true, None, None) => {
+            NativeHistorySetting::ReuseServerPassword
+        }
+        (DiskCredentialKind::ApiKey, true, Some(username), Some(password)) => {
+            validate_credential_part(username, MAX_USERNAME_BYTES)?;
+            validate_credential_part(password, MAX_PASSWORD_BYTES)?;
+            NativeHistorySetting::DedicatedPassword {
+                username: SecretString::from(username.to_owned()),
+                password: SecretString::from(password.to_owned()),
+            }
+        }
+        _ => return Err(StoreError::InvalidState),
+    };
     Ok(OpenSubsonicPrivateState {
         revision: disk.revision,
         backend_id: disk.backend_id.clone(),
         account_scope_id: disk.account_scope_id.clone(),
         credential,
+        native_history,
     })
 }
 
@@ -252,12 +404,15 @@ mod tests {
 
     #[test]
     fn password_round_trip_preserves_account_binding() {
-        let state = OpenSubsonicPrivateState::new(
+        let mut state = OpenSubsonicPrivateState::new(
             BackendId::new("backend").unwrap(),
             AccountScopeId::new("account").unwrap(),
             ServerCredential::password("alice", SecretString::from("secret-password".to_owned()))
                 .unwrap(),
         );
+        state
+            .enable_native_history_reusing_server_password()
+            .unwrap();
         let decoded = decode_private(&encode_private(&state).unwrap()).unwrap();
         assert_eq!(decoded.backend_id().as_str(), "backend");
         assert_eq!(decoded.account_scope_id().as_str(), "account");
@@ -265,6 +420,128 @@ mod tests {
             decoded.credential().username().unwrap().expose_secret(),
             "alice"
         );
+        assert!(decoded.native_history_enabled());
+        assert!(decoded.native_history_credential().unwrap().is_some());
+        let disk: serde_json::Value = serde_json::from_slice(&encode_private(&state).unwrap())
+            .expect("private state should be valid JSON");
+        assert_eq!(disk["schema_version"], PRIVATE_SCHEMA_VERSION);
+        assert_eq!(disk["native_history_enabled"], true);
+        assert!(disk.get("native_history_password").is_none());
+    }
+
+    #[test]
+    fn api_key_history_password_round_trips_and_disable_clears_it() {
+        let mut state = OpenSubsonicPrivateState::new(
+            BackendId::new("backend").unwrap(),
+            AccountScopeId::new("account").unwrap(),
+            ServerCredential::api_key(SecretString::from("api-secret".to_owned())).unwrap(),
+        );
+        assert!(
+            state
+                .enable_native_history_reusing_server_password()
+                .is_err()
+        );
+        state
+            .enable_native_history_with_password(
+                "alice",
+                SecretString::from("native-password".to_owned()),
+            )
+            .unwrap();
+        let decoded = decode_private(&encode_private(&state).unwrap()).unwrap();
+        assert!(decoded.native_history_enabled());
+        assert!(decoded.native_history_credential().unwrap().is_some());
+
+        state.disable_native_history();
+        let bytes = encode_private(&state).unwrap();
+        let disk: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(disk["native_history_enabled"], false);
+        assert!(disk.get("native_history_username").is_none());
+        assert!(disk.get("native_history_password").is_none());
+        assert!(!decode_private(&bytes).unwrap().native_history_enabled());
+    }
+
+    #[test]
+    fn schema_one_migrates_to_disabled_schema_two() {
+        let legacy = br#"{
+            "kind":"yututui_open_subsonic_private",
+            "schema_version":1,
+            "revision":7,
+            "backend_id":"backend",
+            "account_scope_id":"account",
+            "credential_kind":"password",
+            "username":"alice",
+            "secret":"legacy-password"
+        }"#;
+        let state = decode_private(legacy).unwrap();
+        assert!(!state.native_history_enabled());
+        let encoded = encode_private(&state).unwrap();
+        let disk: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(disk["schema_version"], 2);
+        assert_eq!(disk["native_history_enabled"], false);
+    }
+
+    #[test]
+    fn malformed_native_history_combinations_fail_closed() {
+        let state = OpenSubsonicPrivateState::new(
+            BackendId::new("backend").unwrap(),
+            AccountScopeId::new("account").unwrap(),
+            ServerCredential::api_key(SecretString::from("api-secret".to_owned())).unwrap(),
+        );
+        let mut disk: serde_json::Value =
+            serde_json::from_slice(&encode_private(&state).unwrap()).unwrap();
+        disk["native_history_enabled"] = true.into();
+        assert!(decode_private(&serde_json::to_vec(&disk).unwrap()).is_err());
+
+        disk["schema_version"] = 1.into();
+        disk["native_history_username"] = "alice".into();
+        disk["native_history_password"] = "native-password".into();
+        assert!(decode_private(&serde_json::to_vec(&disk).unwrap()).is_err());
+    }
+
+    #[test]
+    fn same_account_credential_changes_preserve_history_without_reusing_api_keys() {
+        let backend = BackendId::new("backend").unwrap();
+        let account = AccountScopeId::new("account").unwrap();
+        let mut password_state = OpenSubsonicPrivateState::new(
+            backend.clone(),
+            account.clone(),
+            ServerCredential::password(
+                "alice",
+                SecretString::from("native-capable-password".to_owned()),
+            )
+            .unwrap(),
+        );
+        password_state
+            .enable_native_history_reusing_server_password()
+            .unwrap();
+
+        let mut api_key_state = OpenSubsonicPrivateState::new(
+            backend.clone(),
+            account.clone(),
+            ServerCredential::api_key(SecretString::from("api-key".to_owned())).unwrap(),
+        );
+        api_key_state
+            .preserve_native_history_from(&password_state)
+            .unwrap();
+        assert!(api_key_state.native_history_enabled());
+        assert!(api_key_state.native_history_credential().unwrap().is_some());
+
+        let mut replacement_password = OpenSubsonicPrivateState::new(
+            backend,
+            account,
+            ServerCredential::password(
+                "alice",
+                SecretString::from("replacement-password".to_owned()),
+            )
+            .unwrap(),
+        );
+        replacement_password
+            .preserve_native_history_from(&api_key_state)
+            .unwrap();
+        let disk: serde_json::Value =
+            serde_json::from_slice(&encode_private(&replacement_password).unwrap()).unwrap();
+        assert_eq!(disk["native_history_enabled"], true);
+        assert!(disk.get("native_history_password").is_none());
     }
 
     #[test]

--- a/src/open_subsonic/profile.rs
+++ b/src/open_subsonic/profile.rs
@@ -40,6 +40,7 @@ impl std::fmt::Display for StoreError {
 impl std::error::Error for StoreError {}
 
 /// Fixed paths for the OpenSubsonic owner-only store set. Deliberately not `Debug`.
+#[derive(Clone)]
 pub struct OpenSubsonicPaths {
     root: PathBuf,
     profile: PathBuf,

--- a/src/open_subsonic/rating.rs
+++ b/src/open_subsonic/rating.rs
@@ -1,0 +1,115 @@
+//! Pure mapping between exact OpenSubsonic rating observations and YuTuTui ratings.
+
+use serde::{Deserialize, Serialize};
+
+use crate::personal_state::Rating;
+
+/// Exact values observed from an OpenSubsonic `Child`.
+///
+/// `user_rating` deliberately remains an `i64`: malformed values must survive a read/write
+/// round-trip in the server shadow instead of being silently normalized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawServerRating {
+    pub user_rating: Option<i64>,
+    pub starred: bool,
+}
+
+/// Map a server observation into YuTuTui's tri-state rating.
+///
+/// Ratings `1` and `5` are authoritative even when the star flag contradicts them. Ratings
+/// `2..=4`, missing/zero ratings, and malformed values use the star flag.
+pub fn map_server_rating(raw: RawServerRating) -> Rating {
+    match raw.user_rating {
+        Some(1) => Rating::Disliked,
+        Some(5) => Rating::Liked,
+        _ if raw.starred => Rating::Liked,
+        _ => Rating::Neutral,
+    }
+}
+
+/// Return the normalized server values written after an explicit YuTuTui rating change.
+///
+/// Callers still have to perform the two server mutations in order (`setRating`, then
+/// `star`/`unstar`) and verify the result with a readback.
+pub fn canonical_server_rating(rating: Rating) -> RawServerRating {
+    match rating {
+        Rating::Liked => RawServerRating {
+            user_rating: Some(5),
+            starred: true,
+        },
+        Rating::Disliked => RawServerRating {
+            user_rating: Some(1),
+            starred: false,
+        },
+        Rating::Neutral => RawServerRating {
+            user_rating: Some(0),
+            starred: false,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_supported_and_malformed_combination_has_the_fixed_mapping() {
+        let cases = [
+            (None, false, Rating::Neutral),
+            (None, true, Rating::Liked),
+            (Some(0), false, Rating::Neutral),
+            (Some(0), true, Rating::Liked),
+            (Some(1), false, Rating::Disliked),
+            (Some(1), true, Rating::Disliked),
+            (Some(2), false, Rating::Neutral),
+            (Some(2), true, Rating::Liked),
+            (Some(3), false, Rating::Neutral),
+            (Some(3), true, Rating::Liked),
+            (Some(4), false, Rating::Neutral),
+            (Some(4), true, Rating::Liked),
+            (Some(5), false, Rating::Liked),
+            (Some(5), true, Rating::Liked),
+            (Some(-1), false, Rating::Neutral),
+            (Some(-1), true, Rating::Liked),
+            (Some(6), false, Rating::Neutral),
+            (Some(6), true, Rating::Liked),
+        ];
+
+        for (user_rating, starred, expected) in cases {
+            assert_eq!(
+                map_server_rating(RawServerRating {
+                    user_rating,
+                    starred,
+                }),
+                expected,
+                "user_rating={user_rating:?}, starred={starred}"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_local_ratings_have_one_canonical_server_representation() {
+        assert_eq!(
+            canonical_server_rating(Rating::Liked),
+            RawServerRating {
+                user_rating: Some(5),
+                starred: true,
+            }
+        );
+        assert_eq!(
+            canonical_server_rating(Rating::Disliked),
+            RawServerRating {
+                user_rating: Some(1),
+                starred: false,
+            }
+        );
+        assert_eq!(
+            canonical_server_rating(Rating::Neutral),
+            RawServerRating {
+                user_rating: Some(0),
+                starred: false,
+            }
+        );
+    }
+}

--- a/src/open_subsonic/transaction.rs
+++ b/src/open_subsonic/transaction.rs
@@ -146,24 +146,36 @@ pub fn commit_store_set(
         return Err(StoreError::RevisionConflict);
     }
     validate_identity(candidate)?;
-    candidate
-        .profile
-        .set_revision(next_revision(expected.profile)?);
-    candidate
-        .private_state
-        .set_revision(next_revision(expected.private_state)?);
-    candidate
-        .bridge_state
-        .set_revision(next_revision(expected.bridge_state)?);
-    let profile = encode_profile(&candidate.profile)?;
-    let private_state = encode_private(&candidate.private_state)?;
-    let bridge = encode_bridge(&candidate.bridge_state)?;
-    install_transaction(
-        paths,
-        Some(profile.as_slice()),
-        Some(private_state.as_slice()),
-        Some(bridge.as_slice()),
-    )
+    let previous_profile = candidate.profile.revision();
+    let previous_private = candidate.private_state.revision();
+    let previous_bridge = candidate.bridge_state.revision();
+    let next_profile = next_revision(expected.profile)?;
+    let next_private = next_revision(expected.private_state)?;
+    let next_bridge = next_revision(expected.bridge_state)?;
+    candidate.profile.set_revision(next_profile);
+    candidate.private_state.set_revision(next_private);
+    candidate.bridge_state.set_revision(next_bridge);
+    let result = (|| {
+        let profile = encode_profile(&candidate.profile)?;
+        let private_state = encode_private(&candidate.private_state)?;
+        let bridge = encode_bridge(&candidate.bridge_state)?;
+        install_transaction(
+            paths,
+            Some(profile.as_slice()),
+            Some(private_state.as_slice()),
+            Some(bridge.as_slice()),
+        )
+    })();
+    if result.is_err() {
+        // Encoding/install may fail after assigning the optimistic next revision (including an
+        // ambiguous failure after the commit marker). Callers that retain this candidate must not
+        // subsequently present revisions which were never acknowledged. A writer can recover and
+        // reload a committed transaction before retrying.
+        candidate.profile.set_revision(previous_profile);
+        candidate.private_state.set_revision(previous_private);
+        candidate.bridge_state.set_revision(previous_bridge);
+    }
+    result
 }
 
 pub fn remove_store_set(
@@ -644,6 +656,30 @@ mod tests {
         assert_eq!(
             commit_store_set(&fixture.paths, StoreRevisions::MISSING, &mut second),
             Err(StoreError::RevisionConflict)
+        );
+    }
+
+    #[test]
+    fn failed_install_restores_candidate_revisions_before_recovery() {
+        let fixture = fixture();
+        let mut candidate = candidate();
+        let previous = candidate.revisions();
+        fail_after_commit_marker_once_for_test();
+
+        assert_eq!(
+            commit_store_set(&fixture.paths, StoreRevisions::MISSING, &mut candidate),
+            Err(StoreError::StorageUnavailable)
+        );
+        assert_eq!(candidate.revisions(), previous);
+
+        let recovered = load_store_set(&fixture.paths).unwrap().unwrap();
+        assert_eq!(
+            recovered.revisions(),
+            StoreRevisions {
+                profile: Some(1),
+                private_state: Some(1),
+                bridge_state: Some(1),
+            }
         );
     }
 

--- a/src/open_subsonic/wire.rs
+++ b/src/open_subsonic/wire.rs
@@ -47,6 +47,7 @@ pub(crate) struct RawResponse {
     pub playlist: Option<RawPlaylist>,
     pub album: Option<RawAlbumWithSongs>,
     pub artist: Option<RawArtistWithAlbums>,
+    pub song: Option<RawChild>,
 }
 
 impl RawResponse {
@@ -174,6 +175,8 @@ pub(crate) struct RawChild {
     pub media_type: Option<String>,
     pub user_rating: Option<i64>,
     pub starred: Option<String>,
+    pub play_count: Option<u64>,
+    pub played: Option<String>,
     #[serde(default, deserialize_with = "deserialize_child_artists")]
     pub artists: Vec<RawNamedId>,
 }

--- a/src/owner_event_policy.rs
+++ b/src/owner_event_policy.rs
@@ -130,6 +130,9 @@ pub(crate) fn scrobble_event_policy(event: &crate::scrobble::ScrobbleEvent) -> E
         | crate::scrobble::ScrobbleEvent::QueueDropped { .. } => EventPolicy::MustDeliver {
             lane: Lane::Control,
         },
+        crate::scrobble::ScrobbleEvent::OpenSubsonic { .. } => EventPolicy::MustDeliver {
+            lane: Lane::WorkResult,
+        },
         crate::scrobble::ScrobbleEvent::QueueStalled { .. } => EventPolicy::CoalesceLatest {
             lane: Lane::Telemetry,
             key: Key::ScrobbleQueueStalled,
@@ -200,6 +203,26 @@ mod tests {
             EventPolicy::CoalesceLatest {
                 lane: Lane::Telemetry,
                 key: Key::ScrobbleQueueStalled,
+            }
+        );
+        assert_eq!(
+            scrobble_event_policy(&crate::scrobble::ScrobbleEvent::OpenSubsonic {
+                event_id: "server-play-1".to_owned(),
+                kind: crate::open_subsonic::OpenSubsonicScrobbleKind::Submission,
+                track: crate::scrobble::service::ScrobbleTrack {
+                    key: "server-track".to_owned(),
+                    open_subsonic_item: None,
+                    artist: "Artist".to_owned(),
+                    title: "Title".to_owned(),
+                    album: None,
+                    duration_secs: None,
+                    origin_url: None,
+                    started_unix: 1,
+                },
+                confirmation: None,
+            }),
+            EventPolicy::MustDeliver {
+                lane: Lane::WorkResult,
             }
         );
         assert_eq!(

--- a/src/personal_state.rs
+++ b/src/personal_state.rs
@@ -9,14 +9,18 @@ mod import;
 pub(crate) mod legacy;
 mod model;
 mod reducer;
+mod server_rating;
 mod transaction;
 
 pub(crate) use compaction::operation_survives_checkpoint;
 pub use compaction::{
     EngagementCompactionPlan, engagement_compaction_leader, plan_engagement_compaction,
 };
-pub(crate) use coordinator::reconcile_runtime;
-pub use coordinator::{append_operation_as, reconcile_runtime_as};
+pub use coordinator::{
+    append_external_operation, append_external_operation_as, append_operation_as,
+    external_operation_envelope_id, reconcile_runtime_as,
+};
+pub(crate) use coordinator::{external_operation_envelope_id_for_state, reconcile_runtime};
 pub(crate) use import::validate_join_import_extension;
 pub use import::{ImportPlan, ImportSummary, plan_import, plan_join_import};
 pub use legacy::{LegacyProjection, legacy_state};
@@ -32,6 +36,7 @@ pub use model::{
 };
 pub(crate) use reducer::runtime_fingerprint;
 pub use reducer::{MergeSummary, PersonalProjection, merge, project};
+pub use server_rating::{OpenSubsonicRatingWinner, open_subsonic_rating_winners};
 pub use transaction::{PersonalStateCommit, PersonalStatePaths, recover_pending_transactions};
 pub(crate) use transaction::{load_ledger, load_ledger_read_only};
 

--- a/src/personal_state/coordinator.rs
+++ b/src/personal_state/coordinator.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use super::legacy::{
-    LegacyPlaylist, LegacyPlaylistEntry, LegacyProjection, rating_from_legacy, stable_hash,
+    LegacyPlaylist, LegacyPlaylistEntry, LegacyProjection, rating_from_legacy, sha256_hex,
+    stable_hash,
 };
 use super::{
     CausalStamp, DeviceId, Dot, EngagementKind, Operation, OperationEnvelope, OperationOrigin,
@@ -50,6 +51,166 @@ pub fn append_operation_as(
     operation: Operation,
     recorded_at_unix: i64,
 ) -> Result<PersonalStateV2, PersonalStateError> {
+    append_operation_with_origin_as(
+        state,
+        local_device_id,
+        None,
+        OperationOrigin::Local,
+        operation,
+        recorded_at_unix,
+    )
+}
+
+/// Append one operation observed from an external bridge under the local device's causal dot.
+///
+/// `operation_id` is the bridge's portable acknowledgement key. The ledger envelope derives a
+/// deterministic device-scoped identifier from it, while a `RecordEngagement` keeps the portable
+/// key as its event ID. Replaying the same observation on one device is therefore a no-op, while
+/// two devices may independently observe and safely merge the same portable event.
+pub fn append_external_operation_as(
+    state: &PersonalStateV2,
+    local_device_id: &DeviceId,
+    operation_id: String,
+    origin: OperationOrigin,
+    operation: Operation,
+    recorded_at_unix: i64,
+) -> Result<PersonalStateV2, PersonalStateError> {
+    if matches!(origin, OperationOrigin::Local) {
+        return Err(PersonalStateError::InvalidOperation(
+            "external operation origin cannot be local",
+        ));
+    }
+    validate_external_origin(&origin, &operation)?;
+    let envelope_id = external_operation_envelope_id(local_device_id, &operation_id)?;
+    append_operation_with_origin_as(
+        state,
+        local_device_id,
+        Some(envelope_id),
+        origin,
+        operation,
+        recorded_at_unix,
+    )
+}
+
+/// Append one externally observed operation for an unsynced single-device ledger.
+///
+/// Before encrypted sync is configured, the deterministic migration device deliberately has no
+/// signing identity. That device may still own local-first server observations; once a real sync
+/// device is enrolled, callers must switch to [`append_external_operation_as`] so the author is
+/// explicit.
+pub fn append_external_operation(
+    state: &PersonalStateV2,
+    operation_id: String,
+    origin: OperationOrigin,
+    operation: Operation,
+    recorded_at_unix: i64,
+) -> Result<PersonalStateV2, PersonalStateError> {
+    if matches!(origin, OperationOrigin::Local) {
+        return Err(PersonalStateError::InvalidOperation(
+            "external operation origin cannot be local",
+        ));
+    }
+    validate_external_origin(&origin, &operation)?;
+    let local_device_id = local_device(state)?;
+    let envelope_id = external_operation_envelope_id(&local_device_id, &operation_id)?;
+    append_operation_with_origin_as_inner(
+        state,
+        &local_device_id,
+        Some(envelope_id),
+        origin,
+        operation,
+        recorded_at_unix,
+        false,
+    )
+}
+
+/// Return the stable ledger envelope ID for one external acknowledgement on one local device.
+///
+/// The bridge acknowledgement remains portable across devices. Only the surrounding ledger
+/// operation is scoped so independently authored observations cannot collide during merge.
+pub fn external_operation_envelope_id(
+    local_device_id: &DeviceId,
+    acknowledgement_id: &str,
+) -> Result<String, PersonalStateError> {
+    super::model::validate_id(
+        "external operation acknowledgement id",
+        acknowledgement_id,
+        256,
+    )?;
+    let mut material =
+        Vec::with_capacity(48 + local_device_id.as_str().len() + acknowledgement_id.len());
+    material.extend_from_slice(b"yututui-external-operation-envelope-v1\0");
+    for part in [
+        local_device_id.as_str().as_bytes(),
+        acknowledgement_id.as_bytes(),
+    ] {
+        material.extend_from_slice(&(part.len() as u64).to_be_bytes());
+        material.extend_from_slice(part);
+    }
+    Ok(format!("external-{}", sha256_hex(&material)))
+}
+
+pub(crate) fn external_operation_envelope_id_for_state(
+    state: &PersonalStateV2,
+    acknowledgement_id: &str,
+) -> Result<String, PersonalStateError> {
+    external_operation_envelope_id(&local_device(state)?, acknowledgement_id)
+}
+
+fn validate_external_origin(
+    origin: &OperationOrigin,
+    operation: &Operation,
+) -> Result<(), PersonalStateError> {
+    let OperationOrigin::OpenSubsonic { backend_id } = origin else {
+        return Ok(());
+    };
+    let track = match operation {
+        Operation::SetRating { track, .. } | Operation::RecordEngagement { track, .. } => track,
+        _ => {
+            return Err(PersonalStateError::InvalidOperation(
+                "OpenSubsonic origin requires a track observation",
+            ));
+        }
+    };
+    match &track.key {
+        PortableTrackKey::OpenSubsonic {
+            backend_id: track_backend,
+            ..
+        } if track_backend == backend_id => Ok(()),
+        _ => Err(PersonalStateError::InvalidOperation(
+            "OpenSubsonic origin does not match track backend",
+        )),
+    }
+}
+
+fn append_operation_with_origin_as(
+    state: &PersonalStateV2,
+    local_device_id: &DeviceId,
+    operation_id: Option<String>,
+    origin: OperationOrigin,
+    operation: Operation,
+    recorded_at_unix: i64,
+) -> Result<PersonalStateV2, PersonalStateError> {
+    append_operation_with_origin_as_inner(
+        state,
+        local_device_id,
+        operation_id,
+        origin,
+        operation,
+        recorded_at_unix,
+        true,
+    )
+}
+
+fn append_operation_with_origin_as_inner(
+    state: &PersonalStateV2,
+    local_device_id: &DeviceId,
+    operation_id: Option<String>,
+    origin: OperationOrigin,
+    operation: Operation,
+    recorded_at_unix: i64,
+    require_keyed: bool,
+) -> Result<PersonalStateV2, PersonalStateError> {
     state.validate()?;
     let enrollment = matches!(
         &operation,
@@ -61,11 +222,28 @@ pub fn append_operation_as(
                     .get(local_device_id)
                     .is_some_and(|current| current.public_identity.is_none())
     );
-    validate_local_device_binding(state, local_device_id, !enrollment)?;
+    validate_local_device_binding(state, local_device_id, require_keyed && !enrollment)?;
+
+    if let Some(operation_id) = operation_id.as_deref()
+        && let Some(existing) = state
+            .operations
+            .iter()
+            .find(|existing| existing.operation_id == operation_id)
+    {
+        return if existing.origin == origin && existing.operation == operation {
+            Ok(state.clone())
+        } else {
+            Err(PersonalStateError::ConflictingOperationId)
+        };
+    }
 
     let mut candidate = state.clone();
-    OperationAppender::new(&mut candidate, local_device_id.clone())
-        .append(operation, recorded_at_unix)?;
+    OperationAppender::new(&mut candidate, local_device_id.clone()).append_with_metadata(
+        operation_id,
+        origin,
+        operation,
+        recorded_at_unix,
+    )?;
     refresh_device_registry(&mut candidate)?;
     candidate.normalize()?;
     Ok(candidate)
@@ -122,6 +300,16 @@ impl<'a> OperationAppender<'a> {
         operation: Operation,
         recorded_at_unix: i64,
     ) -> Result<Dot, PersonalStateError> {
+        self.append_with_metadata(None, OperationOrigin::Local, operation, recorded_at_unix)
+    }
+
+    fn append_with_metadata(
+        &mut self,
+        operation_id: Option<String>,
+        origin: OperationOrigin,
+        operation: Operation,
+        recorded_at_unix: i64,
+    ) -> Result<Dot, PersonalStateError> {
         // A different durable state must never reuse the terminal revision. The transaction
         // coordinator advances this revision when it publishes the candidate; rejecting here
         // keeps a MAX-valued imported ledger immutable instead of manufacturing same-revision
@@ -133,13 +321,14 @@ impl<'a> OperationAppender<'a> {
             sequence,
         };
         let envelope = OperationEnvelope {
-            operation_id: format!("{}:{sequence}", self.device.as_str()),
+            operation_id: operation_id
+                .unwrap_or_else(|| format!("{}:{sequence}", self.device.as_str())),
             stamp: CausalStamp {
                 dot: dot.clone(),
                 observed: self.state.version_vector.clone(),
                 recorded_at_unix,
             },
-            origin: OperationOrigin::Local,
+            origin,
             operation,
         };
         self.state.version_vector.observe(&dot);
@@ -231,30 +420,38 @@ fn reconcile_ratings(
     current: &LegacyProjection,
     appender: &mut OperationAppender<'_>,
 ) -> Result<(), PersonalStateError> {
-    let base = rating_from_legacy(&base.favorites, &base.signals);
-    let current = rating_from_legacy(&current.favorites, &current.signals);
-    let keys = base
+    let base_ratings = rating_from_legacy(&base.favorites, &base.signals);
+    let current_ratings = rating_from_legacy(&current.favorites, &current.signals);
+    let keys = base_ratings
         .keys()
-        .chain(current.keys())
+        .chain(current_ratings.keys())
         .cloned()
         .collect::<BTreeSet<_>>();
     for key in keys {
-        let before = base
+        let before = base_ratings
             .get(&key)
             .map(|(_, rating)| *rating)
             .unwrap_or_default();
-        let after = current
+        let after = current_ratings
             .get(&key)
             .map(|(_, rating)| *rating)
             .unwrap_or_default();
         if before == after {
             continue;
         }
-        let track = current
-            .get(&key)
-            .or_else(|| base.get(&key))
-            .map(|(track, _)| track.clone())
-            .expect("union key has a track");
+        let track = match (current_ratings.get(&key), base_ratings.get(&key)) {
+            (Some((current, _)), base_rating) => {
+                let existing = base_rating
+                    .map(|(track, _)| track)
+                    .or_else(|| base.signals.tracks.get(&key).map(|signal| &signal.track));
+                existing.map_or_else(
+                    || current.clone(),
+                    |existing| enrich_portable_track(current.clone(), existing),
+                )
+            }
+            (None, Some((base, _))) => base.clone(),
+            (None, None) => unreachable!("union key has a track"),
+        };
         appender.append(
             Operation::SetRating {
                 track,
@@ -264,6 +461,33 @@ fn reconcile_ratings(
         )?;
     }
     Ok(())
+}
+
+/// Preserve portable metadata that the legacy signal store cannot represent.
+///
+/// A disliked track may no longer occur in favorites, history, or playlists. In that case the
+/// runtime-to-v2 adapter can recover its exact key from `Signals`, but only has empty fallback
+/// metadata. Reconciliation must not let that lossy projection erase metadata already carried by
+/// the winning v2 rating operation, since the artist is also the stable input to affinity
+/// projection.
+fn enrich_portable_track(mut current: PortableTrack, existing: &PortableTrack) -> PortableTrack {
+    debug_assert_eq!(current.key, existing.key);
+    if current.title.is_empty() {
+        current.title.clone_from(&existing.title);
+    }
+    if current.artist.is_empty() {
+        current.artist.clone_from(&existing.artist);
+    }
+    if current.album.is_none() {
+        current.album.clone_from(&existing.album);
+    }
+    if current.duration_secs.is_none() {
+        current.duration_secs = existing.duration_secs;
+    }
+    if current.isrc.is_none() {
+        current.isrc.clone_from(&existing.isrc);
+    }
+    current
 }
 
 fn reconcile_radio(

--- a/src/personal_state/reducer.rs
+++ b/src/personal_state/reducer.rs
@@ -730,8 +730,13 @@ fn bump_artist(weights: &mut BTreeMap<String, f32>, artist_key: &str, delta: f32
     if artist_key.is_empty() || delta == 0.0 {
         return;
     }
-    let weight = weights.entry(artist_key.to_owned()).or_default();
-    *weight = (*weight + delta).clamp(ARTIST_WEIGHT_MIN, ARTIST_WEIGHT_MAX);
+    let next = (weights.get(artist_key).copied().unwrap_or(0.0) + delta)
+        .clamp(ARTIST_WEIGHT_MIN, ARTIST_WEIGHT_MAX);
+    if next == 0.0 {
+        weights.remove(artist_key);
+    } else {
+        weights.insert(artist_key.to_owned(), next);
+    }
 }
 
 fn empty_playlist(
@@ -931,6 +936,10 @@ fn enforce_projection_caps(legacy: &mut LegacyProjection) {
     legacy.history.truncate(HISTORY_MAX);
     legacy.radio_favorites.truncate(RADIO_MAX);
     legacy.radio_history.truncate(RADIO_MAX);
+    legacy
+        .signals
+        .artist_affinity
+        .retain(|_, weight| *weight != 0.0);
     legacy.playlists.truncate(PLAYLISTS_MAX);
     for playlist in &mut legacy.playlists {
         playlist.entries.truncate(PLAYLIST_ENTRIES_MAX);

--- a/src/personal_state/server_rating.rs
+++ b/src/personal_state/server_rating.rs
@@ -1,0 +1,134 @@
+//! Effective OpenSubsonic rating winners for the server projection bridge.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::legacy::rating_from_legacy;
+use super::reducer::stamp_order;
+use super::{
+    CausalStamp, Operation, OperationOrigin, PersonalStateError, PersonalStateV2, PortableTrack,
+    PortableTrackKey, Rating, project,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenSubsonicRatingWinner {
+    pub operation_id: String,
+    pub track: PortableTrack,
+    pub rating: Rating,
+    pub origin: OperationOrigin,
+}
+
+struct WinnerRegister {
+    stamp: CausalStamp,
+    operation_id: String,
+    origin: OperationOrigin,
+    track: PortableTrack,
+    rating: Rating,
+    from_baseline: bool,
+}
+
+impl WinnerRegister {
+    fn explicit(envelope: &super::OperationEnvelope, track: PortableTrack, rating: Rating) -> Self {
+        Self {
+            stamp: envelope.stamp.clone(),
+            operation_id: envelope.operation_id.clone(),
+            origin: envelope.origin.clone(),
+            track,
+            rating,
+            from_baseline: false,
+        }
+    }
+
+    fn baseline(envelope: &super::OperationEnvelope, track: PortableTrack, rating: Rating) -> Self {
+        Self {
+            stamp: envelope.stamp.clone(),
+            operation_id: envelope.operation_id.clone(),
+            origin: envelope.origin.clone(),
+            track,
+            rating,
+            from_baseline: true,
+        }
+    }
+
+    fn accepts(&self, envelope: &super::OperationEnvelope) -> bool {
+        self.from_baseline
+            || stamp_order(
+                &envelope.stamp,
+                &envelope.operation_id,
+                &self.stamp,
+                &self.operation_id,
+            )
+            .is_gt()
+    }
+}
+
+/// Return only effective, non-evicted exact server ratings together with the causal operation
+/// that won. The bridge uses the operation ID as its durable echo/projection watermark.
+pub fn open_subsonic_rating_winners(
+    state: &PersonalStateV2,
+) -> Result<Vec<OpenSubsonicRatingWinner>, PersonalStateError> {
+    state.validate()?;
+    let mut registers = BTreeMap::<PortableTrackKey, WinnerRegister>::new();
+    for envelope in &state.operations {
+        match &envelope.operation {
+            Operation::LegacyBaseline { baseline } => {
+                for (key, (track, rating)) in
+                    rating_from_legacy(&baseline.favorites, &baseline.signals)
+                {
+                    registers
+                        .entry(key)
+                        .or_insert_with(|| WinnerRegister::baseline(envelope, track, rating));
+                }
+            }
+            Operation::SetRating { track, rating } => match registers.get_mut(&track.key) {
+                Some(current) if current.accepts(envelope) => {
+                    *current = WinnerRegister::explicit(envelope, track.clone(), *rating);
+                }
+                None => {
+                    registers.insert(
+                        track.key.clone(),
+                        WinnerRegister::explicit(envelope, track.clone(), *rating),
+                    );
+                }
+                Some(_) => {}
+            },
+            _ => {}
+        }
+    }
+
+    let projected = project(state)?;
+    let liked = projected
+        .legacy
+        .favorites
+        .iter()
+        .map(|track| track.key.clone())
+        .collect::<BTreeSet<_>>();
+    let disliked = projected
+        .legacy
+        .signals
+        .tracks
+        .iter()
+        .filter(|(_, signal)| signal.disliked)
+        .map(|(key, _)| key.clone())
+        .collect::<BTreeSet<_>>();
+
+    Ok(registers
+        .into_iter()
+        .filter_map(|(key, winner)| {
+            if !matches!(key, PortableTrackKey::OpenSubsonic { .. })
+                || match winner.rating {
+                    Rating::Liked => !liked.contains(&key),
+                    Rating::Disliked => !disliked.contains(&key),
+                    Rating::Neutral => false,
+                }
+            {
+                return None;
+            }
+            Some(OpenSubsonicRatingWinner {
+                operation_id: winner.operation_id,
+                track: winner.track,
+                rating: winner.rating,
+                origin: winner.origin,
+            })
+        })
+        .collect())
+}

--- a/src/personal_state/tests.rs
+++ b/src/personal_state/tests.rs
@@ -7,6 +7,8 @@ use base64::Engine;
 use super::transaction::{CommitPoint, TargetFile};
 use super::*;
 
+mod external_observations;
+
 fn track(id: &str) -> PortableTrack {
     PortableTrack {
         key: PortableTrackKey::Catalog {
@@ -14,6 +16,21 @@ fn track(id: &str) -> PortableTrack {
             exact_catalog_id: id.to_owned(),
         },
         title: format!("title-{id}"),
+        artist: "artist".to_owned(),
+        album: None,
+        duration_secs: Some(180),
+        isrc: None,
+    }
+}
+
+fn open_subsonic_track(id: &str) -> PortableTrack {
+    PortableTrack {
+        key: PortableTrackKey::OpenSubsonic {
+            backend_id: "backend-a".to_owned(),
+            account_scope_id: "account-a".to_owned(),
+            item_id: id.to_owned(),
+        },
+        title: format!("server-{id}"),
         artist: "artist".to_owned(),
         album: None,
         duration_secs: Some(180),
@@ -530,6 +547,120 @@ fn explicit_device_bindings_produce_distinct_dots() {
 }
 
 #[test]
+fn external_operation_identifier_conflicts_fail_closed() {
+    let device = DeviceId::new("device-a").unwrap();
+    let state = state_with_keyed_devices(&[device.as_str()]);
+    let first = append_external_operation_as(
+        &state,
+        &device,
+        "open-subsonic-observation-1".to_owned(),
+        OperationOrigin::OpenSubsonic {
+            backend_id: "backend-a".to_owned(),
+        },
+        Operation::SetRating {
+            track: open_subsonic_track("server-track"),
+            rating: Rating::Liked,
+        },
+        100,
+    )
+    .unwrap();
+
+    assert_eq!(
+        append_external_operation_as(
+            &first,
+            &device,
+            "open-subsonic-observation-1".to_owned(),
+            OperationOrigin::OpenSubsonic {
+                backend_id: "backend-a".to_owned(),
+            },
+            Operation::SetRating {
+                track: open_subsonic_track("server-track"),
+                rating: Rating::Disliked,
+            },
+            100,
+        ),
+        Err(PersonalStateError::ConflictingOperationId)
+    );
+    assert!(
+        append_external_operation_as(
+            &first,
+            &device,
+            "local-is-not-external".to_owned(),
+            OperationOrigin::Local,
+            Operation::SetRating {
+                track: open_subsonic_track("server-track"),
+                rating: Rating::Neutral,
+            },
+            100,
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn open_subsonic_winners_preserve_exact_source_operation_and_origin() {
+    let device = DeviceId::new("device-a").unwrap();
+    let state = state_with_keyed_devices(&[device.as_str()]);
+    let server_track = PortableTrack {
+        key: PortableTrackKey::OpenSubsonic {
+            backend_id: "backend-a".to_owned(),
+            account_scope_id: "account-a".to_owned(),
+            item_id: "item-a".to_owned(),
+        },
+        title: "Server track".to_owned(),
+        artist: "Artist".to_owned(),
+        album: None,
+        duration_secs: Some(180),
+        isrc: None,
+    };
+    let liked = append_operation_as(
+        &state,
+        &device,
+        Operation::SetRating {
+            track: server_track.clone(),
+            rating: Rating::Liked,
+        },
+        10,
+    )
+    .unwrap();
+    let winner = open_subsonic_rating_winners(&liked).unwrap().pop().unwrap();
+    assert_eq!(winner.rating, Rating::Liked);
+    assert_eq!(winner.origin, OperationOrigin::Local);
+    assert_eq!(winner.operation_id, "device-a:1");
+    assert_eq!(winner.track, server_track);
+
+    let neutral = append_external_operation_as(
+        &liked,
+        &device,
+        "server-rating-observation-1".to_owned(),
+        OperationOrigin::OpenSubsonic {
+            backend_id: "backend-a".to_owned(),
+        },
+        Operation::SetRating {
+            track: winner.track,
+            rating: Rating::Neutral,
+        },
+        11,
+    )
+    .unwrap();
+    let winner = open_subsonic_rating_winners(&neutral)
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(winner.rating, Rating::Neutral);
+    assert_eq!(
+        winner.origin,
+        OperationOrigin::OpenSubsonic {
+            backend_id: "backend-a".to_owned()
+        }
+    );
+    assert_eq!(
+        winner.operation_id,
+        external_operation_envelope_id(&device, "server-rating-observation-1").unwrap()
+    );
+}
+
+#[test]
 fn local_device_binding_rejects_missing_revoked_unkeyed_and_ambiguous_states() {
     let empty_library = crate::library::Library::default();
     let empty_playlists = crate::playlists::Playlists::default();
@@ -660,6 +791,63 @@ fn legacy_artist_affinity_is_preserved_once_without_migration_reweighting() {
         project(&reconciled).unwrap().legacy.signals.artist_affinity["artist"],
         0.7
     );
+}
+
+#[test]
+fn rating_reconciliation_retains_metadata_and_affinity_across_projection_round_trips() {
+    let song = crate::api::Song::remote("track", "Track", "Artist", "3:00");
+    let artist_key = crate::signals::normalize_artist(&song.artist);
+    let empty_library = crate::library::Library::default();
+    let empty_playlists = crate::playlists::Playlists::default();
+    let empty_signals = crate::signals::Signals::default();
+    let empty_station = crate::station::StationStore::default();
+    let baseline = legacy_state(
+        &empty_library,
+        &empty_playlists,
+        &empty_signals,
+        &empty_station,
+    )
+    .unwrap();
+
+    let mut library = empty_library;
+    let mut signals = empty_signals;
+    crate::rating::set(&mut library, &mut signals, &song, Rating::Liked, 1);
+    let liked = reconcile_runtime(
+        &baseline,
+        &library,
+        &empty_playlists,
+        &signals,
+        &empty_station,
+    )
+    .unwrap();
+    let liked = PersonalStateCommit::prepare(liked).unwrap();
+    let (mut library, playlists, mut signals, station) = liked.runtime_stores();
+    assert_eq!(signals.artist_weight(&artist_key), 0.30);
+
+    crate::rating::set(&mut library, &mut signals, &song, Rating::Disliked, 2);
+    assert_eq!(signals.artist_weight(&artist_key), -0.60);
+    let disliked =
+        reconcile_runtime(liked.state(), &library, &playlists, &signals, &station).unwrap();
+    let disliked = PersonalStateCommit::prepare(disliked).unwrap();
+    let (mut library, playlists, mut signals, station) = disliked.runtime_stores();
+    assert_eq!(signals.artist_weight(&artist_key), -0.60);
+    assert!(signals.is_disliked(&song.video_id));
+
+    crate::rating::set(&mut library, &mut signals, &song, Rating::Neutral, 3);
+    let neutral =
+        reconcile_runtime(disliked.state(), &library, &playlists, &signals, &station).unwrap();
+    let neutral = PersonalStateCommit::prepare(neutral).unwrap();
+    let (mut library, playlists, mut signals, station) = neutral.runtime_stores();
+    assert!(signals.artist_weight(&artist_key).abs() < f32::EPSILON);
+    assert!(!signals.is_disliked(&song.video_id));
+
+    crate::rating::set(&mut library, &mut signals, &song, Rating::Disliked, 4);
+    let disliked_after_neutral =
+        reconcile_runtime(neutral.state(), &library, &playlists, &signals, &station).unwrap();
+    let disliked_after_neutral = PersonalStateCommit::prepare(disliked_after_neutral).unwrap();
+    let (_, _, signals, _) = disliked_after_neutral.runtime_stores();
+    assert_eq!(signals.artist_weight(&artist_key), -0.60);
+    assert!(signals.is_disliked(&song.video_id));
 }
 
 #[test]

--- a/src/personal_state/tests/external_observations.rs
+++ b/src/personal_state/tests/external_observations.rs
@@ -1,0 +1,133 @@
+use super::*;
+
+#[test]
+fn external_operation_replay_is_exactly_once_and_keeps_origin() {
+    let device = DeviceId::new("device-a").unwrap();
+    let state = state_with_keyed_devices(&[device.as_str()]);
+    let operation = Operation::SetRating {
+        track: open_subsonic_track("server-track"),
+        rating: Rating::Liked,
+    };
+    let origin = OperationOrigin::OpenSubsonic {
+        backend_id: "backend-a".to_owned(),
+    };
+    let first = append_external_operation_as(
+        &state,
+        &device,
+        "open-subsonic-rating-backend-a-1".to_owned(),
+        origin.clone(),
+        operation.clone(),
+        100,
+    )
+    .unwrap();
+    let repeated = append_external_operation_as(
+        &first,
+        &device,
+        "open-subsonic-rating-backend-a-1".to_owned(),
+        origin.clone(),
+        operation.clone(),
+        200,
+    )
+    .unwrap();
+
+    assert_eq!(repeated, first);
+    let envelope_id =
+        external_operation_envelope_id(&device, "open-subsonic-rating-backend-a-1").unwrap();
+    let observed = first
+        .operations
+        .iter()
+        .find(|candidate| candidate.operation_id == envelope_id)
+        .unwrap();
+    assert_ne!(observed.operation_id, "open-subsonic-rating-backend-a-1");
+    assert_eq!(observed.origin, origin);
+    assert_eq!(observed.operation, operation);
+}
+
+#[test]
+fn external_observations_use_device_scoped_envelopes_and_portable_event_dedupe() {
+    let device_a = DeviceId::new("device-a").unwrap();
+    let device_b = DeviceId::new("device-b").unwrap();
+    let state = state_with_keyed_devices(&[device_a.as_str(), device_b.as_str()]);
+    let track = open_subsonic_track("server-track");
+    let origin = OperationOrigin::OpenSubsonic {
+        backend_id: "backend-a".to_owned(),
+    };
+    let engagement = Operation::RecordEngagement {
+        event_id: "portable-native-row-7".to_owned(),
+        track: track.clone(),
+        engagement: EngagementKind::Play,
+        played_duration_ms: None,
+        total_duration_ms: Some(180_000),
+        artist_key: "artist".to_owned(),
+    };
+    let from_a = append_external_operation_as(
+        &state,
+        &device_a,
+        "portable-native-row-7".to_owned(),
+        origin.clone(),
+        engagement.clone(),
+        100,
+    )
+    .unwrap();
+    let from_b = append_external_operation_as(
+        &state,
+        &device_b,
+        "portable-native-row-7".to_owned(),
+        origin.clone(),
+        engagement,
+        101,
+    )
+    .unwrap();
+    let id_a = external_operation_envelope_id(&device_a, "portable-native-row-7").unwrap();
+    let id_b = external_operation_envelope_id(&device_b, "portable-native-row-7").unwrap();
+    assert_ne!(id_a, id_b);
+
+    let (merged_ab, _) = merge(&from_a, &from_b).unwrap();
+    let (merged_ba, _) = merge(&from_b, &from_a).unwrap();
+    assert_eq!(merged_ab.operations, merged_ba.operations);
+    let projection = super::super::reducer::project_at(&merged_ab, 101).unwrap();
+    let signal = projection.legacy.signals.tracks.get(&track.key).unwrap();
+    assert_eq!(signal.play_count, 1);
+    assert_eq!(projection.legacy.signals.play_log.len(), 1);
+    assert_eq!(
+        projection.legacy.signals.play_log[0].event_id,
+        "portable-native-row-7"
+    );
+
+    let liked = append_external_operation_as(
+        &state,
+        &device_a,
+        "portable-rating-observation".to_owned(),
+        origin.clone(),
+        Operation::SetRating {
+            track: track.clone(),
+            rating: Rating::Liked,
+        },
+        200,
+    )
+    .unwrap();
+    let disliked = append_external_operation_as(
+        &state,
+        &device_b,
+        "portable-rating-observation".to_owned(),
+        origin,
+        Operation::SetRating {
+            track,
+            rating: Rating::Disliked,
+        },
+        1,
+    )
+    .unwrap();
+    let (rating_ab, _) = merge(&liked, &disliked).unwrap();
+    let (rating_ba, _) = merge(&disliked, &liked).unwrap();
+    let winner_ab = open_subsonic_rating_winners(&rating_ab)
+        .unwrap()
+        .pop()
+        .unwrap();
+    let winner_ba = open_subsonic_rating_winners(&rating_ba)
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(winner_ab, winner_ba);
+    assert_eq!(winner_ab.rating, Rating::Disliked);
+}

--- a/src/rating.rs
+++ b/src/rating.rs
@@ -19,6 +19,40 @@ impl RatingChange {
     }
 }
 
+/// Session-only recommendation feedback emitted by an explicit track-rating change.
+///
+/// Persistent affinity still lives in [`Signals`]. This short-lived signal lets both playback
+/// owners apply the same immediate rerank nudge without teaching radio favorites as track taste.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionRatingSignal {
+    Like,
+    Dislike,
+}
+
+impl SessionRatingSignal {
+    pub const fn affinity_delta(self) -> f32 {
+        match self {
+            Self::Like => 0.15,
+            Self::Dislike => -0.40,
+        }
+    }
+}
+
+/// Translate one semantic track-rating transition into its session recommendation signal.
+///
+/// Projection-only repairs and transitions to neutral are deliberately silent. Radio stations
+/// retain their independent favorite collection and never enter track recommendation feedback.
+pub fn session_signal(song: &Song, change: RatingChange) -> Option<SessionRatingSignal> {
+    if song.is_radio_station() || change.before == change.after {
+        return None;
+    }
+    match change.after {
+        Rating::Liked => Some(SessionRatingSignal::Like),
+        Rating::Disliked => Some(SessionRatingSignal::Dislike),
+        Rating::Neutral => None,
+    }
+}
+
 /// Read the one canonical rating. A contradictory legacy projection resolves to Disliked.
 pub fn current(library: &Library, signals: &Signals, video_id: &str) -> Rating {
     if signals.is_disliked(video_id) {
@@ -36,6 +70,68 @@ pub fn cycled(rating: Rating) -> Rating {
         Rating::Liked => Rating::Disliked,
         Rating::Disliked => Rating::Neutral,
     }
+}
+
+/// Toggle only the liked side of the tri-state register.
+///
+/// Radio stations retain their separate binary favorite collection and never create track
+/// affinity signals.
+pub fn toggle_liked(
+    library: &mut Library,
+    signals: &mut Signals,
+    song: &Song,
+    now: i64,
+) -> RatingChange {
+    if song.is_radio_station() {
+        let before = if library.is_favorite(&song.video_id) {
+            Rating::Liked
+        } else {
+            Rating::Neutral
+        };
+        let after = if library.toggle_favorite(song) {
+            Rating::Liked
+        } else {
+            Rating::Neutral
+        };
+        return RatingChange {
+            before,
+            after,
+            library_changed: true,
+            signals_changed: false,
+        };
+    }
+    let target = if current(library, signals, &song.video_id) == Rating::Liked {
+        Rating::Neutral
+    } else {
+        Rating::Liked
+    };
+    set(library, signals, song, target, now)
+}
+
+/// Toggle only the disliked side of the tri-state register.
+///
+/// A radio station has no disliked state, so that request is an explicit no-op.
+pub fn toggle_disliked(
+    library: &mut Library,
+    signals: &mut Signals,
+    song: &Song,
+    now: i64,
+) -> RatingChange {
+    let before = current(library, signals, &song.video_id);
+    if song.is_radio_station() {
+        return RatingChange {
+            before,
+            after: before,
+            library_changed: false,
+            signals_changed: false,
+        };
+    }
+    let target = if before == Rating::Disliked {
+        Rating::Neutral
+    } else {
+        Rating::Disliked
+    };
+    set(library, signals, song, target, now)
 }
 
 /// Apply one explicit rating and repair any legacy liked+disliked contradiction.
@@ -99,6 +195,9 @@ pub fn set(
 }
 
 pub fn cycle(library: &mut Library, signals: &mut Signals, song: &Song, now: i64) -> RatingChange {
+    if song.is_radio_station() {
+        return toggle_liked(library, signals, song, now);
+    }
     set(
         library,
         signals,
@@ -156,5 +255,63 @@ mod tests {
         assert!(change.library_changed);
         assert!(!library.is_favorite(&song.video_id));
         assert!(signals.is_disliked(&song.video_id));
+    }
+
+    #[test]
+    fn liked_toggle_repairs_dislike_and_radio_stays_out_of_signals() {
+        let song = song();
+        let mut library = Library::default();
+        let mut signals = Signals::default();
+        set(&mut library, &mut signals, &song, Rating::Disliked, 1);
+        assert_eq!(
+            toggle_liked(&mut library, &mut signals, &song, 2).after,
+            Rating::Liked
+        );
+        assert!(!signals.is_disliked(&song.video_id));
+
+        let mut station = Song::remote("station", "Station", "Radio", "");
+        station.playable = Some(crate::api::PlayableRef::RadioStream {
+            url: "https://radio.example/station.mp3".to_owned(),
+        });
+        assert_eq!(
+            cycle(&mut library, &mut signals, &station, 3).after,
+            Rating::Liked
+        );
+        assert_eq!(
+            cycle(&mut library, &mut signals, &station, 4).after,
+            Rating::Neutral
+        );
+        assert!(!signals.is_disliked(&station.video_id));
+    }
+
+    #[test]
+    fn session_signal_only_tracks_semantic_non_radio_feedback() {
+        let track = song();
+        let liked = RatingChange {
+            before: Rating::Neutral,
+            after: Rating::Liked,
+            library_changed: true,
+            signals_changed: true,
+        };
+        assert_eq!(
+            session_signal(&track, liked),
+            Some(SessionRatingSignal::Like)
+        );
+        assert_eq!(SessionRatingSignal::Like.affinity_delta(), 0.15);
+        assert_eq!(SessionRatingSignal::Dislike.affinity_delta(), -0.40);
+
+        let projection_repair = RatingChange {
+            before: Rating::Disliked,
+            after: Rating::Disliked,
+            library_changed: true,
+            signals_changed: false,
+        };
+        assert_eq!(session_signal(&track, projection_repair), None);
+
+        let mut station = Song::remote("station", "Station", "Radio", "");
+        station.playable = Some(crate::api::PlayableRef::RadioStream {
+            url: "https://radio.example/station.mp3".to_owned(),
+        });
+        assert_eq!(session_signal(&station, liked), None);
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -25,6 +25,7 @@ mod dispatch;
 mod event_policy;
 pub(crate) mod ingress;
 mod local_find;
+mod open_subsonic_bridge;
 mod open_subsonic_runtime;
 mod persist_delivery;
 mod personal_sync_commit;
@@ -89,6 +90,9 @@ pub enum RuntimeEvent {
             crate::open_subsonic::ServiceError,
         >,
     },
+    /// A path/URL/credential-free server observation retained by the bridge until the owner
+    /// confirms its personal-state transaction.
+    OpenSubsonicBridge(crate::open_subsonic::OpenSubsonicBridgeImport),
     TelemetryWake,
 }
 
@@ -174,6 +178,9 @@ impl RuntimeEvent {
             RuntimeEvent::OpenSubsonicReloaded { .. } => EventPolicy::MustDeliver {
                 lane: Lane::WorkResult,
             },
+            RuntimeEvent::OpenSubsonicBridge(_) => EventPolicy::MustDeliver {
+                lane: Lane::WorkResult,
+            },
             RuntimeEvent::TelemetryWake => EventPolicy::MustDeliver {
                 lane: Lane::Control,
             },
@@ -200,6 +207,7 @@ impl RuntimeEvent {
             RuntimeEvent::Update(_) => "update",
             RuntimeEvent::Transfer(_) => "transfer",
             RuntimeEvent::OpenSubsonicReloaded { .. } => "open_subsonic_reloaded",
+            RuntimeEvent::OpenSubsonicBridge(_) => "open_subsonic_bridge",
             RuntimeEvent::TelemetryWake => "telemetry_wake",
         }
     }
@@ -512,6 +520,11 @@ impl From<RuntimeEvent> for Msg {
                     "OpenSubsonicReloaded must be installed by the owner loop before Msg conversion"
                 )
             }
+            RuntimeEvent::OpenSubsonicBridge(_) => {
+                unreachable!(
+                    "OpenSubsonicBridge must be committed by the owner loop before Msg conversion"
+                )
+            }
             RuntimeEvent::TelemetryWake => {
                 unreachable!(
                     "TelemetryWake must be drained by the owner loop before Msg conversion"
@@ -566,6 +579,14 @@ where
     }
 }
 
+fn open_subsonic_bridge_sink(
+    emitter: task_set::RuntimeTaskEmitter,
+) -> crate::open_subsonic::OpenSubsonicBridgeSink {
+    std::sync::Arc::new(move |event| {
+        emitter.emit_terminal_blocking(RuntimeEvent::OpenSubsonicBridge(event));
+    })
+}
+
 pub fn remote_sink(
     tx: RuntimeSender,
 ) -> impl Fn(crate::remote::server::RemoteEvent) -> bool + Send + Sync + 'static {
@@ -588,7 +609,7 @@ pub struct RuntimeHandles {
     download_handle: crate::download::DownloadHandle,
     resolver_handle: crate::resolver::ResolverHandle,
     ai_handle: Option<crate::ai::AiHandle>,
-    scrobble_handle: crate::scrobble::ScrobbleHandle,
+    scrobble_handle: Option<crate::scrobble::ScrobbleHandle>,
     /// Spawned on the first transfer command — costs nothing until the feature is used.
     transfer_handle: Option<crate::transfer::actor::TransferHandle>,
     /// Debounced background store writes (the `Cmd::Persist` family).
@@ -607,6 +628,18 @@ pub struct RuntimeHandles {
     open_subsonic_runtime: Option<crate::open_subsonic::OpenSubsonicRuntime>,
     /// Latest reload generation requested by the owner. Out-of-order candidates are dropped.
     open_subsonic_reload_generation: u64,
+    /// Bridge acknowledgement IDs mapped to their device-scoped ledger envelope while persistence
+    /// is outstanding.
+    open_subsonic_pending_imports: std::collections::BTreeMap<String, String>,
+    /// Imports known durable and waiting for bridge-store acknowledgement.
+    open_subsonic_committed_imports: std::collections::BTreeSet<String>,
+    /// Ledger identity last admitted to the server rating projection.
+    open_subsonic_rating_identity: Option<String>,
+    /// Ledger identity awaiting proof that its rating projection crossed the bridge-store fsync.
+    open_subsonic_pending_rating: Option<open_subsonic_bridge::PendingOpenSubsonicRatingProjection>,
+    /// Exact playback reports retained while a runtime generation is being replaced.
+    open_subsonic_pending_scrobbles:
+        std::collections::VecDeque<open_subsonic_bridge::PendingOpenSubsonicScrobble>,
 }
 
 fn settle_video_load_delivery(app: &mut App, result: DeliveryResult) -> Vec<Cmd> {
@@ -670,7 +703,7 @@ impl RuntimeHandles {
             download_handle,
             resolver_handle,
             ai_handle,
-            scrobble_handle,
+            scrobble_handle: Some(scrobble_handle),
             transfer_handle: None,
             persist,
             background_tasks: RuntimeTaskSet::new(),
@@ -682,6 +715,11 @@ impl RuntimeHandles {
             open_subsonic_routes,
             open_subsonic_runtime: None,
             open_subsonic_reload_generation: 0,
+            open_subsonic_pending_imports: std::collections::BTreeMap::new(),
+            open_subsonic_committed_imports: std::collections::BTreeSet::new(),
+            open_subsonic_rating_identity: None,
+            open_subsonic_pending_rating: None,
+            open_subsonic_pending_scrobbles: std::collections::VecDeque::new(),
         }
     }
 
@@ -692,15 +730,33 @@ impl RuntimeHandles {
         &mut self,
         snapshot: &crate::media::MediaSnapshot,
     ) -> crate::util::delivery::DeliveryResult {
-        self.scrobble_handle.observe(snapshot)
+        self.scrobble_handle
+            .as_mut()
+            .ok_or(crate::util::delivery::DeliveryError::Closed)?
+            .observe(snapshot)
+    }
+
+    /// Admit one fresh terminal observation while the player snapshot is still available.
+    pub(crate) fn scrobble_observe_shutdown(
+        &mut self,
+        snapshot: &crate::media::MediaSnapshot,
+    ) -> crate::util::delivery::DeliveryResult {
+        self.scrobble_handle
+            .as_mut()
+            .ok_or(crate::util::delivery::DeliveryError::Closed)?
+            .observe_shutdown(snapshot)
     }
 
     pub fn scrobble_heartbeat_due(&self) -> bool {
-        self.scrobble_handle.heartbeat_due()
+        self.scrobble_handle
+            .as_ref()
+            .is_some_and(crate::scrobble::ScrobbleHandle::heartbeat_due)
     }
 
     pub fn scrobble_retry_needed(&self) -> bool {
-        self.scrobble_handle.retry_needed()
+        self.scrobble_handle
+            .as_ref()
+            .is_some_and(crate::scrobble::ScrobbleHandle::retry_needed)
     }
 
     /// Cancel and join every accepted yt-dlp task before the terminal runtime exits.
@@ -771,6 +827,30 @@ impl RuntimeHandles {
             return;
         }
         match event {
+            RuntimeEvent::OpenSubsonicBridge(import) => {
+                self.apply_open_subsonic_bridge_import(app, import);
+            }
+            RuntimeEvent::Scrobble(crate::scrobble::ScrobbleEvent::OpenSubsonic {
+                event_id,
+                kind,
+                track,
+                confirmation,
+            }) => {
+                self.queue_open_subsonic_scrobble(event_id, kind, track, confirmation);
+            }
+            RuntimeEvent::Persist(crate::persist::PersistEvent::PersonalStateCommitted {
+                revision,
+                state_identity,
+            }) => {
+                self.note_open_subsonic_personal_state_commit(app, &state_identity);
+                self.reduce_owner_msg(
+                    app,
+                    Msg::PersonalStatePersisted {
+                        revision,
+                        state_identity,
+                    },
+                );
+            }
             RuntimeEvent::Remote(crate::remote::server::RemoteEvent::Command(_, reply))
             | RuntimeEvent::Remote(crate::remote::server::RemoteEvent::SessionCommand {
                 reply,
@@ -785,6 +865,7 @@ impl RuntimeHandles {
             }
             event => self.reduce_owner_msg(app, event.into()),
         }
+        self.maintain_open_subsonic_bridge(app);
     }
 
     /// Abort and join any active transfer/auth/playlist work before the owner runtime exits.
@@ -800,13 +881,10 @@ impl RuntimeHandles {
         self.transfer_handle = None;
     }
 
-    /// Confirm the durable scrobble frontier and join its isolated owner thread. `budget` is a
-    /// diagnostic warning deadline, not permission to cancel an accepted append/fsync.
-    pub async fn scrobble_shutdown(
-        &mut self,
-        budget: std::time::Duration,
-    ) -> Result<(), crate::util::delivery::DeliveryError> {
-        self.scrobble_handle.shutdown_and_join(budget).await
+    /// Move the scrobble owner into terminal teardown so its final threshold events can be pumped
+    /// through this runtime while the actor joins.
+    pub(crate) fn take_scrobble_for_shutdown(&mut self) -> Option<crate::scrobble::ScrobbleHandle> {
+        self.scrobble_handle.take()
     }
 
     /// Settle a synchronous actor rejection on the owner which already holds `App`.

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -158,11 +158,13 @@ impl RuntimeHandles {
                     crate::app::MusicServerCommand::Refresh { generation } => {
                         self.begin_open_subsonic_reload(generation);
                         let read_only = self.persistence_read_only.is_some();
+                        let bridge_sink =
+                            (!read_only).then(|| super::open_subsonic_bridge_sink(emitter.clone()));
                         self.background_tasks.spawn_cancellable(
                             "music_server_connection_test",
                             async move {
                                 let (runtime_result, result) =
-                                    refresh_music_server_runtime(read_only).await;
+                                    refresh_music_server_runtime(read_only, bridge_sink).await;
                                 emitter
                                     .emit_terminal(RuntimeEvent::OpenSubsonicReloaded {
                                         generation,
@@ -206,6 +208,7 @@ impl RuntimeHandles {
                         prepared,
                     } => {
                         self.begin_open_subsonic_reload(generation);
+                        let bridge_sink = super::open_subsonic_bridge_sink(emitter.clone());
                         self.background_tasks.spawn_cancellable(
                             "music_server_commit",
                             async move {
@@ -219,35 +222,27 @@ impl RuntimeHandles {
                                 .await
                                 .map_err(|_| crate::open_subsonic::ServiceError::ActorUnavailable)
                                 .and_then(std::convert::identity);
-                                let result = match committed {
-                                    Ok(status) => {
-                                        let mut summary = music_server_summary(status);
-                                        let runtime_result =
-                                            match crate::open_subsonic::OpenSubsonicPaths::current()
-                                            {
-                                                Ok(paths) => {
-                                                    crate::open_subsonic::load_actor(&paths).await
-                                                }
-                                                Err(error) => Err(error.into()),
-                                            };
-                                        if runtime_result.is_err() {
-                                            // The durable commit already succeeded. Keep the
-                                            // configured identity visible and offer retry instead
-                                            // of reopening a first-time wizard whose Create
-                                            // intent can no longer be valid.
-                                            summary.health =
-                                                crate::app::MusicServerHealth::NeedsAttention;
-                                        }
-                                        emitter
-                                            .emit_terminal(RuntimeEvent::OpenSubsonicReloaded {
-                                                generation,
-                                                result: runtime_result,
-                                            })
-                                            .await;
-                                        Ok(summary)
-                                    }
-                                    Err(error) => Err(music_server_failure(error)),
-                                };
+                                // commit_setup revokes the previous credential owner before its
+                                // transaction begins. Reload on both success and failure so an
+                                // ambiguous post-marker error cannot leave a stale local route.
+                                let runtime_result =
+                                    reload_music_server_runtime(Some(bridge_sink)).await;
+                                let mut result = committed
+                                    .map(music_server_summary)
+                                    .map_err(music_server_failure);
+                                if runtime_result.is_err()
+                                    && let Ok(summary) = result.as_mut()
+                                {
+                                    // The durable commit already succeeded. Keep the configured
+                                    // identity visible and offer retry.
+                                    summary.health = crate::app::MusicServerHealth::NeedsAttention;
+                                }
+                                emitter
+                                    .emit_terminal(RuntimeEvent::OpenSubsonicReloaded {
+                                        generation,
+                                        result: runtime_result,
+                                    })
+                                    .await;
                                 emitter
                                     .emit_terminal(RuntimeEvent::App(Msg::Server(
                                         crate::app::ServerEvent::Settings(
@@ -261,8 +256,62 @@ impl RuntimeHandles {
                             },
                         );
                     }
+                    crate::app::MusicServerCommand::DisableHistory { generation } => {
+                        self.begin_open_subsonic_reload(generation);
+                        // The old actor may retain a dedicated native-history password. Drop it
+                        // before the owner-only store removes that secret, then reload only from
+                        // the committed snapshot.
+                        self.retire_open_subsonic_runtime();
+                        let bridge_sink = super::open_subsonic_bridge_sink(emitter.clone());
+                        self.background_tasks.spawn_cancellable(
+                            "music_server_history_disable",
+                            async move {
+                                let disabled = tokio::task::spawn_blocking(move || {
+                                    crate::open_subsonic::OpenSubsonicPaths::current()
+                                        .map_err(crate::open_subsonic::ServiceError::from)
+                                        .and_then(|paths| {
+                                            crate::open_subsonic::disable_native_history(&paths)
+                                        })
+                                })
+                                .await
+                                .map_err(|_| crate::open_subsonic::ServiceError::ActorUnavailable)
+                                .and_then(std::convert::identity);
+                                let runtime_result =
+                                    reload_music_server_runtime(Some(bridge_sink)).await;
+                                let mut result = disabled
+                                    .map(music_server_summary)
+                                    .map_err(music_server_failure);
+                                if runtime_result.is_err()
+                                    && let Ok(summary) = result.as_mut()
+                                {
+                                    summary.health = crate::app::MusicServerHealth::NeedsAttention;
+                                }
+                                emitter
+                                    .emit_terminal(RuntimeEvent::OpenSubsonicReloaded {
+                                        generation,
+                                        result: runtime_result,
+                                    })
+                                    .await;
+                                emitter
+                                    .emit_terminal(RuntimeEvent::App(Msg::Server(
+                                        crate::app::ServerEvent::Settings(
+                                            crate::app::MusicServerEvent::HistoryDisabled {
+                                                generation,
+                                                result,
+                                            },
+                                        ),
+                                    )))
+                                    .await;
+                            },
+                        );
+                    }
                     crate::app::MusicServerCommand::Remove { generation } => {
                         self.begin_open_subsonic_reload(generation);
+                        // Removal is explicit and destructive. Stop credentialed routes before
+                        // deleting their owner-only store; refresh/setup probes retain the active
+                        // runtime until a replacement is fully ready.
+                        self.retire_open_subsonic_runtime();
+                        let bridge_sink = super::open_subsonic_bridge_sink(emitter.clone());
                         self.background_tasks.spawn_cancellable(
                             "music_server_remove",
                             async move {
@@ -276,29 +325,23 @@ impl RuntimeHandles {
                                 .await
                                 .map_err(|_| crate::open_subsonic::ServiceError::ActorUnavailable)
                                 .and_then(std::convert::identity);
-                                let result = match removed {
-                                    Ok(_) => {
-                                        let runtime_result =
-                                            match crate::open_subsonic::OpenSubsonicPaths::current()
-                                            {
-                                                Ok(paths) => {
-                                                    crate::open_subsonic::load_actor(&paths).await
-                                                }
-                                                Err(error) => Err(error.into()),
-                                            };
-                                        emitter
-                                            .emit_terminal(RuntimeEvent::OpenSubsonicReloaded {
-                                                generation,
-                                                result: runtime_result,
-                                            })
-                                            .await;
-                                        // Removal is already durable and clears the active
-                                        // credential boundary synchronously. A follow-up reload
-                                        // failure cannot turn it back into a configured profile.
-                                        Ok(())
-                                    }
-                                    Err(error) => Err(music_server_failure(error)),
+                                // A failed removal must not strand the process without the actor
+                                // it retired above. Reloading the coherent current snapshot also
+                                // resolves an ambiguous post-commit storage error safely.
+                                let runtime_result =
+                                    reload_music_server_runtime(Some(bridge_sink)).await;
+                                let reload_state = match &runtime_result {
+                                    Ok(runtime) => Ok(runtime.is_some()),
+                                    Err(error) => Err(*error),
                                 };
+                                let result =
+                                    resolve_music_server_remove(removed.err(), reload_state);
+                                emitter
+                                    .emit_terminal(RuntimeEvent::OpenSubsonicReloaded {
+                                        generation,
+                                        result: runtime_result,
+                                    })
+                                    .await;
                                 emitter
                                     .emit_terminal(RuntimeEvent::App(Msg::Server(
                                         crate::app::ServerEvent::Settings(
@@ -990,14 +1033,18 @@ impl RuntimeHandles {
             }
             Cmd::Scrobble(scrobble) => match scrobble {
                 ScrobbleCmd::AuthStart => {
-                    report_actor_delivery(app, "scrobble.auth", self.scrobble_handle.auth_start());
+                    let result = self.scrobble_handle.as_ref().map_or(
+                        Err(crate::util::delivery::DeliveryError::Closed),
+                        |handle| handle.auth_start(),
+                    );
+                    report_actor_delivery(app, "scrobble.auth", result);
                 }
                 ScrobbleCmd::Reconfigure(settings) => {
-                    report_actor_delivery(
-                        app,
-                        "scrobble.reconfigure",
-                        self.scrobble_handle.reconfigure(*settings),
+                    let result = self.scrobble_handle.as_ref().map_or(
+                        Err(crate::util::delivery::DeliveryError::Closed),
+                        |handle| handle.reconfigure(*settings),
                     );
+                    report_actor_delivery(app, "scrobble.reconfigure", result);
                 }
             },
             Cmd::Transfer(cmd) => {
@@ -1034,6 +1081,7 @@ impl RuntimeHandles {
 
 async fn refresh_music_server_runtime(
     read_only: bool,
+    bridge_sink: Option<crate::open_subsonic::OpenSubsonicBridgeSink>,
 ) -> (
     Result<Option<crate::open_subsonic::OpenSubsonicRuntime>, crate::open_subsonic::ServiceError>,
     Result<crate::app::MusicServerRefreshOutcome, crate::app::MusicServerFailure>,
@@ -1053,14 +1101,14 @@ async fn refresh_music_server_runtime(
     let runtime_result = if read_only {
         crate::open_subsonic::load_actor_read_only(&paths).await
     } else {
-        crate::open_subsonic::load_actor(&paths).await
+        crate::open_subsonic::load_actor_with_bridge_sink(&paths, bridge_sink).await
     };
     let outcome = match &runtime_result {
         Ok(Some(_)) => {
             let mut summary = crate::open_subsonic::read_status(&paths)
                 .map(music_server_summary)
                 .unwrap_or(local_summary);
-            summary.health = crate::app::MusicServerHealth::UpToDate;
+            summary.health = live_music_server_health(summary.playback_reports_needing_decision);
             summary.configured = true;
             crate::app::MusicServerRefreshOutcome {
                 summary,
@@ -1080,6 +1128,28 @@ async fn refresh_music_server_runtime(
         }
     };
     (runtime_result, Ok(outcome))
+}
+
+async fn reload_music_server_runtime(
+    bridge_sink: Option<crate::open_subsonic::OpenSubsonicBridgeSink>,
+) -> Result<Option<crate::open_subsonic::OpenSubsonicRuntime>, crate::open_subsonic::ServiceError> {
+    let paths = crate::open_subsonic::OpenSubsonicPaths::current()?;
+    crate::open_subsonic::load_actor_with_bridge_sink(&paths, bridge_sink).await
+}
+
+pub(super) fn resolve_music_server_remove(
+    removal_error: Option<crate::open_subsonic::ServiceError>,
+    reload: Result<bool, crate::open_subsonic::ServiceError>,
+) -> Result<(), crate::app::MusicServerFailure> {
+    match reload {
+        // The coherent store is absent. This is also the proof that an error returned after the
+        // removal commit marker was an ambiguous success.
+        Ok(false) => Ok(()),
+        Ok(true) => Err(removal_error
+            .map(music_server_failure)
+            .unwrap_or(crate::app::MusicServerFailure::Unavailable)),
+        Err(error) => Err(music_server_failure(error)),
+    }
 }
 
 async fn prepare_music_server_setup(
@@ -1162,9 +1232,13 @@ fn music_server_summary(
     status: crate::open_subsonic::OpenSubsonicStatus,
 ) -> crate::app::MusicServerSummary {
     let configured = status.kind != crate::open_subsonic::OpenSubsonicStatusKind::Off;
-    let credential_label = status.credential_kind.map(|kind| match kind {
-        crate::open_subsonic::CredentialKind::Password => "Password".to_owned(),
-        crate::open_subsonic::CredentialKind::ApiKey => "API key".to_owned(),
+    let credential_kind = status.credential_kind.map(|kind| match kind {
+        crate::open_subsonic::CredentialKind::Password => {
+            crate::app::MusicServerCredentialMode::Password
+        }
+        crate::open_subsonic::CredentialKind::ApiKey => {
+            crate::app::MusicServerCredentialMode::ApiKey
+        }
     });
     crate::app::MusicServerSummary {
         health: match status.kind {
@@ -1178,9 +1252,37 @@ fn music_server_summary(
         },
         configured,
         display_name: status.display_name,
-        credential_label,
+        credential_kind,
         lan_http: status.uses_lan_http,
         custom_ca: status.uses_custom_ca,
+        playback_reports_needing_decision: status.outbound_scrobbles_needing_attention,
+        history: match status.native_history_health {
+            crate::open_subsonic::NativeHistoryHealth::Off => {
+                crate::app::MusicServerHistoryHealth::Off
+            }
+            crate::open_subsonic::NativeHistoryHealth::Probing => {
+                crate::app::MusicServerHistoryHealth::Probing
+            }
+            crate::open_subsonic::NativeHistoryHealth::Detailed => {
+                crate::app::MusicServerHistoryHealth::Detailed
+            }
+            crate::open_subsonic::NativeHistoryHealth::PlayCountsOnly => {
+                crate::app::MusicServerHistoryHealth::PlayCountsOnly
+            }
+            crate::open_subsonic::NativeHistoryHealth::UpdatePassword => {
+                crate::app::MusicServerHistoryHealth::UpdatePassword
+            }
+        },
+    }
+}
+
+pub(super) const fn live_music_server_health(
+    playback_reports_needing_decision: usize,
+) -> crate::app::MusicServerHealth {
+    if playback_reports_needing_decision == 0 {
+        crate::app::MusicServerHealth::UpToDate
+    } else {
+        crate::app::MusicServerHealth::NeedsAttention
     }
 }
 

--- a/src/runtime/open_subsonic_bridge.rs
+++ b/src/runtime/open_subsonic_bridge.rs
@@ -1,0 +1,822 @@
+//! Owner-lane handoff between the credential owner and canonical personal state.
+
+use super::{RuntimeHandles, persist_delivery};
+use crate::app::{App, PersistCmd};
+
+/// The durable bridge store can expose at most 20,000 rating plus 20,000 engagement imports.
+///
+/// This owner-side set is only a hand-off ledger. Refusing new hand-offs at the same aggregate
+/// bound is lossless: the bridge keeps an unacknowledged import durable and re-emits it later.
+const OWNER_BRIDGE_IMPORT_TRACKING_MAX: usize = 40_000;
+
+pub(super) struct PendingOpenSubsonicScrobble {
+    event_id: String,
+    kind: crate::open_subsonic::OpenSubsonicScrobbleKind,
+    track: crate::scrobble::ScrobbleTrack,
+    confirmation: Option<crate::scrobble::OpenSubsonicSubmissionAck>,
+    receipt: Option<crate::open_subsonic::OpenSubsonicScrobbleReceipt>,
+    source_receipt: Option<crate::open_subsonic::OpenSubsonicScrobbleReceipt>,
+    bridge_durable: bool,
+    source_ack_durable: bool,
+}
+
+pub(super) struct PendingOpenSubsonicRatingProjection {
+    identity: String,
+    receipt: crate::open_subsonic::OpenSubsonicRatingReceipt,
+}
+
+fn same_server_track(
+    left: &crate::scrobble::ScrobbleTrack,
+    right: &crate::scrobble::ScrobbleTrack,
+) -> bool {
+    match (&left.open_subsonic_item, &right.open_subsonic_item) {
+        (Some(left), Some(right)) => left == right,
+        _ => left.key == right.key,
+    }
+}
+
+fn wrong_account_scope(error: &crate::open_subsonic::ServiceError) -> bool {
+    matches!(
+        error,
+        crate::open_subsonic::ServiceError::Server(
+            crate::open_subsonic::ServerError::WrongAccountScope
+        )
+    )
+}
+
+fn request_scope_retirement(pending: &PendingOpenSubsonicScrobble) {
+    if let Some(confirmation) = pending.confirmation.as_ref()
+        && let Err(error) = confirmation.retire_account_scope()
+    {
+        tracing::debug!(
+            %error,
+            "retired music-server account marker waits for source-journal durability"
+        );
+    }
+}
+
+fn admit_pending_scrobble(
+    queue: &mut std::collections::VecDeque<PendingOpenSubsonicScrobble>,
+    pending: PendingOpenSubsonicScrobble,
+) -> bool {
+    use crate::open_subsonic::{OWNER_PLAYBACK_REPORT_QUEUE_MAX, OpenSubsonicScrobbleKind as Kind};
+
+    if queue
+        .iter()
+        .any(|queued| queued.event_id == pending.event_id)
+    {
+        return false;
+    }
+
+    if pending.kind == Kind::NowPlaying {
+        let mut index = 0;
+        while index < queue.len() {
+            let duplicate = queue.get(index).is_some_and(|queued| {
+                queued.kind == Kind::NowPlaying && same_server_track(&queued.track, &pending.track)
+            });
+            if duplicate {
+                queue.remove(index);
+            } else {
+                index += 1;
+            }
+        }
+    }
+
+    while queue.len() >= OWNER_PLAYBACK_REPORT_QUEUE_MAX {
+        if let Some(index) = queue
+            .iter()
+            .position(|queued| queued.kind == Kind::NowPlaying)
+        {
+            queue.remove(index);
+            continue;
+        }
+        if pending.kind == Kind::NowPlaying {
+            tracing::debug!(
+                capacity = OWNER_PLAYBACK_REPORT_QUEUE_MAX,
+                "ephemeral music server now-playing report coalesced at owner queue capacity"
+            );
+            return false;
+        }
+        // All retained submissions may be between two durable acknowledgement boundaries. Do not
+        // evict one: defer the newly announced marker to restart replay instead.
+        tracing::warn!(
+            capacity = OWNER_PLAYBACK_REPORT_QUEUE_MAX,
+            "music server submission owner queue full; newest journaled report deferred"
+        );
+        if let Some(confirmation) = pending.confirmation.as_ref() {
+            confirmation.defer_submission();
+        }
+        return false;
+    }
+    queue.push_back(pending);
+    true
+}
+
+enum RatingProjectionReceipt {
+    Idle,
+    Waiting,
+    Durable(String),
+    Retry(Option<crate::open_subsonic::ServiceError>),
+}
+
+fn poll_rating_projection_receipt(
+    pending: &mut Option<PendingOpenSubsonicRatingProjection>,
+) -> RatingProjectionReceipt {
+    let Some(receipt) = pending.as_mut().map(|pending| &mut pending.receipt) else {
+        return RatingProjectionReceipt::Idle;
+    };
+    match receipt.try_recv() {
+        Ok(Ok(())) => RatingProjectionReceipt::Durable(
+            pending.take().expect("rating receipt was present").identity,
+        ),
+        Ok(Err(error)) => {
+            *pending = None;
+            RatingProjectionReceipt::Retry(Some(error))
+        }
+        Err(tokio::sync::oneshot::error::TryRecvError::Empty) => RatingProjectionReceipt::Waiting,
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+            *pending = None;
+            RatingProjectionReceipt::Retry(None)
+        }
+    }
+}
+
+fn bridge_import_tracking_has_capacity(
+    pending: &std::collections::BTreeMap<String, String>,
+    committed: &std::collections::BTreeSet<String>,
+) -> bool {
+    pending.len().saturating_add(committed.len()) < OWNER_BRIDGE_IMPORT_TRACKING_MAX
+}
+
+impl RuntimeHandles {
+    /// Apply one durable server observation and request the personal-state transaction that makes
+    /// it acknowledgeable. Re-delivery is expected after crashes and is idempotent by operation ID.
+    pub(crate) fn apply_open_subsonic_bridge_import(
+        &mut self,
+        app: &mut App,
+        import: crate::open_subsonic::OpenSubsonicBridgeImport,
+    ) {
+        let operation_id = import.operation_id().to_owned();
+        if self.open_subsonic_committed_imports.contains(&operation_id)
+            || self
+                .open_subsonic_pending_imports
+                .contains_key(&operation_id)
+        {
+            self.maintain_open_subsonic_bridge(app);
+            return;
+        }
+        if !bridge_import_tracking_has_capacity(
+            &self.open_subsonic_pending_imports,
+            &self.open_subsonic_committed_imports,
+        ) {
+            // First try to release locally committed hand-offs. If the credential owner is busy
+            // or unavailable, leave this import unacknowledged in its durable source journal.
+            self.maintain_open_subsonic_bridge(app);
+            if !bridge_import_tracking_has_capacity(
+                &self.open_subsonic_pending_imports,
+                &self.open_subsonic_committed_imports,
+            ) {
+                tracing::warn!(
+                    capacity = OWNER_BRIDGE_IMPORT_TRACKING_MAX,
+                    "music server observation hand-off is full; durable source will retry"
+                );
+                return;
+            }
+        }
+        let envelope_id = match app.apply_open_subsonic_bridge_import(&import) {
+            Ok(envelope_id) => envelope_id,
+            Err(error) => {
+                tracing::warn!(%error, "music server observation could not be merged");
+                return;
+            }
+        };
+        match persist_delivery::admit(&self.persist, app, PersistCmd::Library) {
+            Ok(_) => {
+                self.open_subsonic_pending_imports
+                    .insert(operation_id, envelope_id);
+                debug_assert!(
+                    self.open_subsonic_pending_imports
+                        .len()
+                        .saturating_add(self.open_subsonic_committed_imports.len())
+                        <= OWNER_BRIDGE_IMPORT_TRACKING_MAX
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "music server observation is waiting for personal-state persistence"
+                );
+            }
+        }
+    }
+
+    /// Record which bridge imports are covered by a completed personal-state transaction.
+    pub(crate) fn note_open_subsonic_personal_state_commit(
+        &mut self,
+        app: &App,
+        state_identity: &str,
+    ) {
+        if !app
+            .personal_state
+            .ledger
+            .identity()
+            .is_ok_and(|identity| identity == state_identity)
+        {
+            return;
+        }
+        let committed = self
+            .open_subsonic_pending_imports
+            .iter()
+            .filter(|(_, envelope_id)| {
+                app.personal_state
+                    .ledger
+                    .operations
+                    .iter()
+                    .any(|operation| operation.operation_id == envelope_id.as_str())
+            })
+            .map(|(acknowledgement_id, _)| acknowledgement_id.clone())
+            .collect::<Vec<_>>();
+        for acknowledgement_id in committed {
+            self.open_subsonic_pending_imports
+                .remove(&acknowledgement_id);
+            self.open_subsonic_committed_imports
+                .insert(acknowledgement_id);
+        }
+    }
+
+    /// Queue one exact playback action into the credential owner's durable bridge store.
+    pub(crate) fn queue_open_subsonic_scrobble(
+        &mut self,
+        event_id: String,
+        kind: crate::open_subsonic::OpenSubsonicScrobbleKind,
+        track: crate::scrobble::ScrobbleTrack,
+        confirmation: Option<crate::scrobble::OpenSubsonicSubmissionAck>,
+    ) {
+        let bridge_durable = confirmation
+            .as_ref()
+            .is_some_and(crate::scrobble::OpenSubsonicSubmissionAck::bridge_marker_is_durable);
+        let _admitted = admit_pending_scrobble(
+            &mut self.open_subsonic_pending_scrobbles,
+            PendingOpenSubsonicScrobble {
+                event_id,
+                kind,
+                track,
+                confirmation,
+                receipt: None,
+                source_receipt: None,
+                bridge_durable,
+                source_ack_durable: false,
+            },
+        );
+        self.drive_open_subsonic_scrobbles();
+    }
+
+    /// Retry acknowledgements, playback reports, and rating projection from the current ledger.
+    /// The identity guard makes the common owner turn allocation-free.
+    pub(crate) fn maintain_open_subsonic_bridge(&mut self, app: &App) {
+        self.drive_open_subsonic_scrobbles();
+        let Some(runtime) = self.open_subsonic_runtime.as_ref() else {
+            return;
+        };
+        let handle = runtime.handle();
+
+        let acknowledged = self
+            .open_subsonic_committed_imports
+            .iter()
+            .filter(|operation_id| {
+                handle
+                    .acknowledge_bridge_import((*operation_id).clone())
+                    .is_ok()
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        for operation_id in acknowledged {
+            self.open_subsonic_committed_imports.remove(&operation_id);
+        }
+
+        match poll_rating_projection_receipt(&mut self.open_subsonic_pending_rating) {
+            RatingProjectionReceipt::Idle => {}
+            RatingProjectionReceipt::Waiting => return,
+            RatingProjectionReceipt::Durable(identity) => {
+                self.open_subsonic_rating_identity = Some(identity);
+            }
+            RatingProjectionReceipt::Retry(Some(error)) => {
+                tracing::warn!(
+                    reason = %error,
+                    "music server ratings are waiting for local durability"
+                );
+            }
+            RatingProjectionReceipt::Retry(None) => {}
+        }
+
+        let Ok(identity) = app.personal_state.ledger.identity() else {
+            return;
+        };
+        if self.open_subsonic_rating_identity.as_deref() == Some(identity.as_str()) {
+            return;
+        }
+        let winners =
+            match crate::personal_state::open_subsonic_rating_winners(&app.personal_state.ledger) {
+                Ok(winners) => winners,
+                Err(error) => {
+                    tracing::warn!(%error, "music server rating projection could not be prepared");
+                    return;
+                }
+            };
+        if let Ok(receipt) = handle.reconcile_ratings(winners) {
+            self.open_subsonic_pending_rating =
+                Some(PendingOpenSubsonicRatingProjection { identity, receipt });
+        }
+    }
+
+    pub(crate) fn reset_open_subsonic_rating_projection(&mut self) {
+        self.open_subsonic_rating_identity = None;
+        self.open_subsonic_pending_rating = None;
+    }
+
+    /// Give already-ready bridge receipts one final owner-lane pump without waiting for the
+    /// credential actor. A Submission that is still queued or in flight remains protected by the
+    /// scrobble JSONL marker; ratings remain derivable from the durable personal-state ledger.
+    pub(crate) fn pump_open_subsonic_for_shutdown(
+        &mut self,
+        _app: &App,
+    ) -> Result<(), crate::open_subsonic::ServiceError> {
+        match poll_rating_projection_receipt(&mut self.open_subsonic_pending_rating) {
+            RatingProjectionReceipt::Durable(identity) => {
+                self.open_subsonic_rating_identity = Some(identity);
+            }
+            RatingProjectionReceipt::Retry(Some(error)) => return Err(error),
+            RatingProjectionReceipt::Idle
+            | RatingProjectionReceipt::Waiting
+            | RatingProjectionReceipt::Retry(None) => {}
+        }
+
+        loop {
+            let Some(pending) = self.open_subsonic_pending_scrobbles.front_mut() else {
+                return Ok(());
+            };
+            if pending
+                .confirmation
+                .as_ref()
+                .is_some_and(crate::scrobble::OpenSubsonicSubmissionAck::account_scope_is_retired)
+            {
+                self.open_subsonic_pending_scrobbles.pop_front();
+                continue;
+            }
+            if pending.confirmation.as_ref().is_some_and(
+                crate::scrobble::OpenSubsonicSubmissionAck::account_scope_retirement_is_pending,
+            ) {
+                return Ok(());
+            }
+            if pending.bridge_durable {
+                if pending.kind == crate::open_subsonic::OpenSubsonicScrobbleKind::Submission
+                    && let Some(confirmation) = pending.confirmation.as_ref()
+                {
+                    if !confirmation.bridge_marker_is_durable() {
+                        // This may or may not finish before teardown. Pending and intermediate
+                        // journal states are both restart-safe.
+                        let _ = confirmation.confirm_bridge_durable();
+                    } else if pending.source_ack_durable {
+                        let _ = confirmation.confirm_source_acknowledged();
+                    } else if let Some(receipt) = pending.source_receipt.as_mut() {
+                        match receipt.try_recv() {
+                            Ok(Ok(())) => {
+                                let _ = confirmation.confirm_source_acknowledged();
+                            }
+                            Ok(Err(error)) if wrong_account_scope(&error) => {
+                                pending.source_receipt = None;
+                                request_scope_retirement(pending);
+                                return Ok(());
+                            }
+                            Ok(Err(error)) => return Err(error),
+                            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+                            | Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {}
+                        }
+                    } else if let Some(runtime) = self.open_subsonic_runtime.as_ref() {
+                        let _ = runtime.handle().acknowledge_scrobble_source(
+                            pending.event_id.clone(),
+                            pending.track.clone(),
+                        );
+                    }
+                }
+                self.open_subsonic_pending_scrobbles.pop_front();
+                continue;
+            }
+            if let Some(receipt) = pending.receipt.as_mut() {
+                match receipt.try_recv() {
+                    Ok(Ok(())) => {
+                        pending.receipt = None;
+                        pending.bridge_durable = true;
+                        continue;
+                    }
+                    Ok(Err(error)) if wrong_account_scope(&error) => {
+                        pending.receipt = None;
+                        if pending.kind
+                            == crate::open_subsonic::OpenSubsonicScrobbleKind::NowPlaying
+                        {
+                            self.open_subsonic_pending_scrobbles.pop_front();
+                            continue;
+                        }
+                        request_scope_retirement(pending);
+                        return Ok(());
+                    }
+                    Ok(Err(error))
+                        if pending.kind
+                            == crate::open_subsonic::OpenSubsonicScrobbleKind::NowPlaying =>
+                    {
+                        tracing::debug!(
+                            reason = %error,
+                            "ephemeral music server now-playing report retired during shutdown"
+                        );
+                        self.open_subsonic_pending_scrobbles.pop_front();
+                        continue;
+                    }
+                    Ok(Err(error)) => return Err(error),
+                    Err(tokio::sync::oneshot::error::TryRecvError::Empty) => return Ok(()),
+                    Err(tokio::sync::oneshot::error::TryRecvError::Closed) => return Ok(()),
+                }
+            }
+            if let Some(runtime) = self.open_subsonic_runtime.as_ref() {
+                let handle = runtime.handle();
+                match handle.queue_scrobble(
+                    pending.event_id.clone(),
+                    pending.kind,
+                    pending.track.clone(),
+                ) {
+                    Ok(receipt) => {
+                        pending.receipt = Some(receipt);
+                        continue;
+                    }
+                    Err(error) => {
+                        tracing::debug!(
+                            reason = %error,
+                            "music server playback report remains journaled for restart replay"
+                        );
+                    }
+                }
+            }
+            return Ok(());
+        }
+    }
+
+    fn drive_open_subsonic_scrobbles(&mut self) {
+        loop {
+            let Some(pending) = self.open_subsonic_pending_scrobbles.front_mut() else {
+                return;
+            };
+            if pending
+                .confirmation
+                .as_ref()
+                .is_some_and(crate::scrobble::OpenSubsonicSubmissionAck::account_scope_is_retired)
+            {
+                self.open_subsonic_pending_scrobbles.pop_front();
+                continue;
+            }
+            if pending.confirmation.as_ref().is_some_and(
+                crate::scrobble::OpenSubsonicSubmissionAck::account_scope_retirement_is_pending,
+            ) {
+                return;
+            }
+            if pending.kind == crate::open_subsonic::OpenSubsonicScrobbleKind::NowPlaying
+                && pending.bridge_durable
+            {
+                self.open_subsonic_pending_scrobbles.pop_front();
+                continue;
+            }
+            if !pending.bridge_durable {
+                if let Some(receipt) = pending.receipt.as_mut() {
+                    match receipt.try_recv() {
+                        Ok(Ok(())) => {
+                            pending.receipt = None;
+                            pending.bridge_durable = true;
+                            continue;
+                        }
+                        Ok(Err(error)) if wrong_account_scope(&error) => {
+                            pending.receipt = None;
+                            if pending.kind
+                                == crate::open_subsonic::OpenSubsonicScrobbleKind::NowPlaying
+                            {
+                                self.open_subsonic_pending_scrobbles.pop_front();
+                                continue;
+                            }
+                            request_scope_retirement(pending);
+                            return;
+                        }
+                        Ok(Err(error)) => {
+                            tracing::warn!(
+                                reason = %error,
+                                "music server playback report is waiting for local durability"
+                            );
+                            pending.receipt = None;
+                            return;
+                        }
+                        Err(tokio::sync::oneshot::error::TryRecvError::Empty) => return,
+                        Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                            pending.receipt = None;
+                            return;
+                        }
+                    }
+                }
+                let Some(runtime) = self.open_subsonic_runtime.as_ref() else {
+                    return;
+                };
+                let handle = runtime.handle();
+                match handle.queue_scrobble(
+                    pending.event_id.clone(),
+                    pending.kind,
+                    pending.track.clone(),
+                ) {
+                    Ok(receipt) => {
+                        pending.receipt = Some(receipt);
+                        return;
+                    }
+                    Err(_) => return,
+                }
+            }
+
+            let Some(confirmation) = pending.confirmation.as_ref() else {
+                self.open_subsonic_pending_scrobbles.pop_front();
+                continue;
+            };
+            if !confirmation.bridge_marker_is_durable() {
+                match confirmation.confirm_bridge_durable() {
+                    Ok(()) | Err(crate::util::delivery::DeliveryError::Busy) => return,
+                    Err(crate::util::delivery::DeliveryError::Closed) => {
+                        // The marker remains in its Pending state and will replay against the
+                        // bridge's durable row on restart.
+                        self.open_subsonic_pending_scrobbles.pop_front();
+                        continue;
+                    }
+                    Err(_) => return,
+                }
+            }
+            if !pending.source_ack_durable {
+                if let Some(receipt) = pending.source_receipt.as_mut() {
+                    match receipt.try_recv() {
+                        Ok(Ok(())) => {
+                            pending.source_receipt = None;
+                            pending.source_ack_durable = true;
+                            continue;
+                        }
+                        Ok(Err(error)) if wrong_account_scope(&error) => {
+                            pending.source_receipt = None;
+                            request_scope_retirement(pending);
+                            return;
+                        }
+                        Ok(Err(error)) => {
+                            tracing::warn!(
+                                reason = %error,
+                                "music server source acknowledgement is waiting for durability"
+                            );
+                            pending.source_receipt = None;
+                            return;
+                        }
+                        Err(tokio::sync::oneshot::error::TryRecvError::Empty) => return,
+                        Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                            pending.source_receipt = None;
+                            return;
+                        }
+                    }
+                }
+                let Some(runtime) = self.open_subsonic_runtime.as_ref() else {
+                    return;
+                };
+                match runtime
+                    .handle()
+                    .acknowledge_scrobble_source(pending.event_id.clone(), pending.track.clone())
+                {
+                    Ok(receipt) => {
+                        pending.source_receipt = Some(receipt);
+                        return;
+                    }
+                    Err(_) => return,
+                }
+            }
+            if confirmation.source_marker_is_removed() {
+                self.open_subsonic_pending_scrobbles.pop_front();
+                continue;
+            }
+            match confirmation.confirm_source_acknowledged() {
+                Ok(()) | Err(crate::util::delivery::DeliveryError::Busy) => return,
+                Err(crate::util::delivery::DeliveryError::Closed) => {
+                    // The bridge already knows the source is acknowledged. The intermediate
+                    // journal marker will replay only this idempotent finalization after restart.
+                    self.open_subsonic_pending_scrobbles.pop_front();
+                    continue;
+                }
+                Err(_) => return,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        OWNER_BRIDGE_IMPORT_TRACKING_MAX, PendingOpenSubsonicRatingProjection,
+        PendingOpenSubsonicScrobble, RatingProjectionReceipt, admit_pending_scrobble,
+        bridge_import_tracking_has_capacity, poll_rating_projection_receipt,
+    };
+
+    fn pending(
+        event_id: impl Into<String>,
+        kind: crate::open_subsonic::OpenSubsonicScrobbleKind,
+        confirmation: Option<crate::scrobble::OpenSubsonicSubmissionAck>,
+    ) -> PendingOpenSubsonicScrobble {
+        PendingOpenSubsonicScrobble {
+            event_id: event_id.into(),
+            kind,
+            track: crate::scrobble::ScrobbleTrack {
+                key: "server-song".to_owned(),
+                open_subsonic_item: None,
+                artist: "Artist".to_owned(),
+                title: "Song".to_owned(),
+                album: None,
+                duration_secs: Some(180),
+                origin_url: None,
+                started_unix: 100,
+            },
+            confirmation,
+            receipt: None,
+            source_receipt: None,
+            bridge_durable: false,
+            source_ack_durable: false,
+        }
+    }
+
+    #[test]
+    fn tui_rating_projection_waits_for_durability_receipt() {
+        let (reply, receipt) = tokio::sync::oneshot::channel();
+        let mut pending = Some(PendingOpenSubsonicRatingProjection {
+            identity: "durable-ledger".to_owned(),
+            receipt,
+        });
+
+        assert!(matches!(
+            poll_rating_projection_receipt(&mut pending),
+            RatingProjectionReceipt::Waiting
+        ));
+        assert!(pending.is_some());
+
+        reply.send(Ok(())).unwrap();
+        assert!(matches!(
+            poll_rating_projection_receipt(&mut pending),
+            RatingProjectionReceipt::Durable(identity) if identity == "durable-ledger"
+        ));
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn tui_owner_queue_coalesces_ephemeral_reports_and_bounds_submission_backlog() {
+        use crate::open_subsonic::{
+            OWNER_PLAYBACK_REPORT_QUEUE_MAX, OpenSubsonicScrobbleKind as Kind,
+        };
+
+        let mut queue = std::collections::VecDeque::new();
+        assert!(admit_pending_scrobble(
+            &mut queue,
+            pending("now-1", Kind::NowPlaying, None)
+        ));
+        assert!(admit_pending_scrobble(
+            &mut queue,
+            pending("now-2", Kind::NowPlaying, None)
+        ));
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue.front().unwrap().event_id, "now-2");
+
+        queue.clear();
+        for index in 0..OWNER_PLAYBACK_REPORT_QUEUE_MAX {
+            queue.push_back(pending(
+                format!("submission-{index}"),
+                Kind::Submission,
+                None,
+            ));
+        }
+        assert!(!admit_pending_scrobble(
+            &mut queue,
+            pending("now-at-cap", Kind::NowPlaying, None)
+        ));
+        assert_eq!(queue.len(), OWNER_PLAYBACK_REPORT_QUEUE_MAX);
+        assert!(queue.iter().all(|queued| queued.kind == Kind::Submission));
+    }
+
+    #[test]
+    fn tui_owner_queue_retries_a_deferred_submission_after_same_run_capacity_release() {
+        use crate::open_subsonic::{
+            OWNER_PLAYBACK_REPORT_QUEUE_MAX, OpenSubsonicScrobbleKind as Kind,
+        };
+
+        let (confirmation_tx, mut confirmation_rx) = tokio::sync::mpsc::channel(2);
+        let _keepalive = confirmation_tx.clone();
+        let oldest_confirmation =
+            crate::scrobble::OpenSubsonicSubmissionAck::new("oldest".to_owned(), confirmation_tx);
+        let mut queue = std::collections::VecDeque::new();
+        queue.push_back(pending(
+            "oldest",
+            Kind::Submission,
+            Some(oldest_confirmation),
+        ));
+        for index in 1..OWNER_PLAYBACK_REPORT_QUEUE_MAX {
+            queue.push_back(pending(
+                format!("submission-{index}"),
+                Kind::Submission,
+                None,
+            ));
+        }
+
+        let newest_confirmation = crate::scrobble::OpenSubsonicSubmissionAck::new(
+            "newest".to_owned(),
+            _keepalive.clone(),
+        );
+        assert!(!admit_pending_scrobble(
+            &mut queue,
+            pending(
+                "newest",
+                Kind::Submission,
+                Some(newest_confirmation.clone())
+            )
+        ));
+        assert_eq!(queue.len(), OWNER_PLAYBACK_REPORT_QUEUE_MAX);
+        assert!(queue.iter().any(|queued| queued.event_id == "oldest"));
+        assert!(!queue.iter().any(|queued| queued.event_id == "newest"));
+        assert!(newest_confirmation.submission_is_deferred());
+        assert!(matches!(
+            confirmation_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+
+        queue.pop_front();
+        assert!(newest_confirmation.take_deferred_submission());
+        assert!(admit_pending_scrobble(
+            &mut queue,
+            pending(
+                "newest",
+                Kind::Submission,
+                Some(newest_confirmation.clone())
+            )
+        ));
+        assert_eq!(queue.len(), OWNER_PLAYBACK_REPORT_QUEUE_MAX);
+        assert_eq!(
+            queue
+                .iter()
+                .filter(|queued| queued.event_id == "newest")
+                .count(),
+            1
+        );
+
+        let duplicate_confirmation =
+            crate::scrobble::OpenSubsonicSubmissionAck::new("newest".to_owned(), _keepalive);
+        assert!(!admit_pending_scrobble(
+            &mut queue,
+            pending(
+                "newest",
+                Kind::Submission,
+                Some(duplicate_confirmation.clone())
+            )
+        ));
+        assert!(!duplicate_confirmation.submission_is_deferred());
+        assert_eq!(queue.len(), OWNER_PLAYBACK_REPORT_QUEUE_MAX);
+    }
+
+    #[test]
+    fn tui_scope_retirement_is_distinct_and_only_matches_wrong_account_scope() {
+        use crate::open_subsonic::{OpenSubsonicScrobbleKind as Kind, ServerError, ServiceError};
+
+        let (ack_tx, mut ack_rx) = tokio::sync::mpsc::channel(2);
+        let confirmation =
+            crate::scrobble::OpenSubsonicSubmissionAck::new("old-a".to_owned(), ack_tx);
+        let stale = pending("old-a", Kind::Submission, Some(confirmation.clone()));
+        let mismatch = ServiceError::Server(ServerError::WrongAccountScope);
+
+        assert!(super::wrong_account_scope(&mismatch));
+        assert!(!super::wrong_account_scope(&ServiceError::InvalidSetup));
+        super::request_scope_retirement(&stale);
+        assert!(confirmation.account_scope_retirement_is_pending());
+        assert!(!confirmation.bridge_marker_is_durable());
+        assert!(ack_rx.try_recv().is_ok());
+
+        confirmation.mark_account_scope_retired();
+        assert!(confirmation.account_scope_is_retired());
+
+        let ephemeral = pending("now-a", Kind::NowPlaying, None);
+        super::request_scope_retirement(&ephemeral);
+        assert!(matches!(
+            ack_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[test]
+    fn owner_import_handoff_refuses_overflow_without_inventing_an_acknowledgement() {
+        let pending = std::collections::BTreeMap::new();
+        let mut committed = std::collections::BTreeSet::new();
+        for index in 0..OWNER_BRIDGE_IMPORT_TRACKING_MAX {
+            committed.insert(format!("committed-{index}"));
+        }
+
+        assert!(!bridge_import_tracking_has_capacity(&pending, &committed));
+        assert_eq!(committed.len(), OWNER_BRIDGE_IMPORT_TRACKING_MAX);
+        assert!(pending.is_empty());
+        assert!(!committed.contains("overflow-import"));
+    }
+}

--- a/src/runtime/open_subsonic_runtime.rs
+++ b/src/runtime/open_subsonic_runtime.rs
@@ -25,7 +25,8 @@ impl RuntimeHandles {
                 let result = if read_only {
                     crate::open_subsonic::load_actor_read_only(&paths).await
                 } else {
-                    crate::open_subsonic::load_actor(&paths).await
+                    let sink = super::open_subsonic_bridge_sink(emitter.clone());
+                    crate::open_subsonic::load_actor_with_bridge_sink(&paths, Some(sink)).await
                 };
                 emitter
                     .emit_terminal(RuntimeEvent::OpenSubsonicReloaded { generation, result })
@@ -55,13 +56,25 @@ impl RuntimeHandles {
                 runtime.activate();
                 self.open_subsonic_routes.install(runtime.route_provider());
                 self.open_subsonic_runtime = Some(runtime);
+                self.reset_open_subsonic_rating_projection();
             }
             Ok(None) => {
                 self.retire_open_subsonic_runtime();
             }
             Err(error) => {
-                self.retire_open_subsonic_runtime();
-                tracing::warn!(reason = %error, "music server runtime is unavailable");
+                // Refresh probes leave the active global owner installed, so their transient
+                // failure may retain the working route. A committed remove/history mutation
+                // revokes that owner first; never keep its stale local route object afterward.
+                let retain_existing =
+                    retain_after_reload_error(crate::open_subsonic::current_handle().is_some());
+                if !retain_existing {
+                    self.retire_open_subsonic_runtime();
+                }
+                tracing::warn!(
+                    reason = %error,
+                    retained_existing = retain_existing && self.open_subsonic_runtime.is_some(),
+                    "music server runtime is unavailable"
+                );
             }
         }
         true
@@ -71,5 +84,10 @@ impl RuntimeHandles {
     pub(crate) fn retire_open_subsonic_runtime(&mut self) {
         self.open_subsonic_routes.disable();
         self.open_subsonic_runtime = None;
+        self.reset_open_subsonic_rating_projection();
     }
+}
+
+pub(super) const fn retain_after_reload_error(current_owner_alive: bool) -> bool {
+    current_owner_alive
 }

--- a/src/runtime/player_delivery.rs
+++ b/src/runtime/player_delivery.rs
@@ -673,24 +673,16 @@ impl super::RuntimeHandles {
         }
     }
 
-    /// Close owner/player/background admission and retire the active process before slower
-    /// shutdown.
+    /// Close player/background admission and retire the active process before slower shutdown.
     /// Repeated calls are harmless, which lets every owner-exit branch latch teardown eagerly and
     /// the common cleanup path enforce it once more defensively.
     pub fn begin_player_shutdown(&mut self, app: &mut App) {
-        // This is the shutdown ordering boundary for every owner producer. Close the shared
-        // ingress first, while task admission is still open: completions which finish from this
-        // point onward retain their exact event in the task outbox. Consequently no later actor
-        // event can enter the main queue and overtake that fallback during the final drain.
-        self.worker_tx.close_admission();
         // Manual WebDAV preparation is deliberately detached from the joined runtime task set.
         // Settle its retained caller before remote wire shutdown; a late candidate is discarded by
         // the reducer and cannot install after this owner boundary.
         app.settle_personal_sync_shutdown();
         let follow_ups =
             begin_player_shutdown_state(&mut self.player, &mut self.pending_player_intents, app);
-        // No credential-owning loopback listener or minted route outlives the audio owner.
-        self.retire_open_subsonic_runtime();
         for follow_up in follow_ups {
             self.dispatch(app, follow_up);
         }
@@ -699,9 +691,10 @@ impl super::RuntimeHandles {
         for follow_up in app.settle_recorder_owner_shutdown() {
             self.dispatch(app, follow_up);
         }
-        // Automatic recorder Saves cross their synchronous journal boundary above. Their terminal
-        // result now targets the fallback outbox because owner ingress is already closed. Closing
-        // the pool rejects any later worker while the accepted journal/source remains recoverable.
+        // Automatic recorder Saves cross their synchronous journal boundary above. Closing the
+        // pool rejects any later worker while accepted completions retain their terminal outbox.
+        // The shared owner ingress and credential runtime stay live until the scrobble producer is
+        // joined and its final playback report crosses local durability.
         self.background_tasks.close_admission();
     }
 

--- a/src/runtime/read_only.rs
+++ b/src/runtime/read_only.rs
@@ -34,6 +34,7 @@ pub(super) fn durable_mutation_component(cmd: &Cmd) -> Option<&'static str> {
         Cmd::MusicServer(
             crate::app::MusicServerCommand::TestAndPrepare { .. }
             | crate::app::MusicServerCommand::Commit { .. }
+            | crate::app::MusicServerCommand::DisableHistory { .. }
             | crate::app::MusicServerCommand::Remove { .. },
         ) => Some("music server settings"),
         Cmd::PlayerControl(_)

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -6,6 +6,7 @@ use crate::util::event_policy::{EventKey, EventLane, EventPolicy};
 
 mod coalescing;
 mod downloads;
+mod music_server;
 mod persistence;
 mod player_startup;
 mod policy;

--- a/src/runtime/tests/music_server.rs
+++ b/src/runtime/tests/music_server.rs
@@ -1,0 +1,41 @@
+#[test]
+fn coherent_reload_resolves_remove_ambiguity_and_failure() {
+    let store_error = crate::open_subsonic::ServiceError::Store(
+        crate::open_subsonic::StoreError::StorageUnavailable,
+    );
+    assert_eq!(
+        super::super::dispatch::resolve_music_server_remove(Some(store_error), Ok(false)),
+        Ok(())
+    );
+    assert_eq!(
+        super::super::dispatch::resolve_music_server_remove(Some(store_error), Ok(true)),
+        Err(crate::app::MusicServerFailure::Storage)
+    );
+    assert_eq!(
+        super::super::dispatch::resolve_music_server_remove(
+            None,
+            Err(crate::open_subsonic::ServiceError::ActorUnavailable),
+        ),
+        Err(crate::app::MusicServerFailure::Unavailable)
+    );
+}
+
+#[test]
+fn failed_reload_retains_only_a_live_global_owner() {
+    assert!(super::super::open_subsonic_runtime::retain_after_reload_error(true));
+    assert!(!super::super::open_subsonic_runtime::retain_after_reload_error(false));
+}
+
+#[test]
+fn live_connection_does_not_hide_playback_reports_needing_a_decision() {
+    use crate::app::MusicServerHealth;
+
+    assert_eq!(
+        super::super::dispatch::live_music_server_health(0),
+        MusicServerHealth::UpToDate
+    );
+    assert_eq!(
+        super::super::dispatch::live_music_server_health(1),
+        MusicServerHealth::NeedsAttention
+    );
+}

--- a/src/scrobble/actor.rs
+++ b/src/scrobble/actor.rs
@@ -3,8 +3,11 @@
 //! [`super::ScrobbleHandle::observe`]; talks back only for auth results and rare
 //! service-health notices (scrobbling itself is fire-and-forget from the app's view).
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use tokio::sync::mpsc::Receiver;
@@ -14,7 +17,10 @@ use tokio::sync::oneshot;
 use super::lastfm::{LastfmClient, SCROBBLE_BATCH_MAX, SessionPoll};
 use super::listenbrainz::ListenBrainzClient;
 use super::monitor::{ScrobbleAction, ScrobbleMonitor};
-use super::queue::{QUEUE_CAP, QueueEntry, QueueFile, QueueFlushLock, compact};
+use super::queue::{
+    OPEN_SUBSONIC_QUEUE_CAP, QUEUE_CAP, QueueDropSummary, QueueEntry, QueueFile, QueueFlushLock,
+    compact,
+};
 use super::service::{ScrobbleError, ScrobbleService, ScrobbleTrack, ServiceKind};
 use super::{
     ObservationBatch, PendingCommands, ScrobbleHandle, ScrobbleSettings, ShutdownRequest,
@@ -22,6 +28,12 @@ use super::{
 };
 use crate::util::backpressure::{SCROBBLE_CONTROL_QUEUE, SCROBBLE_QUEUE, bounded_channel};
 use crate::util::delivery::DeliveryError;
+
+mod open_subsonic_ack;
+pub use open_subsonic_ack::OpenSubsonicSubmissionAck;
+#[cfg(test)]
+use open_subsonic_ack::{MARKER_ACK_IDLE, MARKER_ACK_QUEUED, OpenSubsonicMarkerAckStage};
+use open_subsonic_ack::{OpenSubsonicMarkerAckRequest, PendingOpenSubsonicMarkerAcks};
 
 /// Debounce between a queue append and the flush that delivers it.
 const FLUSH_DEBOUNCE: Duration = Duration::from_secs(2);
@@ -53,6 +65,10 @@ pub enum ScrobbleCmd {
 }
 
 /// Events back to the app. No `Debug`: `AuthDone` carries the session key.
+#[allow(
+    clippy::large_enum_variant,
+    reason = "submission events cross a bounded channel and retaining the full track avoids a second allocation"
+)]
 pub enum ScrobbleEvent {
     /// Open this URL for the user (and show it, in case the browser can't launch).
     AuthUrl(String),
@@ -70,11 +86,21 @@ pub enum ScrobbleEvent {
     QueueStalled {
         pending: usize,
     },
-    /// The offline queue exceeded its retention cap and oldest entries were dropped.
+    /// A queue retention category exceeded its cap and eligible delivery markers were dropped.
     /// `dropped` is the actor-lifetime cumulative total, so a latest-value event transport
     /// may coalesce repeated notifications without understating permanent data loss.
     QueueDropped {
         dropped: usize,
+    },
+    /// An exact OpenSubsonic item crossed a playback threshold. Delivery to the server
+    /// bridge stays on the playback owner's durable work lane; the scrobble actor never
+    /// owns server credentials or mutates the bridge store directly.
+    OpenSubsonic {
+        event_id: String,
+        kind: crate::open_subsonic::OpenSubsonicScrobbleKind,
+        track: ScrobbleTrack,
+        /// Present only for durable submissions. Now-playing remains an ephemeral notification.
+        confirmation: Option<OpenSubsonicSubmissionAck>,
     },
 }
 
@@ -236,9 +262,12 @@ struct Actor {
     auth_task: Option<tokio::task::JoinHandle<()>>,
     next_flush: Option<Instant>,
     last_stall_notice: Option<Instant>,
-    /// Threshold crossings whose durable append failed. The bound matches the on-disk retention
-    /// cap; overflow follows the same explicit oldest-first loss policy as queue compaction.
+    /// Threshold crossings whose durable append failed. Either retention category may briefly
+    /// exceed its cap while the redacted loss audit is unavailable; command ingress pauses until
+    /// retry resolves that durable boundary.
     pending_appends: VecDeque<QueueEntry>,
+    pending_generic_appends: usize,
+    pending_open_subsonic_appends: usize,
     /// Queue ownership retained across an ambiguous append result. A retry uses `append_locked`
     /// with this exact guard, avoiding self-deadlock and excluding cross-process resubmission.
     pending_append_lock: Option<QueueFlushLock>,
@@ -248,9 +277,24 @@ struct Actor {
     /// Latches append-health notifications so a full disk produces one failure and one recovery
     /// event instead of a toast on every observation/retry.
     append_failure_active: bool,
+    /// A malformed/unreadable queue is fail-closed and surfaces one needs-attention event until a
+    /// later strict load succeeds.
+    queue_read_failure_active: bool,
     /// Actor-lifetime cumulative permanent loss. Events publish this total rather than a delta,
     /// which makes replacement/coalescing safe under event-channel pressure.
     dropped_total: usize,
+    /// A cap replacement whose write acknowledgement was ambiguous. The next strict queue load
+    /// decides whether the audited removal was installed before publishing its loss notification.
+    pending_queue_drop_outcome: Option<QueueDropSummary>,
+    /// Separate from the observation inbox so a bridge durability acknowledgement never waits
+    /// behind heartbeat coalescing or participates in its shutdown admission barrier.
+    open_subsonic_ack_tx: tokio::sync::mpsc::Sender<OpenSubsonicMarkerAckRequest>,
+    /// Owner-confirmed markers waiting for one successful atomic queue rewrite.
+    pending_open_subsonic_acks: HashMap<String, PendingOpenSubsonicMarkerAcks>,
+    /// Durable submissions are announced once per actor lifetime unless the credential owner's
+    /// bounded queue explicitly defers them. The shared flag permits a same-process retry while
+    /// the map remains bounded by the exact durable queue cap.
+    announced_open_subsonic: HashMap<String, Arc<AtomicBool>>,
     /// In-flight love/unlove sub-tasks keyed by `(artist, title)`. A newer toggle for the same
     /// track aborts the prior one (last-writer-wins) so rapid liking can't settle the wrong way.
     love_tasks: HashMap<(String, String), tokio::task::JoinHandle<()>>,
@@ -264,6 +308,7 @@ async fn run_actor(
     emit: EventSink,
     queue: Option<QueueFile>,
 ) {
+    let (open_subsonic_ack_tx, mut open_subsonic_ack_rx) = bounded_channel(SCROBBLE_CONTROL_QUEUE);
     let http = reqwest::Client::builder()
         .user_agent(format!("yututui/{}", env!("CARGO_PKG_VERSION")))
         .timeout(Duration::from_secs(15))
@@ -283,15 +328,22 @@ async fn run_actor(
         next_flush: None,
         last_stall_notice: None,
         pending_appends: VecDeque::new(),
+        pending_generic_appends: 0,
+        pending_open_subsonic_appends: 0,
         pending_append_lock: None,
         pending_compaction: None,
         append_failure_active: false,
+        queue_read_failure_active: false,
         dropped_total: 0,
+        pending_queue_drop_outcome: None,
+        open_subsonic_ack_tx,
+        pending_open_subsonic_acks: HashMap::new(),
+        announced_open_subsonic: HashMap::new(),
         love_tasks: HashMap::new(),
     };
-    // Leftovers from the previous run (crash, offline quit) get an early delivery try —
-    // but only when something could receive them.
-    if actor.settings.any_active() {
+    // Leftovers from the previous run include durable OpenSubsonic submissions even when no
+    // external scrobble service is active, so every writable queue gets an early replay pass.
+    if actor.queue.is_some() {
         actor.schedule_flush(FLUSH_ON_START);
     }
 
@@ -309,7 +361,12 @@ async fn run_actor(
                     break;
                 }
             },
-            cmd = rx.recv() => match cmd {
+            acknowledgement = open_subsonic_ack_rx.recv() => {
+                if let Some(event_id) = acknowledgement {
+                    actor.confirm_open_subsonic_submission(event_id);
+                }
+            },
+            cmd = rx.recv(), if actor.accepts_command_ingress() => match cmd {
                 None => break,
                 Some(ScrobbleCmd::Observe(obs)) => {
                     // Commit durable actions before polling any ephemeral network work. If
@@ -487,7 +544,76 @@ fn emit_queue_drop(dropped_total: &mut usize, emit: &EventSink, dropped: usize) 
     });
 }
 
+fn publish_queue_drop(dropped_total: &mut usize, emit: &EventSink, dropped: &QueueDropSummary) {
+    tracing::warn!(
+        generic_dropped = dropped.generic_dropped(),
+        open_subsonic_dropped = dropped.open_subsonic_dropped(),
+        "scrobble queue exceeded a retention cap; dropped eligible markers"
+    );
+    emit_queue_drop(dropped_total, emit, dropped.affected_entries());
+}
+
+fn announce_open_subsonic_submission(
+    emit: &EventSink,
+    acknowledgement_tx: &tokio::sync::mpsc::Sender<OpenSubsonicMarkerAckRequest>,
+    announced: &mut HashMap<String, Arc<AtomicBool>>,
+    entry: &QueueEntry,
+) {
+    if !entry.open_subsonic_pending
+        || !entry.open_subsonic_handoff_started
+        || entry.open_subsonic_item.is_none()
+    {
+        return;
+    }
+    let (deferred_submission, should_emit) = match announced.entry(entry.id.clone()) {
+        std::collections::hash_map::Entry::Vacant(slot) => {
+            let signal = Arc::new(AtomicBool::new(false));
+            slot.insert(Arc::clone(&signal));
+            (signal, true)
+        }
+        std::collections::hash_map::Entry::Occupied(slot) => {
+            let signal = Arc::clone(slot.get());
+            let retry = signal.swap(false, Ordering::AcqRel);
+            (signal, retry)
+        }
+    };
+    if !should_emit {
+        return;
+    }
+    (emit)(ScrobbleEvent::OpenSubsonic {
+        event_id: entry.id.clone(),
+        kind: crate::open_subsonic::OpenSubsonicScrobbleKind::Submission,
+        track: entry.to_track(),
+        confirmation: Some(OpenSubsonicSubmissionAck::with_bridge_marker_state(
+            entry.id.clone(),
+            acknowledgement_tx.clone(),
+            entry.open_subsonic_bridge_durable,
+            deferred_submission,
+        )),
+    });
+}
+
+fn prune_announced_open_subsonic(
+    announced: &mut HashMap<String, Arc<AtomicBool>>,
+    durable_entries: &[QueueEntry],
+) {
+    let pending = durable_entries
+        .iter()
+        .filter(|entry| entry.open_subsonic_pending)
+        .map(|entry| entry.id.as_str())
+        .collect::<HashSet<_>>();
+    announced.retain(|event_id, _| pending.contains(event_id.as_str()));
+    debug_assert!(announced.len() <= OPEN_SUBSONIC_QUEUE_CAP);
+}
+
 impl Actor {
+    fn accepts_command_ingress(&self) -> bool {
+        // Stop polling the bounded inbox after an accepted batch crosses either cap. Flush,
+        // acknowledgement, and shutdown lanes remain live while its loss audit is retried.
+        self.pending_generic_appends <= QUEUE_CAP
+            && self.pending_open_subsonic_appends <= OPEN_SUBSONIC_QUEUE_CAP
+    }
+
     fn record_observation_batch(&mut self, batch: ObservationBatch) -> Vec<ScrobbleTrack> {
         let (first, tail) = batch.into_parts();
         let mut actions = self.monitor.observe(&first, self.settings.local_files);
@@ -509,8 +635,13 @@ impl Actor {
                 // now-playing request. Shutdown is allowed to cancel those network
                 // awaits, but it must never cancel the durable queue append that was
                 // produced by the same observation.
-                ScrobbleAction::NowPlaying(track) => now_playing.push(track),
-                ScrobbleAction::Scrobble(track) => self.enqueue_scrobble(track),
+                ScrobbleAction::NowPlaying(track) => {
+                    self.emit_open_subsonic_now_playing(&track);
+                    now_playing.push(track);
+                }
+                ScrobbleAction::Scrobble(track) => {
+                    self.enqueue_scrobble(track);
+                }
                 ScrobbleAction::Love {
                     artist,
                     title,
@@ -519,6 +650,38 @@ impl Actor {
             }
         }
         now_playing
+    }
+
+    fn emit_open_subsonic_now_playing(&self, track: &ScrobbleTrack) {
+        if track.open_subsonic_item.is_some() {
+            (self.emit)(ScrobbleEvent::OpenSubsonic {
+                event_id: super::queue::next_event_id(track.started_unix),
+                kind: crate::open_subsonic::OpenSubsonicScrobbleKind::NowPlaying,
+                track: track.clone(),
+                confirmation: None,
+            });
+        }
+    }
+
+    fn confirm_open_subsonic_submission(&mut self, request: OpenSubsonicMarkerAckRequest) {
+        let event_id = request.event_id.clone();
+        if !self.pending_open_subsonic_acks.contains_key(&event_id)
+            && self.pending_open_subsonic_acks.len() >= OPEN_SUBSONIC_QUEUE_CAP
+        {
+            // The durable JSONL marker remains untouched and will replay on restart. Never evict
+            // an already accepted acknowledgement merely to make room for another one.
+            tracing::warn!(
+                capacity = OPEN_SUBSONIC_QUEUE_CAP,
+                "music server acknowledgement hand-off is full; durable marker remains queued"
+            );
+            request.retry();
+        } else {
+            self.pending_open_subsonic_acks
+                .entry(event_id)
+                .or_default()
+                .push(request);
+        }
+        self.schedule_flush(Duration::ZERO);
     }
 
     /// Now-playing is ephemeral: one attempt per service, never queued.
@@ -558,7 +721,7 @@ impl Actor {
             pending.push(ServiceKind::ListenBrainz);
         }
         let Some(_queue) = &self.queue else { return };
-        if pending.is_empty() {
+        if pending.is_empty() && track.open_subsonic_item.is_none() {
             return;
         }
         // Clock-skew guard: Last.fm rejects future timestamps.
@@ -566,17 +729,16 @@ impl Actor {
         if track.started_unix > now_unix + 60 {
             track.started_unix = now_unix - 1;
         }
-        let entry = QueueEntry::from_track(&track, pending);
-        if self.pending_appends.len() == QUEUE_CAP {
-            self.pending_appends.pop_front();
-            tracing::warn!(
-                capacity = QUEUE_CAP,
-                "pending scrobble append queue full; dropped oldest entry"
-            );
-            emit_queue_drop(&mut self.dropped_total, &self.emit, 1);
-        }
-        self.pending_appends.push_back(entry);
+        self.retain_pending_append(QueueEntry::from_track(&track, pending));
         let _ = self.retry_pending_appends();
+    }
+
+    fn retain_pending_append(&mut self, entry: QueueEntry) {
+        if entry.has_pending_delivery() {
+            self.pending_generic_appends += usize::from(!entry.pending.is_empty());
+            self.pending_open_subsonic_appends += usize::from(entry.open_subsonic_pending);
+            self.pending_appends.push_back(entry);
+        }
     }
 
     /// Retry retained appends in listen order. An append error can be ambiguous (the line may
@@ -585,6 +747,103 @@ impl Actor {
     /// stays held from the first uncertain result through its successful retry so another process
     /// cannot observe, submit, and remove that id between attempts.
     fn retry_pending_appends(&mut self) -> Result<(), DeliveryError> {
+        let generic_excess = self.pending_generic_appends.saturating_sub(QUEUE_CAP);
+        let exact_excess = self
+            .pending_open_subsonic_appends
+            .saturating_sub(OPEN_SUBSONIC_QUEUE_CAP);
+        if generic_excess > 0 || exact_excess > 0 {
+            if self.pending_append_lock.is_none() {
+                let lock = match self
+                    .queue
+                    .as_ref()
+                    .expect("pending appends require a durable queue")
+                    .try_lock_result()
+                {
+                    Ok(Some(lock)) => lock,
+                    Ok(None) => {
+                        self.note_append_failure(None);
+                        return Err(DeliveryError::Busy);
+                    }
+                    Err(error) => {
+                        self.note_append_failure(Some(&error));
+                        return Err(DeliveryError::Saturated);
+                    }
+                };
+                self.pending_append_lock = Some(lock);
+            }
+            let mut dropped = QueueDropSummary::default();
+            let generic_ids = self
+                .pending_appends
+                .iter()
+                .filter(|entry| !entry.pending.is_empty())
+                .take(generic_excess)
+                .map(|entry| entry.id.clone())
+                .collect::<HashSet<_>>();
+            for entry_id in &generic_ids {
+                dropped.note_generic(entry_id);
+            }
+            let exact_ids = self
+                .pending_appends
+                .iter()
+                .rev()
+                .filter(|entry| entry.open_subsonic_pending && !entry.open_subsonic_handoff_started)
+                .take(exact_excess)
+                .map(|entry| entry.id.clone())
+                .collect::<HashSet<_>>();
+            for entry_id in &exact_ids {
+                dropped.note_open_subsonic(entry_id);
+            }
+            if generic_ids.len() != generic_excess || exact_ids.len() != exact_excess {
+                tracing::error!(
+                    generic_excess,
+                    generic_eligible = generic_ids.len(),
+                    excess = exact_excess,
+                    eligible = exact_ids.len(),
+                    "protected pending delivery marker cannot be evicted from append memory"
+                );
+                self.note_append_failure(None);
+                return Err(DeliveryError::Saturated);
+            }
+            let audit = self
+                .queue
+                .as_ref()
+                .expect("pending appends require a durable queue")
+                .record_drop_audit_locked(
+                    &dropped,
+                    crate::signals::unix_now(),
+                    self.pending_append_lock
+                        .as_ref()
+                        .expect("pending overflow audit owns the queue lock"),
+                );
+            if let Err(error) = audit {
+                self.note_append_failure(Some(&error));
+                return Err(DeliveryError::Saturated);
+            }
+            for entry in &mut self.pending_appends {
+                if generic_ids.contains(&entry.id) {
+                    entry.pending.clear();
+                }
+                if exact_ids.contains(&entry.id) {
+                    entry.open_subsonic_pending = false;
+                    entry.open_subsonic_handoff_started = false;
+                    entry.open_subsonic_bridge_durable = false;
+                }
+            }
+            self.pending_appends
+                .retain(QueueEntry::has_pending_delivery);
+            self.pending_generic_appends = self
+                .pending_appends
+                .iter()
+                .filter(|entry| !entry.pending.is_empty())
+                .count();
+            self.pending_open_subsonic_appends = self
+                .pending_appends
+                .iter()
+                .filter(|entry| entry.open_subsonic_pending)
+                .count();
+            publish_queue_drop(&mut self.dropped_total, &self.emit, &dropped);
+        }
+
         let mut appended = 0usize;
         while let Some(entry) = self.pending_appends.front().cloned() {
             if self.pending_append_lock.is_none() {
@@ -618,7 +877,16 @@ impl Actor {
                 );
             match result {
                 Ok(()) => {
-                    self.pending_appends.pop_front();
+                    let appended_entry = self
+                        .pending_appends
+                        .pop_front()
+                        .expect("the appended entry remains at the queue front");
+                    self.pending_generic_appends = self
+                        .pending_generic_appends
+                        .saturating_sub(usize::from(!appended_entry.pending.is_empty()));
+                    self.pending_open_subsonic_appends = self
+                        .pending_open_subsonic_appends
+                        .saturating_sub(usize::from(appended_entry.open_subsonic_pending));
                     // A confirmed append ends this ownership interval. A later pending entry
                     // obtains a fresh guard so other processes are not excluded unnecessarily.
                     self.pending_append_lock = None;
@@ -832,16 +1100,142 @@ impl Actor {
         if loaded.read_failed {
             // Present but unreadable: skip the whole round so we never compact-to-empty and
             // delete a queue we simply couldn't read. Retried on the next natural flush.
+            if !self.queue_read_failure_active {
+                self.queue_read_failure_active = true;
+                (self.emit)(ScrobbleEvent::QueueStalled { pending: 1 });
+            }
             self.schedule_flush(FLUSH_RETRY);
             return Err(DeliveryError::Saturated);
+        }
+        if self.queue_read_failure_active {
+            self.queue_read_failure_active = false;
+            (self.emit)(ScrobbleEvent::QueueStalled { pending: 0 });
         }
         if loaded.corrupt > 0 {
             tracing::warn!(corrupt = loaded.corrupt, "scrobble queue had corrupt lines");
         }
-        let (mut entries, capped) = compact(loaded.entries, crate::signals::unix_now());
-        if capped > 0 {
-            tracing::warn!(dropped = capped, "scrobble queue over cap; dropped oldest");
-            emit_queue_drop(&mut self.dropped_total, &self.emit, capped);
+        let mut entries = loaded.entries;
+        if let Some(pending) = self.pending_queue_drop_outcome.take()
+            && pending.is_installed_in(&entries)
+        {
+            publish_queue_drop(&mut self.dropped_total, &self.emit, &pending);
+        }
+        let applying_open_subsonic_acks = !self.pending_open_subsonic_acks.is_empty();
+        let mut scope_retirements = QueueDropSummary::default();
+        for entry in &entries {
+            if entry.open_subsonic_pending
+                && self
+                    .pending_open_subsonic_acks
+                    .get(&entry.id)
+                    .is_some_and(|acks| !acks.scope_retired.is_empty())
+            {
+                scope_retirements.note_scope_retired(&entry.id);
+            }
+        }
+        if !scope_retirements.is_empty()
+            && let Err(error) = queue.record_drop_audit_locked(
+                &scope_retirements,
+                crate::signals::unix_now(),
+                &lock,
+            )
+        {
+            tracing::warn!(
+                error = %error,
+                retired = scope_retirements.scope_retired(),
+                "failed to persist retired music-server scope audit; source markers left intact"
+            );
+            self.schedule_flush(FLUSH_RETRY);
+            return Err(DeliveryError::Saturated);
+        }
+        let invalid_source_ack = entries.iter().any(|entry| {
+            entry.open_subsonic_pending
+                && !entry.open_subsonic_bridge_durable
+                && self
+                    .pending_open_subsonic_acks
+                    .get(&entry.id)
+                    .is_some_and(|acks| {
+                        acks.scope_retired.is_empty() && !acks.source_acknowledged.is_empty()
+                    })
+        });
+        if invalid_source_ack {
+            for (_, acknowledgements) in self.pending_open_subsonic_acks.drain() {
+                acknowledgements.retry();
+            }
+            tracing::warn!(
+                "music server source acknowledgement arrived before its intermediate marker"
+            );
+            self.schedule_flush(FLUSH_RETRY);
+            return Err(DeliveryError::Saturated);
+        }
+        for entry in &mut entries {
+            let Some(acknowledgements) = self.pending_open_subsonic_acks.get(&entry.id) else {
+                continue;
+            };
+            if entry.open_subsonic_pending && !acknowledgements.scope_retired.is_empty() {
+                entry.open_subsonic_pending = false;
+                entry.open_subsonic_handoff_started = false;
+                entry.open_subsonic_bridge_durable = false;
+                continue;
+            }
+            if entry.open_subsonic_pending && !acknowledgements.bridge_queued.is_empty() {
+                entry.open_subsonic_handoff_started = true;
+                entry.open_subsonic_bridge_durable = true;
+            }
+            if entry.open_subsonic_pending && !acknowledgements.source_acknowledged.is_empty() {
+                entry.open_subsonic_pending = false;
+                entry.open_subsonic_handoff_started = false;
+                entry.open_subsonic_bridge_durable = false;
+            }
+        }
+        let now_unix = crate::signals::unix_now();
+        let (mut entries, capped) = compact(entries, now_unix);
+        if !capped.is_empty()
+            && let Err(error) = queue.record_drop_audit_locked(&capped, now_unix, &lock)
+        {
+            tracing::warn!(
+                error = %error,
+                "failed to persist scrobble retention loss audit; queue left intact"
+            );
+            self.schedule_flush(FLUSH_RETRY);
+            return Err(DeliveryError::Saturated);
+        }
+        let mut started_handoffs = false;
+        for entry in &mut entries {
+            if entry.open_subsonic_pending && !entry.open_subsonic_handoff_started {
+                entry.open_subsonic_handoff_started = true;
+                started_handoffs = true;
+            }
+        }
+        if applying_open_subsonic_acks || !capped.is_empty() || started_handoffs {
+            // Commit every source-journal decision before exposing a surviving exact event to
+            // the credential owner. After this boundary, compaction protects the marker even if
+            // the bridge accepts it and the process crashes before its acknowledgement returns.
+            if let Err(error) = queue.rewrite_locked(&entries, &lock) {
+                if !capped.is_empty() {
+                    self.pending_queue_drop_outcome = Some(capped.clone());
+                }
+                tracing::warn!(
+                    error = %error,
+                    "failed to persist music server playback handoff state"
+                );
+                self.schedule_flush(FLUSH_RETRY);
+                return Err(DeliveryError::Saturated);
+            }
+            if !capped.is_empty() {
+                publish_queue_drop(&mut self.dropped_total, &self.emit, &capped);
+            }
+            prune_announced_open_subsonic(&mut self.announced_open_subsonic, &entries);
+            for (_, acknowledgements) in self.pending_open_subsonic_acks.drain() {
+                acknowledgements.mark_durable();
+            }
+        }
+        for entry in &entries {
+            announce_open_subsonic_submission(
+                &self.emit,
+                &self.open_subsonic_ack_tx,
+                &mut self.announced_open_subsonic,
+                entry,
+            );
         }
 
         if let Some(client) = self.lastfm.clone()
@@ -888,9 +1282,17 @@ impl Actor {
             self.schedule_flush(FLUSH_RETRY);
             return Err(DeliveryError::Saturated);
         }
-        let pending = entries.len();
-        if pending > 0 && self.settings.any_active() {
+        prune_announced_open_subsonic(&mut self.announced_open_subsonic, &entries);
+        for (_, acknowledgements) in self.pending_open_subsonic_acks.drain() {
+            acknowledgements.mark_durable();
+        }
+        let exact_pending = entries.iter().any(|entry| entry.open_subsonic_pending);
+        let external_pending = entries.iter().any(|entry| !entry.pending.is_empty());
+        if exact_pending || (external_pending && self.settings.any_active()) {
             self.schedule_flush(FLUSH_RETRY);
+        }
+        let pending = entries.len();
+        if external_pending && self.settings.any_active() {
             let notice_due = self
                 .last_stall_notice
                 .is_none_or(|t| t.elapsed() >= STALL_NOTICE_EVERY);
@@ -964,7 +1366,7 @@ async fn flush_service<S: ScrobbleService>(
                 e.pending.retain(|s| *s != kind);
             }
         }
-        entries.retain(|e| !e.pending.is_empty());
+        entries.retain(QueueEntry::has_pending_delivery);
         if let Err(e) = queue.rewrite_locked(entries, lock) {
             tracing::warn!(error = %e, "failed to compact scrobble queue after chunk");
             return Some(acknowledgements);
@@ -982,7 +1384,7 @@ fn apply_compaction_acks(entries: &mut Vec<QueueEntry>, acknowledgements: &[Comp
             }
         }
     }
-    entries.retain(|entry| !entry.pending.is_empty());
+    entries.retain(QueueEntry::has_pending_delivery);
 }
 
 fn retry_pending_compaction(

--- a/src/scrobble/actor/open_subsonic_ack.rs
+++ b/src/scrobble/actor/open_subsonic_ack.rs
@@ -1,0 +1,223 @@
+//! Cross-owner durability acknowledgements for exact OpenSubsonic submissions.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+use crate::util::delivery::DeliveryError;
+
+/// Secret-free confirmation lane for a durable OpenSubsonic submission.
+///
+/// The source journal first records that handoff began, then that the bridge queued the event.
+/// It removes the marker only after the bridge durably acknowledges the source transition.
+#[derive(Clone)]
+pub struct OpenSubsonicSubmissionAck {
+    event_id: String,
+    tx: tokio::sync::mpsc::Sender<OpenSubsonicMarkerAckRequest>,
+    bridge_marker_durability: Arc<AtomicU8>,
+    removal_durability: Arc<AtomicU8>,
+    scope_retirement_durability: Arc<AtomicU8>,
+    deferred_submission: Arc<AtomicBool>,
+}
+
+pub(super) const MARKER_ACK_IDLE: u8 = 0;
+pub(super) const MARKER_ACK_QUEUED: u8 = 1;
+pub(super) const MARKER_ACK_DURABLE: u8 = 2;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) enum OpenSubsonicMarkerAckStage {
+    BridgeQueued,
+    SourceAcknowledged,
+    ScopeRetired,
+}
+
+pub(crate) struct OpenSubsonicMarkerAckRequest {
+    pub(super) event_id: String,
+    pub(super) stage: OpenSubsonicMarkerAckStage,
+    pub(super) durability: Arc<AtomicU8>,
+}
+
+impl OpenSubsonicMarkerAckRequest {
+    pub(super) fn retry(self) {
+        self.durability.store(MARKER_ACK_IDLE, Ordering::Release);
+    }
+
+    fn mark_durable(self) {
+        self.durability.store(MARKER_ACK_DURABLE, Ordering::Release);
+    }
+}
+
+impl OpenSubsonicSubmissionAck {
+    #[cfg(test)]
+    pub(crate) fn new(
+        event_id: String,
+        tx: tokio::sync::mpsc::Sender<OpenSubsonicMarkerAckRequest>,
+    ) -> Self {
+        Self::with_bridge_marker_state(event_id, tx, false, Arc::new(AtomicBool::new(false)))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_bridge_marker(
+        event_id: String,
+        tx: tokio::sync::mpsc::Sender<OpenSubsonicMarkerAckRequest>,
+    ) -> Self {
+        Self::with_bridge_marker_state(event_id, tx, true, Arc::new(AtomicBool::new(false)))
+    }
+
+    pub(super) fn with_bridge_marker_state(
+        event_id: String,
+        tx: tokio::sync::mpsc::Sender<OpenSubsonicMarkerAckRequest>,
+        bridge_marker_durable: bool,
+        deferred_submission: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            event_id,
+            tx,
+            bridge_marker_durability: Arc::new(AtomicU8::new(if bridge_marker_durable {
+                MARKER_ACK_DURABLE
+            } else {
+                MARKER_ACK_IDLE
+            })),
+            removal_durability: Arc::new(AtomicU8::new(MARKER_ACK_IDLE)),
+            scope_retirement_durability: Arc::new(AtomicU8::new(MARKER_ACK_IDLE)),
+            deferred_submission,
+        }
+    }
+
+    /// Ask the source actor to re-announce this durable event in the current process.
+    pub(crate) fn defer_submission(&self) {
+        self.deferred_submission.store(true, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn submission_is_deferred(&self) -> bool {
+        self.deferred_submission.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take_deferred_submission(&self) -> bool {
+        self.deferred_submission.swap(false, Ordering::AcqRel)
+    }
+
+    pub(crate) fn confirm_bridge_durable(&self) -> Result<(), DeliveryError> {
+        self.request(
+            OpenSubsonicMarkerAckStage::BridgeQueued,
+            &self.bridge_marker_durability,
+        )
+    }
+
+    pub(crate) fn bridge_marker_is_durable(&self) -> bool {
+        self.bridge_marker_durability.load(Ordering::Acquire) == MARKER_ACK_DURABLE
+    }
+
+    pub(crate) fn confirm_source_acknowledged(&self) -> Result<(), DeliveryError> {
+        self.request(
+            OpenSubsonicMarkerAckStage::SourceAcknowledged,
+            &self.removal_durability,
+        )
+    }
+
+    pub(crate) fn source_marker_is_removed(&self) -> bool {
+        self.removal_durability.load(Ordering::Acquire) == MARKER_ACK_DURABLE
+    }
+
+    /// Retire a marker whose exact server/account identity no longer belongs to the active
+    /// profile. This is a distinct, audited source-journal outcome, never a fake server ack.
+    pub(crate) fn retire_account_scope(&self) -> Result<(), DeliveryError> {
+        self.request(
+            OpenSubsonicMarkerAckStage::ScopeRetired,
+            &self.scope_retirement_durability,
+        )
+    }
+
+    pub(crate) fn account_scope_is_retired(&self) -> bool {
+        self.scope_retirement_durability.load(Ordering::Acquire) == MARKER_ACK_DURABLE
+    }
+
+    pub(crate) fn account_scope_retirement_is_pending(&self) -> bool {
+        self.scope_retirement_durability.load(Ordering::Acquire) == MARKER_ACK_QUEUED
+    }
+
+    #[cfg(test)]
+    pub(crate) fn mark_account_scope_retired(&self) {
+        self.scope_retirement_durability
+            .store(MARKER_ACK_DURABLE, Ordering::Release);
+    }
+
+    fn request(
+        &self,
+        stage: OpenSubsonicMarkerAckStage,
+        durability: &Arc<AtomicU8>,
+    ) -> Result<(), DeliveryError> {
+        if durability.load(Ordering::Acquire) == MARKER_ACK_DURABLE {
+            return Ok(());
+        }
+        if durability
+            .compare_exchange(
+                MARKER_ACK_IDLE,
+                MARKER_ACK_QUEUED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return Ok(());
+        }
+        let request = OpenSubsonicMarkerAckRequest {
+            event_id: self.event_id.clone(),
+            stage,
+            durability: Arc::clone(durability),
+        };
+        match self.tx.try_send(request) {
+            Ok(()) => Ok(()),
+            Err(tokio::sync::mpsc::error::TrySendError::Full(request)) => {
+                request.retry();
+                Err(DeliveryError::Busy)
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(request)) => {
+                request.retry();
+                Err(DeliveryError::Closed)
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+pub(super) struct PendingOpenSubsonicMarkerAcks {
+    pub(super) bridge_queued: Vec<OpenSubsonicMarkerAckRequest>,
+    pub(super) source_acknowledged: Vec<OpenSubsonicMarkerAckRequest>,
+    pub(super) scope_retired: Vec<OpenSubsonicMarkerAckRequest>,
+}
+
+impl PendingOpenSubsonicMarkerAcks {
+    pub(super) fn push(&mut self, request: OpenSubsonicMarkerAckRequest) {
+        match request.stage {
+            OpenSubsonicMarkerAckStage::BridgeQueued => self.bridge_queued.push(request),
+            OpenSubsonicMarkerAckStage::SourceAcknowledged => {
+                self.source_acknowledged.push(request);
+            }
+            OpenSubsonicMarkerAckStage::ScopeRetired => self.scope_retired.push(request),
+        }
+    }
+
+    pub(super) fn mark_durable(self) {
+        for request in self
+            .bridge_queued
+            .into_iter()
+            .chain(self.source_acknowledged)
+            .chain(self.scope_retired)
+        {
+            request.mark_durable();
+        }
+    }
+
+    pub(super) fn retry(self) {
+        for request in self
+            .bridge_queued
+            .into_iter()
+            .chain(self.source_acknowledged)
+            .chain(self.scope_retired)
+        {
+            request.retry();
+        }
+    }
+}

--- a/src/scrobble/actor/tests.rs
+++ b/src/scrobble/actor/tests.rs
@@ -6,6 +6,9 @@ use super::super::{
     monitor::{Observation, ObservedTrack},
 };
 
+mod open_subsonic_durability_tests;
+mod queue_drop_durability_tests;
+
 struct FakeService {
     kind: ServiceKind,
     results: Mutex<Vec<Result<(), ScrobbleError>>>,
@@ -61,12 +64,16 @@ fn entry(idx: usize, pending: Vec<ServiceKind>) -> QueueEntry {
     QueueEntry {
         id: format!("1000-track-{idx}"),
         track_key: format!("track-{idx}"),
+        open_subsonic_item: None,
         ts: 1000 + idx as i64,
         artist: format!("artist-{idx}"),
         title: format!("title-{idx}"),
         album: Some(format!("album-{idx}")),
         duration: Some(180 + idx as u32),
         origin_url: Some(format!("https://music.youtube.com/watch?v=track-{idx}")),
+        open_subsonic_pending: false,
+        open_subsonic_handoff_started: false,
+        open_subsonic_bridge_durable: false,
         pending,
     }
 }
@@ -74,6 +81,7 @@ fn entry(idx: usize, pending: Vec<ServiceKind>) -> QueueEntry {
 fn track(started_unix: i64) -> ScrobbleTrack {
     ScrobbleTrack {
         key: "track-key".to_owned(),
+        open_subsonic_item: None,
         artist: "artist".to_owned(),
         title: "title".to_owned(),
         album: Some("album".to_owned()),
@@ -81,6 +89,16 @@ fn track(started_unix: i64) -> ScrobbleTrack {
         origin_url: Some("https://music.youtube.com/watch?v=track-key".to_owned()),
         started_unix,
     }
+}
+
+fn open_subsonic_track(started_unix: i64) -> ScrobbleTrack {
+    let mut track = track(started_unix);
+    track.open_subsonic_item = Some(crate::open_subsonic::OpenSubsonicItemRef::new(
+        crate::open_subsonic::BackendId::new("server-backend").unwrap(),
+        crate::open_subsonic::AccountScopeId::new("account-scope").unwrap(),
+        crate::open_subsonic::ItemId::new("song-42").unwrap(),
+    ));
+    track
 }
 
 fn inactive_settings() -> ScrobbleSettings {
@@ -127,6 +145,7 @@ fn durable_only_settings() -> ScrobbleSettings {
 fn threshold_observations(key: &str) -> (i64, Vec<Observation>) {
     let track = ObservedTrack {
         key: key.to_owned(),
+        open_subsonic_item: None,
         title: "Shutdown Track".to_owned(),
         artist: "Artist".to_owned(),
         album: Some("Album".to_owned()),
@@ -154,11 +173,20 @@ fn threshold_observations(key: &str) -> (i64, Vec<Observation>) {
 }
 
 fn test_actor(settings: ScrobbleSettings, queue: Option<QueueFile>, emit: EventSink) -> Actor {
+    test_actor_with_ack(settings, queue, emit).0
+}
+
+fn test_actor_with_ack(
+    settings: ScrobbleSettings,
+    queue: Option<QueueFile>,
+    emit: EventSink,
+) -> (Actor, Receiver<OpenSubsonicMarkerAckRequest>) {
+    let (open_subsonic_ack_tx, open_subsonic_ack_rx) = bounded_channel(SCROBBLE_CONTROL_QUEUE);
     let http = reqwest::Client::builder()
         .timeout(Duration::from_millis(50))
         .build()
         .unwrap_or_default();
-    Actor {
+    let actor = Actor {
         lastfm: lastfm_client(&http, &settings),
         listenbrainz: listenbrainz_client(&http, &settings),
         settings,
@@ -172,12 +200,20 @@ fn test_actor(settings: ScrobbleSettings, queue: Option<QueueFile>, emit: EventS
         next_flush: None,
         last_stall_notice: None,
         pending_appends: VecDeque::new(),
+        pending_generic_appends: 0,
+        pending_open_subsonic_appends: 0,
         pending_append_lock: None,
         pending_compaction: None,
         append_failure_active: false,
+        queue_read_failure_active: false,
         dropped_total: 0,
+        pending_queue_drop_outcome: None,
+        open_subsonic_ack_tx,
+        pending_open_subsonic_acks: HashMap::new(),
+        announced_open_subsonic: HashMap::new(),
         love_tasks: HashMap::new(),
-    }
+    };
+    (actor, open_subsonic_ack_rx)
 }
 
 fn captured_events() -> (Arc<Mutex<Vec<ScrobbleEvent>>>, EventSink) {
@@ -187,6 +223,50 @@ fn captured_events() -> (Arc<Mutex<Vec<ScrobbleEvent>>>, EventSink) {
         sink_events.lock().unwrap().push(event);
     });
     (events, sink)
+}
+
+#[tokio::test]
+async fn malformed_queue_is_never_rewritten_and_surfaces_one_stalled_event() {
+    let (dir, queue) = temp_queue("malformed-fail-closed");
+    let exact = QueueEntry::from_track(
+        &ScrobbleTrack {
+            key: "server-track".to_owned(),
+            open_subsonic_item: Some(crate::open_subsonic::OpenSubsonicItemRef::new(
+                crate::open_subsonic::BackendId::new("backend").unwrap(),
+                crate::open_subsonic::AccountScopeId::new("account").unwrap(),
+                crate::open_subsonic::ItemId::new("song").unwrap(),
+            )),
+            artist: "artist".to_owned(),
+            title: "title".to_owned(),
+            album: None,
+            duration_secs: Some(180),
+            origin_url: None,
+            started_unix: 100,
+        },
+        Vec::new(),
+    );
+    queue.append(&exact).unwrap();
+    crate::util::safe_fs::append_private_jsonl(queue.path(), "{torn").unwrap();
+    let before = std::fs::read(queue.path()).unwrap();
+    let (events, emit) = captured_events();
+    let mut actor = test_actor(inactive_settings(), Some(queue), emit);
+
+    assert_eq!(actor.flush().await, Err(DeliveryError::Saturated));
+    assert_eq!(actor.flush().await, Err(DeliveryError::Saturated));
+    assert_eq!(
+        std::fs::read(dir.join("scrobble-queue.jsonl")).unwrap(),
+        before
+    );
+    assert_eq!(
+        events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|event| matches!(event, ScrobbleEvent::QueueStalled { pending: 1 }))
+            .count(),
+        1
+    );
+    let _ = std::fs::remove_dir_all(dir);
 }
 
 #[test]
@@ -641,6 +721,7 @@ fn failed_append_retention_is_bounded_and_reports_oldest_loss() {
             .pending_appends
             .push_back(entry(index, vec![ServiceKind::Lastfm]));
     }
+    actor.pending_generic_appends = QUEUE_CAP;
     let oldest_id = actor.pending_appends.front().unwrap().id.clone();
 
     actor.enqueue_scrobble(track(9_999));
@@ -699,6 +780,87 @@ fn observation_records_scrobble_before_returning_ephemeral_network_work() {
     assert_eq!(loaded.entries[0].track_key, scrobble.key);
     assert_eq!(loaded.entries[0].ts, scrobble.started_unix);
     let _ = std::fs::remove_dir_all(dir);
+}
+
+#[tokio::test]
+async fn exact_server_actions_emit_owner_lane_events_without_changing_service_delivery() {
+    let (dir, queue) = temp_queue("open-subsonic-owner-lane");
+    let (events, emit) = captured_events();
+    let mut actor = test_actor(inactive_settings(), Some(queue), emit);
+    let now_playing = open_subsonic_track(1_000);
+    let submission = open_subsonic_track(1_000);
+
+    let deferred_network = actor.record_durable_actions(vec![
+        ScrobbleAction::NowPlaying(now_playing.clone()),
+        ScrobbleAction::Scrobble(submission.clone()),
+    ]);
+    assert_eq!(actor.flush().await, Ok(()));
+
+    assert_eq!(deferred_network, vec![now_playing.clone()]);
+    assert!(actor.pending_appends.is_empty());
+    let loaded = actor.queue.as_ref().unwrap().load();
+    assert_eq!(loaded.entries.len(), 1);
+    assert!(loaded.entries[0].pending.is_empty());
+    assert!(loaded.entries[0].open_subsonic_pending);
+    assert!(loaded.entries[0].open_subsonic_handoff_started);
+    let captured = events.lock().unwrap();
+    assert_eq!(captured.len(), 2);
+    assert!(matches!(
+        &captured[0],
+        ScrobbleEvent::OpenSubsonic {
+            event_id,
+            kind: crate::open_subsonic::OpenSubsonicScrobbleKind::NowPlaying,
+            track,
+            confirmation: None,
+        } if !event_id.is_empty() && track == &now_playing
+    ));
+    assert!(matches!(
+        &captured[1],
+        ScrobbleEvent::OpenSubsonic {
+            event_id,
+            kind: crate::open_subsonic::OpenSubsonicScrobbleKind::Submission,
+            track,
+            confirmation: Some(_),
+        } if !event_id.is_empty() && track == &submission
+    ));
+    let (
+        ScrobbleEvent::OpenSubsonic {
+            event_id: now_playing_id,
+            ..
+        },
+        ScrobbleEvent::OpenSubsonic {
+            event_id: submission_id,
+            ..
+        },
+    ) = (&captured[0], &captured[1])
+    else {
+        unreachable!("captured events were asserted above");
+    };
+    assert_ne!(
+        now_playing_id, submission_id,
+        "same-second thresholds must retain distinct owner event identities"
+    );
+    assert_eq!(
+        loaded.entries[0].id.as_str(),
+        submission_id.as_str(),
+        "the bridge event must reuse the journaled dedupe identity"
+    );
+    drop(captured);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn non_server_actions_do_not_emit_open_subsonic_events() {
+    let (events, emit) = captured_events();
+    let mut actor = test_actor(inactive_settings(), None, emit);
+
+    let deferred_network = actor.record_durable_actions(vec![
+        ScrobbleAction::NowPlaying(track(1_000)),
+        ScrobbleAction::Scrobble(track(1_001)),
+    ]);
+
+    assert_eq!(deferred_network.len(), 1);
+    assert!(events.lock().unwrap().is_empty());
 }
 
 #[tokio::test]
@@ -823,6 +985,7 @@ async fn immediate_shutdown_applies_latest_terminal_observation_rejected_as_busy
     let started_unix = crate::signals::unix_now() - 20;
     let long_track = ObservedTrack {
         key: "shutdown-terminal-retry".to_owned(),
+        open_subsonic_item: None,
         title: "Shutdown Terminal Retry".to_owned(),
         artist: "Artist".to_owned(),
         album: Some("Album".to_owned()),
@@ -881,6 +1044,7 @@ async fn immediate_shutdown_applies_latest_terminal_observation_rejected_as_busy
     latest.position_epoch = 1_000;
     latest.track = Some(crate::media::MediaTrack {
         key: long_track.key.clone(),
+        open_subsonic_item: None,
         title: long_track.title.clone(),
         artist: long_track.artist.clone(),
         album: long_track.album.clone(),

--- a/src/scrobble/actor/tests/open_subsonic_durability_tests.rs
+++ b/src/scrobble/actor/tests/open_subsonic_durability_tests.rs
@@ -1,0 +1,619 @@
+use super::*;
+
+#[test]
+fn failed_exact_append_retention_uses_its_independent_twenty_thousand_event_cap() {
+    let (dir, queue) = temp_queue("open-subsonic-append-cap");
+    queue.fail_next_appends(1);
+    let (events, emit) = captured_events();
+    let mut actor = test_actor(inactive_settings(), Some(queue), emit);
+    for index in 0..OPEN_SUBSONIC_QUEUE_CAP {
+        let mut pending =
+            QueueEntry::from_track(&open_subsonic_track(1_000 + index as i64), Vec::new());
+        pending.id = format!("exact-pending-{index}");
+        actor.pending_appends.push_back(pending);
+    }
+    actor.pending_open_subsonic_appends = OPEN_SUBSONIC_QUEUE_CAP;
+    let oldest_id = actor.pending_appends.front().unwrap().id.clone();
+
+    actor.enqueue_scrobble(open_subsonic_track(30_000));
+
+    assert_eq!(actor.pending_appends.len(), OPEN_SUBSONIC_QUEUE_CAP);
+    assert_eq!(actor.pending_open_subsonic_appends, OPEN_SUBSONIC_QUEUE_CAP);
+    assert_eq!(actor.pending_appends.front().unwrap().id, oldest_id);
+    assert_eq!(
+        actor.queue.as_ref().unwrap().drop_audit_counts().unwrap(),
+        (0, 1, 1)
+    );
+    let captured = events.lock().unwrap();
+    assert!(matches!(
+        captured.first(),
+        Some(ScrobbleEvent::QueueDropped { dropped: 1 })
+    ));
+    assert!(matches!(
+        captured.get(1),
+        Some(ScrobbleEvent::QueueStalled {
+            pending: OPEN_SUBSONIC_QUEUE_CAP
+        })
+    ));
+    drop(captured);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn exact_in_memory_overflow_remains_retained_until_its_loss_audit_is_durable() {
+    let (dir, queue) = temp_queue("open-subsonic-append-audit-failure");
+    let audit_path = queue.path().with_extension("drops.json");
+    std::fs::create_dir_all(audit_path.parent().unwrap()).unwrap();
+    std::fs::write(&audit_path, b"{invalid").unwrap();
+    let (events, emit) = captured_events();
+    let mut actor = test_actor(inactive_settings(), Some(queue), emit);
+    for index in 0..OPEN_SUBSONIC_QUEUE_CAP {
+        let mut pending =
+            QueueEntry::from_track(&open_subsonic_track(1_000 + index as i64), Vec::new());
+        pending.id = format!("retained-{index}");
+        actor.pending_appends.push_back(pending);
+    }
+    actor.pending_open_subsonic_appends = OPEN_SUBSONIC_QUEUE_CAP;
+
+    actor.enqueue_scrobble(open_subsonic_track(30_000));
+
+    assert_eq!(
+        actor.pending_open_subsonic_appends,
+        OPEN_SUBSONIC_QUEUE_CAP + 1
+    );
+    assert!(
+        !actor.accepts_command_ingress(),
+        "cap+1 closes the bounded command inbox until the audit retry finishes"
+    );
+    assert_eq!(actor.pending_appends.len(), OPEN_SUBSONIC_QUEUE_CAP + 1);
+    assert!(actor.pending_appends.back().unwrap().open_subsonic_pending);
+    assert!(
+        events
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|event| !matches!(event, ScrobbleEvent::QueueDropped { .. }))
+    );
+
+    std::fs::remove_file(audit_path).unwrap();
+    actor.queue.as_ref().unwrap().fail_next_appends(1);
+    assert_eq!(actor.retry_pending_appends(), Err(DeliveryError::Saturated));
+    assert_eq!(actor.pending_open_subsonic_appends, OPEN_SUBSONIC_QUEUE_CAP);
+    assert!(actor.accepts_command_ingress());
+    assert_eq!(actor.pending_appends.len(), OPEN_SUBSONIC_QUEUE_CAP);
+    assert_eq!(
+        actor.queue.as_ref().unwrap().drop_audit_counts().unwrap(),
+        (0, 1, 1)
+    );
+    assert!(
+        events
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|event| matches!(event, ScrobbleEvent::QueueDropped { dropped: 1 }))
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn owner_acknowledgement_handoff_is_bounded_without_retiring_accepted_markers() {
+    let (dir, queue) = temp_queue("open-subsonic-ack-cap");
+    let (_events, emit) = captured_events();
+    let mut actor = test_actor(inactive_settings(), Some(queue), emit);
+    for index in 0..OPEN_SUBSONIC_QUEUE_CAP {
+        actor.pending_open_subsonic_acks.insert(
+            format!("accepted-{index}"),
+            PendingOpenSubsonicMarkerAcks::default(),
+        );
+    }
+    let durability = Arc::new(AtomicU8::new(MARKER_ACK_QUEUED));
+    actor.confirm_open_subsonic_submission(OpenSubsonicMarkerAckRequest {
+        event_id: "overflow".to_owned(),
+        stage: OpenSubsonicMarkerAckStage::BridgeQueued,
+        durability: Arc::clone(&durability),
+    });
+
+    assert_eq!(
+        actor.pending_open_subsonic_acks.len(),
+        OPEN_SUBSONIC_QUEUE_CAP
+    );
+    assert!(!actor.pending_open_subsonic_acks.contains_key("overflow"));
+    assert!(actor.pending_open_subsonic_acks.contains_key("accepted-0"));
+    assert_eq!(durability.load(Ordering::Acquire), MARKER_ACK_IDLE);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn fresh_terminal_owner_observation_crosses_threshold_before_actor_shutdown() {
+    let (dir, queue) = temp_queue("open-subsonic-final-owner-observation");
+    let queue_path = queue.path().to_path_buf();
+    let (tx, rx) = tokio::sync::mpsc::channel(8);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel(1);
+    let (_events, emit) = captured_events();
+    let mut handle = ScrobbleHandle::new(tx, shutdown_tx);
+    let pending = Arc::clone(&handle.pending);
+    let actor = tokio::spawn(run_actor(
+        rx,
+        shutdown_rx,
+        pending,
+        inactive_settings(),
+        emit,
+        Some(queue),
+    ));
+    let item = crate::open_subsonic::OpenSubsonicItemRef::new(
+        crate::open_subsonic::BackendId::new("server-backend").unwrap(),
+        crate::open_subsonic::AccountScopeId::new("account-scope").unwrap(),
+        crate::open_subsonic::ItemId::new("final-song").unwrap(),
+    );
+    let observed_track = ObservedTrack {
+        key: "final-song".to_owned(),
+        open_subsonic_item: Some(item.clone()),
+        title: "Final Song".to_owned(),
+        artist: "Artist".to_owned(),
+        album: Some("Album".to_owned()),
+        duration: Some(40.0),
+        is_live: false,
+        is_local: false,
+        origin_url: None,
+        liked: false,
+    };
+    let started_at = Instant::now()
+        .checked_sub(Duration::from_secs(20))
+        .expect("monotonic clock represents a short prior listen");
+    let started_unix = crate::signals::unix_now() - 20;
+    for step in 0..4_u64 {
+        assert!(
+            handle
+                .admit_pending(PendingCommand::Observe(Box::new(ObservationBatch::single(
+                    Observation {
+                        track: Some(observed_track.clone()),
+                        playing: true,
+                        stopped: false,
+                        position: (step * 5) as f64,
+                        position_epoch: 1,
+                        rate: 1.0,
+                        at: started_at + Duration::from_secs(step * 5),
+                        wall_unix: started_unix + (step * 5) as i64,
+                    },
+                ))))
+                .is_ok()
+        );
+    }
+    let mut final_snapshot = crate::media::MediaSnapshot::idle();
+    final_snapshot.status = crate::media::MediaPlaybackStatus::Playing;
+    final_snapshot.position = 20.0;
+    final_snapshot.track = Some(crate::media::MediaTrack {
+        key: "final-song".to_owned(),
+        open_subsonic_item: Some(item),
+        title: "Final Song".to_owned(),
+        artist: "Artist".to_owned(),
+        album: Some("Album".to_owned()),
+        duration: Some(40.0),
+        is_live: false,
+        url: None,
+        art_remote_url: None,
+        art_file: None,
+        art_query: None,
+        liked: false,
+        disliked: false,
+    });
+
+    assert!(handle.observe_shutdown(&final_snapshot).is_ok());
+    assert_eq!(handle.shutdown_flush().await, Ok(()));
+    actor.await.expect("scrobble actor joins");
+
+    let loaded = QueueFile::at(queue_path).load();
+    assert!(!loaded.read_failed);
+    assert_eq!(loaded.entries.len(), 1);
+    assert_eq!(loaded.entries[0].track_key, "final-song");
+    assert!(loaded.entries[0].open_subsonic_pending);
+    assert!(loaded.entries[0].open_subsonic_handoff_started);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[tokio::test]
+async fn same_second_server_submissions_keep_distinct_shared_journal_ids() {
+    let (dir, queue) = temp_queue("open-subsonic-same-second");
+    let (events, emit) = captured_events();
+    let mut actor = test_actor(inactive_settings(), Some(queue), emit);
+    let first = open_subsonic_track(1_000);
+    let second = open_subsonic_track(1_000);
+
+    actor.record_durable_actions(vec![
+        ScrobbleAction::Scrobble(first),
+        ScrobbleAction::Scrobble(second),
+    ]);
+    assert_eq!(actor.flush().await, Ok(()));
+
+    let loaded = actor.queue.as_ref().unwrap().load();
+    assert_eq!(loaded.entries.len(), 2);
+    assert_ne!(loaded.entries[0].id, loaded.entries[1].id);
+    let captured = events.lock().unwrap();
+    let event_ids = captured
+        .iter()
+        .map(|event| match event {
+            ScrobbleEvent::OpenSubsonic {
+                event_id,
+                kind: crate::open_subsonic::OpenSubsonicScrobbleKind::Submission,
+                confirmation: Some(_),
+                ..
+            } => event_id.as_str(),
+            _ => panic!("only durable server submissions are expected"),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        event_ids,
+        loaded
+            .entries
+            .iter()
+            .map(|entry| entry.id.as_str())
+            .collect::<Vec<_>>()
+    );
+    drop(captured);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[tokio::test]
+async fn owner_backpressure_reannounces_only_the_deferred_event_in_the_same_actor_run() {
+    let (dir, queue) = temp_queue("open-subsonic-same-run-defer");
+    let (events, emit) = captured_events();
+    let (mut actor, _acknowledgement_rx) =
+        test_actor_with_ack(inactive_settings(), Some(queue), emit);
+    actor.record_durable_actions(vec![ScrobbleAction::Scrobble(open_subsonic_track(1_000))]);
+    assert_eq!(actor.flush().await, Ok(()));
+
+    let first = events.lock().unwrap().pop().unwrap();
+    let (event_id, confirmation) = match first {
+        ScrobbleEvent::OpenSubsonic {
+            event_id,
+            kind: crate::open_subsonic::OpenSubsonicScrobbleKind::Submission,
+            confirmation: Some(confirmation),
+            ..
+        } => (event_id, confirmation),
+        _ => panic!("expected one exact music-server submission"),
+    };
+    confirmation.defer_submission();
+    assert!(confirmation.submission_is_deferred());
+
+    assert_eq!(actor.flush().await, Ok(()));
+    let retry = events.lock().unwrap().pop().unwrap();
+    assert!(matches!(
+        retry,
+        ScrobbleEvent::OpenSubsonic {
+            event_id: retried,
+            kind: crate::open_subsonic::OpenSubsonicScrobbleKind::Submission,
+            confirmation: Some(_),
+            ..
+        } if retried == event_id
+    ));
+    assert!(!confirmation.submission_is_deferred());
+    assert!(
+        actor.next_flush.is_some(),
+        "an exact marker keeps the 30-second owner retry poll alive without external services"
+    );
+
+    assert_eq!(actor.flush().await, Ok(()));
+    assert!(
+        events.lock().unwrap().is_empty(),
+        "the shared defer bit authorizes exactly one additional emission"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[tokio::test]
+async fn cap_rewrite_failure_never_emits_or_evicts_a_started_handoff() {
+    let (dir, queue) = temp_queue("open-subsonic-protected-cap-rewrite");
+    let queue_path = queue.path().to_path_buf();
+    let mut entries = (0..OPEN_SUBSONIC_QUEUE_CAP)
+        .map(|index| {
+            let mut entry =
+                QueueEntry::from_track(&open_subsonic_track(1_000 + index as i64), Vec::new());
+            entry.id = format!("protected-{index}");
+            entry.open_subsonic_handoff_started = true;
+            entry
+        })
+        .collect::<Vec<_>>();
+    entries[0].open_subsonic_bridge_durable = true;
+    let mut overflow = QueueEntry::from_track(&open_subsonic_track(30_000), Vec::new());
+    overflow.id = "newest-never-handed-off".to_owned();
+    entries.push(overflow);
+    queue.rewrite(&entries).unwrap();
+    queue.fail_next_rewrites(1);
+    let (failed_events, failed_emit) = captured_events();
+    let mut failed = test_actor(inactive_settings(), Some(queue), failed_emit);
+
+    assert_eq!(failed.flush().await, Err(DeliveryError::Saturated));
+    assert!(failed_events.lock().unwrap().is_empty());
+    let unchanged = QueueFile::at(queue_path.clone()).load();
+    assert_eq!(unchanged.entries.len(), OPEN_SUBSONIC_QUEUE_CAP + 1);
+    assert!(
+        unchanged
+            .entries
+            .iter()
+            .any(|entry| entry.id == "protected-0"
+                && entry.open_subsonic_handoff_started
+                && entry.open_subsonic_bridge_durable)
+    );
+    drop(failed);
+
+    let emitted = Arc::new(Mutex::new((0usize, false)));
+    let emitted_for_sink = Arc::clone(&emitted);
+    let emit: EventSink = Arc::new(move |event| {
+        if let ScrobbleEvent::OpenSubsonic { event_id, .. } = event {
+            let mut emitted = emitted_for_sink.lock().unwrap();
+            emitted.0 += 1;
+            emitted.1 |= event_id == "newest-never-handed-off";
+        }
+    });
+    let mut restarted = test_actor(
+        inactive_settings(),
+        Some(QueueFile::at(queue_path.clone())),
+        emit,
+    );
+    assert_eq!(restarted.flush().await, Ok(()));
+    assert_eq!(*emitted.lock().unwrap(), (OPEN_SUBSONIC_QUEUE_CAP, false));
+    let recovered = QueueFile::at(queue_path).load();
+    assert_eq!(recovered.entries.len(), OPEN_SUBSONIC_QUEUE_CAP);
+    assert!(
+        recovered
+            .entries
+            .iter()
+            .all(|entry| entry.open_subsonic_handoff_started)
+    );
+    assert!(
+        recovered
+            .entries
+            .iter()
+            .any(|entry| entry.id == "protected-0" && entry.open_subsonic_bridge_durable),
+        "an AwaitingSourceAck marker cannot be orphaned by exact-event compaction"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[tokio::test]
+async fn scope_retirement_requires_audit_and_rewrite_before_preserving_generic_delivery() {
+    let (dir, queue) = temp_queue("open-subsonic-scope-retirement");
+    let queue_path = queue.path().to_path_buf();
+    let mut marker =
+        QueueEntry::from_track(&open_subsonic_track(1_000), vec![ServiceKind::ListenBrainz]);
+    marker.open_subsonic_handoff_started = true;
+    marker.open_subsonic_bridge_durable = true;
+    queue.rewrite(std::slice::from_ref(&marker)).unwrap();
+    let (events, emit) = captured_events();
+    let (mut actor, mut acknowledgement_rx) =
+        test_actor_with_ack(inactive_settings(), Some(queue), emit);
+    assert_eq!(actor.flush().await, Ok(()));
+    let confirmation = match events.lock().unwrap().pop().unwrap() {
+        ScrobbleEvent::OpenSubsonic {
+            confirmation: Some(confirmation),
+            ..
+        } => confirmation,
+        _ => panic!("expected an awaiting-source-ack marker"),
+    };
+    assert!(confirmation.bridge_marker_is_durable());
+    confirmation.retire_account_scope().unwrap();
+    actor.confirm_open_subsonic_submission(acknowledgement_rx.try_recv().unwrap());
+
+    let audit_path = queue_path.with_extension("drops.json");
+    std::fs::write(&audit_path, b"{invalid").unwrap();
+    assert_eq!(actor.flush().await, Err(DeliveryError::Saturated));
+    let after_audit_failure = QueueFile::at(queue_path.clone()).load().entries.remove(0);
+    assert!(after_audit_failure.open_subsonic_pending);
+    assert!(after_audit_failure.open_subsonic_handoff_started);
+    assert!(after_audit_failure.open_subsonic_bridge_durable);
+    assert_eq!(after_audit_failure.pending, vec![ServiceKind::ListenBrainz]);
+    assert!(!confirmation.account_scope_is_retired());
+
+    std::fs::remove_file(audit_path).unwrap();
+    actor.queue.as_ref().unwrap().fail_next_rewrites(1);
+    assert_eq!(actor.flush().await, Err(DeliveryError::Saturated));
+    let after_rewrite_failure = QueueFile::at(queue_path.clone()).load().entries.remove(0);
+    assert!(after_rewrite_failure.open_subsonic_pending);
+    assert!(after_rewrite_failure.open_subsonic_handoff_started);
+    assert!(after_rewrite_failure.open_subsonic_bridge_durable);
+    assert_eq!(
+        after_rewrite_failure.pending,
+        vec![ServiceKind::ListenBrainz]
+    );
+    assert!(!confirmation.account_scope_is_retired());
+
+    assert_eq!(actor.flush().await, Ok(()));
+    let retired = QueueFile::at(queue_path).load().entries.remove(0);
+    assert!(!retired.open_subsonic_pending);
+    assert!(!retired.open_subsonic_handoff_started);
+    assert!(!retired.open_subsonic_bridge_durable);
+    assert_eq!(retired.pending, vec![ServiceKind::ListenBrainz]);
+    assert!(confirmation.account_scope_is_retired());
+    assert_eq!(
+        actor
+            .queue
+            .as_ref()
+            .unwrap()
+            .scope_retirement_audit_count()
+            .unwrap(),
+        1
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[tokio::test]
+async fn server_submission_three_stage_journal_survives_both_crash_boundaries() {
+    let (dir, queue) = temp_queue("open-subsonic-crash-replay");
+    let queue_path = queue.path().to_path_buf();
+    let (first_events, first_emit) = captured_events();
+    let mut producer = test_actor(inactive_settings(), Some(queue), first_emit);
+    producer.record_durable_actions(vec![ScrobbleAction::Scrobble(open_subsonic_track(1_000))]);
+    assert_eq!(producer.flush().await, Ok(()));
+    let event_id = producer.queue.as_ref().unwrap().load().entries[0]
+        .id
+        .clone();
+    assert!(matches!(
+        &first_events.lock().unwrap()[0],
+        ScrobbleEvent::OpenSubsonic {
+            event_id: emitted,
+            confirmation: Some(_),
+            ..
+        } if emitted == &event_id
+    ));
+    drop(producer);
+
+    // A fresh actor replays the journal marker with the original owner-event identity.
+    let (replay_events, replay_emit) = captured_events();
+    let (mut replay, mut acknowledgement_rx) = test_actor_with_ack(
+        inactive_settings(),
+        Some(QueueFile::at(queue_path.clone())),
+        replay_emit,
+    );
+    assert_eq!(replay.flush().await, Ok(()));
+    let replay_event = replay_events
+        .lock()
+        .unwrap()
+        .pop()
+        .expect("restart emits the pending submission");
+    let confirmation = match replay_event {
+        ScrobbleEvent::OpenSubsonic {
+            event_id: replayed,
+            kind: crate::open_subsonic::OpenSubsonicScrobbleKind::Submission,
+            confirmation: Some(confirmation),
+            ..
+        } => {
+            assert_eq!(replayed, event_id);
+            confirmation
+        }
+        _ => panic!("restart emitted an unexpected event"),
+    };
+    assert!(replay.announced_open_subsonic.contains_key(&event_id));
+
+    // Boundary 1: bridge durability is known, but the Pending -> AwaitingSourceAck rewrite fails.
+    confirmation.confirm_bridge_durable().unwrap();
+    let acknowledgement = acknowledgement_rx
+        .try_recv()
+        .expect("confirmation reaches the independent acknowledgement lane");
+    assert_eq!(acknowledgement.event_id, event_id);
+    replay.confirm_open_subsonic_submission(acknowledgement);
+    replay.queue.as_ref().unwrap().fail_next_rewrites(1);
+    assert_eq!(replay.flush().await, Err(DeliveryError::Saturated));
+    let failed = QueueFile::at(queue_path.clone()).load().entries.remove(0);
+    assert!(failed.open_subsonic_pending);
+    assert!(failed.open_subsonic_handoff_started);
+    assert!(!failed.open_subsonic_bridge_durable);
+    drop(replay);
+
+    // Restart still emits a real submission phase. A successful retry persists the intermediate
+    // state without removing the only source marker.
+    let (second_replay_events, second_replay_emit) = captured_events();
+    let (mut second_replay, mut second_ack_rx) = test_actor_with_ack(
+        inactive_settings(),
+        Some(QueueFile::at(queue_path.clone())),
+        second_replay_emit,
+    );
+    assert_eq!(second_replay.flush().await, Ok(()));
+    let second_confirmation = match second_replay_events.lock().unwrap().pop().unwrap() {
+        ScrobbleEvent::OpenSubsonic {
+            event_id: replayed,
+            confirmation: Some(confirmation),
+            ..
+        } => {
+            assert_eq!(replayed, event_id);
+            confirmation
+        }
+        _ => panic!("restart emitted an unexpected event"),
+    };
+    assert!(!second_confirmation.bridge_marker_is_durable());
+    second_confirmation.confirm_bridge_durable().unwrap();
+    second_replay.confirm_open_subsonic_submission(second_ack_rx.try_recv().unwrap());
+    assert_eq!(second_replay.flush().await, Ok(()));
+    let intermediate = QueueFile::at(queue_path.clone()).load().entries.remove(0);
+    assert!(intermediate.open_subsonic_pending);
+    assert!(intermediate.open_subsonic_handoff_started);
+    assert!(intermediate.open_subsonic_bridge_durable);
+    drop(second_replay);
+
+    // Boundary 2: the bridge source-ack is durable, but final marker removal fails. Restart sees
+    // AwaitingSourceAck and therefore must never submit the event again.
+    let (third_events, third_emit) = captured_events();
+    let (mut third, mut third_ack_rx) = test_actor_with_ack(
+        inactive_settings(),
+        Some(QueueFile::at(queue_path.clone())),
+        third_emit,
+    );
+    assert_eq!(third.flush().await, Ok(()));
+    let third_confirmation = match third_events.lock().unwrap().pop().unwrap() {
+        ScrobbleEvent::OpenSubsonic {
+            event_id: replayed,
+            confirmation: Some(confirmation),
+            ..
+        } => {
+            assert_eq!(replayed, event_id);
+            confirmation
+        }
+        _ => panic!("restart emitted an unexpected event"),
+    };
+    assert!(third_confirmation.bridge_marker_is_durable());
+    third_confirmation.confirm_source_acknowledged().unwrap();
+    third.confirm_open_subsonic_submission(third_ack_rx.try_recv().unwrap());
+    third.queue.as_ref().unwrap().fail_next_rewrites(1);
+    assert_eq!(third.flush().await, Err(DeliveryError::Saturated));
+    let still_intermediate = QueueFile::at(queue_path.clone()).load().entries.remove(0);
+    assert!(still_intermediate.open_subsonic_pending);
+    assert!(still_intermediate.open_subsonic_handoff_started);
+    assert!(still_intermediate.open_subsonic_bridge_durable);
+    drop(third);
+
+    let (fourth_events, fourth_emit) = captured_events();
+    let (mut fourth, mut fourth_ack_rx) = test_actor_with_ack(
+        inactive_settings(),
+        Some(QueueFile::at(queue_path.clone())),
+        fourth_emit,
+    );
+    assert_eq!(fourth.flush().await, Ok(()));
+    let fourth_confirmation = match fourth_events.lock().unwrap().pop().unwrap() {
+        ScrobbleEvent::OpenSubsonic {
+            confirmation: Some(confirmation),
+            ..
+        } => confirmation,
+        _ => panic!("restart emitted an unexpected event"),
+    };
+    assert!(fourth_confirmation.bridge_marker_is_durable());
+    fourth_confirmation.confirm_source_acknowledged().unwrap();
+    fourth.confirm_open_subsonic_submission(fourth_ack_rx.try_recv().unwrap());
+    assert_eq!(fourth.flush().await, Ok(()));
+    assert!(QueueFile::at(queue_path).load().entries.is_empty());
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[tokio::test]
+async fn external_service_compaction_preserves_server_marker_until_owner_ack() {
+    let (dir, queue) = temp_queue("open-subsonic-service-compaction");
+    let marker = QueueEntry::from_track(&open_subsonic_track(1_000), vec![ServiceKind::Lastfm]);
+    let event_id = marker.id.clone();
+    queue.rewrite(std::slice::from_ref(&marker)).unwrap();
+    let mut entries = vec![marker];
+    let service = FakeService::new(ServiceKind::Lastfm, Vec::new());
+    let mut health = Health::default();
+    let (_events, emit) = captured_events();
+    let lock = queue.try_lock().expect("test owns queue");
+
+    assert!(
+        flush_service(&service, &mut entries, &queue, &lock, &mut health, &emit,)
+            .await
+            .is_none()
+    );
+    drop(lock);
+    let loaded = queue.load();
+    assert_eq!(loaded.entries.len(), 1);
+    assert!(loaded.entries[0].pending.is_empty());
+    assert!(loaded.entries[0].open_subsonic_pending);
+
+    let (mut actor, mut acknowledgement_rx) =
+        test_actor_with_ack(inactive_settings(), Some(queue), emit);
+    let confirmation = OpenSubsonicSubmissionAck::new(event_id, actor.open_subsonic_ack_tx.clone());
+    confirmation.confirm_bridge_durable().unwrap();
+    actor.confirm_open_subsonic_submission(acknowledgement_rx.try_recv().unwrap());
+    assert_eq!(actor.flush().await, Ok(()));
+    confirmation.confirm_source_acknowledged().unwrap();
+    actor.confirm_open_subsonic_submission(acknowledgement_rx.try_recv().unwrap());
+    assert_eq!(actor.flush().await, Ok(()));
+    assert!(actor.queue.as_ref().unwrap().load().entries.is_empty());
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/src/scrobble/actor/tests/queue_drop_durability_tests.rs
+++ b/src/scrobble/actor/tests/queue_drop_durability_tests.rs
@@ -1,0 +1,179 @@
+use super::*;
+
+fn generic_entry(index: usize) -> QueueEntry {
+    entry(index, vec![ServiceKind::ListenBrainz])
+}
+
+fn queue_drop_values(events: &[ScrobbleEvent]) -> Vec<usize> {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            ScrobbleEvent::QueueDropped { dropped } => Some(*dropped),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn generic_in_memory_overflow_waits_for_a_durable_loss_audit() {
+    let (dir, queue) = temp_queue("generic-append-audit-failure");
+    let audit_path = queue.path().with_extension("drops.json");
+    std::fs::create_dir_all(audit_path.parent().unwrap()).unwrap();
+    std::fs::write(&audit_path, b"{invalid").unwrap();
+    let (events, emit) = captured_events();
+    let mut actor = test_actor(durable_only_settings(), Some(queue), emit);
+    for index in 0..QUEUE_CAP {
+        actor.pending_appends.push_back(generic_entry(index));
+    }
+    actor.pending_generic_appends = QUEUE_CAP;
+    let oldest_id = actor.pending_appends.front().unwrap().id.clone();
+
+    actor.enqueue_scrobble(track(9_999));
+
+    assert_eq!(actor.pending_generic_appends, QUEUE_CAP + 1);
+    assert_eq!(actor.pending_appends.len(), QUEUE_CAP + 1);
+    assert_eq!(actor.pending_appends.front().unwrap().id, oldest_id);
+    assert!(!actor.accepts_command_ingress());
+    assert!(queue_drop_values(&events.lock().unwrap()).is_empty());
+
+    std::fs::remove_file(audit_path).unwrap();
+    actor.queue.as_ref().unwrap().fail_next_appends(1);
+    assert_eq!(actor.retry_pending_appends(), Err(DeliveryError::Saturated));
+
+    assert_eq!(actor.pending_generic_appends, QUEUE_CAP);
+    assert_eq!(actor.pending_appends.len(), QUEUE_CAP);
+    assert_ne!(actor.pending_appends.front().unwrap().id, oldest_id);
+    assert!(actor.accepts_command_ingress());
+    assert_eq!(queue_drop_values(&events.lock().unwrap()), vec![1]);
+    assert_eq!(
+        actor.queue.as_ref().unwrap().drop_audit_counts().unwrap(),
+        (1, 0, 1)
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn generic_in_memory_cap_preserves_the_same_entrys_exact_marker() {
+    let (dir, queue) = temp_queue("generic-cap-preserves-exact");
+    queue.fail_next_appends(1);
+    let (events, emit) = captured_events();
+    let mut actor = test_actor(durable_only_settings(), Some(queue), emit);
+    let mut mixed =
+        QueueEntry::from_track(&open_subsonic_track(1_000), vec![ServiceKind::ListenBrainz]);
+    mixed.id = "oldest-mixed-marker".to_owned();
+    actor.pending_appends.push_back(mixed);
+    for index in 1..QUEUE_CAP {
+        actor.pending_appends.push_back(generic_entry(index));
+    }
+    actor.pending_generic_appends = QUEUE_CAP;
+    actor.pending_open_subsonic_appends = 1;
+
+    actor.enqueue_scrobble(track(9_999));
+
+    let retained = actor
+        .pending_appends
+        .iter()
+        .find(|entry| entry.id == "oldest-mixed-marker")
+        .unwrap();
+    assert!(retained.pending.is_empty());
+    assert!(retained.open_subsonic_pending);
+    assert_eq!(actor.pending_generic_appends, QUEUE_CAP);
+    assert_eq!(actor.pending_open_subsonic_appends, 1);
+    assert_eq!(queue_drop_values(&events.lock().unwrap()), vec![1]);
+    assert_eq!(
+        actor.queue.as_ref().unwrap().drop_audit_counts().unwrap(),
+        (1, 0, 1)
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn exact_in_memory_cap_preserves_the_same_entrys_generic_marker() {
+    let (dir, queue) = temp_queue("exact-cap-preserves-generic");
+    queue.fail_next_appends(1);
+    let (events, emit) = captured_events();
+    let mut actor = test_actor(durable_only_settings(), Some(queue), emit);
+    for index in 0..OPEN_SUBSONIC_QUEUE_CAP {
+        let mut pending =
+            QueueEntry::from_track(&open_subsonic_track(1_000 + index as i64), Vec::new());
+        pending.id = format!("exact-pending-{index}");
+        actor.pending_appends.push_back(pending);
+    }
+    actor.pending_open_subsonic_appends = OPEN_SUBSONIC_QUEUE_CAP;
+
+    actor.enqueue_scrobble(open_subsonic_track(30_000));
+
+    let retained = actor.pending_appends.back().unwrap();
+    assert!(!retained.pending.is_empty());
+    assert!(!retained.open_subsonic_pending);
+    assert_eq!(actor.pending_generic_appends, 1);
+    assert_eq!(actor.pending_open_subsonic_appends, OPEN_SUBSONIC_QUEUE_CAP);
+    assert_eq!(queue_drop_values(&events.lock().unwrap()), vec![1]);
+    assert_eq!(
+        actor.queue.as_ref().unwrap().drop_audit_counts().unwrap(),
+        (0, 1, 1)
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[tokio::test]
+async fn pre_replace_cap_failure_notifies_once_after_confirmed_retry() {
+    assert_cap_rewrite_notification(false).await;
+}
+
+#[tokio::test]
+async fn post_replace_cap_ambiguity_notifies_once_after_readback() {
+    assert_cap_rewrite_notification(true).await;
+}
+
+async fn assert_cap_rewrite_notification(after_replace: bool) {
+    let label = if after_replace {
+        "cap-notification-post-replace"
+    } else {
+        "cap-notification-pre-replace"
+    };
+    let (dir, queue) = temp_queue(label);
+    let entries = (0..=QUEUE_CAP).map(generic_entry).collect::<Vec<_>>();
+    queue.rewrite(&entries).unwrap();
+    if after_replace {
+        queue.fail_next_rewrites_after_replace(1);
+    } else {
+        queue.fail_next_rewrites(1);
+    }
+    let (events, emit) = captured_events();
+    let mut actor = test_actor(inactive_settings(), Some(queue), emit);
+
+    assert_eq!(actor.flush().await, Err(DeliveryError::Saturated));
+    assert!(queue_drop_values(&events.lock().unwrap()).is_empty());
+    assert!(actor.pending_queue_drop_outcome.is_some());
+    assert_eq!(
+        actor.queue.as_ref().unwrap().load().entries.len(),
+        if after_replace {
+            QUEUE_CAP
+        } else {
+            QUEUE_CAP + 1
+        }
+    );
+
+    assert_eq!(actor.flush().await, Ok(()));
+    assert_eq!(queue_drop_values(&events.lock().unwrap()), vec![1]);
+    assert!(actor.pending_queue_drop_outcome.is_none());
+    assert_eq!(
+        actor.queue.as_ref().unwrap().load().entries.len(),
+        QUEUE_CAP
+    );
+
+    assert_eq!(actor.flush().await, Ok(()));
+    assert_eq!(queue_drop_values(&events.lock().unwrap()), vec![1]);
+
+    actor
+        .queue
+        .as_ref()
+        .unwrap()
+        .append(&generic_entry(QUEUE_CAP + 2))
+        .unwrap();
+    assert_eq!(actor.flush().await, Ok(()));
+    assert_eq!(queue_drop_values(&events.lock().unwrap()), vec![1, 2]);
+    assert_eq!(actor.dropped_total, 2);
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/src/scrobble/handle_closed_tests.rs
+++ b/src/scrobble/handle_closed_tests.rs
@@ -1,0 +1,39 @@
+use super::*;
+
+fn settings() -> ScrobbleSettings {
+    ScrobbleSettings {
+        lastfm_app: None,
+        lastfm: None,
+        listenbrainz: None,
+        local_files: false,
+    }
+}
+
+#[test]
+fn observe_preserves_admission_state_after_closed_queue() {
+    let (tx, rx) = tokio::sync::mpsc::channel(1);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel(1);
+    drop(rx);
+    drop(shutdown_rx);
+    let mut handle = ScrobbleHandle::new(tx, shutdown_tx);
+
+    assert_eq!(
+        handle.observe(&crate::media::MediaSnapshot::idle()),
+        Err(DeliveryError::Closed)
+    );
+    assert!(handle.last_fingerprint.is_none());
+    assert!(handle.last_sent.is_none());
+}
+
+#[tokio::test]
+async fn control_commands_report_closed_queue() {
+    let (tx, rx) = tokio::sync::mpsc::channel(1);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel(1);
+    drop(rx);
+    drop(shutdown_rx);
+    let handle = ScrobbleHandle::new(tx, shutdown_tx);
+
+    assert_eq!(handle.reconfigure(settings()), Err(DeliveryError::Closed));
+    assert_eq!(handle.auth_start(), Err(DeliveryError::Closed));
+    assert_eq!(handle.shutdown_flush().await, Err(DeliveryError::Closed));
+}

--- a/src/scrobble/listenbrainz.rs
+++ b/src/scrobble/listenbrainz.rs
@@ -184,6 +184,7 @@ mod tests {
     fn listen_payload_shape() {
         let track = ScrobbleTrack {
             key: "abc".to_owned(),
+            open_subsonic_item: None,
             artist: "IU".to_owned(),
             title: "Blueming".to_owned(),
             album: Some("Love poem".to_owned()),

--- a/src/scrobble/mod.rs
+++ b/src/scrobble/mod.rs
@@ -18,14 +18,17 @@ pub mod queue;
 pub mod service;
 
 #[cfg(test)]
+mod handle_closed_tests;
+#[cfg(test)]
 mod terminal_delivery_tests;
 
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-pub use actor::{ScrobbleCmd, ScrobbleEvent, spawn};
+pub use actor::{OpenSubsonicSubmissionAck, ScrobbleCmd, ScrobbleEvent, spawn};
 pub use monitor::{Observation, ObservedTrack};
+pub use service::ScrobbleTrack;
 
 use tokio::sync::{Notify, mpsc::Sender};
 
@@ -86,6 +89,7 @@ impl Observation {
             let is_local = t.key.starts_with("local:");
             ObservedTrack {
                 key: t.key.clone(),
+                open_subsonic_item: t.open_subsonic_item.clone(),
                 title: t.title.clone(),
                 // `Song::local_file` fills a "Local file" placeholder for untagged files;
                 // that is display text, not an artist — scrobbling treats it as absent.
@@ -296,7 +300,23 @@ impl ScrobbleHandle {
     }
 
     pub fn observe(&mut self, snapshot: &crate::media::MediaSnapshot) -> DeliveryResult {
-        let obs = Observation::from_media(snapshot);
+        self.observe_derived(Observation::from_media(snapshot))
+    }
+
+    /// Seal the current playback interval at a fresh monotonic instant before the audio owner is
+    /// retired.
+    ///
+    /// Marking the snapshot non-playing makes it a terminal observation for the bounded delivery
+    /// lane, so saturation retains it in the shutdown-only retry slot. The track itself remains
+    /// present: the monitor first credits the elapsed playing interval, evaluates its threshold,
+    /// and only then disarms further wall-clock credit.
+    pub fn observe_shutdown(&mut self, snapshot: &crate::media::MediaSnapshot) -> DeliveryResult {
+        let mut observation = Observation::from_media(snapshot);
+        observation.playing = false;
+        self.observe_derived(observation)
+    }
+
+    fn observe_derived(&mut self, obs: Observation) -> DeliveryResult {
         let terminal = !obs.playing;
         let fingerprint = Fingerprint {
             track: obs.track.clone(),
@@ -1193,6 +1213,7 @@ mod tests {
 
         let track = |key: &str| ObservedTrack {
             key: key.to_owned(),
+            open_subsonic_item: None,
             title: key.to_owned(),
             artist: "Artist".to_owned(),
             album: None,
@@ -1264,6 +1285,7 @@ mod tests {
         assert!(handle.auth_start().is_ok());
         let track = ObservedTrack {
             key: "saturated-track".to_owned(),
+            open_subsonic_item: None,
             title: "Saturated Track".to_owned(),
             artist: "Artist".to_owned(),
             album: None,
@@ -1332,22 +1354,6 @@ mod tests {
             monitor::ScrobbleAction::Scrobble(track) if track.key == "saturated-track"
         )));
         assert_eq!(delivered_credit, 30.0);
-    }
-
-    #[test]
-    fn observe_preserves_admission_state_after_closed_queue() {
-        let (tx, rx) = tokio::sync::mpsc::channel(1);
-        let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel(1);
-        drop(rx);
-        drop(shutdown_rx);
-        let mut handle = ScrobbleHandle::new(tx, shutdown_tx);
-
-        assert_eq!(
-            handle.observe(&crate::media::MediaSnapshot::idle()),
-            Err(DeliveryError::Closed)
-        );
-        assert!(handle.last_fingerprint.is_none());
-        assert!(handle.last_sent.is_none());
     }
 
     #[test]
@@ -1462,19 +1468,6 @@ mod tests {
                     && !observation.latest().playing
                     && !observation.latest().stopped
         ));
-    }
-
-    #[tokio::test]
-    async fn control_commands_report_closed_queue() {
-        let (tx, rx) = tokio::sync::mpsc::channel(1);
-        let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel(1);
-        drop(rx);
-        drop(shutdown_rx);
-        let handle = ScrobbleHandle::new(tx, shutdown_tx);
-
-        assert_eq!(handle.reconfigure(settings()), Err(DeliveryError::Closed));
-        assert_eq!(handle.auth_start(), Err(DeliveryError::Closed));
-        assert_eq!(handle.shutdown_flush().await, Err(DeliveryError::Closed));
     }
 
     #[tokio::test]

--- a/src/scrobble/monitor.rs
+++ b/src/scrobble/monitor.rs
@@ -76,6 +76,8 @@ impl Observation {
 pub struct ObservedTrack {
     /// Stable identity (the queue `video_id`).
     pub key: String,
+    /// Exact server item for OpenSubsonic-origin playback. No credential or URL is carried.
+    pub open_subsonic_item: Option<crate::open_subsonic::OpenSubsonicItemRef>,
     pub title: String,
     pub artist: String,
     pub album: Option<String>,
@@ -142,6 +144,7 @@ impl Listen {
     fn scrobble_track(&self) -> ScrobbleTrack {
         ScrobbleTrack {
             key: self.track.key.clone(),
+            open_subsonic_item: self.track.open_subsonic_item.clone(),
             artist: self.track.artist.clone(),
             title: self.track.title.clone(),
             album: self.track.album.clone(),
@@ -315,6 +318,7 @@ mod tests {
     fn track(key: &str, duration: Option<f64>) -> ObservedTrack {
         ObservedTrack {
             key: key.to_owned(),
+            open_subsonic_item: None,
             title: format!("title-{key}"),
             artist: "artist".to_owned(),
             album: Some("album".to_owned()),
@@ -406,6 +410,38 @@ mod tests {
         assert_eq!(s[0].started_unix, started, "timestamp = listen START");
         assert_eq!(s[0].duration_secs, Some(200));
         assert_eq!(now_playings(&actions), 1);
+    }
+
+    #[test]
+    fn exact_server_item_survives_now_playing_and_submission_thresholds() {
+        let mut sim = Sim::new();
+        let item = crate::open_subsonic::OpenSubsonicItemRef::new(
+            crate::open_subsonic::BackendId::new("server-backend").unwrap(),
+            crate::open_subsonic::AccountScopeId::new("account-scope").unwrap(),
+            crate::open_subsonic::ItemId::new("song-42").unwrap(),
+        );
+        let mut observed = track("server-song", Some(40.0));
+        observed.open_subsonic_item = Some(item.clone());
+
+        let actions = sim.play(&observed, 30, 0.0);
+
+        let mut saw_now_playing = false;
+        let mut saw_submission = false;
+        for action in actions {
+            match action {
+                ScrobbleAction::NowPlaying(track) => {
+                    saw_now_playing = true;
+                    assert_eq!(track.open_subsonic_item, Some(item.clone()));
+                }
+                ScrobbleAction::Scrobble(track) => {
+                    saw_submission = true;
+                    assert_eq!(track.open_subsonic_item, Some(item.clone()));
+                }
+                ScrobbleAction::Love { .. } => {}
+            }
+        }
+        assert!(saw_now_playing);
+        assert!(saw_submission);
     }
 
     #[test]

--- a/src/scrobble/queue.rs
+++ b/src/scrobble/queue.rs
@@ -27,19 +27,111 @@ use serde::{Deserialize, Serialize};
 use super::service::{ScrobbleTrack, ServiceKind};
 use crate::util::safe_fs;
 
-/// Compaction keeps at most this many entries (newest first) — a two-week offline stretch
-/// of heavy listening fits comfortably; beyond that the oldest listens are the right loss.
+mod audit;
+
+/// External scrobble services keep at most this many pending listens. Exact music-server
+/// submissions have an independent, larger retention budget below.
 pub const QUEUE_CAP: usize = 2000;
+/// Exact OpenSubsonic submissions are local-first engagement events, not best-effort third-party
+/// scrobbles. Keep a full personal-state event window even when external services hit their cap.
+pub const OPEN_SUBSONIC_QUEUE_CAP: usize = 20_000;
 /// Last.fm silently ignores scrobbles older than two weeks; stop owing it those. Other
 /// services (ListenBrainz imports) accept arbitrary ages and keep their markers.
 const LASTFM_MAX_AGE: Duration = Duration::from_secs(14 * 24 * 3600);
-/// Queue reads cap at this size; the CAP-compaction keeps real files far below it.
-const QUEUE_READ_MAX: u64 = 4 * 1024 * 1024;
+/// Personal-state payloads share the repository-wide 192 MiB interpretation ceiling. The normal
+/// 22,000-entry post-compaction queue stays much smaller, while this permits recovery from a
+/// pre-compaction exact-event backlog.
+const QUEUE_READ_MAX: u64 = 192 * 1024 * 1024;
+/// Refuse adversarial line-count growth before allocating an unbounded parsed queue.
+const QUEUE_RESOURCE_MAX: usize = 40_000;
+const MAX_EXACT_EVENT_ID_BYTES: usize = 1_024;
+const MAX_EXACT_TRACK_KEY_BYTES: usize = 2_048;
 static ENTRY_SEQ: AtomicU64 = AtomicU64::new(1);
 static BOOT_NONCE: OnceLock<String> = OnceLock::new();
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct QueueDropKinds {
+    generic: bool,
+    open_subsonic: bool,
+    scope_retired: bool,
+}
+
+/// Exact loss description produced before compaction mutates the durable queue.
+///
+/// Keeping marker categories separate prevents the generic 2,000-listen policy from silently
+/// consuming the larger exact OpenSubsonic budget. IDs make the audit write idempotent across a
+/// crash between its fsync and the queue replacement.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct QueueDropSummary {
+    records: std::collections::BTreeMap<String, QueueDropKinds>,
+}
+
+impl QueueDropSummary {
+    pub(crate) fn note_generic(&mut self, entry_id: &str) {
+        self.records.entry(entry_id.to_owned()).or_default().generic = true;
+    }
+
+    pub(crate) fn note_open_subsonic(&mut self, entry_id: &str) {
+        self.records
+            .entry(entry_id.to_owned())
+            .or_default()
+            .open_subsonic = true;
+    }
+
+    pub(crate) fn note_scope_retired(&mut self, entry_id: &str) {
+        self.records
+            .entry(entry_id.to_owned())
+            .or_default()
+            .scope_retired = true;
+    }
+
+    pub fn generic_dropped(&self) -> usize {
+        self.records.values().filter(|kinds| kinds.generic).count()
+    }
+
+    pub fn open_subsonic_dropped(&self) -> usize {
+        self.records
+            .values()
+            .filter(|kinds| kinds.open_subsonic)
+            .count()
+    }
+
+    pub fn scope_retired(&self) -> usize {
+        self.records
+            .values()
+            .filter(|kinds| kinds.scope_retired)
+            .count()
+    }
+
+    pub fn affected_entries(&self) -> usize {
+        self.records.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// Whether an atomic queue replacement installed every marker removal described here.
+    ///
+    /// A rewrite error may be reported after the replacement reached disk. The actor retains the
+    /// bounded summary and checks the next strict load before publishing a permanent-loss event.
+    pub(crate) fn is_installed_in(&self, entries: &[QueueEntry]) -> bool {
+        self.records.iter().all(|(entry_id, kinds)| {
+            entries
+                .iter()
+                .find(|entry| entry.id == entry_id.as_str())
+                .is_none_or(|entry| {
+                    (!kinds.generic || entry.pending.is_empty())
+                        && (!kinds.open_subsonic || !entry.open_subsonic_pending)
+                        && (!kinds.scope_retired || !entry.open_subsonic_pending)
+                })
+        })
+    }
+}
+
 /// One queued listen. The field names are a stable on-disk format (JSONL, one per line).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct QueueEntry {
     /// Unique per listen, stable across reloads (dedupe key). New entries use
     /// `"{ts}-{boot nonce}-{monotonic seq}"`; old JSONL used `"{ts}-{track key}"`.
@@ -47,6 +139,8 @@ pub struct QueueEntry {
     /// Stable track identity. Added after the original id format; old entries derive this from id.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub track_key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub open_subsonic_item: Option<crate::open_subsonic::OpenSubsonicItemRef>,
     /// Listen start, unix seconds (the scrobble timestamp).
     pub ts: i64,
     pub artist: String,
@@ -57,6 +151,20 @@ pub struct QueueEntry {
     pub duration: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub origin_url: Option<String>,
+    /// An exact OpenSubsonic submission still needs confirmation that the credential owner's
+    /// bridge store crossed its durability boundary. This marker is independent from external
+    /// scrobble-service delivery and survives restarts with the same `id`.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub open_subsonic_pending: bool,
+    /// This exact marker crossed the source journal's pre-handoff durability boundary. Once set,
+    /// the credential owner may have accepted the event even if its acknowledgement has not
+    /// returned, so retention compaction must never evict it.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub open_subsonic_handoff_started: bool,
+    /// The bridge has durably queued this exact event, so restart must replay only the source
+    /// acknowledgement and never the server submission itself.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub open_subsonic_bridge_durable: bool,
     /// Services that still owe this listen a delivery.
     pub pending: Vec<ServiceKind>,
 }
@@ -64,16 +172,24 @@ pub struct QueueEntry {
 impl QueueEntry {
     pub fn from_track(track: &ScrobbleTrack, pending: Vec<ServiceKind>) -> Self {
         Self {
-            id: next_entry_id(track.started_unix),
+            id: next_event_id(track.started_unix),
             track_key: track.key.clone(),
+            open_subsonic_item: track.open_subsonic_item.clone(),
             ts: track.started_unix,
             artist: track.artist.clone(),
             title: track.title.clone(),
             album: track.album.clone(),
             duration: track.duration_secs,
             origin_url: track.origin_url.clone(),
+            open_subsonic_pending: track.open_subsonic_item.is_some(),
+            open_subsonic_handoff_started: false,
+            open_subsonic_bridge_durable: false,
             pending,
         }
+    }
+
+    pub fn has_pending_delivery(&self) -> bool {
+        self.open_subsonic_pending || !self.pending.is_empty()
     }
 
     pub fn to_track(&self) -> ScrobbleTrack {
@@ -83,6 +199,7 @@ impl QueueEntry {
             } else {
                 self.track_key.clone()
             },
+            open_subsonic_item: self.open_subsonic_item.clone(),
             artist: self.artist.clone(),
             title: self.title.clone(),
             album: self.album.clone(),
@@ -91,9 +208,48 @@ impl QueueEntry {
             started_unix: self.ts,
         }
     }
+
+    fn validate_on_disk(&self) -> bool {
+        if self.open_subsonic_bridge_durable
+            && (!self.open_subsonic_pending || !self.open_subsonic_handoff_started)
+        {
+            return false;
+        }
+        if self.open_subsonic_handoff_started && !self.open_subsonic_pending {
+            return false;
+        }
+        if !self.open_subsonic_pending {
+            return true;
+        }
+        self.open_subsonic_item.is_some()
+            && valid_exact_component(&self.id, MAX_EXACT_EVENT_ID_BYTES)
+            && valid_exact_component(&self.track_key, MAX_EXACT_TRACK_KEY_BYTES)
+    }
 }
 
-fn next_entry_id(started_unix: i64) -> String {
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+fn valid_exact_component(value: &str, max_bytes: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_bytes
+        && !value.chars().any(|character| {
+            character.is_control()
+                || matches!(
+                    character,
+                    '\u{202a}'..='\u{202e}'
+                        | '\u{2066}'..='\u{2069}'
+                        | '\u{feff}'
+                )
+        })
+}
+
+/// Allocate one process-unique playback event ID.
+///
+/// The scrobble actor also uses this at the exact OpenSubsonic threshold so the same owner event
+/// keeps one identity across deferred delivery and bridge-store retries.
+pub(crate) fn next_event_id(started_unix: i64) -> String {
     let seq = ENTRY_SEQ.fetch_add(1, Ordering::Relaxed);
     format!("{started_unix}-{}-{seq}", boot_nonce())
 }
@@ -122,8 +278,8 @@ fn legacy_track_key_from_id(id: &str) -> String {
         .unwrap_or_else(|| id.to_owned())
 }
 
-/// What [`QueueFile::load`] found: parsed entries (id-deduped, keep-first) plus how many
-/// lines were corrupt (skipped, never fatal — one mangled line must not strand the rest).
+/// What [`QueueFile::load`] found. Any malformed input makes the whole snapshot unreadable so a
+/// later compaction can never erase an exact marker hidden in a torn or future-schema line.
 #[derive(Debug, Default)]
 pub struct LoadedQueue {
     pub entries: Vec<QueueEntry>,
@@ -327,19 +483,83 @@ impl QueueFile {
                 };
             }
         };
-        let text = String::from_utf8_lossy(&bytes);
+        let text = match std::str::from_utf8(&bytes) {
+            Ok(text) => text,
+            Err(_) => {
+                return LoadedQueue {
+                    corrupt: 1,
+                    read_failed: true,
+                    ..LoadedQueue::default()
+                };
+            }
+        };
         let mut out = LoadedQueue::default();
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = std::collections::HashMap::<String, usize>::new();
+        let mut resources = 0usize;
         for line in text.lines() {
             let line = line.trim();
             if line.is_empty() {
                 continue;
             }
-            match serde_json::from_str::<QueueEntry>(line) {
-                Ok(e) if seen.insert(e.id.clone()) => out.entries.push(e),
-                Ok(_) => {} // duplicate id (crash between submit and rewrite): keep-first
-                Err(_) => out.corrupt += 1,
+            resources = resources.saturating_add(1);
+            if resources > QUEUE_RESOURCE_MAX {
+                tracing::warn!(
+                    resources,
+                    limit = QUEUE_RESOURCE_MAX,
+                    "scrobble queue resource limit exceeded; leaving it intact"
+                );
+                return LoadedQueue {
+                    read_failed: true,
+                    ..LoadedQueue::default()
+                };
             }
+            match serde_json::from_str::<QueueEntry>(line) {
+                Ok(entry) if !entry.validate_on_disk() => {
+                    return LoadedQueue {
+                        corrupt: out.corrupt.saturating_add(1),
+                        read_failed: true,
+                        ..LoadedQueue::default()
+                    };
+                }
+                Ok(entry) => {
+                    if let Some(position) = seen.get(&entry.id).copied() {
+                        if out.entries[position] != entry {
+                            return LoadedQueue {
+                                corrupt: out.corrupt.saturating_add(1),
+                                read_failed: true,
+                                ..LoadedQueue::default()
+                            };
+                        }
+                    } else {
+                        seen.insert(entry.id.clone(), out.entries.len());
+                        out.entries.push(entry);
+                    }
+                }
+                Err(_) => {
+                    return LoadedQueue {
+                        corrupt: out.corrupt.saturating_add(1),
+                        read_failed: true,
+                        ..LoadedQueue::default()
+                    };
+                }
+            }
+        }
+        if out
+            .entries
+            .iter()
+            .filter(|entry| entry.open_subsonic_pending && entry.open_subsonic_handoff_started)
+            .count()
+            > OPEN_SUBSONIC_QUEUE_CAP
+        {
+            tracing::warn!(
+                limit = OPEN_SUBSONIC_QUEUE_CAP,
+                "protected music server handoff marker limit exceeded; leaving queue intact"
+            );
+            return LoadedQueue {
+                corrupt: out.corrupt.saturating_add(1),
+                read_failed: true,
+                ..LoadedQueue::default()
+            };
         }
         out
     }
@@ -403,6 +623,26 @@ impl QueueFile {
         Ok(safe_fs::try_lock_private_file(&lock_path)?
             .map(|guard| QueueFlushLock { _guard: guard }))
     }
+
+    /// Persist a loss record before installing a capped queue replacement.
+    pub(super) fn record_drop_audit_locked(
+        &self,
+        summary: &QueueDropSummary,
+        observed_at_unix: i64,
+        _lock: &QueueFlushLock,
+    ) -> std::io::Result<()> {
+        audit::record(&self.path, summary, observed_at_unix)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn drop_audit_counts(&self) -> std::io::Result<(u64, u64, usize)> {
+        audit::counts(&self.path)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn scope_retirement_audit_count(&self) -> std::io::Result<u64> {
+        audit::scope_retired_count(&self.path)
+    }
 }
 
 #[cfg(test)]
@@ -419,23 +659,50 @@ pub struct QueueFlushLock {
     _guard: safe_fs::AdvisoryFileLock,
 }
 
-/// Compaction policy, pure so it's testable: age out Last.fm markers past two weeks,
-/// drop fully-delivered entries, and cap to the newest [`QUEUE_CAP`] by timestamp.
-/// Returns the surviving entries plus how many were dropped by the cap.
-pub fn compact(mut entries: Vec<QueueEntry>, now_unix: i64) -> (Vec<QueueEntry>, usize) {
+/// Compaction policy, pure so it's testable: age out Last.fm markers past two weeks, drop
+/// fully-delivered entries, then cap generic and exact-server markers independently.
+pub fn compact(mut entries: Vec<QueueEntry>, now_unix: i64) -> (Vec<QueueEntry>, QueueDropSummary) {
     let lastfm_cutoff = now_unix - LASTFM_MAX_AGE.as_secs() as i64;
     for e in &mut entries {
         if e.ts < lastfm_cutoff {
             e.pending.retain(|s| *s != ServiceKind::Lastfm);
         }
     }
-    entries.retain(|e| !e.pending.is_empty());
-    let mut dropped = 0;
-    if entries.len() > QUEUE_CAP {
-        entries.sort_by_key(|e| e.ts);
-        dropped = entries.len() - QUEUE_CAP;
-        entries.drain(..dropped);
+    entries.retain(QueueEntry::has_pending_delivery);
+    entries.sort_by(|left, right| left.ts.cmp(&right.ts).then_with(|| left.id.cmp(&right.id)));
+
+    let mut dropped = QueueDropSummary::default();
+    let open_subsonic_excess = entries
+        .iter()
+        .filter(|entry| entry.open_subsonic_pending)
+        .count()
+        .saturating_sub(OPEN_SUBSONIC_QUEUE_CAP);
+    for entry in entries
+        .iter_mut()
+        .rev()
+        .filter(|entry| entry.open_subsonic_pending && !entry.open_subsonic_handoff_started)
+        .take(open_subsonic_excess)
+    {
+        entry.open_subsonic_pending = false;
+        entry.open_subsonic_handoff_started = false;
+        entry.open_subsonic_bridge_durable = false;
+        dropped.note_open_subsonic(&entry.id);
     }
+
+    let generic_excess = entries
+        .iter()
+        .filter(|entry| !entry.pending.is_empty())
+        .count()
+        .saturating_sub(QUEUE_CAP);
+    for entry in entries
+        .iter_mut()
+        .filter(|entry| !entry.pending.is_empty())
+        .take(generic_excess)
+    {
+        entry.pending.clear();
+        dropped.note_generic(&entry.id);
+    }
+    entries.retain(QueueEntry::has_pending_delivery);
     (entries, dropped)
 }
 
@@ -459,14 +726,29 @@ mod tests {
         QueueEntry {
             id: format!("{ts}-{id_key}"),
             track_key: id_key.to_owned(),
+            open_subsonic_item: None,
             ts,
             artist: "artist".to_owned(),
             title: "title".to_owned(),
             album: None,
             duration: Some(200),
             origin_url: None,
+            open_subsonic_pending: false,
+            open_subsonic_handoff_started: false,
+            open_subsonic_bridge_durable: false,
             pending,
         }
+    }
+
+    fn server_entry(id_key: &str, ts: i64, pending: Vec<ServiceKind>) -> QueueEntry {
+        let mut entry = entry(id_key, ts, pending);
+        entry.open_subsonic_item = Some(crate::open_subsonic::OpenSubsonicItemRef::new(
+            crate::open_subsonic::BackendId::new("server-backend").unwrap(),
+            crate::open_subsonic::AccountScopeId::new("account-scope").unwrap(),
+            crate::open_subsonic::ItemId::new(id_key).unwrap(),
+        ));
+        entry.open_subsonic_pending = true;
+        entry
     }
 
     #[test]
@@ -493,7 +775,7 @@ mod tests {
     }
 
     #[test]
-    fn corrupt_lines_are_skipped_not_fatal() {
+    fn corrupt_json_fails_closed_without_returning_a_partial_queue() {
         let (dir, q) = temp_queue("corrupt");
         let a = entry("a", 100, vec![ServiceKind::Lastfm]);
         q.append(&a).unwrap();
@@ -501,13 +783,14 @@ mod tests {
         let b = entry("b", 200, vec![ServiceKind::Lastfm]);
         q.append(&b).unwrap();
         let loaded = q.load();
-        assert_eq!(loaded.entries, vec![a, b]);
+        assert!(loaded.read_failed);
+        assert!(loaded.entries.is_empty());
         assert_eq!(loaded.corrupt, 1);
         let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]
-    fn jsonl_loader_handles_deterministic_corrupt_corpus() {
+    fn jsonl_loader_fails_closed_on_deterministic_corrupt_corpus() {
         let (dir, q) = temp_queue("corrupt-corpus");
         let a = entry("a", 100, vec![ServiceKind::Lastfm]);
         let b = entry("b", 200, vec![ServiceKind::ListenBrainz]);
@@ -533,10 +816,31 @@ mod tests {
 
         let loaded = q.load();
 
-        assert!(!loaded.read_failed);
-        assert_eq!(loaded.entries, vec![a, b]);
-        assert!(loaded.corrupt >= 128);
+        assert!(loaded.read_failed);
+        assert!(loaded.entries.is_empty());
+        assert_eq!(loaded.corrupt, 1);
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn invalid_utf8_and_invalid_exact_marker_shape_fail_closed() {
+        let (utf8_dir, utf8_queue) = temp_queue("invalid-utf8");
+        std::fs::create_dir_all(utf8_queue.path().parent().unwrap()).unwrap();
+        std::fs::write(utf8_queue.path(), [0xff, b'\n']).unwrap();
+        let loaded = utf8_queue.load();
+        assert!(loaded.read_failed);
+        assert!(loaded.entries.is_empty());
+
+        let (shape_dir, shape_queue) = temp_queue("invalid-exact-shape");
+        let mut malformed = entry("server", 100, Vec::new());
+        malformed.open_subsonic_pending = true;
+        shape_queue.append(&malformed).unwrap();
+        let loaded = shape_queue.load();
+        assert!(loaded.read_failed);
+        assert!(loaded.entries.is_empty());
+
+        let _ = std::fs::remove_dir_all(utf8_dir);
+        let _ = std::fs::remove_dir_all(shape_dir);
     }
 
     #[test]
@@ -544,7 +848,8 @@ mod tests {
         let (dir, q) = temp_queue("oversize");
         std::fs::create_dir_all(q.path().parent().unwrap()).unwrap();
         // A file just over the read cap must not read as an empty queue.
-        std::fs::write(q.path(), vec![b'x'; (QUEUE_READ_MAX as usize) + 1]).unwrap();
+        let file = std::fs::File::create(q.path()).unwrap();
+        file.set_len(QUEUE_READ_MAX + 1).unwrap();
         let loaded = q.load();
         assert!(
             loaded.read_failed,
@@ -571,8 +876,27 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_ids_keep_first() {
-        let (dir, q) = temp_queue("dupe");
+    fn identical_duplicate_ids_are_an_idempotent_single_entry() {
+        let (dir, q) = temp_queue("identical-dupe");
+        let a = entry(
+            "a",
+            100,
+            vec![ServiceKind::Lastfm, ServiceKind::ListenBrainz],
+        );
+        q.append(&a).unwrap();
+        q.append(&a).unwrap();
+
+        let loaded = q.load();
+
+        assert!(!loaded.read_failed);
+        assert_eq!(loaded.corrupt, 0);
+        assert_eq!(loaded.entries, vec![a]);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn conflicting_duplicate_ids_fail_closed_and_preserve_the_journal() {
+        let (dir, q) = temp_queue("conflicting-dupe");
         let a = entry(
             "a",
             100,
@@ -582,7 +906,14 @@ mod tests {
         a_later.pending = vec![ServiceKind::Lastfm];
         q.append(&a).unwrap();
         q.append(&a_later).unwrap();
-        assert_eq!(q.load().entries, vec![a]);
+        let before = std::fs::read(q.path()).unwrap();
+
+        let loaded = q.load();
+
+        assert!(loaded.read_failed);
+        assert_eq!(loaded.corrupt, 1);
+        assert!(loaded.entries.is_empty());
+        assert_eq!(std::fs::read(q.path()).unwrap(), before);
         let _ = std::fs::remove_dir_all(dir);
     }
 
@@ -600,7 +931,7 @@ mod tests {
             entry("fresh", now - 60, vec![ServiceKind::Lastfm]),
         ];
         let (kept, dropped) = compact(entries, now);
-        assert_eq!(dropped, 0);
+        assert!(dropped.is_empty());
         // old-lastfm lost its only marker → gone; old-both keeps LB only.
         assert_eq!(kept.len(), 2);
         assert_eq!(kept[0].pending, vec![ServiceKind::ListenBrainz]);
@@ -620,9 +951,185 @@ mod tests {
             })
             .collect();
         let (kept, dropped) = compact(entries, now);
-        assert_eq!(dropped, 10);
+        assert_eq!(dropped.generic_dropped(), 10);
+        assert_eq!(dropped.open_subsonic_dropped(), 0);
         assert_eq!(kept.len(), QUEUE_CAP);
         assert!(kept.iter().all(|e| e.ts >= now - 100_000 + 10));
+    }
+
+    #[test]
+    fn generic_cap_clears_external_markers_without_dropping_exact_server_events() {
+        let now = 10_000_000;
+        let entries = (0..QUEUE_CAP + 10)
+            .map(|index| {
+                server_entry(
+                    &format!("song-{index}"),
+                    now - 100_000 + index as i64,
+                    vec![ServiceKind::ListenBrainz],
+                )
+            })
+            .collect();
+
+        let (kept, dropped) = compact(entries, now);
+
+        assert_eq!(kept.len(), QUEUE_CAP + 10);
+        assert_eq!(dropped.generic_dropped(), 10);
+        assert_eq!(dropped.open_subsonic_dropped(), 0);
+        assert!(kept.iter().all(|entry| entry.open_subsonic_pending));
+        assert_eq!(
+            kept.iter()
+                .filter(|entry| !entry.pending.is_empty())
+                .count(),
+            QUEUE_CAP
+        );
+    }
+
+    #[test]
+    fn exact_server_cap_is_independent_and_drops_only_its_newest_unstarted_markers() {
+        let now = 10_000_000;
+        let entries = (0..OPEN_SUBSONIC_QUEUE_CAP + 10)
+            .map(|index| {
+                server_entry(
+                    &format!("song-{index}"),
+                    now - 100_000 + index as i64,
+                    Vec::new(),
+                )
+            })
+            .collect();
+
+        let (kept, dropped) = compact(entries, now);
+
+        assert_eq!(kept.len(), OPEN_SUBSONIC_QUEUE_CAP);
+        assert_eq!(dropped.generic_dropped(), 0);
+        assert_eq!(dropped.open_subsonic_dropped(), 10);
+        assert!(
+            kept.iter()
+                .all(|entry| entry.ts < now - 100_000 + OPEN_SUBSONIC_QUEUE_CAP as i64)
+        );
+    }
+
+    #[test]
+    fn exact_cap_never_evicts_started_or_awaiting_source_handoffs() {
+        let now = 10_000_000;
+        let mut entries = (0..OPEN_SUBSONIC_QUEUE_CAP)
+            .map(|index| {
+                let mut entry = server_entry(
+                    &format!("protected-{index}"),
+                    now - 100_000 + index as i64,
+                    Vec::new(),
+                );
+                entry.open_subsonic_handoff_started = true;
+                entry
+            })
+            .collect::<Vec<_>>();
+        entries[0].open_subsonic_bridge_durable = true;
+        let newest = server_entry("never-handed-off", now, Vec::new());
+        entries.push(newest.clone());
+
+        let (kept, dropped) = compact(entries, now);
+
+        assert_eq!(kept.len(), OPEN_SUBSONIC_QUEUE_CAP);
+        assert_eq!(dropped.open_subsonic_dropped(), 1);
+        assert!(
+            kept.iter().any(
+                |entry| entry.id.ends_with("protected-0") && entry.open_subsonic_bridge_durable
+            )
+        );
+        assert!(kept.iter().all(|entry| entry.open_subsonic_handoff_started));
+        assert!(!kept.iter().any(|entry| entry.id == newest.id));
+    }
+
+    #[test]
+    fn drop_audit_is_durable_and_idempotent_across_queue_reopen() {
+        let (dir, queue) = temp_queue("drop-audit");
+        let now = 10_000_000;
+        let entries = (0..QUEUE_CAP + 3)
+            .map(|index| {
+                entry(
+                    &format!("track-{index}"),
+                    now - 100_000 + index as i64,
+                    vec![ServiceKind::ListenBrainz],
+                )
+            })
+            .collect();
+        let (_kept, dropped) = compact(entries, now);
+        let lock = queue.try_lock().unwrap();
+        queue
+            .record_drop_audit_locked(&dropped, now, &lock)
+            .unwrap();
+        drop(lock);
+
+        let reopened = QueueFile::at(queue.path().to_path_buf());
+        let lock = reopened.try_lock().unwrap();
+        reopened
+            .record_drop_audit_locked(&dropped, now + 1, &lock)
+            .unwrap();
+        drop(lock);
+
+        assert_eq!(reopened.drop_audit_counts().unwrap(), (3, 0, 1));
+        let audit_path = queue.path().with_extension("drops.json");
+        let serialized = std::fs::read_to_string(&audit_path).unwrap();
+        assert!(!serialized.contains("track-0"));
+        assert!(!serialized.contains("https://"));
+        assert!(!serialized.contains(&dir.to_string_lossy().to_string()));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                std::fs::metadata(audit_path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn capped_exact_queue_and_audit_survive_reopen() {
+        let (dir, queue) = temp_queue("exact-cap-reopen");
+        let now = 10_000_000;
+        let entries = (0..OPEN_SUBSONIC_QUEUE_CAP + 2)
+            .map(|index| {
+                server_entry(
+                    &format!("song-{index}"),
+                    now - 100_000 + index as i64,
+                    Vec::new(),
+                )
+            })
+            .collect();
+        let (kept, dropped) = compact(entries, now);
+        let lock = queue.try_lock().unwrap();
+        queue
+            .record_drop_audit_locked(&dropped, now, &lock)
+            .unwrap();
+        queue.rewrite_locked(&kept, &lock).unwrap();
+        drop(lock);
+
+        let reopened = QueueFile::at(queue.path().to_path_buf());
+        let loaded = reopened.load();
+        assert!(!loaded.read_failed);
+        assert_eq!(loaded.entries.len(), OPEN_SUBSONIC_QUEUE_CAP);
+        assert!(
+            loaded
+                .entries
+                .iter()
+                .all(|entry| entry.open_subsonic_pending)
+        );
+        assert_eq!(reopened.drop_audit_counts().unwrap(), (0, 2, 1));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn excessive_resource_count_is_read_failed_not_a_partial_queue() {
+        let (dir, queue) = temp_queue("resource-count");
+        std::fs::create_dir_all(queue.path().parent().unwrap()).unwrap();
+        let rows = "{}\n".repeat(QUEUE_RESOURCE_MAX + 1);
+        std::fs::write(queue.path(), rows).unwrap();
+
+        let loaded = queue.load();
+
+        assert!(loaded.read_failed);
+        assert!(loaded.entries.is_empty());
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]
@@ -692,8 +1199,14 @@ mod tests {
 
     #[test]
     fn queue_entry_round_trips_scrobble_track() {
+        let (dir, queue) = temp_queue("server-item-round-trip");
         let track = ScrobbleTrack {
             key: "dQw4w9WgXcQ".to_owned(),
+            open_subsonic_item: Some(crate::open_subsonic::OpenSubsonicItemRef::new(
+                crate::open_subsonic::BackendId::new("server-backend").unwrap(),
+                crate::open_subsonic::AccountScopeId::new("account-scope").unwrap(),
+                crate::open_subsonic::ItemId::new("song-42").unwrap(),
+            )),
             artist: "아이유".to_owned(),
             title: "Love wins all".to_owned(),
             album: Some("The Winning".to_owned()),
@@ -705,12 +1218,19 @@ mod tests {
         assert!(e.id.starts_with("1751400000-"));
         assert_eq!(e.track_key, "dQw4w9WgXcQ");
         assert_eq!(e.to_track(), track);
+        queue.append(&e).unwrap();
+        let loaded = queue.load();
+        assert!(!loaded.read_failed);
+        assert_eq!(loaded.entries, vec![e]);
+        assert_eq!(loaded.entries[0].to_track(), track);
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]
     fn same_second_same_track_entries_get_distinct_ids() {
         let track = ScrobbleTrack {
             key: "same".to_owned(),
+            open_subsonic_item: None,
             artist: "artist".to_owned(),
             title: "title".to_owned(),
             album: None,
@@ -732,12 +1252,16 @@ mod tests {
         let entry = QueueEntry {
             id: "100-old-key".to_owned(),
             track_key: String::new(),
+            open_subsonic_item: None,
             ts: 100,
             artist: "artist".to_owned(),
             title: "title".to_owned(),
             album: None,
             duration: None,
             origin_url: None,
+            open_subsonic_pending: false,
+            open_subsonic_handoff_started: false,
+            open_subsonic_bridge_durable: false,
             pending: vec![ServiceKind::Lastfm],
         };
 

--- a/src/scrobble/queue/audit.rs
+++ b/src/scrobble/queue/audit.rs
@@ -1,0 +1,135 @@
+//! Durable, idempotent accounting for retention loss and retired server scopes.
+
+use std::path::Path;
+
+use data_encoding::HEXLOWER;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use super::QueueDropSummary;
+use crate::util::safe_fs;
+
+const AUDIT_SCHEMA_VERSION: u8 = 1;
+const AUDIT_READ_MAX: u64 = 256 * 1024;
+const AUDIT_BATCH_CAP: usize = 128;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct QueueDropAudit {
+    schema_version: u8,
+    generic_dropped: u64,
+    open_subsonic_dropped: u64,
+    #[serde(default)]
+    scope_retired: u64,
+    recent_batches: Vec<QueueDropBatch>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct QueueDropBatch {
+    batch_id: String,
+    observed_at_unix: i64,
+    affected_entries: u64,
+    generic_dropped: u64,
+    open_subsonic_dropped: u64,
+    #[serde(default)]
+    scope_retired: u64,
+}
+
+pub(super) fn record(
+    queue_path: &Path,
+    summary: &QueueDropSummary,
+    observed_at_unix: i64,
+) -> std::io::Result<()> {
+    if summary.is_empty() {
+        return Ok(());
+    }
+    let path = audit_path(queue_path);
+    let mut audit = load(&path)?;
+    let batch_id = batch_id(summary);
+    if audit
+        .recent_batches
+        .iter()
+        .any(|batch| batch.batch_id == batch_id)
+    {
+        return Ok(());
+    }
+
+    let generic_dropped = summary.generic_dropped() as u64;
+    let open_subsonic_dropped = summary.open_subsonic_dropped() as u64;
+    let scope_retired = summary.scope_retired() as u64;
+    audit.schema_version = AUDIT_SCHEMA_VERSION;
+    audit.generic_dropped = audit.generic_dropped.saturating_add(generic_dropped);
+    audit.open_subsonic_dropped = audit
+        .open_subsonic_dropped
+        .saturating_add(open_subsonic_dropped);
+    audit.scope_retired = audit.scope_retired.saturating_add(scope_retired);
+    audit.recent_batches.push(QueueDropBatch {
+        batch_id,
+        observed_at_unix,
+        affected_entries: summary.affected_entries() as u64,
+        generic_dropped,
+        open_subsonic_dropped,
+        scope_retired,
+    });
+    if audit.recent_batches.len() > AUDIT_BATCH_CAP {
+        let excess = audit.recent_batches.len() - AUDIT_BATCH_CAP;
+        audit.recent_batches.drain(..excess);
+    }
+    safe_fs::write_private_atomic_json(&path, &audit)
+}
+
+fn load(path: &Path) -> std::io::Result<QueueDropAudit> {
+    let bytes = match safe_fs::read_no_symlink_limited(path, AUDIT_READ_MAX) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(QueueDropAudit::default());
+        }
+        Err(error) => return Err(error),
+    };
+    let audit: QueueDropAudit = serde_json::from_slice(&bytes).map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid scrobble queue drop audit: {error}"),
+        )
+    })?;
+    if audit.schema_version != AUDIT_SCHEMA_VERSION {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "unsupported scrobble queue drop audit schema",
+        ));
+    }
+    Ok(audit)
+}
+
+fn batch_id(summary: &QueueDropSummary) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"yututui-scrobble-queue-drop-v1\0");
+    for (entry_id, kinds) in &summary.records {
+        digest.update((entry_id.len() as u64).to_be_bytes());
+        digest.update(entry_id.as_bytes());
+        digest.update([
+            u8::from(kinds.generic),
+            u8::from(kinds.open_subsonic),
+            u8::from(kinds.scope_retired),
+        ]);
+    }
+    HEXLOWER.encode(&digest.finalize())
+}
+
+fn audit_path(queue_path: &Path) -> std::path::PathBuf {
+    queue_path.with_extension("drops.json")
+}
+
+#[cfg(test)]
+pub(super) fn counts(queue_path: &Path) -> std::io::Result<(u64, u64, usize)> {
+    let audit = load(&audit_path(queue_path))?;
+    Ok((
+        audit.generic_dropped,
+        audit.open_subsonic_dropped,
+        audit.recent_batches.len(),
+    ))
+}
+
+#[cfg(test)]
+pub(super) fn scope_retired_count(queue_path: &Path) -> std::io::Result<u64> {
+    Ok(load(&audit_path(queue_path))?.scope_retired)
+}

--- a/src/scrobble/service.rs
+++ b/src/scrobble/service.rs
@@ -31,6 +31,8 @@ impl ServiceKind {
 pub struct ScrobbleTrack {
     /// Stable track identity (the app's `video_id`); keys queue entries and dedupe.
     pub key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub open_subsonic_item: Option<crate::open_subsonic::OpenSubsonicItemRef>,
     pub artist: String,
     pub title: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/scrobble/terminal_delivery_tests.rs
+++ b/src/scrobble/terminal_delivery_tests.rs
@@ -3,6 +3,7 @@ use super::*;
 fn track(duration: Option<f64>, liked: bool) -> ObservedTrack {
     ObservedTrack {
         key: "repeat-a".to_owned(),
+        open_subsonic_item: None,
         title: "Repeat A".to_owned(),
         artist: "Artist".to_owned(),
         album: None,
@@ -21,6 +22,7 @@ fn paused_snapshot(duration: Option<f64>, artist: &str, epoch: u64) -> crate::me
     snapshot.position_epoch = epoch;
     snapshot.track = Some(crate::media::MediaTrack {
         key: "repeat-a".to_owned(),
+        open_subsonic_item: None,
         title: "Repeat A".to_owned(),
         artist: artist.to_owned(),
         album: None,

--- a/src/server_cli.rs
+++ b/src/server_cli.rs
@@ -11,9 +11,11 @@ use age::secrecy::SecretString;
 use serde::Serialize;
 
 use yututui::open_subsonic::{
-    CredentialKind, OpenSubsonicPaths, OpenSubsonicStatus, OpenSubsonicStatusKind,
-    ServerCredential, ServerFeature, SetupIdentityIntent, SetupInput, commit_setup, read_status,
-    remove_profile, test_and_prepare_setup, test_connection_read_only,
+    CredentialKind, NativeHistoryHealth, OpenSubsonicPaths, OpenSubsonicStatus,
+    OpenSubsonicStatusKind, OutboundScrobbleResolution, ServerCredential, ServerFeature,
+    SetupIdentityIntent, SetupInput, commit_setup, commit_store_set, list_scrobble_attention_ids,
+    load_store_set, read_status, remove_profile, resolve_scrobble_attention,
+    test_and_prepare_setup, test_connection_read_only,
 };
 
 const EXIT_OK: i32 = 0;
@@ -28,6 +30,8 @@ const MAX_PASSWORD_BYTES: usize = 64 * 1_024;
 const MAX_API_KEY_BYTES: usize = 2_048;
 const MAX_CA_PATH_BYTES: usize = 16 * 1_024;
 const MAX_CHOICE_BYTES: usize = 64;
+const OPAQUE_SCROBBLE_ID_PREFIX: &str = "sub-scrobble-";
+const OPAQUE_SCROBBLE_DIGEST_BYTES: usize = 64;
 
 const SERVER_USAGE: &str = "\
 Usage: ytt server <command>
@@ -37,17 +41,39 @@ Connect one OpenSubsonic or Navidrome music server.
 Commands:
   setup             Test and save a music server connection
   status [--json]   Show the redacted connection status
+  history enable --experimental
+                    Enable experimental detailed Navidrome history
+  history disable   Disable detailed history and remove its saved password
+  scrobbles list [--json]
+                    List opaque playback reports needing a decision
+  scrobbles retry <OPAQUE_ID>
+                    Treat one report as unsent and retry it
+  scrobbles mark-sent <OPAQUE_ID>
+                    Treat one report as sent without retrying it
   remove            Remove the profile and credentials; keep local personal data
 
 Passwords and API keys are prompted with echo disabled and are never accepted as arguments.
+Experimental detailed history is off by default and never disables standard server access.
 ";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum Command {
     Help,
     Setup,
     Status { json: bool },
+    HistoryEnableExperimental,
+    HistoryDisable,
+    ScrobblesList { json: bool },
+    ScrobbleRetry { event_id: String },
+    ScrobbleMarkSent { event_id: String },
     Remove,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HistoryEnableAction {
+    Enable,
+    UpdateDedicatedPassword,
+    AlreadyEnabled,
 }
 
 #[derive(Serialize)]
@@ -59,6 +85,15 @@ struct JsonStatus<'a> {
     credential: Option<&'static str>,
     lan_http_enabled: bool,
     custom_ca_configured: bool,
+    detailed_history_enabled: bool,
+    detailed_history_status: &'static str,
+    playback_reports_needing_decision: usize,
+}
+
+#[derive(Serialize)]
+struct JsonScrobbleAttention<'a> {
+    count: usize,
+    opaque_ids: &'a [String],
 }
 
 pub fn run(args: &[String]) -> i32 {
@@ -73,6 +108,15 @@ pub fn run(args: &[String]) -> i32 {
         }
         Command::Setup => run_setup(),
         Command::Status { json } => run_status(json),
+        Command::HistoryEnableExperimental => run_history_enable(),
+        Command::HistoryDisable => run_history_disable(),
+        Command::ScrobblesList { json } => run_scrobbles_list(json),
+        Command::ScrobbleRetry { event_id } => {
+            run_scrobble_resolution(&event_id, OutboundScrobbleResolution::Retry)
+        }
+        Command::ScrobbleMarkSent { event_id } => {
+            run_scrobble_resolution(&event_id, OutboundScrobbleResolution::MarkSent)
+        }
         Command::Remove => run_remove(),
     };
     match result {
@@ -92,6 +136,8 @@ fn parse(args: &[String]) -> Result<Command, String> {
         "-h" | "--help" | "help" => no_args(&args[1..], Command::Help, "help"),
         "setup" => no_args(&args[1..], Command::Setup, "setup"),
         "remove" => no_args(&args[1..], Command::Remove, "remove"),
+        "history" => parse_history(&args[1..]),
+        "scrobbles" => parse_scrobbles(&args[1..]),
         "status" => match &args[1..] {
             [] => Ok(Command::Status { json: false }),
             [flag] if flag == "--json" => Ok(Command::Status { json: true }),
@@ -99,6 +145,63 @@ fn parse(args: &[String]) -> Result<Command, String> {
             _ => Err("status only accepts `--json`".to_owned()),
         },
         other => Err(format!("unknown command `{other}`")),
+    }
+}
+
+fn parse_scrobbles(args: &[String]) -> Result<Command, String> {
+    match args {
+        [action] if action == "list" => Ok(Command::ScrobblesList { json: false }),
+        [action, flag] if action == "list" && flag == "--json" => {
+            Ok(Command::ScrobblesList { json: true })
+        }
+        [action, event_id] if action == "retry" && valid_opaque_scrobble_id(event_id) => {
+            Ok(Command::ScrobbleRetry {
+                event_id: event_id.clone(),
+            })
+        }
+        [action, event_id] if action == "mark-sent" && valid_opaque_scrobble_id(event_id) => {
+            Ok(Command::ScrobbleMarkSent {
+                event_id: event_id.clone(),
+            })
+        }
+        [flag] | [_, flag] if matches!(flag.as_str(), "-h" | "--help" | "help") => {
+            Ok(Command::Help)
+        }
+        [action, _] if matches!(action.as_str(), "retry" | "mark-sent") => {
+            Err("scrobble recovery requires the exact opaque ID from `scrobbles list`".to_owned())
+        }
+        [] => Err("scrobbles requires `list`, `retry`, or `mark-sent`".to_owned()),
+        _ => Err(
+            "scrobbles accepts `list [--json]`, `retry <OPAQUE_ID>`, or `mark-sent <OPAQUE_ID>`"
+                .to_owned(),
+        ),
+    }
+}
+
+fn valid_opaque_scrobble_id(value: &str) -> bool {
+    value
+        .strip_prefix(OPAQUE_SCROBBLE_ID_PREFIX)
+        .is_some_and(|digest| {
+            digest.len() == OPAQUE_SCROBBLE_DIGEST_BYTES
+                && digest
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        })
+}
+
+fn parse_history(args: &[String]) -> Result<Command, String> {
+    match args {
+        [action, flag] if action == "enable" && flag == "--experimental" => {
+            Ok(Command::HistoryEnableExperimental)
+        }
+        [action] if action == "enable" => {
+            Err("history enable requires the explicit `--experimental` flag".to_owned())
+        }
+        [action] if action == "disable" => Ok(Command::HistoryDisable),
+        [flag] if matches!(flag.as_str(), "-h" | "--help" | "help") => Ok(Command::Help),
+        [_, flag] if matches!(flag.as_str(), "-h" | "--help") => Ok(Command::Help),
+        [] => Err("history requires `enable --experimental` or `disable`".to_owned()),
+        _ => Err("history only accepts `enable --experimental` or `disable`".to_owned()),
     }
 }
 
@@ -187,6 +290,126 @@ fn run_status(json: bool) -> Result<(), String> {
     Ok(())
 }
 
+fn run_scrobbles_list(json: bool) -> Result<(), String> {
+    initialize_reader()?;
+    let ids = list_scrobble_attention_ids(&paths()?).map_err(|error| error.to_string())?;
+    if json {
+        println!("{}", render_json_scrobble_list(&ids)?);
+    } else {
+        for line in human_scrobble_list_lines(&ids) {
+            println!("{line}");
+        }
+    }
+    Ok(())
+}
+
+fn run_scrobble_resolution(
+    event_id: &str,
+    resolution: OutboundScrobbleResolution,
+) -> Result<(), String> {
+    initialize_writer()?;
+    let prompt = match resolution {
+        OutboundScrobbleResolution::Retry => {
+            "The server may already have this report. Retrying can count it twice. Retry? [y/N]: "
+        }
+        OutboundScrobbleResolution::MarkSent => {
+            "Treat this report as already sent and stop retrying? Local history is kept. [y/N]: "
+        }
+    };
+    if !confirm(prompt)? {
+        println!("Playback report was not changed.");
+        return Ok(());
+    }
+    resolve_scrobble_attention(&paths()?, event_id, resolution)
+        .map_err(|error| error.to_string())?;
+    match resolution {
+        OutboundScrobbleResolution::Retry => {
+            println!("Playback report will retry from a fresh server baseline.");
+        }
+        OutboundScrobbleResolution::MarkSent => {
+            println!("Playback report was marked as sent; local history was kept.");
+        }
+    }
+    Ok(())
+}
+
+fn run_history_enable() -> Result<(), String> {
+    initialize_writer()?;
+    let paths = paths()?;
+    let mut store_set = load_store_set(&paths)
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "connect a music server before enabling detailed history".to_owned())?;
+    let action = history_enable_action(
+        store_set.private_state.native_history_enabled(),
+        store_set.bridge_state.native_history_health(),
+        store_set.private_state.credential_kind(),
+    );
+    if action == HistoryEnableAction::AlreadyEnabled {
+        println!("Experimental detailed history is already enabled.");
+        return Ok(());
+    }
+    let expected = store_set.revisions();
+    match store_set.private_state.credential_kind() {
+        CredentialKind::Password => store_set
+            .private_state
+            .enable_native_history_reusing_server_password()
+            .map_err(|error| error.to_string())?,
+        CredentialKind::ApiKey => {
+            let username = prompt_required("Navidrome username: ", MAX_USERNAME_BYTES)?;
+            let password = prompt_secret("Navidrome password: ", MAX_PASSWORD_BYTES)?;
+            store_set
+                .private_state
+                .enable_native_history_with_password(username, SecretString::from(password))
+                .map_err(|error| error.to_string())?;
+        }
+    }
+    store_set
+        .bridge_state
+        .set_native_history_health(NativeHistoryHealth::Probing);
+    commit_store_set(&paths, expected, &mut store_set).map_err(|error| error.to_string())?;
+    println!("Experimental detailed history is enabled.");
+    if action == HistoryEnableAction::UpdateDedicatedPassword {
+        println!("The detailed-history password was updated.");
+    }
+    println!("Standard OpenSubsonic access stays available if detailed history is unsupported.");
+    Ok(())
+}
+
+fn history_enable_action(
+    enabled: bool,
+    health: NativeHistoryHealth,
+    credential: CredentialKind,
+) -> HistoryEnableAction {
+    if !enabled {
+        return HistoryEnableAction::Enable;
+    }
+    if health == NativeHistoryHealth::UpdatePassword && credential == CredentialKind::ApiKey {
+        HistoryEnableAction::UpdateDedicatedPassword
+    } else {
+        HistoryEnableAction::AlreadyEnabled
+    }
+}
+
+fn run_history_disable() -> Result<(), String> {
+    initialize_writer()?;
+    let paths = paths()?;
+    let mut store_set = load_store_set(&paths)
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "no music server is connected".to_owned())?;
+    if !store_set.private_state.native_history_enabled() {
+        println!("Experimental detailed history is already off.");
+        return Ok(());
+    }
+    let expected = store_set.revisions();
+    store_set.private_state.disable_native_history();
+    store_set
+        .bridge_state
+        .set_native_history_health(NativeHistoryHealth::Off);
+    commit_store_set(&paths, expected, &mut store_set).map_err(|error| error.to_string())?;
+    println!("Experimental detailed history is off; standard server access was kept.");
+    Ok(())
+}
+
 fn checked_status(paths: &OpenSubsonicPaths) -> Result<OpenSubsonicStatus, String> {
     let mut stored = read_status(paths).map_err(|error| error.to_string())?;
     if stored.kind != OpenSubsonicStatusKind::UpToDate {
@@ -216,8 +439,30 @@ fn render_json_status(status: &OpenSubsonicStatus) -> Result<String, String> {
         credential: status.credential_kind.map(credential_label),
         lan_http_enabled: status.uses_lan_http,
         custom_ca_configured: status.uses_custom_ca,
+        detailed_history_enabled: status.native_history_enabled,
+        detailed_history_status: history_status_label(status.native_history_health),
+        playback_reports_needing_decision: status.outbound_scrobbles_needing_attention,
     };
     serde_json::to_string_pretty(&value).map_err(|_| "could not encode status JSON".to_owned())
+}
+
+fn render_json_scrobble_list(ids: &[String]) -> Result<String, String> {
+    serde_json::to_string_pretty(&JsonScrobbleAttention {
+        count: ids.len(),
+        opaque_ids: ids,
+    })
+    .map_err(|_| "could not encode playback-report JSON".to_owned())
+}
+
+fn human_scrobble_list_lines(ids: &[String]) -> Vec<String> {
+    if ids.is_empty() {
+        return vec!["No playback reports need a decision.".to_owned()];
+    }
+    let mut lines = Vec::with_capacity(ids.len().saturating_add(2));
+    lines.push(playback_report_attention_summary(ids.len()));
+    lines.extend(ids.iter().cloned());
+    lines.push("Choose `retry <OPAQUE_ID>` or `mark-sent <OPAQUE_ID>` for each report.".to_owned());
+    lines
 }
 
 fn run_remove() -> Result<(), String> {
@@ -249,12 +494,40 @@ fn print_human_status(status: &OpenSubsonicStatus) {
             if status.uses_custom_ca {
                 println!("Custom CA: configured");
             }
+            println!(
+                "History: {}",
+                history_status_human(status.native_history_health)
+            );
         }
         OpenSubsonicStatusKind::NeedsAttention => {
             println!("Needs attention");
-            println!("Action: update the connection settings");
+            if status.outbound_scrobbles_needing_attention > 0 {
+                println!(
+                    "{}",
+                    playback_report_attention_summary(status.outbound_scrobbles_needing_attention)
+                );
+                println!("{}", playback_report_attention_action());
+            } else {
+                println!("Action: update the connection settings");
+            }
+            println!(
+                "History: {}",
+                history_status_human(status.native_history_health)
+            );
         }
     }
+}
+
+fn playback_report_attention_summary(count: usize) -> String {
+    if count == 1 {
+        "1 playback report needs a decision.".to_owned()
+    } else {
+        format!("{count} playback reports need a decision.")
+    }
+}
+
+fn playback_report_attention_action() -> &'static str {
+    "Action: review them with `ytt server scrobbles list`."
 }
 
 fn status_label(kind: OpenSubsonicStatusKind) -> &'static str {
@@ -262,6 +535,28 @@ fn status_label(kind: OpenSubsonicStatusKind) -> &'static str {
         OpenSubsonicStatusKind::Off => "off",
         OpenSubsonicStatusKind::UpToDate => "up_to_date",
         OpenSubsonicStatusKind::NeedsAttention => "needs_attention",
+    }
+}
+
+fn history_status_label(health: NativeHistoryHealth) -> &'static str {
+    match health {
+        NativeHistoryHealth::Off => "off",
+        NativeHistoryHealth::Probing => "probing",
+        NativeHistoryHealth::Detailed => "detailed",
+        NativeHistoryHealth::PlayCountsOnly => "play_counts_only",
+        NativeHistoryHealth::UpdatePassword => "update_password",
+    }
+}
+
+fn history_status_human(health: NativeHistoryHealth) -> &'static str {
+    match health {
+        NativeHistoryHealth::Off => "play counts only (detailed history off)",
+        NativeHistoryHealth::Probing => "checking detailed history; play counts remain available",
+        NativeHistoryHealth::Detailed => "detailed history available (experimental)",
+        NativeHistoryHealth::PlayCountsOnly => "play counts only (detailed history unsupported)",
+        NativeHistoryHealth::UpdatePassword => {
+            "update the detailed-history password; play counts remain available"
+        }
     }
 }
 
@@ -279,18 +574,18 @@ fn initialize_reader() -> Result<(), String> {
 }
 
 fn initialize_writer() -> Result<(), String> {
-    match yututui::persist::initialize_persistence_writer(false) {
-        Ok(_) => {}
-        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-            return Err(
-                "another ytt process owns settings; use its controls or close it and retry"
-                    .to_owned(),
-            );
-        }
-        Err(_) => return Err("could not secure the settings writer".to_owned()),
-    }
+    yututui::persist::initialize_persistence_writer(false)
+        .map_err(|error| writer_initialization_error(&error).to_owned())?;
     yututui::persist::preflight_all_startup_stores()
         .map_err(|_| "local recovery must be completed before changing the server".to_owned())
+}
+
+fn writer_initialization_error(error: &io::Error) -> &'static str {
+    if error.kind() == io::ErrorKind::WouldBlock {
+        "another ytt process owns settings; use its controls or close it and retry"
+    } else {
+        "could not secure the settings writer"
+    }
 }
 
 fn paths() -> Result<OpenSubsonicPaths, String> {
@@ -422,13 +717,14 @@ fn prompt_custom_ca() -> Result<Option<Vec<u8>>, String> {
 }
 
 fn confirm(prompt: &str) -> Result<bool, String> {
-    Ok(matches!(
-        prompt_line(prompt, MAX_CHOICE_BYTES)?
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "y" | "yes"
-    ))
+    Ok(is_affirmative_confirmation(&prompt_line(
+        prompt,
+        MAX_CHOICE_BYTES,
+    )?))
+}
+
+fn is_affirmative_confirmation(value: &str) -> bool {
+    matches!(value.trim().to_ascii_lowercase().as_str(), "y" | "yes")
 }
 
 fn usage_error(message: &str) -> i32 {
@@ -453,12 +749,27 @@ mod tests {
         values.iter().map(|value| (*value).to_owned()).collect()
     }
 
+    fn opaque_scrobble_id(digit: char) -> String {
+        format!(
+            "{OPAQUE_SCROBBLE_ID_PREFIX}{}",
+            digit.to_string().repeat(64)
+        )
+    }
+
     #[test]
     fn parses_public_commands_without_secret_arguments() {
         assert_eq!(parse(&args(&["setup"])), Ok(Command::Setup));
         assert_eq!(
             parse(&args(&["status", "--json"])),
             Ok(Command::Status { json: true })
+        );
+        assert_eq!(
+            parse(&args(&["history", "enable", "--experimental"])),
+            Ok(Command::HistoryEnableExperimental)
+        );
+        assert_eq!(
+            parse(&args(&["history", "disable"])),
+            Ok(Command::HistoryDisable)
         );
         assert_eq!(parse(&args(&["remove"])), Ok(Command::Remove));
     }
@@ -470,15 +781,180 @@ mod tests {
     }
 
     #[test]
+    fn history_requires_explicit_opt_in_and_never_accepts_a_password_argument() {
+        assert!(parse(&args(&["history", "enable"])).is_err());
+        assert!(parse(&args(&["history", "--experimental"])).is_err());
+        assert!(
+            parse(&args(&[
+                "history",
+                "enable",
+                "--experimental",
+                "password-sentinel"
+            ]))
+            .is_err()
+        );
+        assert!(parse(&args(&["history", "disable", "--force"])).is_err());
+        assert!(SERVER_USAGE.contains("history enable --experimental"));
+        assert!(SERVER_USAGE.contains("off by default"));
+        assert!(!SERVER_USAGE.contains("password-sentinel"));
+    }
+
+    #[test]
+    fn enabled_api_key_history_prompts_again_only_when_password_needs_update() {
+        assert_eq!(
+            history_enable_action(
+                true,
+                NativeHistoryHealth::UpdatePassword,
+                CredentialKind::ApiKey
+            ),
+            HistoryEnableAction::UpdateDedicatedPassword
+        );
+        assert_eq!(
+            history_enable_action(true, NativeHistoryHealth::Detailed, CredentialKind::ApiKey),
+            HistoryEnableAction::AlreadyEnabled
+        );
+        assert_eq!(
+            history_enable_action(
+                true,
+                NativeHistoryHealth::UpdatePassword,
+                CredentialKind::Password
+            ),
+            HistoryEnableAction::AlreadyEnabled,
+            "the main server password is updated through server setup"
+        );
+    }
+
+    #[test]
     fn status_only_accepts_json() {
         assert!(parse(&args(&["status", "--verbose"])).is_err());
         assert_eq!(parse(&args(&["status", "-h"])), Ok(Command::Help));
     }
 
     #[test]
+    fn scrobble_recovery_parser_requires_an_exact_opaque_id() {
+        let retry_id = opaque_scrobble_id('a');
+        let mark_sent_id = opaque_scrobble_id('9');
+        assert_eq!(
+            parse(&args(&["scrobbles", "list"])),
+            Ok(Command::ScrobblesList { json: false })
+        );
+        assert_eq!(
+            parse(&args(&["scrobbles", "list", "--json"])),
+            Ok(Command::ScrobblesList { json: true })
+        );
+        assert_eq!(
+            parse(&["scrobbles".to_owned(), "retry".to_owned(), retry_id.clone()]),
+            Ok(Command::ScrobbleRetry { event_id: retry_id })
+        );
+        assert_eq!(
+            parse(&[
+                "scrobbles".to_owned(),
+                "mark-sent".to_owned(),
+                mark_sent_id.clone(),
+            ]),
+            Ok(Command::ScrobbleMarkSent {
+                event_id: mark_sent_id
+            })
+        );
+
+        for invalid in [
+            "sub-scrobble-short",
+            "sub-scrobble-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "https://secret.example/report",
+            "password-sentinel",
+        ] {
+            assert!(parse(&args(&["scrobbles", "retry", invalid])).is_err());
+            assert!(parse(&args(&["scrobbles", "mark-sent", invalid])).is_err());
+        }
+        assert!(
+            parse(&[
+                "scrobbles".to_owned(),
+                "retry".to_owned(),
+                opaque_scrobble_id('b'),
+                "credential-sentinel".to_owned(),
+            ])
+            .is_err()
+        );
+        assert_eq!(
+            parse(&args(&["scrobbles", "retry", "--help"])),
+            Ok(Command::Help)
+        );
+        assert!(SERVER_USAGE.contains("scrobbles list [--json]"));
+        assert!(SERVER_USAGE.contains("scrobbles retry <OPAQUE_ID>"));
+        assert!(SERVER_USAGE.contains("scrobbles mark-sent <OPAQUE_ID>"));
+        assert!(!SERVER_USAGE.contains("credential-sentinel"));
+    }
+
+    #[test]
+    fn scrobble_recovery_output_contains_only_counts_and_opaque_ids() {
+        let ids = vec![opaque_scrobble_id('a'), opaque_scrobble_id('b')];
+        let json = render_json_scrobble_list(&ids).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let object = value.as_object().unwrap();
+        assert_eq!(object.len(), 2);
+        assert_eq!(
+            object.get("count").and_then(serde_json::Value::as_u64),
+            Some(2)
+        );
+        assert_eq!(
+            object
+                .get("opaque_ids")
+                .and_then(serde_json::Value::as_array)
+                .map(Vec::len),
+            Some(2)
+        );
+        assert!(!json.contains("http"));
+        assert!(!json.contains("secret"));
+        assert!(!json.contains("path"));
+
+        let human = human_scrobble_list_lines(&ids);
+        assert_eq!(human[0], "2 playback reports need a decision.");
+        assert_eq!(&human[1..=2], ids.as_slice());
+        assert_eq!(
+            human[3],
+            "Choose `retry <OPAQUE_ID>` or `mark-sent <OPAQUE_ID>` for each report."
+        );
+        assert_eq!(
+            human_scrobble_list_lines(&[]),
+            vec!["No playback reports need a decision."]
+        );
+    }
+
+    #[test]
+    fn destructive_scrobble_choices_default_to_no() {
+        for rejected in ["", "n", "no", "later", "1"] {
+            assert!(!is_affirmative_confirmation(rejected));
+        }
+        for accepted in ["y", "Y", "yes", " YES "] {
+            assert!(is_affirmative_confirmation(accepted));
+        }
+    }
+
+    #[test]
+    fn scrobble_mutation_reports_owner_rejection_without_error_details() {
+        let blocked = io::Error::new(io::ErrorKind::WouldBlock, "owner-secret-sentinel");
+        assert_eq!(
+            writer_initialization_error(&blocked),
+            "another ytt process owns settings; use its controls or close it and retry"
+        );
+        assert!(!writer_initialization_error(&blocked).contains("sentinel"));
+
+        let other = io::Error::new(io::ErrorKind::PermissionDenied, "path-secret-sentinel");
+        assert_eq!(
+            writer_initialization_error(&other),
+            "could not secure the settings writer"
+        );
+        assert!(!writer_initialization_error(&other).contains("sentinel"));
+    }
+
+    #[test]
     fn status_labels_are_stable() {
         assert_eq!(status_label(OpenSubsonicStatusKind::Off), "off");
         assert_eq!(credential_label(CredentialKind::ApiKey), "api_key");
+        assert_eq!(
+            history_status_label(NativeHistoryHealth::UpdatePassword),
+            "update_password"
+        );
     }
 
     #[test]
@@ -535,9 +1011,28 @@ mod tests {
         assert_eq!(status.kind, OpenSubsonicStatusKind::NeedsAttention);
         let json = render_json_status(&status).unwrap();
         assert!(json.contains(r#""status": "needs_attention""#));
+        assert!(json.contains(r#""detailed_history_status": "off""#));
+        assert!(json.contains(r#""playback_reports_needing_decision": 0"#));
         assert!(json.contains("Offline fixture"));
         assert!(!json.contains("json-secret-sentinel"));
         assert!(!json.contains("https://"));
+
+        let mut playback_attention = status;
+        playback_attention.outbound_scrobbles_needing_attention = 2;
+        let json = render_json_status(&playback_attention).unwrap();
+        assert!(json.contains(r#""playback_reports_needing_decision": 2"#));
+        assert_eq!(
+            playback_report_attention_summary(1),
+            "1 playback report needs a decision."
+        );
+        assert_eq!(
+            playback_report_attention_summary(2),
+            "2 playback reports need a decision."
+        );
+        assert_eq!(
+            playback_report_attention_action(),
+            "Action: review them with `ytt server scrobbles list`."
+        );
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -247,17 +247,20 @@ impl Signals {
         if artist_key.is_empty() {
             return;
         }
-        let w = self
-            .artist_weight
-            .entry(artist_key.to_owned())
-            .or_insert(0.0);
-        *w = (*w + delta).clamp(ARTIST_WEIGHT_MIN, ARTIST_WEIGHT_MAX);
+        let next = (self.artist_weight.get(artist_key).copied().unwrap_or(0.0) + delta)
+            .clamp(ARTIST_WEIGHT_MIN, ARTIST_WEIGHT_MAX);
+        if next == 0.0 {
+            self.artist_weight.remove(artist_key);
+        } else {
+            self.artist_weight.insert(artist_key.to_owned(), next);
+        }
     }
 
     /// Bound every growable collection so memory stays flat over long-lived (or bloated-on-load)
     /// installs: `play_log`, `artist_weight`, and per-track signals (evicting non-disliked,
     /// oldest tracks first — dislikes are a deliberate, lasting signal).
     fn enforce_caps(&mut self) {
+        self.artist_weight.retain(|_, weight| *weight != 0.0);
         // play_log is bounded on runtime insert; bound it on load too, since a loaded file could
         // arrive over the cap (external edit / sync / corruption).
         while self.play_log.len() > PLAY_LOG_MAX {
@@ -367,6 +370,7 @@ impl Signals {
             artist_affinity: self
                 .artist_weight
                 .iter()
+                .filter(|(_, weight)| **weight != 0.0)
                 .map(|(key, weight)| (key.clone(), *weight))
                 .collect(),
             play_log,
@@ -399,7 +403,7 @@ impl Signals {
             artist_weight: projection
                 .artist_affinity
                 .into_iter()
-                .filter(|(_, weight)| weight.is_finite())
+                .filter(|(_, weight)| weight.is_finite() && *weight != 0.0)
                 .map(|(key, weight)| (key, weight.clamp(ARTIST_WEIGHT_MIN, ARTIST_WEIGHT_MAX)))
                 .collect(),
             play_log: projection
@@ -567,8 +571,8 @@ mod tests {
         assert!(after_dislike < 0.0);
         assert!(!s.toggle_dislike("a", "x", 11));
         assert!(!s.is_disliked("a"));
-        // Undo restores the affinity to ~zero.
-        assert!((*s.artist_weight.get("x").unwrap()).abs() < f32::EPSILON);
+        // Undo restores the affinity to the canonical absent-zero representation.
+        assert!(!s.artist_weight.contains_key("x"));
     }
 
     #[test]

--- a/src/terminal_runtime/runner.rs
+++ b/src/terminal_runtime/runner.rs
@@ -30,12 +30,12 @@ mod terminal_events;
 mod terminal_output;
 use buffered_events::BufferedWorkerEvents;
 use perf_stats::PerfStats;
+use player_startup::spawn_audio_player;
 #[cfg(test)]
 use player_startup::spawn_player_startup;
-use player_startup::{PlayerStartup, spawn_audio_player};
 use recorder_status::recorder_capacity_blocked_status;
 use runtime_paths::{TerminalRuntimePaths, resolve as terminal_runtime_paths};
-use teardown::{OwnerIngressDrain, OwnerTeardown, complete_owner_teardown};
+use teardown::{LiveOwnerTeardown, complete_owner_teardown};
 use terminal_events::TerminalEventWorker;
 #[cfg(test)]
 use terminal_output::finish_draw_cycle;
@@ -267,220 +267,6 @@ impl TerminalBackgroundTasks {
             self.update_check.shutdown(),
         );
         terminal_error
-    }
-}
-
-struct LiveOwnerTeardown<'a> {
-    app: &'a mut App,
-    handles: &'a mut runtime::RuntimeHandles,
-    player_startup: &'a mut PlayerStartup,
-    terminal_background: &'a mut TerminalBackgroundTasks,
-    media: &'a mut media::MediaSession,
-    publisher: Option<&'a remote::publish::Publisher>,
-    remote_guard: Option<&'a mut remote::server::InstanceGuard>,
-    persist: &'a persist::PersistHandle,
-    pending_worker_events: &'a mut BufferedWorkerEvents,
-    pending_shutdown_events: &'a mut VecDeque<RuntimeEvent>,
-    worker_rx: &'a mut tokio::sync::mpsc::Receiver<RuntimeEvent>,
-}
-
-impl LiveOwnerTeardown<'_> {
-    fn reduce_runtime_shutdown_event(
-        &mut self,
-        event: RuntimeEvent,
-        drain: &mut OwnerIngressDrain,
-    ) {
-        match event {
-            RuntimeEvent::Remote(
-                remote_event @ (remote::server::RemoteEvent::Command(_, _)
-                | remote::server::RemoteEvent::SessionCommand { .. }),
-            ) => {
-                drain.remote_requests += 1;
-                self.handles
-                    .reduce_shutdown_event(self.app, RuntimeEvent::Remote(remote_event));
-            }
-            RuntimeEvent::Remote(remote::server::RemoteEvent::SessionSubscribe {
-                session,
-                frame_id,
-                page_id,
-                topics: _,
-                settlement,
-            }) => {
-                drain.subscribe_requests += 1;
-                if !self.publisher.is_some_and(|publisher| {
-                    publisher.reject_subscribe_for_shutdown(
-                        &session,
-                        page_id.as_deref(),
-                        frame_id,
-                        settlement,
-                    )
-                }) {
-                    tracing::debug!(
-                        frame_id,
-                        ?page_id,
-                        "retired queued session subscribe during owner shutdown"
-                    );
-                }
-            }
-            RuntimeEvent::TelemetryWake => {
-                for coalesced in self.handles.drain_background_coalesced() {
-                    self.reduce_runtime_shutdown_event(coalesced, drain);
-                }
-            }
-            event => self.handles.reduce_shutdown_event(self.app, event),
-        }
-    }
-}
-
-impl OwnerTeardown for LiveOwnerTeardown<'_> {
-    fn quiesce_remote(&mut self) {
-        if let Some(guard) = self.remote_guard.as_deref_mut() {
-            guard.quiesce_owner_admission();
-        } else if let Some(publisher) = self.publisher {
-            publisher.quiesce_owner_admission();
-        }
-    }
-
-    fn retire_player(&mut self) {
-        self.handles.begin_player_shutdown(self.app);
-    }
-
-    fn close_ingress(&mut self) {
-        // Reject new producers without closing the receiver: callback retries are released, while
-        // already accepted main/deferred/coalesced events remain available to the final drain.
-        self.handles.close_event_ingress();
-    }
-
-    fn deactivate_media(&mut self) {
-        let _ = self.media.set_enabled(false);
-    }
-
-    async fn drain_owner_ingress(&mut self) -> OwnerIngressDrain {
-        let mut drain = OwnerIngressDrain::default();
-        while let Some(event) = self.pending_worker_events.pop_front() {
-            self.reduce_runtime_shutdown_event(event, &mut drain);
-        }
-        while let Some(event) = self.pending_shutdown_events.pop_front() {
-            self.reduce_runtime_shutdown_event(event, &mut drain);
-        }
-        loop {
-            while let Ok(event) = self.worker_rx.try_recv() {
-                self.reduce_runtime_shutdown_event(event, &mut drain);
-            }
-            if self.handles.background_ingress_is_idle() {
-                match self.worker_rx.try_recv() {
-                    Ok(event) => {
-                        self.reduce_runtime_shutdown_event(event, &mut drain);
-                        continue;
-                    }
-                    Err(
-                        tokio::sync::mpsc::error::TryRecvError::Empty
-                        | tokio::sync::mpsc::error::TryRecvError::Disconnected,
-                    ) => break,
-                }
-            }
-            // The drainer may publish after the empty try-receive or may have completed its final
-            // send without retiring in-flight accounting yet. Yield and recheck both predicates;
-            // never wait on a receiver whose sender handles deliberately remain alive.
-            tokio::task::yield_now().await;
-        }
-        for coalesced in self.handles.drain_background_coalesced() {
-            self.reduce_runtime_shutdown_event(coalesced, &mut drain);
-        }
-        self.worker_rx.close();
-        drain
-    }
-
-    async fn await_remote_reply_flush(&mut self) {
-        if let Some(publisher) = self.publisher
-            && !publisher.wait_for_wire_settlements().await
-        {
-            // The structural barrier owns the normal path. This tiny final window is only a
-            // scheduler fallback after the bounded writer budget was exhausted and logged.
-            remote::await_shutdown_reply_grace().await;
-        }
-    }
-
-    async fn shutdown_remote(&mut self) {
-        // The endpoint must be unlinked while this guard still owns the listener. If the hub were
-        // latched first, the listener could drop and a successor could rebind before our late
-        // path cleanup, letting the old process delete the new socket.
-        if let Some(guard) = self.remote_guard.as_deref_mut() {
-            guard.release_endpoint();
-        }
-        if let Some(publisher) = self.publisher {
-            publisher.shutting_down();
-        }
-        if let Some(guard) = self.remote_guard.as_deref_mut() {
-            guard.shutdown().await;
-        }
-    }
-
-    async fn reap_player_startup(&mut self) {
-        self.player_startup.cancel_and_join().await;
-    }
-
-    fn close_video(&mut self) {
-        self.app.close_video();
-    }
-
-    async fn shutdown_terminal_background(&mut self) -> Option<std::io::Error> {
-        self.terminal_background.shutdown().await
-    }
-
-    async fn shutdown_resolver(&mut self) {
-        self.handles
-            .resolver_shutdown(Duration::from_millis(3500))
-            .await;
-    }
-
-    async fn shutdown_runtime_background(&mut self) -> runtime::BackgroundShutdown {
-        // Runtime-local jobs close admission together with the player barrier. Cancellable work
-        // is aborted; real blocking work gets a bounded join window and reports exact leftovers.
-        // The teardown driver preserves a timeout and invokes this once more after transfer and
-        // download actors stop, before persistence flush.
-        self.handles
-            .background_shutdown(Duration::from_millis(3500))
-            .await
-    }
-
-    async fn shutdown_transfer(&mut self) {
-        // Transfer owns auth, playlist, and import child tasks. Stop it while the runtime ingress
-        // still exists so the actor can interrupt reliable retries, then reap every child.
-        self.handles
-            .transfer_shutdown(Duration::from_millis(3500))
-            .await;
-    }
-
-    async fn shutdown_downloads(&mut self) {
-        // Stop yt-dlp/ffmpeg process groups before slower persistence/scrobble work.
-        self.handles
-            .download_shutdown(Duration::from_millis(3500))
-            .await;
-    }
-
-    async fn finalize_runtime_background(&mut self) {
-        let fallback = self.handles.finalize_background().await;
-        // Main/deferred/coalesced work was settled before the remote/session owner closed. Only
-        // exact terminal completions which crossed the closed-ingress boundary remain here.
-        for event in fallback {
-            self.handles.reduce_shutdown_event(self.app, event);
-        }
-    }
-
-    async fn flush_persistence(&mut self) -> Result<()> {
-        // Publish all authoritative quit snapshots, then drain the actor. A timeout retries every
-        // still-owned journal frontier and reports any operation whose durability is unconfirmed.
-        flush_owner_persistence(self.app, self.persist).await
-    }
-
-    async fn shutdown_scrobble(&mut self) -> Result<()> {
-        // The deadline is diagnostic only. Accepted local durability is joined before the
-        // terminal returns, while the actor's network flush remains internally bounded.
-        self.handles
-            .scrobble_shutdown(Duration::from_millis(1500))
-            .await
-            .map_err(|error| anyhow::anyhow!("scrobble shutdown durability failed: {error}"))
     }
 }
 
@@ -1372,11 +1158,43 @@ pub async fn run(
             })
             | OwnerTurnInput::Worker(RuntimeEvent::OpenSubsonicReloaded { generation, result }) => {
                 handles.install_open_subsonic_runtime(generation, result);
+                handles.maintain_open_subsonic_bridge(&app);
+                continue;
+            }
+            OwnerTurnInput::BufferedWorker(RuntimeEvent::OpenSubsonicBridge(import))
+            | OwnerTurnInput::Worker(RuntimeEvent::OpenSubsonicBridge(import)) => {
+                handles.apply_open_subsonic_bridge_import(&mut app, import);
+                handles.maintain_open_subsonic_bridge(&app);
+                continue;
+            }
+            OwnerTurnInput::BufferedWorker(RuntimeEvent::Scrobble(
+                crate::scrobble::ScrobbleEvent::OpenSubsonic {
+                    event_id,
+                    kind,
+                    track,
+                    confirmation,
+                },
+            ))
+            | OwnerTurnInput::Worker(RuntimeEvent::Scrobble(
+                crate::scrobble::ScrobbleEvent::OpenSubsonic {
+                    event_id,
+                    kind,
+                    track,
+                    confirmation,
+                },
+            )) => {
+                handles.queue_open_subsonic_scrobble(event_id, kind, track, confirmation);
                 continue;
             }
             OwnerTurnInput::BufferedWorker(mut event) | OwnerTurnInput::Worker(mut event) => {
                 if let RuntimeEvent::Player(player_event) = &mut event {
                     handles.reconcile_cache_safety_event(player_event);
+                }
+                if let RuntimeEvent::Persist(
+                    crate::persist::PersistEvent::PersonalStateCommitted { state_identity, .. },
+                ) = &event
+                {
+                    handles.note_open_subsonic_personal_state_commit(&app, state_identity);
                 }
                 event.into()
             }
@@ -1453,6 +1271,7 @@ pub async fn run(
             );
             player_ready_pending = true;
         }
+        handles.maintain_open_subsonic_bridge(&app);
         if resized_artwork {
             perf.record_art_resize();
         }

--- a/src/terminal_runtime/runner/teardown.rs
+++ b/src/terminal_runtime/runner/teardown.rs
@@ -1,6 +1,15 @@
+use std::collections::VecDeque;
+use std::time::Duration;
+
 use anyhow::Result;
 
-use crate::runtime;
+use crate::app::App;
+use crate::runtime::RuntimeEvent;
+use crate::{media, persist, remote, runtime};
+
+use super::buffered_events::BufferedWorkerEvents;
+use super::player_startup::PlayerStartup;
+use super::{TerminalBackgroundTasks, flush_owner_persistence};
 
 const SECONDARY_OWNER_IO_MARKER: &str = "; secondary owner I/O failure: ";
 
@@ -10,6 +19,13 @@ pub(super) struct OwnerIngressDrain {
     pub(super) subscribe_requests: usize,
 }
 
+impl OwnerIngressDrain {
+    pub(super) fn absorb(&mut self, other: Self) {
+        self.remote_requests += other.remote_requests;
+        self.subscribe_requests += other.subscribe_requests;
+    }
+}
+
 /// One ordered teardown protocol shared by clean exits and fatal owner-loop errors.
 ///
 /// Keeping the ordering in a small driver makes it impossible for a newly added error branch to
@@ -17,9 +33,12 @@ pub(super) struct OwnerIngressDrain {
 /// terminal, mpv, or any background actor.
 pub(super) trait OwnerTeardown {
     fn quiesce_remote(&mut self);
+    fn seal_playback_observation(&mut self);
     fn retire_player(&mut self);
-    fn close_ingress(&mut self);
     fn deactivate_media(&mut self);
+    async fn shutdown_scrobble_with_owner_pump(&mut self) -> (OwnerIngressDrain, Result<()>);
+    fn pump_open_subsonic(&mut self) -> Result<()>;
+    fn close_ingress(&mut self);
     async fn drain_owner_ingress(&mut self) -> OwnerIngressDrain;
     async fn await_remote_reply_flush(&mut self);
     async fn shutdown_remote(&mut self);
@@ -32,7 +51,268 @@ pub(super) trait OwnerTeardown {
     async fn shutdown_downloads(&mut self);
     async fn finalize_runtime_background(&mut self);
     async fn flush_persistence(&mut self) -> Result<()>;
-    async fn shutdown_scrobble(&mut self) -> Result<()>;
+}
+
+pub(super) struct LiveOwnerTeardown<'a> {
+    pub(super) app: &'a mut App,
+    pub(super) handles: &'a mut runtime::RuntimeHandles,
+    pub(super) player_startup: &'a mut PlayerStartup,
+    pub(super) terminal_background: &'a mut TerminalBackgroundTasks,
+    pub(super) media: &'a mut media::MediaSession,
+    pub(super) publisher: Option<&'a remote::publish::Publisher>,
+    pub(super) remote_guard: Option<&'a mut remote::server::InstanceGuard>,
+    pub(super) persist: &'a persist::PersistHandle,
+    pub(super) pending_worker_events: &'a mut BufferedWorkerEvents,
+    pub(super) pending_shutdown_events: &'a mut VecDeque<RuntimeEvent>,
+    pub(super) worker_rx: &'a mut tokio::sync::mpsc::Receiver<RuntimeEvent>,
+}
+
+impl LiveOwnerTeardown<'_> {
+    fn reduce_runtime_shutdown_event(
+        &mut self,
+        event: RuntimeEvent,
+        drain: &mut OwnerIngressDrain,
+    ) {
+        match event {
+            RuntimeEvent::Remote(
+                remote_event @ (remote::server::RemoteEvent::Command(_, _)
+                | remote::server::RemoteEvent::SessionCommand { .. }),
+            ) => {
+                drain.remote_requests += 1;
+                self.handles
+                    .reduce_shutdown_event(self.app, RuntimeEvent::Remote(remote_event));
+            }
+            RuntimeEvent::Remote(remote::server::RemoteEvent::SessionSubscribe {
+                session,
+                frame_id,
+                page_id,
+                topics: _,
+                settlement,
+            }) => {
+                drain.subscribe_requests += 1;
+                if !self.publisher.is_some_and(|publisher| {
+                    publisher.reject_subscribe_for_shutdown(
+                        &session,
+                        page_id.as_deref(),
+                        frame_id,
+                        settlement,
+                    )
+                }) {
+                    tracing::debug!(
+                        frame_id,
+                        ?page_id,
+                        "retired queued session subscribe during owner shutdown"
+                    );
+                }
+            }
+            RuntimeEvent::TelemetryWake => {
+                for coalesced in self.handles.drain_background_coalesced() {
+                    self.reduce_runtime_shutdown_event(coalesced, drain);
+                }
+            }
+            event => self.handles.reduce_shutdown_event(self.app, event),
+        }
+    }
+}
+
+impl OwnerTeardown for LiveOwnerTeardown<'_> {
+    fn quiesce_remote(&mut self) {
+        if let Some(guard) = self.remote_guard.as_deref_mut() {
+            guard.quiesce_owner_admission();
+        } else if let Some(publisher) = self.publisher {
+            publisher.quiesce_owner_admission();
+        }
+    }
+
+    fn seal_playback_observation(&mut self) {
+        let snapshot = self.app.media_snapshot();
+        if let Err(error) = self.handles.scrobble_observe_shutdown(&snapshot) {
+            // Busy terminal observations are retained by ScrobbleHandle's shutdown retry slot.
+            // Other outcomes are diagnosed by the correlated actor shutdown receipt below.
+            tracing::debug!(
+                delivery_outcome = error.reason(),
+                "final scrobble observation will settle at the shutdown frontier"
+            );
+        }
+    }
+
+    fn retire_player(&mut self) {
+        self.handles.begin_player_shutdown(self.app);
+    }
+
+    fn deactivate_media(&mut self) {
+        let _ = self.media.set_enabled(false);
+    }
+
+    async fn shutdown_scrobble_with_owner_pump(&mut self) -> (OwnerIngressDrain, Result<()>) {
+        let mut drain = OwnerIngressDrain::default();
+        while let Some(event) = self.pending_worker_events.pop_front() {
+            self.reduce_runtime_shutdown_event(event, &mut drain);
+        }
+        while let Some(event) = self.pending_shutdown_events.pop_front() {
+            self.reduce_runtime_shutdown_event(event, &mut drain);
+        }
+
+        let Some(mut scrobble) = self.handles.take_scrobble_for_shutdown() else {
+            return (drain, Ok(()));
+        };
+        let shutdown = scrobble.shutdown_and_join(Duration::from_millis(1500));
+        tokio::pin!(shutdown);
+        let mut ingress_open = true;
+        loop {
+            tokio::select! {
+                biased;
+                outcome = shutdown.as_mut() => {
+                    let outcome = outcome.map_err(|error| {
+                        anyhow::anyhow!("scrobble shutdown durability failed: {error}")
+                    });
+                    return (drain, outcome);
+                }
+                event = self.worker_rx.recv(), if ingress_open => match event {
+                    Some(event) => self.reduce_runtime_shutdown_event(event, &mut drain),
+                    None => ingress_open = false,
+                },
+            }
+        }
+    }
+
+    fn pump_open_subsonic(&mut self) -> Result<()> {
+        let result = self
+            .handles
+            .pump_open_subsonic_for_shutdown(self.app)
+            .map_err(|error| {
+                anyhow::anyhow!("music server playback report durability failed: {error}")
+            });
+        // The credential owner remains live through the final receipt pump, but no loopback route
+        // or secret-bearing task may outlive the completed playback durability frontier.
+        self.handles.retire_open_subsonic_runtime();
+        result
+    }
+
+    fn close_ingress(&mut self) {
+        // Reject new producers without closing the receiver: callback retries are released, while
+        // already accepted main/deferred/coalesced events remain available to the final drain.
+        self.handles.close_event_ingress();
+    }
+
+    async fn drain_owner_ingress(&mut self) -> OwnerIngressDrain {
+        let mut drain = OwnerIngressDrain::default();
+        while let Some(event) = self.pending_worker_events.pop_front() {
+            self.reduce_runtime_shutdown_event(event, &mut drain);
+        }
+        while let Some(event) = self.pending_shutdown_events.pop_front() {
+            self.reduce_runtime_shutdown_event(event, &mut drain);
+        }
+        loop {
+            while let Ok(event) = self.worker_rx.try_recv() {
+                self.reduce_runtime_shutdown_event(event, &mut drain);
+            }
+            if self.handles.background_ingress_is_idle() {
+                match self.worker_rx.try_recv() {
+                    Ok(event) => {
+                        self.reduce_runtime_shutdown_event(event, &mut drain);
+                        continue;
+                    }
+                    Err(
+                        tokio::sync::mpsc::error::TryRecvError::Empty
+                        | tokio::sync::mpsc::error::TryRecvError::Disconnected,
+                    ) => break,
+                }
+            }
+            // The drainer may publish after the empty try-receive or may have completed its final
+            // send without retiring in-flight accounting yet. Yield and recheck both predicates;
+            // never wait on a receiver whose sender handles deliberately remain alive.
+            tokio::task::yield_now().await;
+        }
+        for coalesced in self.handles.drain_background_coalesced() {
+            self.reduce_runtime_shutdown_event(coalesced, &mut drain);
+        }
+        self.worker_rx.close();
+        drain
+    }
+
+    async fn await_remote_reply_flush(&mut self) {
+        if let Some(publisher) = self.publisher
+            && !publisher.wait_for_wire_settlements().await
+        {
+            // The structural barrier owns the normal path. This tiny final window is only a
+            // scheduler fallback after the bounded writer budget was exhausted and logged.
+            remote::await_shutdown_reply_grace().await;
+        }
+    }
+
+    async fn shutdown_remote(&mut self) {
+        // The endpoint must be unlinked while this guard still owns the listener. If the hub were
+        // latched first, the listener could drop and a successor could rebind before our late
+        // path cleanup, letting the old process delete the new socket.
+        if let Some(guard) = self.remote_guard.as_deref_mut() {
+            guard.release_endpoint();
+        }
+        if let Some(publisher) = self.publisher {
+            publisher.shutting_down();
+        }
+        if let Some(guard) = self.remote_guard.as_deref_mut() {
+            guard.shutdown().await;
+        }
+    }
+
+    async fn reap_player_startup(&mut self) {
+        self.player_startup.cancel_and_join().await;
+    }
+
+    fn close_video(&mut self) {
+        self.app.close_video();
+    }
+
+    async fn shutdown_terminal_background(&mut self) -> Option<std::io::Error> {
+        self.terminal_background.shutdown().await
+    }
+
+    async fn shutdown_resolver(&mut self) {
+        self.handles
+            .resolver_shutdown(Duration::from_millis(3500))
+            .await;
+    }
+
+    async fn shutdown_runtime_background(&mut self) -> runtime::BackgroundShutdown {
+        // Runtime-local jobs close admission together with the player barrier. Cancellable work
+        // is aborted; real blocking work gets a bounded join window and reports exact leftovers.
+        // The teardown driver preserves a timeout and invokes this once more after transfer and
+        // download actors stop, before persistence flush.
+        self.handles
+            .background_shutdown(Duration::from_millis(3500))
+            .await
+    }
+
+    async fn shutdown_transfer(&mut self) {
+        // Transfer owns auth, playlist, and import child tasks. Stop it while the runtime ingress
+        // still exists so the actor can interrupt reliable retries, then reap every child.
+        self.handles
+            .transfer_shutdown(Duration::from_millis(3500))
+            .await;
+    }
+
+    async fn shutdown_downloads(&mut self) {
+        // Stop yt-dlp/ffmpeg process groups before slower persistence/scrobble work.
+        self.handles
+            .download_shutdown(Duration::from_millis(3500))
+            .await;
+    }
+
+    async fn finalize_runtime_background(&mut self) {
+        let fallback = self.handles.finalize_background().await;
+        // Main/deferred/coalesced work was settled before the remote/session owner closed. Only
+        // exact terminal completions which crossed the closed-ingress boundary remain here.
+        for event in fallback {
+            self.handles.reduce_shutdown_event(self.app, event);
+        }
+    }
+
+    async fn flush_persistence(&mut self) -> Result<()> {
+        // Publish all authoritative quit snapshots, then drain the actor. A timeout retries every
+        // still-owned journal frontier and reports any operation whose durability is unconfirmed.
+        flush_owner_persistence(self.app, self.persist).await
+    }
 }
 
 pub(super) async fn complete_owner_teardown<T: OwnerTeardown>(
@@ -43,19 +323,28 @@ pub(super) async fn complete_owner_teardown<T: OwnerTeardown>(
     // Both boundaries are synchronous; this total order proves no untracked remote event can
     // cross between owner-ingress close and the final drain.
     teardown.quiesce_remote();
+    // Capture a fresh monotonic observation while the player projection is still available.
+    // Converting it to a terminal observation credits the final wall-clock interval exactly once.
+    teardown.seal_playback_observation();
     teardown.retire_player();
-    // Close every producer-facing ingress before awaiting actor joins. A callback that started
-    // just before shutdown can otherwise block on a saturated must-deliver lane while the owner
-    // waits for the callback's actor, forming a shutdown cycle.
-    teardown.close_ingress();
-    // Remove the OS media surface while its callbacks can still observe the now-closed ingress.
-    // Leaving it registered through the slower actor barrier advertises controls which can only
-    // fail and can keep a fast successor from becoming the active system media target.
+    // Remove the OS media surface before slower durability work so a fast successor can become the
+    // active system media target.
     teardown.deactivate_media();
+    // The scrobble actor can discover one final OpenSubsonic threshold while draining observations
+    // accepted before player retirement. Keep the owner ingress open and actively reduce those
+    // events until the actor joins.
+    let (mut ingress_drain, scrobble_result) = teardown.shutdown_scrobble_with_owner_pump().await;
+    // Every producer which can create a playback report is now joined. Close the remaining
+    // producer-facing ingress before other actor joins to break callback saturation cycles.
+    teardown.close_ingress();
     // Settle every request/event accepted before the ingress boundary while the remote session
     // writers and ordinary reducer dependencies are still live. Post-boundary task completions
     // are retained separately and applied by the final background barrier below.
-    let ingress_drain = teardown.drain_owner_ingress().await;
+    ingress_drain.absorb(teardown.drain_owner_ingress().await);
+    // A threshold emitted immediately before the scrobble actor joined can be part of this final
+    // drain. Pump already-ready bridge receipts after the complete accepted set is visible; an
+    // unresolved Submission stays in the scrobble journal for restart replay.
+    let open_subsonic_result = teardown.pump_open_subsonic();
     tracing::debug!(
         remote_requests = ingress_drain.remote_requests,
         subscribe_requests = ingress_drain.subscribe_requests,
@@ -85,7 +374,8 @@ pub(super) async fn complete_owner_teardown<T: OwnerTeardown>(
     // mutator. Recover every non-abortable join and synchronously apply all retained completions.
     teardown.finalize_runtime_background().await;
     let persistence_error = teardown.flush_persistence().await.err();
-    let scrobble_error = teardown.shutdown_scrobble().await.err();
+    let scrobble_error = scrobble_result.err();
+    let open_subsonic_error = open_subsonic_result.err();
 
     let mut terminal_error = merge_terminal_shutdown_error(owner_error, terminal_background_error);
     if let Some(persistence_error) = persistence_error {
@@ -102,6 +392,14 @@ pub(super) async fn complete_owner_teardown<T: OwnerTeardown>(
                 error.context(format!("scrobble shutdown also failed: {scrobble_error:#}"))
             }
             None => scrobble_error,
+        });
+    }
+    if let Some(open_subsonic_error) = open_subsonic_error {
+        terminal_error = Some(match terminal_error {
+            Some(error) => error.context(format!(
+                "music server bridge shutdown also failed: {open_subsonic_error:#}"
+            )),
+            None => open_subsonic_error,
         });
     }
     terminal_error.map_or(Ok(()), Err)

--- a/src/terminal_runtime/runner/teardown_tests.rs
+++ b/src/terminal_runtime/runner/teardown_tests.rs
@@ -12,6 +12,7 @@ struct RecordingTeardown {
     background_outcomes: VecDeque<runtime::BackgroundShutdown>,
     ingress_drain: OwnerIngressDrain,
     fail_scrobble: bool,
+    fail_open_subsonic: bool,
     terminal_background_error: Option<std::io::Error>,
 }
 
@@ -20,16 +21,39 @@ impl OwnerTeardown for RecordingTeardown {
         self.steps.push("remote_quiesce");
     }
 
+    fn seal_playback_observation(&mut self) {
+        self.steps.push("final_observation");
+    }
+
     fn retire_player(&mut self) {
         self.steps.push("player");
     }
 
-    fn close_ingress(&mut self) {
-        self.steps.push("ingress");
-    }
-
     fn deactivate_media(&mut self) {
         self.steps.push("media");
+    }
+
+    async fn shutdown_scrobble_with_owner_pump(&mut self) -> (OwnerIngressDrain, Result<()>) {
+        self.steps.push("scrobble");
+        let result = if self.fail_scrobble {
+            Err(anyhow::anyhow!("injected scrobble durability failure"))
+        } else {
+            Ok(())
+        };
+        (OwnerIngressDrain::default(), result)
+    }
+
+    fn pump_open_subsonic(&mut self) -> Result<()> {
+        self.steps.push("open_subsonic");
+        if self.fail_open_subsonic {
+            Err(anyhow::anyhow!("injected music server durability failure"))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn close_ingress(&mut self) {
+        self.steps.push("ingress");
     }
 
     async fn drain_owner_ingress(&mut self) -> OwnerIngressDrain {
@@ -85,14 +109,6 @@ impl OwnerTeardown for RecordingTeardown {
         self.steps.push("persistence");
         Ok(())
     }
-
-    async fn shutdown_scrobble(&mut self) -> Result<()> {
-        self.steps.push("scrobble");
-        if self.fail_scrobble {
-            anyhow::bail!("injected scrobble durability failure");
-        }
-        Ok(())
-    }
 }
 
 #[tokio::test]
@@ -114,10 +130,25 @@ async fn accepted_remote_requests_flush_before_the_hub_is_shut_down() {
         .iter()
         .position(|step| *step == "remote_quiesce")
         .unwrap();
+    let final_observation = teardown
+        .steps
+        .iter()
+        .position(|step| *step == "final_observation")
+        .unwrap();
     let player = teardown
         .steps
         .iter()
         .position(|step| *step == "player")
+        .unwrap();
+    let scrobble = teardown
+        .steps
+        .iter()
+        .position(|step| *step == "scrobble")
+        .unwrap();
+    let ingress = teardown
+        .steps
+        .iter()
+        .position(|step| *step == "ingress")
         .unwrap();
     let drain = teardown
         .steps
@@ -134,7 +165,15 @@ async fn accepted_remote_requests_flush_before_the_hub_is_shut_down() {
         .iter()
         .position(|step| *step == "remote")
         .unwrap();
-    assert!(quiesce < player && player < drain && drain < flush && flush < remote);
+    assert!(
+        quiesce < final_observation
+            && final_observation < player
+            && player < scrobble
+            && scrobble < ingress
+            && ingress < drain
+            && drain < flush
+            && flush < remote
+    );
 }
 
 #[tokio::test]
@@ -155,10 +194,13 @@ async fn owner_draw_error_runs_the_full_barrier_before_returning_the_original_er
         teardown.steps,
         [
             "remote_quiesce",
+            "final_observation",
             "player",
-            "ingress",
             "media",
+            "scrobble",
+            "ingress",
             "ingress_drain",
+            "open_subsonic",
             "remote_reply_flush",
             "remote",
             "startup",
@@ -170,7 +212,6 @@ async fn owner_draw_error_runs_the_full_barrier_before_returning_the_original_er
             "downloads",
             "runtime_finalize",
             "persistence",
-            "scrobble",
         ]
     );
     let returned_io = returned
@@ -199,10 +240,13 @@ async fn background_timeout_is_reaped_again_before_persistence_flush() {
         teardown.steps,
         [
             "remote_quiesce",
+            "final_observation",
             "player",
-            "ingress",
             "media",
+            "scrobble",
+            "ingress",
             "ingress_drain",
+            "open_subsonic",
             "remote_reply_flush",
             "remote",
             "startup",
@@ -215,7 +259,6 @@ async fn background_timeout_is_reaped_again_before_persistence_flush() {
             "runtime_background",
             "runtime_finalize",
             "persistence",
-            "scrobble",
         ]
     );
 }
@@ -242,10 +285,13 @@ async fn repeated_background_timeout_still_joins_without_a_final_deadline_before
         teardown.steps,
         [
             "remote_quiesce",
+            "final_observation",
             "player",
-            "ingress",
             "media",
+            "scrobble",
+            "ingress",
             "ingress_drain",
+            "open_subsonic",
             "remote_reply_flush",
             "remote",
             "startup",
@@ -258,7 +304,6 @@ async fn repeated_background_timeout_still_joins_without_a_final_deadline_before
             "runtime_background",
             "runtime_finalize",
             "persistence",
-            "scrobble",
         ],
         "persistence cannot start before the unbounded final ownership barrier"
     );
@@ -279,7 +324,43 @@ async fn scrobble_durability_failure_is_returned_after_the_full_barrier() {
             .to_string()
             .contains("injected scrobble durability failure")
     );
-    assert_eq!(teardown.steps.last(), Some(&"scrobble"));
+    assert!(
+        teardown.steps.iter().position(|step| *step == "scrobble")
+            < teardown.steps.iter().position(|step| *step == "ingress")
+    );
+}
+
+#[tokio::test]
+async fn open_subsonic_nonblocking_pump_runs_after_final_drain_and_failure_remains_fatal() {
+    let mut teardown = RecordingTeardown {
+        fail_open_subsonic: true,
+        ..Default::default()
+    };
+
+    let error = complete_owner_teardown(&mut teardown, None)
+        .await
+        .expect_err("an unconfirmed server bridge frontier cannot look like a clean exit");
+    assert!(
+        error
+            .to_string()
+            .contains("injected music server durability failure")
+    );
+    let drain = teardown
+        .steps
+        .iter()
+        .position(|step| *step == "ingress_drain")
+        .unwrap();
+    let open_subsonic = teardown
+        .steps
+        .iter()
+        .position(|step| *step == "open_subsonic")
+        .unwrap();
+    let persistence = teardown
+        .steps
+        .iter()
+        .position(|step| *step == "persistence")
+        .unwrap();
+    assert!(drain < open_subsonic && open_subsonic < persistence);
 }
 
 #[tokio::test]

--- a/src/ui/views/settings/music_server.rs
+++ b/src/ui/views/settings/music_server.rs
@@ -8,8 +8,8 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use zeroize::Zeroizing;
 
 use crate::app::{
-    App, MouseTarget, MusicServerBusy, MusicServerHealth, MusicServerSetupField, MusicServerWizard,
-    SyncArea,
+    App, MouseTarget, MusicServerBusy, MusicServerCredentialMode, MusicServerHealth,
+    MusicServerHistoryHealth, MusicServerSetupField, MusicServerWizard, SyncArea,
 };
 use crate::settings::SettingsState;
 use crate::settings::sync::health_label;
@@ -124,22 +124,33 @@ pub(crate) fn render_status(frame: &mut Frame, app: &App, settings: &SettingsSta
         ])),
         rows[2],
     );
+    let server_detail = if server.playback_reports_needing_decision > 0 {
+        playback_report_attention_detail(server.playback_reports_needing_decision)
+    } else if server.configured {
+        t!(
+            "Server browsing is optional; local search and playback stay independent.",
+            "서버 탐색은 선택 사항이며 로컬 검색과 재생은 독립적으로 동작해요.",
+            "サーバー閲覧は任意で、ローカル検索と再生は独立して動作します。"
+        )
+        .to_owned()
+    } else {
+        t!(
+            "No music server is connected.",
+            "연결된 음악 서버가 없어요.",
+            "音楽サーバーは接続されていません。"
+        )
+        .to_owned()
+    };
     frame.render_widget(
-        Paragraph::new(if server.configured {
-            t!(
-                "Server browsing is optional; local search and playback stay independent.",
-                "서버 탐색은 선택 사항이며 로컬 검색과 재생은 독립적으로 동작해요.",
-                "サーバー閲覧は任意で、ローカル検索と再生は独立して動作します。"
+        Paragraph::new(server_detail)
+            .style(
+                theme.style(if server.playback_reports_needing_decision > 0 {
+                    R::Error
+                } else {
+                    R::TextMuted
+                }),
             )
-        } else {
-            t!(
-                "No music server is connected.",
-                "연결된 음악 서버가 없어요.",
-                "音楽サーバーは接続されていません。"
-            )
-        })
-        .style(theme.style(R::TextMuted))
-        .wrap(Wrap { trim: true }),
+            .wrap(Wrap { trim: true }),
         rows[3],
     );
 }
@@ -182,16 +193,22 @@ pub(crate) fn render_music_server(
     );
     let detail = app.server.settings.failure.map_or_else(
         || {
-            if summary.configured {
-                let auth = summary.credential_label.as_deref().unwrap_or("—");
+            if summary.playback_reports_needing_decision > 0 {
+                playback_report_attention_detail(summary.playback_reports_needing_decision)
+            } else if summary.configured {
+                let auth = summary
+                    .credential_kind
+                    .map(MusicServerCredentialMode::label)
+                    .unwrap_or("—");
                 format!(
-                    "{}  ·  {}",
+                    "{}  ·  {}  ·  {}",
                     auth,
                     if summary.lan_http {
                         t!("LAN HTTP allowed", "LAN HTTP 허용", "LAN HTTP 許可")
                     } else {
                         "HTTPS"
-                    }
+                    },
+                    history_health_label(summary.history, summary.credential_kind),
                 )
             } else {
                 t!(
@@ -204,9 +221,11 @@ pub(crate) fn render_music_server(
         },
         |failure| format!("{}  ·  {}", failure.label(), failure.recovery_label()),
     );
+    let detail_is_error =
+        app.server.settings.failure.is_some() || summary.playback_reports_needing_decision > 0;
     frame.render_widget(
         Paragraph::new(detail)
-            .style(theme.style(if app.server.settings.failure.is_some() {
+            .style(theme.style(if detail_is_error {
                 R::Error
             } else {
                 R::TextMuted
@@ -219,6 +238,7 @@ pub(crate) fn render_music_server(
         vec![
             t!("Test connection", "연결 테스트", "接続テスト"),
             t!("Edit connection", "연결 정보 수정", "接続情報を編集"),
+            history_action_label(summary.history),
             t!("Remove server", "서버 제거", "サーバーを削除"),
         ]
     } else {
@@ -252,6 +272,79 @@ pub(crate) fn render_music_server(
             rect,
         );
         app.register_mouse_button(rect, MouseTarget::SettingsMusicServerRow(index));
+    }
+}
+
+fn playback_report_attention_detail(count: usize) -> String {
+    if count == 1 {
+        t!(
+            "1 report needs a decision.\nytt server scrobbles list",
+            "재생 보고 1건 확인 필요\nytt server scrobbles list",
+            "再生レポート1件・確認が必要\nytt server scrobbles list"
+        )
+        .to_owned()
+    } else {
+        t!(
+            format!("{count} reports need a decision.\nytt server scrobbles list"),
+            format!("재생 보고 {count}건 확인 필요\nytt server scrobbles list"),
+            format!("再生レポート{count}件・確認が必要\nytt server scrobbles list")
+        )
+    }
+}
+
+fn history_health_label(
+    health: MusicServerHistoryHealth,
+    credential: Option<MusicServerCredentialMode>,
+) -> &'static str {
+    match health {
+        MusicServerHistoryHealth::Off => t!("Play counts only", "재생 횟수만", "再生回数のみ"),
+        MusicServerHistoryHealth::Probing => t!(
+            "Checking detailed history · play counts available",
+            "상세 이력 확인 중 · 재생 횟수 사용 가능",
+            "詳細履歴を確認中・再生回数は利用可能"
+        ),
+        MusicServerHistoryHealth::Detailed => t!(
+            "Detailed history available (experimental)",
+            "상세 이력 사용 가능 (실험적)",
+            "詳細履歴を利用可能（実験的）"
+        ),
+        MusicServerHistoryHealth::PlayCountsOnly => t!(
+            "Detailed history unavailable · play counts only",
+            "상세 이력 미지원 · 재생 횟수만",
+            "詳細履歴は未対応・再生回数のみ"
+        ),
+        MusicServerHistoryHealth::UpdatePassword
+            if credential == Some(MusicServerCredentialMode::Password) =>
+        {
+            t!(
+                "Update via: ytt server setup",
+                "다음 명령으로 업데이트: ytt server setup",
+                "次のコマンドで更新: ytt server setup"
+            )
+        }
+        MusicServerHistoryHealth::UpdatePassword => t!(
+            "Update via: ytt server history enable --experimental",
+            "다음 명령으로 업데이트: ytt server history enable --experimental",
+            "次のコマンドで更新: ytt server history enable --experimental"
+        ),
+    }
+}
+
+fn history_action_label(health: MusicServerHistoryHealth) -> &'static str {
+    match health {
+        MusicServerHistoryHealth::Off => t!(
+            "Enable detailed history in CLI",
+            "CLI에서 상세 이력 켜기",
+            "CLIで詳細履歴を有効化"
+        ),
+        MusicServerHistoryHealth::Probing
+        | MusicServerHistoryHealth::Detailed
+        | MusicServerHistoryHealth::PlayCountsOnly
+        | MusicServerHistoryHealth::UpdatePassword => t!(
+            "Turn off detailed history",
+            "상세 이력 끄기",
+            "詳細履歴をオフ"
+        ),
     }
 }
 
@@ -586,6 +679,80 @@ mod tests {
                     .iter()
                     .all(|area| !compact_area_label(*area).is_empty())
             );
+        }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn history_health_labels_cover_every_state_and_language() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for language in [
+            crate::i18n::Language::English,
+            crate::i18n::Language::Korean,
+            crate::i18n::Language::Japanese,
+        ] {
+            crate::i18n::set_language(language);
+            for health in [
+                MusicServerHistoryHealth::Off,
+                MusicServerHistoryHealth::Probing,
+                MusicServerHistoryHealth::Detailed,
+                MusicServerHistoryHealth::PlayCountsOnly,
+                MusicServerHistoryHealth::UpdatePassword,
+            ] {
+                assert!(
+                    !history_health_label(health, Some(MusicServerCredentialMode::ApiKey))
+                        .is_empty()
+                );
+                assert!(!history_action_label(health).is_empty());
+            }
+            assert!(
+                history_health_label(
+                    MusicServerHistoryHealth::UpdatePassword,
+                    Some(MusicServerCredentialMode::ApiKey),
+                )
+                .contains("ytt server history enable --experimental")
+            );
+            assert!(
+                history_health_label(
+                    MusicServerHistoryHealth::UpdatePassword,
+                    Some(MusicServerCredentialMode::Password),
+                )
+                .contains("ytt server setup")
+            );
+            let expected = match language {
+                crate::i18n::Language::English => ("Password", "API key"),
+                crate::i18n::Language::Korean => ("비밀번호", "API 키"),
+                crate::i18n::Language::Japanese => ("パスワード", "APIキー"),
+            };
+            assert_eq!(MusicServerCredentialMode::Password.label(), expected.0);
+            assert_eq!(MusicServerCredentialMode::ApiKey.label(), expected.1);
+        }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn playback_report_attention_copy_is_localized_and_points_to_cli_recovery() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for (language, expected) in [
+            (
+                crate::i18n::Language::English,
+                "2 reports need a decision.\nytt server scrobbles list",
+            ),
+            (
+                crate::i18n::Language::Korean,
+                "재생 보고 2건 확인 필요\nytt server scrobbles list",
+            ),
+            (
+                crate::i18n::Language::Japanese,
+                "再生レポート2件・確認が必要\nytt server scrobbles list",
+            ),
+        ] {
+            crate::i18n::set_language(language);
+            let detail = playback_report_attention_detail(2);
+            assert_eq!(detail, expected);
+            assert!(detail.lines().all(|line| buttons::text_width(line) <= 30));
         }
         crate::i18n::set_language(original);
     }


### PR DESCRIPTION
## Summary

- map OpenSubsonic rating/star observations into YuTuTui's tri-state ratings while preserving the server's raw shadow and acknowledging local writes only after readback
- import experimental exact Navidrome scrobble history with bounded probing/pagination, plus standard OpenSubsonic play-count fallback and exact echo deduplication
- durably journal outbound playback reports across restarts and shutdown, classify ambiguous delivery, and expose redacted `server scrobbles list`, `retry`, and `mark-sent` recovery commands
- keep App and daemon rating/recommendation behavior in parity, including immediate session reranking and neutral-to-dislike metadata preservation
- surface detailed-history and playback-report health in the Music Server TUI, including localized narrow-layout recovery guidance

## User impact

OpenSubsonic ratings, mobile plays, and YuTuTui playback reports now converge into the local-first personal-state model without turning a server outage into a playback or search outage. Detailed Navidrome history remains an explicit experimental opt-in; unsupported or unhealthy native history degrades to standard play-count observations.

Ambiguous outbound reports are never blindly resent. They remain durable in `Needs attention` until an exact echo arrives or the user explicitly retries or marks the report as already sent. Recovery output exposes only opaque event IDs, and destructive confirmation defaults to No.

## Safety

- credentials and native JWTs remain owner-only and are excluded from status, audit output, URLs, and playback arguments
- native requests keep the configured exact-origin and redirect policy
- source journal, bridge store, and personal-state commits preserve crash consistency and replay safety
- no dependency, GUI frontend, packaging, release workflow, or tag changes

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `~/.fable-harness/bin/run-gates .`
- focused OpenSubsonic, scrobble durability, personal-state, shutdown, CLI, and App/daemon parity suites
- isolated `verify` tmux run with temporary HOME/XDG/YTM roots and a loopback fake server at 80×24 and 30×30: secret masking, setup, detailed history, `Needs attention`, default-No recovery, explicit mark-sent, and return to `Up to date`

Refs #114