### PR TITLE
feat: sync linked OpenSubsonic playlists

### DIFF
--- a/scripts/recovery-state-budget.tsv
+++ b/scripts/recovery-state-budget.tsv
@@ -24,6 +24,7 @@ core	2	src/persist/recovery.rs	ConfigRecoveryTransactionState
 core	3	src/player/recovery.rs	RecoveryEpisodeState
 core	8	src/runtime/player_delivery.rs	RuntimePlayerLifecycle
 core	4	src/daemon/engine/transport.rs	TransportRecoveryState
+core	2	src/app/server_library/playlist_recovery.rs	ServerPlaylistRecoveryStage
 
 # Typed transition, plan, mode, and result projections.
 transition	2	src/persist/writer_lease.rs	InitializedWriterState
@@ -43,6 +44,7 @@ core	3	src/player/ipc/resume.rs	ResumeTelemetryPhase
 core	4	src/player/ipc/resume.rs	ResumeStage
 transition	3	src/player/ipc/resume.rs	TelemetryCompletion
 transition	3	src/player/ipc/resume.rs	PositionDisposition
+transition	5	src/app/server_library/playlist_recovery.rs	ServerPlaylistRecoveryAction
 
 # Recovery classifications which are not retained lifecycle state.
 support	7	src/runtime/delivery_reporting.rs	ActorRejectionRecovery
@@ -51,3 +53,4 @@ support	2	src/persist/recovery.rs	ConfigRecoveryReceipt
 support	2	src/persist/recovery.rs	RecoveryLockError
 support	3	src/persist/recovery.rs	StartupRecoveryFailure
 support	6	src/player/recovery.rs	RecoverableSourceFailure
+support	2	src/open_subsonic/playlist_create_recovery.rs	PlaylistCreateRecoveryState

--- a/src/app/artwork.rs
+++ b/src/app/artwork.rs
@@ -684,12 +684,15 @@ impl App {
                 self.overlays.pending_settings_confirm.is_some(),
                 ART_OVERLAY_SETTINGS_CONFIRM_BIT,
             )
-            // Bit 9 is shared by Library/Local file-operation confirm modals. They are modal
-            // and use the same centered footprint, so one bit tracks them without claiming
-            // another scarce overlay bit.
+            // Bit 9 is shared by Library/Local confirmation modals, including the explicit
+            // server-playlist preview. They are modal and use the same centered footprint, so
+            // one bit tracks them without claiming another scarce overlay bit.
             | flag(
                 self.library_ui.confirm_delete.is_some()
                     || self.library_ui.confirm_download.is_some()
+                    || self.server.library.playlist_preview.is_some()
+                    || self.server.library.playlist_create.is_some()
+                    || self.server.library.playlist_recovery.is_some()
                     || self.local_mode.pending_organize_confirm.is_some()
                     || self.local_mode.pending_accept_all_confirm.is_some()
                     || self.local_mode.pending_import_record_delete.is_some()

--- a/src/app/context_menu.rs
+++ b/src/app/context_menu.rs
@@ -93,12 +93,29 @@ enum ServerLibraryRowIdentity {
     Song(crate::open_subsonic::OpenSubsonicItemRef),
     Album(crate::open_subsonic::AlbumId),
     Artist(crate::open_subsonic::ArtistId),
-    Playlist(crate::open_subsonic::ServerPlaylistId),
+    Playlist {
+        id: crate::open_subsonic::ServerPlaylistId,
+        access: crate::open_subsonic::ServerPlaylistAccess,
+        link: Option<crate::open_subsonic::ServerPlaylistLinkSummary>,
+    },
 }
 
 impl ServerLibraryRowIdentity {
     const fn is_song(&self) -> bool {
         matches!(self, Self::Song(_))
+    }
+
+    fn playlist(
+        &self,
+    ) -> Option<(
+        &crate::open_subsonic::ServerPlaylistId,
+        crate::open_subsonic::ServerPlaylistAccess,
+        Option<&crate::open_subsonic::ServerPlaylistLinkSummary>,
+    )> {
+        match self {
+            Self::Playlist { id, access, link } => Some((id, *access, link.as_ref())),
+            Self::Song(_) | Self::Album(_) | Self::Artist(_) => None,
+        }
     }
 }
 
@@ -125,6 +142,14 @@ pub(crate) enum ContextCommand {
     AddToPlaylist,
     Download,
     ImportPlaylist,
+    ImportServerPlaylistCopy,
+    LinkServerPlaylist,
+    CreateLinkedServerPlaylist,
+    RestoreServerPlaylist,
+    UnlinkKeepServerPlaylist,
+    UnlinkKeepLocalPlaylist,
+    DeleteLinkedPlaylistBoth,
+    DeleteLinkedPlaylistLocal,
     OpenPlaylist,
     OpenArtist,
     Remove,
@@ -205,6 +230,42 @@ impl ContextMenuItem {
                 "プレイリストをインポート"
             )
             .to_owned(),
+            ContextCommand::ImportServerPlaylistCopy => {
+                t!("Import a copy", "복사본 가져오기", "コピーとしてインポート").to_owned()
+            }
+            ContextCommand::LinkServerPlaylist => {
+                t!("Link and sync", "연결 및 동기화", "リンクして同期").to_owned()
+            }
+            ContextCommand::CreateLinkedServerPlaylist => t!(
+                "Create linked server playlist",
+                "서버 연결 목록 만들기",
+                "サーバー連携リストを作成"
+            )
+            .to_owned(),
+            ContextCommand::RestoreServerPlaylist => t!(
+                "Restore server playlist",
+                "서버 목록 복구",
+                "サーバー側を復元"
+            )
+            .to_owned(),
+            ContextCommand::UnlinkKeepServerPlaylist => t!(
+                "Unlink; keep server",
+                "연결 해제·서버 유지",
+                "リンク解除・サーバー保持"
+            )
+            .to_owned(),
+            ContextCommand::UnlinkKeepLocalPlaylist => t!(
+                "Unlink; keep local",
+                "연결 해제·로컬 유지",
+                "リンク解除・ローカル保持"
+            )
+            .to_owned(),
+            ContextCommand::DeleteLinkedPlaylistBoth => {
+                t!("Delete both", "둘 다 삭제", "両方を削除").to_owned()
+            }
+            ContextCommand::DeleteLinkedPlaylistLocal => {
+                t!("Delete local too", "로컬 목록도 삭제", "ローカル側も削除").to_owned()
+            }
             ContextCommand::OpenPlaylist => {
                 t!("Open playlist", "플레이리스트 열기", "プレイリストを開く").to_owned()
             }
@@ -242,6 +303,9 @@ impl App {
     fn context_menu_blocked(&self) -> bool {
         self.personal_state.sync_ui.modal_open()
             || self.server.settings.modal_open()
+            || self.server.library.playlist_preview.is_some()
+            || self.server.library.playlist_create.is_some()
+            || self.server.library.playlist_recovery.is_some()
             || self.overlays.help_visible
             || self.overlays.mouse_help_visible
             || self.overlays.about_visible
@@ -506,9 +570,11 @@ impl App {
                     Row::Song(song) => ServerLibraryRowIdentity::Song(song.item.clone()),
                     Row::Album(album) => ServerLibraryRowIdentity::Album(album.id.clone()),
                     Row::Artist(artist) => ServerLibraryRowIdentity::Artist(artist.id.clone()),
-                    Row::Playlist(playlist) => {
-                        ServerLibraryRowIdentity::Playlist(playlist.id.clone())
-                    }
+                    Row::Playlist(playlist) => ServerLibraryRowIdentity::Playlist {
+                        id: playlist.id.clone(),
+                        access: playlist.access,
+                        link: playlist.link.clone(),
+                    },
                 }),
         }
     }
@@ -841,15 +907,47 @@ impl App {
                 }
                 commands
             }
-            ContextTarget::LibraryPlaylist { .. } => vec![
-                C::OpenPlaylist,
-                C::PlayNow,
-                C::Enqueue,
-                C::Download,
-                C::Remove,
-            ],
+            ContextTarget::LibraryPlaylist { .. } => {
+                let mut commands = vec![C::OpenPlaylist, C::PlayNow, C::Enqueue, C::Download];
+                if self.server.settings.summary.configured {
+                    commands.push(C::CreateLinkedServerPlaylist);
+                }
+                commands.push(C::Remove);
+                commands
+            }
             ContextTarget::ServerLibrary { identity, .. } if identity.is_song() => {
                 vec![C::PlayNow, C::Enqueue, C::ToggleFavorite, C::AddToPlaylist]
+            }
+            ContextTarget::ServerLibrary { identity, .. } if identity.playlist().is_some() => {
+                let Some((_, access, link)) = identity.playlist() else {
+                    return Vec::new();
+                };
+                if let Some(link) = link {
+                    let commands = match link.health {
+                        crate::open_subsonic::ServerPlaylistLinkHealth::UpToDate => vec![
+                            C::Activate,
+                            C::ImportServerPlaylistCopy,
+                            C::UnlinkKeepServerPlaylist,
+                            C::DeleteLinkedPlaylistBoth,
+                        ],
+                        crate::open_subsonic::ServerPlaylistLinkHealth::NeedsAttention => vec![
+                            C::Activate,
+                            C::ImportServerPlaylistCopy,
+                            C::UnlinkKeepServerPlaylist,
+                        ],
+                        crate::open_subsonic::ServerPlaylistLinkHealth::ServerMissing => vec![
+                            C::RestoreServerPlaylist,
+                            C::UnlinkKeepLocalPlaylist,
+                            C::DeleteLinkedPlaylistLocal,
+                        ],
+                    };
+                    return commands.into_iter().map(ContextMenuItem::new).collect();
+                }
+                let mut commands = vec![C::Activate, C::ImportServerPlaylistCopy];
+                if access == crate::open_subsonic::ServerPlaylistAccess::Server {
+                    commands.push(C::LinkServerPlaylist);
+                }
+                commands
             }
             ContextTarget::ServerLibrary { .. } => vec![C::Activate],
             ContextTarget::Queue { .. } => vec![C::PlayFromHere, C::Remove],
@@ -1151,6 +1249,19 @@ impl App {
                     .unwrap_or_default();
                 self.open_confirm_download(songs)
             }
+            ContextCommand::CreateLinkedServerPlaylist
+                if self.server.settings.summary.configured =>
+            {
+                let Ok(Some(snapshot)) =
+                    crate::personal_state::personal_playlist_snapshot_for_runtime_id(
+                        &self.personal_state.ledger,
+                        &playlist_id,
+                    )
+                else {
+                    return self.context_target_stale();
+                };
+                self.start_server_playlist_create(snapshot.playlist_id)
+            }
             ContextCommand::Remove => {
                 self.request_playlist_delete(index);
                 Vec::new()
@@ -1203,6 +1314,73 @@ impl App {
                     self.open_playlist_picker(vec![song]);
                 }
                 Vec::new()
+            }
+            ContextCommand::ImportServerPlaylistCopy => identity
+                .playlist()
+                .map(|(id, _, _)| {
+                    self.start_server_playlist_preview(
+                        id.clone(),
+                        crate::app::ServerPlaylistPreviewKind::ImportCopy,
+                    )
+                })
+                .unwrap_or_default(),
+            ContextCommand::LinkServerPlaylist => identity
+                .playlist()
+                .filter(|(_, access, _)| {
+                    *access == crate::open_subsonic::ServerPlaylistAccess::Server
+                })
+                .map(|(id, _, _)| {
+                    self.start_server_playlist_preview(
+                        id.clone(),
+                        crate::app::ServerPlaylistPreviewKind::LinkAndSync,
+                    )
+                })
+                .unwrap_or_default(),
+            ContextCommand::RestoreServerPlaylist
+            | ContextCommand::UnlinkKeepServerPlaylist
+            | ContextCommand::UnlinkKeepLocalPlaylist
+            | ContextCommand::DeleteLinkedPlaylistBoth
+            | ContextCommand::DeleteLinkedPlaylistLocal => {
+                let Some((server_id, _, Some(link))) = identity.playlist() else {
+                    return Vec::new();
+                };
+                let action = match command {
+                    ContextCommand::RestoreServerPlaylist => {
+                        crate::app::ServerPlaylistRecoveryAction::Restore
+                    }
+                    ContextCommand::UnlinkKeepServerPlaylist => {
+                        crate::app::ServerPlaylistRecoveryAction::UnlinkKeepServer
+                    }
+                    ContextCommand::UnlinkKeepLocalPlaylist => {
+                        crate::app::ServerPlaylistRecoveryAction::UnlinkKeepLocal
+                    }
+                    ContextCommand::DeleteLinkedPlaylistBoth => {
+                        crate::app::ServerPlaylistRecoveryAction::DeleteBoth
+                    }
+                    ContextCommand::DeleteLinkedPlaylistLocal => {
+                        crate::app::ServerPlaylistRecoveryAction::DeleteLocal
+                    }
+                    _ => unreachable!(),
+                };
+                let name = self
+                    .server
+                    .library
+                    .page
+                    .as_ref()
+                    .and_then(|page| page.rows.get(index))
+                    .and_then(|row| match row {
+                        crate::open_subsonic::ServerLibraryRow::Playlist(summary) => {
+                            Some(summary.name.clone())
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| t!("Playlist", "플레이리스트", "プレイリスト").to_owned());
+                self.start_server_playlist_recovery(
+                    server_id.clone(),
+                    link.local_playlist_id.clone(),
+                    name,
+                    action,
+                )
             }
             _ => Vec::new(),
         }
@@ -1312,199 +1490,5 @@ impl App {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::mousemap::{MouseAction, MouseContext, MouseGesture};
-    use crate::open_subsonic::{
-        AccountScopeId, AlbumId, BackendId, ItemId, OpenSubsonicItemRef, ServerAlbum,
-        ServerLibraryPage, ServerLibraryRow, ServerLibrarySection, ServerSong,
-    };
-
-    fn server_song(id: &str) -> ServerSong {
-        ServerSong {
-            item: OpenSubsonicItemRef::new(
-                BackendId::new("backend").unwrap(),
-                AccountScopeId::new("account").unwrap(),
-                ItemId::new(id).unwrap(),
-            ),
-            title: format!("Song {id}"),
-            artist: "Artist".to_owned(),
-            artists: vec!["Artist".to_owned()],
-            album: None,
-            album_id: None,
-            album_artist: None,
-            duration_secs: Some(120),
-            track_number: None,
-            disc_number: None,
-            year: None,
-            cover_art_id: None,
-            content_type: None,
-            suffix: None,
-            starred: false,
-            user_rating: None,
-            play_count: None,
-            played_at: None,
-        }
-    }
-
-    fn server_album(id: &str) -> ServerAlbum {
-        ServerAlbum {
-            id: AlbumId::new(id).unwrap(),
-            name: format!("Album {id}"),
-            artist: "Artist".to_owned(),
-            artist_id: None,
-            song_count: Some(1),
-            duration_secs: None,
-            year: None,
-            cover_art_id: None,
-        }
-    }
-
-    fn server_app(rows: Vec<ServerLibraryRow>) -> App {
-        let mut app = App::new(50);
-        app.mode = Mode::Library;
-        app.server.library.source = LibrarySource::OpenSubsonic;
-        app.server.library.section = ServerLibrarySection::Songs;
-        app.server.library.generation = 9;
-        app.server.library.page = Some(ServerLibraryPage {
-            section: ServerLibrarySection::Songs,
-            rows,
-            next_offset: None,
-            warning: None,
-        });
-        app
-    }
-
-    fn register_server_row(app: &App, index: usize) -> (u16, u16) {
-        app.register_mouse_button(
-            Rect::new(1, index as u16 + 1, 20, 1),
-            MouseTarget::ServerLibraryRow {
-                generation: app.server.library.generation,
-                index,
-            },
-        );
-        (2, index as u16 + 1)
-    }
-
-    #[test]
-    fn server_song_right_click_opens_only_safe_actions() {
-        let _guard = crate::i18n::lock_for_test();
-        crate::i18n::set_language(crate::i18n::Language::English);
-        let mut app = server_app(vec![ServerLibraryRow::Song(server_song("one"))]);
-        let (col, row) = register_server_row(&app, 0);
-
-        assert!(app.on_mouse_right_click(col, row).is_empty());
-        let menu = app.overlays.context_menu.as_ref().expect("server menu");
-        let labels: Vec<String> = menu
-            .items
-            .iter()
-            .map(|item| item.label(menu.target_count()))
-            .collect();
-        assert_eq!(
-            labels,
-            vec![
-                "Play now",
-                "Add to queue",
-                "Favorite / unfavorite",
-                "Add to playlist"
-            ]
-        );
-        assert!(labels.iter().all(|label| !label.contains("Download")));
-
-        assert!(app.activate_context_menu_item(3).is_empty());
-        assert_eq!(
-            app.playlist_picker
-                .as_ref()
-                .expect("local playlist picker")
-                .songs[0]
-                .title,
-            "Song one"
-        );
-    }
-
-    #[test]
-    fn server_right_click_obeys_disabled_enqueue_and_activate_mouse_actions() {
-        let mut disabled = server_app(vec![
-            ServerLibraryRow::Song(server_song("one")),
-            ServerLibraryRow::Song(server_song("two")),
-        ]);
-        disabled.server.library.selected = 1;
-        disabled
-            .mousemap
-            .set(
-                MouseContext::Library,
-                MouseGesture::RightClick,
-                MouseAction::Disabled,
-            )
-            .unwrap();
-        let (col, row) = register_server_row(&disabled, 0);
-        assert!(disabled.on_mouse_right_click(col, row).is_empty());
-        assert_eq!(disabled.server.library.selected, 1);
-        assert!(disabled.overlays.context_menu.is_none());
-
-        let mut enqueue = server_app(vec![ServerLibraryRow::Song(server_song("one"))]);
-        enqueue
-            .mousemap
-            .set(
-                MouseContext::Library,
-                MouseGesture::RightClick,
-                MouseAction::Enqueue,
-            )
-            .unwrap();
-        let (col, row) = register_server_row(&enqueue, 0);
-        assert!(!enqueue.on_mouse_right_click(col, row).is_empty());
-        assert_eq!(enqueue.server.library.selected, 0);
-        assert!(enqueue.overlays.context_menu.is_none());
-
-        let mut activate = server_app(vec![ServerLibraryRow::Album(server_album("album"))]);
-        activate
-            .mousemap
-            .set(
-                MouseContext::Library,
-                MouseGesture::RightClick,
-                MouseAction::Activate,
-            )
-            .unwrap();
-        let (col, row) = register_server_row(&activate, 0);
-        let commands = activate.on_mouse_right_click(col, row);
-        assert!(matches!(
-            commands.as_slice(),
-            [Cmd::ServerLibrary(ServerLibraryCommand::LoadDetail {
-                target: ServerLibraryDetailTarget::Album(id),
-                ..
-            })] if id.as_str() == "album"
-        ));
-    }
-
-    #[test]
-    fn delayed_server_menu_action_validates_generation_and_stable_identity() {
-        let mut app = server_app(vec![ServerLibraryRow::Song(server_song("one"))]);
-        let (col, row) = register_server_row(&app, 0);
-        app.on_mouse_right_click(col, row);
-
-        app.server.library.page.as_mut().unwrap().rows[0] =
-            ServerLibraryRow::Song(server_song("replacement"));
-        assert!(app.activate_context_menu_item(0).is_empty());
-        assert!(app.overlays.context_menu.is_none());
-        assert!(app.status.text.contains("list changed"));
-
-        let (col, row) = register_server_row(&app, 0);
-        app.on_mouse_right_click(col, row);
-        app.server.library.generation += 1;
-        assert!(app.activate_context_menu_item(0).is_empty());
-        assert!(app.status.text.contains("list changed"));
-    }
-
-    #[test]
-    fn server_container_context_menu_exposes_activate_only() {
-        let _guard = crate::i18n::lock_for_test();
-        crate::i18n::set_language(crate::i18n::Language::English);
-        let mut app = server_app(vec![ServerLibraryRow::Album(server_album("album"))]);
-        let (col, row) = register_server_row(&app, 0);
-
-        app.on_mouse_right_click(col, row);
-        let menu = app.overlays.context_menu.as_ref().expect("container menu");
-        assert_eq!(menu.items.len(), 1);
-        assert_eq!(menu.items[0].label(1), "Activate");
-    }
-}
+#[path = "context_menu/tests.rs"]
+mod tests;

--- a/src/app/context_menu/tests.rs
+++ b/src/app/context_menu/tests.rs
@@ -1,0 +1,647 @@
+use super::*;
+use crate::mousemap::{MouseAction, MouseContext, MouseGesture};
+use crate::open_subsonic::{
+    AccountScopeId, AlbumId, BackendId, ItemId, OpenSubsonicItemRef, ServerAlbum,
+    ServerLibraryPage, ServerLibraryRow, ServerLibrarySection, ServerPlaylistAccess,
+    ServerPlaylistId, ServerPlaylistLinkHealth, ServerPlaylistLinkSummary, ServerPlaylistSummary,
+    ServerSong,
+};
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+
+fn server_song(id: &str) -> ServerSong {
+    ServerSong {
+        item: OpenSubsonicItemRef::new(
+            BackendId::new("backend").unwrap(),
+            AccountScopeId::new("account").unwrap(),
+            ItemId::new(id).unwrap(),
+        ),
+        title: format!("Song {id}"),
+        artist: "Artist".to_owned(),
+        artists: vec!["Artist".to_owned()],
+        album: None,
+        album_id: None,
+        album_artist: None,
+        duration_secs: Some(120),
+        track_number: None,
+        disc_number: None,
+        year: None,
+        cover_art_id: None,
+        content_type: None,
+        suffix: None,
+        starred: false,
+        user_rating: None,
+        play_count: None,
+        played_at: None,
+    }
+}
+
+fn server_album(id: &str) -> ServerAlbum {
+    ServerAlbum {
+        id: AlbumId::new(id).unwrap(),
+        name: format!("Album {id}"),
+        artist: "Artist".to_owned(),
+        artist_id: None,
+        song_count: Some(1),
+        duration_secs: None,
+        year: None,
+        cover_art_id: None,
+    }
+}
+
+fn server_playlist(id: &str, access: ServerPlaylistAccess) -> ServerPlaylistSummary {
+    ServerPlaylistSummary {
+        id: ServerPlaylistId::new(id).unwrap(),
+        name: format!("Playlist {id}"),
+        owner: Some("owner".to_owned()),
+        song_count: Some(2),
+        duration_secs: None,
+        public: Some(false),
+        cover_art_id: None,
+        access,
+        link: None,
+        readonly_evidence: Some(access == ServerPlaylistAccess::ReadOnly),
+        owner_evidence: Some("owner".to_owned()),
+    }
+}
+
+fn linked_server_playlist(id: &str, health: ServerPlaylistLinkHealth) -> ServerPlaylistSummary {
+    let mut playlist = server_playlist(id, ServerPlaylistAccess::Linked);
+    playlist.link = Some(ServerPlaylistLinkSummary {
+        local_playlist_id: crate::personal_state::PlaylistId::new(format!("local-{id}")).unwrap(),
+        health,
+    });
+    playlist
+}
+
+fn server_app(rows: Vec<ServerLibraryRow>) -> App {
+    let mut app = App::new(50);
+    app.mode = Mode::Library;
+    app.server.library.source = LibrarySource::OpenSubsonic;
+    app.server.library.section = ServerLibrarySection::Songs;
+    app.server.library.generation = 9;
+    app.server.library.page = Some(ServerLibraryPage {
+        section: ServerLibrarySection::Songs,
+        rows,
+        next_offset: None,
+        warning: None,
+    });
+    app
+}
+
+fn register_server_row(app: &App, index: usize) -> (u16, u16) {
+    app.register_mouse_button(
+        Rect::new(1, index as u16 + 1, 20, 1),
+        MouseTarget::ServerLibraryRow {
+            generation: app.server.library.generation,
+            index,
+        },
+    );
+    (2, index as u16 + 1)
+}
+
+fn local_playlist_app(server_configured: bool) -> App {
+    let mut app = App::new(50);
+    app.mode = Mode::Library;
+    app.library_ui.tab = LibraryTab::Playlists;
+    app.server.settings.summary.configured = server_configured;
+    let (ledger, _) = crate::personal_state::append_external_operations(
+        &app.personal_state.ledger,
+        crate::personal_state::OperationOrigin::Imported,
+        &[crate::personal_state::ExternalOperationInput {
+            acknowledgement_id: "context-local-playlist".to_owned(),
+            operation: crate::personal_state::Operation::UpsertPlaylist {
+                playlist_id: crate::personal_state::PlaylistId::new("road-trip").unwrap(),
+                name: "Road Trip".to_owned(),
+            },
+            recorded_at_unix: 1,
+        }],
+    )
+    .unwrap();
+    app.install_personal_state_runtime(ledger).unwrap();
+    app.register_mouse_button(Rect::new(1, 1, 20, 1), MouseTarget::ListRow(0));
+    app
+}
+
+#[test]
+fn server_song_right_click_opens_only_safe_actions() {
+    let _guard = crate::i18n::lock_for_test();
+    crate::i18n::set_language(crate::i18n::Language::English);
+    let mut app = server_app(vec![ServerLibraryRow::Song(server_song("one"))]);
+    let (col, row) = register_server_row(&app, 0);
+
+    assert!(app.on_mouse_right_click(col, row).is_empty());
+    let menu = app.overlays.context_menu.as_ref().expect("server menu");
+    let labels: Vec<String> = menu
+        .items
+        .iter()
+        .map(|item| item.label(menu.target_count()))
+        .collect();
+    assert_eq!(
+        labels,
+        vec![
+            "Play now",
+            "Add to queue",
+            "Favorite / unfavorite",
+            "Add to playlist"
+        ]
+    );
+    assert!(labels.iter().all(|label| !label.contains("Download")));
+
+    assert!(app.activate_context_menu_item(3).is_empty());
+    assert_eq!(
+        app.playlist_picker
+            .as_ref()
+            .expect("local playlist picker")
+            .songs[0]
+            .title,
+        "Song one"
+    );
+}
+
+#[test]
+fn server_right_click_obeys_disabled_enqueue_and_activate_mouse_actions() {
+    let mut disabled = server_app(vec![
+        ServerLibraryRow::Song(server_song("one")),
+        ServerLibraryRow::Song(server_song("two")),
+    ]);
+    disabled.server.library.selected = 1;
+    disabled
+        .mousemap
+        .set(
+            MouseContext::Library,
+            MouseGesture::RightClick,
+            MouseAction::Disabled,
+        )
+        .unwrap();
+    let (col, row) = register_server_row(&disabled, 0);
+    assert!(disabled.on_mouse_right_click(col, row).is_empty());
+    assert_eq!(disabled.server.library.selected, 1);
+    assert!(disabled.overlays.context_menu.is_none());
+
+    let mut enqueue = server_app(vec![ServerLibraryRow::Song(server_song("one"))]);
+    enqueue
+        .mousemap
+        .set(
+            MouseContext::Library,
+            MouseGesture::RightClick,
+            MouseAction::Enqueue,
+        )
+        .unwrap();
+    let (col, row) = register_server_row(&enqueue, 0);
+    assert!(!enqueue.on_mouse_right_click(col, row).is_empty());
+    assert_eq!(enqueue.server.library.selected, 0);
+    assert!(enqueue.overlays.context_menu.is_none());
+
+    let mut activate = server_app(vec![ServerLibraryRow::Album(server_album("album"))]);
+    activate
+        .mousemap
+        .set(
+            MouseContext::Library,
+            MouseGesture::RightClick,
+            MouseAction::Activate,
+        )
+        .unwrap();
+    let (col, row) = register_server_row(&activate, 0);
+    let commands = activate.on_mouse_right_click(col, row);
+    assert!(matches!(
+        commands.as_slice(),
+        [Cmd::ServerLibrary(ServerLibraryCommand::LoadDetail {
+            target: ServerLibraryDetailTarget::Album(id),
+            ..
+        })] if id.as_str() == "album"
+    ));
+}
+
+#[test]
+fn delayed_server_menu_action_validates_generation_and_stable_identity() {
+    let mut app = server_app(vec![ServerLibraryRow::Song(server_song("one"))]);
+    let (col, row) = register_server_row(&app, 0);
+    app.on_mouse_right_click(col, row);
+
+    app.server.library.page.as_mut().unwrap().rows[0] =
+        ServerLibraryRow::Song(server_song("replacement"));
+    assert!(app.activate_context_menu_item(0).is_empty());
+    assert!(app.overlays.context_menu.is_none());
+    assert!(app.status.text.contains("list changed"));
+
+    let (col, row) = register_server_row(&app, 0);
+    app.on_mouse_right_click(col, row);
+    app.server.library.generation += 1;
+    assert!(app.activate_context_menu_item(0).is_empty());
+    assert!(app.status.text.contains("list changed"));
+}
+
+#[test]
+fn server_container_context_menu_exposes_activate_only() {
+    let _guard = crate::i18n::lock_for_test();
+    crate::i18n::set_language(crate::i18n::Language::English);
+    let mut app = server_app(vec![ServerLibraryRow::Album(server_album("album"))]);
+    let (col, row) = register_server_row(&app, 0);
+
+    app.on_mouse_right_click(col, row);
+    let menu = app.overlays.context_menu.as_ref().expect("server menu");
+    assert_eq!(menu.items.len(), 1);
+    assert_eq!(menu.items[0].label(1), "Activate");
+}
+
+#[test]
+fn server_playlist_menu_offers_copy_and_only_exact_server_access_can_link() {
+    let _guard = crate::i18n::lock_for_test();
+    crate::i18n::set_language(crate::i18n::Language::English);
+
+    for access in [ServerPlaylistAccess::ReadOnly, ServerPlaylistAccess::Linked] {
+        let mut app = server_app(vec![ServerLibraryRow::Playlist(server_playlist(
+            "remote", access,
+        ))]);
+        let (col, row) = register_server_row(&app, 0);
+        app.on_mouse_right_click(col, row);
+        let menu = app.overlays.context_menu.as_ref().expect("playlist menu");
+        let labels: Vec<_> = menu
+            .items
+            .iter()
+            .map(|item| item.label(menu.target_count()))
+            .collect();
+        assert_eq!(labels, ["Activate", "Import a copy"]);
+    }
+
+    let mut app = server_app(vec![ServerLibraryRow::Playlist(server_playlist(
+        "remote",
+        ServerPlaylistAccess::Server,
+    ))]);
+    let (col, row) = register_server_row(&app, 0);
+    app.on_mouse_right_click(col, row);
+    let menu = app.overlays.context_menu.as_ref().expect("playlist menu");
+    let labels: Vec<_> = menu
+        .items
+        .iter()
+        .map(|item| item.label(menu.target_count()))
+        .collect();
+    assert_eq!(labels, ["Activate", "Import a copy", "Link and sync"]);
+
+    let commands = app.activate_context_menu_item(2);
+    assert!(matches!(
+        commands.as_slice(),
+        [Cmd::ServerLibrary(ServerLibraryCommand::PreparePlaylist {
+            server_playlist_id,
+            kind: ServerPlaylistPreviewKind::LinkAndSync,
+            ..
+        })] if server_playlist_id.as_str() == "remote"
+    ));
+}
+
+#[test]
+fn server_playlist_context_labels_are_localized() {
+    let _guard = crate::i18n::lock_for_test();
+    let original = crate::i18n::current();
+    for (language, copy, link, restore, unlink_server, unlink_local, delete_both, delete_local) in [
+        (
+            crate::i18n::Language::English,
+            "Import a copy",
+            "Link and sync",
+            "Restore server playlist",
+            "Unlink; keep server",
+            "Unlink; keep local",
+            "Delete both",
+            "Delete local too",
+        ),
+        (
+            crate::i18n::Language::Korean,
+            "복사본 가져오기",
+            "연결 및 동기화",
+            "서버 목록 복구",
+            "연결 해제·서버 유지",
+            "연결 해제·로컬 유지",
+            "둘 다 삭제",
+            "로컬 목록도 삭제",
+        ),
+        (
+            crate::i18n::Language::Japanese,
+            "コピーとしてインポート",
+            "リンクして同期",
+            "サーバー側を復元",
+            "リンク解除・サーバー保持",
+            "リンク解除・ローカル保持",
+            "両方を削除",
+            "ローカル側も削除",
+        ),
+    ] {
+        crate::i18n::set_language(language);
+        assert_eq!(
+            ContextMenuItem::new(ContextCommand::ImportServerPlaylistCopy).label(1),
+            copy
+        );
+        assert_eq!(
+            ContextMenuItem::new(ContextCommand::LinkServerPlaylist).label(1),
+            link
+        );
+        for (command, expected) in [
+            (ContextCommand::RestoreServerPlaylist, restore),
+            (ContextCommand::UnlinkKeepServerPlaylist, unlink_server),
+            (ContextCommand::UnlinkKeepLocalPlaylist, unlink_local),
+            (ContextCommand::DeleteLinkedPlaylistBoth, delete_both),
+            (ContextCommand::DeleteLinkedPlaylistLocal, delete_local),
+        ] {
+            assert_eq!(ContextMenuItem::new(command).label(1), expected);
+        }
+    }
+    crate::i18n::set_language(original);
+}
+
+#[test]
+fn linked_playlist_context_choices_follow_remote_health() {
+    let _guard = crate::i18n::lock_for_test();
+    crate::i18n::set_language(crate::i18n::Language::English);
+
+    let mut linked = server_app(vec![ServerLibraryRow::Playlist(linked_server_playlist(
+        "linked",
+        ServerPlaylistLinkHealth::UpToDate,
+    ))]);
+    let (col, row) = register_server_row(&linked, 0);
+    linked.on_mouse_right_click(col, row);
+    let menu = linked.overlays.context_menu.as_ref().expect("linked menu");
+    let labels: Vec<_> = menu
+        .items
+        .iter()
+        .map(|item| item.label(menu.target_count()))
+        .collect();
+    assert_eq!(
+        labels,
+        [
+            "Activate",
+            "Import a copy",
+            "Unlink; keep server",
+            "Delete both",
+        ]
+    );
+
+    let mut attention = server_app(vec![ServerLibraryRow::Playlist(linked_server_playlist(
+        "attention",
+        ServerPlaylistLinkHealth::NeedsAttention,
+    ))]);
+    let (col, row) = register_server_row(&attention, 0);
+    attention.on_mouse_right_click(col, row);
+    let menu = attention
+        .overlays
+        .context_menu
+        .as_ref()
+        .expect("attention menu");
+    let labels: Vec<_> = menu
+        .items
+        .iter()
+        .map(|item| item.label(menu.target_count()))
+        .collect();
+    assert_eq!(labels, ["Activate", "Import a copy", "Unlink; keep server"]);
+
+    let mut missing = server_app(vec![ServerLibraryRow::Playlist(linked_server_playlist(
+        "missing",
+        ServerPlaylistLinkHealth::ServerMissing,
+    ))]);
+    let (col, row) = register_server_row(&missing, 0);
+    missing.on_mouse_right_click(col, row);
+    let menu = missing
+        .overlays
+        .context_menu
+        .as_ref()
+        .expect("missing menu");
+    let labels: Vec<_> = menu
+        .items
+        .iter()
+        .map(|item| item.label(menu.target_count()))
+        .collect();
+    assert_eq!(
+        labels,
+        [
+            "Restore server playlist",
+            "Unlink; keep local",
+            "Delete local too",
+        ]
+    );
+}
+
+#[test]
+fn local_playlist_create_link_action_requires_a_configured_server_and_opens_confirmation() {
+    let _guard = crate::i18n::lock_for_test();
+    crate::i18n::set_language(crate::i18n::Language::English);
+
+    let mut off = local_playlist_app(false);
+    off.on_mouse_right_click(2, 1);
+    let labels = off
+        .overlays
+        .context_menu
+        .as_ref()
+        .unwrap()
+        .items
+        .iter()
+        .map(|item| item.label(1))
+        .collect::<Vec<_>>();
+    assert!(!labels.iter().any(|label| label.contains("server playlist")));
+
+    let mut configured = local_playlist_app(true);
+    configured.on_mouse_right_click(2, 1);
+    let menu = configured.overlays.context_menu.as_ref().unwrap();
+    let labels = menu
+        .items
+        .iter()
+        .map(|item| item.label(1))
+        .collect::<Vec<_>>();
+    let create_index = labels
+        .iter()
+        .position(|label| label == "Create linked server playlist")
+        .unwrap();
+    assert!(
+        configured
+            .activate_context_menu_item(create_index)
+            .is_empty()
+    );
+    assert!(matches!(
+        configured.server.library.playlist_create.as_ref(),
+        Some(crate::app::ServerPlaylistCreateModal {
+            stage: crate::app::ServerPlaylistCreateStage::Confirming,
+            snapshot,
+            ..
+        }) if snapshot.playlist_id.as_str() == "road-trip" && snapshot.name == "Road Trip"
+    ));
+}
+
+#[test]
+fn local_playlist_create_link_context_label_is_localized() {
+    let _guard = crate::i18n::lock_for_test();
+    let original = crate::i18n::current();
+    for (language, expected) in [
+        (
+            crate::i18n::Language::English,
+            "Create linked server playlist",
+        ),
+        (crate::i18n::Language::Korean, "서버 연결 목록 만들기"),
+        (crate::i18n::Language::Japanese, "サーバー連携リストを作成"),
+    ] {
+        crate::i18n::set_language(language);
+        assert_eq!(
+            ContextMenuItem::new(ContextCommand::CreateLinkedServerPlaylist).label(1),
+            expected
+        );
+    }
+    crate::i18n::set_language(original);
+}
+
+#[test]
+fn linked_playlist_recovery_choices_are_complete_at_thirty_columns_in_all_languages() {
+    let _guard = crate::i18n::lock_for_test();
+    let original = crate::i18n::current();
+    for (language, keep_server, keep_local) in [
+        (
+            crate::i18n::Language::English,
+            "Unlink; keep server",
+            "Unlink; keep local",
+        ),
+        (
+            crate::i18n::Language::Korean,
+            "연결 해제·서버 유지",
+            "연결 해제·로컬 유지",
+        ),
+        (
+            crate::i18n::Language::Japanese,
+            "リンク解除・サーバー保持",
+            "リンク解除・ローカル保持",
+        ),
+    ] {
+        crate::i18n::set_language(language);
+        for (health, expected) in [
+            (ServerPlaylistLinkHealth::UpToDate, keep_server),
+            (ServerPlaylistLinkHealth::ServerMissing, keep_local),
+        ] {
+            let mut app = server_app(vec![ServerLibraryRow::Playlist(linked_server_playlist(
+                "remote", health,
+            ))]);
+            let (col, row) = register_server_row(&app, 0);
+            app.on_mouse_right_click(col, row);
+            let item_count = app
+                .overlays
+                .context_menu
+                .as_ref()
+                .expect("linked playlist menu")
+                .items
+                .len();
+            let backend = TestBackend::new(30, 30);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| {
+                    crate::ui::views::context_menu::render(frame, &app, frame.area());
+                })
+                .unwrap();
+            let text: String = terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .map(|cell| cell.symbol())
+                .collect();
+            let comparable: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
+            let expected: String = expected.chars().filter(|ch| !ch.is_whitespace()).collect();
+            assert!(
+                comparable.contains(&expected),
+                "{language:?} {health:?}: {text:?}"
+            );
+            for index in 0..item_count {
+                let rect = app
+                    .hits
+                    .rect_of_target(MouseTarget::ContextMenuItem(index))
+                    .expect("visible context-menu choice");
+                assert!(rect.right() <= 30);
+                assert!(rect.bottom() <= 30);
+            }
+        }
+    }
+    crate::i18n::set_language(original);
+}
+
+#[test]
+fn linked_playlist_context_actions_preserve_confirmation_policy() {
+    let _guard = crate::i18n::lock_for_test();
+    crate::i18n::set_language(crate::i18n::Language::English);
+
+    for (health, item, action, immediate) in [
+        (
+            ServerPlaylistLinkHealth::UpToDate,
+            2,
+            ServerPlaylistRecoveryAction::UnlinkKeepServer,
+            true,
+        ),
+        (
+            ServerPlaylistLinkHealth::UpToDate,
+            3,
+            ServerPlaylistRecoveryAction::DeleteBoth,
+            false,
+        ),
+        (
+            ServerPlaylistLinkHealth::ServerMissing,
+            1,
+            ServerPlaylistRecoveryAction::UnlinkKeepLocal,
+            true,
+        ),
+        (
+            ServerPlaylistLinkHealth::ServerMissing,
+            2,
+            ServerPlaylistRecoveryAction::DeleteLocal,
+            false,
+        ),
+    ] {
+        let mut app = server_app(vec![ServerLibraryRow::Playlist(linked_server_playlist(
+            "remote", health,
+        ))]);
+        let (col, row) = register_server_row(&app, 0);
+        app.on_mouse_right_click(col, row);
+        let commands = app.activate_context_menu_item(item);
+        let modal = app
+            .server
+            .library
+            .playlist_recovery
+            .as_ref()
+            .expect("recovery modal");
+        assert_eq!(modal.action, action);
+        assert_eq!(
+            modal.stage,
+            if immediate {
+                ServerPlaylistRecoveryStage::Applying
+            } else {
+                ServerPlaylistRecoveryStage::Confirming
+            }
+        );
+        if immediate {
+            assert!(matches!(
+                commands.as_slice(),
+                [Cmd::ServerLibrary(ServerLibraryCommand::RecoverPlaylist {
+                    action: command_action,
+                    ..
+                })] if *command_action == action
+            ));
+        } else {
+            assert!(commands.is_empty());
+        }
+    }
+}
+
+#[test]
+fn delayed_missing_playlist_recovery_rejects_a_changed_link_health() {
+    let mut app = server_app(vec![ServerLibraryRow::Playlist(linked_server_playlist(
+        "remote",
+        ServerPlaylistLinkHealth::ServerMissing,
+    ))]);
+    let (col, row) = register_server_row(&app, 0);
+    app.on_mouse_right_click(col, row);
+    let Some(ServerLibraryRow::Playlist(playlist)) = app
+        .server
+        .library
+        .page
+        .as_mut()
+        .and_then(|page| page.rows.first_mut())
+    else {
+        panic!("playlist row");
+    };
+    playlist.link.as_mut().unwrap().health = ServerPlaylistLinkHealth::UpToDate;
+
+    assert!(app.activate_context_menu_item(0).is_empty());
+    assert!(app.server.library.playlist_recovery.is_none());
+    assert!(app.status.text.contains("list changed"));
+}

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -47,6 +47,17 @@ impl App {
         if self.personal_state.sync_ui.modal_open() {
             return self.on_key_sync_wizard(k);
         }
+        if self.server.library.playlist_create.is_some() {
+            return self.on_key_server_playlist_create(k);
+        }
+        if self.server.library.playlist_recovery.is_some() {
+            return self.on_key_server_playlist_recovery(k);
+        }
+        // A server-playlist preview owns input through preparation and apply. Enter/`y`
+        // confirms a ready preview once; every other key backs out without leaking to Library.
+        if self.server.library.playlist_preview.is_some() {
+            return self.on_key_server_playlist_preview(k);
+        }
         // Beginner Mode's F6 focus bridge runs before ordinary surface routing, while every
         // established overlay keeps precedence. Unowned keys continue through unchanged.
         if !self.beginner_higher_overlay_open()

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -86,7 +86,10 @@ pub use types::*;
 mod server_library;
 pub use server_library::{
     LibrarySource, SERVER_LIBRARY_PAGE_LIMIT, ServerLibraryCommand, ServerLibraryDetailTarget,
-    ServerLibraryEvent, ServerLibraryFailure, ServerLibraryState,
+    ServerLibraryEvent, ServerLibraryFailure, ServerLibraryState, ServerPlaylistCreateModal,
+    ServerPlaylistCreateStage, ServerPlaylistPreviewKind, ServerPlaylistPreviewModal,
+    ServerPlaylistPreviewStage, ServerPlaylistRecoveryAction, ServerPlaylistRecoveryModal,
+    ServerPlaylistRecoveryStage,
 };
 mod server_history_settings;
 mod server_settings;

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -155,6 +155,7 @@ impl App {
             || self.local_mode.find.refine_popup.open
             || self.local_import_confirmation_open()
             || self.overlays.pending_settings_confirm.is_some()
+            || self.server.library.playlist_modal_open()
             || self.library_ui.confirm_delete.is_some()
             || self.library_ui.confirm_playlist_delete.is_some()
             || self.library_ui.create_input.is_some()

--- a/src/app/mouse_routing.rs
+++ b/src/app/mouse_routing.rs
@@ -33,6 +33,35 @@ impl App {
                 _ => Vec::new(),
             };
         }
+        if self.server.library.playlist_create.is_some() {
+            return match self.mouse_target_at(col, row) {
+                Some(
+                    target @ (MouseTarget::ConfirmServerPlaylistCreate
+                    | MouseTarget::CancelServerPlaylistCreate),
+                ) => self.on_mouse_target(target),
+                _ => self.cancel_server_playlist_create(),
+            };
+        }
+        if self.server.library.playlist_recovery.is_some() {
+            return match self.mouse_target_at(col, row) {
+                Some(
+                    target @ (MouseTarget::ConfirmServerPlaylistRecovery
+                    | MouseTarget::CancelServerPlaylistRecovery),
+                ) => self.on_mouse_target(target),
+                _ => self.cancel_server_playlist_recovery(),
+            };
+        }
+        // Server-playlist previews are modal. Only the explicit Apply/Back buttons act; an
+        // outside click backs out and stale hit targets fail closed in `route_mouse_target`.
+        if self.server.library.playlist_preview.is_some() {
+            return match self.mouse_target_at(col, row) {
+                Some(
+                    target @ (MouseTarget::ConfirmServerPlaylistPreview
+                    | MouseTarget::CancelServerPlaylistPreview),
+                ) => self.on_mouse_target(target),
+                _ => self.cancel_server_playlist_preview(),
+            };
+        }
         if self.tool_setup.is_some() {
             return self
                 .mouse_target_at(col, row)
@@ -927,6 +956,43 @@ impl App {
                 self.dirty = true;
                 Vec::new()
             }
+            MouseTarget::ConfirmServerPlaylistPreview
+                if self.server.library.playlist_preview.is_some() =>
+            {
+                self.apply_server_playlist_preview()
+            }
+            MouseTarget::CancelServerPlaylistPreview
+                if self.server.library.playlist_preview.is_some() =>
+            {
+                self.cancel_server_playlist_preview()
+            }
+            MouseTarget::ConfirmServerPlaylistPreview
+            | MouseTarget::CancelServerPlaylistPreview => Vec::new(),
+            MouseTarget::ConfirmServerPlaylistCreate
+                if self.server.library.playlist_create.is_some() =>
+            {
+                self.apply_server_playlist_create()
+            }
+            MouseTarget::CancelServerPlaylistCreate
+                if self.server.library.playlist_create.is_some() =>
+            {
+                self.cancel_server_playlist_create()
+            }
+            MouseTarget::ConfirmServerPlaylistCreate | MouseTarget::CancelServerPlaylistCreate => {
+                Vec::new()
+            }
+            MouseTarget::ConfirmServerPlaylistRecovery
+                if self.server.library.playlist_recovery.is_some() =>
+            {
+                self.apply_server_playlist_recovery()
+            }
+            MouseTarget::CancelServerPlaylistRecovery
+                if self.server.library.playlist_recovery.is_some() =>
+            {
+                self.cancel_server_playlist_recovery()
+            }
+            MouseTarget::ConfirmServerPlaylistRecovery
+            | MouseTarget::CancelServerPlaylistRecovery => Vec::new(),
             MouseTarget::ConfirmRadioMode => {
                 let Some(confirm) = self.radio_mode.pending_radio_mode_confirm else {
                     return Vec::new();

--- a/src/app/open_subsonic_bridge.rs
+++ b/src/app/open_subsonic_bridge.rs
@@ -8,43 +8,30 @@ impl App {
     pub(crate) fn apply_open_subsonic_bridge_import(
         &mut self,
         import: &crate::open_subsonic::OpenSubsonicBridgeImport,
-    ) -> Result<String, crate::personal_state::PersonalStateError> {
+    ) -> Result<Vec<String>, crate::personal_state::PersonalStateError> {
         let current = self.reconcile_personal_state(&self.playlists)?;
-        let operation = import.operation();
+        if import.remote_playlist_is_absent(&current)? {
+            // The event may already have crossed the must-deliver owner queue before the bridge
+            // observed the local deletion and retired its source record. Keep the current local
+            // winner; the runtime still persists this snapshot before acknowledging the import.
+            self.install_personal_state_runtime(current)?;
+            return Ok(Vec::new());
+        }
         let origin = import.origin()?;
-        let (candidate, envelope_id) = match &self.personal_state.device_id {
-            Some(device_id) => {
-                let envelope_id = crate::personal_state::external_operation_envelope_id(
-                    device_id,
-                    import.operation_id(),
-                )?;
-                let candidate = crate::personal_state::append_external_operation_as(
-                    &current,
-                    device_id,
-                    import.operation_id().to_owned(),
-                    origin,
-                    operation,
-                    import.observed_at_unix(),
-                )?;
-                (candidate, envelope_id)
-            }
+        let operations = import.external_operations();
+        let (candidate, envelope_ids) = match &self.personal_state.device_id {
+            Some(device_id) => crate::personal_state::append_external_operations_as(
+                &current,
+                device_id,
+                origin,
+                &operations,
+            )?,
             None => {
-                let envelope_id = crate::personal_state::external_operation_envelope_id_for_state(
-                    &current,
-                    import.operation_id(),
-                )?;
-                let candidate = crate::personal_state::append_external_operation(
-                    &current,
-                    import.operation_id().to_owned(),
-                    origin,
-                    operation,
-                    import.observed_at_unix(),
-                )?;
-                (candidate, envelope_id)
+                crate::personal_state::append_external_operations(&current, origin, &operations)?
             }
         };
         self.install_personal_state_runtime(candidate)?;
-        Ok(envelope_id)
+        Ok(envelope_ids)
     }
 }
 
@@ -92,18 +79,19 @@ mod tests {
             observed_at_unix: 100,
         };
 
-        let envelope_id = app.apply_open_subsonic_bridge_import(&import).unwrap();
+        let envelope_ids = app.apply_open_subsonic_bridge_import(&import).unwrap();
         assert_eq!(
             app.apply_open_subsonic_bridge_import(&import).unwrap(),
-            envelope_id
+            envelope_ids
         );
+        let envelope_id = &envelope_ids[0];
 
         assert_eq!(
             app.personal_state
                 .ledger
                 .operations
                 .iter()
-                .filter(|operation| operation.operation_id == envelope_id)
+                .filter(|operation| operation.operation_id == *envelope_id)
                 .count(),
             1
         );

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -5,7 +5,7 @@ use super::{MusicServerEvent, MusicServerSettingsState, ServerLibraryEvent, Serv
 /// All OpenSubsonic UI state owned by the primary reducer.
 #[derive(Default)]
 pub struct ServerUiState {
-    /// Read-only source, paging, and drill-down state.
+    /// Browsing plus explicit deletion-free playlist import/link previews.
     pub library: ServerLibraryState,
     /// Redacted connection status plus the move-only setup wizard.
     pub settings: MusicServerSettingsState,

--- a/src/app/server_library.rs
+++ b/src/app/server_library.rs
@@ -1,18 +1,31 @@
-//! Read-only OpenSubsonic library state and reducer.
+//! OpenSubsonic library state, reducer, and explicit playlist-preview flow.
 //!
 //! The local YuTuTui library remains authoritative and fully usable when this surface is
-//! unavailable. Server pages are bounded, generation-stamped snapshots; no server rating or
-//! playlist mutation is reachable from this module.
+//! unavailable. Server pages are bounded, generation-stamped snapshots. Playlist imports and
+//! links are separately generation-stamped, deletion-free previews which require confirmation.
+
+mod playlist_preview;
+pub use playlist_preview::{
+    ServerPlaylistPreviewKind, ServerPlaylistPreviewModal, ServerPlaylistPreviewStage,
+};
+mod playlist_create;
+pub use playlist_create::{ServerPlaylistCreateModal, ServerPlaylistCreateStage};
+mod playlist_recovery;
+pub use playlist_recovery::{
+    ServerPlaylistRecoveryAction, ServerPlaylistRecoveryModal, ServerPlaylistRecoveryStage,
+};
 
 use crossterm::event::{KeyCode, KeyEvent};
 
 use super::{App, Cmd, Mode, MouseTarget, StatusKind};
 use crate::api::Song;
 use crate::keymap::{Action, Chord, KeyContext};
+use crate::open_subsonic::PlaylistMergePreview;
 use crate::open_subsonic::model::{
     AlbumId, ArtistId, ServerLibraryDetail, ServerLibraryPage, ServerLibraryRow,
     ServerLibrarySection, ServerPlaylistId, ServerSong,
 };
+use crate::personal_state::PlaylistId;
 
 pub const SERVER_LIBRARY_PAGE_LIMIT: u32 = 50;
 const SERVER_LIBRARY_MAX_OFFSET: u32 = 20_000;
@@ -93,6 +106,26 @@ pub enum ServerLibraryCommand {
         generation: u64,
         target: ServerLibraryDetailTarget,
     },
+    PreparePlaylist {
+        generation: u64,
+        server_playlist_id: ServerPlaylistId,
+        kind: ServerPlaylistPreviewKind,
+    },
+    ApplyPlaylistPreview {
+        generation: u64,
+        preview_id: String,
+        server_playlist_id: ServerPlaylistId,
+    },
+    CreateLinkedPlaylist {
+        generation: u64,
+        snapshot: crate::personal_state::PersonalPlaylistSnapshot,
+    },
+    RecoverPlaylist {
+        generation: u64,
+        action: ServerPlaylistRecoveryAction,
+        server_playlist_id: ServerPlaylistId,
+        snapshot: Option<crate::personal_state::PersonalPlaylistSnapshot>,
+    },
 }
 
 pub enum ServerLibraryEvent {
@@ -104,6 +137,24 @@ pub enum ServerLibraryEvent {
     DetailLoaded {
         generation: u64,
         result: Result<ServerLibraryDetail, ServerLibraryFailure>,
+    },
+    PlaylistPrepared {
+        generation: u64,
+        result: Result<PlaylistMergePreview, ServerLibraryFailure>,
+    },
+    PlaylistApplied {
+        generation: u64,
+        result: Result<PlaylistId, ServerLibraryFailure>,
+    },
+    PlaylistCreated {
+        generation: u64,
+        local_playlist_id: PlaylistId,
+        result: Result<ServerPlaylistId, ServerLibraryFailure>,
+    },
+    PlaylistRecovered {
+        generation: u64,
+        action: ServerPlaylistRecoveryAction,
+        result: Result<(), ServerLibraryFailure>,
     },
 }
 
@@ -124,6 +175,12 @@ pub struct ServerLibraryState {
     pub generation: u64,
     pub busy: Option<ServerLibraryBusy>,
     pub failure: Option<ServerLibraryFailure>,
+    pub playlist_preview: Option<ServerPlaylistPreviewModal>,
+    preview_generation: u64,
+    pub playlist_create: Option<ServerPlaylistCreateModal>,
+    create_generation: u64,
+    pub playlist_recovery: Option<ServerPlaylistRecoveryModal>,
+    recovery_generation: u64,
 }
 
 impl Default for ServerLibraryState {
@@ -139,14 +196,41 @@ impl Default for ServerLibraryState {
             generation: 0,
             busy: None,
             failure: None,
+            playlist_preview: None,
+            preview_generation: 0,
+            playlist_create: None,
+            create_generation: 0,
+            playlist_recovery: None,
+            recovery_generation: 0,
         }
     }
 }
 
 impl ServerLibraryState {
+    pub fn playlist_modal_open(&self) -> bool {
+        self.playlist_preview.is_some()
+            || self.playlist_create.is_some()
+            || self.playlist_recovery.is_some()
+    }
+
     fn next_generation(&mut self) -> u64 {
         self.generation = self.generation.wrapping_add(1).max(1);
         self.generation
+    }
+
+    fn next_preview_generation(&mut self) -> u64 {
+        self.preview_generation = self.preview_generation.wrapping_add(1).max(1);
+        self.preview_generation
+    }
+
+    fn next_create_generation(&mut self) -> u64 {
+        self.create_generation = self.create_generation.wrapping_add(1).max(1);
+        self.create_generation
+    }
+
+    fn next_recovery_generation(&mut self) -> u64 {
+        self.recovery_generation = self.recovery_generation.wrapping_add(1).max(1);
+        self.recovery_generation
     }
 
     pub fn rows_len(&self) -> usize {
@@ -225,6 +309,12 @@ impl ServerLibraryState {
         self.selected = 0;
         self.failure = None;
         self.busy = None;
+        self.playlist_preview = None;
+        self.next_preview_generation();
+        self.playlist_create = None;
+        self.next_create_generation();
+        self.playlist_recovery = None;
+        self.next_recovery_generation();
         self.next_generation();
     }
 }
@@ -268,6 +358,12 @@ impl App {
         // returning to the local library while a server request is in flight must not leave a
         // stale `busy` latch that prevents a later fresh server request.
         self.server.library.next_generation();
+        self.server.library.next_preview_generation();
+        self.server.library.playlist_preview = None;
+        self.server.library.next_create_generation();
+        self.server.library.playlist_create = None;
+        self.server.library.next_recovery_generation();
+        self.server.library.playlist_recovery = None;
         self.server.library.busy = None;
         self.server.library.source = source;
         self.server.library.selected = 0;
@@ -598,6 +694,16 @@ impl App {
         let event_generation = match &event {
             ServerLibraryEvent::PageLoaded { generation, .. }
             | ServerLibraryEvent::DetailLoaded { generation, .. } => *generation,
+            ServerLibraryEvent::PlaylistPrepared { .. }
+            | ServerLibraryEvent::PlaylistApplied { .. } => {
+                return self.finish_server_playlist_preview_event(event);
+            }
+            ServerLibraryEvent::PlaylistCreated { .. } => {
+                return self.finish_server_playlist_create_event(event);
+            }
+            ServerLibraryEvent::PlaylistRecovered { .. } => {
+                return self.finish_server_playlist_recovery_event(event);
+            }
         };
         if event_generation != self.server.library.generation
             || self.server.library.source != LibrarySource::OpenSubsonic
@@ -641,6 +747,16 @@ impl App {
                     self.status.text = failure.label().to_owned();
                 }
             },
+            ServerLibraryEvent::PlaylistPrepared { .. }
+            | ServerLibraryEvent::PlaylistApplied { .. } => unreachable!(
+                "playlist events return through finish_server_playlist_preview_event above"
+            ),
+            ServerLibraryEvent::PlaylistCreated { .. } => unreachable!(
+                "playlist creation returns through finish_server_playlist_create_event above"
+            ),
+            ServerLibraryEvent::PlaylistRecovered { .. } => unreachable!(
+                "playlist recovery returns through finish_server_playlist_recovery_event above"
+            ),
         }
         self.dirty = true;
         Vec::new()
@@ -800,6 +916,10 @@ mod tests {
                         duration_secs: None,
                         public: None,
                         cover_art_id: None,
+                        access: crate::open_subsonic::ServerPlaylistAccess::ReadOnly,
+                        link: None,
+                        readonly_evidence: None,
+                        owner_evidence: None,
                     },
                     entries,
                 },

--- a/src/app/server_library/playlist_create.rs
+++ b/src/app/server_library/playlist_create.rs
@@ -1,0 +1,375 @@
+//! Explicit, deletion-free creation of a linked server copy from one local playlist.
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+use super::{
+    App, Cmd, LibrarySource, ServerLibraryCommand, ServerLibraryEvent, ServerLibraryFailure,
+    StatusKind,
+};
+use crate::personal_state::{PersonalPlaylistSnapshot, PlaylistId};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ServerPlaylistCreateStage {
+    Confirming,
+    Applying,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServerPlaylistCreateModal {
+    pub generation: u64,
+    pub snapshot: PersonalPlaylistSnapshot,
+    pub stage: ServerPlaylistCreateStage,
+}
+
+impl ServerPlaylistCreateModal {
+    pub fn playlist_id(&self) -> &PlaylistId {
+        &self.snapshot.playlist_id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.snapshot.name
+    }
+
+    pub fn server_additions(&self) -> usize {
+        self.snapshot.entries.len()
+    }
+}
+
+impl App {
+    pub(in crate::app) fn start_server_playlist_create(
+        &mut self,
+        local_playlist_id: PlaylistId,
+    ) -> Vec<Cmd> {
+        if !self.server.settings.summary.configured
+            || self.server.library.source != LibrarySource::Yututui
+            || self.server.library.playlist_preview.is_some()
+            || self.server.library.playlist_create.is_some()
+            || self.server.library.playlist_recovery.is_some()
+        {
+            return Vec::new();
+        }
+        let snapshot = match crate::personal_state::personal_playlist_snapshot(
+            &self.personal_state.ledger,
+            &local_playlist_id,
+        ) {
+            Ok(Some(snapshot)) => snapshot,
+            Ok(None) | Err(_) => {
+                self.fail_server_playlist_create_changed();
+                return Vec::new();
+            }
+        };
+        let generation = self.server.library.next_create_generation();
+        self.server.library.failure = None;
+        self.server.library.playlist_create = Some(ServerPlaylistCreateModal {
+            generation,
+            snapshot,
+            stage: ServerPlaylistCreateStage::Confirming,
+        });
+        self.dirty = true;
+        Vec::new()
+    }
+
+    pub(in crate::app) fn apply_server_playlist_create(&mut self) -> Vec<Cmd> {
+        let Some(modal) = self.server.library.playlist_create.as_ref() else {
+            return Vec::new();
+        };
+        if modal.stage != ServerPlaylistCreateStage::Confirming {
+            return Vec::new();
+        }
+        let generation = modal.generation;
+        let expected = modal.snapshot.clone();
+        let current = crate::personal_state::personal_playlist_snapshot(
+            &self.personal_state.ledger,
+            &expected.playlist_id,
+        );
+        if !matches!(current, Ok(Some(ref snapshot)) if snapshot == &expected) {
+            self.fail_server_playlist_create_changed();
+            return Vec::new();
+        }
+        let Some(modal) = self.server.library.playlist_create.as_mut() else {
+            return Vec::new();
+        };
+        modal.stage = ServerPlaylistCreateStage::Applying;
+        self.dirty = true;
+        vec![Cmd::ServerLibrary(
+            ServerLibraryCommand::CreateLinkedPlaylist {
+                generation,
+                snapshot: expected,
+            },
+        )]
+    }
+
+    pub(in crate::app) fn cancel_server_playlist_create(&mut self) -> Vec<Cmd> {
+        if self
+            .server
+            .library
+            .playlist_create
+            .as_ref()
+            .is_some_and(|modal| modal.stage == ServerPlaylistCreateStage::Applying)
+        {
+            return Vec::new();
+        }
+        if self.server.library.playlist_create.take().is_some() {
+            self.server.library.next_create_generation();
+            self.dirty = true;
+        }
+        Vec::new()
+    }
+
+    pub(in crate::app) fn on_key_server_playlist_create(&mut self, key: KeyEvent) -> Vec<Cmd> {
+        if self
+            .server
+            .library
+            .playlist_create
+            .as_ref()
+            .is_some_and(|modal| modal.stage == ServerPlaylistCreateStage::Applying)
+        {
+            return Vec::new();
+        }
+        match key.code {
+            KeyCode::Enter => self.apply_server_playlist_create(),
+            KeyCode::Esc => self.cancel_server_playlist_create(),
+            _ => Vec::new(),
+        }
+    }
+
+    pub(in crate::app) fn finish_server_playlist_create_event(
+        &mut self,
+        event: ServerLibraryEvent,
+    ) -> Vec<Cmd> {
+        let ServerLibraryEvent::PlaylistCreated {
+            generation,
+            local_playlist_id,
+            result,
+        } = event
+        else {
+            return Vec::new();
+        };
+        let Some(modal) = self.server.library.playlist_create.as_ref() else {
+            return Vec::new();
+        };
+        if modal.generation != generation
+            || modal.playlist_id() != &local_playlist_id
+            || modal.stage != ServerPlaylistCreateStage::Applying
+        {
+            return Vec::new();
+        }
+        match result {
+            Ok(_) => {
+                let name = modal.name().to_owned();
+                self.server.library.playlist_create = None;
+                self.server.library.failure = None;
+                self.status.kind = StatusKind::Info;
+                self.status.text = match crate::i18n::current() {
+                    crate::i18n::Language::Korean => {
+                        format!("“{name}”의 서버 복사본을 만들고 연결했어요.")
+                    }
+                    crate::i18n::Language::Japanese => {
+                        format!("「{name}」のサーバーコピーを作成してリンクしました。")
+                    }
+                    _ => format!("Created and linked the server copy of “{name}”."),
+                };
+                self.dirty = true;
+                self.request_music_server_status()
+            }
+            Err(failure) => {
+                self.fail_server_playlist_create(failure);
+                Vec::new()
+            }
+        }
+    }
+
+    fn fail_server_playlist_create(&mut self, failure: ServerLibraryFailure) {
+        self.server.library.playlist_create = None;
+        self.server.library.failure = Some(failure);
+        self.status.kind = StatusKind::Error;
+        self.status.text = failure.label().to_owned();
+        self.dirty = true;
+    }
+
+    fn fail_server_playlist_create_changed(&mut self) {
+        self.server.library.playlist_create = None;
+        self.server.library.next_create_generation();
+        self.status.kind = StatusKind::Error;
+        self.status.text = crate::t!(
+            "Playlist changed. Open Create linked server playlist again.",
+            "플레이리스트가 바뀌었어요. 서버 연결 목록 만들기를 다시 열어 주세요.",
+            "プレイリストが変更されました。サーバー連携リストの作成を開き直してください。"
+        )
+        .to_owned();
+        self.dirty = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::KeyModifiers;
+
+    use super::*;
+    use crate::personal_state::{
+        ExternalOperationInput, Operation, OperationOrigin, append_external_operations,
+    };
+
+    fn app_with_playlist() -> App {
+        let mut app = App::new(50);
+        app.server.settings.summary.configured = true;
+        let (ledger, _) = append_external_operations(
+            &app.personal_state.ledger,
+            OperationOrigin::Imported,
+            &[ExternalOperationInput {
+                acknowledgement_id: "create-local-playlist".to_owned(),
+                operation: Operation::UpsertPlaylist {
+                    playlist_id: PlaylistId::new("local").unwrap(),
+                    name: "Road Trip".to_owned(),
+                },
+                recorded_at_unix: 1,
+            }],
+        )
+        .unwrap();
+        app.personal_state.replace_ledger(ledger);
+        app
+    }
+
+    #[test]
+    fn confirmation_dispatches_the_exact_snapshot_once() {
+        let mut app = app_with_playlist();
+        assert!(
+            app.start_server_playlist_create(PlaylistId::new("local").unwrap())
+                .is_empty()
+        );
+        assert!(matches!(
+            app.server.library.playlist_create.as_ref(),
+            Some(ServerPlaylistCreateModal {
+                stage: ServerPlaylistCreateStage::Confirming,
+                ..
+            })
+        ));
+
+        let commands =
+            app.on_key_server_playlist_create(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(matches!(
+            commands.as_slice(),
+            [Cmd::ServerLibrary(ServerLibraryCommand::CreateLinkedPlaylist {
+                snapshot,
+                ..
+            })] if snapshot.playlist_id.as_str() == "local" && snapshot.name == "Road Trip"
+        ));
+        assert!(
+            app.on_key_server_playlist_create(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE,))
+                .is_empty()
+        );
+        assert!(
+            app.on_key_server_playlist_create(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+                .is_empty()
+        );
+        assert!(matches!(
+            app.server.library.playlist_create.as_ref(),
+            Some(ServerPlaylistCreateModal {
+                stage: ServerPlaylistCreateStage::Applying,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn confirmation_rejects_a_playlist_changed_after_opening() {
+        let mut app = app_with_playlist();
+        app.start_server_playlist_create(PlaylistId::new("local").unwrap());
+        let (ledger, _) = append_external_operations(
+            &app.personal_state.ledger,
+            OperationOrigin::Imported,
+            &[ExternalOperationInput {
+                acknowledgement_id: "rename-after-create-preview".to_owned(),
+                operation: Operation::UpsertPlaylist {
+                    playlist_id: PlaylistId::new("local").unwrap(),
+                    name: "Changed".to_owned(),
+                },
+                recorded_at_unix: 2,
+            }],
+        )
+        .unwrap();
+        app.personal_state.replace_ledger(ledger);
+
+        assert!(app.apply_server_playlist_create().is_empty());
+        assert!(app.server.library.playlist_create.is_none());
+        assert_eq!(app.status.kind, StatusKind::Error);
+        assert!(!app.status.text.is_empty());
+    }
+
+    #[test]
+    fn stale_mismatched_and_duplicate_results_are_ignored() {
+        let mut app = app_with_playlist();
+        app.start_server_playlist_create(PlaylistId::new("local").unwrap());
+        let commands = app.apply_server_playlist_create();
+        let generation = match commands.as_slice() {
+            [
+                Cmd::ServerLibrary(ServerLibraryCommand::CreateLinkedPlaylist {
+                    generation, ..
+                }),
+            ] => *generation,
+            _ => panic!("create command"),
+        };
+        for event in [
+            ServerLibraryEvent::PlaylistCreated {
+                generation: generation + 1,
+                local_playlist_id: PlaylistId::new("local").unwrap(),
+                result: Ok(crate::open_subsonic::ServerPlaylistId::new("remote").unwrap()),
+            },
+            ServerLibraryEvent::PlaylistCreated {
+                generation,
+                local_playlist_id: PlaylistId::new("other").unwrap(),
+                result: Ok(crate::open_subsonic::ServerPlaylistId::new("remote").unwrap()),
+            },
+        ] {
+            assert!(app.finish_server_playlist_create_event(event).is_empty());
+            assert!(matches!(
+                app.server.library.playlist_create.as_ref(),
+                Some(ServerPlaylistCreateModal {
+                    stage: ServerPlaylistCreateStage::Applying,
+                    ..
+                })
+            ));
+        }
+
+        let completed = ServerLibraryEvent::PlaylistCreated {
+            generation,
+            local_playlist_id: PlaylistId::new("local").unwrap(),
+            result: Ok(crate::open_subsonic::ServerPlaylistId::new("remote").unwrap()),
+        };
+        assert!(matches!(
+            app.finish_server_playlist_create_event(completed)
+                .as_slice(),
+            [Cmd::MusicServer(
+                crate::app::MusicServerCommand::Refresh { .. }
+            )]
+        ));
+        assert!(app.server.library.playlist_create.is_none());
+        assert!(
+            app.finish_server_playlist_create_event(ServerLibraryEvent::PlaylistCreated {
+                generation,
+                local_playlist_id: PlaylistId::new("local").unwrap(),
+                result: Ok(crate::open_subsonic::ServerPlaylistId::new("remote").unwrap()),
+            })
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn create_is_hidden_without_a_configured_server_and_escape_cancels() {
+        let mut app = app_with_playlist();
+        app.server.settings.summary.configured = false;
+        assert!(
+            app.start_server_playlist_create(PlaylistId::new("local").unwrap())
+                .is_empty()
+        );
+        assert!(app.server.library.playlist_create.is_none());
+
+        app.server.settings.summary.configured = true;
+        app.start_server_playlist_create(PlaylistId::new("local").unwrap());
+        assert!(
+            app.on_key_server_playlist_create(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+                .is_empty()
+        );
+        assert!(app.server.library.playlist_create.is_none());
+    }
+}

--- a/src/app/server_library/playlist_preview.rs
+++ b/src/app/server_library/playlist_preview.rs
@@ -1,0 +1,387 @@
+//! App-owned, generation-stamped server-playlist preview state.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::{
+    App, Cmd, LibrarySource, ServerLibraryCommand, ServerLibraryEvent, ServerLibraryFailure,
+    ServerPlaylistId, StatusKind,
+};
+use crate::keymap::Chord;
+use crate::open_subsonic::{PlaylistMergePreview, PlaylistPreviewMode};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ServerPlaylistPreviewKind {
+    ImportCopy,
+    LinkAndSync,
+}
+
+impl ServerPlaylistPreviewKind {
+    const fn expected_mode(self) -> PlaylistPreviewMode {
+        match self {
+            Self::ImportCopy => PlaylistPreviewMode::ImportCopy,
+            Self::LinkAndSync => PlaylistPreviewMode::LinkNew,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ServerPlaylistPreviewStage {
+    Preparing {
+        server_playlist_id: ServerPlaylistId,
+        kind: ServerPlaylistPreviewKind,
+    },
+    Ready(PlaylistMergePreview),
+    Applying(PlaylistMergePreview),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServerPlaylistPreviewModal {
+    pub generation: u64,
+    pub kind: ServerPlaylistPreviewKind,
+    pub stage: ServerPlaylistPreviewStage,
+}
+
+impl ServerPlaylistPreviewModal {
+    pub fn preview(&self) -> Option<&PlaylistMergePreview> {
+        match &self.stage {
+            ServerPlaylistPreviewStage::Ready(preview)
+            | ServerPlaylistPreviewStage::Applying(preview) => Some(preview),
+            ServerPlaylistPreviewStage::Preparing { .. } => None,
+        }
+    }
+
+    pub const fn busy(&self) -> bool {
+        matches!(
+            self.stage,
+            ServerPlaylistPreviewStage::Preparing { .. } | ServerPlaylistPreviewStage::Applying(_)
+        )
+    }
+}
+
+impl App {
+    pub(in crate::app) fn start_server_playlist_preview(
+        &mut self,
+        server_playlist_id: ServerPlaylistId,
+        kind: ServerPlaylistPreviewKind,
+    ) -> Vec<Cmd> {
+        if self.server.library.source != LibrarySource::OpenSubsonic
+            || self.server.library.busy.is_some()
+            || self.server.library.playlist_preview.is_some()
+            || self.server.library.playlist_create.is_some()
+            || self.server.library.playlist_recovery.is_some()
+        {
+            return Vec::new();
+        }
+        let generation = self.server.library.next_preview_generation();
+        self.server.library.failure = None;
+        self.server.library.playlist_preview = Some(ServerPlaylistPreviewModal {
+            generation,
+            kind,
+            stage: ServerPlaylistPreviewStage::Preparing {
+                server_playlist_id: server_playlist_id.clone(),
+                kind,
+            },
+        });
+        self.dirty = true;
+        vec![Cmd::ServerLibrary(ServerLibraryCommand::PreparePlaylist {
+            generation,
+            server_playlist_id,
+            kind,
+        })]
+    }
+
+    pub(in crate::app) fn cancel_server_playlist_preview(&mut self) -> Vec<Cmd> {
+        if self
+            .server
+            .library
+            .playlist_preview
+            .as_ref()
+            .is_some_and(|modal| matches!(modal.stage, ServerPlaylistPreviewStage::Applying(_)))
+        {
+            // Apply already crossed the actor boundary and cannot honestly be cancelled.
+            return Vec::new();
+        }
+        if self.server.library.playlist_preview.take().is_some() {
+            self.server.library.next_preview_generation();
+            self.dirty = true;
+        }
+        Vec::new()
+    }
+
+    pub(in crate::app) fn apply_server_playlist_preview(&mut self) -> Vec<Cmd> {
+        let Some(modal) = self.server.library.playlist_preview.as_mut() else {
+            return Vec::new();
+        };
+        let ServerPlaylistPreviewStage::Ready(preview) = &modal.stage else {
+            return Vec::new();
+        };
+        let generation = modal.generation;
+        let preview_id = preview.preview_id.clone();
+        let server_playlist_id = preview.server_playlist_id.clone();
+        modal.stage = ServerPlaylistPreviewStage::Applying(preview.clone());
+        self.dirty = true;
+        vec![Cmd::ServerLibrary(
+            ServerLibraryCommand::ApplyPlaylistPreview {
+                generation,
+                preview_id,
+                server_playlist_id,
+            },
+        )]
+    }
+
+    pub(in crate::app) fn on_key_server_playlist_preview(&mut self, key: KeyEvent) -> Vec<Cmd> {
+        if self
+            .server
+            .library
+            .playlist_preview
+            .as_ref()
+            .is_some_and(|modal| matches!(modal.stage, ServerPlaylistPreviewStage::Applying(_)))
+        {
+            return Vec::new();
+        }
+        let chord = Chord::from(key);
+        let confirmed = key.code == KeyCode::Enter
+            || chord == Chord::new(KeyCode::Char('y'), KeyModifiers::empty());
+        if confirmed {
+            self.apply_server_playlist_preview()
+        } else {
+            self.cancel_server_playlist_preview()
+        }
+    }
+
+    pub(in crate::app) fn finish_server_playlist_preview_event(
+        &mut self,
+        event: ServerLibraryEvent,
+    ) -> Vec<Cmd> {
+        let generation = match &event {
+            ServerLibraryEvent::PlaylistPrepared { generation, .. }
+            | ServerLibraryEvent::PlaylistApplied { generation, .. } => *generation,
+            ServerLibraryEvent::PageLoaded { .. }
+            | ServerLibraryEvent::DetailLoaded { .. }
+            | ServerLibraryEvent::PlaylistCreated { .. }
+            | ServerLibraryEvent::PlaylistRecovered { .. } => {
+                return Vec::new();
+            }
+        };
+        let Some(modal) = self.server.library.playlist_preview.as_ref() else {
+            return Vec::new();
+        };
+        if modal.generation != generation
+            || self.server.library.source != LibrarySource::OpenSubsonic
+        {
+            return Vec::new();
+        }
+
+        match event {
+            ServerLibraryEvent::PlaylistPrepared { result, .. } => {
+                let (expected_id, kind) = match &modal.stage {
+                    ServerPlaylistPreviewStage::Preparing {
+                        server_playlist_id,
+                        kind,
+                    } => (server_playlist_id.clone(), *kind),
+                    ServerPlaylistPreviewStage::Ready(_)
+                    | ServerPlaylistPreviewStage::Applying(_) => return Vec::new(),
+                };
+                match result {
+                    Ok(preview)
+                        if preview.server_playlist_id == expected_id
+                            && preview.mode == kind.expected_mode() =>
+                    {
+                        self.server.library.playlist_preview = Some(ServerPlaylistPreviewModal {
+                            generation,
+                            kind,
+                            stage: ServerPlaylistPreviewStage::Ready(preview),
+                        });
+                    }
+                    Ok(_) => {
+                        self.fail_server_playlist_preview(ServerLibraryFailure::InvalidResponse)
+                    }
+                    Err(failure) => self.fail_server_playlist_preview(failure),
+                }
+            }
+            ServerLibraryEvent::PlaylistApplied { result, .. } => {
+                let (kind, name) = match &modal.stage {
+                    ServerPlaylistPreviewStage::Applying(preview) => {
+                        (modal.kind, preview.name.clone())
+                    }
+                    ServerPlaylistPreviewStage::Preparing { .. }
+                    | ServerPlaylistPreviewStage::Ready(_) => return Vec::new(),
+                };
+                match result {
+                    Ok(_) => {
+                        self.server.library.playlist_preview = None;
+                        self.server.library.failure = None;
+                        self.status.kind = StatusKind::Info;
+                        self.status.text = success_message(kind, &name);
+                        self.dirty = true;
+                        if kind == ServerPlaylistPreviewKind::LinkAndSync
+                            && self.server.library.detail.is_none()
+                        {
+                            return self
+                                .request_server_library_page(self.server.library.offset, false);
+                        }
+                    }
+                    Err(failure) => self.fail_server_playlist_preview(failure),
+                }
+            }
+            ServerLibraryEvent::PageLoaded { .. }
+            | ServerLibraryEvent::DetailLoaded { .. }
+            | ServerLibraryEvent::PlaylistCreated { .. }
+            | ServerLibraryEvent::PlaylistRecovered { .. } => {
+                return Vec::new();
+            }
+        }
+        self.dirty = true;
+        Vec::new()
+    }
+
+    fn fail_server_playlist_preview(&mut self, failure: ServerLibraryFailure) {
+        self.server.library.playlist_preview = None;
+        self.server.library.failure = Some(failure);
+        self.status.kind = StatusKind::Error;
+        self.status.text = failure.label().to_owned();
+    }
+}
+
+fn success_message(kind: ServerPlaylistPreviewKind, name: &str) -> String {
+    match (crate::i18n::current(), kind) {
+        (crate::i18n::Language::Korean, ServerPlaylistPreviewKind::ImportCopy) => {
+            format!("“{name}” 복사본을 가져왔어요.")
+        }
+        (crate::i18n::Language::Japanese, ServerPlaylistPreviewKind::ImportCopy) => {
+            format!("「{name}」をコピーとしてインポートしました。")
+        }
+        (_, ServerPlaylistPreviewKind::ImportCopy) => {
+            format!("Imported a copy of “{name}”.")
+        }
+        (crate::i18n::Language::Korean, ServerPlaylistPreviewKind::LinkAndSync) => {
+            format!("“{name}”을(를) 연결했어요.")
+        }
+        (crate::i18n::Language::Japanese, ServerPlaylistPreviewKind::LinkAndSync) => {
+            format!("「{name}」をリンクしました。")
+        }
+        (_, ServerPlaylistPreviewKind::LinkAndSync) => {
+            format!("Linked “{name}”.")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::open_subsonic::ServerPlaylistId;
+    use crate::personal_state::PlaylistId;
+
+    fn preview(kind: ServerPlaylistPreviewKind) -> PlaylistMergePreview {
+        PlaylistMergePreview {
+            preview_id: "preview".to_owned(),
+            mode: kind.expected_mode(),
+            server_playlist_id: ServerPlaylistId::new("remote").unwrap(),
+            local_playlist_id: PlaylistId::new("local").unwrap(),
+            name: "Road Trip".to_owned(),
+            remote_tracks: 4,
+            add_to_local: 3,
+            add_to_server: 0,
+        }
+    }
+
+    fn app() -> App {
+        let mut app = App::new(50);
+        app.server.library.source = LibrarySource::OpenSubsonic;
+        app
+    }
+
+    #[test]
+    fn ready_preview_only_dispatches_apply_once() {
+        let mut app = app();
+        let prepare = app.start_server_playlist_preview(
+            ServerPlaylistId::new("remote").unwrap(),
+            ServerPlaylistPreviewKind::ImportCopy,
+        );
+        let generation = match prepare.as_slice() {
+            [Cmd::ServerLibrary(ServerLibraryCommand::PreparePlaylist { generation, .. })] => {
+                *generation
+            }
+            _ => panic!("expected prepare command"),
+        };
+        app.finish_server_playlist_preview_event(ServerLibraryEvent::PlaylistPrepared {
+            generation,
+            result: Ok(preview(ServerPlaylistPreviewKind::ImportCopy)),
+        });
+
+        assert_eq!(app.apply_server_playlist_preview().len(), 1);
+        assert!(app.apply_server_playlist_preview().is_empty());
+        assert!(matches!(
+            app.server
+                .library
+                .playlist_preview
+                .as_ref()
+                .map(|modal| &modal.stage),
+            Some(ServerPlaylistPreviewStage::Applying(_))
+        ));
+    }
+
+    #[test]
+    fn stale_or_mismatched_prepare_result_never_opens_confirmation() {
+        let mut app = app();
+        let commands = app.start_server_playlist_preview(
+            ServerPlaylistId::new("remote").unwrap(),
+            ServerPlaylistPreviewKind::LinkAndSync,
+        );
+        let generation = match commands.as_slice() {
+            [Cmd::ServerLibrary(ServerLibraryCommand::PreparePlaylist { generation, .. })] => {
+                *generation
+            }
+            _ => panic!("expected prepare command"),
+        };
+
+        app.finish_server_playlist_preview_event(ServerLibraryEvent::PlaylistPrepared {
+            generation: generation + 1,
+            result: Ok(preview(ServerPlaylistPreviewKind::LinkAndSync)),
+        });
+        assert!(matches!(
+            app.server
+                .library
+                .playlist_preview
+                .as_ref()
+                .map(|modal| &modal.stage),
+            Some(ServerPlaylistPreviewStage::Preparing { .. })
+        ));
+
+        app.finish_server_playlist_preview_event(ServerLibraryEvent::PlaylistPrepared {
+            generation,
+            result: Ok(preview(ServerPlaylistPreviewKind::ImportCopy)),
+        });
+        assert!(app.server.library.playlist_preview.is_none());
+        assert_eq!(
+            app.server.library.failure,
+            Some(ServerLibraryFailure::InvalidResponse)
+        );
+    }
+
+    #[test]
+    fn any_non_confirmation_key_cancels_and_late_result_is_ignored() {
+        let mut app = app();
+        let commands = app.start_server_playlist_preview(
+            ServerPlaylistId::new("remote").unwrap(),
+            ServerPlaylistPreviewKind::ImportCopy,
+        );
+        let generation = match commands.as_slice() {
+            [Cmd::ServerLibrary(ServerLibraryCommand::PreparePlaylist { generation, .. })] => {
+                *generation
+            }
+            _ => panic!("expected prepare command"),
+        };
+        assert!(
+            app.on_key_server_playlist_preview(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE,))
+                .is_empty()
+        );
+        assert!(app.server.library.playlist_preview.is_none());
+
+        app.finish_server_playlist_preview_event(ServerLibraryEvent::PlaylistPrepared {
+            generation,
+            result: Ok(preview(ServerPlaylistPreviewKind::ImportCopy)),
+        });
+        assert!(app.server.library.playlist_preview.is_none());
+    }
+}

--- a/src/app/server_library/playlist_recovery.rs
+++ b/src/app/server_library/playlist_recovery.rs
@@ -1,0 +1,418 @@
+//! Explicit linked-playlist recovery and destructive confirmation state.
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+use super::{
+    App, Cmd, LibrarySource, ServerLibraryCommand, ServerLibraryEvent, ServerLibraryFailure,
+    ServerPlaylistId, StatusKind,
+};
+use crate::personal_state::PlaylistId;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ServerPlaylistRecoveryAction {
+    Restore,
+    UnlinkKeepServer,
+    UnlinkKeepLocal,
+    DeleteBoth,
+    DeleteLocal,
+}
+
+impl ServerPlaylistRecoveryAction {
+    pub const fn destructive(self) -> bool {
+        matches!(self, Self::DeleteBoth | Self::DeleteLocal)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ServerPlaylistRecoveryStage {
+    Confirming,
+    Applying,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServerPlaylistRecoveryModal {
+    pub generation: u64,
+    pub action: ServerPlaylistRecoveryAction,
+    pub server_playlist_id: ServerPlaylistId,
+    pub local_playlist_id: PlaylistId,
+    pub name: String,
+    pub stage: ServerPlaylistRecoveryStage,
+}
+
+impl App {
+    pub(in crate::app) fn start_server_playlist_recovery(
+        &mut self,
+        server_playlist_id: ServerPlaylistId,
+        local_playlist_id: PlaylistId,
+        name: String,
+        action: ServerPlaylistRecoveryAction,
+    ) -> Vec<Cmd> {
+        if self.server.library.source != LibrarySource::OpenSubsonic
+            || self.server.library.busy.is_some()
+            || self.server.library.playlist_preview.is_some()
+            || self.server.library.playlist_create.is_some()
+            || self.server.library.playlist_recovery.is_some()
+        {
+            return Vec::new();
+        }
+        let generation = self.server.library.next_recovery_generation();
+        let stage = if action.destructive() {
+            ServerPlaylistRecoveryStage::Confirming
+        } else {
+            ServerPlaylistRecoveryStage::Applying
+        };
+        self.server.library.playlist_recovery = Some(ServerPlaylistRecoveryModal {
+            generation,
+            action,
+            server_playlist_id,
+            local_playlist_id,
+            name,
+            stage,
+        });
+        self.dirty = true;
+        if action.destructive() {
+            Vec::new()
+        } else {
+            self.server_playlist_recovery_command()
+        }
+    }
+
+    pub(in crate::app) fn apply_server_playlist_recovery(&mut self) -> Vec<Cmd> {
+        let Some(modal) = self.server.library.playlist_recovery.as_mut() else {
+            return Vec::new();
+        };
+        if modal.stage != ServerPlaylistRecoveryStage::Confirming {
+            return Vec::new();
+        }
+        modal.stage = ServerPlaylistRecoveryStage::Applying;
+        self.dirty = true;
+        self.server_playlist_recovery_command()
+    }
+
+    fn server_playlist_recovery_command(&mut self) -> Vec<Cmd> {
+        let (generation, action, server_playlist_id, local_playlist_id) = {
+            let Some(modal) = self.server.library.playlist_recovery.as_ref() else {
+                return Vec::new();
+            };
+            (
+                modal.generation,
+                modal.action,
+                modal.server_playlist_id.clone(),
+                modal.local_playlist_id.clone(),
+            )
+        };
+        let snapshot = if action == ServerPlaylistRecoveryAction::Restore {
+            match crate::personal_state::personal_playlist_snapshot(
+                &self.personal_state.ledger,
+                &local_playlist_id,
+            ) {
+                Ok(Some(snapshot)) => Some(snapshot),
+                Ok(None) | Err(_) => {
+                    self.fail_server_playlist_recovery(ServerLibraryFailure::InvalidResponse);
+                    return Vec::new();
+                }
+            }
+        } else {
+            None
+        };
+        vec![Cmd::ServerLibrary(ServerLibraryCommand::RecoverPlaylist {
+            generation,
+            action,
+            server_playlist_id,
+            snapshot,
+        })]
+    }
+
+    pub(in crate::app) fn cancel_server_playlist_recovery(&mut self) -> Vec<Cmd> {
+        if self
+            .server
+            .library
+            .playlist_recovery
+            .as_ref()
+            .is_some_and(|modal| modal.stage == ServerPlaylistRecoveryStage::Applying)
+        {
+            return Vec::new();
+        }
+        if self.server.library.playlist_recovery.take().is_some() {
+            self.server.library.next_recovery_generation();
+            self.dirty = true;
+        }
+        Vec::new()
+    }
+
+    pub(in crate::app) fn on_key_server_playlist_recovery(&mut self, key: KeyEvent) -> Vec<Cmd> {
+        if self
+            .server
+            .library
+            .playlist_recovery
+            .as_ref()
+            .is_some_and(|modal| modal.stage == ServerPlaylistRecoveryStage::Applying)
+        {
+            return Vec::new();
+        }
+        if key.code == KeyCode::Enter {
+            self.apply_server_playlist_recovery()
+        } else {
+            self.cancel_server_playlist_recovery()
+        }
+    }
+
+    pub(in crate::app) fn finish_server_playlist_recovery_event(
+        &mut self,
+        event: ServerLibraryEvent,
+    ) -> Vec<Cmd> {
+        let ServerLibraryEvent::PlaylistRecovered {
+            generation,
+            action,
+            result,
+        } = event
+        else {
+            return Vec::new();
+        };
+        let Some(modal) = self.server.library.playlist_recovery.as_ref() else {
+            return Vec::new();
+        };
+        if modal.generation != generation
+            || modal.action != action
+            || modal.stage != ServerPlaylistRecoveryStage::Applying
+            || self.server.library.source != LibrarySource::OpenSubsonic
+        {
+            return Vec::new();
+        }
+        match result {
+            Ok(()) => {
+                let name = modal.name.clone();
+                self.server.library.playlist_recovery = None;
+                self.server.library.failure = None;
+                self.status.kind = StatusKind::Info;
+                self.status.text = recovery_success(action, &name);
+                self.dirty = true;
+                self.request_server_library_page(self.server.library.offset, false)
+            }
+            Err(failure) => {
+                self.fail_server_playlist_recovery(failure);
+                Vec::new()
+            }
+        }
+    }
+
+    fn fail_server_playlist_recovery(&mut self, failure: ServerLibraryFailure) {
+        self.server.library.playlist_recovery = None;
+        self.server.library.failure = Some(failure);
+        self.status.kind = StatusKind::Error;
+        self.status.text = failure.label().to_owned();
+        self.dirty = true;
+    }
+}
+
+fn recovery_success(action: ServerPlaylistRecoveryAction, name: &str) -> String {
+    let action = match action {
+        ServerPlaylistRecoveryAction::Restore => {
+            crate::t!("Restored", "복구됨", "復元しました")
+        }
+        ServerPlaylistRecoveryAction::UnlinkKeepServer
+        | ServerPlaylistRecoveryAction::UnlinkKeepLocal => {
+            crate::t!("Unlinked", "연결 해제됨", "リンクを解除しました")
+        }
+        ServerPlaylistRecoveryAction::DeleteBoth | ServerPlaylistRecoveryAction::DeleteLocal => {
+            crate::t!("Deleted", "삭제됨", "削除しました")
+        }
+    };
+    format!("{action}: {name}")
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::KeyModifiers;
+
+    use super::*;
+    use crate::personal_state::{
+        ExternalOperationInput, Operation, OperationOrigin, PersonalPlaylistSnapshot,
+        append_external_operations,
+    };
+
+    fn app_with_playlist() -> App {
+        let mut app = App::new(50);
+        app.server.library.source = LibrarySource::OpenSubsonic;
+        let id = PlaylistId::new("local").unwrap();
+        let (ledger, _) = append_external_operations(
+            &app.personal_state.ledger,
+            OperationOrigin::Imported,
+            &[ExternalOperationInput {
+                acknowledgement_id: "local-playlist".to_owned(),
+                operation: Operation::UpsertPlaylist {
+                    playlist_id: id,
+                    name: "Road Trip".to_owned(),
+                },
+                recorded_at_unix: 1,
+            }],
+        )
+        .unwrap();
+        app.personal_state.replace_ledger(ledger);
+        app
+    }
+
+    #[test]
+    fn delete_requires_confirmation_and_dispatches_only_once() {
+        for action in [
+            ServerPlaylistRecoveryAction::DeleteBoth,
+            ServerPlaylistRecoveryAction::DeleteLocal,
+        ] {
+            let mut app = app_with_playlist();
+            assert!(
+                app.start_server_playlist_recovery(
+                    ServerPlaylistId::new("remote").unwrap(),
+                    PlaylistId::new("local").unwrap(),
+                    "Road Trip".to_owned(),
+                    action,
+                )
+                .is_empty()
+            );
+            assert!(matches!(
+                app.server.library.playlist_recovery.as_ref(),
+                Some(ServerPlaylistRecoveryModal {
+                    stage: ServerPlaylistRecoveryStage::Confirming,
+                    ..
+                })
+            ));
+            let commands = app
+                .on_key_server_playlist_recovery(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+            assert!(matches!(
+                commands.as_slice(),
+                [Cmd::ServerLibrary(ServerLibraryCommand::RecoverPlaylist {
+                    action: command_action,
+                    ..
+                })] if *command_action == action
+            ));
+            assert!(
+                app.on_key_server_playlist_recovery(KeyEvent::new(
+                    KeyCode::Enter,
+                    KeyModifiers::NONE,
+                ))
+                .is_empty()
+            );
+            assert!(
+                app.on_key_server_playlist_recovery(KeyEvent::new(
+                    KeyCode::Esc,
+                    KeyModifiers::NONE,
+                ))
+                .is_empty()
+            );
+            assert!(app.cancel_server_playlist_recovery().is_empty());
+            assert!(
+                app.on_mouse_target(crate::app::MouseTarget::CancelServerPlaylistRecovery)
+                    .is_empty()
+            );
+            assert!(matches!(
+                app.server.library.playlist_recovery.as_ref(),
+                Some(ServerPlaylistRecoveryModal {
+                    stage: ServerPlaylistRecoveryStage::Applying,
+                    ..
+                })
+            ));
+        }
+    }
+
+    #[test]
+    fn delete_confirmation_rejects_shortcut_keys_and_defaults_to_cancel() {
+        for code in [KeyCode::Char('y'), KeyCode::Char('n'), KeyCode::Esc] {
+            let mut app = app_with_playlist();
+            app.start_server_playlist_recovery(
+                ServerPlaylistId::new("remote").unwrap(),
+                PlaylistId::new("local").unwrap(),
+                "Road Trip".to_owned(),
+                ServerPlaylistRecoveryAction::DeleteLocal,
+            );
+
+            assert!(
+                app.on_key_server_playlist_recovery(KeyEvent::new(code, KeyModifiers::NONE))
+                    .is_empty()
+            );
+            assert!(app.server.library.playlist_recovery.is_none());
+        }
+    }
+
+    #[test]
+    fn stale_wrong_and_duplicate_recovery_results_are_ignored() {
+        let mut app = app_with_playlist();
+        app.start_server_playlist_recovery(
+            ServerPlaylistId::new("remote").unwrap(),
+            PlaylistId::new("local").unwrap(),
+            "Road Trip".to_owned(),
+            ServerPlaylistRecoveryAction::DeleteBoth,
+        );
+        let commands = app.apply_server_playlist_recovery();
+        let generation = match commands.as_slice() {
+            [Cmd::ServerLibrary(ServerLibraryCommand::RecoverPlaylist { generation, .. })] => {
+                *generation
+            }
+            _ => panic!("recovery command"),
+        };
+
+        for event in [
+            ServerLibraryEvent::PlaylistRecovered {
+                generation: generation + 1,
+                action: ServerPlaylistRecoveryAction::DeleteBoth,
+                result: Ok(()),
+            },
+            ServerLibraryEvent::PlaylistRecovered {
+                generation,
+                action: ServerPlaylistRecoveryAction::DeleteLocal,
+                result: Ok(()),
+            },
+        ] {
+            assert!(app.finish_server_playlist_recovery_event(event).is_empty());
+            assert!(matches!(
+                app.server.library.playlist_recovery.as_ref(),
+                Some(ServerPlaylistRecoveryModal {
+                    stage: ServerPlaylistRecoveryStage::Applying,
+                    ..
+                })
+            ));
+        }
+
+        let completed = ServerLibraryEvent::PlaylistRecovered {
+            generation,
+            action: ServerPlaylistRecoveryAction::DeleteBoth,
+            result: Ok(()),
+        };
+        assert!(matches!(
+            app.finish_server_playlist_recovery_event(completed),
+            commands if matches!(
+                commands.as_slice(),
+                [Cmd::ServerLibrary(ServerLibraryCommand::LoadPage { .. })]
+            )
+        ));
+        assert!(app.server.library.playlist_recovery.is_none());
+        assert!(
+            app.finish_server_playlist_recovery_event(ServerLibraryEvent::PlaylistRecovered {
+                generation,
+                action: ServerPlaylistRecoveryAction::DeleteBoth,
+                result: Ok(()),
+            })
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn restore_carries_the_exact_canonical_local_snapshot() {
+        let mut app = app_with_playlist();
+        let commands = app.start_server_playlist_recovery(
+            ServerPlaylistId::new("missing").unwrap(),
+            PlaylistId::new("local").unwrap(),
+            "Road Trip".to_owned(),
+            ServerPlaylistRecoveryAction::Restore,
+        );
+        assert!(matches!(
+            commands.as_slice(),
+            [Cmd::ServerLibrary(ServerLibraryCommand::RecoverPlaylist {
+                snapshot: Some(PersonalPlaylistSnapshot {
+                    playlist_id,
+                    name,
+                    ..
+                }),
+                ..
+            })] if playlist_id.as_str() == "local" && name == "Road Trip"
+        ));
+    }
+}

--- a/src/app/server_settings.rs
+++ b/src/app/server_settings.rs
@@ -4,14 +4,21 @@
 //! material is move-only, zeroized on drop, and reaches durable storage only after the
 //! connection test has produced a prepared core transaction.
 
+mod playlist_create_recovery;
+mod state;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use zeroize::{Zeroize, Zeroizing};
 
 use super::{App, Cmd, MouseTarget, PersistCmd, StatusKind};
 use crate::keymap::Action;
-use crate::open_subsonic::PreparedSetup;
+use crate::open_subsonic::{PlaylistCreateAttention, PreparedSetup};
 use crate::search_source::SearchSource;
 use crate::util::text_edit::TextCursor;
+
+pub use state::{
+    MusicServerHealth, MusicServerHistoryHealth, MusicServerSettingsState, MusicServerSummary,
+};
 
 const MAX_SETUP_DISPLAY_NAME_BYTES: usize = 1_024;
 const MAX_SETUP_ORIGIN_BYTES: usize = 4_096;
@@ -60,45 +67,6 @@ impl SyncArea {
             (index + Self::ALL.len() - 1) % Self::ALL.len()
         };
         Self::ALL[next]
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum MusicServerHealth {
-    #[default]
-    Off,
-    UpToDate,
-    NeedsAttention,
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum MusicServerHistoryHealth {
-    #[default]
-    Off,
-    Probing,
-    Detailed,
-    PlayCountsOnly,
-    UpdatePassword,
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct MusicServerSummary {
-    pub health: MusicServerHealth,
-    pub configured: bool,
-    pub display_name: Option<String>,
-    pub credential_kind: Option<MusicServerCredentialMode>,
-    pub lan_http: bool,
-    pub custom_ca: bool,
-    pub history: MusicServerHistoryHealth,
-    /// Ambiguously delivered playback reports awaiting an explicit user decision.
-    pub playback_reports_needing_decision: usize,
-}
-
-impl MusicServerSummary {
-    pub fn display_name(&self) -> &str {
-        self.display_name
-            .as_deref()
-            .unwrap_or_else(|| crate::t!("Music server", "음악 서버", "音楽サーバー"))
     }
 }
 
@@ -230,6 +198,10 @@ pub enum MusicServerCommand {
     Remove {
         generation: u64,
     },
+    AbandonPlaylistCreate {
+        generation: u64,
+        local_playlist_id: crate::personal_state::PlaylistId,
+    },
 }
 
 pub enum MusicServerEvent {
@@ -253,6 +225,10 @@ pub enum MusicServerEvent {
         generation: u64,
         result: Result<(), MusicServerFailure>,
     },
+    PlaylistCreateAbandoned {
+        generation: u64,
+        result: Result<MusicServerSummary, MusicServerFailure>,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -268,6 +244,7 @@ pub enum MusicServerBusy {
     Saving,
     History,
     Removing,
+    PlaylistRecovery,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -431,46 +408,7 @@ pub enum MusicServerWizard {
     Setup(MusicServerSetupForm),
     Waiting,
     RemoveConfirm,
-}
-
-/// Settings/UI state. It intentionally has no `Debug`/`Clone` because `wizard` may own secrets.
-pub struct MusicServerSettingsState {
-    pub area: SyncArea,
-    pub selected: usize,
-    pub generation: u64,
-    pub busy: Option<MusicServerBusy>,
-    pub summary: MusicServerSummary,
-    pub failure: Option<MusicServerFailure>,
-    pub wizard: Option<MusicServerWizard>,
-}
-
-impl Default for MusicServerSettingsState {
-    fn default() -> Self {
-        Self {
-            area: SyncArea::Status,
-            selected: 0,
-            generation: 0,
-            busy: None,
-            summary: MusicServerSummary::default(),
-            failure: None,
-            wizard: None,
-        }
-    }
-}
-
-impl MusicServerSettingsState {
-    pub fn row_count(&self) -> usize {
-        if self.summary.configured { 4 } else { 2 }
-    }
-
-    pub fn modal_open(&self) -> bool {
-        self.wizard.is_some()
-    }
-
-    pub(in crate::app) fn next_generation(&mut self) -> u64 {
-        self.generation = self.generation.wrapping_add(1).max(1);
-        self.generation
-    }
+    AbandonPlaylistCreateConfirm(PlaylistCreateAttention),
 }
 
 impl App {
@@ -609,6 +547,12 @@ impl App {
         }
         self.server.settings.selected = row;
         if self.server.settings.summary.configured {
+            let has_pending_create = !self
+                .server
+                .settings
+                .summary
+                .playlist_create_attention
+                .is_empty();
             match row {
                 0 => self.request_music_server_status(),
                 1 => {
@@ -616,7 +560,8 @@ impl App {
                     Vec::new()
                 }
                 2 => self.activate_music_server_history(),
-                3 => {
+                3 if has_pending_create => self.open_playlist_create_abandon_confirmation(),
+                3 | 4 => {
                     self.server.settings.wizard = Some(MusicServerWizard::RemoveConfirm);
                     self.dirty = true;
                     Vec::new()
@@ -650,7 +595,11 @@ impl App {
     fn on_key_music_server_wizard(&mut self, key: KeyEvent) -> Vec<Cmd> {
         let durable_change_in_flight = matches!(
             self.server.settings.busy,
-            Some(MusicServerBusy::Saving | MusicServerBusy::Removing)
+            Some(
+                MusicServerBusy::Saving
+                    | MusicServerBusy::Removing
+                    | MusicServerBusy::PlaylistRecovery
+            )
         );
         if durable_change_in_flight {
             return Vec::new();
@@ -677,6 +626,15 @@ impl App {
         ) {
             return match key.code {
                 KeyCode::Enter => self.start_music_server_remove(),
+                _ => Vec::new(),
+            };
+        }
+        if matches!(
+            self.server.settings.wizard,
+            Some(MusicServerWizard::AbandonPlaylistCreateConfirm(_))
+        ) {
+            return match key.code {
+                KeyCode::Enter => self.start_abandon_playlist_create(),
                 _ => Vec::new(),
             };
         }
@@ -851,7 +809,11 @@ impl App {
             MouseTarget::MusicServerWizardSecondary
                 if matches!(
                     self.server.settings.busy,
-                    Some(MusicServerBusy::Saving | MusicServerBusy::Removing)
+                    Some(
+                        MusicServerBusy::Saving
+                            | MusicServerBusy::Removing
+                            | MusicServerBusy::PlaylistRecovery
+                    )
                 ) =>
             {
                 Vec::new()
@@ -867,6 +829,9 @@ impl App {
             MouseTarget::MusicServerWizardPrimary => match self.server.settings.wizard.as_ref() {
                 Some(MusicServerWizard::Setup(_)) => self.start_music_server_setup(),
                 Some(MusicServerWizard::RemoveConfirm) => self.start_music_server_remove(),
+                Some(MusicServerWizard::AbandonPlaylistCreateConfirm(_)) => {
+                    self.start_abandon_playlist_create()
+                }
                 Some(MusicServerWizard::Waiting) | None => Vec::new(),
             },
             MouseTarget::MusicServerWizardReveal => {
@@ -913,7 +878,8 @@ impl App {
             | MusicServerEvent::Prepared { generation, .. }
             | MusicServerEvent::Committed { generation, .. }
             | MusicServerEvent::HistoryDisabled { generation, .. }
-            | MusicServerEvent::Removed { generation, .. } => *generation,
+            | MusicServerEvent::Removed { generation, .. }
+            | MusicServerEvent::PlaylistCreateAbandoned { generation, .. } => *generation,
         };
         if event_generation != self.server.settings.generation {
             return Vec::new();
@@ -1068,6 +1034,9 @@ impl App {
                 };
                 self.dirty = true;
                 commands
+            }
+            MusicServerEvent::PlaylistCreateAbandoned { result, .. } => {
+                self.finish_playlist_create_abandoned(result)
             }
         }
     }
@@ -1309,6 +1278,11 @@ mod tests {
                 custom_ca: false,
                 history: MusicServerHistoryHealth::Off,
                 playback_reports_needing_decision: 0,
+                playlist_creates_needing_decision: 0,
+                playlist_create_attention: Vec::new(),
+                playlist_links_needing_decision: 0,
+                playlist_projections_needing_decision: 0,
+                playlist_contents_needing_decision: 0,
             }),
         });
 
@@ -1343,6 +1317,11 @@ mod tests {
                 custom_ca: false,
                 history: MusicServerHistoryHealth::Off,
                 playback_reports_needing_decision: 0,
+                playlist_creates_needing_decision: 0,
+                playlist_create_attention: Vec::new(),
+                playlist_links_needing_decision: 0,
+                playlist_projections_needing_decision: 0,
+                playlist_contents_needing_decision: 0,
             }),
         });
 
@@ -1369,6 +1348,11 @@ mod tests {
                 custom_ca: false,
                 history: MusicServerHistoryHealth::Off,
                 playback_reports_needing_decision: 0,
+                playlist_creates_needing_decision: 0,
+                playlist_create_attention: Vec::new(),
+                playlist_links_needing_decision: 0,
+                playlist_projections_needing_decision: 0,
+                playlist_contents_needing_decision: 0,
             }),
         });
 
@@ -1407,6 +1391,11 @@ mod tests {
                         custom_ca: false,
                         history: MusicServerHistoryHealth::Off,
                         playback_reports_needing_decision: 0,
+                        playlist_creates_needing_decision: 0,
+                        playlist_create_attention: Vec::new(),
+                        playlist_links_needing_decision: 0,
+                        playlist_projections_needing_decision: 0,
+                        playlist_contents_needing_decision: 0,
                     },
                     failure: Some(failure),
                 }),

--- a/src/app/server_settings/playlist_create_recovery.rs
+++ b/src/app/server_settings/playlist_create_recovery.rs
@@ -1,0 +1,128 @@
+//! Explicit UI recovery for replay-unsafe server playlist creation.
+
+use super::*;
+
+impl App {
+    pub(super) fn open_playlist_create_abandon_confirmation(&mut self) -> Vec<Cmd> {
+        let Some(attention) = self
+            .server
+            .settings
+            .summary
+            .playlist_create_attention
+            .first()
+            .cloned()
+        else {
+            return Vec::new();
+        };
+        self.server.settings.wizard =
+            Some(MusicServerWizard::AbandonPlaylistCreateConfirm(attention));
+        self.dirty = true;
+        Vec::new()
+    }
+
+    pub(super) fn start_abandon_playlist_create(&mut self) -> Vec<Cmd> {
+        if self.server.settings.busy.is_some() {
+            return Vec::new();
+        }
+        let Some(MusicServerWizard::AbandonPlaylistCreateConfirm(attention)) =
+            self.server.settings.wizard.take()
+        else {
+            return Vec::new();
+        };
+        let generation = self.server.settings.next_generation();
+        self.server.settings.busy = Some(MusicServerBusy::PlaylistRecovery);
+        self.server.settings.wizard = Some(MusicServerWizard::Waiting);
+        self.dirty = true;
+        vec![Cmd::MusicServer(
+            MusicServerCommand::AbandonPlaylistCreate {
+                generation,
+                local_playlist_id: attention.local_playlist_id,
+            },
+        )]
+    }
+
+    pub(super) fn finish_playlist_create_abandoned(
+        &mut self,
+        result: Result<MusicServerSummary, MusicServerFailure>,
+    ) -> Vec<Cmd> {
+        self.server.settings.busy = None;
+        self.server.settings.wizard = None;
+        match result {
+            Ok(summary) => {
+                self.server.settings.summary = summary;
+                self.server.settings.failure = None;
+                self.status.kind = StatusKind::Info;
+                self.status.text = crate::t!(
+                    "Pending playlist creation forgotten; any server copy was left untouched",
+                    "보류 중인 플레이리스트 생성을 잊었어요. 서버 복사본은 건드리지 않았어요",
+                    "保留中のプレイリスト作成を破棄しました。サーバー上のコピーは変更していません"
+                )
+                .to_owned();
+            }
+            Err(failure) => {
+                self.server.settings.failure = Some(failure);
+                self.server.settings.summary.health = MusicServerHealth::NeedsAttention;
+                self.status.kind = StatusKind::Error;
+                self.status.text = failure.label().to_owned();
+            }
+        }
+        self.dirty = true;
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn pending_playlist_create_adds_a_confirmed_abandon_action() {
+        let local_playlist_id = crate::personal_state::PlaylistId::new("local-pending").unwrap();
+        let mut app = App::new(50);
+        app.server.settings.summary.configured = true;
+        app.server.settings.summary.health = MusicServerHealth::NeedsAttention;
+        app.server
+            .settings
+            .summary
+            .playlist_creates_needing_decision = 1;
+        app.server.settings.summary.playlist_create_attention = vec![PlaylistCreateAttention {
+            local_playlist_id: local_playlist_id.clone(),
+            state: crate::open_subsonic::PlaylistCreateRecoveryState::ServerIdentityUnknown,
+        }];
+
+        assert_eq!(app.server.settings.row_count(), 5);
+        assert!(app.activate_music_server_row(3).is_empty());
+        assert!(matches!(
+            app.server.settings.wizard,
+            Some(MusicServerWizard::AbandonPlaylistCreateConfirm(ref attention))
+                if attention.local_playlist_id == local_playlist_id
+        ));
+
+        let commands = app.on_key_music_server_settings(key(KeyCode::Enter));
+        assert!(matches!(
+            commands.as_slice(),
+            [Cmd::MusicServer(MusicServerCommand::AbandonPlaylistCreate {
+                local_playlist_id: pending,
+                ..
+            })] if pending == &local_playlist_id
+        ));
+        assert_eq!(
+            app.server.settings.busy,
+            Some(MusicServerBusy::PlaylistRecovery)
+        );
+        assert!(matches!(
+            app.server.settings.wizard,
+            Some(MusicServerWizard::Waiting)
+        ));
+        assert!(
+            app.on_key_music_server_settings(key(KeyCode::Enter))
+                .is_empty()
+        );
+    }
+}

--- a/src/app/server_settings/state.rs
+++ b/src/app/server_settings/state.rs
@@ -1,0 +1,100 @@
+//! Redacted music-server settings summary and UI session state.
+
+use crate::open_subsonic::PlaylistCreateAttention;
+
+use super::{
+    MusicServerBusy, MusicServerCredentialMode, MusicServerFailure, MusicServerWizard, SyncArea,
+};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MusicServerHealth {
+    #[default]
+    Off,
+    UpToDate,
+    NeedsAttention,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MusicServerHistoryHealth {
+    #[default]
+    Off,
+    Probing,
+    Detailed,
+    PlayCountsOnly,
+    UpdatePassword,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MusicServerSummary {
+    pub health: MusicServerHealth,
+    pub configured: bool,
+    pub display_name: Option<String>,
+    pub credential_kind: Option<MusicServerCredentialMode>,
+    pub lan_http: bool,
+    pub custom_ca: bool,
+    pub history: MusicServerHistoryHealth,
+    /// Ambiguously delivered playback reports awaiting an explicit user decision.
+    pub playback_reports_needing_decision: usize,
+    /// Replay-unsafe server playlist creates awaiting an explicit keep/abandon decision.
+    pub playlist_creates_needing_decision: usize,
+    /// Redacted local identities for each replay-unsafe server playlist create.
+    pub playlist_create_attention: Vec<PlaylistCreateAttention>,
+    /// Linked playlists deleted on the server and awaiting a keep/restore decision.
+    pub playlist_links_needing_decision: usize,
+    /// Linked playlist writes that need a successful reconnect before they can safely retry.
+    pub playlist_projections_needing_decision: usize,
+    /// Linked local playlists containing tracks outside the exact connected server account.
+    pub playlist_contents_needing_decision: usize,
+}
+
+impl MusicServerSummary {
+    pub fn display_name(&self) -> &str {
+        self.display_name
+            .as_deref()
+            .unwrap_or_else(|| crate::t!("Music server", "음악 서버", "音楽サーバー"))
+    }
+}
+
+/// Settings/UI state. It intentionally has no `Debug`/`Clone` because `wizard` may own secrets.
+pub struct MusicServerSettingsState {
+    pub area: SyncArea,
+    pub selected: usize,
+    pub generation: u64,
+    pub busy: Option<MusicServerBusy>,
+    pub summary: MusicServerSummary,
+    pub failure: Option<MusicServerFailure>,
+    pub wizard: Option<MusicServerWizard>,
+}
+
+impl Default for MusicServerSettingsState {
+    fn default() -> Self {
+        Self {
+            area: SyncArea::Status,
+            selected: 0,
+            generation: 0,
+            busy: None,
+            summary: MusicServerSummary::default(),
+            failure: None,
+            wizard: None,
+        }
+    }
+}
+
+impl MusicServerSettingsState {
+    pub fn row_count(&self) -> usize {
+        if self.summary.configured {
+            4 + usize::from(!self.summary.playlist_create_attention.is_empty())
+        } else {
+            2
+        }
+    }
+
+    pub fn modal_open(&self) -> bool {
+        self.wizard.is_some()
+    }
+
+    pub(in crate::app) fn next_generation(&mut self) -> u64 {
+        self.generation = self.generation.wrapping_add(1).max(1);
+        self.generation
+    }
+}

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -383,7 +383,7 @@ pub enum Cmd {
     Search(SearchCmd),
     /// Test, commit, refresh, or remove the one configured music-server profile.
     MusicServer(MusicServerCommand),
-    /// Read-only OpenSubsonic library page/detail fetches.
+    /// OpenSubsonic library fetches and explicit playlist preview/apply requests.
     ServerLibrary(ServerLibraryCommand),
     /// Persist a store to disk (or clear one) via the debounced persistence actor. The
     /// [`PersistCmd`] payload selects which store; for the marker variants the runtime clones
@@ -867,6 +867,18 @@ pub enum MouseTarget {
     ConfirmSettings,
     /// Cancel button on a Settings confirmation modal.
     CancelSettings,
+    /// Apply button on a prepared server-playlist import/link preview.
+    ConfirmServerPlaylistPreview,
+    /// Back button on a server-playlist import/link preview.
+    CancelServerPlaylistPreview,
+    /// Create-and-link button on the local-to-server playlist confirmation.
+    ConfirmServerPlaylistCreate,
+    /// Back button on the local-to-server playlist confirmation.
+    CancelServerPlaylistCreate,
+    /// Confirm a destructive linked-playlist recovery action.
+    ConfirmServerPlaylistRecovery,
+    /// Back out of a linked-playlist recovery confirmation.
+    CancelServerPlaylistRecovery,
     /// Confirm button on the radio-mode confirmation modal.
     ConfirmRadioMode,
     /// Cancel button on the radio-mode confirmation modal.

--- a/src/daemon/engine.rs
+++ b/src/daemon/engine.rs
@@ -136,6 +136,9 @@ pub struct DaemonEngine {
     open_subsonic: open_subsonic_runtime::OpenSubsonicOwner,
     open_subsonic_rating_identity: Option<String>,
     open_subsonic_pending_rating: Option<open_subsonic_bridge::PendingOpenSubsonicRatingProjection>,
+    open_subsonic_playlist_identity: Option<String>,
+    open_subsonic_pending_playlist:
+        Option<open_subsonic_bridge::PendingOpenSubsonicPlaylistProjection>,
     open_subsonic_pending_scrobbles: VecDeque<open_subsonic_bridge::PendingOpenSubsonicScrobble>,
     player_emit: Arc<dyn Fn(PlayerEvent) + Send + Sync>,
     queue: Queue,
@@ -322,6 +325,8 @@ impl DaemonEngine {
             open_subsonic: Default::default(),
             open_subsonic_rating_identity: None,
             open_subsonic_pending_rating: None,
+            open_subsonic_playlist_identity: None,
+            open_subsonic_pending_playlist: None,
             open_subsonic_pending_scrobbles: VecDeque::new(),
             player_emit,
             queue,

--- a/src/daemon/engine/open_subsonic_bridge.rs
+++ b/src/daemon/engine/open_subsonic_bridge.rs
@@ -2,6 +2,9 @@
 
 use super::DaemonEngine;
 
+mod playlists;
+pub(super) use playlists::PendingOpenSubsonicPlaylistProjection;
+
 pub(super) struct PendingOpenSubsonicScrobble {
     event_id: String,
     kind: crate::open_subsonic::OpenSubsonicScrobbleKind,
@@ -16,6 +19,35 @@ pub(super) struct PendingOpenSubsonicScrobble {
 pub(super) struct PendingOpenSubsonicRatingProjection {
     identity: String,
     receipt: crate::open_subsonic::OpenSubsonicRatingReceipt,
+}
+
+enum ProjectionReceipt {
+    Idle,
+    Waiting,
+    Durable(String),
+    Retry(Option<crate::open_subsonic::ServiceError>),
+}
+
+fn poll_rating_projection_receipt(
+    pending: &mut Option<PendingOpenSubsonicRatingProjection>,
+) -> ProjectionReceipt {
+    let Some(receipt) = pending.as_mut().map(|pending| &mut pending.receipt) else {
+        return ProjectionReceipt::Idle;
+    };
+    match receipt.try_recv() {
+        Ok(Ok(())) => {
+            ProjectionReceipt::Durable(pending.take().expect("rating receipt was present").identity)
+        }
+        Ok(Err(error)) => {
+            *pending = None;
+            ProjectionReceipt::Retry(Some(error))
+        }
+        Err(tokio::sync::oneshot::error::TryRecvError::Empty) => ProjectionReceipt::Waiting,
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+            *pending = None;
+            ProjectionReceipt::Retry(None)
+        }
+    }
 }
 
 fn same_server_track(
@@ -110,7 +142,7 @@ impl DaemonEngine {
     pub(in crate::daemon) fn apply_open_subsonic_bridge_import(
         &mut self,
         import: &crate::open_subsonic::OpenSubsonicBridgeImport,
-    ) -> Result<String, crate::personal_state::PersonalStateError> {
+    ) -> Result<Vec<String>, crate::personal_state::PersonalStateError> {
         let current = match &self.personal_state_device_id {
             Some(device_id) => crate::personal_state::reconcile_runtime_as(
                 &self.personal_state,
@@ -128,35 +160,24 @@ impl DaemonEngine {
                 &self.station,
             )?,
         };
-        let (candidate, envelope_id) = match &self.personal_state_device_id {
-            Some(device_id) => {
-                let envelope_id = crate::personal_state::external_operation_envelope_id(
-                    device_id,
-                    import.operation_id(),
-                )?;
-                let candidate = crate::personal_state::append_external_operation_as(
+        let (candidate, envelope_ids) = if import.remote_playlist_is_absent(&current)? {
+            // Persist the current deletion before acknowledging an older event which was already
+            // admitted to the owner queue. An empty envelope list is the durable retirement marker.
+            (current, Vec::new())
+        } else {
+            let operations = import.external_operations();
+            match &self.personal_state_device_id {
+                Some(device_id) => crate::personal_state::append_external_operations_as(
                     &current,
                     device_id,
-                    import.operation_id().to_owned(),
                     import.origin()?,
-                    import.operation(),
-                    import.observed_at_unix(),
-                )?;
-                (candidate, envelope_id)
-            }
-            None => {
-                let envelope_id = crate::personal_state::external_operation_envelope_id_for_state(
+                    &operations,
+                )?,
+                None => crate::personal_state::append_external_operations(
                     &current,
-                    import.operation_id(),
-                )?;
-                let candidate = crate::personal_state::append_external_operation(
-                    &current,
-                    import.operation_id().to_owned(),
                     import.origin()?,
-                    import.operation(),
-                    import.observed_at_unix(),
-                )?;
-                (candidate, envelope_id)
+                    &operations,
+                )?,
             }
         };
         let commit = crate::personal_state::PersonalStateCommit::prepare_for_runtime(
@@ -180,7 +201,7 @@ impl DaemonEngine {
             self.bump_playlists_rev();
         }
         self.library_invalidations = self.library_invalidations.wrapping_add(1);
-        Ok(envelope_id)
+        Ok(envelope_ids)
     }
 
     pub(in crate::daemon) fn accept_open_subsonic_bridge_import(
@@ -226,28 +247,24 @@ impl DaemonEngine {
 
     pub(in crate::daemon) fn maintain_open_subsonic_bridge(&mut self) {
         self.drive_open_subsonic_scrobbles();
-        if let Some(pending) = self.open_subsonic_pending_rating.as_mut() {
-            match pending.receipt.try_recv() {
-                Ok(Ok(())) => {
-                    let pending = self
-                        .open_subsonic_pending_rating
-                        .take()
-                        .expect("rating receipt was present");
-                    self.open_subsonic_rating_identity = Some(pending.identity);
+        let rating_waiting =
+            match poll_rating_projection_receipt(&mut self.open_subsonic_pending_rating) {
+                ProjectionReceipt::Idle => false,
+                ProjectionReceipt::Waiting => true,
+                ProjectionReceipt::Durable(identity) => {
+                    self.open_subsonic_rating_identity = Some(identity);
+                    false
                 }
-                Ok(Err(error)) => {
+                ProjectionReceipt::Retry(Some(error)) => {
                     tracing::warn!(
                         reason = %error,
                         "music server ratings are waiting for local durability"
                     );
-                    self.open_subsonic_pending_rating = None;
+                    false
                 }
-                Err(tokio::sync::oneshot::error::TryRecvError::Empty) => return,
-                Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
-                    self.open_subsonic_pending_rating = None;
-                }
-            }
-        }
+                ProjectionReceipt::Retry(None) => false,
+            };
+        let playlist_waiting = self.poll_open_subsonic_playlist_projection();
         let Some(handle) = crate::open_subsonic::current_handle() else {
             return;
         };
@@ -255,21 +272,25 @@ impl DaemonEngine {
         let Ok(identity) = self.personal_state.identity() else {
             return;
         };
-        if self.open_subsonic_rating_identity.as_deref() == Some(identity.as_str()) {
-            return;
-        }
-        let winners =
+        if !rating_waiting
+            && self.open_subsonic_rating_identity.as_deref() != Some(identity.as_str())
+        {
             match crate::personal_state::open_subsonic_rating_winners(&self.personal_state) {
-                Ok(winners) => winners,
+                Ok(winners) => {
+                    if let Ok(receipt) = handle.reconcile_ratings(winners) {
+                        self.open_subsonic_pending_rating =
+                            Some(PendingOpenSubsonicRatingProjection {
+                                identity: identity.clone(),
+                                receipt,
+                            });
+                    }
+                }
                 Err(error) => {
                     tracing::warn!(%error, "music server rating projection could not be prepared");
-                    return;
                 }
-            };
-        if let Ok(receipt) = handle.reconcile_ratings(winners) {
-            self.open_subsonic_pending_rating =
-                Some(PendingOpenSubsonicRatingProjection { identity, receipt });
+            }
         }
+        self.reconcile_open_subsonic_playlists(&handle, &identity, playlist_waiting);
     }
 
     /// Poll only receipts which are already ready. An unresolved Submission remains protected by
@@ -586,18 +607,19 @@ mod tests {
             observed_at_unix: 100,
         };
 
-        let envelope_id = engine.apply_open_subsonic_bridge_import(&import).unwrap();
+        let envelope_ids = engine.apply_open_subsonic_bridge_import(&import).unwrap();
         assert_eq!(
             engine.apply_open_subsonic_bridge_import(&import).unwrap(),
-            envelope_id
+            envelope_ids
         );
+        let envelope_id = &envelope_ids[0];
 
         assert_eq!(
             engine
                 .personal_state
                 .operations
                 .iter()
-                .filter(|operation| operation.operation_id == envelope_id)
+                .filter(|operation| operation.operation_id == *envelope_id)
                 .count(),
             1
         );

--- a/src/daemon/engine/open_subsonic_bridge/playlists.rs
+++ b/src/daemon/engine/open_subsonic_bridge/playlists.rs
@@ -1,0 +1,436 @@
+//! Linked server-playlist projection on the daemon owner's durability lane.
+
+use super::DaemonEngine;
+
+pub(in crate::daemon::engine) struct PendingOpenSubsonicPlaylistProjection {
+    identity: String,
+    receipt: crate::open_subsonic::OpenSubsonicPlaylistReceipt,
+}
+
+enum PlaylistProjectionReceipt {
+    Idle,
+    Waiting,
+    Durable(String),
+    Retry(Option<crate::open_subsonic::ServiceError>),
+}
+
+fn poll_playlist_projection_receipt(
+    pending: &mut Option<PendingOpenSubsonicPlaylistProjection>,
+) -> PlaylistProjectionReceipt {
+    let Some(receipt) = pending.as_mut().map(|pending| &mut pending.receipt) else {
+        return PlaylistProjectionReceipt::Idle;
+    };
+    match receipt.try_recv() {
+        Ok(Ok(())) => PlaylistProjectionReceipt::Durable(
+            pending
+                .take()
+                .expect("playlist receipt was present")
+                .identity,
+        ),
+        Ok(Err(error)) => {
+            *pending = None;
+            PlaylistProjectionReceipt::Retry(Some(error))
+        }
+        Err(tokio::sync::oneshot::error::TryRecvError::Empty) => PlaylistProjectionReceipt::Waiting,
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+            *pending = None;
+            PlaylistProjectionReceipt::Retry(None)
+        }
+    }
+}
+
+impl DaemonEngine {
+    pub(super) fn poll_open_subsonic_playlist_projection(&mut self) -> bool {
+        match poll_playlist_projection_receipt(&mut self.open_subsonic_pending_playlist) {
+            PlaylistProjectionReceipt::Idle => false,
+            PlaylistProjectionReceipt::Waiting => true,
+            PlaylistProjectionReceipt::Durable(identity) => {
+                self.open_subsonic_playlist_identity = Some(identity);
+                false
+            }
+            PlaylistProjectionReceipt::Retry(Some(error)) => {
+                tracing::warn!(
+                    reason = %error,
+                    "music server playlists are waiting for local durability"
+                );
+                false
+            }
+            PlaylistProjectionReceipt::Retry(None) => false,
+        }
+    }
+
+    pub(super) fn reconcile_open_subsonic_playlists(
+        &mut self,
+        handle: &crate::open_subsonic::OpenSubsonicHandle,
+        identity: &str,
+        receipt_pending: bool,
+    ) {
+        if receipt_pending || self.open_subsonic_playlist_identity.as_deref() == Some(identity) {
+            return;
+        }
+        match crate::personal_state::personal_playlist_snapshots(&self.personal_state) {
+            Ok(snapshots) => {
+                if let Ok(receipt) = handle.reconcile_playlists(snapshots) {
+                    self.open_subsonic_pending_playlist =
+                        Some(PendingOpenSubsonicPlaylistProjection {
+                            identity: identity.to_owned(),
+                            receipt,
+                        });
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "music server playlist projection could not be prepared"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    fn track_for(item_id: &str) -> crate::personal_state::PortableTrack {
+        crate::personal_state::PortableTrack {
+            key: crate::personal_state::PortableTrackKey::OpenSubsonic {
+                backend_id: "backend".to_owned(),
+                account_scope_id: "account".to_owned(),
+                item_id: item_id.to_owned(),
+            },
+            title: format!("Song {item_id}"),
+            artist: "Artist".to_owned(),
+            album: None,
+            duration_secs: Some(180),
+            isrc: None,
+        }
+    }
+
+    fn track() -> crate::personal_state::PortableTrack {
+        track_for("song")
+    }
+
+    fn occurrence_values(
+        snapshot: &crate::personal_state::PersonalPlaylistSnapshot,
+    ) -> Vec<(&str, &str)> {
+        snapshot
+            .entries
+            .iter()
+            .map(|entry| {
+                let crate::personal_state::PortableTrackKey::OpenSubsonic { item_id, .. } =
+                    &entry.track.key
+                else {
+                    unreachable!("server playlist contains server tracks")
+                };
+                (entry.entry_id.as_str(), item_id.as_str())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn app_and_daemon_reduce_server_playlist_batch_in_lockstep() {
+        let mut app = crate::app::App::new(50);
+        let initial = crate::personal_state::legacy_state(
+            &app.library,
+            &app.playlists,
+            &app.signals,
+            &app.station,
+        )
+        .unwrap();
+        app.install_personal_state_runtime(initial).unwrap();
+        let mut engine = super::super::super::tests::engine_with_queue(&[]);
+        let import = crate::open_subsonic::OpenSubsonicBridgeImport::Playlist {
+            operation_id: "shared-playlist-batch".to_owned(),
+            backend_id: crate::open_subsonic::BackendId::new("backend").unwrap(),
+            local_playlist_id: crate::personal_state::PlaylistId::new("server-list").unwrap(),
+            purpose: crate::open_subsonic::PendingPlaylistImportPurpose::InitialOrImportCopy,
+            operations: vec![
+                crate::personal_state::ExternalOperationInput {
+                    acknowledgement_id: "shared-playlist".to_owned(),
+                    operation: crate::personal_state::Operation::UpsertPlaylist {
+                        playlist_id: crate::personal_state::PlaylistId::new("server-list").unwrap(),
+                        name: "Server list".to_owned(),
+                    },
+                    recorded_at_unix: 102,
+                },
+                crate::personal_state::ExternalOperationInput {
+                    acknowledgement_id: "shared-playlist-entry".to_owned(),
+                    operation: crate::personal_state::Operation::UpsertPlaylistEntry {
+                        playlist_id: crate::personal_state::PlaylistId::new("server-list").unwrap(),
+                        entry_id: crate::personal_state::PlaylistEntryId::new("entry").unwrap(),
+                        track: track(),
+                        after_entry_id: None,
+                    },
+                    recorded_at_unix: 102,
+                },
+            ],
+        };
+
+        app.apply_open_subsonic_bridge_import(&import).unwrap();
+        engine.apply_open_subsonic_bridge_import(&import).unwrap();
+
+        let app_projection = crate::personal_state::project(&app.personal_state.ledger).unwrap();
+        let daemon_projection = crate::personal_state::project(&engine.personal_state).unwrap();
+        assert_eq!(
+            app_projection.legacy.playlists,
+            daemon_projection.legacy.playlists
+        );
+        assert_eq!(app_projection.legacy.playlists.len(), 1);
+        assert_eq!(app_projection.legacy.playlists[0].entries.len(), 1);
+    }
+
+    #[test]
+    fn app_and_daemon_replay_third_state_playlist_merge_exactly_once() {
+        use crate::personal_state::{
+            ExternalOperationInput, Operation, PlaylistEntryId, PlaylistId,
+        };
+
+        let mut app = crate::app::App::new(50);
+        let initial_state = crate::personal_state::legacy_state(
+            &app.library,
+            &app.playlists,
+            &app.signals,
+            &app.station,
+        )
+        .unwrap();
+        app.install_personal_state_runtime(initial_state).unwrap();
+        let mut engine = super::super::super::tests::engine_with_queue(&[]);
+        let playlist_id = PlaylistId::new("server-list").unwrap();
+        let entry_a = PlaylistEntryId::new("entry-a").unwrap();
+        let entry_b = PlaylistEntryId::new("entry-b").unwrap();
+        let entry_c = PlaylistEntryId::new("remote-entry-c").unwrap();
+        let initial = crate::open_subsonic::OpenSubsonicBridgeImport::Playlist {
+            operation_id: "initial-local-desired".to_owned(),
+            backend_id: crate::open_subsonic::BackendId::new("backend").unwrap(),
+            local_playlist_id: playlist_id.clone(),
+            purpose: crate::open_subsonic::PendingPlaylistImportPurpose::InitialOrImportCopy,
+            operations: vec![
+                ExternalOperationInput {
+                    acknowledgement_id: "initial-playlist".to_owned(),
+                    operation: Operation::UpsertPlaylist {
+                        playlist_id: playlist_id.clone(),
+                        name: "Desired".to_owned(),
+                    },
+                    recorded_at_unix: 100,
+                },
+                ExternalOperationInput {
+                    acknowledgement_id: "initial-a".to_owned(),
+                    operation: Operation::UpsertPlaylistEntry {
+                        playlist_id: playlist_id.clone(),
+                        entry_id: entry_a.clone(),
+                        track: track_for("a"),
+                        after_entry_id: None,
+                    },
+                    recorded_at_unix: 100,
+                },
+                ExternalOperationInput {
+                    acknowledgement_id: "initial-b".to_owned(),
+                    operation: Operation::UpsertPlaylistEntry {
+                        playlist_id: playlist_id.clone(),
+                        entry_id: entry_b.clone(),
+                        track: track_for("b"),
+                        after_entry_id: Some(entry_a.clone()),
+                    },
+                    recorded_at_unix: 100,
+                },
+            ],
+        };
+        let third_state = crate::open_subsonic::OpenSubsonicBridgeImport::Playlist {
+            operation_id: "third-state-batch".to_owned(),
+            backend_id: crate::open_subsonic::BackendId::new("backend").unwrap(),
+            local_playlist_id: playlist_id.clone(),
+            purpose: crate::open_subsonic::PendingPlaylistImportPurpose::RemoteObservation,
+            operations: vec![
+                ExternalOperationInput {
+                    acknowledgement_id: "third-state-c".to_owned(),
+                    operation: Operation::UpsertPlaylistEntry {
+                        playlist_id: playlist_id.clone(),
+                        entry_id: entry_c,
+                        track: track_for("c"),
+                        after_entry_id: Some(entry_b.clone()),
+                    },
+                    recorded_at_unix: 101,
+                },
+                ExternalOperationInput {
+                    acknowledgement_id: "third-state-move-a".to_owned(),
+                    operation: Operation::MovePlaylistEntry {
+                        playlist_id: playlist_id.clone(),
+                        entry_id: entry_a.clone(),
+                        after_entry_id: None,
+                    },
+                    recorded_at_unix: 101,
+                },
+                ExternalOperationInput {
+                    acknowledgement_id: "third-state-move-b".to_owned(),
+                    operation: Operation::MovePlaylistEntry {
+                        playlist_id: playlist_id.clone(),
+                        entry_id: entry_b,
+                        after_entry_id: Some(entry_a),
+                    },
+                    recorded_at_unix: 101,
+                },
+            ],
+        };
+
+        app.apply_open_subsonic_bridge_import(&initial).unwrap();
+        engine.apply_open_subsonic_bridge_import(&initial).unwrap();
+        app.apply_open_subsonic_bridge_import(&third_state).unwrap();
+        engine
+            .apply_open_subsonic_bridge_import(&third_state)
+            .unwrap();
+        let app_operation_count = app.personal_state.ledger.operations.len();
+        let daemon_operation_count = engine.personal_state.operations.len();
+
+        app.apply_open_subsonic_bridge_import(&third_state).unwrap();
+        engine
+            .apply_open_subsonic_bridge_import(&third_state)
+            .unwrap();
+
+        assert_eq!(
+            app.personal_state.ledger.operations.len(),
+            app_operation_count
+        );
+        assert_eq!(
+            engine.personal_state.operations.len(),
+            daemon_operation_count
+        );
+        let app_snapshot = crate::personal_state::personal_playlist_snapshot(
+            &app.personal_state.ledger,
+            &playlist_id,
+        )
+        .unwrap()
+        .unwrap();
+        let daemon_snapshot =
+            crate::personal_state::personal_playlist_snapshot(&engine.personal_state, &playlist_id)
+                .unwrap()
+                .unwrap();
+        assert_eq!(
+            occurrence_values(&app_snapshot),
+            vec![("entry-a", "a"), ("entry-b", "b"), ("remote-entry-c", "c")]
+        );
+        assert_eq!(
+            occurrence_values(&daemon_snapshot),
+            occurrence_values(&app_snapshot)
+        );
+    }
+
+    #[test]
+    fn app_and_daemon_retire_queued_remote_observation_after_local_delete() {
+        use crate::personal_state::{ExternalOperationInput, Operation, PlaylistId};
+
+        let mut app = crate::app::App::new(50);
+        let initial_state = crate::personal_state::legacy_state(
+            &app.library,
+            &app.playlists,
+            &app.signals,
+            &app.station,
+        )
+        .unwrap();
+        app.install_personal_state_runtime(initial_state).unwrap();
+        let mut engine = super::super::super::tests::engine_with_queue(&[]);
+        let playlist_id = PlaylistId::new("server-list").unwrap();
+        let initial = crate::open_subsonic::OpenSubsonicBridgeImport::Playlist {
+            operation_id: "initial-before-local-delete".to_owned(),
+            backend_id: crate::open_subsonic::BackendId::new("backend").unwrap(),
+            local_playlist_id: playlist_id.clone(),
+            purpose: crate::open_subsonic::PendingPlaylistImportPurpose::InitialOrImportCopy,
+            operations: vec![ExternalOperationInput {
+                acknowledgement_id: "initial-before-local-delete-name".to_owned(),
+                operation: Operation::UpsertPlaylist {
+                    playlist_id: playlist_id.clone(),
+                    name: "Current".to_owned(),
+                },
+                recorded_at_unix: 100,
+            }],
+        };
+        app.apply_open_subsonic_bridge_import(&initial).unwrap();
+        engine.apply_open_subsonic_bridge_import(&initial).unwrap();
+        assert!(
+            std::sync::Arc::make_mut(&mut app.playlists)
+                .delete("Current")
+                .is_some()
+        );
+        assert!(engine.playlists.delete("Current").is_some());
+
+        let stale = crate::open_subsonic::OpenSubsonicBridgeImport::Playlist {
+            operation_id: "queued-before-local-delete".to_owned(),
+            backend_id: crate::open_subsonic::BackendId::new("backend").unwrap(),
+            local_playlist_id: playlist_id.clone(),
+            purpose: crate::open_subsonic::PendingPlaylistImportPurpose::RemoteObservation,
+            operations: vec![ExternalOperationInput {
+                acknowledgement_id: "queued-before-local-delete-name".to_owned(),
+                operation: Operation::UpsertPlaylist {
+                    playlist_id: playlist_id.clone(),
+                    name: "Stale remote name".to_owned(),
+                },
+                recorded_at_unix: 101,
+            }],
+        };
+
+        assert!(
+            app.apply_open_subsonic_bridge_import(&stale)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            engine
+                .apply_open_subsonic_bridge_import(&stale)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            crate::personal_state::personal_playlist_snapshot(
+                &app.personal_state.ledger,
+                &playlist_id,
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            crate::personal_state::personal_playlist_snapshot(
+                &engine.personal_state,
+                &playlist_id,
+            )
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn daemon_playlist_receipt_progresses_while_rating_receipt_is_pending() {
+        let mut engine = super::super::super::tests::engine_with_queue(&[]);
+        let identity = engine.personal_state.identity().unwrap();
+        let (rating_reply, rating_receipt) = tokio::sync::oneshot::channel();
+        let (playlist_reply, playlist_receipt) = tokio::sync::oneshot::channel();
+        engine.open_subsonic_pending_rating =
+            Some(super::super::PendingOpenSubsonicRatingProjection {
+                identity: identity.clone(),
+                receipt: rating_receipt,
+            });
+        engine.open_subsonic_pending_playlist =
+            Some(super::PendingOpenSubsonicPlaylistProjection {
+                identity: identity.clone(),
+                receipt: playlist_receipt,
+            });
+
+        engine.maintain_open_subsonic_bridge();
+        assert_eq!(engine.open_subsonic_rating_identity, None);
+        assert_eq!(engine.open_subsonic_playlist_identity, None);
+
+        playlist_reply.send(Ok(())).unwrap();
+        engine.maintain_open_subsonic_bridge();
+        assert_eq!(
+            engine.open_subsonic_playlist_identity.as_deref(),
+            Some(identity.as_str())
+        );
+        assert!(engine.open_subsonic_pending_playlist.is_none());
+        assert!(engine.open_subsonic_pending_rating.is_some());
+
+        rating_reply.send(Ok(())).unwrap();
+        engine.maintain_open_subsonic_bridge();
+        assert_eq!(
+            engine.open_subsonic_rating_identity.as_deref(),
+            Some(identity.as_str())
+        );
+        assert!(engine.open_subsonic_pending_rating.is_none());
+    }
+}

--- a/src/daemon/engine/tests.rs
+++ b/src/daemon/engine/tests.rs
@@ -46,6 +46,8 @@ pub(in crate::daemon) fn engine_with_queue(ids: &[&str]) -> DaemonEngine {
         open_subsonic: Default::default(),
         open_subsonic_rating_identity: None,
         open_subsonic_pending_rating: None,
+        open_subsonic_playlist_identity: None,
+        open_subsonic_pending_playlist: None,
         open_subsonic_pending_scrobbles: VecDeque::new(),
         player_emit: Arc::new(|_| {}),
         queue,

--- a/src/open_subsonic/actor.rs
+++ b/src/open_subsonic/actor.rs
@@ -1,8 +1,13 @@
 //! Long-lived credential owner plus setup/status lifecycle facade.
 
+mod playlist_catalog;
+mod playlist_ownership;
+mod playlists;
+
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
 
+use age::secrecy::ExposeSecret as _;
 use tokio::sync::{Notify, mpsc, oneshot};
 use tokio::task::{JoinHandle, JoinSet};
 use zeroize::Zeroize;
@@ -10,7 +15,7 @@ use zeroize::Zeroize;
 use super::bridge_event::{OpenSubsonicBridgeSink, OpenSubsonicScrobbleKind};
 use super::bridge_runtime::BridgeRuntime;
 pub use super::bridge_runtime::OutboundScrobbleResolution;
-use super::capabilities::ServerCapabilities;
+use super::capabilities::{ServerCapabilities, ServerFeature};
 use super::catalog::OpenSubsonicCatalog;
 use super::client::{BinaryPayload, OpenSubsonicClient, ServerError};
 use super::model::{
@@ -18,6 +23,9 @@ use super::model::{
     ServerLibraryDetail, ServerLibraryPage, ServerLibrarySection, ServerPlaylistId, ServerSong,
 };
 use super::origin::ConfiguredPrivateOrigin;
+use super::playlist_create_recovery::{
+    PlaylistCreateAttention, playlist_create_attention_from_state,
+};
 use super::private_store::{CredentialKind, OpenSubsonicPrivateState, ServerCredential};
 use super::profile::{OpenSubsonicPaths, OpenSubsonicProfile, StoreError};
 use super::proxy::{
@@ -30,6 +38,19 @@ use super::transaction::{
 };
 use super::{NativeHistoryHealth, OpenSubsonicBridgeState};
 use crate::personal_state::OpenSubsonicRatingWinner;
+
+use playlist_catalog::{
+    PlaylistCatalogSession, finalize_detail_playlist_access, finalize_page_playlist_access,
+};
+use playlists::PlaylistPreviewCache;
+pub(crate) use playlists::remote_fingerprint as playlist_snapshot_fingerprint;
+pub use playlists::{PlaylistMergePreview, PlaylistPreviewMode, PlaylistPreviewTarget};
+
+#[derive(Default)]
+struct ActorPlaylistState {
+    previews: PlaylistPreviewCache,
+    catalog_session: PlaylistCatalogSession,
+}
 
 const ACTOR_CAPACITY: usize = 32;
 const BRIDGE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
@@ -157,6 +178,16 @@ pub struct OpenSubsonicStatus {
     pub native_history_health: NativeHistoryHealth,
     /// Bounded count of opaque outbound reports requiring an explicit delivery decision.
     pub outbound_scrobbles_needing_attention: usize,
+    /// Replay-unsafe playlist creates requiring an explicit keep/abandon decision.
+    pub playlist_creates_needing_attention: usize,
+    /// Redacted local identities and recovery states for replay-unsafe playlist creates.
+    pub playlist_create_attention: Vec<PlaylistCreateAttention>,
+    /// Linked playlists deleted on the server and awaiting an explicit keep/restore decision.
+    pub playlist_links_needing_decision: usize,
+    /// Linked playlist writes that exhausted bounded verification and require reconnection.
+    pub playlist_projections_needing_attention: usize,
+    /// Linked local playlists containing tracks outside this exact server/account.
+    pub playlist_contents_needing_attention: usize,
 }
 
 impl OpenSubsonicStatus {
@@ -172,6 +203,11 @@ impl OpenSubsonicStatus {
             native_history_enabled: false,
             native_history_health: NativeHistoryHealth::Off,
             outbound_scrobbles_needing_attention: 0,
+            playlist_creates_needing_attention: 0,
+            playlist_create_attention: Vec::new(),
+            playlist_links_needing_decision: 0,
+            playlist_projections_needing_attention: 0,
+            playlist_contents_needing_attention: 0,
         }
     }
 
@@ -187,6 +223,11 @@ impl OpenSubsonicStatus {
             native_history_enabled: false,
             native_history_health: NativeHistoryHealth::Off,
             outbound_scrobbles_needing_attention: 0,
+            playlist_creates_needing_attention: 0,
+            playlist_create_attention: Vec::new(),
+            playlist_links_needing_decision: 0,
+            playlist_projections_needing_attention: 0,
+            playlist_contents_needing_attention: 0,
         }
     }
 }
@@ -257,6 +298,16 @@ pub async fn test_and_prepare_setup(
     let mut private_state =
         OpenSubsonicPrivateState::new(backend_id.clone(), account_scope_id.clone(), credential);
     if input.identity_intent == SetupIdentityIntent::UpdateSameServerAndAccount {
+        if private_state.credential_kind() == CredentialKind::Password {
+            require_same_account_owner(
+                current
+                    .as_ref()
+                    .ok_or(ServiceError::InvalidSetup)?
+                    .private_state
+                    .credential(),
+                private_state.credential(),
+            )?;
+        }
         private_state.preserve_native_history_from(
             &current
                 .as_ref()
@@ -276,15 +327,64 @@ pub async fn test_and_prepare_setup(
     // Candidates are identity-coherent at revision zero; commit assigns the next shared store
     // revision after its optimistic check.
     bridge_state.set_revision(0);
-    let store_set = OpenSubsonicStoreSet::new(profile, private_state, bridge_state)?;
+    let mut store_set = OpenSubsonicStoreSet::new(profile, private_state, bridge_state)?;
     let client = OpenSubsonicClient::connect(&store_set.profile).await?;
     let capabilities =
         ServerCapabilities::probe(&client, store_set.private_state.credential()).await?;
+    if store_set.private_state.credential_kind() == CredentialKind::ApiKey {
+        if capabilities.supports(ServerFeature::ApiKeyAuthentication) {
+            let username = client
+                .api_key_username(store_set.private_state.credential())
+                .await?;
+            store_set
+                .private_state
+                .bind_api_key_username(username)
+                .map_err(ServiceError::Store)?;
+            if input.identity_intent == SetupIdentityIntent::UpdateSameServerAndAccount {
+                require_same_account_owner(
+                    current
+                        .as_ref()
+                        .ok_or(ServiceError::InvalidSetup)?
+                        .private_state
+                        .credential(),
+                    store_set.private_state.credential(),
+                )?;
+            }
+        } else if input.identity_intent == SetupIdentityIntent::UpdateSameServerAndAccount {
+            // An unbound API key cannot prove that a replacement credential still belongs to the
+            // same account. Preserve neither the account scope nor its linked-playlist authority.
+            // The caller must choose ReplaceServerOrAccount instead.
+            return Err(ServiceError::InvalidSetup);
+        }
+    }
+    if input.identity_intent == SetupIdentityIntent::UpdateSameServerAndAccount {
+        store_set
+            .bridge_state
+            .requeue_playlist_projections_needing_attention();
+    }
     Ok(PreparedSetup {
         expected,
         store_set: Some(store_set),
         capabilities,
     })
+}
+
+fn require_same_account_owner(
+    previous: &ServerCredential,
+    candidate: &ServerCredential,
+) -> Result<(), ServiceError> {
+    let previous = previous
+        .username()
+        .ok_or(ServiceError::InvalidSetup)?
+        .expose_secret();
+    let candidate = candidate
+        .username()
+        .ok_or(ServiceError::InvalidSetup)?
+        .expose_secret();
+    if previous != candidate {
+        return Err(ServiceError::InvalidSetup);
+    }
+    Ok(())
 }
 
 pub fn commit_setup(
@@ -393,8 +493,21 @@ fn status_from_store_set(store_set: &OpenSubsonicStoreSet) -> OpenSubsonicStatus
         .bridge_state
         .outbound_scrobble_attention_ids()
         .len();
+    let playlist_create_attention = playlist_create_attention_from_state(&store_set.bridge_state);
+    let playlist_creates_needing_attention = playlist_create_attention.len();
+    let playlist_links_needing_decision = store_set.bridge_state.playlist_links_needing_decision();
+    let playlist_projections_needing_attention = store_set
+        .bridge_state
+        .playlist_projections_needing_attention();
+    let playlist_contents_needing_attention =
+        store_set.bridge_state.playlist_contents_needing_attention();
     OpenSubsonicStatus {
-        kind: if outbound_scrobbles_needing_attention == 0 {
+        kind: if outbound_scrobbles_needing_attention == 0
+            && playlist_creates_needing_attention == 0
+            && playlist_links_needing_decision == 0
+            && playlist_projections_needing_attention == 0
+            && playlist_contents_needing_attention == 0
+        {
             OpenSubsonicStatusKind::UpToDate
         } else {
             OpenSubsonicStatusKind::NeedsAttention
@@ -408,6 +521,11 @@ fn status_from_store_set(store_set: &OpenSubsonicStoreSet) -> OpenSubsonicStatus
         native_history_enabled,
         native_history_health,
         outbound_scrobbles_needing_attention,
+        playlist_creates_needing_attention,
+        playlist_create_attention,
+        playlist_links_needing_decision,
+        playlist_projections_needing_attention,
+        playlist_contents_needing_attention,
     }
 }
 
@@ -794,6 +912,7 @@ async fn run_actor(
     let mut bridge_active = false;
     let mut last_native_history_error = None;
     let mut native_history_was_truncated = false;
+    let mut playlists = ActorPlaylistState::default();
 
     loop {
         if let Err(error) = activate_bridge_if_needed(
@@ -833,6 +952,8 @@ async fn run_actor(
                     &client,
                     &summary,
                     &bridge,
+                    bridge.is_writable() && bridge_active,
+                    &mut playlists,
                 )
                 .await;
             }
@@ -1023,6 +1144,8 @@ async fn handle_actor_command(
     client: &OpenSubsonicClient,
     summary: &OpenSubsonicProfileSummary,
     bridge: &BridgeRuntime,
+    playlist_mutations_allowed: bool,
+    playlists: &mut ActorPlaylistState,
 ) {
     match command {
         ActorCommand::Search {
@@ -1044,18 +1167,48 @@ async fn handle_actor_command(
         }
         ActorCommand::LibraryPage { request, mut reply } => {
             let catalog = catalog(store_set, client);
-            let result = tokio::select! {
+            let page_plan = match playlists
+                .catalog_session
+                .start_page(request, &store_set.bridge_state)
+            {
+                Ok(plan) => plan,
+                Err(error) => {
+                    let _ = reply.send(Err(error));
+                    return;
+                }
+            };
+            let (catalog_offset, catalog_limit) = page_plan.remote_window();
+            let mut result = tokio::select! {
                 _ = reply.closed() => return,
                 result = catalog.library_page(
                     request.section,
-                    request.offset,
-                    request.limit,
+                    catalog_offset,
+                    catalog_limit,
                 ) => result,
             };
             if let Ok(page) = &result
                 && let Err(error) = bridge.observe_page(store_set, page)
             {
                 tracing::warn!(reason = %error, "music server observations were not persisted");
+            }
+            if let Ok(page) = &mut result {
+                finalize_page_playlist_access(
+                    page,
+                    store_set.private_state.credential(),
+                    &store_set.bridge_state,
+                );
+            }
+            let finish_result = match &mut result {
+                Ok(page) => playlists.catalog_session.finish_page(
+                    page,
+                    &store_set.bridge_state,
+                    request,
+                    &page_plan,
+                ),
+                Err(_) => Ok(()),
+            };
+            if let Err(error) = finish_result {
+                result = Err(error);
             }
             let _ = reply.send(result);
         }
@@ -1068,7 +1221,7 @@ async fn handle_actor_command(
                     ServerLibraryDetailRequest::Playlist(id) => catalog.playlist_detail(&id).await,
                 }
             };
-            let result = tokio::select! {
+            let mut result = tokio::select! {
                 _ = reply.closed() => return,
                 result = operation => result,
             };
@@ -1076,6 +1229,13 @@ async fn handle_actor_command(
                 && let Err(error) = bridge.observe_detail(store_set, detail)
             {
                 tracing::warn!(reason = %error, "music server observations were not persisted");
+            }
+            if let Ok(detail) = &mut result {
+                finalize_detail_playlist_access(
+                    detail,
+                    store_set.private_state.credential(),
+                    &store_set.bridge_state,
+                );
             }
             let _ = reply.send(result);
         }
@@ -1125,6 +1285,14 @@ async fn handle_actor_command(
             if let Some(error) = failed {
                 tracing::warn!(reason = %error, "music server ratings will retry");
             }
+        }
+        ActorCommand::Playlist(command) => {
+            let Some(command) = playlist_ownership::authorize(command, playlist_mutations_allowed)
+            else {
+                return;
+            };
+            playlists::handle_command(command, &mut playlists.previews, store_set, client, bridge)
+                .await;
         }
         ActorCommand::AcknowledgeBridgeImport { operation_id } => {
             if let Err(error) = bridge.acknowledge_import(store_set, &operation_id) {
@@ -1223,6 +1391,7 @@ enum ActorCommand {
         winners: Vec<OpenSubsonicRatingWinner>,
         reply: oneshot::Sender<Result<(), ServiceError>>,
     },
+    Playlist(playlists::PlaylistActorCommand),
     AcknowledgeBridgeImport {
         operation_id: String,
     },
@@ -1252,6 +1421,9 @@ pub type OpenSubsonicScrobbleReceipt = oneshot::Receiver<Result<(), ServiceError
 
 /// Correlated proof that a rating projection crossed the bridge-store fsync boundary.
 pub type OpenSubsonicRatingReceipt = oneshot::Receiver<Result<(), ServiceError>>;
+
+/// Correlated proof that linked playlist projection crossed the bridge-store fsync boundary.
+pub type OpenSubsonicPlaylistReceipt = oneshot::Receiver<Result<(), ServiceError>>;
 
 fn proxy_error(error: ServerError) -> ProxyUpstreamError {
     let reason = match error {

--- a/src/open_subsonic/actor/playlist_catalog.rs
+++ b/src/open_subsonic/actor/playlist_catalog.rs
@@ -1,0 +1,494 @@
+//! Playlist access evidence and combined remote/recovery pagination.
+
+use std::collections::BTreeSet;
+
+use age::secrecy::ExposeSecret as _;
+use sha2::{Digest as _, Sha256};
+
+use super::super::bridge_store::{OpenSubsonicBridgeState, PlaylistLinkState};
+use super::super::client::ServerError;
+use super::super::model::{
+    ServerLibraryDetail, ServerLibraryPage, ServerLibraryRow, ServerLibrarySection,
+    ServerPlaylistAccess, ServerPlaylistLinkHealth, ServerPlaylistLinkSummary,
+    ServerPlaylistSummary,
+};
+use super::super::private_store::ServerCredential;
+use super::ServerLibraryRequest;
+
+#[derive(Clone, PartialEq, Eq)]
+struct RecoveryPrefixVersion {
+    count: u32,
+    revision: [u8; 32],
+}
+
+pub(super) struct PlaylistCatalogPagePlan {
+    remote_offset: u32,
+    remote_limit: u32,
+    recovery_prefix: Option<RecoveryPrefixVersion>,
+}
+
+impl PlaylistCatalogPagePlan {
+    pub(super) const fn remote_window(&self) -> (u32, u32) {
+        (self.remote_offset, self.remote_limit)
+    }
+}
+
+#[derive(Default)]
+pub(super) struct PlaylistCatalogSession {
+    recovery_prefix: Option<RecoveryPrefixVersion>,
+    issued_offsets: BTreeSet<u32>,
+}
+
+impl PlaylistCatalogSession {
+    pub(super) fn start_page(
+        &mut self,
+        request: ServerLibraryRequest,
+        bridge_state: &OpenSubsonicBridgeState,
+    ) -> Result<PlaylistCatalogPagePlan, ServerError> {
+        let (remote_offset, remote_limit) = playlist_catalog_window(request, bridge_state);
+        if request.section != ServerLibrarySection::Playlists || request.limit == 0 {
+            return Ok(PlaylistCatalogPagePlan {
+                remote_offset,
+                remote_limit,
+                recovery_prefix: None,
+            });
+        }
+
+        let current = recovery_prefix_version(bridge_state);
+        if request.offset == 0 {
+            self.recovery_prefix = Some(current.clone());
+            self.issued_offsets.clear();
+            self.issued_offsets.insert(0);
+        } else if self.recovery_prefix.as_ref() != Some(&current)
+            || !self.issued_offsets.contains(&request.offset)
+        {
+            self.recovery_prefix = None;
+            self.issued_offsets.clear();
+            return Err(ServerError::TemporarilyUnavailable);
+        }
+        Ok(PlaylistCatalogPagePlan {
+            remote_offset,
+            remote_limit,
+            recovery_prefix: Some(current),
+        })
+    }
+
+    pub(super) fn finish_page(
+        &mut self,
+        page: &mut ServerLibraryPage,
+        bridge_state: &OpenSubsonicBridgeState,
+        request: ServerLibraryRequest,
+        plan: &PlaylistCatalogPagePlan,
+    ) -> Result<(), ServerError> {
+        let Some(expected) = &plan.recovery_prefix else {
+            return Ok(());
+        };
+        if recovery_prefix_version(bridge_state) != *expected {
+            self.recovery_prefix = None;
+            self.issued_offsets.clear();
+            return Err(ServerError::TemporarilyUnavailable);
+        }
+        merge_missing_playlist_recovery_rows(page, bridge_state, request.offset, request.limit);
+        if let Some(next_offset) = page.next_offset {
+            self.issued_offsets.insert(next_offset);
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn finalize_page_playlist_access(
+    page: &mut ServerLibraryPage,
+    credential: &ServerCredential,
+    bridge_state: &OpenSubsonicBridgeState,
+) {
+    for row in &mut page.rows {
+        if let ServerLibraryRow::Playlist(summary) = row {
+            finalize_playlist_access(summary, credential, bridge_state);
+        }
+    }
+}
+
+pub(super) fn finalize_detail_playlist_access(
+    detail: &mut ServerLibraryDetail,
+    credential: &ServerCredential,
+    bridge_state: &OpenSubsonicBridgeState,
+) {
+    if let ServerLibraryDetail::PlaylistEntries(playlist) = detail {
+        finalize_playlist_access(&mut playlist.summary, credential, bridge_state);
+    }
+}
+
+fn finalize_playlist_access(
+    summary: &mut ServerPlaylistSummary,
+    credential: &ServerCredential,
+    bridge_state: &OpenSubsonicBridgeState,
+) {
+    if let Some(link) = bridge_state
+        .playlist_links()
+        .values()
+        .find(|link| link.server_playlist_id == summary.id)
+    {
+        summary.access = ServerPlaylistAccess::Linked;
+        summary.link = Some(ServerPlaylistLinkSummary {
+            local_playlist_id: link.local_playlist_id.clone(),
+            health: match link.state {
+                PlaylistLinkState::ServerMissing => ServerPlaylistLinkHealth::ServerMissing,
+                PlaylistLinkState::AccessNeedsAttention => {
+                    ServerPlaylistLinkHealth::NeedsAttention
+                }
+                PlaylistLinkState::Linked if link.content_needs_attention => {
+                    ServerPlaylistLinkHealth::NeedsAttention
+                }
+                PlaylistLinkState::Linked
+                    if !has_exact_playlist_write_access(summary, credential)
+                        || bridge_state
+                            .pending_playlist_projections()
+                            .get(&link.local_playlist_id)
+                            .is_some_and(|pending| {
+                                pending.stage
+                                    == crate::open_subsonic::bridge_store::PendingPlaylistProjectionStage::NeedsAttention
+                            }) =>
+                {
+                    ServerPlaylistLinkHealth::NeedsAttention
+                }
+                PlaylistLinkState::Linked => ServerPlaylistLinkHealth::UpToDate,
+            },
+        });
+        return;
+    }
+    summary.link = None;
+    let credential_owner_is_exact = credential
+        .username()
+        .is_some_and(|username| summary.owner_evidence() == Some(username.expose_secret()));
+    summary.access = if summary.readonly_evidence() == Some(false) && credential_owner_is_exact {
+        ServerPlaylistAccess::Server
+    } else {
+        ServerPlaylistAccess::ReadOnly
+    };
+}
+
+fn has_exact_playlist_write_access(
+    summary: &ServerPlaylistSummary,
+    credential: &ServerCredential,
+) -> bool {
+    summary.readonly_evidence() == Some(false)
+        && credential
+            .username()
+            .is_some_and(|username| summary.owner_evidence() == Some(username.expose_secret()))
+}
+
+/// Translate a combined recovery/remote cursor into the remote catalog window.
+pub(super) fn playlist_catalog_window(
+    request: ServerLibraryRequest,
+    bridge_state: &OpenSubsonicBridgeState,
+) -> (u32, u32) {
+    if request.section != ServerLibrarySection::Playlists || request.limit == 0 {
+        return (request.offset, request.limit);
+    }
+    let missing = missing_playlist_link_count(bridge_state);
+    let missing_on_page = missing.saturating_sub(request.offset).min(request.limit);
+    let remote_slots = request.limit.saturating_sub(missing_on_page);
+    (request.offset.saturating_sub(missing), remote_slots.max(1))
+}
+
+/// Prepend the requested slice of local recovery rows without dropping remote rows.
+///
+/// `page` must have been fetched with [`playlist_catalog_window`]. Its remote cursor is translated
+/// back into the combined cursor returned to the caller. A one-row remote probe is used when a
+/// page is entirely occupied by recovery rows, so more than one page of missing links remains
+/// reachable without falsely hiding a following remote page.
+pub(super) fn merge_missing_playlist_recovery_rows(
+    page: &mut ServerLibraryPage,
+    bridge_state: &OpenSubsonicBridgeState,
+    offset: u32,
+    limit: u32,
+) {
+    if page.section != ServerLibrarySection::Playlists || limit == 0 {
+        return;
+    }
+    let missing = bridge_state
+        .playlist_links()
+        .values()
+        .filter(|link| link.state == PlaylistLinkState::ServerMissing)
+        .map(|link| {
+            ServerLibraryRow::Playlist(ServerPlaylistSummary {
+                id: link.server_playlist_id.clone(),
+                name: link.shadow.name.clone(),
+                owner: None,
+                song_count: u32::try_from(link.shadow.occurrences.len()).ok(),
+                duration_secs: None,
+                public: None,
+                cover_art_id: None,
+                access: ServerPlaylistAccess::Linked,
+                link: Some(ServerPlaylistLinkSummary {
+                    local_playlist_id: link.local_playlist_id.clone(),
+                    health: ServerPlaylistLinkHealth::ServerMissing,
+                }),
+                readonly_evidence: None,
+                owner_evidence: None,
+            })
+        })
+        .collect::<Vec<_>>();
+    let missing_count = u32::try_from(missing.len()).unwrap_or(u32::MAX);
+    if missing_count == 0 {
+        return;
+    }
+    let missing_start = usize::try_from(offset.min(missing_count)).unwrap_or(usize::MAX);
+    let limit_usize = usize::try_from(limit).unwrap_or(usize::MAX);
+    let mut rows = missing
+        .into_iter()
+        .skip(missing_start)
+        .take(limit_usize)
+        .collect::<Vec<_>>();
+    let remote_slots = limit_usize.saturating_sub(rows.len());
+    let remote_offset = offset.saturating_sub(missing_count);
+    let remote_probe_found_rows = !page.rows.is_empty();
+    rows.extend(page.rows.drain(..).take(remote_slots));
+    let more_missing =
+        offset.saturating_add(u32::try_from(rows.len()).unwrap_or(u32::MAX)) < missing_count;
+    page.next_offset = if more_missing {
+        Some(offset.saturating_add(limit))
+    } else if remote_slots == 0 {
+        (remote_probe_found_rows || page.next_offset.is_some())
+            .then_some(missing_count.saturating_add(remote_offset))
+    } else {
+        page.next_offset
+            .map(|next| missing_count.saturating_add(next))
+    };
+    page.rows = rows;
+}
+
+fn missing_playlist_link_count(bridge_state: &OpenSubsonicBridgeState) -> u32 {
+    u32::try_from(
+        bridge_state
+            .playlist_links()
+            .values()
+            .filter(|link| link.state == PlaylistLinkState::ServerMissing)
+            .count(),
+    )
+    .unwrap_or(u32::MAX)
+}
+
+fn recovery_prefix_version(bridge_state: &OpenSubsonicBridgeState) -> RecoveryPrefixVersion {
+    let mut digest = Sha256::new();
+    digest.update(b"yututui-open-subsonic-recovery-prefix-v1\0");
+    let mut count = 0_u32;
+    for link in bridge_state
+        .playlist_links()
+        .values()
+        .filter(|link| link.state == PlaylistLinkState::ServerMissing)
+    {
+        count = count.saturating_add(1);
+        for part in [
+            link.local_playlist_id.as_str().as_bytes(),
+            link.server_playlist_id.as_str().as_bytes(),
+            link.shadow.name.as_bytes(),
+        ] {
+            digest.update((part.len() as u64).to_be_bytes());
+            digest.update(part);
+        }
+        digest.update((link.shadow.occurrences.len() as u64).to_be_bytes());
+    }
+    RecoveryPrefixVersion {
+        count,
+        revision: digest.finalize().into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::open_subsonic::bridge_store::{PlaylistLink, PlaylistShadow};
+    use crate::open_subsonic::model::{AccountScopeId, BackendId, ServerPlaylistId};
+    use crate::personal_state::PlaylistId;
+
+    fn state_with_missing(count: usize) -> OpenSubsonicBridgeState {
+        let mut state = OpenSubsonicBridgeState::new(
+            BackendId::new("backend").unwrap(),
+            AccountScopeId::new("account").unwrap(),
+        );
+        for index in 0..count {
+            state
+                .upsert_playlist_link(PlaylistLink {
+                    local_playlist_id: PlaylistId::new(format!("local-{index:03}")).unwrap(),
+                    server_playlist_id: ServerPlaylistId::new(format!("missing-{index:03}"))
+                        .unwrap(),
+                    managed_by_yututui: true,
+                    state: PlaylistLinkState::ServerMissing,
+                    content_needs_attention: false,
+                    shadow: PlaylistShadow {
+                        name: format!("Missing {index}"),
+                        occurrences: Vec::new(),
+                        verified_at_unix: 100,
+                    },
+                })
+                .unwrap();
+        }
+        state
+    }
+
+    fn remote_row(id: &str) -> ServerLibraryRow {
+        ServerLibraryRow::Playlist(ServerPlaylistSummary {
+            id: ServerPlaylistId::new(id).unwrap(),
+            name: id.to_owned(),
+            owner: Some("alice".to_owned()),
+            song_count: Some(0),
+            duration_secs: None,
+            public: None,
+            cover_art_id: None,
+            access: ServerPlaylistAccess::Server,
+            link: None,
+            readonly_evidence: Some(false),
+            owner_evidence: Some("alice".to_owned()),
+        })
+    }
+
+    fn page(rows: &[&str], next_offset: Option<u32>) -> ServerLibraryPage {
+        ServerLibraryPage {
+            section: ServerLibrarySection::Playlists,
+            rows: rows.iter().map(|id| remote_row(id)).collect(),
+            next_offset,
+            warning: None,
+        }
+    }
+
+    fn row_ids(page: &ServerLibraryPage) -> Vec<&str> {
+        page.rows
+            .iter()
+            .map(|row| match row {
+                ServerLibraryRow::Playlist(summary) => summary.id.as_str(),
+                _ => unreachable!(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn combined_cursor_preserves_the_trimmed_remote_tail() {
+        let state = state_with_missing(1);
+        let first_request = ServerLibraryRequest {
+            section: ServerLibrarySection::Playlists,
+            offset: 0,
+            limit: 3,
+        };
+        assert_eq!(playlist_catalog_window(first_request, &state), (0, 2));
+        let mut first = page(&["remote-0", "remote-1"], Some(2));
+
+        merge_missing_playlist_recovery_rows(&mut first, &state, 0, 3);
+
+        assert_eq!(row_ids(&first), ["missing-000", "remote-0", "remote-1"]);
+        assert_eq!(first.next_offset, Some(3));
+        assert_eq!(
+            playlist_catalog_window(
+                ServerLibraryRequest {
+                    offset: first.next_offset.unwrap(),
+                    ..first_request
+                },
+                &state
+            ),
+            (2, 3),
+            "the next remote page resumes after the two rows actually consumed"
+        );
+    }
+
+    #[test]
+    fn missing_links_larger_than_the_page_remain_reachable_before_remote_rows() {
+        let state = state_with_missing(5);
+        let request = ServerLibraryRequest {
+            section: ServerLibrarySection::Playlists,
+            offset: 0,
+            limit: 2,
+        };
+        assert_eq!(playlist_catalog_window(request, &state), (0, 1));
+
+        let mut first = page(&["remote-0"], Some(1));
+        merge_missing_playlist_recovery_rows(&mut first, &state, 0, 2);
+        assert_eq!(row_ids(&first), ["missing-000", "missing-001"]);
+        assert_eq!(first.next_offset, Some(2));
+
+        let mut second = page(&["remote-0"], Some(1));
+        merge_missing_playlist_recovery_rows(&mut second, &state, 2, 2);
+        assert_eq!(row_ids(&second), ["missing-002", "missing-003"]);
+        assert_eq!(second.next_offset, Some(4));
+
+        let mut third = page(&["remote-0"], Some(1));
+        merge_missing_playlist_recovery_rows(&mut third, &state, 4, 2);
+        assert_eq!(row_ids(&third), ["missing-004", "remote-0"]);
+        assert_eq!(third.next_offset, Some(6));
+    }
+
+    #[test]
+    fn recovery_prefix_change_invalidates_an_issued_combined_offset() {
+        let mut state = state_with_missing(3);
+        let mut session = PlaylistCatalogSession::default();
+        let request = ServerLibraryRequest {
+            section: ServerLibrarySection::Playlists,
+            offset: 0,
+            limit: 2,
+        };
+        let plan = session.start_page(request, &state).unwrap();
+        assert_eq!(plan.remote_window(), (0, 1));
+        let mut first = page(&["remote-0"], Some(1));
+        session
+            .finish_page(&mut first, &state, request, &plan)
+            .unwrap();
+        assert_eq!(row_ids(&first), ["missing-000", "missing-001"]);
+        let stale_offset = first.next_offset.unwrap();
+
+        let local_id = PlaylistId::new("local-000").unwrap();
+        let mut recovered = state.playlist_link(&local_id).unwrap().clone();
+        recovered.state = PlaylistLinkState::Linked;
+        state.upsert_playlist_link(recovered).unwrap();
+        assert!(matches!(
+            session.start_page(
+                ServerLibraryRequest {
+                    offset: stale_offset,
+                    ..request
+                },
+                &state
+            ),
+            Err(ServerError::TemporarilyUnavailable)
+        ));
+
+        let restarted = session
+            .start_page(
+                ServerLibraryRequest {
+                    offset: 0,
+                    ..request
+                },
+                &state,
+            )
+            .unwrap();
+        assert_eq!(
+            restarted.remote_window(),
+            (0, 1),
+            "restarting at the first page establishes the new stable recovery prefix"
+        );
+    }
+
+    #[test]
+    fn recovery_prefix_change_during_fetch_rejects_merge_without_rows() {
+        let mut state = state_with_missing(2);
+        let mut session = PlaylistCatalogSession::default();
+        let request = ServerLibraryRequest {
+            section: ServerLibrarySection::Playlists,
+            offset: 0,
+            limit: 2,
+        };
+        let plan = session.start_page(request, &state).unwrap();
+        let mut remote = page(&["remote-0"], Some(1));
+        let local_id = PlaylistId::new("local-000").unwrap();
+        let mut renamed = state.playlist_link(&local_id).unwrap().clone();
+        renamed.shadow.name = "Changed during fetch".to_owned();
+        state.upsert_playlist_link(renamed).unwrap();
+
+        assert_eq!(
+            session.finish_page(&mut remote, &state, request, &plan),
+            Err(ServerError::TemporarilyUnavailable)
+        );
+        assert_eq!(
+            row_ids(&remote),
+            ["remote-0"],
+            "stale recovery rows must never be combined with the fetched remote page"
+        );
+    }
+}

--- a/src/open_subsonic/actor/playlist_lifecycle_tests.rs
+++ b/src/open_subsonic/actor/playlist_lifecycle_tests.rs
@@ -1,0 +1,1091 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use age::secrecy::SecretString;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+use super::*;
+use crate::open_subsonic::bridge_store::{PlaylistLinkState, PlaylistShadow};
+use crate::open_subsonic::{
+    ConfiguredPrivateOrigin, OpenSubsonicBridgeState, OpenSubsonicPaths, OpenSubsonicPrivateState,
+    OpenSubsonicProfile, ServerCredential, StoreRevisions, commit_store_set, load_store_set,
+};
+
+static NEXT_ROOT: AtomicU64 = AtomicU64::new(1);
+
+enum Reply {
+    Json(String),
+    NotFound,
+    Unavailable,
+    DropConnection,
+}
+
+struct Step {
+    endpoint: &'static str,
+    reply: Reply,
+}
+
+struct Fixture {
+    root: std::path::PathBuf,
+    paths: OpenSubsonicPaths,
+    store_set: OpenSubsonicStoreSet,
+    client: OpenSubsonicClient,
+    bridge: BridgeRuntime,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+async fn fixture(port: u16) -> Fixture {
+    let backend_id = BackendId::new("playlist-actor-backend").unwrap();
+    let account_scope_id = AccountScopeId::new("playlist-actor-account").unwrap();
+    let profile = OpenSubsonicProfile::with_ids(
+        0,
+        backend_id.clone(),
+        account_scope_id.clone(),
+        "Playlist actor",
+        ConfiguredPrivateOrigin::new(&format!("http://127.0.0.1:{port}/"), true).unwrap(),
+        None,
+    )
+    .unwrap();
+    let private_state = OpenSubsonicPrivateState::new(
+        backend_id.clone(),
+        account_scope_id.clone(),
+        ServerCredential::api_key(SecretString::from("playlist-api-key".to_owned())).unwrap(),
+    );
+    let bridge_state = OpenSubsonicBridgeState::new(backend_id, account_scope_id);
+    let mut store_set = OpenSubsonicStoreSet::new(profile, private_state, bridge_state).unwrap();
+    let root = std::env::temp_dir().join(format!(
+        "yututui-playlist-actor-{}-{}",
+        std::process::id(),
+        NEXT_ROOT.fetch_add(1, Ordering::Relaxed)
+    ));
+    let paths = OpenSubsonicPaths::for_data_root(root.clone());
+    commit_store_set(&paths, StoreRevisions::MISSING, &mut store_set).unwrap();
+    let client = OpenSubsonicClient::connect(&store_set.profile)
+        .await
+        .unwrap();
+    let bridge = BridgeRuntime::writable(paths.clone(), None);
+    Fixture {
+        root,
+        paths,
+        store_set,
+        client,
+        bridge,
+    }
+}
+
+fn bind_fixture_owner(fixture: &mut Fixture) {
+    let expected = fixture.store_set.revisions();
+    fixture
+        .store_set
+        .private_state
+        .bind_api_key_username("alice")
+        .unwrap();
+    commit_store_set(&fixture.paths, expected, &mut fixture.store_set).unwrap();
+}
+
+async fn scripted_server(steps: Vec<Step>) -> (u16, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        for step in steps {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut stream).await;
+            let target = request
+                .lines()
+                .next()
+                .and_then(|line| line.split_ascii_whitespace().nth(1))
+                .unwrap_or_default();
+            assert!(target.starts_with(step.endpoint), "{target}");
+            match step.reply {
+                Reply::Json(body) => write_response(&mut stream, "200 OK", &body).await,
+                Reply::NotFound => write_response(&mut stream, "404 Not Found", "").await,
+                Reply::Unavailable => {
+                    write_response(&mut stream, "503 Service Unavailable", "").await
+                }
+                Reply::DropConnection => {}
+            }
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err(),
+            "replay-unsafe playlist mutations must not be retried blindly"
+        );
+    });
+    (port, server)
+}
+
+async fn read_request(stream: &mut tokio::net::TcpStream) -> String {
+    let mut request = Vec::new();
+    let mut byte = [0_u8; 1];
+    while request.len() < 32 * 1024 {
+        if stream.read(&mut byte).await.unwrap_or(0) == 0 {
+            break;
+        }
+        request.push(byte[0]);
+        if request.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    String::from_utf8(request).unwrap()
+}
+
+async fn write_response(stream: &mut tokio::net::TcpStream, status: &str, body: &str) {
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(response.as_bytes()).await.unwrap();
+}
+
+fn playlist_body(id: &str, name: &str, read_only: Option<bool>) -> String {
+    playlist_body_with_access(id, name, Some("alice"), read_only)
+}
+
+fn playlist_body_with_access(
+    id: &str,
+    name: &str,
+    owner: Option<&str>,
+    read_only: Option<bool>,
+) -> String {
+    let mut playlist = serde_json::json!({
+        "id": id,
+        "name": name,
+        "songCount": 0,
+        "entry": []
+    });
+    if let Some(owner) = owner {
+        playlist["owner"] = owner.into();
+    }
+    if let Some(read_only) = read_only {
+        playlist["readonly"] = read_only.into();
+    }
+    serde_json::json!({
+        "subsonic-response": {
+            "status": "ok",
+            "playlist": playlist
+        }
+    })
+    .to_string()
+}
+
+fn local_snapshot() -> PersonalPlaylistSnapshot {
+    PersonalPlaylistSnapshot {
+        playlist_id: PlaylistId::new("local-playlist").unwrap(),
+        name: "Local playlist".to_owned(),
+        entries: Vec::new(),
+    }
+}
+
+fn pending_restore(link: &PlaylistLink) -> PendingPlaylistCreate {
+    PendingPlaylistCreate {
+        local_playlist_id: link.local_playlist_id.clone(),
+        expected_missing_server_id: Some(link.server_playlist_id.clone()),
+        created_server_playlist_id: None,
+        desired_name: "Local playlist".to_owned(),
+        ordered_entry_ids: Vec::new(),
+        ordered_item_ids: Vec::new(),
+        started_at_unix: 100,
+    }
+}
+
+fn install_link(fixture: &mut Fixture, managed: bool, state: PlaylistLinkState) -> PlaylistLink {
+    let link = PlaylistLink {
+        local_playlist_id: PlaylistId::new("local-playlist").unwrap(),
+        server_playlist_id: ServerPlaylistId::new("server-playlist").unwrap(),
+        managed_by_yututui: managed,
+        state,
+        content_needs_attention: false,
+        shadow: PlaylistShadow {
+            name: "Local playlist".to_owned(),
+            occurrences: Vec::new(),
+            verified_at_unix: 100,
+        },
+    };
+    fixture
+        .store_set
+        .bridge_state
+        .upsert_playlist_link(link.clone())
+        .unwrap();
+    let expected = fixture.store_set.revisions();
+    commit_store_set(&fixture.paths, expected, &mut fixture.store_set).unwrap();
+    link
+}
+
+#[tokio::test]
+async fn ambiguous_create_is_durable_and_never_blindly_retried() {
+    let (port, server) = scripted_server(vec![Step {
+        endpoint: "/rest/createPlaylist.view?",
+        reply: Reply::DropConnection,
+    }])
+    .await;
+    let mut fixture = fixture(port).await;
+
+    assert!(
+        create_linked(
+            &mut fixture.store_set,
+            &fixture.client,
+            &fixture.bridge,
+            local_snapshot(),
+            false,
+            None,
+        )
+        .await
+        .is_err()
+    );
+    assert_eq!(
+        fixture
+            .store_set
+            .bridge_state
+            .pending_playlist_creates()
+            .len(),
+        1
+    );
+    let status = super::super::status_from_store_set(&fixture.store_set);
+    assert_eq!(
+        status.kind,
+        crate::open_subsonic::OpenSubsonicStatusKind::NeedsAttention
+    );
+    assert_eq!(status.playlist_creates_needing_attention, 1);
+    assert!(
+        create_linked(
+            &mut fixture.store_set,
+            &fixture.client,
+            &fixture.bridge,
+            local_snapshot(),
+            false,
+            None,
+        )
+        .await
+        .is_err()
+    );
+    server.await.unwrap();
+    assert!(fixture.store_set.bridge_state.playlist_links().is_empty());
+    let durable = load_store_set(&fixture.paths).unwrap().unwrap();
+    assert!(durable.bridge_state.playlist_links().is_empty());
+    assert_eq!(durable.bridge_state.pending_playlist_creates().len(), 1);
+
+    fixture
+        .bridge
+        .cancel_playlist_create(
+            &mut fixture.store_set,
+            &PlaylistId::new("local-playlist").unwrap(),
+        )
+        .unwrap();
+    assert!(
+        fixture
+            .store_set
+            .bridge_state
+            .pending_playlist_creates()
+            .is_empty()
+    );
+    let status = super::super::status_from_store_set(&fixture.store_set);
+    assert_eq!(
+        status.kind,
+        crate::open_subsonic::OpenSubsonicStatusKind::UpToDate
+    );
+    assert_eq!(status.playlist_creates_needing_attention, 0);
+}
+
+#[tokio::test]
+async fn confirmed_create_id_resumes_readback_without_creating_twice() {
+    let body = playlist_body("created-playlist", "Local playlist", Some(false));
+    let (port, server) = scripted_server(vec![
+        Step {
+            endpoint: "/rest/createPlaylist.view?",
+            reply: Reply::Json(body.clone()),
+        },
+        Step {
+            endpoint: "/rest/getPlaylist.view?",
+            reply: Reply::Unavailable,
+        },
+        Step {
+            endpoint: "/rest/getPlaylist.view?",
+            reply: Reply::Json(body),
+        },
+    ])
+    .await;
+    let mut fixture = fixture(port).await;
+    bind_fixture_owner(&mut fixture);
+
+    assert!(
+        create_linked(
+            &mut fixture.store_set,
+            &fixture.client,
+            &fixture.bridge,
+            local_snapshot(),
+            false,
+            None,
+        )
+        .await
+        .is_err()
+    );
+    let pending = fixture
+        .store_set
+        .bridge_state
+        .pending_playlist_creates()
+        .values()
+        .next()
+        .unwrap();
+    assert_eq!(
+        pending
+            .created_server_playlist_id
+            .as_ref()
+            .map(ServerPlaylistId::as_str),
+        Some("created-playlist")
+    );
+
+    fixture.store_set = load_store_set(&fixture.paths).unwrap().unwrap();
+    let mut edited = local_snapshot();
+    edited.name = "Edited after create".to_owned();
+    let created = create_linked(
+        &mut fixture.store_set,
+        &fixture.client,
+        &fixture.bridge,
+        edited.clone(),
+        false,
+        None,
+    )
+    .await
+    .unwrap();
+    server.await.unwrap();
+
+    assert_eq!(created.as_str(), "created-playlist");
+    assert!(
+        fixture
+            .store_set
+            .bridge_state
+            .pending_playlist_creates()
+            .is_empty()
+    );
+    assert_eq!(fixture.store_set.bridge_state.playlist_links().len(), 1);
+    assert_eq!(
+        fixture
+            .store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .values()
+            .next()
+            .map(|pending| pending.desired_name.as_str()),
+        Some("Edited after create")
+    );
+}
+
+#[tokio::test]
+async fn closed_reply_receiver_does_not_cancel_a_replay_unsafe_create() {
+    let body = playlist_body("created-playlist", "Local playlist", Some(false));
+    let (port, server) = scripted_server(vec![
+        Step {
+            endpoint: "/rest/createPlaylist.view?",
+            reply: Reply::Json(body.clone()),
+        },
+        Step {
+            endpoint: "/rest/getPlaylist.view?",
+            reply: Reply::Json(body),
+        },
+    ])
+    .await;
+    let mut fixture = fixture(port).await;
+    bind_fixture_owner(&mut fixture);
+    let (reply, receiver) = tokio::sync::oneshot::channel();
+    drop(receiver);
+
+    handle_command(
+        PlaylistActorCommand::CreateLinked {
+            snapshot: local_snapshot(),
+            replace_missing: false,
+            expected_missing_server_id: None,
+            reply,
+        },
+        &mut PlaylistPreviewCache::default(),
+        &mut fixture.store_set,
+        &fixture.client,
+        &fixture.bridge,
+    )
+    .await;
+    server.await.unwrap();
+
+    assert!(
+        fixture
+            .store_set
+            .bridge_state
+            .pending_playlist_creates()
+            .is_empty()
+    );
+    assert_eq!(fixture.store_set.bridge_state.playlist_links().len(), 1);
+    let durable = load_store_set(&fixture.paths).unwrap().unwrap();
+    assert!(durable.bridge_state.pending_playlist_creates().is_empty());
+    assert_eq!(durable.bridge_state.playlist_links().len(), 1);
+}
+
+#[tokio::test]
+async fn ambiguous_delete_commits_only_after_exact_not_found_readback() {
+    let body = playlist_body("server-playlist", "Local playlist", Some(false));
+    let (port, server) = scripted_server(vec![
+        Step {
+            endpoint: "/rest/getPlaylist.view?",
+            reply: Reply::Json(body),
+        },
+        Step {
+            endpoint: "/rest/deletePlaylist.view?",
+            reply: Reply::Unavailable,
+        },
+        Step {
+            endpoint: "/rest/getPlaylist.view?",
+            reply: Reply::NotFound,
+        },
+    ])
+    .await;
+    let mut fixture = fixture(port).await;
+    bind_fixture_owner(&mut fixture);
+    install_link(&mut fixture, true, PlaylistLinkState::Linked);
+    let server_id = ServerPlaylistId::new("server-playlist").unwrap();
+
+    delete_both(
+        &mut fixture.store_set,
+        &fixture.client,
+        &fixture.bridge,
+        &server_id,
+    )
+    .await
+    .unwrap();
+    server.await.unwrap();
+
+    assert!(fixture.store_set.bridge_state.playlist_links().is_empty());
+    let batch = fixture
+        .store_set
+        .bridge_state
+        .pending_playlist_imports()
+        .values()
+        .next()
+        .unwrap();
+    assert!(matches!(
+        batch.operations.as_slice(),
+        [ExternalOperationInput {
+            operation: Operation::DeletePlaylist { deleted: true, .. },
+            ..
+        }]
+    ));
+}
+
+#[tokio::test]
+async fn ambiguous_delete_that_still_exists_is_not_retried_or_committed() {
+    let body = playlist_body("server-playlist", "Local playlist", Some(false));
+    let (port, server) = scripted_server(vec![
+        Step {
+            endpoint: "/rest/getPlaylist.view?",
+            reply: Reply::Json(body.clone()),
+        },
+        Step {
+            endpoint: "/rest/deletePlaylist.view?",
+            reply: Reply::Unavailable,
+        },
+        Step {
+            endpoint: "/rest/getPlaylist.view?",
+            reply: Reply::Json(body),
+        },
+    ])
+    .await;
+    let mut fixture = fixture(port).await;
+    bind_fixture_owner(&mut fixture);
+    let link = install_link(&mut fixture, true, PlaylistLinkState::Linked);
+    let server_id = link.server_playlist_id.clone();
+
+    assert_eq!(
+        delete_both(
+            &mut fixture.store_set,
+            &fixture.client,
+            &fixture.bridge,
+            &server_id,
+        )
+        .await,
+        Err(ServerError::TemporarilyUnavailable)
+    );
+    server.await.unwrap();
+    assert_eq!(
+        fixture
+            .store_set
+            .bridge_state
+            .playlist_link(&link.local_playlist_id),
+        Some(&link)
+    );
+    assert!(
+        fixture
+            .store_set
+            .bridge_state
+            .pending_playlist_imports()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn delete_local_for_missing_link_never_contacts_a_reappeared_server_copy() {
+    // The empty scripted server fails if any request arrives. A remote copy may have reappeared
+    // since the durable missing observation, but DeleteLocal must never inspect or mutate it.
+    let (port, server) = scripted_server(Vec::new()).await;
+    let mut fixture = fixture(port).await;
+    let link = install_link(&mut fixture, true, PlaylistLinkState::ServerMissing);
+    let status = super::super::status_from_store_set(&fixture.store_set);
+    assert_eq!(
+        status.kind,
+        crate::open_subsonic::OpenSubsonicStatusKind::NeedsAttention
+    );
+    assert_eq!(status.playlist_links_needing_decision, 1);
+    assert_eq!(status.playlist_projections_needing_attention, 0);
+    fixture
+        .bridge
+        .begin_playlist_create(&mut fixture.store_set, pending_restore(&link))
+        .unwrap();
+    let restoring = super::super::status_from_store_set(&fixture.store_set);
+    assert_eq!(restoring.playlist_creates_needing_attention, 1);
+    assert_eq!(restoring.playlist_links_needing_decision, 0);
+
+    delete_missing_local(
+        &mut fixture.store_set,
+        &fixture.bridge,
+        &link.server_playlist_id,
+    )
+    .unwrap();
+    server.await.unwrap();
+
+    assert!(
+        fixture
+            .store_set
+            .bridge_state
+            .playlist_link(&link.local_playlist_id)
+            .is_none()
+    );
+    assert!(
+        fixture
+            .store_set
+            .bridge_state
+            .pending_playlist_creates()
+            .is_empty()
+    );
+    let batch = fixture
+        .store_set
+        .bridge_state
+        .pending_playlist_imports()
+        .values()
+        .next()
+        .expect("local delete tombstone");
+    assert!(matches!(
+        batch.operations.as_slice(),
+        [ExternalOperationInput {
+            operation: Operation::DeletePlaylist { deleted: true, .. },
+            ..
+        }]
+    ));
+    let durable = load_store_set(&fixture.paths).unwrap().unwrap();
+    assert!(
+        durable
+            .bridge_state
+            .playlist_link(&link.local_playlist_id)
+            .is_none()
+    );
+    assert!(durable.bridge_state.pending_playlist_creates().is_empty());
+}
+
+#[tokio::test]
+async fn delete_restore_delete_uses_a_fresh_causal_acknowledgement() {
+    let (port, server) = scripted_server(Vec::new()).await;
+    let mut fixture = fixture(port).await;
+    let link = install_link(&mut fixture, true, PlaylistLinkState::ServerMissing);
+
+    delete_missing_local(
+        &mut fixture.store_set,
+        &fixture.bridge,
+        &link.server_playlist_id,
+    )
+    .unwrap();
+    let first = fixture
+        .store_set
+        .bridge_state
+        .pending_playlist_imports()
+        .values()
+        .next()
+        .cloned()
+        .unwrap();
+    fixture
+        .bridge
+        .acknowledge_import(&mut fixture.store_set, &first.operation_id)
+        .unwrap();
+
+    fixture
+        .store_set
+        .bridge_state
+        .upsert_playlist_link(link.clone())
+        .unwrap();
+    let expected = fixture.store_set.revisions();
+    commit_store_set(&fixture.paths, expected, &mut fixture.store_set).unwrap();
+    delete_missing_local(
+        &mut fixture.store_set,
+        &fixture.bridge,
+        &link.server_playlist_id,
+    )
+    .unwrap();
+    let second = fixture
+        .store_set
+        .bridge_state
+        .pending_playlist_imports()
+        .values()
+        .next()
+        .cloned()
+        .unwrap();
+    server.await.unwrap();
+
+    assert_ne!(first.operation_id, second.operation_id);
+    assert_ne!(
+        first.operations[0].acknowledgement_id,
+        second.operations[0].acknowledgement_id
+    );
+
+    let initial = crate::personal_state::legacy_state(
+        &crate::library::Library::default(),
+        &crate::playlists::Playlists::default(),
+        &crate::signals::Signals::default(),
+        &crate::station::StationStore::default(),
+    )
+    .unwrap();
+    let origin = crate::personal_state::OperationOrigin::OpenSubsonic {
+        backend_id: fixture.store_set.profile.backend_id().as_str().to_owned(),
+    };
+    let (first_deleted, _) = crate::personal_state::append_external_operations(
+        &initial,
+        origin.clone(),
+        &first.operations,
+    )
+    .unwrap();
+    let restored = crate::personal_state::append_external_operation(
+        &first_deleted,
+        "restore-between-deletes".to_owned(),
+        origin.clone(),
+        Operation::UpsertPlaylist {
+            playlist_id: link.local_playlist_id.clone(),
+            name: "Restored".to_owned(),
+        },
+        200,
+    )
+    .unwrap();
+    assert!(
+        crate::personal_state::personal_playlist_snapshot(&restored, &link.local_playlist_id)
+            .unwrap()
+            .is_some()
+    );
+    let (second_deleted, _) =
+        crate::personal_state::append_external_operations(&restored, origin, &second.operations)
+            .unwrap();
+    assert!(
+        crate::personal_state::personal_playlist_snapshot(
+            &second_deleted,
+            &link.local_playlist_id,
+        )
+        .unwrap()
+        .is_none()
+    );
+}
+
+#[tokio::test]
+async fn read_only_runtime_rejects_delete_before_any_playlist_request_or_store_change() {
+    let (port, server) = scripted_server(vec![
+        Step {
+            endpoint: "/rest/getOpenSubsonicExtensions.view?",
+            reply: Reply::Json(
+                r#"{"subsonic-response":{"status":"ok","openSubsonicExtensions":[]}}"#.to_owned(),
+            ),
+        },
+        Step {
+            endpoint: "/rest/ping.view?",
+            reply: Reply::Json(
+                r#"{"subsonic-response":{"status":"ok","version":"1.16.1"}}"#.to_owned(),
+            ),
+        },
+    ])
+    .await;
+    let mut fixture = fixture(port).await;
+    let link = install_link(&mut fixture, true, PlaylistLinkState::Linked);
+    let revisions_before = fixture.store_set.revisions();
+
+    let runtime = super::super::load_actor_read_only(&fixture.paths)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        runtime
+            .handle()
+            .delete_linked_playlist(link.server_playlist_id.clone())
+            .await,
+        Err(ServerError::PermissionDenied)
+    );
+    runtime.shutdown().await;
+    server.await.unwrap();
+
+    let durable = load_store_set(&fixture.paths).unwrap().unwrap();
+    assert_eq!(durable.revisions(), revisions_before);
+    assert_eq!(
+        durable.bridge_state.playlist_link(&link.local_playlist_id),
+        Some(&link)
+    );
+}
+
+#[tokio::test]
+async fn unlink_missing_playlist_clears_an_unresolved_restore_intent() {
+    let (port, server) = scripted_server(Vec::new()).await;
+    let mut fixture = fixture(port).await;
+    let link = install_link(&mut fixture, true, PlaylistLinkState::ServerMissing);
+    fixture
+        .bridge
+        .begin_playlist_create(&mut fixture.store_set, pending_restore(&link))
+        .unwrap();
+
+    fixture
+        .bridge
+        .unlink_playlist(&mut fixture.store_set, &link.local_playlist_id)
+        .unwrap();
+    server.await.unwrap();
+
+    assert!(
+        fixture
+            .store_set
+            .bridge_state
+            .playlist_link(&link.local_playlist_id)
+            .is_none()
+    );
+    assert!(
+        fixture
+            .store_set
+            .bridge_state
+            .pending_playlist_creates()
+            .is_empty()
+    );
+    let durable = load_store_set(&fixture.paths).unwrap().unwrap();
+    assert!(durable.bridge_state.playlist_links().is_empty());
+    assert!(durable.bridge_state.pending_playlist_creates().is_empty());
+}
+
+#[tokio::test]
+async fn delete_local_rejects_a_link_that_is_no_longer_server_missing() {
+    let (port, server) = scripted_server(Vec::new()).await;
+    let mut fixture = fixture(port).await;
+    let link = install_link(&mut fixture, true, PlaylistLinkState::Linked);
+
+    assert_eq!(
+        delete_missing_local(
+            &mut fixture.store_set,
+            &fixture.bridge,
+            &link.server_playlist_id,
+        ),
+        Err(ServerError::NotFound)
+    );
+    server.await.unwrap();
+
+    assert_eq!(
+        fixture
+            .store_set
+            .bridge_state
+            .playlist_link(&link.local_playlist_id),
+        Some(&link)
+    );
+    assert!(
+        fixture
+            .store_set
+            .bridge_state
+            .pending_playlist_imports()
+            .is_empty()
+    );
+    assert_eq!(
+        load_store_set(&fixture.paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .playlist_link(&link.local_playlist_id),
+        Some(&link)
+    );
+}
+
+#[tokio::test]
+async fn unmanaged_link_never_selects_the_managed_api_key_bypass() {
+    let (port, server) = scripted_server(vec![Step {
+        endpoint: "/rest/getPlaylist.view?",
+        reply: Reply::Json(playlist_body(
+            "server-playlist",
+            "Local playlist",
+            Some(false),
+        )),
+    }])
+    .await;
+    let mut fixture = fixture(port).await;
+    let link = install_link(&mut fixture, false, PlaylistLinkState::Linked);
+
+    assert_eq!(
+        delete_both(
+            &mut fixture.store_set,
+            &fixture.client,
+            &fixture.bridge,
+            &link.server_playlist_id,
+        )
+        .await,
+        Err(ServerError::PermissionDenied)
+    );
+    server.await.unwrap();
+    assert_eq!(
+        fixture
+            .store_set
+            .bridge_state
+            .playlist_link(&link.local_playlist_id),
+        Some(&link)
+    );
+}
+
+#[tokio::test]
+async fn managed_delete_both_fails_closed_without_exact_remote_access_evidence() {
+    for (owner, read_only) in [
+        (None, Some(false)),
+        (Some("alice"), None),
+        (Some("mallory"), Some(false)),
+    ] {
+        let (port, server) = scripted_server(vec![Step {
+            endpoint: "/rest/getPlaylist.view?",
+            reply: Reply::Json(playlist_body_with_access(
+                "server-playlist",
+                "Local playlist",
+                owner,
+                read_only,
+            )),
+        }])
+        .await;
+        let mut fixture = fixture(port).await;
+        bind_fixture_owner(&mut fixture);
+        let link = install_link(&mut fixture, true, PlaylistLinkState::Linked);
+
+        assert_eq!(
+            delete_both(
+                &mut fixture.store_set,
+                &fixture.client,
+                &fixture.bridge,
+                &link.server_playlist_id,
+            )
+            .await,
+            Err(ServerError::PermissionDenied)
+        );
+        server.await.unwrap();
+        assert_eq!(
+            fixture
+                .store_set
+                .bridge_state
+                .playlist_link(&link.local_playlist_id),
+            Some(&link)
+        );
+        assert!(
+            fixture
+                .store_set
+                .bridge_state
+                .pending_playlist_imports()
+                .is_empty()
+        );
+        let durable = load_store_set(&fixture.paths).unwrap().unwrap();
+        assert_eq!(
+            durable.bridge_state.playlist_link(&link.local_playlist_id),
+            Some(&link)
+        );
+        assert!(durable.bridge_state.pending_playlist_imports().is_empty());
+    }
+}
+
+#[tokio::test]
+async fn restore_reuses_a_reappeared_original_server_playlist_without_creating_a_duplicate() {
+    let original = playlist_body("server-playlist", "Local playlist", Some(false));
+    let (port, server) = scripted_server(vec![Step {
+        endpoint: "/rest/getPlaylist.view?",
+        reply: Reply::Json(original),
+    }])
+    .await;
+    let mut fixture = fixture(port).await;
+    bind_fixture_owner(&mut fixture);
+    let missing = install_link(&mut fixture, false, PlaylistLinkState::ServerMissing);
+
+    let restored_id = create_linked(
+        &mut fixture.store_set,
+        &fixture.client,
+        &fixture.bridge,
+        local_snapshot(),
+        true,
+        Some(&missing.server_playlist_id),
+    )
+    .await
+    .unwrap();
+    server.await.unwrap();
+
+    assert_eq!(restored_id, missing.server_playlist_id);
+    let link = fixture
+        .store_set
+        .bridge_state
+        .playlist_link(&missing.local_playlist_id)
+        .unwrap();
+    assert_eq!(link.server_playlist_id, missing.server_playlist_id);
+    assert_eq!(link.state, PlaylistLinkState::Linked);
+    assert!(
+        fixture
+            .store_set
+            .bridge_state
+            .pending_playlist_creates()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn restore_keeps_a_reappeared_original_missing_without_exact_write_access() {
+    for (owner, read_only) in [
+        (None, Some(false)),
+        (Some("alice"), None),
+        (Some("alice"), Some(true)),
+        (Some("mallory"), Some(false)),
+    ] {
+        let (port, server) = scripted_server(vec![Step {
+            endpoint: "/rest/getPlaylist.view?",
+            reply: Reply::Json(playlist_body_with_access(
+                "server-playlist",
+                "Local playlist",
+                owner,
+                read_only,
+            )),
+        }])
+        .await;
+        let mut fixture = fixture(port).await;
+        bind_fixture_owner(&mut fixture);
+        let missing = install_link(&mut fixture, false, PlaylistLinkState::ServerMissing);
+
+        assert_eq!(
+            create_linked(
+                &mut fixture.store_set,
+                &fixture.client,
+                &fixture.bridge,
+                local_snapshot(),
+                true,
+                Some(&missing.server_playlist_id),
+            )
+            .await,
+            Err(ServerError::PermissionDenied)
+        );
+        server.await.unwrap();
+
+        assert_eq!(
+            fixture
+                .store_set
+                .bridge_state
+                .playlist_link(&missing.local_playlist_id),
+            Some(&missing)
+        );
+        assert!(
+            fixture
+                .store_set
+                .bridge_state
+                .pending_playlist_creates()
+                .is_empty()
+        );
+        assert!(
+            fixture
+                .store_set
+                .bridge_state
+                .pending_playlist_imports()
+                .is_empty()
+        );
+    }
+}
+
+#[tokio::test]
+async fn restore_replaces_only_the_expected_missing_link_with_verified_managed_state() {
+    let restored = playlist_body("restored-playlist", "Local playlist", Some(false));
+    let (port, server) = scripted_server(vec![
+        Step {
+            endpoint: "/rest/getPlaylist.view?",
+            reply: Reply::NotFound,
+        },
+        Step {
+            endpoint: "/rest/createPlaylist.view?",
+            reply: Reply::Json(restored.clone()),
+        },
+        Step {
+            endpoint: "/rest/getPlaylist.view?",
+            reply: Reply::Json(restored),
+        },
+    ])
+    .await;
+    let mut fixture = fixture(port).await;
+    bind_fixture_owner(&mut fixture);
+    let missing = install_link(&mut fixture, false, PlaylistLinkState::ServerMissing);
+
+    let restored_id = create_linked(
+        &mut fixture.store_set,
+        &fixture.client,
+        &fixture.bridge,
+        local_snapshot(),
+        true,
+        Some(&missing.server_playlist_id),
+    )
+    .await
+    .unwrap();
+    server.await.unwrap();
+
+    assert_eq!(restored_id.as_str(), "restored-playlist");
+    let link = fixture
+        .store_set
+        .bridge_state
+        .playlist_link(&missing.local_playlist_id)
+        .unwrap();
+    assert_eq!(link.server_playlist_id, restored_id);
+    assert_eq!(link.state, PlaylistLinkState::Linked);
+    assert!(link.managed_by_yututui);
+}
+
+#[test]
+fn created_readback_requires_exact_owner_and_explicit_writable_evidence() {
+    let pending = PendingPlaylistCreate {
+        local_playlist_id: PlaylistId::new("local-playlist").unwrap(),
+        expected_missing_server_id: None,
+        created_server_playlist_id: Some(ServerPlaylistId::new("server").unwrap()),
+        desired_name: "Local playlist".to_owned(),
+        ordered_entry_ids: Vec::new(),
+        ordered_item_ids: Vec::new(),
+        started_at_unix: 100,
+    };
+    let credential =
+        ServerCredential::password("alice", SecretString::from("password".to_owned())).unwrap();
+    let remote = |owner: Option<&str>, read_only| {
+        ServerPlaylistWriteSnapshot::new(
+            BackendId::new("backend").unwrap(),
+            AccountScopeId::new("account").unwrap(),
+            ServerPlaylistId::new("server").unwrap(),
+            "Local playlist".to_owned(),
+            owner.map(str::to_owned),
+            read_only,
+            Vec::new(),
+        )
+    };
+
+    assert_eq!(
+        verify_created_snapshot(&pending, &remote(Some("alice"), Some(true)), &credential),
+        Err(ServerError::PermissionDenied)
+    );
+    assert_eq!(
+        verify_created_snapshot(&pending, &remote(Some("mallory"), Some(false)), &credential),
+        Err(ServerError::PermissionDenied)
+    );
+    assert_eq!(
+        verify_created_snapshot(&pending, &remote(None, Some(false)), &credential),
+        Err(ServerError::PermissionDenied)
+    );
+    assert_eq!(
+        verify_created_snapshot(&pending, &remote(Some("alice"), None), &credential),
+        Err(ServerError::PermissionDenied)
+    );
+    assert_eq!(
+        verify_created_snapshot(&pending, &remote(Some("alice"), Some(false)), &credential),
+        Ok(())
+    );
+}

--- a/src/open_subsonic/actor/playlist_ownership.rs
+++ b/src/open_subsonic/actor/playlist_ownership.rs
@@ -1,0 +1,167 @@
+//! Credential-owner boundary for server-playlist mutations.
+
+use super::playlists::PlaylistActorCommand;
+use crate::open_subsonic::ServerError;
+
+/// Keep previews available to read-only consumers while failing every mutation before network or
+/// durable bridge work can begin.
+pub(super) fn authorize(
+    command: PlaylistActorCommand,
+    mutations_allowed: bool,
+) -> Option<PlaylistActorCommand> {
+    if mutations_allowed || matches!(&command, PlaylistActorCommand::Prepare { .. }) {
+        return Some(command);
+    }
+    match command {
+        PlaylistActorCommand::Prepare { .. } => unreachable!("preview commands are read-only"),
+        PlaylistActorCommand::ApplyPreview { reply, .. } => {
+            let _ = reply.send(Err(ServerError::PermissionDenied));
+        }
+        PlaylistActorCommand::Reconcile { reply, .. } => {
+            let _ = reply.send(Err(ServerError::PermissionDenied.into()));
+        }
+        PlaylistActorCommand::CreateLinked { reply, .. } => {
+            let _ = reply.send(Err(ServerError::PermissionDenied));
+        }
+        PlaylistActorCommand::Unlink { reply, .. }
+        | PlaylistActorCommand::DeleteBoth { reply, .. }
+        | PlaylistActorCommand::DeleteLocal { reply, .. }
+        | PlaylistActorCommand::AbandonCreate { reply, .. } => {
+            let _ = reply.send(Err(ServerError::PermissionDenied));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::open_subsonic::{PlaylistPreviewTarget, ServiceError};
+    use crate::personal_state::{PersonalPlaylistSnapshot, PlaylistId};
+
+    fn local_snapshot() -> PersonalPlaylistSnapshot {
+        PersonalPlaylistSnapshot {
+            playlist_id: PlaylistId::new("local").unwrap(),
+            name: "Local".to_owned(),
+            entries: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn preview_is_allowed_but_every_mutation_is_denied_without_an_active_owner() {
+        let server_id = crate::open_subsonic::ServerPlaylistId::new("server").unwrap();
+        let (reply, _response) = tokio::sync::oneshot::channel();
+        assert!(
+            authorize(
+                PlaylistActorCommand::Prepare {
+                    server_playlist_id: server_id.clone(),
+                    target: PlaylistPreviewTarget::ImportCopy,
+                    reply,
+                },
+                false,
+            )
+            .is_some()
+        );
+
+        let (reply, response) = tokio::sync::oneshot::channel();
+        assert!(
+            authorize(
+                PlaylistActorCommand::ApplyPreview {
+                    preview_id: "preview".to_owned(),
+                    server_playlist_id: server_id.clone(),
+                    current_local: None,
+                    reply,
+                },
+                false,
+            )
+            .is_none()
+        );
+        assert_eq!(
+            response.blocking_recv().unwrap(),
+            Err(ServerError::PermissionDenied)
+        );
+
+        let (reply, response) = tokio::sync::oneshot::channel();
+        assert!(
+            authorize(
+                PlaylistActorCommand::Reconcile {
+                    snapshots: vec![local_snapshot()],
+                    reply,
+                },
+                false,
+            )
+            .is_none()
+        );
+        assert_eq!(
+            response.blocking_recv().unwrap(),
+            Err(ServiceError::Server(ServerError::PermissionDenied))
+        );
+
+        let (reply, response) = tokio::sync::oneshot::channel();
+        assert!(
+            authorize(
+                PlaylistActorCommand::CreateLinked {
+                    snapshot: local_snapshot(),
+                    replace_missing: false,
+                    expected_missing_server_id: None,
+                    reply,
+                },
+                false,
+            )
+            .is_none()
+        );
+        assert_eq!(
+            response.blocking_recv().unwrap(),
+            Err(ServerError::PermissionDenied)
+        );
+
+        for (command, response) in [
+            {
+                let (reply, response) = tokio::sync::oneshot::channel();
+                (
+                    PlaylistActorCommand::Unlink {
+                        server_playlist_id: server_id.clone(),
+                        reply,
+                    },
+                    response,
+                )
+            },
+            {
+                let (reply, response) = tokio::sync::oneshot::channel();
+                (
+                    PlaylistActorCommand::DeleteBoth {
+                        server_playlist_id: server_id.clone(),
+                        reply,
+                    },
+                    response,
+                )
+            },
+            {
+                let (reply, response) = tokio::sync::oneshot::channel();
+                (
+                    PlaylistActorCommand::DeleteLocal {
+                        server_playlist_id: server_id,
+                        reply,
+                    },
+                    response,
+                )
+            },
+            {
+                let (reply, response) = tokio::sync::oneshot::channel();
+                (
+                    PlaylistActorCommand::AbandonCreate {
+                        local_playlist_id: PlaylistId::new("local").unwrap(),
+                        reply,
+                    },
+                    response,
+                )
+            },
+        ] {
+            assert!(authorize(command, false).is_none());
+            assert_eq!(
+                response.blocking_recv().unwrap(),
+                Err(ServerError::PermissionDenied)
+            );
+        }
+    }
+}

--- a/src/open_subsonic/actor/playlists.rs
+++ b/src/open_subsonic/actor/playlists.rs
@@ -1,0 +1,1512 @@
+//! Preview-only preparation for explicit server-playlist imports and links.
+//!
+//! Nothing in this module persists or performs a mutation. The credential-owning actor first
+//! fetches a strict full remote snapshot, prepares one bounded entry-occurrence plan here, shows
+//! only the redacted counts to the App, then re-fetches and compares the fingerprint before
+//! committing the prepared bridge-store records.
+
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+
+use age::secrecy::ExposeSecret as _;
+use data_encoding::HEXLOWER;
+use sha2::{Digest as _, Sha256};
+
+use crate::personal_state::{
+    ExternalOperationInput, Operation, PersonalPlaylistSnapshot, PlaylistEntryId, PlaylistId,
+    PortableTrack, PortableTrackKey,
+};
+
+use super::super::OpenSubsonicClient;
+use super::super::ServerError;
+use super::super::bridge_event::portable_server_track;
+use super::super::bridge_runtime::BridgeRuntime;
+use super::super::bridge_store::{
+    PendingPlaylistCreate, PendingPlaylistImportBatch, PendingPlaylistImportPurpose,
+    PendingPlaylistProjection, PendingPlaylistProjectionStage, PlaylistLink, PlaylistLinkState,
+    PlaylistShadow, PlaylistShadowOccurrence,
+};
+use super::super::client::MutationDeliveryError;
+use super::super::linked_playlists::{
+    InitialMergeOccurrence, LinkedPlaylistEntry, plan_initial_merge,
+};
+use super::super::model::{
+    AccountScopeId, BackendId, ItemId, ServerPlaylistId, ServerPlaylistWriteSnapshot,
+};
+use super::super::transaction::OpenSubsonicStoreSet;
+use super::{ActorCommand, OpenSubsonicHandle, OpenSubsonicPlaylistReceipt};
+
+const MAX_PREVIEWS: usize = 32;
+const PREVIEW_TTL: Duration = Duration::from_secs(10 * 60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlaylistPreviewMode {
+    ImportCopy,
+    LinkNew,
+    LinkExisting,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlaylistPreviewTarget {
+    ImportCopy,
+    LinkNew,
+    LinkExisting(PersonalPlaylistSnapshot),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlaylistMergePreview {
+    pub preview_id: String,
+    pub mode: PlaylistPreviewMode,
+    pub server_playlist_id: ServerPlaylistId,
+    pub local_playlist_id: PlaylistId,
+    pub name: String,
+    pub remote_tracks: usize,
+    pub add_to_local: usize,
+    pub add_to_server: usize,
+}
+
+impl OpenSubsonicHandle {
+    /// Prepare a bounded, deletion-free preview without changing either side.
+    pub async fn prepare_playlist(
+        &self,
+        server_playlist_id: ServerPlaylistId,
+        target: PlaylistPreviewTarget,
+    ) -> Result<PlaylistMergePreview, ServerError> {
+        self.request(|reply| {
+            ActorCommand::Playlist(PlaylistActorCommand::Prepare {
+                server_playlist_id,
+                target,
+                reply,
+            })
+        })
+        .await
+    }
+
+    /// Apply one single-use preview after the actor revalidates both snapshots.
+    pub async fn apply_playlist_preview(
+        &self,
+        preview_id: String,
+        server_playlist_id: ServerPlaylistId,
+        current_local: Option<PersonalPlaylistSnapshot>,
+    ) -> Result<PlaylistId, ServerError> {
+        self.request(|reply| {
+            ActorCommand::Playlist(PlaylistActorCommand::ApplyPreview {
+                preview_id,
+                server_playlist_id,
+                current_local,
+                reply,
+            })
+        })
+        .await
+    }
+
+    /// Queue current local playlist winners for durable linked-server projection.
+    pub fn reconcile_playlists(
+        &self,
+        snapshots: Vec<PersonalPlaylistSnapshot>,
+    ) -> Result<OpenSubsonicPlaylistReceipt, ServerError> {
+        let (reply, receipt) = tokio::sync::oneshot::channel();
+        self.try_send(ActorCommand::Playlist(PlaylistActorCommand::Reconcile {
+            snapshots,
+            reply,
+        }))?;
+        Ok(receipt)
+    }
+
+    /// Create a server-owned copy of one exact local playlist and link it after readback.
+    pub async fn create_linked_playlist(
+        &self,
+        snapshot: PersonalPlaylistSnapshot,
+    ) -> Result<ServerPlaylistId, ServerError> {
+        self.request(|reply| {
+            ActorCommand::Playlist(PlaylistActorCommand::CreateLinked {
+                snapshot,
+                replace_missing: false,
+                expected_missing_server_id: None,
+                reply,
+            })
+        })
+        .await
+    }
+
+    /// Re-create the missing server side of an existing durable link.
+    pub async fn restore_linked_playlist(
+        &self,
+        server_playlist_id: ServerPlaylistId,
+        snapshot: PersonalPlaylistSnapshot,
+    ) -> Result<ServerPlaylistId, ServerError> {
+        self.request(|reply| {
+            ActorCommand::Playlist(PlaylistActorCommand::CreateLinked {
+                snapshot,
+                replace_missing: true,
+                expected_missing_server_id: Some(server_playlist_id),
+                reply,
+            })
+        })
+        .await
+    }
+
+    /// Stop synchronization while preserving both local and server playlists.
+    pub async fn unlink_playlist(
+        &self,
+        server_playlist_id: ServerPlaylistId,
+    ) -> Result<(), ServerError> {
+        self.request(|reply| {
+            ActorCommand::Playlist(PlaylistActorCommand::Unlink {
+                server_playlist_id,
+                reply,
+            })
+        })
+        .await
+    }
+
+    /// Delete both sides of one explicitly linked playlist.
+    pub async fn delete_linked_playlist(
+        &self,
+        server_playlist_id: ServerPlaylistId,
+    ) -> Result<(), ServerError> {
+        self.request(|reply| {
+            ActorCommand::Playlist(PlaylistActorCommand::DeleteBoth {
+                server_playlist_id,
+                reply,
+            })
+        })
+        .await
+    }
+
+    /// Delete only the local side of a link already known to be missing on the server.
+    ///
+    /// This path deliberately performs no server request. A server copy may have reappeared since
+    /// the missing observation; deleting it would require the separate `DeleteBoth` confirmation.
+    pub async fn delete_missing_local_playlist(
+        &self,
+        server_playlist_id: ServerPlaylistId,
+    ) -> Result<(), ServerError> {
+        self.request(|reply| {
+            ActorCommand::Playlist(PlaylistActorCommand::DeleteLocal {
+                server_playlist_id,
+                reply,
+            })
+        })
+        .await
+    }
+
+    /// Forget an unresolved create intent after an explicit user decision to keep only the local
+    /// side. The server may still contain a playlist when the original response was lost.
+    pub async fn abandon_playlist_create(
+        &self,
+        local_playlist_id: PlaylistId,
+    ) -> Result<(), ServerError> {
+        self.request(|reply| {
+            ActorCommand::Playlist(PlaylistActorCommand::AbandonCreate {
+                local_playlist_id,
+                reply,
+            })
+        })
+        .await
+    }
+}
+
+pub(super) enum PlaylistActorCommand {
+    Prepare {
+        server_playlist_id: ServerPlaylistId,
+        target: PlaylistPreviewTarget,
+        reply: tokio::sync::oneshot::Sender<Result<PlaylistMergePreview, ServerError>>,
+    },
+    ApplyPreview {
+        preview_id: String,
+        server_playlist_id: ServerPlaylistId,
+        current_local: Option<PersonalPlaylistSnapshot>,
+        reply: tokio::sync::oneshot::Sender<Result<PlaylistId, ServerError>>,
+    },
+    Reconcile {
+        snapshots: Vec<PersonalPlaylistSnapshot>,
+        reply: tokio::sync::oneshot::Sender<Result<(), super::ServiceError>>,
+    },
+    CreateLinked {
+        snapshot: PersonalPlaylistSnapshot,
+        replace_missing: bool,
+        expected_missing_server_id: Option<ServerPlaylistId>,
+        reply: tokio::sync::oneshot::Sender<Result<ServerPlaylistId, ServerError>>,
+    },
+    Unlink {
+        server_playlist_id: ServerPlaylistId,
+        reply: tokio::sync::oneshot::Sender<Result<(), ServerError>>,
+    },
+    DeleteBoth {
+        server_playlist_id: ServerPlaylistId,
+        reply: tokio::sync::oneshot::Sender<Result<(), ServerError>>,
+    },
+    DeleteLocal {
+        server_playlist_id: ServerPlaylistId,
+        reply: tokio::sync::oneshot::Sender<Result<(), ServerError>>,
+    },
+    AbandonCreate {
+        local_playlist_id: PlaylistId,
+        reply: tokio::sync::oneshot::Sender<Result<(), ServerError>>,
+    },
+}
+
+pub(super) async fn handle_command(
+    command: PlaylistActorCommand,
+    cache: &mut PlaylistPreviewCache,
+    store_set: &mut OpenSubsonicStoreSet,
+    client: &OpenSubsonicClient,
+    bridge: &BridgeRuntime,
+) {
+    match command {
+        PlaylistActorCommand::Prepare {
+            server_playlist_id,
+            target,
+            mut reply,
+        } => {
+            let operation = async {
+                let remote = client
+                    .get_playlist_write_snapshot(
+                        store_set.private_state.credential(),
+                        &server_playlist_id,
+                    )
+                    .await?;
+                let writable =
+                    has_exact_playlist_write_access(&remote, store_set.private_state.credential());
+                cache.prepare(&remote, target, writable, crate::signals::unix_now())
+            };
+            let result = tokio::select! {
+                _ = reply.closed() => return,
+                result = operation => result,
+            };
+            let _ = reply.send(result);
+        }
+        PlaylistActorCommand::ApplyPreview {
+            preview_id,
+            server_playlist_id,
+            current_local,
+            mut reply,
+        } => {
+            let operation = async {
+                let remote = client
+                    .get_playlist_write_snapshot(
+                        store_set.private_state.credential(),
+                        &server_playlist_id,
+                    )
+                    .await?;
+                let writable =
+                    has_exact_playlist_write_access(&remote, store_set.private_state.credential());
+                let prepared =
+                    cache.take(&preview_id, &remote, current_local.as_ref(), writable)?;
+                let local_playlist_id = prepared.preview.local_playlist_id.clone();
+                let PreparedPlaylistCommit {
+                    pending_import,
+                    link,
+                    projection,
+                    ..
+                } = prepared;
+                bridge
+                    .commit_playlist_preview(store_set, pending_import, link, projection)
+                    .map_err(service_error_as_server)?;
+                Ok(local_playlist_id)
+            };
+            let result = tokio::select! {
+                _ = reply.closed() => return,
+                result = operation => result,
+            };
+            let _ = reply.send(result);
+        }
+        PlaylistActorCommand::Reconcile { snapshots, reply } => {
+            let result = bridge.reconcile_linked_playlists(store_set, &snapshots);
+            let failed = result.err();
+            let _ = reply.send(failed.map_or(Ok(()), Err));
+            if let Some(error) = failed {
+                tracing::warn!(reason = %error, "music server playlists will retry");
+            }
+        }
+        PlaylistActorCommand::CreateLinked {
+            snapshot,
+            replace_missing,
+            expected_missing_server_id,
+            reply,
+        } => {
+            // A create request is replay-unsafe. Once its durable intent exists, finish the
+            // operation even if the caller disappears so receiver cancellation cannot strand an
+            // avoidable unknown outcome.
+            let result = create_linked(
+                store_set,
+                client,
+                bridge,
+                snapshot,
+                replace_missing,
+                expected_missing_server_id.as_ref(),
+            )
+            .await;
+            let _ = reply.send(result);
+        }
+        PlaylistActorCommand::Unlink {
+            server_playlist_id,
+            reply,
+        } => {
+            let result = linked_by_server(store_set, &server_playlist_id)
+                .ok_or(ServerError::NotFound)
+                .and_then(|link| {
+                    bridge
+                        .unlink_playlist(store_set, &link.local_playlist_id)
+                        .map_err(service_error_as_server)
+                });
+            let _ = reply.send(result);
+        }
+        PlaylistActorCommand::DeleteBoth {
+            server_playlist_id,
+            mut reply,
+        } => {
+            let operation = delete_both(store_set, client, bridge, &server_playlist_id);
+            let result = tokio::select! {
+                _ = reply.closed() => return,
+                result = operation => result,
+            };
+            let _ = reply.send(result);
+        }
+        PlaylistActorCommand::DeleteLocal {
+            server_playlist_id,
+            reply,
+        } => {
+            let result = delete_missing_local(store_set, bridge, &server_playlist_id);
+            let _ = reply.send(result);
+        }
+        PlaylistActorCommand::AbandonCreate {
+            local_playlist_id,
+            reply,
+        } => {
+            let result = bridge
+                .cancel_playlist_create(store_set, &local_playlist_id)
+                .map_err(service_error_as_server);
+            let _ = reply.send(result);
+        }
+    }
+}
+
+fn has_exact_playlist_write_access(
+    remote: &ServerPlaylistWriteSnapshot,
+    credential: &super::super::private_store::ServerCredential,
+) -> bool {
+    remote.read_only() == Some(false)
+        && credential
+            .username()
+            .is_some_and(|username| remote.owner() == Some(username.expose_secret()))
+}
+
+async fn create_linked(
+    store_set: &mut OpenSubsonicStoreSet,
+    client: &OpenSubsonicClient,
+    bridge: &BridgeRuntime,
+    snapshot: PersonalPlaylistSnapshot,
+    replace_missing: bool,
+    expected_missing_server_id: Option<&ServerPlaylistId>,
+) -> Result<ServerPlaylistId, ServerError> {
+    let existing = store_set
+        .bridge_state
+        .playlist_link(&snapshot.playlist_id)
+        .cloned();
+    if replace_missing {
+        if !existing.as_ref().is_some_and(|link| {
+            link.state == PlaylistLinkState::ServerMissing
+                && expected_missing_server_id
+                    .is_none_or(|expected| &link.server_playlist_id == expected)
+        }) {
+            return Err(ServerError::NotFound);
+        }
+    } else if existing.is_some() {
+        return Err(ServerError::InvalidResponse);
+    }
+    let pending = store_set
+        .bridge_state
+        .pending_playlist_creates()
+        .get(&snapshot.playlist_id)
+        .cloned();
+    if replace_missing && pending.is_none() {
+        let missing = existing.ok_or(ServerError::NotFound)?;
+        match client
+            .get_playlist_write_snapshot(
+                store_set.private_state.credential(),
+                &missing.server_playlist_id,
+            )
+            .await
+        {
+            Ok(remote) => {
+                if !has_exact_playlist_write_access(&remote, store_set.private_state.credential()) {
+                    return Err(ServerError::PermissionDenied);
+                }
+                let server_playlist_id = remote.id().clone();
+                bridge
+                    .restore_reappeared_playlist(store_set, missing, remote)
+                    .map_err(service_error_as_server)?;
+                return Ok(server_playlist_id);
+            }
+            Err(ServerError::NotFound) => {}
+            Err(error) => return Err(error),
+        }
+    }
+    let (intent, created_id) = if let Some(pending) = pending {
+        if pending.expected_missing_server_id.as_ref() != expected_missing_server_id {
+            return Err(ServerError::InvalidResponse);
+        }
+        let created_id = pending
+            .created_server_playlist_id
+            .clone()
+            .ok_or(ServerError::TemporarilyUnavailable)?;
+        (pending, created_id)
+    } else {
+        let entries = local_item_refs(store_set, &snapshot)?;
+        let intent = PendingPlaylistCreate {
+            local_playlist_id: snapshot.playlist_id.clone(),
+            expected_missing_server_id: expected_missing_server_id.cloned(),
+            created_server_playlist_id: None,
+            desired_name: snapshot.name.clone(),
+            ordered_entry_ids: snapshot
+                .entries
+                .iter()
+                .map(|entry| entry.entry_id.clone())
+                .collect(),
+            ordered_item_ids: entries
+                .iter()
+                .map(|entry| entry.item_id().clone())
+                .collect(),
+            started_at_unix: crate::signals::unix_now(),
+        };
+        bridge
+            .begin_playlist_create(store_set, intent.clone())
+            .map_err(service_error_as_server)?;
+        let created = match client
+            .create_playlist(
+                store_set.private_state.credential(),
+                &snapshot.name,
+                &entries,
+            )
+            .await
+        {
+            Ok(Some(created)) => created,
+            Ok(None) => return Err(ServerError::TemporarilyUnavailable),
+            Err(MutationDeliveryError::Ambiguous(error)) => return Err(error),
+            Err(MutationDeliveryError::DefinitelyNotApplied(error)) => {
+                bridge
+                    .cancel_playlist_create(store_set, &snapshot.playlist_id)
+                    .map_err(service_error_as_server)?;
+                return Err(error);
+            }
+        };
+        let created_id = created.id().clone();
+        bridge
+            .record_playlist_create_server_id(store_set, &snapshot.playlist_id, created_id.clone())
+            .map_err(service_error_as_server)?;
+        (intent, created_id)
+    };
+    let remote = client
+        .get_playlist_write_snapshot(store_set.private_state.credential(), &created_id)
+        .await?;
+    verify_created_snapshot(&intent, &remote, store_set.private_state.credential())?;
+    let server_playlist_id = remote.id().clone();
+    let link = PlaylistLink {
+        local_playlist_id: intent.local_playlist_id,
+        server_playlist_id: server_playlist_id.clone(),
+        managed_by_yututui: true,
+        state: PlaylistLinkState::Linked,
+        content_needs_attention: false,
+        shadow: PlaylistShadow {
+            name: remote.name().to_owned(),
+            occurrences: intent
+                .ordered_entry_ids
+                .into_iter()
+                .zip(remote.entries())
+                .map(|(entry_id, remote)| PlaylistShadowOccurrence {
+                    entry_id,
+                    item_id: remote.item.item_id().clone(),
+                })
+                .collect(),
+            verified_at_unix: crate::signals::unix_now(),
+        },
+    };
+    bridge
+        .commit_created_playlist_link(store_set, link, &snapshot, replace_missing)
+        .map_err(service_error_as_server)?;
+    Ok(server_playlist_id)
+}
+
+async fn delete_both(
+    store_set: &mut OpenSubsonicStoreSet,
+    client: &OpenSubsonicClient,
+    bridge: &BridgeRuntime,
+    server_playlist_id: &ServerPlaylistId,
+) -> Result<(), ServerError> {
+    let link = linked_by_server(store_set, server_playlist_id).ok_or(ServerError::NotFound)?;
+    let remote = match client
+        .get_playlist_write_snapshot(store_set.private_state.credential(), server_playlist_id)
+        .await
+    {
+        Ok(remote) => Some(remote),
+        Err(ServerError::NotFound) => None,
+        Err(error) => return Err(error),
+    };
+    if let Some(remote) = remote {
+        let deletion = if link.managed_by_yututui {
+            client
+                .delete_managed_playlist(store_set.private_state.credential(), &remote)
+                .await
+        } else {
+            client
+                .delete_playlist(store_set.private_state.credential(), &remote)
+                .await
+        };
+        if let Err(MutationDeliveryError::DefinitelyNotApplied(error)) = deletion {
+            return Err(error);
+        }
+        match client
+            .get_playlist_write_snapshot(store_set.private_state.credential(), server_playlist_id)
+            .await
+        {
+            Err(ServerError::NotFound) => {}
+            Ok(_) => return Err(ServerError::TemporarilyUnavailable),
+            Err(error) => return Err(error),
+        }
+    }
+    // Each accepted lifecycle deletion is a distinct causal operation. Reusing a hash of the
+    // local/server pair would make delete -> restore/re-link -> delete collapse into the first
+    // ledger envelope.
+    let operation_id = random_opaque_id("playlist-delete")?;
+    bridge
+        .commit_deleted_playlist(store_set, &link, operation_id)
+        .map_err(service_error_as_server)
+}
+
+fn delete_missing_local(
+    store_set: &mut OpenSubsonicStoreSet,
+    bridge: &BridgeRuntime,
+    server_playlist_id: &ServerPlaylistId,
+) -> Result<(), ServerError> {
+    let link = linked_by_server(store_set, server_playlist_id).ok_or(ServerError::NotFound)?;
+    if link.state != PlaylistLinkState::ServerMissing {
+        return Err(ServerError::NotFound);
+    }
+    let operation_id = random_opaque_id("playlist-delete")?;
+    bridge
+        .commit_deleted_playlist(store_set, &link, operation_id)
+        .map_err(service_error_as_server)
+}
+
+fn linked_by_server(
+    store_set: &OpenSubsonicStoreSet,
+    server_playlist_id: &ServerPlaylistId,
+) -> Option<PlaylistLink> {
+    store_set
+        .bridge_state
+        .playlist_links()
+        .values()
+        .find(|link| &link.server_playlist_id == server_playlist_id)
+        .cloned()
+}
+
+fn local_item_refs(
+    store_set: &OpenSubsonicStoreSet,
+    snapshot: &PersonalPlaylistSnapshot,
+) -> Result<Vec<super::super::OpenSubsonicItemRef>, ServerError> {
+    snapshot
+        .entries
+        .iter()
+        .map(|entry| {
+            let PortableTrackKey::OpenSubsonic {
+                backend_id,
+                account_scope_id,
+                item_id,
+            } = &entry.track.key
+            else {
+                return Err(ServerError::InvalidResponse);
+            };
+            if backend_id != store_set.profile.backend_id().as_str()
+                || account_scope_id != store_set.profile.account_scope_id().as_str()
+            {
+                return Err(ServerError::WrongAccountScope);
+            }
+            Ok(super::super::OpenSubsonicItemRef::new(
+                store_set.profile.backend_id().clone(),
+                store_set.profile.account_scope_id().clone(),
+                ItemId::new(item_id.clone()).map_err(|_| ServerError::InvalidResponse)?,
+            ))
+        })
+        .collect()
+}
+
+fn verify_created_snapshot(
+    pending: &PendingPlaylistCreate,
+    remote: &ServerPlaylistWriteSnapshot,
+    credential: &super::super::private_store::ServerCredential,
+) -> Result<(), ServerError> {
+    if remote.read_only() != Some(false) {
+        return Err(ServerError::PermissionDenied);
+    }
+    let owner_matches = credential
+        .username()
+        .zip(remote.owner())
+        .is_some_and(|(username, owner)| username.expose_secret() == owner);
+    if !owner_matches {
+        return Err(ServerError::PermissionDenied);
+    }
+    let remote_ids = remote
+        .entries()
+        .iter()
+        .map(|entry| entry.item.item_id())
+        .collect::<Vec<_>>();
+    if remote.name() != pending.desired_name
+        || pending.ordered_item_ids.iter().collect::<Vec<_>>() != remote_ids
+    {
+        return Err(ServerError::InvalidResponse);
+    }
+    Ok(())
+}
+
+fn service_error_as_server(error: super::ServiceError) -> ServerError {
+    match error {
+        super::ServiceError::Server(error) => error,
+        super::ServiceError::Store(_)
+        | super::ServiceError::ActorUnavailable
+        | super::ServiceError::ProxyUnavailable
+        | super::ServiceError::InvalidSetup => ServerError::TemporarilyUnavailable,
+    }
+}
+
+pub(super) struct PreparedPlaylistCommit {
+    pub preview: PlaylistMergePreview,
+    pub remote_fingerprint: String,
+    pub local_fingerprint: Option<String>,
+    pub pending_import: PendingPlaylistImportBatch,
+    pub link: Option<PlaylistLink>,
+    pub projection: Option<PendingPlaylistProjection>,
+}
+
+struct CachedPreview {
+    expires_at: Instant,
+    prepared: PreparedPlaylistCommit,
+}
+
+#[derive(Default)]
+pub(super) struct PlaylistPreviewCache {
+    previews: BTreeMap<String, CachedPreview>,
+}
+
+impl PlaylistPreviewCache {
+    pub(super) fn prepare(
+        &mut self,
+        remote: &ServerPlaylistWriteSnapshot,
+        target: PlaylistPreviewTarget,
+        link_is_writable: bool,
+        observed_at_unix: i64,
+    ) -> Result<PlaylistMergePreview, ServerError> {
+        self.expire();
+        if self.previews.len() >= MAX_PREVIEWS {
+            let Some(oldest) = self
+                .previews
+                .iter()
+                .min_by_key(|(_, cached)| cached.expires_at)
+                .map(|(id, _)| id.clone())
+            else {
+                return Err(ServerError::TemporarilyUnavailable);
+            };
+            self.previews.remove(&oldest);
+        }
+        let prepared = prepare_commit(remote, target, link_is_writable, observed_at_unix)?;
+        let preview = prepared.preview.clone();
+        self.previews.insert(
+            preview.preview_id.clone(),
+            CachedPreview {
+                expires_at: Instant::now() + PREVIEW_TTL,
+                prepared,
+            },
+        );
+        Ok(preview)
+    }
+
+    pub(super) fn take(
+        &mut self,
+        preview_id: &str,
+        remote: &ServerPlaylistWriteSnapshot,
+        current_local: Option<&PersonalPlaylistSnapshot>,
+        link_is_writable: bool,
+    ) -> Result<PreparedPlaylistCommit, ServerError> {
+        self.expire();
+        let cached = self
+            .previews
+            .remove(preview_id)
+            .ok_or(ServerError::InvalidResponse)?;
+        if cached.prepared.preview.mode != PlaylistPreviewMode::ImportCopy && !link_is_writable {
+            return Err(ServerError::PermissionDenied);
+        }
+        if remote_fingerprint(remote) != cached.prepared.remote_fingerprint {
+            return Err(ServerError::TemporarilyUnavailable);
+        }
+        match (&cached.prepared.local_fingerprint, current_local) {
+            (None, None) => {}
+            (Some(expected), Some(current)) if *expected == local_fingerprint(current) => {}
+            _ => return Err(ServerError::TemporarilyUnavailable),
+        }
+        Ok(cached.prepared)
+    }
+
+    fn expire(&mut self) {
+        let now = Instant::now();
+        self.previews.retain(|_, cached| cached.expires_at > now);
+    }
+}
+
+fn prepare_commit(
+    remote: &ServerPlaylistWriteSnapshot,
+    target: PlaylistPreviewTarget,
+    link_is_writable: bool,
+    observed_at_unix: i64,
+) -> Result<PreparedPlaylistCommit, ServerError> {
+    let mode = match &target {
+        PlaylistPreviewTarget::ImportCopy => PlaylistPreviewMode::ImportCopy,
+        PlaylistPreviewTarget::LinkNew => PlaylistPreviewMode::LinkNew,
+        PlaylistPreviewTarget::LinkExisting(_) => PlaylistPreviewMode::LinkExisting,
+    };
+    if mode != PlaylistPreviewMode::ImportCopy && !link_is_writable {
+        return Err(ServerError::PermissionDenied);
+    }
+    let preview_id = random_opaque_id("playlist-preview")?;
+
+    let local = match &target {
+        PlaylistPreviewTarget::LinkExisting(local) => Some(local.clone()),
+        PlaylistPreviewTarget::ImportCopy | PlaylistPreviewTarget::LinkNew => None,
+    };
+    let local_playlist_id = local.as_ref().map_or_else(
+        || random_playlist_id(&preview_id),
+        |playlist| Ok(playlist.playlist_id.clone()),
+    )?;
+    let local_name = local.as_ref().map_or_else(
+        || remote.name().to_owned(),
+        |playlist| playlist.name.clone(),
+    );
+    let local_entries = local
+        .as_ref()
+        .map(|playlist| linked_local_entries(remote, playlist))
+        .transpose()?
+        .unwrap_or_default();
+    let remote_items = remote
+        .entries()
+        .iter()
+        .map(|song| song.item.item_id().clone())
+        .collect::<Vec<_>>();
+    let merge = plan_initial_merge(&local_entries, &remote_items)
+        .map_err(|_| ServerError::InvalidResponse)?;
+
+    let mut local_tracks = BTreeMap::<PlaylistEntryId, PortableTrack>::new();
+    if let Some(local) = &local {
+        for entry in &local.entries {
+            local_tracks.insert(entry.entry_id.clone(), entry.track.clone());
+        }
+    }
+    let mut ordered = Vec::<(PlaylistEntryId, ItemId, PortableTrack)>::with_capacity(
+        merge.ordered_occurrences().len(),
+    );
+    for occurrence in merge.ordered_occurrences() {
+        match occurrence {
+            InitialMergeOccurrence::Matched(matched) => {
+                let song = remote
+                    .entries()
+                    .get(matched.remote_index)
+                    .ok_or(ServerError::InvalidResponse)?;
+                ordered.push((
+                    matched.entry_id.clone(),
+                    matched.item_id.clone(),
+                    portable_server_track(song),
+                ));
+            }
+            InitialMergeOccurrence::RemoteOnly(remote_only) => {
+                let song = remote
+                    .entries()
+                    .get(remote_only.index)
+                    .ok_or(ServerError::InvalidResponse)?;
+                ordered.push((
+                    deterministic_entry_id(&preview_id, remote_only.index, &remote_only.item_id)?,
+                    remote_only.item_id.clone(),
+                    portable_server_track(song),
+                ));
+            }
+            InitialMergeOccurrence::LocalOnly(local_only) => {
+                let track = local_tracks
+                    .get(&local_only.entry.entry_id)
+                    .cloned()
+                    .ok_or(ServerError::InvalidResponse)?;
+                ordered.push((
+                    local_only.entry.entry_id.clone(),
+                    local_only.entry.item_id.clone(),
+                    track,
+                ));
+            }
+        }
+    }
+
+    let mut operations = Vec::with_capacity(ordered.len() + 1);
+    operations.push(ExternalOperationInput {
+        acknowledgement_id: operation_acknowledgement(&preview_id, 0),
+        operation: Operation::UpsertPlaylist {
+            playlist_id: local_playlist_id.clone(),
+            name: local_name.clone(),
+        },
+        recorded_at_unix: observed_at_unix,
+    });
+    let mut after_entry_id = None;
+    for (index, (entry_id, _, track)) in ordered.iter().enumerate() {
+        operations.push(ExternalOperationInput {
+            acknowledgement_id: operation_acknowledgement(&preview_id, index + 1),
+            operation: Operation::UpsertPlaylistEntry {
+                playlist_id: local_playlist_id.clone(),
+                entry_id: entry_id.clone(),
+                track: track.clone(),
+                after_entry_id: after_entry_id.clone(),
+            },
+            recorded_at_unix: observed_at_unix,
+        });
+        after_entry_id = Some(entry_id.clone());
+    }
+    let pending_import = PendingPlaylistImportBatch {
+        operation_id: format!("playlist-batch-{}", digest_text(&preview_id)),
+        local_playlist_id: local_playlist_id.clone(),
+        purpose: PendingPlaylistImportPurpose::InitialOrImportCopy,
+        operations,
+    };
+
+    let (link, projection) =
+        if mode == PlaylistPreviewMode::ImportCopy {
+            (None, None)
+        } else {
+            let current_occurrences = ordered
+                .iter()
+                .take(remote_items.len())
+                .map(|(entry_id, item_id, _)| PlaylistShadowOccurrence {
+                    entry_id: entry_id.clone(),
+                    item_id: item_id.clone(),
+                })
+                .collect();
+            let link = PlaylistLink {
+                local_playlist_id: local_playlist_id.clone(),
+                server_playlist_id: remote.id().clone(),
+                managed_by_yututui: false,
+                state: PlaylistLinkState::Linked,
+                content_needs_attention: false,
+                shadow: PlaylistShadow {
+                    name: remote.name().to_owned(),
+                    occurrences: current_occurrences,
+                    verified_at_unix: observed_at_unix,
+                },
+            };
+            let desired_item_ids = ordered
+                .iter()
+                .map(|(_, item_id, _)| item_id.clone())
+                .collect::<Vec<_>>();
+            let projection = (desired_item_ids != remote_items || local_name != remote.name())
+                .then(|| PendingPlaylistProjection {
+                    desired_name: local_name.clone(),
+                    ordered_entry_ids: ordered
+                        .iter()
+                        .map(|(entry_id, _, _)| entry_id.clone())
+                        .collect(),
+                    ordered_item_ids: desired_item_ids,
+                    stage: PendingPlaylistProjectionStage::Queued,
+                    base_remote_fingerprint: remote_fingerprint(remote),
+                });
+            (Some(link), projection)
+        };
+
+    let preview = PlaylistMergePreview {
+        preview_id,
+        mode,
+        server_playlist_id: remote.id().clone(),
+        local_playlist_id,
+        name: local_name,
+        remote_tracks: remote.entries().len(),
+        add_to_local: merge.preview().add_to_local,
+        add_to_server: merge.preview().add_to_remote,
+    };
+    Ok(PreparedPlaylistCommit {
+        remote_fingerprint: remote_fingerprint(remote),
+        local_fingerprint: local.as_ref().map(local_fingerprint),
+        preview,
+        pending_import,
+        link,
+        projection,
+    })
+}
+
+fn linked_local_entries(
+    remote: &ServerPlaylistWriteSnapshot,
+    local: &PersonalPlaylistSnapshot,
+) -> Result<Vec<LinkedPlaylistEntry>, ServerError> {
+    local
+        .entries
+        .iter()
+        .map(|entry| {
+            let PortableTrackKey::OpenSubsonic {
+                backend_id,
+                account_scope_id,
+                item_id,
+            } = &entry.track.key
+            else {
+                return Err(ServerError::InvalidResponse);
+            };
+            if backend_id != remote.backend_id().as_str()
+                || account_scope_id != remote.account_scope_id().as_str()
+            {
+                return Err(ServerError::WrongAccountScope);
+            }
+            Ok(LinkedPlaylistEntry::new(
+                entry.entry_id.clone(),
+                ItemId::new(item_id.clone()).map_err(|_| ServerError::InvalidResponse)?,
+            ))
+        })
+        .collect()
+}
+
+pub(crate) fn remote_fingerprint(remote: &ServerPlaylistWriteSnapshot) -> String {
+    sequence_fingerprint(
+        remote.backend_id(),
+        remote.account_scope_id(),
+        remote.id(),
+        remote.name(),
+        remote.entries().iter().map(|song| song.item.item_id()),
+    )
+}
+
+fn local_fingerprint(local: &PersonalPlaylistSnapshot) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"yututui-local-playlist-preview-v1\0");
+    update_part(&mut digest, local.playlist_id.as_str().as_bytes());
+    update_part(&mut digest, local.name.as_bytes());
+    for entry in &local.entries {
+        update_part(&mut digest, entry.entry_id.as_str().as_bytes());
+        let encoded =
+            serde_json::to_vec(&entry.track).expect("portable playlist tracks always serialize");
+        update_part(&mut digest, &encoded);
+    }
+    HEXLOWER.encode(&digest.finalize())
+}
+
+fn sequence_fingerprint<'a>(
+    backend_id: &BackendId,
+    account_scope_id: &AccountScopeId,
+    playlist_id: &ServerPlaylistId,
+    name: &str,
+    item_ids: impl Iterator<Item = &'a ItemId>,
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"yututui-open-subsonic-playlist-snapshot-v1\0");
+    for part in [
+        backend_id.as_str(),
+        account_scope_id.as_str(),
+        playlist_id.as_str(),
+        name,
+    ] {
+        update_part(&mut digest, part.as_bytes());
+    }
+    for item_id in item_ids {
+        update_part(&mut digest, item_id.as_str().as_bytes());
+    }
+    HEXLOWER.encode(&digest.finalize())
+}
+
+fn random_opaque_id(prefix: &str) -> Result<String, ServerError> {
+    let mut random = [0_u8; 16];
+    getrandom::fill(&mut random).map_err(|_| ServerError::TemporarilyUnavailable)?;
+    Ok(format!("{prefix}-{}", HEXLOWER.encode(&random)))
+}
+
+fn random_playlist_id(preview_id: &str) -> Result<PlaylistId, ServerError> {
+    PlaylistId::new(format!("server-{}", digest_text(preview_id)))
+        .map_err(|_| ServerError::InvalidResponse)
+}
+
+fn deterministic_entry_id(
+    preview_id: &str,
+    index: usize,
+    item_id: &ItemId,
+) -> Result<PlaylistEntryId, ServerError> {
+    let material = format!("{preview_id}\0{index}\0{}", item_id.as_str());
+    PlaylistEntryId::new(format!("server-entry-{}", digest_text(&material)))
+        .map_err(|_| ServerError::InvalidResponse)
+}
+
+fn operation_acknowledgement(preview_id: &str, index: usize) -> String {
+    digest_text(&format!("{preview_id}\0operation\0{index}"))
+}
+
+fn digest_text(value: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(value.as_bytes());
+    HEXLOWER.encode(&digest.finalize())
+}
+
+fn update_part(digest: &mut Sha256, bytes: &[u8]) {
+    digest.update((bytes.len() as u64).to_be_bytes());
+    digest.update(bytes);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::open_subsonic::{OpenSubsonicItemRef, ServerSong};
+    use crate::personal_state::PersonalPlaylistEntry;
+
+    const BACKEND: &str = "backend";
+    const ACCOUNT: &str = "account";
+
+    fn item_id(value: &str) -> ItemId {
+        ItemId::new(value).unwrap()
+    }
+
+    fn server_song(backend: &str, account: &str, item: &str) -> ServerSong {
+        ServerSong {
+            item: OpenSubsonicItemRef::new(
+                BackendId::new(backend).unwrap(),
+                AccountScopeId::new(account).unwrap(),
+                item_id(item),
+            ),
+            title: format!("Server {item}"),
+            artist: "Server artist".to_owned(),
+            artists: vec!["Server artist".to_owned()],
+            album: Some("Server album".to_owned()),
+            album_id: None,
+            album_artist: None,
+            duration_secs: Some(180),
+            track_number: None,
+            disc_number: None,
+            year: None,
+            cover_art_id: None,
+            content_type: Some("audio/flac".to_owned()),
+            suffix: Some("flac".to_owned()),
+            starred: false,
+            user_rating: None,
+            play_count: None,
+            played_at: None,
+        }
+    }
+
+    fn remote(name: &str, items: &[&str]) -> ServerPlaylistWriteSnapshot {
+        remote_with_access(name, items, Some("owner"), Some(false))
+    }
+
+    fn remote_with_access(
+        name: &str,
+        items: &[&str],
+        owner: Option<&str>,
+        read_only: Option<bool>,
+    ) -> ServerPlaylistWriteSnapshot {
+        ServerPlaylistWriteSnapshot::new(
+            BackendId::new(BACKEND).unwrap(),
+            AccountScopeId::new(ACCOUNT).unwrap(),
+            ServerPlaylistId::new("server-playlist").unwrap(),
+            name.to_owned(),
+            owner.map(str::to_owned),
+            read_only,
+            items
+                .iter()
+                .map(|item| server_song(BACKEND, ACCOUNT, item))
+                .collect(),
+        )
+    }
+
+    fn portable_track(backend: &str, account: &str, item: &str) -> PortableTrack {
+        PortableTrack {
+            key: PortableTrackKey::OpenSubsonic {
+                backend_id: backend.to_owned(),
+                account_scope_id: account.to_owned(),
+                item_id: item.to_owned(),
+            },
+            title: format!("Local {item}"),
+            artist: "Local artist".to_owned(),
+            album: Some("Local album".to_owned()),
+            duration_secs: Some(181),
+            isrc: None,
+        }
+    }
+
+    fn local(name: &str, entries: &[(&str, &str)]) -> PersonalPlaylistSnapshot {
+        PersonalPlaylistSnapshot {
+            playlist_id: PlaylistId::new("local-playlist").unwrap(),
+            name: name.to_owned(),
+            entries: entries
+                .iter()
+                .map(|(entry_id, item)| PersonalPlaylistEntry {
+                    entry_id: PlaylistEntryId::new(*entry_id).unwrap(),
+                    track: portable_track(BACKEND, ACCOUNT, item),
+                })
+                .collect(),
+        }
+    }
+
+    fn imported_entries(
+        prepared: &PreparedPlaylistCommit,
+    ) -> Vec<(&PlaylistEntryId, &PortableTrack, &Option<PlaylistEntryId>)> {
+        prepared
+            .pending_import
+            .operations
+            .iter()
+            .filter_map(|input| match &input.operation {
+                Operation::UpsertPlaylistEntry {
+                    entry_id,
+                    track,
+                    after_entry_id,
+                    ..
+                } => Some((entry_id, track, after_entry_id)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn track_item_id(track: &PortableTrack) -> &str {
+        match &track.key {
+            PortableTrackKey::OpenSubsonic { item_id, .. } => item_id,
+            _ => panic!("expected an exact OpenSubsonic item"),
+        }
+    }
+
+    #[test]
+    fn import_copy_preserves_duplicate_occurrences_without_creating_a_link() {
+        let remote = remote("Duplicates", &["same", "same"]);
+
+        let prepared =
+            prepare_commit(&remote, PlaylistPreviewTarget::ImportCopy, false, 100).unwrap();
+
+        assert_eq!(prepared.preview.mode, PlaylistPreviewMode::ImportCopy);
+        assert_eq!(prepared.preview.remote_tracks, 2);
+        assert_eq!(prepared.preview.add_to_local, 2);
+        assert_eq!(prepared.preview.add_to_server, 0);
+        assert!(prepared.link.is_none());
+        assert!(prepared.projection.is_none());
+        let entries = imported_entries(&prepared);
+        assert_eq!(entries.len(), 2);
+        assert_ne!(entries[0].0, entries[1].0);
+        assert_eq!(track_item_id(entries[0].1), "same");
+        assert_eq!(track_item_id(entries[1].1), "same");
+        assert_eq!(entries[0].2, &None);
+        assert_eq!(entries[1].2.as_ref(), Some(entries[0].0));
+    }
+
+    #[test]
+    fn link_new_requires_explicit_writable_proof() {
+        assert!(matches!(
+            prepare_commit(
+                &remote("Remote", &["a"]),
+                PlaylistPreviewTarget::LinkNew,
+                false,
+                100,
+            ),
+            Err(ServerError::PermissionDenied)
+        ));
+    }
+
+    #[test]
+    fn link_existing_keeps_remote_order_then_appends_local_only_occurrences() {
+        let remote = remote("Same name", &["a", "b"]);
+        let local = local("Same name", &[("local-a", "a"), ("local-c", "c")]);
+
+        let prepared = prepare_commit(
+            &remote,
+            PlaylistPreviewTarget::LinkExisting(local.clone()),
+            true,
+            100,
+        )
+        .unwrap();
+
+        assert_eq!(prepared.preview.mode, PlaylistPreviewMode::LinkExisting);
+        assert_eq!(prepared.preview.local_playlist_id, local.playlist_id);
+        assert_eq!(prepared.preview.add_to_local, 1);
+        assert_eq!(prepared.preview.add_to_server, 1);
+        assert_eq!(
+            imported_entries(&prepared)
+                .iter()
+                .map(|(_, track, _)| track_item_id(track))
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+        let link = prepared.link.as_ref().unwrap();
+        assert_eq!(link.local_playlist_id, local.playlist_id);
+        assert_eq!(&link.server_playlist_id, remote.id());
+        assert_eq!(
+            link.shadow
+                .occurrences
+                .iter()
+                .map(|occurrence| occurrence.item_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+        assert_eq!(
+            prepared
+                .projection
+                .as_ref()
+                .unwrap()
+                .ordered_item_ids
+                .iter()
+                .map(ItemId::as_str)
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+    }
+
+    #[test]
+    fn equal_names_do_not_infer_a_different_local_identity() {
+        let remote = remote("Shared display name", &["a"]);
+        let mut explicitly_selected = local("Shared display name", &[("entry", "a")]);
+        explicitly_selected.playlist_id = PlaylistId::new("explicit-selection").unwrap();
+
+        let prepared = prepare_commit(
+            &remote,
+            PlaylistPreviewTarget::LinkExisting(explicitly_selected.clone()),
+            true,
+            100,
+        )
+        .unwrap();
+
+        assert_eq!(
+            prepared.preview.local_playlist_id,
+            explicitly_selected.playlist_id
+        );
+        assert_eq!(
+            prepared.link.unwrap().local_playlist_id,
+            explicitly_selected.playlist_id
+        );
+    }
+
+    #[test]
+    fn link_existing_rejects_wrong_backend_and_local_placeholder_tracks() {
+        let remote = remote("Remote", &["a"]);
+        let wrong_backend = PersonalPlaylistSnapshot {
+            playlist_id: PlaylistId::new("wrong-backend").unwrap(),
+            name: "Local".to_owned(),
+            entries: vec![PersonalPlaylistEntry {
+                entry_id: PlaylistEntryId::new("entry").unwrap(),
+                track: portable_track("other-backend", ACCOUNT, "a"),
+            }],
+        };
+        assert!(matches!(
+            prepare_commit(
+                &remote,
+                PlaylistPreviewTarget::LinkExisting(wrong_backend),
+                true,
+                100,
+            ),
+            Err(ServerError::WrongAccountScope)
+        ));
+
+        let placeholder = PersonalPlaylistSnapshot {
+            playlist_id: PlaylistId::new("placeholder").unwrap(),
+            name: "Local".to_owned(),
+            entries: vec![PersonalPlaylistEntry {
+                entry_id: PlaylistEntryId::new("entry").unwrap(),
+                track: PortableTrack {
+                    key: PortableTrackKey::LocalPlaceholder {
+                        portable_placeholder_id: "placeholder-track".to_owned(),
+                    },
+                    title: "Local file".to_owned(),
+                    artist: "Artist".to_owned(),
+                    album: None,
+                    duration_secs: None,
+                    isrc: None,
+                },
+            }],
+        };
+        assert!(matches!(
+            prepare_commit(
+                &remote,
+                PlaylistPreviewTarget::LinkExisting(placeholder),
+                true,
+                100,
+            ),
+            Err(ServerError::InvalidResponse)
+        ));
+    }
+
+    #[test]
+    fn take_rejects_remote_change_and_consumes_the_preview() {
+        let mut cache = PlaylistPreviewCache::default();
+        let original = remote("Remote", &["a", "b"]);
+        let preview = cache
+            .prepare(&original, PlaylistPreviewTarget::LinkNew, true, 100)
+            .unwrap();
+        let changed = remote("Remote", &["b", "a"]);
+
+        assert!(matches!(
+            cache.take(&preview.preview_id, &changed, None, true),
+            Err(ServerError::TemporarilyUnavailable)
+        ));
+        assert!(matches!(
+            cache.take(&preview.preview_id, &original, None, true),
+            Err(ServerError::InvalidResponse)
+        ));
+    }
+
+    #[test]
+    fn take_rechecks_exact_owner_and_writable_evidence_for_link_previews() {
+        let credential = super::super::super::ServerCredential::password(
+            "owner",
+            age::secrecy::SecretString::from("password".to_owned()),
+        )
+        .unwrap();
+        for changed_access in [
+            remote_with_access("Remote", &["a"], Some("other-owner"), Some(false)),
+            remote_with_access("Remote", &["a"], Some("owner"), Some(true)),
+            remote_with_access("Remote", &["a"], None, Some(false)),
+            remote_with_access("Remote", &["a"], Some("owner"), None),
+        ] {
+            let mut cache = PlaylistPreviewCache::default();
+            let original = remote("Remote", &["a"]);
+            assert!(has_exact_playlist_write_access(&original, &credential));
+            let preview = cache
+                .prepare(&original, PlaylistPreviewTarget::LinkNew, true, 100)
+                .unwrap();
+            assert_eq!(
+                remote_fingerprint(&changed_access),
+                remote_fingerprint(&original),
+                "content-only equality must not hide changed access evidence"
+            );
+            let writable = has_exact_playlist_write_access(&changed_access, &credential);
+            assert!(!writable);
+            assert!(matches!(
+                cache.take(&preview.preview_id, &changed_access, None, writable),
+                Err(ServerError::PermissionDenied)
+            ));
+        }
+    }
+
+    #[test]
+    fn take_rejects_any_local_snapshot_revision_change() {
+        let mut cache = PlaylistPreviewCache::default();
+        let remote = remote("Remote", &["a"]);
+        let original = local("Local", &[("entry", "a")]);
+        let preview = cache
+            .prepare(
+                &remote,
+                PlaylistPreviewTarget::LinkExisting(original.clone()),
+                true,
+                100,
+            )
+            .unwrap();
+        let mut changed_metadata = original.clone();
+        changed_metadata.entries[0].track.title = "Edited after preview".to_owned();
+
+        assert!(matches!(
+            cache.take(&preview.preview_id, &remote, Some(&changed_metadata), true),
+            Err(ServerError::TemporarilyUnavailable)
+        ));
+        assert!(matches!(
+            cache.take(&preview.preview_id, &remote, Some(&original), true),
+            Err(ServerError::InvalidResponse)
+        ));
+    }
+
+    #[test]
+    fn take_is_single_use_after_success() {
+        let mut cache = PlaylistPreviewCache::default();
+        let remote = remote("Remote", &["a"]);
+        let preview = cache
+            .prepare(&remote, PlaylistPreviewTarget::ImportCopy, false, 100)
+            .unwrap();
+
+        let prepared = cache
+            .take(&preview.preview_id, &remote, None, false)
+            .unwrap();
+        assert_eq!(prepared.preview.preview_id, preview.preview_id);
+        assert!(matches!(
+            cache.take(&preview.preview_id, &remote, None, false),
+            Err(ServerError::InvalidResponse)
+        ));
+    }
+
+    #[test]
+    fn take_rejects_an_expired_preview() {
+        let mut cache = PlaylistPreviewCache::default();
+        let remote = remote("Remote", &["a"]);
+        let preview = cache
+            .prepare(&remote, PlaylistPreviewTarget::ImportCopy, false, 100)
+            .unwrap();
+        cache
+            .previews
+            .get_mut(&preview.preview_id)
+            .unwrap()
+            .expires_at = Instant::now() - Duration::from_secs(1);
+
+        assert!(matches!(
+            cache.take(&preview.preview_id, &remote, None, false),
+            Err(ServerError::InvalidResponse)
+        ));
+    }
+
+    #[test]
+    fn unchanged_existing_link_has_no_remote_projection() {
+        let remote = remote("Same", &["a", "b"]);
+        let local = local("Same", &[("a-entry", "a"), ("b-entry", "b")]);
+
+        let prepared = prepare_commit(
+            &remote,
+            PlaylistPreviewTarget::LinkExisting(local),
+            true,
+            100,
+        )
+        .unwrap();
+
+        assert_eq!(prepared.preview.add_to_local, 0);
+        assert_eq!(prepared.preview.add_to_server, 0);
+        assert!(prepared.link.is_some());
+        assert!(prepared.projection.is_none());
+    }
+
+    #[test]
+    fn changed_name_and_order_projection_keeps_entry_and_item_ids_parallel() {
+        let remote = remote("Remote name", &["a", "b"]);
+        let local = local(
+            "Local name",
+            &[("local-b", "b"), ("local-a", "a"), ("local-c", "c")],
+        );
+
+        let prepared = prepare_commit(
+            &remote,
+            PlaylistPreviewTarget::LinkExisting(local),
+            true,
+            100,
+        )
+        .unwrap();
+        let projection = prepared.projection.as_ref().unwrap();
+
+        assert_eq!(projection.desired_name, "Local name");
+        assert_eq!(
+            projection.ordered_entry_ids.len(),
+            projection.ordered_item_ids.len()
+        );
+        assert_eq!(
+            projection
+                .ordered_item_ids
+                .iter()
+                .map(ItemId::as_str)
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "a", "c"]
+        );
+        let imported = imported_entries(&prepared);
+        let imported_by_id = imported
+            .iter()
+            .map(|(entry_id, track, _)| {
+                (
+                    entry_id.as_str().to_owned(),
+                    track_item_id(track).to_owned(),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        for (entry_id, item_id) in projection
+            .ordered_entry_ids
+            .iter()
+            .zip(&projection.ordered_item_ids)
+        {
+            assert_eq!(
+                imported_by_id.get(entry_id.as_str()).map(String::as_str),
+                Some(item_id.as_str())
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "playlist_lifecycle_tests.rs"]
+mod lifecycle_tests;

--- a/src/open_subsonic/actor/tests.rs
+++ b/src/open_subsonic/actor/tests.rs
@@ -1,11 +1,18 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use age::secrecy::SecretString;
+use age::secrecy::{ExposeSecret as _, SecretString};
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
+use super::playlist_catalog::merge_missing_playlist_recovery_rows;
 use super::*;
-use crate::open_subsonic::bridge_store::RatingShadow;
+use crate::open_subsonic::bridge_store::{
+    PendingPlaylistProjection, PendingPlaylistProjectionStage, PlaylistLink, PlaylistLinkState,
+    PlaylistShadow, RatingShadow,
+};
 use crate::open_subsonic::rating::RawServerRating;
+use crate::open_subsonic::{
+    ServerLibraryRow, ServerPlaylistAccess, ServerPlaylistLinkHealth, ServerPlaylistSummary,
+};
 
 static NEXT_ROOT: AtomicU64 = AtomicU64::new(0);
 static LIFECYCLE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
@@ -23,10 +30,361 @@ fn status_never_contains_origin_or_credentials() {
         native_history_enabled: false,
         native_history_health: NativeHistoryHealth::Off,
         outbound_scrobbles_needing_attention: 0,
+        playlist_creates_needing_attention: 0,
+        playlist_create_attention: Vec::new(),
+        playlist_links_needing_decision: 0,
+        playlist_projections_needing_attention: 0,
+        playlist_contents_needing_attention: 0,
     };
     let rendered = format!("{status:?}");
     assert!(!rendered.contains("https://"));
     assert!(!rendered.contains("sentinel-secret"));
+}
+
+fn playlist_summary_for_access(
+    owner: Option<&str>,
+    owner_evidence: Option<&str>,
+    readonly_evidence: Option<bool>,
+) -> ServerPlaylistSummary {
+    ServerPlaylistSummary {
+        id: ServerPlaylistId::new("playlist").unwrap(),
+        name: "Playlist".to_owned(),
+        owner: owner.map(str::to_owned),
+        song_count: Some(0),
+        duration_secs: None,
+        public: None,
+        cover_art_id: None,
+        access: ServerPlaylistAccess::ReadOnly,
+        link: None,
+        readonly_evidence,
+        owner_evidence: owner_evidence.map(str::to_owned),
+    }
+}
+
+fn empty_playlist_bridge_state() -> OpenSubsonicBridgeState {
+    OpenSubsonicBridgeState::new(
+        BackendId::new("backend").unwrap(),
+        AccountScopeId::new("account").unwrap(),
+    )
+}
+
+#[test]
+fn actor_exposes_server_access_only_for_exact_credential_owner() {
+    let password =
+        ServerCredential::password("alice", SecretString::from("server-password".to_owned()))
+            .unwrap();
+    let mut page = ServerLibraryPage {
+        section: ServerLibrarySection::Playlists,
+        rows: vec![
+            ServerLibraryRow::Playlist(playlist_summary_for_access(
+                Some("alice"),
+                Some("alice"),
+                Some(false),
+            )),
+            ServerLibraryRow::Playlist(playlist_summary_for_access(
+                Some("bob"),
+                Some("bob"),
+                Some(false),
+            )),
+            ServerLibraryRow::Playlist(playlist_summary_for_access(
+                Some("alice"),
+                Some("alice"),
+                None,
+            )),
+            ServerLibraryRow::Playlist(playlist_summary_for_access(
+                Some("alice"),
+                None,
+                Some(false),
+            )),
+        ],
+        next_offset: None,
+        warning: None,
+    };
+    finalize_page_playlist_access(&mut page, &password, &empty_playlist_bridge_state());
+    let accesses = page
+        .rows
+        .iter()
+        .map(|row| match row {
+            ServerLibraryRow::Playlist(summary) => summary.access,
+            _ => unreachable!(),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        accesses,
+        [
+            ServerPlaylistAccess::Server,
+            ServerPlaylistAccess::ReadOnly,
+            ServerPlaylistAccess::ReadOnly,
+            ServerPlaylistAccess::ReadOnly,
+        ]
+    );
+
+    let api_key =
+        ServerCredential::api_key(SecretString::from("server-api-key".to_owned())).unwrap();
+    finalize_page_playlist_access(&mut page, &api_key, &empty_playlist_bridge_state());
+    assert!(page.rows.iter().all(|row| matches!(
+        row,
+        ServerLibraryRow::Playlist(ServerPlaylistSummary {
+            access: ServerPlaylistAccess::ReadOnly,
+            ..
+        })
+    )));
+
+    let mut bound_api_key =
+        ServerCredential::api_key(SecretString::from("server-api-key".to_owned())).unwrap();
+    bound_api_key.bind_api_key_username("alice").unwrap();
+    finalize_page_playlist_access(&mut page, &bound_api_key, &empty_playlist_bridge_state());
+    assert!(matches!(
+        &page.rows[0],
+        ServerLibraryRow::Playlist(ServerPlaylistSummary {
+            access: ServerPlaylistAccess::Server,
+            ..
+        })
+    ));
+    assert!(page.rows[1..].iter().all(|row| matches!(
+        row,
+        ServerLibraryRow::Playlist(ServerPlaylistSummary {
+            access: ServerPlaylistAccess::ReadOnly,
+            ..
+        })
+    )));
+}
+
+#[test]
+fn actor_applies_the_same_access_rule_to_playlist_detail() {
+    let password =
+        ServerCredential::password("alice", SecretString::from("server-password".to_owned()))
+            .unwrap();
+    let mut detail = ServerLibraryDetail::PlaylistEntries(crate::open_subsonic::ServerPlaylist {
+        summary: playlist_summary_for_access(Some("alice"), Some("alice"), Some(false)),
+        entries: Vec::new(),
+    });
+    finalize_detail_playlist_access(&mut detail, &password, &empty_playlist_bridge_state());
+    assert!(matches!(
+        detail,
+        ServerLibraryDetail::PlaylistEntries(crate::open_subsonic::ServerPlaylist {
+            summary: ServerPlaylistSummary {
+                access: ServerPlaylistAccess::Server,
+                ..
+            },
+            ..
+        })
+    ));
+}
+
+#[test]
+fn actor_marks_linked_rows_and_surfaces_missing_server_recovery_rows() {
+    let password =
+        ServerCredential::password("alice", SecretString::from("server-password".to_owned()))
+            .unwrap();
+    let mut bridge_state = empty_playlist_bridge_state();
+    bridge_state
+        .upsert_playlist_link(PlaylistLink {
+            local_playlist_id: crate::personal_state::PlaylistId::new("local").unwrap(),
+            server_playlist_id: ServerPlaylistId::new("missing-server").unwrap(),
+            managed_by_yututui: true,
+            state: PlaylistLinkState::ServerMissing,
+            content_needs_attention: false,
+            shadow: PlaylistShadow {
+                name: "Keep me".to_owned(),
+                occurrences: Vec::new(),
+                verified_at_unix: 100,
+            },
+        })
+        .unwrap();
+    let mut page = ServerLibraryPage {
+        section: ServerLibrarySection::Playlists,
+        rows: Vec::new(),
+        next_offset: None,
+        warning: None,
+    };
+
+    finalize_page_playlist_access(&mut page, &password, &bridge_state);
+    merge_missing_playlist_recovery_rows(&mut page, &bridge_state, 0, 50);
+
+    let ServerLibraryRow::Playlist(summary) = &page.rows[0] else {
+        panic!("missing playlist recovery row");
+    };
+    assert_eq!(summary.id.as_str(), "missing-server");
+    assert_eq!(summary.access, ServerPlaylistAccess::Linked);
+    assert_eq!(
+        summary.link.as_ref().map(|link| link.health),
+        Some(ServerPlaylistLinkHealth::ServerMissing)
+    );
+    assert_eq!(
+        summary
+            .link
+            .as_ref()
+            .map(|link| link.local_playlist_id.as_str()),
+        Some("local")
+    );
+}
+
+#[test]
+fn actor_keeps_server_missing_recovery_action_when_content_also_needs_attention() {
+    let password =
+        ServerCredential::password("alice", SecretString::from("server-password".to_owned()))
+            .unwrap();
+    let mut bridge_state = empty_playlist_bridge_state();
+    bridge_state
+        .upsert_playlist_link(PlaylistLink {
+            local_playlist_id: crate::personal_state::PlaylistId::new("local").unwrap(),
+            server_playlist_id: ServerPlaylistId::new("playlist").unwrap(),
+            managed_by_yututui: true,
+            state: PlaylistLinkState::ServerMissing,
+            content_needs_attention: true,
+            shadow: PlaylistShadow {
+                name: "Keep me".to_owned(),
+                occurrences: Vec::new(),
+                verified_at_unix: 100,
+            },
+        })
+        .unwrap();
+    let mut page = ServerLibraryPage {
+        section: ServerLibrarySection::Playlists,
+        rows: vec![ServerLibraryRow::Playlist(playlist_summary_for_access(
+            Some("alice"),
+            Some("alice"),
+            Some(false),
+        ))],
+        next_offset: None,
+        warning: None,
+    };
+
+    finalize_page_playlist_access(&mut page, &password, &bridge_state);
+
+    let ServerLibraryRow::Playlist(summary) = &page.rows[0] else {
+        panic!("playlist row");
+    };
+    assert_eq!(
+        summary.link.as_ref().map(|link| link.health),
+        Some(ServerPlaylistLinkHealth::ServerMissing),
+        "the actionable restore/unlink recovery state must not be hidden by content attention"
+    );
+}
+
+#[test]
+fn actor_surfaces_a_dormant_projection_as_link_attention() {
+    let password =
+        ServerCredential::password("alice", SecretString::from("server-password".to_owned()))
+            .unwrap();
+    let mut bridge_state = empty_playlist_bridge_state();
+    let local_playlist_id = crate::personal_state::PlaylistId::new("local").unwrap();
+    bridge_state
+        .upsert_playlist_link(PlaylistLink {
+            local_playlist_id: local_playlist_id.clone(),
+            server_playlist_id: ServerPlaylistId::new("playlist").unwrap(),
+            managed_by_yututui: true,
+            state: PlaylistLinkState::Linked,
+            content_needs_attention: false,
+            shadow: PlaylistShadow {
+                name: "Playlist".to_owned(),
+                occurrences: Vec::new(),
+                verified_at_unix: 100,
+            },
+        })
+        .unwrap();
+    bridge_state
+        .queue_playlist_projection(
+            local_playlist_id,
+            PendingPlaylistProjection {
+                desired_name: "Local edit".to_owned(),
+                ordered_entry_ids: Vec::new(),
+                ordered_item_ids: Vec::new(),
+                stage: PendingPlaylistProjectionStage::NeedsAttention,
+                base_remote_fingerprint: "fingerprint".to_owned(),
+            },
+        )
+        .unwrap();
+    let mut page = ServerLibraryPage {
+        section: ServerLibrarySection::Playlists,
+        rows: vec![ServerLibraryRow::Playlist(playlist_summary_for_access(
+            Some("alice"),
+            Some("alice"),
+            Some(false),
+        ))],
+        next_offset: None,
+        warning: None,
+    };
+
+    finalize_page_playlist_access(&mut page, &password, &bridge_state);
+
+    let ServerLibraryRow::Playlist(summary) = &page.rows[0] else {
+        panic!("playlist row");
+    };
+    assert_eq!(summary.access, ServerPlaylistAccess::Linked);
+    assert_eq!(
+        summary.link.as_ref().map(|link| link.health),
+        Some(ServerPlaylistLinkHealth::NeedsAttention)
+    );
+}
+
+#[test]
+fn actor_surfaces_current_and_durable_playlist_access_attention() {
+    let password =
+        ServerCredential::password("alice", SecretString::from("server-password".to_owned()))
+            .unwrap();
+    let mut bridge_state = empty_playlist_bridge_state();
+    let local_playlist_id = crate::personal_state::PlaylistId::new("local").unwrap();
+    let mut link = PlaylistLink {
+        local_playlist_id,
+        server_playlist_id: ServerPlaylistId::new("playlist").unwrap(),
+        managed_by_yututui: true,
+        state: PlaylistLinkState::Linked,
+        content_needs_attention: false,
+        shadow: PlaylistShadow {
+            name: "Playlist".to_owned(),
+            occurrences: Vec::new(),
+            verified_at_unix: 100,
+        },
+    };
+    bridge_state.upsert_playlist_link(link.clone()).unwrap();
+
+    for (owner, read_only) in [("mallory", Some(false)), ("alice", None)] {
+        let mut page = ServerLibraryPage {
+            section: ServerLibrarySection::Playlists,
+            rows: vec![ServerLibraryRow::Playlist(playlist_summary_for_access(
+                Some(owner),
+                Some(owner),
+                read_only,
+            ))],
+            next_offset: None,
+            warning: None,
+        };
+
+        finalize_page_playlist_access(&mut page, &password, &bridge_state);
+
+        let ServerLibraryRow::Playlist(summary) = &page.rows[0] else {
+            panic!("playlist row");
+        };
+        assert_eq!(
+            summary.link.as_ref().map(|link| link.health),
+            Some(ServerPlaylistLinkHealth::NeedsAttention)
+        );
+    }
+
+    link.state = PlaylistLinkState::AccessNeedsAttention;
+    bridge_state.upsert_playlist_link(link).unwrap();
+    let mut page = ServerLibraryPage {
+        section: ServerLibrarySection::Playlists,
+        rows: vec![ServerLibraryRow::Playlist(playlist_summary_for_access(
+            Some("alice"),
+            Some("alice"),
+            Some(false),
+        ))],
+        next_offset: None,
+        warning: None,
+    };
+
+    finalize_page_playlist_access(&mut page, &password, &bridge_state);
+
+    let ServerLibraryRow::Playlist(summary) = &page.rows[0] else {
+        panic!("playlist row");
+    };
+    assert_eq!(
+        summary.link.as_ref().map(|link| link.health),
+        Some(ServerPlaylistLinkHealth::NeedsAttention)
+    );
 }
 
 #[test]
@@ -182,6 +540,335 @@ fn setup_input_is_move_only_and_accepts_secret_credential() {
         SetupIdentityIntent::Create,
     );
     assert_eq!(input.identity_intent, SetupIdentityIntent::Create);
+}
+
+#[test]
+fn same_account_update_requires_matching_exact_owner_for_password_candidates() {
+    let previous_password =
+        ServerCredential::password("alice", SecretString::from("old-password".to_owned())).unwrap();
+    let same_password =
+        ServerCredential::password("alice", SecretString::from("new-password".to_owned())).unwrap();
+    let changed_password =
+        ServerCredential::password("bob", SecretString::from("new-password".to_owned())).unwrap();
+    assert_eq!(
+        require_same_account_owner(&previous_password, &same_password),
+        Ok(())
+    );
+    assert_eq!(
+        require_same_account_owner(&previous_password, &changed_password),
+        Err(ServiceError::InvalidSetup)
+    );
+
+    let mut bound_api_key =
+        ServerCredential::api_key(SecretString::from("old-api-key".to_owned())).unwrap();
+    bound_api_key.bind_api_key_username("alice").unwrap();
+    assert_eq!(
+        require_same_account_owner(&bound_api_key, &same_password),
+        Ok(()),
+        "an API-key to password update may preserve scope only with the same exact owner"
+    );
+    let unbound_api_key =
+        ServerCredential::api_key(SecretString::from("legacy-api-key".to_owned())).unwrap();
+    assert_eq!(
+        require_same_account_owner(&unbound_api_key, &same_password),
+        Err(ServiceError::InvalidSetup),
+        "legacy API keys without owner evidence must use Replace"
+    );
+}
+
+#[tokio::test]
+async fn api_key_setup_binds_token_info_owner_without_sending_legacy_username_auth() {
+    let _lifecycle = LIFECYCLE_LOCK.lock().await;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let replies = [
+            (
+                "/rest/getOpenSubsonicExtensions.view?",
+                r#"{"subsonic-response":{"status":"ok","openSubsonicExtensions":[{"name":"apiKeyAuthentication","versions":[1]}]}}"#,
+            ),
+            (
+                "/rest/ping.view?",
+                r#"{"subsonic-response":{"status":"ok","version":"1.16.1"}}"#,
+            ),
+            (
+                "/rest/tokenInfo.view?",
+                r#"{"subsonic-response":{"status":"ok","tokenInfo":{"username":"alice"}}}"#,
+            ),
+        ];
+        for (expected_endpoint, body) in replies {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request_head(&mut stream).await;
+            let target = request
+                .lines()
+                .next()
+                .and_then(|line| line.split_ascii_whitespace().nth(1))
+                .unwrap();
+            assert!(target.starts_with(expected_endpoint), "{target}");
+            if expected_endpoint.contains("tokenInfo") {
+                let query = reqwest::Url::parse(&format!("http://fixture{target}")).unwrap();
+                let fields = query.query_pairs().collect::<Vec<_>>();
+                assert!(
+                    fields
+                        .iter()
+                        .any(|(name, value)| name == "apiKey" && value == "setup-api-key")
+                );
+                assert!(fields.iter().all(|(name, _)| name != "u"));
+            }
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+    let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
+    let root = std::env::temp_dir().join(format!(
+        "yututui-open-subsonic-token-info-{}-{id}",
+        std::process::id()
+    ));
+    crate::util::safe_fs::ensure_private_dir(&root).unwrap();
+    let paths = OpenSubsonicPaths::for_data_root(root.clone());
+    let input = SetupInput::new(
+        "API-key server",
+        format!("http://127.0.0.1:{port}/"),
+        true,
+        None,
+        ServerCredential::api_key(SecretString::from("setup-api-key".to_owned())).unwrap(),
+        SetupIdentityIntent::Create,
+    );
+
+    let prepared = test_and_prepare_setup(&paths, input).await.unwrap();
+    commit_setup(&paths, prepared).unwrap();
+    server.await.unwrap();
+    let stored = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        stored
+            .private_state
+            .credential()
+            .username()
+            .unwrap()
+            .expose_secret(),
+        "alice"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn unbound_api_key_update_cannot_preserve_account_scope_without_token_info() {
+    let _lifecycle = LIFECYCLE_LOCK.lock().await;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let replies = [
+            (
+                "/rest/getOpenSubsonicExtensions.view?",
+                r#"{"subsonic-response":{"status":"ok","openSubsonicExtensions":[]}}"#,
+            ),
+            (
+                "/rest/ping.view?",
+                r#"{"subsonic-response":{"status":"ok","version":"1.16.1"}}"#,
+            ),
+            (
+                "/rest/getOpenSubsonicExtensions.view?",
+                r#"{"subsonic-response":{"status":"ok","openSubsonicExtensions":[]}}"#,
+            ),
+            (
+                "/rest/ping.view?",
+                r#"{"subsonic-response":{"status":"ok","version":"1.16.1"}}"#,
+            ),
+        ];
+        for (expected_endpoint, body) in replies {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request_head(&mut stream).await;
+            let target = request
+                .lines()
+                .next()
+                .and_then(|line| line.split_ascii_whitespace().nth(1))
+                .unwrap();
+            assert!(target.starts_with(expected_endpoint), "{target}");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+    let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
+    let root = std::env::temp_dir().join(format!(
+        "yututui-open-subsonic-unbound-api-key-{}-{id}",
+        std::process::id()
+    ));
+    crate::util::safe_fs::ensure_private_dir(&root).unwrap();
+    let paths = OpenSubsonicPaths::for_data_root(root.clone());
+    let create = SetupInput::new(
+        "Legacy API-key server",
+        format!("http://127.0.0.1:{port}/"),
+        true,
+        None,
+        ServerCredential::api_key(SecretString::from("old-api-key".to_owned())).unwrap(),
+        SetupIdentityIntent::Create,
+    );
+    let initial = commit_setup(
+        &paths,
+        test_and_prepare_setup(&paths, create).await.unwrap(),
+    )
+    .unwrap();
+    let update = SetupInput::new(
+        "Updated API-key server",
+        format!("http://127.0.0.1:{port}/"),
+        true,
+        None,
+        ServerCredential::api_key(SecretString::from("new-api-key".to_owned())).unwrap(),
+        SetupIdentityIntent::UpdateSameServerAndAccount,
+    );
+
+    assert!(matches!(
+        test_and_prepare_setup(&paths, update).await,
+        Err(ServiceError::InvalidSetup)
+    ));
+    server.await.unwrap();
+    let retained = read_status(&paths).unwrap();
+    assert_eq!(retained.backend_id, initial.backend_id);
+    assert_eq!(retained.account_scope_id, initial.account_scope_id);
+    assert_eq!(retained.display_name, initial.display_name);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn same_account_setup_requeues_playlist_access_for_verification_once() {
+    let _lifecycle = LIFECYCLE_LOCK.lock().await;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let replies = [
+            r#"{"subsonic-response":{"status":"ok","openSubsonicExtensions":[]}}"#,
+            r#"{"subsonic-response":{"status":"ok","version":"1.16.1"}}"#,
+            r#"{"subsonic-response":{"status":"ok","openSubsonicExtensions":[]}}"#,
+            r#"{"subsonic-response":{"status":"ok","version":"1.16.1"}}"#,
+        ];
+        for body in replies {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _request = read_request_head(&mut stream).await;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+    let id = NEXT_ROOT.fetch_add(1, Ordering::Relaxed);
+    let root = std::env::temp_dir().join(format!(
+        "yututui-open-subsonic-playlist-requeue-{}-{id}",
+        std::process::id()
+    ));
+    crate::util::safe_fs::ensure_private_dir(&root).unwrap();
+    let paths = OpenSubsonicPaths::for_data_root(root.clone());
+    let create = SetupInput::new(
+        "Test server",
+        format!("http://127.0.0.1:{port}/"),
+        true,
+        None,
+        ServerCredential::password("alice", SecretString::from("old-secret".to_owned())).unwrap(),
+        SetupIdentityIntent::Create,
+    );
+    commit_setup(
+        &paths,
+        test_and_prepare_setup(&paths, create).await.unwrap(),
+    )
+    .unwrap();
+
+    let mut current = load_store_set(&paths).unwrap().unwrap();
+    let expected = current.revisions();
+    let local_playlist_id = crate::personal_state::PlaylistId::new("local").unwrap();
+    current
+        .bridge_state
+        .upsert_playlist_link(PlaylistLink {
+            local_playlist_id: local_playlist_id.clone(),
+            server_playlist_id: ServerPlaylistId::new("playlist").unwrap(),
+            managed_by_yututui: true,
+            state: PlaylistLinkState::AccessNeedsAttention,
+            content_needs_attention: false,
+            shadow: PlaylistShadow {
+                name: "Playlist".to_owned(),
+                occurrences: Vec::new(),
+                verified_at_unix: 100,
+            },
+        })
+        .unwrap();
+    current
+        .bridge_state
+        .queue_playlist_projection(
+            local_playlist_id.clone(),
+            PendingPlaylistProjection {
+                desired_name: "Local edit".to_owned(),
+                ordered_entry_ids: Vec::new(),
+                ordered_item_ids: Vec::new(),
+                stage: PendingPlaylistProjectionStage::NeedsAttention,
+                base_remote_fingerprint: "fingerprint".to_owned(),
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        current
+            .bridge_state
+            .playlist_projections_needing_attention(),
+        1,
+        "link and projection attention for one local playlist are counted once"
+    );
+    commit_store_set(&paths, expected, &mut current).unwrap();
+
+    let update = SetupInput::new(
+        "Updated server",
+        format!("http://127.0.0.1:{port}/"),
+        true,
+        None,
+        ServerCredential::password("alice", SecretString::from("new-secret".to_owned())).unwrap(),
+        SetupIdentityIntent::UpdateSameServerAndAccount,
+    );
+    let prepared = test_and_prepare_setup(&paths, update).await.unwrap();
+    let candidate = prepared.store_set.as_ref().unwrap();
+    assert_eq!(
+        candidate
+            .bridge_state
+            .playlist_link(&local_playlist_id)
+            .map(|link| link.state),
+        Some(PlaylistLinkState::Linked)
+    );
+    assert_eq!(
+        candidate
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&local_playlist_id)
+            .map(|pending| pending.stage),
+        Some(PendingPlaylistProjectionStage::Queued)
+    );
+    assert_eq!(
+        candidate
+            .bridge_state
+            .playlist_projections_needing_attention(),
+        0
+    );
+    commit_setup(&paths, prepared).unwrap();
+    server.await.unwrap();
+
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        durable
+            .bridge_state
+            .playlist_link(&local_playlist_id)
+            .map(|link| link.state),
+        Some(PlaylistLinkState::Linked)
+    );
+    assert_eq!(
+        durable
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&local_playlist_id)
+            .map(|pending| pending.stage),
+        Some(PendingPlaylistProjectionStage::Queued)
+    );
+    let _ = std::fs::remove_dir_all(root);
 }
 
 struct LifecycleFixture {
@@ -498,7 +1185,7 @@ async fn tested_setup_commits_all_stores_and_remove_is_local_only() {
         format!("http://127.0.0.1:{port}/"),
         true,
         None,
-        ServerCredential::api_key(SecretString::from("secret".to_owned())).unwrap(),
+        ServerCredential::password("alice", SecretString::from("secret".to_owned())).unwrap(),
         SetupIdentityIntent::Create,
     );
     let prepared = test_and_prepare_setup(&paths, input).await.unwrap();
@@ -550,7 +1237,8 @@ async fn tested_setup_commits_all_stores_and_remove_is_local_only() {
         format!("http://127.0.0.1:{port}/"),
         true,
         None,
-        ServerCredential::api_key(SecretString::from("updated-secret".to_owned())).unwrap(),
+        ServerCredential::password("alice", SecretString::from("updated-secret".to_owned()))
+            .unwrap(),
         SetupIdentityIntent::UpdateSameServerAndAccount,
     );
     crate::open_subsonic::transaction::fail_after_commit_marker_once_for_test();
@@ -615,7 +1303,8 @@ async fn tested_setup_commits_all_stores_and_remove_is_local_only() {
         format!("http://127.0.0.1:{port}/"),
         true,
         None,
-        ServerCredential::api_key(SecretString::from("replacement-secret".to_owned())).unwrap(),
+        ServerCredential::password("bob", SecretString::from("replacement-secret".to_owned()))
+            .unwrap(),
         SetupIdentityIntent::ReplaceServerOrAccount,
     );
     let replaced = commit_setup(

--- a/src/open_subsonic/auth.rs
+++ b/src/open_subsonic/auth.rs
@@ -89,8 +89,9 @@ mod tests {
 
     #[test]
     fn api_key_auth_excludes_every_legacy_parameter() {
-        let credential =
+        let mut credential =
             ServerCredential::api_key(SecretString::from("api-secret".to_owned())).unwrap();
+        credential.bind_api_key_username("alice").unwrap();
         let auth = AuthParameters::fresh(&credential).unwrap();
         assert_eq!(
             auth.fields(),

--- a/src/open_subsonic/bridge_event.rs
+++ b/src/open_subsonic/bridge_event.rs
@@ -3,9 +3,11 @@
 use std::sync::Arc;
 
 use crate::personal_state::{
-    EngagementKind, Operation, OperationOrigin, PortableTrack, PortableTrackKey, Rating,
+    EngagementKind, ExternalOperationInput, Operation, OperationOrigin, PersonalStateV2,
+    PlaylistId, PortableTrack, PortableTrackKey, Rating,
 };
 
+use super::bridge_store::PendingPlaylistImportPurpose;
 use super::model::{BackendId, ServerSong};
 
 pub type OpenSubsonicBridgeSink = Arc<dyn Fn(OpenSubsonicBridgeImport) + Send + Sync + 'static>;
@@ -39,45 +41,53 @@ pub enum OpenSubsonicBridgeImport {
         artist_key: String,
         observed_at_unix: i64,
     },
+    /// One ordered playlist observation committed by the personal-state owner as a single
+    /// transaction. The outer ID acknowledges the durable bridge queue; every inner ID is the
+    /// stable, replay-safe acknowledgement key for one causal ledger operation.
+    Playlist {
+        operation_id: String,
+        backend_id: BackendId,
+        local_playlist_id: PlaylistId,
+        purpose: PendingPlaylistImportPurpose,
+        operations: Vec<ExternalOperationInput>,
+    },
 }
 
 impl OpenSubsonicBridgeImport {
     pub fn operation_id(&self) -> &str {
         match self {
-            Self::Rating { operation_id, .. } | Self::Engagement { operation_id, .. } => {
-                operation_id
-            }
+            Self::Rating { operation_id, .. }
+            | Self::Engagement { operation_id, .. }
+            | Self::Playlist { operation_id, .. } => operation_id,
         }
     }
 
-    pub fn track(&self) -> &PortableTrack {
+    fn track(&self) -> Option<&PortableTrack> {
         match self {
-            Self::Rating { track, .. } | Self::Engagement { track, .. } => track,
-        }
-    }
-
-    pub fn observed_at_unix(&self) -> i64 {
-        match self {
-            Self::Rating {
-                observed_at_unix, ..
-            }
-            | Self::Engagement {
-                observed_at_unix, ..
-            } => *observed_at_unix,
+            Self::Rating { track, .. } | Self::Engagement { track, .. } => Some(track),
+            Self::Playlist { .. } => None,
         }
     }
 
     pub fn backend_id(&self) -> Result<BackendId, crate::personal_state::PersonalStateError> {
-        let PortableTrackKey::OpenSubsonic { backend_id, .. } = &self.track().key else {
-            return Err(crate::personal_state::PersonalStateError::InvalidOperation(
-                "server bridge import is not an OpenSubsonic track",
-            ));
-        };
-        BackendId::new(backend_id.clone()).map_err(|_| {
-            crate::personal_state::PersonalStateError::InvalidOperation(
-                "server bridge import has an invalid backend",
-            )
-        })
+        match self {
+            Self::Playlist { backend_id, .. } => Ok(backend_id.clone()),
+            Self::Rating { .. } | Self::Engagement { .. } => {
+                let Some(track) = self.track() else {
+                    unreachable!("rating and engagement imports always carry a track");
+                };
+                let PortableTrackKey::OpenSubsonic { backend_id, .. } = &track.key else {
+                    return Err(crate::personal_state::PersonalStateError::InvalidOperation(
+                        "server bridge import is not an OpenSubsonic track",
+                    ));
+                };
+                BackendId::new(backend_id.clone()).map_err(|_| {
+                    crate::personal_state::PersonalStateError::InvalidOperation(
+                        "server bridge import has an invalid backend",
+                    )
+                })
+            }
+        }
     }
 
     pub fn origin(&self) -> Result<OperationOrigin, crate::personal_state::PersonalStateError> {
@@ -86,12 +96,40 @@ impl OpenSubsonicBridgeImport {
         })
     }
 
-    pub fn operation(&self) -> Operation {
+    /// A later local deletion retires an older remote observation instead of letting event-loop
+    /// scheduling turn that stale observation into a causally newer playlist resurrection.
+    pub(crate) fn remote_playlist_is_absent(
+        &self,
+        state: &PersonalStateV2,
+    ) -> Result<bool, crate::personal_state::PersonalStateError> {
+        let Self::Playlist {
+            local_playlist_id,
+            purpose: PendingPlaylistImportPurpose::RemoteObservation,
+            ..
+        } = self
+        else {
+            return Ok(false);
+        };
+        Ok(!crate::personal_state::personal_playlist_snapshots(state)?
+            .iter()
+            .any(|snapshot| snapshot.playlist_id == *local_playlist_id))
+    }
+
+    pub fn external_operations(&self) -> Vec<ExternalOperationInput> {
         match self {
-            Self::Rating { track, rating, .. } => Operation::SetRating {
-                track: track.clone(),
-                rating: *rating,
-            },
+            Self::Rating {
+                operation_id,
+                track,
+                rating,
+                observed_at_unix,
+            } => vec![ExternalOperationInput {
+                acknowledgement_id: operation_id.clone(),
+                operation: Operation::SetRating {
+                    track: track.clone(),
+                    rating: *rating,
+                },
+                recorded_at_unix: *observed_at_unix,
+            }],
             Self::Engagement {
                 operation_id,
                 track,
@@ -99,15 +137,20 @@ impl OpenSubsonicBridgeImport {
                 played_duration_ms,
                 total_duration_ms,
                 artist_key,
-                ..
-            } => Operation::RecordEngagement {
-                event_id: operation_id.clone(),
-                track: track.clone(),
-                engagement: *engagement,
-                played_duration_ms: *played_duration_ms,
-                total_duration_ms: *total_duration_ms,
-                artist_key: artist_key.clone(),
-            },
+                observed_at_unix,
+            } => vec![ExternalOperationInput {
+                acknowledgement_id: operation_id.clone(),
+                operation: Operation::RecordEngagement {
+                    event_id: operation_id.clone(),
+                    track: track.clone(),
+                    engagement: *engagement,
+                    played_duration_ms: *played_duration_ms,
+                    total_duration_ms: *total_duration_ms,
+                    artist_key: artist_key.clone(),
+                },
+                recorded_at_unix: *observed_at_unix,
+            }],
+            Self::Playlist { operations, .. } => operations.clone(),
         }
     }
 }
@@ -187,14 +230,48 @@ mod tests {
             observed_at_unix: 10,
         };
         assert!(matches!(
-            import.operation(),
-            Operation::RecordEngagement { event_id, .. } if event_id == "native-row-7"
+            import.external_operations().as_slice(),
+            [ExternalOperationInput {
+                operation: Operation::RecordEngagement { event_id, .. },
+                ..
+            }] if event_id == "native-row-7"
         ));
         assert_eq!(
             import.origin().unwrap(),
             OperationOrigin::OpenSubsonic {
                 backend_id: "backend".to_owned()
             }
+        );
+    }
+
+    #[test]
+    fn playlist_batch_keeps_individual_acknowledgements_and_explicit_backend() {
+        let import = OpenSubsonicBridgeImport::Playlist {
+            operation_id: "playlist-batch".to_owned(),
+            backend_id: BackendId::new("backend").unwrap(),
+            local_playlist_id: crate::personal_state::PlaylistId::new("playlist").unwrap(),
+            purpose: PendingPlaylistImportPurpose::InitialOrImportCopy,
+            operations: vec![ExternalOperationInput {
+                acknowledgement_id: "playlist-name".to_owned(),
+                operation: Operation::UpsertPlaylist {
+                    playlist_id: crate::personal_state::PlaylistId::new("playlist").unwrap(),
+                    name: "Mix".to_owned(),
+                },
+                recorded_at_unix: 10,
+            }],
+        };
+
+        assert_eq!(import.operation_id(), "playlist-batch");
+        assert_eq!(import.backend_id().unwrap().as_str(), "backend");
+        assert_eq!(
+            import.origin().unwrap(),
+            OperationOrigin::OpenSubsonic {
+                backend_id: "backend".to_owned()
+            }
+        );
+        assert_eq!(
+            import.external_operations()[0].acknowledgement_id,
+            "playlist-name"
         );
     }
 }

--- a/src/open_subsonic/bridge_runtime.rs
+++ b/src/open_subsonic/bridge_runtime.rs
@@ -11,14 +11,14 @@ use sha2::{Digest as _, Sha256};
 
 use super::actor::ServiceError;
 use super::bridge_event::{
-    OpenSubsonicBridgeImport, OpenSubsonicBridgeSink, OpenSubsonicScrobbleKind,
-    portable_server_track,
+    OpenSubsonicBridgeSink, OpenSubsonicScrobbleKind, portable_server_track,
 };
 use super::bridge_store::{
     AggregatePlayShadow, BridgeMutationError, HistoryCursor, MAX_UNCERTAIN_SCROBBLE_READBACKS,
     NativeHistoryHealth, OutboundScrobbleDelivery, OutboundScrobbleEcho, OutboundScrobbleKind,
     PendingEngagementImport, PendingNativeMetadataRow, PendingOutboundScrobble,
-    PendingRatingImport, PendingRatingProjection, PendingRatingProjectionStage, RatingShadow,
+    PendingPlaylistProjectionStage, PendingRatingImport, PendingRatingProjection,
+    PendingRatingProjectionStage, RatingShadow,
 };
 use super::catalog::OpenSubsonicCatalog;
 use super::client::MutationDeliveryError;
@@ -35,7 +35,8 @@ use super::transaction::{
     OpenSubsonicStoreSet, commit_store_set, load_store_set, load_store_set_read_only,
 };
 use crate::personal_state::{
-    EngagementKind, OpenSubsonicRatingWinner, OperationOrigin, PortableTrack, PortableTrackKey,
+    EngagementKind, OpenSubsonicRatingWinner, OperationOrigin, PlaylistId, PortableTrack,
+    PortableTrackKey,
 };
 
 const NATIVE_CURSOR: &str = "navidrome-native";
@@ -46,9 +47,11 @@ const STANDARD_ALBUM_CONCURRENCY: usize = 4;
 const NATIVE_HISTORY_TOTAL_TIMEOUT: Duration = Duration::from_secs(60);
 const STANDARD_HISTORY_TOTAL_TIMEOUT: Duration = Duration::from_secs(30);
 
+mod emission;
 mod history_metadata;
 mod history_support;
 mod outbound_resolution;
+mod playlists;
 
 pub(super) use history_support::completed_history_overlap;
 use history_support::{
@@ -110,12 +113,14 @@ pub(crate) struct BridgeRuntime {
 #[derive(Default)]
 struct RetryCursors {
     lane_after: Option<RetryLane>,
+    playlist_after: Option<PlaylistId>,
     rating_after: Option<ItemId>,
     outbound_after: Option<String>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum RetryLane {
+    Playlist,
     Rating,
     Outbound,
 }
@@ -474,6 +479,7 @@ impl BridgeRuntime {
         store_set
             .bridge_state
             .remove_engagement_import(operation_id);
+        store_set.bridge_state.remove_playlist_import(operation_id);
         if let Err(error) = store_set
             .bridge_state
             .materialize_pending_aggregate_ranges()
@@ -496,6 +502,9 @@ impl BridgeRuntime {
         }
         self.emit_pending(store_set);
         match self.next_retry_lane(store_set) {
+            Some(RetryLane::Playlist) => {
+                self.flush_one_playlist_projection(store_set, client).await
+            }
             Some(RetryLane::Rating) => self.flush_rating_projections(store_set, client).await,
             Some(RetryLane::Outbound) => self.flush_outbound_scrobbles(store_set, client).await,
             None => Ok(()),
@@ -683,16 +692,52 @@ impl BridgeRuntime {
             .outbound_scrobbles()
             .iter()
             .any(|pending| pending.delivery != OutboundScrobbleDelivery::NeedsAttention);
+        // Linked playlists are also periodic read work: a mobile/server edit must reach the
+        // local ledger even when YuTuTui has no pending write.
+        let has_playlist =
+            store_set
+                .bridge_state
+                .playlist_links()
+                .iter()
+                .any(|(playlist_id, link)| {
+                    let pending = store_set
+                        .bridge_state
+                        .pending_playlist_projections()
+                        .get(playlist_id);
+                    let in_flight = pending.is_some_and(|pending| {
+                        matches!(
+                            pending.stage,
+                            PendingPlaylistProjectionStage::Ambiguous
+                                | PendingPlaylistProjectionStage::Readback
+                        )
+                    });
+                    link.state == super::bridge_store::PlaylistLinkState::Linked
+                        && (!link.content_needs_attention || in_flight)
+                        && store_set
+                            .bridge_state
+                            .pending_playlist_import(playlist_id)
+                            .is_none()
+                        && pending.is_none_or(|pending| {
+                            pending.stage != PendingPlaylistProjectionStage::NeedsAttention
+                        })
+                });
         let mut cursors = self
             .retry_cursors
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let order = if cursors.lane_after == Some(RetryLane::Rating) {
-            [RetryLane::Outbound, RetryLane::Rating]
-        } else {
-            [RetryLane::Rating, RetryLane::Outbound]
+        let order = match cursors.lane_after {
+            Some(RetryLane::Playlist) => {
+                [RetryLane::Rating, RetryLane::Outbound, RetryLane::Playlist]
+            }
+            Some(RetryLane::Rating) => {
+                [RetryLane::Outbound, RetryLane::Playlist, RetryLane::Rating]
+            }
+            Some(RetryLane::Outbound) | None => {
+                [RetryLane::Playlist, RetryLane::Rating, RetryLane::Outbound]
+            }
         };
         let selected = order.into_iter().find(|lane| match lane {
+            RetryLane::Playlist => has_playlist,
             RetryLane::Rating => has_rating,
             RetryLane::Outbound => has_outbound,
         });
@@ -1071,38 +1116,6 @@ impl BridgeRuntime {
 
         store_set.bridge_state = before;
         Err(error.into())
-    }
-
-    pub(crate) fn emit_pending(&self, store_set: &OpenSubsonicStoreSet) {
-        let Some(sink) = &self.sink else {
-            return;
-        };
-        let ratings = store_set.bridge_state.pending_rating_imports().iter().map(
-            |(operation_id, pending)| OpenSubsonicBridgeImport::Rating {
-                operation_id: operation_id.clone(),
-                track: pending.track.clone(),
-                rating: pending.mapped,
-                observed_at_unix: pending.observed_at_unix,
-            },
-        );
-        let engagements = store_set
-            .bridge_state
-            .pending_engagement_imports()
-            .iter()
-            .map(
-                |(operation_id, pending)| OpenSubsonicBridgeImport::Engagement {
-                    operation_id: operation_id.clone(),
-                    track: pending.track.clone(),
-                    engagement: pending.engagement,
-                    played_duration_ms: pending.played_duration_ms,
-                    total_duration_ms: pending.total_duration_ms,
-                    artist_key: pending.artist_key.clone(),
-                    observed_at_unix: pending.observed_at_unix,
-                },
-            );
-        for event in ratings.chain(engagements) {
-            sink(event);
-        }
     }
 }
 

--- a/src/open_subsonic/bridge_runtime/emission.rs
+++ b/src/open_subsonic/bridge_runtime/emission.rs
@@ -1,0 +1,50 @@
+//! Replay durable imports to the current personal-state owner.
+
+use super::super::bridge_event::OpenSubsonicBridgeImport;
+use super::super::transaction::OpenSubsonicStoreSet;
+use super::BridgeRuntime;
+
+impl BridgeRuntime {
+    pub(crate) fn emit_pending(&self, store_set: &OpenSubsonicStoreSet) {
+        let Some(sink) = &self.sink else {
+            return;
+        };
+        let ratings = store_set.bridge_state.pending_rating_imports().iter().map(
+            |(operation_id, pending)| OpenSubsonicBridgeImport::Rating {
+                operation_id: operation_id.clone(),
+                track: pending.track.clone(),
+                rating: pending.mapped,
+                observed_at_unix: pending.observed_at_unix,
+            },
+        );
+        let engagements = store_set
+            .bridge_state
+            .pending_engagement_imports()
+            .iter()
+            .map(
+                |(operation_id, pending)| OpenSubsonicBridgeImport::Engagement {
+                    operation_id: operation_id.clone(),
+                    track: pending.track.clone(),
+                    engagement: pending.engagement,
+                    played_duration_ms: pending.played_duration_ms,
+                    total_duration_ms: pending.total_duration_ms,
+                    artist_key: pending.artist_key.clone(),
+                    observed_at_unix: pending.observed_at_unix,
+                },
+            );
+        let playlists = store_set
+            .bridge_state
+            .pending_playlist_imports()
+            .values()
+            .map(|pending| OpenSubsonicBridgeImport::Playlist {
+                operation_id: pending.operation_id.clone(),
+                backend_id: store_set.profile.backend_id().clone(),
+                local_playlist_id: pending.local_playlist_id.clone(),
+                purpose: pending.purpose,
+                operations: pending.operations.clone(),
+            });
+        for event in ratings.chain(engagements).chain(playlists) {
+            sink(event);
+        }
+    }
+}

--- a/src/open_subsonic/bridge_runtime/playlists.rs
+++ b/src/open_subsonic/bridge_runtime/playlists.rs
@@ -1,0 +1,1412 @@
+//! Durable linked-playlist projection and remote-observation lifecycle.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use age::secrecy::ExposeSecret as _;
+use data_encoding::HEXLOWER;
+use sha2::{Digest as _, Sha256};
+
+use super::super::actor::ServiceError;
+use super::super::bridge_event::portable_server_track;
+use super::super::bridge_store::{
+    BridgeMutationError, PendingPlaylistCreate, PendingPlaylistImportBatch,
+    PendingPlaylistImportPurpose, PendingPlaylistProjection, PendingPlaylistProjectionStage,
+    PlaylistLink, PlaylistLinkState, PlaylistShadow, PlaylistShadowOccurrence,
+};
+use super::super::client::{MutationDeliveryError, OpenSubsonicClient};
+use super::super::linked_playlists::{
+    LinkedPlaylistEntry, PendingMergeOccurrence, PendingRemoteMergeMode, PendingRemoteOccurrence,
+    plan_pending_remote_merge, plan_remote_delta, plan_remote_update,
+};
+use super::super::model::{ItemId, OpenSubsonicItemRef, ServerPlaylistWriteSnapshot};
+use super::super::private_store::ServerCredential;
+use super::super::transaction::OpenSubsonicStoreSet;
+use super::BridgeRuntime;
+use crate::personal_state::{
+    ExternalOperationInput, Operation, PersonalPlaylistSnapshot, PlaylistEntryId, PlaylistId,
+    PortableTrackKey,
+};
+
+impl BridgeRuntime {
+    pub(crate) fn begin_playlist_create(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        pending: PendingPlaylistCreate,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Err(ServiceError::InvalidSetup);
+        }
+        let before = store_set.bridge_state.clone();
+        if let Err(error) = store_set.bridge_state.queue_playlist_create(pending) {
+            store_set.bridge_state = before;
+            return Err(error.into());
+        }
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    pub(crate) fn record_playlist_create_server_id(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        playlist_id: &PlaylistId,
+        server_playlist_id: super::super::model::ServerPlaylistId,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Err(ServiceError::InvalidSetup);
+        }
+        let before = store_set.bridge_state.clone();
+        if let Err(error) = store_set
+            .bridge_state
+            .record_playlist_create_server_id(playlist_id, server_playlist_id)
+        {
+            store_set.bridge_state = before;
+            return Err(error.into());
+        }
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    pub(crate) fn cancel_playlist_create(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        playlist_id: &PlaylistId,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Err(ServiceError::InvalidSetup);
+        }
+        let before = store_set.bridge_state.clone();
+        if store_set
+            .bridge_state
+            .remove_playlist_create(playlist_id)
+            .is_none()
+        {
+            return Err(ServiceError::InvalidSetup);
+        }
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    pub(crate) fn commit_playlist_preview(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        pending_import: PendingPlaylistImportBatch,
+        link: Option<PlaylistLink>,
+        projection: Option<PendingPlaylistProjection>,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Err(ServiceError::InvalidSetup);
+        }
+        let before = store_set.bridge_state.clone();
+        let mutation = (|| {
+            store_set
+                .bridge_state
+                .queue_playlist_import(pending_import)?;
+            if let Some(link) = link {
+                let local_playlist_id = link.local_playlist_id.clone();
+                store_set.bridge_state.upsert_playlist_link(link)?;
+                if let Some(projection) = projection {
+                    store_set
+                        .bridge_state
+                        .queue_playlist_projection(local_playlist_id, projection)?;
+                }
+            } else if projection.is_some() {
+                return Err(BridgeMutationError::InvalidEntry);
+            }
+            Ok::<(), BridgeMutationError>(())
+        })();
+        if let Err(error) = mutation {
+            store_set.bridge_state = before;
+            return Err(error.into());
+        }
+        self.persist_or_restore(store_set, before)?;
+        self.emit_pending(store_set);
+        Ok(())
+    }
+
+    pub(crate) fn commit_created_playlist_link(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        link: PlaylistLink,
+        current_snapshot: &PersonalPlaylistSnapshot,
+        replace_missing: bool,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Err(ServiceError::InvalidSetup);
+        }
+        if current_snapshot.playlist_id != link.local_playlist_id {
+            return Err(ServiceError::InvalidSetup);
+        }
+        let (current_entry_ids, current_item_ids) =
+            exact_local_occurrences(store_set, current_snapshot)?;
+        let current_matches_created_shadow = link.shadow.name == current_snapshot.name
+            && link.shadow.occurrences.len() == current_entry_ids.len()
+            && link
+                .shadow
+                .occurrences
+                .iter()
+                .zip(current_entry_ids.iter().zip(&current_item_ids))
+                .all(|(shadow, (entry_id, item_id))| {
+                    &shadow.entry_id == entry_id && &shadow.item_id == item_id
+                });
+        let follow_up_projection =
+            (!current_matches_created_shadow).then(|| PendingPlaylistProjection {
+                desired_name: current_snapshot.name.clone(),
+                ordered_entry_ids: current_entry_ids,
+                ordered_item_ids: current_item_ids,
+                stage: PendingPlaylistProjectionStage::Queued,
+                base_remote_fingerprint: shadow_fingerprint(store_set, &link),
+            });
+        let before = store_set.bridge_state.clone();
+        let local_playlist_id = link.local_playlist_id.clone();
+        let mutation = (|| {
+            let pending_create = store_set
+                .bridge_state
+                .remove_playlist_create(&local_playlist_id);
+            if let Some(pending) = &pending_create
+                && (pending.created_server_playlist_id.as_ref() != Some(&link.server_playlist_id)
+                    || pending.expected_missing_server_id.is_some() != replace_missing)
+            {
+                return Err(BridgeMutationError::ConflictingEntry);
+            }
+            if replace_missing {
+                let replaceable = store_set
+                    .bridge_state
+                    .playlist_link(&local_playlist_id)
+                    .is_some_and(|existing| existing.state == PlaylistLinkState::ServerMissing);
+                if !replaceable {
+                    return Err(BridgeMutationError::ConflictingEntry);
+                }
+                store_set
+                    .bridge_state
+                    .remove_playlist_projection(&local_playlist_id);
+                store_set
+                    .bridge_state
+                    .remove_playlist_link(&local_playlist_id);
+            }
+            store_set.bridge_state.upsert_playlist_link(link)?;
+            if let Some(projection) = follow_up_projection {
+                store_set
+                    .bridge_state
+                    .queue_playlist_projection(local_playlist_id, projection)?;
+            }
+            Ok::<(), BridgeMutationError>(())
+        })();
+        if let Err(error) = mutation {
+            store_set.bridge_state = before;
+            return Err(error.into());
+        }
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    pub(crate) fn unlink_playlist(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        playlist_id: &PlaylistId,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Err(ServiceError::InvalidSetup);
+        }
+        let before = store_set.bridge_state.clone();
+        store_set
+            .bridge_state
+            .remove_playlist_projection(playlist_id);
+        store_set.bridge_state.remove_playlist_create(playlist_id);
+        if store_set
+            .bridge_state
+            .remove_playlist_link(playlist_id)
+            .is_none()
+        {
+            store_set.bridge_state = before;
+            return Err(ServiceError::InvalidSetup);
+        }
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    pub(crate) fn commit_deleted_playlist(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        link: &PlaylistLink,
+        operation_id: String,
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Err(ServiceError::InvalidSetup);
+        }
+        let before = store_set.bridge_state.clone();
+        let mutation = (|| {
+            // The explicit delete is causally newer than every unacknowledged observation for
+            // this local playlist. Retire the older batch in the same bridge-store transaction so
+            // lexical BTree ordering or restart replay can never resurrect it before the delete.
+            store_set
+                .bridge_state
+                .retire_playlist_import(&link.local_playlist_id);
+            store_set
+                .bridge_state
+                .queue_playlist_import(PendingPlaylistImportBatch {
+                    operation_id: operation_id.clone(),
+                    local_playlist_id: link.local_playlist_id.clone(),
+                    purpose: PendingPlaylistImportPurpose::Delete,
+                    operations: vec![ExternalOperationInput {
+                        acknowledgement_id: format!("{operation_id}-delete"),
+                        operation: Operation::DeletePlaylist {
+                            playlist_id: link.local_playlist_id.clone(),
+                            deleted: true,
+                        },
+                        recorded_at_unix: crate::signals::unix_now(),
+                    }],
+                })?;
+            store_set
+                .bridge_state
+                .remove_playlist_projection(&link.local_playlist_id);
+            store_set
+                .bridge_state
+                .remove_playlist_create(&link.local_playlist_id);
+            let removed = store_set
+                .bridge_state
+                .remove_playlist_link(&link.local_playlist_id)
+                .ok_or(BridgeMutationError::ConflictingEntry)?;
+            if removed.server_playlist_id != link.server_playlist_id {
+                return Err(BridgeMutationError::ConflictingEntry);
+            }
+            Ok::<(), BridgeMutationError>(())
+        })();
+        if let Err(error) = mutation {
+            store_set.bridge_state = before;
+            return Err(error.into());
+        }
+        self.persist_or_restore(store_set, before)?;
+        self.emit_pending(store_set);
+        Ok(())
+    }
+
+    /// Queue the canonical local winners for linked server projection.
+    ///
+    /// A missing local playlist uses the documented safe default: unlink it while leaving the
+    /// server copy untouched. A projection already in an ambiguous/readback stage is never
+    /// replaced; after its readback settles, the latest local snapshot queues a follow-up.
+    pub(crate) fn reconcile_linked_playlists(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        snapshots: &[PersonalPlaylistSnapshot],
+    ) -> Result<(), ServiceError> {
+        if !self.is_writable() {
+            return Err(ServiceError::InvalidSetup);
+        }
+        let by_id = snapshots
+            .iter()
+            .map(|snapshot| (&snapshot.playlist_id, snapshot))
+            .collect::<BTreeMap<_, _>>();
+        let before = store_set.bridge_state.clone();
+        let links = store_set
+            .bridge_state
+            .playlist_links()
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mutation = (|| {
+            for link in links {
+                let snapshot = by_id.get(&link.local_playlist_id).copied();
+                if let Some(pending) = store_set
+                    .bridge_state
+                    .pending_playlist_import(&link.local_playlist_id)
+                    .cloned()
+                {
+                    match (snapshot, pending.purpose) {
+                        // Until the owner acknowledges the initial merge, absence is not evidence
+                        // of deletion and the pre-import snapshot is not a new local winner.
+                        (_, PendingPlaylistImportPurpose::InitialOrImportCopy) | (Some(_), _) => {
+                            continue;
+                        }
+                        // The owner has no current local playlist despite a later remote
+                        // observation. Treat that as the explicit/current local deletion: discard
+                        // the stale observation and unlink while keeping the server copy.
+                        (None, PendingPlaylistImportPurpose::RemoteObservation) => {
+                            store_set
+                                .bridge_state
+                                .retire_playlist_import(&link.local_playlist_id);
+                            store_set
+                                .bridge_state
+                                .remove_playlist_projection(&link.local_playlist_id);
+                            store_set
+                                .bridge_state
+                                .remove_playlist_create(&link.local_playlist_id);
+                            store_set
+                                .bridge_state
+                                .remove_playlist_link(&link.local_playlist_id);
+                            continue;
+                        }
+                        // A delete batch should already have atomically removed its link. If an
+                        // older/corrupt in-memory caller presents both, never advance either side.
+                        (None, PendingPlaylistImportPurpose::Delete) => continue,
+                    }
+                }
+                let Some(snapshot) = snapshot else {
+                    store_set
+                        .bridge_state
+                        .remove_playlist_projection(&link.local_playlist_id);
+                    store_set
+                        .bridge_state
+                        .remove_playlist_create(&link.local_playlist_id);
+                    store_set
+                        .bridge_state
+                        .remove_playlist_link(&link.local_playlist_id);
+                    continue;
+                };
+                if link.state == PlaylistLinkState::ServerMissing {
+                    continue;
+                }
+                let in_flight_projection = store_set
+                    .bridge_state
+                    .pending_playlist_projections()
+                    .get(&link.local_playlist_id)
+                    .is_some_and(|pending| {
+                        matches!(
+                            pending.stage,
+                            PendingPlaylistProjectionStage::Ambiguous
+                                | PendingPlaylistProjectionStage::Readback
+                        )
+                    });
+                let (entry_ids, item_ids) = match exact_local_occurrences(store_set, snapshot) {
+                    Ok(occurrences) => occurrences,
+                    Err(_) => {
+                        let mut attention = link.clone();
+                        attention.content_needs_attention = true;
+                        store_set.bridge_state.upsert_playlist_link(attention)?;
+                        // First settle a write that may already be on the server. The independent
+                        // content bit keeps status red without abandoning or replacing its
+                        // ambiguous/readback record.
+                        if in_flight_projection {
+                            continue;
+                        }
+                        if store_set
+                            .bridge_state
+                            .pending_playlist_projections()
+                            .get(&link.local_playlist_id)
+                            .is_some_and(|pending| {
+                                matches!(
+                                    pending.stage,
+                                    PendingPlaylistProjectionStage::Queued
+                                        | PendingPlaylistProjectionStage::NeedsAttention
+                                )
+                            })
+                        {
+                            store_set
+                                .bridge_state
+                                .remove_playlist_projection(&link.local_playlist_id);
+                        }
+                        continue;
+                    }
+                };
+                if link.content_needs_attention {
+                    let mut recovered = link.clone();
+                    recovered.content_needs_attention = false;
+                    store_set.bridge_state.upsert_playlist_link(recovered)?;
+                }
+                let matches_shadow = link.shadow.name == snapshot.name
+                    && link.shadow.occurrences.len() == entry_ids.len()
+                    && link
+                        .shadow
+                        .occurrences
+                        .iter()
+                        .zip(entry_ids.iter().zip(&item_ids))
+                        .all(|(shadow, (entry_id, item_id))| {
+                            &shadow.entry_id == entry_id && &shadow.item_id == item_id
+                        });
+                let existing = store_set
+                    .bridge_state
+                    .pending_playlist_projections()
+                    .get(&link.local_playlist_id)
+                    .cloned();
+                if matches_shadow {
+                    if existing.is_some_and(|pending| {
+                        matches!(
+                            pending.stage,
+                            PendingPlaylistProjectionStage::Queued
+                                | PendingPlaylistProjectionStage::NeedsAttention
+                        )
+                    }) {
+                        store_set
+                            .bridge_state
+                            .remove_playlist_projection(&link.local_playlist_id);
+                    }
+                    continue;
+                }
+                let pending = PendingPlaylistProjection {
+                    desired_name: snapshot.name.clone(),
+                    ordered_entry_ids: entry_ids,
+                    ordered_item_ids: item_ids,
+                    stage: PendingPlaylistProjectionStage::Queued,
+                    base_remote_fingerprint: shadow_fingerprint(store_set, &link),
+                };
+                if let Some(existing) = existing {
+                    if existing.stage != PendingPlaylistProjectionStage::Queued {
+                        continue;
+                    }
+                    store_set
+                        .bridge_state
+                        .remove_playlist_projection(&link.local_playlist_id);
+                }
+                store_set
+                    .bridge_state
+                    .queue_playlist_projection(link.local_playlist_id, pending)?;
+            }
+            Ok::<(), ServiceError>(())
+        })();
+        if let Err(error) = mutation {
+            store_set.bridge_state = before;
+            return Err(error);
+        }
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    pub(crate) async fn flush_one_playlist_projection(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        client: &OpenSubsonicClient,
+    ) -> Result<(), ServiceError> {
+        let Some((playlist_id, pending)) = self.next_playlist_work(store_set) else {
+            return Ok(());
+        };
+        let Some(link) = store_set.bridge_state.playlist_link(&playlist_id).cloned() else {
+            let before = store_set.bridge_state.clone();
+            store_set
+                .bridge_state
+                .remove_playlist_projection(&playlist_id);
+            self.persist_or_restore(store_set, before)?;
+            return Ok(());
+        };
+        let remote = match client
+            .get_playlist_write_snapshot(
+                store_set.private_state.credential(),
+                &link.server_playlist_id,
+            )
+            .await
+        {
+            Ok(remote) => remote,
+            Err(super::super::ServerError::NotFound) => {
+                return self.mark_server_playlist_missing(store_set, link);
+            }
+            Err(error) if pending.is_some() && playlist_projection_error_needs_attention(error) => {
+                return self.mark_playlist_projection_attention(
+                    store_set,
+                    &playlist_id,
+                    pending.expect("pending projection was checked"),
+                );
+            }
+            Err(error) => return Err(error.into()),
+        };
+
+        let remote_changed = super::super::actor::playlist_snapshot_fingerprint(&remote)
+            != shadow_fingerprint(store_set, &link);
+        if !has_exact_playlist_write_access(&remote, store_set.private_state.credential()) {
+            if remote_changed {
+                if let Some(pending) = pending {
+                    return self.observe_pending_remote_playlist(
+                        store_set,
+                        link,
+                        pending,
+                        remote,
+                        PlaylistLinkState::AccessNeedsAttention,
+                    );
+                }
+                return self.observe_changed_remote_playlist(
+                    store_set,
+                    link,
+                    remote,
+                    PlaylistLinkState::AccessNeedsAttention,
+                );
+            }
+            if pending
+                .as_ref()
+                .is_some_and(|pending| playlist_readback_matches(pending, &remote))
+            {
+                return self.settle_playlist_readback(
+                    store_set,
+                    link,
+                    pending.expect("pending projection was checked"),
+                    remote,
+                );
+            }
+            return self.mark_playlist_link_access_attention(store_set, link);
+        }
+
+        let Some(pending) = pending else {
+            if remote_changed || link.state == PlaylistLinkState::ServerMissing {
+                return self.observe_changed_remote_playlist(
+                    store_set,
+                    link,
+                    remote,
+                    PlaylistLinkState::Linked,
+                );
+            }
+            return Ok(());
+        };
+
+        // A changed readback is always merged using the durable delivery stage. In particular,
+        // Queued means the local write was not sent, even when equal item IDs happen to exist on
+        // both sides; those are distinct occurrences.
+        if remote_changed {
+            return self.observe_pending_remote_playlist(
+                store_set,
+                link,
+                pending,
+                remote,
+                PlaylistLinkState::Linked,
+            );
+        }
+        if playlist_readback_matches(&pending, &remote) {
+            return self.settle_playlist_readback(store_set, link, pending, remote);
+        }
+        if pending.stage != PendingPlaylistProjectionStage::Queued {
+            return self.settle_playlist_readback(store_set, link, pending, remote);
+        }
+
+        let current = remote
+            .entries()
+            .iter()
+            .map(|song| song.item.item_id().clone())
+            .collect::<Vec<_>>();
+        let update = plan_remote_update(&current, &pending.ordered_item_ids)
+            .map_err(|_| ServiceError::InvalidSetup)?;
+        let additions = update
+            .append_item_ids()
+            .iter()
+            .cloned()
+            .map(|item_id| {
+                OpenSubsonicItemRef::new(
+                    store_set.profile.backend_id().clone(),
+                    store_set.profile.account_scope_id().clone(),
+                    item_id,
+                )
+            })
+            .collect::<Vec<_>>();
+        let removals = update
+            .remove_indexes_descending()
+            .iter()
+            .copied()
+            .map(u32::try_from)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| ServiceError::InvalidSetup)?;
+        let desired_name =
+            (pending.desired_name != remote.name()).then_some(pending.desired_name.as_str());
+        let delivery = if link.managed_by_yututui {
+            client
+                .update_managed_playlist(
+                    store_set.private_state.credential(),
+                    &remote,
+                    desired_name,
+                    &additions,
+                    &removals,
+                )
+                .await
+        } else {
+            client
+                .update_playlist(
+                    store_set.private_state.credential(),
+                    &remote,
+                    desired_name,
+                    &additions,
+                    &removals,
+                )
+                .await
+        };
+        match delivery {
+            Ok(()) => {
+                self.set_playlist_projection_stage(
+                    store_set,
+                    &playlist_id,
+                    pending.clone(),
+                    PendingPlaylistProjectionStage::Readback,
+                )?;
+            }
+            Err(MutationDeliveryError::DefinitelyNotApplied(error))
+                if playlist_projection_error_needs_attention(error) =>
+            {
+                return self.mark_playlist_projection_attention(store_set, &playlist_id, pending);
+            }
+            Err(MutationDeliveryError::DefinitelyNotApplied(error)) => return Err(error.into()),
+            Err(MutationDeliveryError::Ambiguous(_)) => {
+                self.set_playlist_projection_stage(
+                    store_set,
+                    &playlist_id,
+                    pending,
+                    PendingPlaylistProjectionStage::Ambiguous,
+                )?;
+                return Ok(());
+            }
+        }
+
+        let readback = client
+            .get_playlist_write_snapshot(
+                store_set.private_state.credential(),
+                &link.server_playlist_id,
+            )
+            .await?;
+        let current_pending = store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&playlist_id)
+            .cloned()
+            .ok_or(ServiceError::InvalidSetup)?;
+        self.settle_playlist_readback(store_set, link, current_pending, readback)
+    }
+
+    fn next_playlist_work(
+        &self,
+        store_set: &OpenSubsonicStoreSet,
+    ) -> Option<(PlaylistId, Option<PendingPlaylistProjection>)> {
+        let mut cursors = self
+            .retry_cursors
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let after = cursors.playlist_after.as_ref();
+        let links = store_set.bridge_state.playlist_links();
+        let is_active = |playlist_id: &PlaylistId, link: &PlaylistLink| {
+            let pending = store_set
+                .bridge_state
+                .pending_playlist_projections()
+                .get(playlist_id);
+            let in_flight = pending.is_some_and(|pending| {
+                matches!(
+                    pending.stage,
+                    PendingPlaylistProjectionStage::Ambiguous
+                        | PendingPlaylistProjectionStage::Readback
+                )
+            });
+            link.state == PlaylistLinkState::Linked
+                && (!link.content_needs_attention || in_flight)
+                && store_set
+                    .bridge_state
+                    .pending_playlist_import(playlist_id)
+                    .is_none()
+                && pending.is_none_or(|pending| {
+                    pending.stage != PendingPlaylistProjectionStage::NeedsAttention
+                })
+        };
+        let selected = links
+            .iter()
+            .filter(|(playlist_id, link)| is_active(playlist_id, link))
+            .find(|(playlist_id, _)| after.is_none_or(|after| *playlist_id > after))
+            .or_else(|| {
+                links
+                    .iter()
+                    .find(|(playlist_id, link)| is_active(playlist_id, link))
+            })
+            .map(|(playlist_id, _)| {
+                (
+                    playlist_id.clone(),
+                    store_set
+                        .bridge_state
+                        .pending_playlist_projections()
+                        .get(playlist_id)
+                        .cloned(),
+                )
+            });
+        if let Some((playlist_id, _)) = &selected {
+            cursors.playlist_after = Some(playlist_id.clone());
+        }
+        selected
+    }
+
+    fn mark_playlist_projection_attention(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        playlist_id: &PlaylistId,
+        pending: PendingPlaylistProjection,
+    ) -> Result<(), ServiceError> {
+        tracing::warn!("linked music server playlist needs review before it can be updated");
+        self.set_playlist_projection_stage(
+            store_set,
+            playlist_id,
+            pending,
+            PendingPlaylistProjectionStage::NeedsAttention,
+        )
+    }
+
+    fn mark_playlist_link_access_attention(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        mut link: PlaylistLink,
+    ) -> Result<(), ServiceError> {
+        tracing::warn!("linked music server playlist access needs review");
+        let before = store_set.bridge_state.clone();
+        link.state = PlaylistLinkState::AccessNeedsAttention;
+        store_set.bridge_state.upsert_playlist_link(link)?;
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    fn settle_playlist_readback(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        mut link: PlaylistLink,
+        pending: PendingPlaylistProjection,
+        remote: ServerPlaylistWriteSnapshot,
+    ) -> Result<(), ServiceError> {
+        let final_state =
+            if has_exact_playlist_write_access(&remote, store_set.private_state.credential()) {
+                PlaylistLinkState::Linked
+            } else {
+                PlaylistLinkState::AccessNeedsAttention
+            };
+        let readback_matches = playlist_readback_matches(&pending, &remote);
+        if readback_matches {
+            let before = store_set.bridge_state.clone();
+            let local_playlist_id = link.local_playlist_id.clone();
+            link.state = final_state;
+            link.shadow = PlaylistShadow {
+                name: pending.desired_name,
+                occurrences: pending
+                    .ordered_entry_ids
+                    .into_iter()
+                    .zip(pending.ordered_item_ids)
+                    .map(|(entry_id, item_id)| PlaylistShadowOccurrence { entry_id, item_id })
+                    .collect(),
+                verified_at_unix: crate::signals::unix_now(),
+            };
+            store_set.bridge_state.upsert_playlist_link(link)?;
+            store_set
+                .bridge_state
+                .remove_playlist_projection(&local_playlist_id);
+            self.persist_or_restore(store_set, before)?;
+            return Ok(());
+        }
+
+        let readback_fingerprint = super::super::actor::playlist_snapshot_fingerprint(&remote);
+        if final_state == PlaylistLinkState::AccessNeedsAttention {
+            if readback_fingerprint != pending.base_remote_fingerprint {
+                return self.observe_pending_remote_playlist(
+                    store_set,
+                    link,
+                    pending,
+                    remote,
+                    final_state,
+                );
+            }
+            return self.mark_playlist_link_access_attention(store_set, link);
+        }
+        if readback_fingerprint == pending.base_remote_fingerprint
+            && pending.stage == PendingPlaylistProjectionStage::Ambiguous
+        {
+            return self.set_playlist_projection_stage(
+                store_set,
+                &link.local_playlist_id,
+                pending,
+                PendingPlaylistProjectionStage::Queued,
+            );
+        }
+        if readback_fingerprint != pending.base_remote_fingerprint {
+            return self.observe_pending_remote_playlist(
+                store_set,
+                link,
+                pending,
+                remote,
+                PlaylistLinkState::Linked,
+            );
+        }
+        Err(ServiceError::Server(
+            super::super::ServerError::InvalidResponse,
+        ))
+    }
+
+    fn set_playlist_projection_stage(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        playlist_id: &PlaylistId,
+        mut pending: PendingPlaylistProjection,
+        stage: PendingPlaylistProjectionStage,
+    ) -> Result<(), ServiceError> {
+        let before = store_set.bridge_state.clone();
+        pending.stage = stage;
+        store_set
+            .bridge_state
+            .replace_playlist_projection(playlist_id, pending)?;
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    fn mark_server_playlist_missing(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        mut link: PlaylistLink,
+    ) -> Result<(), ServiceError> {
+        let before = store_set.bridge_state.clone();
+        link.state = PlaylistLinkState::ServerMissing;
+        store_set
+            .bridge_state
+            .remove_playlist_projection(&link.local_playlist_id);
+        store_set.bridge_state.upsert_playlist_link(link)?;
+        self.persist_or_restore(store_set, before)?;
+        Ok(())
+    }
+
+    pub(crate) fn restore_reappeared_playlist(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        link: PlaylistLink,
+        remote: ServerPlaylistWriteSnapshot,
+    ) -> Result<(), ServiceError> {
+        if link.state != PlaylistLinkState::ServerMissing || link.server_playlist_id != *remote.id()
+        {
+            return Err(ServiceError::InvalidSetup);
+        }
+        self.observe_changed_remote_playlist(store_set, link, remote, PlaylistLinkState::Linked)
+    }
+
+    fn observe_pending_remote_playlist(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        mut link: PlaylistLink,
+        pending: PendingPlaylistProjection,
+        remote: ServerPlaylistWriteSnapshot,
+        final_state: PlaylistLinkState,
+    ) -> Result<(), ServiceError> {
+        let previous = link
+            .shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| {
+                LinkedPlaylistEntry::new(occurrence.entry_id.clone(), occurrence.item_id.clone())
+            })
+            .collect::<Vec<_>>();
+        let desired = pending
+            .ordered_entry_ids
+            .iter()
+            .cloned()
+            .zip(pending.ordered_item_ids.iter().cloned())
+            .map(|(entry_id, item_id)| LinkedPlaylistEntry::new(entry_id, item_id))
+            .collect::<Vec<_>>();
+        let current = remote
+            .entries()
+            .iter()
+            .map(|song| song.item.item_id().clone())
+            .collect::<Vec<_>>();
+        let mode = pending_remote_merge_mode(pending.stage)?;
+        let plan = plan_pending_remote_merge(&previous, &desired, &current, mode)
+            .map_err(|_| ServiceError::InvalidSetup)?;
+        let merged_name = pending_remote_merge_name(
+            &link.shadow.name,
+            &pending.desired_name,
+            remote.name(),
+            mode,
+        )
+        .to_owned();
+        let fingerprint = super::super::actor::playlist_snapshot_fingerprint(&remote);
+        let observation_revision = store_set.bridge_state.revision().saturating_add(1);
+
+        let mut entry_by_remote = BTreeMap::new();
+        for occurrence in plan.remote_occurrences() {
+            let (remote_index, entry_id) = match occurrence {
+                PendingRemoteOccurrence::Existing(existing) => {
+                    (existing.remote_index, existing.entry.entry_id.clone())
+                }
+                PendingRemoteOccurrence::RemoteOnly(remote_only) => (
+                    remote_only.index,
+                    remote_entry_id(
+                        &link.local_playlist_id,
+                        &fingerprint,
+                        observation_revision,
+                        remote_only.index,
+                        &remote_only.item_id,
+                    )?,
+                ),
+            };
+            entry_by_remote.insert(remote_index, entry_id);
+        }
+        let remote_entry_ids = (0..current.len())
+            .map(|index| {
+                entry_by_remote
+                    .get(&index)
+                    .cloned()
+                    .ok_or(ServiceError::InvalidSetup)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut remote_position_in_merged = BTreeMap::new();
+        let merged_entry_ids = plan
+            .ordered_occurrences()
+            .iter()
+            .enumerate()
+            .map(|(merged_index, occurrence)| match occurrence {
+                PendingMergeOccurrence::Existing(existing) => Ok(existing.entry.entry_id.clone()),
+                PendingMergeOccurrence::RemoteOnly(remote_only) => {
+                    remote_position_in_merged.insert(remote_only.index, merged_index);
+                    entry_by_remote
+                        .get(&remote_only.index)
+                        .cloned()
+                        .ok_or(ServiceError::InvalidSetup)
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let observed_at_unix = crate::signals::unix_now();
+        let mut operations = Vec::new();
+        if pending.desired_name != merged_name {
+            operations.push(Operation::UpsertPlaylist {
+                playlist_id: link.local_playlist_id.clone(),
+                name: merged_name.clone(),
+            });
+        }
+        operations.extend(plan.removed_existing().iter().map(|removed| {
+            Operation::RemovePlaylistEntry {
+                playlist_id: link.local_playlist_id.clone(),
+                entry_id: removed.entry.entry_id.clone(),
+                removed: true,
+            }
+        }));
+        for occurrence in plan.remote_occurrences() {
+            let PendingRemoteOccurrence::RemoteOnly(remote_only) = occurrence else {
+                continue;
+            };
+            let merged_index = *remote_position_in_merged
+                .get(&remote_only.index)
+                .ok_or(ServiceError::InvalidSetup)?;
+            let song = remote
+                .entries()
+                .get(remote_only.index)
+                .ok_or(ServiceError::InvalidSetup)?;
+            operations.push(Operation::UpsertPlaylistEntry {
+                playlist_id: link.local_playlist_id.clone(),
+                entry_id: entry_by_remote
+                    .get(&remote_only.index)
+                    .cloned()
+                    .ok_or(ServiceError::InvalidSetup)?,
+                track: portable_server_track(song),
+                after_entry_id: merged_index
+                    .checked_sub(1)
+                    .and_then(|index| merged_entry_ids.get(index).cloned()),
+            });
+        }
+        let retained_existing = plan
+            .ordered_occurrences()
+            .iter()
+            .filter_map(|occurrence| match occurrence {
+                PendingMergeOccurrence::Existing(existing) => Some(existing.entry.entry_id.clone()),
+                PendingMergeOccurrence::RemoteOnly(_) => None,
+            })
+            .collect::<BTreeSet<_>>();
+        let mut current_after = BTreeMap::new();
+        let mut previous_retained = None;
+        for entry_id in &pending.ordered_entry_ids {
+            if retained_existing.contains(entry_id) {
+                current_after.insert(entry_id.clone(), previous_retained.clone());
+                previous_retained = Some(entry_id.clone());
+            }
+        }
+        for (index, occurrence) in plan.ordered_occurrences().iter().enumerate() {
+            let PendingMergeOccurrence::Existing(existing) = occurrence else {
+                continue;
+            };
+            let expected_after = index
+                .checked_sub(1)
+                .and_then(|previous| merged_entry_ids.get(previous).cloned());
+            if current_after.get(&existing.entry.entry_id) == Some(&expected_after) {
+                continue;
+            }
+            operations.push(Operation::MovePlaylistEntry {
+                playlist_id: link.local_playlist_id.clone(),
+                entry_id: existing.entry.entry_id.clone(),
+                after_entry_id: expected_after,
+            });
+        }
+        let inputs = operations
+            .into_iter()
+            .enumerate()
+            .map(|(index, operation)| ExternalOperationInput {
+                acknowledgement_id: remote_operation_id(
+                    &link,
+                    &fingerprint,
+                    observation_revision,
+                    index,
+                ),
+                operation,
+                recorded_at_unix: observed_at_unix,
+            })
+            .collect::<Vec<_>>();
+
+        let playlist_id = link.local_playlist_id.clone();
+        let merged_differs_from_remote = merged_entry_ids != remote_entry_ids
+            || plan.desired_remote() != current.as_slice()
+            || merged_name != remote.name();
+        let follow_up = merged_differs_from_remote.then(|| PendingPlaylistProjection {
+            desired_name: merged_name,
+            ordered_entry_ids: merged_entry_ids,
+            ordered_item_ids: plan.desired_remote().to_vec(),
+            stage: PendingPlaylistProjectionStage::Queued,
+            base_remote_fingerprint: fingerprint.clone(),
+        });
+        let exact_remote_shadow = remote_entry_ids
+            .into_iter()
+            .zip(current)
+            .map(|(entry_id, item_id)| PlaylistShadowOccurrence { entry_id, item_id })
+            .collect();
+        let before = store_set.bridge_state.clone();
+        let mutation = (|| {
+            if !inputs.is_empty() {
+                store_set
+                    .bridge_state
+                    .queue_playlist_import(PendingPlaylistImportBatch {
+                        operation_id: format!(
+                            "playlist-remote-batch-{}",
+                            digest_text(&format!(
+                                "{}\0{fingerprint}\0{observation_revision}",
+                                playlist_id.as_str(),
+                            ))
+                        ),
+                        local_playlist_id: playlist_id.clone(),
+                        purpose: PendingPlaylistImportPurpose::RemoteObservation,
+                        operations: inputs,
+                    })?;
+            }
+            store_set
+                .bridge_state
+                .remove_playlist_projection(&playlist_id);
+            if let Some(follow_up) = follow_up {
+                store_set
+                    .bridge_state
+                    .queue_playlist_projection(playlist_id.clone(), follow_up)?;
+            }
+            link.state = final_state;
+            link.shadow = PlaylistShadow {
+                name: remote.name().to_owned(),
+                occurrences: exact_remote_shadow,
+                verified_at_unix: observed_at_unix,
+            };
+            store_set.bridge_state.upsert_playlist_link(link)?;
+            Ok::<(), BridgeMutationError>(())
+        })();
+        if let Err(error) = mutation {
+            store_set.bridge_state = before;
+            return Err(error.into());
+        }
+        self.persist_or_restore(store_set, before)?;
+        self.emit_pending(store_set);
+        Ok(())
+    }
+
+    fn observe_changed_remote_playlist(
+        &self,
+        store_set: &mut OpenSubsonicStoreSet,
+        mut link: PlaylistLink,
+        remote: ServerPlaylistWriteSnapshot,
+        final_state: PlaylistLinkState,
+    ) -> Result<(), ServiceError> {
+        let previous = link
+            .shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| {
+                LinkedPlaylistEntry::new(occurrence.entry_id.clone(), occurrence.item_id.clone())
+            })
+            .collect::<Vec<_>>();
+        let current = remote
+            .entries()
+            .iter()
+            .map(|song| song.item.item_id().clone())
+            .collect::<Vec<_>>();
+        let delta =
+            plan_remote_delta(&previous, &current).map_err(|_| ServiceError::InvalidSetup)?;
+        let fingerprint = super::super::actor::playlist_snapshot_fingerprint(&remote);
+        // A server can move from A → B → A more than once. The current fingerprint alone would
+        // reuse acknowledgement IDs on the second transition back to A, causing the personal
+        // ledger to deduplicate a real later observation. The bridge revision is the durable
+        // observation sequence: retries before a commit reuse it, while every committed remote
+        // transition advances it.
+        let observation_revision = store_set.bridge_state.revision().saturating_add(1);
+        let mut entry_by_remote = delta
+            .retained
+            .iter()
+            .map(|matched| (matched.remote_index, matched.entry_id.clone()))
+            .collect::<BTreeMap<_, _>>();
+        for added in &delta.added {
+            entry_by_remote.insert(
+                added.index,
+                remote_entry_id(
+                    &link.local_playlist_id,
+                    &fingerprint,
+                    observation_revision,
+                    added.index,
+                    &added.item_id,
+                )?,
+            );
+        }
+        let ordered_entry_ids = (0..current.len())
+            .map(|index| {
+                entry_by_remote
+                    .get(&index)
+                    .cloned()
+                    .ok_or(ServiceError::InvalidSetup)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let observed_at_unix = crate::signals::unix_now();
+        let mut operations = Vec::new();
+        if link.shadow.name != remote.name() {
+            operations.push(Operation::UpsertPlaylist {
+                playlist_id: link.local_playlist_id.clone(),
+                name: remote.name().to_owned(),
+            });
+        }
+        operations.extend(
+            delta
+                .removed
+                .iter()
+                .map(|removed| Operation::RemovePlaylistEntry {
+                    playlist_id: link.local_playlist_id.clone(),
+                    entry_id: removed.entry.entry_id.clone(),
+                    removed: true,
+                }),
+        );
+        for added in &delta.added {
+            let song = remote
+                .entries()
+                .get(added.index)
+                .ok_or(ServiceError::InvalidSetup)?;
+            operations.push(Operation::UpsertPlaylistEntry {
+                playlist_id: link.local_playlist_id.clone(),
+                entry_id: entry_by_remote
+                    .get(&added.index)
+                    .cloned()
+                    .ok_or(ServiceError::InvalidSetup)?,
+                track: portable_server_track(song),
+                after_entry_id: added
+                    .index
+                    .checked_sub(1)
+                    .and_then(|index| entry_by_remote.get(&index).cloned()),
+            });
+        }
+        let retained_entry_ids = delta
+            .retained
+            .iter()
+            .map(|matched| matched.entry_id.clone())
+            .collect::<BTreeSet<_>>();
+        for (index, entry_id) in ordered_entry_ids.iter().enumerate() {
+            if !retained_entry_ids.contains(entry_id) {
+                continue;
+            }
+            operations.push(Operation::MovePlaylistEntry {
+                playlist_id: link.local_playlist_id.clone(),
+                entry_id: entry_id.clone(),
+                after_entry_id: index
+                    .checked_sub(1)
+                    .and_then(|previous| ordered_entry_ids.get(previous).cloned()),
+            });
+        }
+        let inputs = operations
+            .into_iter()
+            .enumerate()
+            .map(|(index, operation)| ExternalOperationInput {
+                acknowledgement_id: remote_operation_id(
+                    &link,
+                    &fingerprint,
+                    observation_revision,
+                    index,
+                ),
+                operation,
+                recorded_at_unix: observed_at_unix,
+            })
+            .collect::<Vec<_>>();
+
+        let before = store_set.bridge_state.clone();
+        if !inputs.is_empty() {
+            store_set
+                .bridge_state
+                .queue_playlist_import(PendingPlaylistImportBatch {
+                    operation_id: format!(
+                        "playlist-remote-batch-{}",
+                        digest_text(&format!(
+                            "{}\0{fingerprint}\0{observation_revision}",
+                            link.local_playlist_id.as_str(),
+                        ))
+                    ),
+                    local_playlist_id: link.local_playlist_id.clone(),
+                    purpose: PendingPlaylistImportPurpose::RemoteObservation,
+                    operations: inputs,
+                })?;
+        }
+        link.state = final_state;
+        link.shadow = PlaylistShadow {
+            name: remote.name().to_owned(),
+            occurrences: ordered_entry_ids
+                .into_iter()
+                .zip(current)
+                .map(|(entry_id, item_id)| PlaylistShadowOccurrence { entry_id, item_id })
+                .collect(),
+            verified_at_unix: observed_at_unix,
+        };
+        store_set
+            .bridge_state
+            .remove_playlist_projection(&link.local_playlist_id);
+        store_set.bridge_state.upsert_playlist_link(link)?;
+        self.persist_or_restore(store_set, before)?;
+        self.emit_pending(store_set);
+        Ok(())
+    }
+}
+
+fn pending_remote_merge_mode(
+    stage: PendingPlaylistProjectionStage,
+) -> Result<PendingRemoteMergeMode, ServiceError> {
+    match stage {
+        PendingPlaylistProjectionStage::Queued => Ok(PendingRemoteMergeMode::LocalNotDelivered),
+        PendingPlaylistProjectionStage::Readback => Ok(PendingRemoteMergeMode::LocalDelivered),
+        PendingPlaylistProjectionStage::Ambiguous => Ok(PendingRemoteMergeMode::DeliveryUnknown),
+        PendingPlaylistProjectionStage::NeedsAttention => Err(ServiceError::InvalidSetup),
+    }
+}
+
+fn pending_remote_merge_name<'a>(
+    base: &'a str,
+    desired: &'a str,
+    remote: &'a str,
+    mode: PendingRemoteMergeMode,
+) -> &'a str {
+    match mode {
+        PendingRemoteMergeMode::LocalDelivered => remote,
+        PendingRemoteMergeMode::LocalNotDelivered | PendingRemoteMergeMode::DeliveryUnknown => {
+            if remote != base {
+                remote
+            } else {
+                desired
+            }
+        }
+    }
+}
+
+fn has_exact_playlist_write_access(
+    remote: &ServerPlaylistWriteSnapshot,
+    credential: &ServerCredential,
+) -> bool {
+    remote.read_only() == Some(false)
+        && credential
+            .username()
+            .is_some_and(|username| remote.owner() == Some(username.expose_secret()))
+}
+
+fn playlist_projection_error_needs_attention(error: super::super::ServerError) -> bool {
+    matches!(
+        error,
+        super::super::ServerError::AuthenticationRequired
+            | super::super::ServerError::PermissionDenied
+            | super::super::ServerError::CertificateFailed
+            | super::super::ServerError::OriginRejected
+            | super::super::ServerError::UnsupportedFeature
+            | super::super::ServerError::InvalidResponse
+            | super::super::ServerError::ResponseTooLarge
+            | super::super::ServerError::WrongAccountScope
+    )
+}
+
+fn playlist_readback_matches(
+    pending: &PendingPlaylistProjection,
+    remote: &ServerPlaylistWriteSnapshot,
+) -> bool {
+    remote.name() == pending.desired_name
+        && remote.entries().len() == pending.ordered_item_ids.len()
+        && remote
+            .entries()
+            .iter()
+            .zip(&pending.ordered_item_ids)
+            .all(|(song, expected)| song.item.item_id() == expected)
+}
+
+fn exact_local_occurrences(
+    store_set: &OpenSubsonicStoreSet,
+    snapshot: &PersonalPlaylistSnapshot,
+) -> Result<(Vec<PlaylistEntryId>, Vec<ItemId>), ServiceError> {
+    let mut entry_ids = Vec::with_capacity(snapshot.entries.len());
+    let mut item_ids = Vec::with_capacity(snapshot.entries.len());
+    for entry in &snapshot.entries {
+        let PortableTrackKey::OpenSubsonic {
+            backend_id,
+            account_scope_id,
+            item_id,
+        } = &entry.track.key
+        else {
+            return Err(ServiceError::InvalidSetup);
+        };
+        if backend_id != store_set.profile.backend_id().as_str()
+            || account_scope_id != store_set.profile.account_scope_id().as_str()
+        {
+            return Err(ServiceError::Server(
+                super::super::ServerError::WrongAccountScope,
+            ));
+        }
+        entry_ids.push(entry.entry_id.clone());
+        item_ids.push(ItemId::new(item_id.clone()).map_err(|_| ServiceError::InvalidSetup)?);
+    }
+    Ok((entry_ids, item_ids))
+}
+
+fn shadow_fingerprint(store_set: &OpenSubsonicStoreSet, link: &PlaylistLink) -> String {
+    sequence_fingerprint(
+        store_set.profile.backend_id().as_str(),
+        store_set.profile.account_scope_id().as_str(),
+        link.server_playlist_id.as_str(),
+        &link.shadow.name,
+        link.shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| occurrence.item_id.as_str()),
+    )
+}
+
+fn sequence_fingerprint<'a>(
+    backend_id: &str,
+    account_scope_id: &str,
+    playlist_id: &str,
+    name: &str,
+    item_ids: impl Iterator<Item = &'a str>,
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"yututui-open-subsonic-playlist-snapshot-v1\0");
+    for part in [backend_id, account_scope_id, playlist_id, name] {
+        update_part(&mut digest, part.as_bytes());
+    }
+    for item_id in item_ids {
+        update_part(&mut digest, item_id.as_bytes());
+    }
+    HEXLOWER.encode(&digest.finalize())
+}
+
+fn remote_entry_id(
+    playlist_id: &PlaylistId,
+    fingerprint: &str,
+    observation_revision: u64,
+    index: usize,
+    item_id: &ItemId,
+) -> Result<PlaylistEntryId, ServiceError> {
+    PlaylistEntryId::new(format!(
+        "server-entry-{}",
+        digest_text(&format!(
+            "{}\0{fingerprint}\0{observation_revision}\0{index}\0{}",
+            playlist_id.as_str(),
+            item_id.as_str()
+        ))
+    ))
+    .map_err(|_| ServiceError::InvalidSetup)
+}
+
+fn remote_operation_id(
+    link: &PlaylistLink,
+    fingerprint: &str,
+    observation_revision: u64,
+    index: usize,
+) -> String {
+    digest_text(&format!(
+        "{}\0{}\0{fingerprint}\0{observation_revision}\0{index}",
+        link.local_playlist_id.as_str(),
+        link.server_playlist_id.as_str()
+    ))
+}
+
+fn digest_text(value: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(value.as_bytes());
+    HEXLOWER.encode(&digest.finalize())
+}
+
+fn update_part(digest: &mut Sha256, bytes: &[u8]) {
+    digest.update((bytes.len() as u64).to_be_bytes());
+    digest.update(bytes);
+}

--- a/src/open_subsonic/bridge_runtime_tests.rs
+++ b/src/open_subsonic/bridge_runtime_tests.rs
@@ -21,6 +21,7 @@ use crate::personal_state::{
 static NEXT_ROOT: AtomicU64 = AtomicU64::new(1);
 
 mod aggregate_continuation;
+mod playlists;
 mod rating_projection;
 mod scrobble_delivery;
 
@@ -45,11 +46,12 @@ async fn fixture(
         None,
     )
     .unwrap();
-    let private_state = OpenSubsonicPrivateState::new(
+    let mut private_state = OpenSubsonicPrivateState::new(
         backend_id.clone(),
         account_scope_id.clone(),
         ServerCredential::api_key(SecretString::from("test-api-key".to_owned())).unwrap(),
     );
+    private_state.bind_api_key_username("owner").unwrap();
     let bridge_state = OpenSubsonicBridgeState::new(backend_id, account_scope_id);
     let mut store_set = OpenSubsonicStoreSet::new(profile, private_state, bridge_state).unwrap();
     let root = std::env::temp_dir().join(format!(

--- a/src/open_subsonic/bridge_runtime_tests/playlists.rs
+++ b/src/open_subsonic/bridge_runtime_tests/playlists.rs
@@ -1,0 +1,1421 @@
+use super::*;
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex};
+
+use crate::open_subsonic::actor::{ServiceError, playlist_snapshot_fingerprint};
+use crate::open_subsonic::bridge_store::{
+    PendingPlaylistImportBatch, PendingPlaylistImportPurpose, PendingPlaylistProjection,
+    PendingPlaylistProjectionStage, PlaylistLink, PlaylistLinkState, PlaylistShadow,
+    PlaylistShadowOccurrence,
+};
+use crate::open_subsonic::model::ServerPlaylistWriteSnapshot;
+use crate::personal_state::{
+    ExternalOperationInput, Operation, PersonalPlaylistEntry, PersonalPlaylistSnapshot,
+    PlaylistEntryId, PlaylistId,
+};
+
+mod backlog;
+mod concurrent_merge;
+mod recovery;
+
+enum PlaylistReply {
+    Json(String),
+    NotFound,
+}
+
+async fn playlist_get_server(replies: Vec<PlaylistReply>) -> (u16, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        for reply in replies {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut stream).await;
+            let request_line = request.lines().next().unwrap_or_default();
+            assert!(
+                request_line.contains("/rest/getPlaylist.view?"),
+                "{request_line}"
+            );
+            match reply {
+                PlaylistReply::Json(body) => write_json(&mut stream, &body).await,
+                PlaylistReply::NotFound => {
+                    stream
+                        .write_all(
+                            b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                        )
+                        .await
+                        .unwrap();
+                }
+            }
+        }
+    });
+    (port, server)
+}
+
+fn item_id(value: &str) -> ItemId {
+    ItemId::new(value).unwrap()
+}
+
+fn playlist_id(value: &str) -> PlaylistId {
+    PlaylistId::new(value).unwrap()
+}
+
+fn entry_id(value: &str) -> PlaylistEntryId {
+    PlaylistEntryId::new(value).unwrap()
+}
+
+fn playlist_song(store_set: &OpenSubsonicStoreSet, item: &str) -> ServerSong {
+    ServerSong {
+        item: OpenSubsonicItemRef::new(
+            store_set.profile.backend_id().clone(),
+            store_set.profile.account_scope_id().clone(),
+            item_id(item),
+        ),
+        title: format!("Server {item}"),
+        artist: "Server artist".to_owned(),
+        artists: Vec::new(),
+        album: Some("Server album".to_owned()),
+        album_id: None,
+        album_artist: None,
+        duration_secs: Some(180),
+        track_number: None,
+        disc_number: None,
+        year: None,
+        cover_art_id: None,
+        content_type: None,
+        suffix: None,
+        starred: false,
+        user_rating: None,
+        play_count: None,
+        played_at: None,
+    }
+}
+
+fn strict_snapshot(
+    store_set: &OpenSubsonicStoreSet,
+    name: &str,
+    items: &[&str],
+) -> ServerPlaylistWriteSnapshot {
+    ServerPlaylistWriteSnapshot::new(
+        store_set.profile.backend_id().clone(),
+        store_set.profile.account_scope_id().clone(),
+        ServerPlaylistId::new("server-playlist").unwrap(),
+        name.to_owned(),
+        Some("owner".to_owned()),
+        Some(false),
+        items
+            .iter()
+            .map(|item| playlist_song(store_set, item))
+            .collect(),
+    )
+}
+
+fn playlist_body(name: &str, items: &[&str]) -> String {
+    playlist_body_with_access(name, items, Some("owner"), Some(false))
+}
+
+fn playlist_body_with_access(
+    name: &str,
+    items: &[&str],
+    owner: Option<&str>,
+    read_only: Option<bool>,
+) -> String {
+    let entries = items
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            serde_json::json!({
+                "id": item,
+                "title": format!("Server {item} occurrence {index}"),
+                "artist": "Server artist",
+                "type": "music"
+            })
+        })
+        .collect::<Vec<_>>();
+    let mut playlist = serde_json::json!({
+        "id": "server-playlist",
+        "name": name,
+        "songCount": items.len(),
+        "entry": entries
+    });
+    if let Some(owner) = owner {
+        playlist["owner"] = owner.into();
+    }
+    if let Some(read_only) = read_only {
+        playlist["readonly"] = read_only.into();
+    }
+    serde_json::json!({
+        "subsonic-response": {
+            "status": "ok",
+            "playlist": playlist
+        }
+    })
+    .to_string()
+}
+
+fn portable_track(store_set: &OpenSubsonicStoreSet, item: &str) -> PortableTrack {
+    PortableTrack {
+        key: PortableTrackKey::OpenSubsonic {
+            backend_id: store_set.profile.backend_id().as_str().to_owned(),
+            account_scope_id: store_set.profile.account_scope_id().as_str().to_owned(),
+            item_id: item.to_owned(),
+        },
+        title: format!("Local {item}"),
+        artist: "Local artist".to_owned(),
+        album: None,
+        duration_secs: Some(180),
+        isrc: None,
+    }
+}
+
+fn local_snapshot(
+    store_set: &OpenSubsonicStoreSet,
+    local: &str,
+    name: &str,
+    occurrences: &[(&str, &str)],
+) -> PersonalPlaylistSnapshot {
+    PersonalPlaylistSnapshot {
+        playlist_id: playlist_id(local),
+        name: name.to_owned(),
+        entries: occurrences
+            .iter()
+            .map(|(entry, item)| PersonalPlaylistEntry {
+                entry_id: entry_id(entry),
+                track: portable_track(store_set, item),
+            })
+            .collect(),
+    }
+}
+
+fn playlist_link(local: &str, name: &str, occurrences: &[(&str, &str)]) -> PlaylistLink {
+    PlaylistLink {
+        local_playlist_id: playlist_id(local),
+        server_playlist_id: ServerPlaylistId::new("server-playlist").unwrap(),
+        managed_by_yututui: true,
+        state: PlaylistLinkState::Linked,
+        content_needs_attention: false,
+        shadow: PlaylistShadow {
+            name: name.to_owned(),
+            occurrences: occurrences
+                .iter()
+                .map(|(entry, item)| PlaylistShadowOccurrence {
+                    entry_id: entry_id(entry),
+                    item_id: item_id(item),
+                })
+                .collect(),
+            verified_at_unix: 100,
+        },
+    }
+}
+
+fn projection(
+    base: &ServerPlaylistWriteSnapshot,
+    desired_name: &str,
+    desired: &[(&str, &str)],
+    stage: PendingPlaylistProjectionStage,
+) -> PendingPlaylistProjection {
+    PendingPlaylistProjection {
+        desired_name: desired_name.to_owned(),
+        ordered_entry_ids: desired.iter().map(|(entry, _)| entry_id(entry)).collect(),
+        ordered_item_ids: desired.iter().map(|(_, item)| item_id(item)).collect(),
+        stage,
+        base_remote_fingerprint: playlist_snapshot_fingerprint(base),
+    }
+}
+
+fn import_batch(operation_id: &str, local: &str) -> PendingPlaylistImportBatch {
+    PendingPlaylistImportBatch {
+        operation_id: operation_id.to_owned(),
+        local_playlist_id: playlist_id(local),
+        purpose: PendingPlaylistImportPurpose::InitialOrImportCopy,
+        operations: vec![ExternalOperationInput {
+            acknowledgement_id: format!("{operation_id}-ack"),
+            operation: Operation::UpsertPlaylist {
+                playlist_id: playlist_id(local),
+                name: "Imported".to_owned(),
+            },
+            recorded_at_unix: 100,
+        }],
+    }
+}
+
+fn persist_store(paths: &OpenSubsonicPaths, store_set: &mut OpenSubsonicStoreSet) {
+    let expected = store_set.revisions();
+    commit_store_set(paths, expected, store_set).unwrap();
+}
+
+fn install_link_and_projection(
+    paths: &OpenSubsonicPaths,
+    store_set: &mut OpenSubsonicStoreSet,
+    link: PlaylistLink,
+    pending: PendingPlaylistProjection,
+) {
+    let local_playlist_id = link.local_playlist_id.clone();
+    store_set.bridge_state.upsert_playlist_link(link).unwrap();
+    store_set
+        .bridge_state
+        .queue_playlist_projection(local_playlist_id, pending)
+        .unwrap();
+    persist_store(paths, store_set);
+}
+
+#[tokio::test]
+async fn preview_commit_is_atomic_durable_and_replay_safe() {
+    let events = Arc::new(Mutex::new(Vec::<OpenSubsonicBridgeImport>::new()));
+    let sink_events = Arc::clone(&events);
+    let sink: OpenSubsonicBridgeSink = Arc::new(move |event| {
+        sink_events.lock().unwrap().push(event);
+    });
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, Some(sink)).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let pending = projection(
+        &base,
+        "Local",
+        &[("entry-a", "a")],
+        PendingPlaylistProjectionStage::Queued,
+    );
+    let import = import_batch("preview-import", "local");
+
+    runtime
+        .commit_playlist_preview(
+            &mut store_set,
+            import.clone(),
+            Some(link.clone()),
+            Some(pending.clone()),
+        )
+        .unwrap();
+    runtime
+        .commit_playlist_preview(
+            &mut store_set,
+            import.clone(),
+            Some(link.clone()),
+            Some(pending.clone()),
+        )
+        .unwrap();
+
+    assert_eq!(store_set.bridge_state.pending_playlist_imports().len(), 1);
+    assert_eq!(store_set.bridge_state.playlist_links().len(), 1);
+    assert_eq!(
+        store_set.bridge_state.pending_playlist_projections().len(),
+        1
+    );
+    assert_eq!(events.lock().unwrap().len(), 2);
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        durable
+            .bridge_state
+            .pending_playlist_imports()
+            .get("preview-import"),
+        Some(&import)
+    );
+    assert_eq!(
+        durable.bridge_state.playlist_link(&playlist_id("local")),
+        Some(&link)
+    );
+    assert_eq!(
+        durable
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&playlist_id("local")),
+        Some(&pending)
+    );
+
+    let before_failure = store_set.bridge_state.clone();
+    assert!(
+        runtime
+            .commit_playlist_preview(
+                &mut store_set,
+                import_batch("must-roll-back", "other-local"),
+                None,
+                Some(pending),
+            )
+            .is_err()
+    );
+    assert_eq!(store_set.bridge_state, before_failure);
+    assert!(
+        load_store_set(&paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .pending_playlist_imports()
+            .get("must-roll-back")
+            .is_none()
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn local_reconcile_preserves_exact_duplicates_and_safely_unlinks_missing_local() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    store_set
+        .bridge_state
+        .upsert_playlist_link(playlist_link(
+            "duplicate-local",
+            "Old",
+            &[("old-entry", "same")],
+        ))
+        .unwrap();
+    store_set
+        .bridge_state
+        .upsert_playlist_link(PlaylistLink {
+            local_playlist_id: playlist_id("missing-local"),
+            server_playlist_id: ServerPlaylistId::new("missing-server").unwrap(),
+            managed_by_yututui: true,
+            state: PlaylistLinkState::Linked,
+            content_needs_attention: false,
+            shadow: PlaylistShadow {
+                name: "Keep remote".to_owned(),
+                occurrences: Vec::new(),
+                verified_at_unix: 100,
+            },
+        })
+        .unwrap();
+    persist_store(&paths, &mut store_set);
+    let duplicate = local_snapshot(
+        &store_set,
+        "duplicate-local",
+        "Duplicates",
+        &[("first", "same"), ("second", "same")],
+    );
+
+    runtime
+        .reconcile_linked_playlists(&mut store_set, &[duplicate])
+        .unwrap();
+
+    assert!(
+        store_set
+            .bridge_state
+            .playlist_link(&playlist_id("missing-local"))
+            .is_none()
+    );
+    let pending = store_set
+        .bridge_state
+        .pending_playlist_projections()
+        .get(&playlist_id("duplicate-local"))
+        .unwrap();
+    assert_eq!(pending.desired_name, "Duplicates");
+    assert_eq!(
+        pending
+            .ordered_item_ids
+            .iter()
+            .map(ItemId::as_str)
+            .collect::<Vec<_>>(),
+        vec!["same", "same"]
+    );
+    assert_eq!(
+        pending
+            .ordered_entry_ids
+            .iter()
+            .map(PlaylistEntryId::as_str)
+            .collect::<Vec<_>>(),
+        vec!["first", "second"]
+    );
+    assert_ne!(pending.ordered_entry_ids[0], pending.ordered_entry_ids[1]);
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert!(
+        durable
+            .bridge_state
+            .playlist_link(&playlist_id("missing-local"))
+            .is_none()
+    );
+    assert!(durable.bridge_state.pending_playlist_imports().is_empty());
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn ambiguous_projection_is_not_replaced_by_a_new_local_snapshot() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let ambiguous = projection(
+        &base,
+        "In flight",
+        &[("entry-a", "a"), ("entry-b", "b")],
+        PendingPlaylistProjectionStage::Ambiguous,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, ambiguous.clone());
+    let latest = local_snapshot(&store_set, "local", "Newer local", &[("entry-c", "c")]);
+
+    runtime
+        .reconcile_linked_playlists(&mut store_set, &[latest])
+        .unwrap();
+
+    assert_eq!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&playlist_id("local")),
+        Some(&ambiguous)
+    );
+    assert_eq!(
+        load_store_set(&paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&playlist_id("local")),
+        Some(&ambiguous)
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn queued_projection_is_removed_when_local_returns_to_verified_shadow() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let queued = projection(
+        &base,
+        "Stale local",
+        &[("entry-b", "b")],
+        PendingPlaylistProjectionStage::Queued,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, queued);
+    let reverted = local_snapshot(&store_set, "local", "Remote", &[("entry-a", "a")]);
+
+    runtime
+        .reconcile_linked_playlists(&mut store_set, &[reverted])
+        .unwrap();
+
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&playlist_id("local"))
+            .is_none()
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn attention_projection_is_resolved_when_local_returns_to_verified_shadow() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let attention = projection(
+        &base,
+        "Stale local",
+        &[("entry-b", "b")],
+        PendingPlaylistProjectionStage::NeedsAttention,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, attention);
+    let reverted = local_snapshot(&store_set, "local", "Remote", &[("entry-a", "a")]);
+
+    runtime
+        .reconcile_linked_playlists(&mut store_set, &[reverted])
+        .unwrap();
+
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&playlist_id("local"))
+            .is_none()
+    );
+    assert_eq!(
+        load_store_set(&paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .playlist_projections_needing_attention(),
+        0
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn remote_add_remove_reorder_becomes_one_stable_batch_and_verified_shadow() {
+    let (port, server) = playlist_get_server(vec![PlaylistReply::Json(playlist_body(
+        "Remote",
+        &["b", "a", "d", "d"],
+    ))])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let link = playlist_link(
+        "local",
+        "Remote",
+        &[("entry-a", "a"), ("entry-b", "b"), ("entry-c", "c")],
+    );
+    let base = strict_snapshot(&store_set, "Remote", &["a", "b", "c"]);
+    let pending = projection(
+        &base,
+        "Remote",
+        &[("entry-a", "a"), ("entry-b", "b"), ("entry-c", "c")],
+        PendingPlaylistProjectionStage::Queued,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, pending);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    let linked = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(
+        linked
+            .shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| occurrence.item_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["b", "a", "d", "d"]
+    );
+    assert_eq!(
+        linked.shadow.occurrences[0].entry_id,
+        entry_id("entry-b"),
+        "a moved exact occurrence keeps its stable local ID"
+    );
+    assert_eq!(linked.shadow.occurrences[1].entry_id, entry_id("entry-a"));
+    assert_ne!(
+        linked.shadow.occurrences[2].entry_id, linked.shadow.occurrences[3].entry_id,
+        "duplicate remote additions are distinct occurrences"
+    );
+    let batch = store_set
+        .bridge_state
+        .pending_playlist_imports()
+        .values()
+        .next()
+        .unwrap();
+    let removed = batch
+        .operations
+        .iter()
+        .filter_map(|input| match &input.operation {
+            Operation::RemovePlaylistEntry { entry_id, .. } => Some(entry_id.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(removed, vec!["entry-c"]);
+    let inserted = batch
+        .operations
+        .iter()
+        .filter_map(|input| match &input.operation {
+            Operation::UpsertPlaylistEntry {
+                entry_id, track, ..
+            } => {
+                let PortableTrackKey::OpenSubsonic { item_id, .. } = &track.key else {
+                    return None;
+                };
+                Some((entry_id, item_id.as_str()))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        inserted.iter().map(|(_, item)| *item).collect::<Vec<_>>(),
+        vec!["d", "d"]
+    );
+    assert_eq!(inserted[0].0, &linked.shadow.occurrences[2].entry_id);
+    assert_eq!(inserted[1].0, &linked.shadow.occurrences[3].entry_id);
+    let moved = batch
+        .operations
+        .iter()
+        .filter_map(|input| match &input.operation {
+            Operation::MovePlaylistEntry {
+                entry_id,
+                after_entry_id,
+                ..
+            } => Some((entry_id, after_entry_id)),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        moved
+            .iter()
+            .map(|(entry_id, after)| (
+                entry_id.as_str(),
+                after.as_ref().map(PlaylistEntryId::as_str)
+            ))
+            .collect::<Vec<_>>(),
+        vec![("entry-b", None), ("entry-a", Some("entry-b"))]
+    );
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        durable
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .unwrap()
+            .shadow,
+        linked.shadow
+    );
+    assert_eq!(
+        durable
+            .bridge_state
+            .pending_playlist_imports()
+            .values()
+            .next(),
+        Some(batch)
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn idle_link_poll_imports_mobile_reorder_without_a_pending_local_write() {
+    let (port, server) = playlist_get_server(vec![PlaylistReply::Json(playlist_body(
+        "Mobile edit",
+        &["b", "a"],
+    ))])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    store_set
+        .bridge_state
+        .upsert_playlist_link(playlist_link(
+            "local",
+            "Remote",
+            &[("entry-a", "a"), ("entry-b", "b")],
+        ))
+        .unwrap();
+    persist_store(&paths, &mut store_set);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    let linked = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(linked.shadow.name, "Mobile edit");
+    let generated_entry_id = &linked.shadow.occurrences[0].entry_id;
+    assert!(generated_entry_id.as_str().starts_with("server-entry-"));
+    assert_ne!(generated_entry_id, &entry_id("entry-b"));
+    assert_eq!(linked.shadow.occurrences[1].entry_id, entry_id("entry-a"));
+    assert_eq!(store_set.bridge_state.pending_playlist_imports().len(), 1);
+    let batch = store_set
+        .bridge_state
+        .pending_playlist_imports()
+        .values()
+        .next()
+        .unwrap();
+    assert!(batch.operations.iter().any(|input| matches!(
+        &input.operation,
+        Operation::RemovePlaylistEntry {
+            entry_id: removed_entry_id,
+            removed: true,
+            ..
+        } if removed_entry_id == &entry_id("entry-b")
+    )));
+    assert!(batch.operations.iter().any(|input| matches!(
+        &input.operation,
+        Operation::UpsertPlaylistEntry {
+            entry_id: inserted_entry_id,
+            after_entry_id: None,
+            ..
+        } if inserted_entry_id == generated_entry_id
+    )));
+    assert!(batch.operations.iter().any(|input| matches!(
+        &input.operation,
+        Operation::MovePlaylistEntry {
+            entry_id: moved_entry_id,
+            after_entry_id: Some(after_entry_id),
+            ..
+        } if moved_entry_id == &entry_id("entry-a")
+            && after_entry_id == generated_entry_id
+    )));
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        durable
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .unwrap()
+            .shadow,
+        linked.shadow
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn unchanged_idle_link_poll_does_not_rewrite_durable_state() {
+    let (port, server) =
+        playlist_get_server(vec![PlaylistReply::Json(playlist_body("Remote", &["a"]))]).await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    store_set
+        .bridge_state
+        .upsert_playlist_link(playlist_link("local", "Remote", &[("entry-a", "a")]))
+        .unwrap();
+    persist_store(&paths, &mut store_set);
+    let before = store_set.bridge_state.clone();
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    assert_eq!(store_set.bridge_state, before);
+    assert_eq!(
+        load_store_set(&paths).unwrap().unwrap().bridge_state,
+        before
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn idle_access_evidence_change_is_durable_and_stays_dormant() {
+    let (port, server) = playlist_get_server(vec![PlaylistReply::Json(playlist_body_with_access(
+        "Remote",
+        &["a"],
+        Some("mallory"),
+        Some(false),
+    ))])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    store_set
+        .bridge_state
+        .upsert_playlist_link(playlist_link("local", "Remote", &[("entry-a", "a")]))
+        .unwrap();
+    persist_store(&paths, &mut store_set);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    assert_eq!(
+        store_set
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .map(|link| link.state),
+        Some(PlaylistLinkState::AccessNeedsAttention)
+    );
+    assert!(
+        store_set.bridge_state.pending_playlist_imports().is_empty(),
+        "an owner-only change is not a remote content edit"
+    );
+    assert_eq!(
+        load_store_set(&paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .map(|link| link.state),
+        Some(PlaylistLinkState::AccessNeedsAttention)
+    );
+    let status = read_status(&paths).unwrap();
+    assert_eq!(status.kind, OpenSubsonicStatusKind::NeedsAttention);
+    assert_eq!(status.playlist_projections_needing_attention, 1);
+
+    let dormant = store_set.bridge_state.clone();
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    assert_eq!(
+        store_set.bridge_state, dormant,
+        "automatic retry must exclude access-attention links"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn inaccessible_remote_content_delta_is_imported_but_keeps_attention() {
+    let (port, server) = playlist_get_server(vec![PlaylistReply::Json(playlist_body_with_access(
+        "Mobile edit",
+        &["b"],
+        Some("mallory"),
+        Some(false),
+    ))])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    store_set
+        .bridge_state
+        .upsert_playlist_link(playlist_link("local", "Remote", &[("entry-a", "a")]))
+        .unwrap();
+    persist_store(&paths, &mut store_set);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    let linked = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(linked.state, PlaylistLinkState::AccessNeedsAttention);
+    assert_eq!(linked.shadow.name, "Mobile edit");
+    assert_eq!(
+        linked
+            .shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| occurrence.item_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["b"]
+    );
+    assert_eq!(store_set.bridge_state.pending_playlist_imports().len(), 1);
+    assert_eq!(
+        store_set
+            .bridge_state
+            .playlist_projections_needing_attention(),
+        1
+    );
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        durable
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .map(|link| link.state),
+        Some(PlaylistLinkState::AccessNeedsAttention)
+    );
+    assert_eq!(durable.bridge_state.pending_playlist_imports().len(), 1);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn repeated_remote_snapshot_cycle_gets_a_fresh_durable_observation_id() {
+    let (port, server) = playlist_get_server(vec![
+        PlaylistReply::Json(playlist_body("B", &["a"])),
+        PlaylistReply::Json(playlist_body("A", &["a"])),
+    ])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    store_set
+        .bridge_state
+        .upsert_playlist_link(playlist_link("local", "A", &[("entry-a", "a")]))
+        .unwrap();
+    persist_store(&paths, &mut store_set);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    let (first_id, first_acknowledgements) = store_set
+        .bridge_state
+        .pending_playlist_imports()
+        .iter()
+        .next()
+        .map(|(operation_id, batch)| {
+            (
+                operation_id.clone(),
+                batch
+                    .operations
+                    .iter()
+                    .map(|input| input.acknowledgement_id.clone())
+                    .collect::<BTreeSet<_>>(),
+            )
+        })
+        .expect("first remote observation");
+    runtime
+        .acknowledge_import(&mut store_set, &first_id)
+        .unwrap();
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    let pending = store_set.bridge_state.pending_playlist_imports();
+    assert_eq!(pending.len(), 1);
+    let (second_id, second) = pending.iter().next().unwrap();
+    assert_ne!(second_id, &first_id);
+    assert!(second.operations.iter().any(|input| matches!(
+        input,
+        ExternalOperationInput {
+            operation: Operation::UpsertPlaylist { name, .. },
+            ..
+        } if name == "A"
+    )));
+    assert!(
+        second
+            .operations
+            .iter()
+            .all(|input| !first_acknowledgements.contains(&input.acknowledgement_id)),
+        "a later A snapshot must not reuse acknowledgement IDs from the earlier transition"
+    );
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        durable
+            .bridge_state
+            .pending_playlist_imports()
+            .keys()
+            .next(),
+        Some(second_id)
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn deleted_remote_occurrence_readded_at_same_position_gets_a_fresh_entry_id() {
+    let (port, server) = playlist_get_server(vec![
+        PlaylistReply::Json(playlist_body("A", &[])),
+        PlaylistReply::Json(playlist_body("A", &["a"])),
+    ])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    store_set
+        .bridge_state
+        .upsert_playlist_link(playlist_link("local", "A", &[("entry-a", "a")]))
+        .unwrap();
+    persist_store(&paths, &mut store_set);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    let first_import_id = store_set
+        .bridge_state
+        .pending_playlist_imports()
+        .keys()
+        .next()
+        .cloned()
+        .expect("remote removal import");
+    runtime
+        .acknowledge_import(&mut store_set, &first_import_id)
+        .unwrap();
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    let linked = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    let replacement_entry_id = linked.shadow.occurrences[0].entry_id.clone();
+    assert_ne!(
+        replacement_entry_id,
+        entry_id("entry-a"),
+        "a later occurrence must not reuse the tombstoned local entry identity"
+    );
+    let pending = store_set
+        .bridge_state
+        .pending_playlist_imports()
+        .values()
+        .next()
+        .expect("remote re-add import");
+    assert!(pending.operations.iter().any(|input| matches!(
+        &input.operation,
+        Operation::UpsertPlaylistEntry { entry_id, .. } if entry_id == &replacement_entry_id
+    )));
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        durable
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .unwrap()
+            .shadow
+            .occurrences[0]
+            .entry_id,
+        replacement_entry_id
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn missing_remote_marks_attention_without_deleting_the_local_playlist() {
+    let (port, server) = playlist_get_server(vec![PlaylistReply::NotFound]).await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let original_shadow = link.shadow.clone();
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let pending = projection(
+        &base,
+        "Local edit",
+        &[("entry-a", "a")],
+        PendingPlaylistProjectionStage::Queued,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, pending);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    let missing = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(missing.state, PlaylistLinkState::ServerMissing);
+    assert_eq!(missing.shadow, original_shadow);
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    assert!(
+        store_set.bridge_state.pending_playlist_imports().is_empty(),
+        "a missing server copy must not queue a local DeletePlaylist"
+    );
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        durable
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .unwrap()
+            .state,
+        PlaylistLinkState::ServerMissing
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn server_missing_link_stays_dormant_until_explicit_recovery() {
+    let (root, paths, mut store_set, client, runtime) = fixture(9, None).await;
+    let mut missing = playlist_link("local", "Missing server copy", &[("entry-a", "a")]);
+    missing.state = PlaylistLinkState::ServerMissing;
+    store_set
+        .bridge_state
+        .upsert_playlist_link(missing.clone())
+        .unwrap();
+    persist_store(&paths, &mut store_set);
+    let before = store_set.bridge_state.clone();
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+
+    assert_eq!(store_set.bridge_state, before);
+    assert_eq!(
+        load_store_set(&paths).unwrap().unwrap().bridge_state,
+        before
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn reappeared_server_copy_reactivates_the_original_link_and_imports_its_snapshot() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let mut missing = playlist_link("local", "Missing server copy", &[("entry-a", "a")]);
+    missing.state = PlaylistLinkState::ServerMissing;
+    store_set
+        .bridge_state
+        .upsert_playlist_link(missing.clone())
+        .unwrap();
+    persist_store(&paths, &mut store_set);
+    let reappeared = strict_snapshot(&store_set, "Reappeared server copy", &["b"]);
+
+    runtime
+        .restore_reappeared_playlist(&mut store_set, missing, reappeared)
+        .unwrap();
+
+    let link = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(link.state, PlaylistLinkState::Linked);
+    assert_eq!(link.server_playlist_id.as_str(), "server-playlist");
+    assert_eq!(link.shadow.name, "Reappeared server copy");
+    assert_eq!(
+        link.shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| occurrence.item_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["b"]
+    );
+    assert_eq!(store_set.bridge_state.pending_playlist_imports().len(), 1);
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        durable
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .map(|link| link.state),
+        Some(PlaylistLinkState::Linked)
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn automatic_managed_update_fails_closed_without_exact_remote_access_evidence() {
+    for (owner, read_only) in [
+        (None, Some(false)),
+        (Some("owner"), None),
+        (Some("mallory"), Some(false)),
+    ] {
+        let remote = playlist_body_with_access("Remote", &["a"], owner, read_only);
+        let (port, server) = playlist_get_server(vec![PlaylistReply::Json(remote)]).await;
+        let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+        store_set
+            .private_state
+            .bind_api_key_username("owner")
+            .unwrap();
+        persist_store(&paths, &mut store_set);
+        let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+        let base = strict_snapshot(&store_set, "Remote", &["a"]);
+        let pending = projection(
+            &base,
+            "Desired",
+            &[("entry-a", "a"), ("entry-b", "b")],
+            PendingPlaylistProjectionStage::Queued,
+        );
+        install_link_and_projection(&paths, &mut store_set, link.clone(), pending);
+
+        runtime
+            .flush_one_playlist_projection(&mut store_set, &client)
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        assert_eq!(
+            store_set
+                .bridge_state
+                .pending_playlist_projections()
+                .get(&playlist_id("local"))
+                .unwrap()
+                .stage,
+            PendingPlaylistProjectionStage::Queued
+        );
+        assert_eq!(
+            store_set
+                .bridge_state
+                .playlist_link(&playlist_id("local"))
+                .map(|link| link.state),
+            Some(PlaylistLinkState::AccessNeedsAttention)
+        );
+        assert!(
+            store_set.bridge_state.pending_playlist_imports().is_empty(),
+            "failed access verification must not turn a local intent into a remote edit"
+        );
+        assert_eq!(
+            load_store_set(&paths)
+                .unwrap()
+                .unwrap()
+                .bridge_state
+                .pending_playlist_projections()
+                .get(&playlist_id("local"))
+                .unwrap()
+                .stage,
+            PendingPlaylistProjectionStage::Queued
+        );
+        assert_eq!(
+            load_store_set(&paths)
+                .unwrap()
+                .unwrap()
+                .bridge_state
+                .playlist_link(&playlist_id("local"))
+                .map(|link| link.state),
+            Some(PlaylistLinkState::AccessNeedsAttention)
+        );
+        let status = read_status(&paths).unwrap();
+        assert_eq!(status.kind, OpenSubsonicStatusKind::NeedsAttention);
+        assert_eq!(status.playlist_projections_needing_attention, 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+}
+
+#[tokio::test]
+async fn exact_readback_updates_shadow_and_removes_the_pending_projection() {
+    let (port, server) = playlist_get_server(vec![PlaylistReply::Json(playlist_body(
+        "Desired",
+        &["a", "b"],
+    ))])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let pending = projection(
+        &base,
+        "Desired",
+        &[("entry-a", "a"), ("entry-b", "b")],
+        PendingPlaylistProjectionStage::Readback,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, pending);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    let linked = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(linked.state, PlaylistLinkState::Linked);
+    assert_eq!(linked.shadow.name, "Desired");
+    assert_eq!(
+        linked
+            .shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| (occurrence.entry_id.as_str(), occurrence.item_id.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("entry-a", "a"), ("entry-b", "b")]
+    );
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert!(
+        durable
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn exact_readback_with_changed_access_settles_but_keeps_link_attention() {
+    for stage in [
+        PendingPlaylistProjectionStage::Ambiguous,
+        PendingPlaylistProjectionStage::Readback,
+    ] {
+        let (port, server) = playlist_get_server(vec![PlaylistReply::Json(
+            playlist_body_with_access("Desired", &["a", "b"], Some("mallory"), Some(false)),
+        )])
+        .await;
+        let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+        let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+        let base = strict_snapshot(&store_set, "Remote", &["a"]);
+        let pending = projection(
+            &base,
+            "Desired",
+            &[("entry-a", "a"), ("entry-b", "b")],
+            stage,
+        );
+        install_link_and_projection(&paths, &mut store_set, link, pending);
+
+        runtime
+            .flush_one_playlist_projection(&mut store_set, &client)
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        assert!(
+            store_set
+                .bridge_state
+                .pending_playlist_projections()
+                .is_empty(),
+            "an exact desired readback acknowledges the projection at stage {stage:?}"
+        );
+        let linked = store_set
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .unwrap();
+        assert_eq!(linked.state, PlaylistLinkState::AccessNeedsAttention);
+        assert_eq!(
+            linked
+                .shadow
+                .occurrences
+                .iter()
+                .map(|occurrence| (occurrence.entry_id.as_str(), occurrence.item_id.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("entry-a", "a"), ("entry-b", "b")],
+            "settlement must keep the pending local occurrence identities"
+        );
+        assert_eq!(
+            read_status(&paths)
+                .unwrap()
+                .playlist_projections_needing_attention,
+            1
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+}
+
+#[tokio::test]
+async fn post_update_readback_rechecks_access_before_marking_link_up_to_date() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let base_body = playlist_body("Remote", &["a"]);
+    let changed_access_body =
+        playlist_body_with_access("Desired", &["a", "b"], Some("mallory"), Some(false));
+    let server = tokio::spawn(async move {
+        let (mut initial, _) = listener.accept().await.unwrap();
+        let initial_request = read_request(&mut initial).await;
+        assert!(
+            initial_request
+                .lines()
+                .next()
+                .unwrap_or_default()
+                .contains("/rest/getPlaylist.view?")
+        );
+        write_json(&mut initial, &base_body).await;
+
+        let (mut update, _) = listener.accept().await.unwrap();
+        let update_request = read_request(&mut update).await;
+        assert!(
+            update_request
+                .lines()
+                .next()
+                .unwrap_or_default()
+                .contains("/rest/updatePlaylist.view?")
+        );
+        write_json(&mut update, r#"{"subsonic-response":{"status":"ok"}}"#).await;
+
+        let (mut readback, _) = listener.accept().await.unwrap();
+        let readback_request = read_request(&mut readback).await;
+        assert!(
+            readback_request
+                .lines()
+                .next()
+                .unwrap_or_default()
+                .contains("/rest/getPlaylist.view?")
+        );
+        write_json(&mut readback, &changed_access_body).await;
+    });
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let pending = projection(
+        &base,
+        "Desired",
+        &[("entry-a", "a"), ("entry-b", "b")],
+        PendingPlaylistProjectionStage::Queued,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, pending);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    let linked = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(linked.state, PlaylistLinkState::AccessNeedsAttention);
+    assert_eq!(
+        linked
+            .shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| occurrence.entry_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["entry-a", "entry-b"]
+    );
+    assert_eq!(
+        read_status(&paths)
+            .unwrap()
+            .playlist_projections_needing_attention,
+        1
+    );
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/src/open_subsonic/bridge_runtime_tests/playlists/backlog.rs
+++ b/src/open_subsonic/bridge_runtime_tests/playlists/backlog.rs
@@ -1,0 +1,410 @@
+use super::*;
+
+#[tokio::test]
+async fn initial_link_import_survives_restart_reconcile_until_owner_acknowledges_it() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let link = playlist_link("new-local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let projection = projection(
+        &base,
+        "Initial merged name",
+        &[("entry-a", "a"), ("entry-b", "b")],
+        PendingPlaylistProjectionStage::Queued,
+    );
+    let import = import_batch("z-initial-link", "new-local");
+    runtime
+        .commit_playlist_preview(
+            &mut store_set,
+            import.clone(),
+            Some(link.clone()),
+            Some(projection.clone()),
+        )
+        .unwrap();
+
+    let mut restarted = load_store_set(&paths).unwrap().unwrap();
+    runtime
+        .reconcile_linked_playlists(&mut restarted, &[])
+        .unwrap();
+
+    assert_eq!(
+        restarted
+            .bridge_state
+            .pending_playlist_imports()
+            .get("z-initial-link"),
+        Some(&import)
+    );
+    assert_eq!(
+        restarted
+            .bridge_state
+            .playlist_link(&playlist_id("new-local")),
+        Some(&link),
+        "absence before owner acknowledgement is not a local deletion"
+    );
+    assert_eq!(
+        restarted
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&playlist_id("new-local")),
+        Some(&projection),
+        "pre-import reconciliation must not replace the deletion-free initial merge"
+    );
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        durable
+            .bridge_state
+            .playlist_link(&playlist_id("new-local")),
+        Some(&link)
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn pending_remote_observation_defers_newer_remote_snapshot_until_owner_ack() {
+    let (port, server) = playlist_get_server(vec![
+        PlaylistReply::Json(playlist_body_with_access(
+            "Remote B",
+            &["b"],
+            Some("owner"),
+            Some(false),
+        )),
+        PlaylistReply::Json(playlist_body_with_access(
+            "Remote C",
+            &["c"],
+            Some("owner"),
+            Some(false),
+        )),
+    ])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    store_set
+        .bridge_state
+        .upsert_playlist_link(playlist_link("local", "Remote A", &[("entry-a", "a")]))
+        .unwrap();
+    persist_store(&paths, &mut store_set);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    let first_operation_id = store_set
+        .bridge_state
+        .pending_playlist_import(&playlist_id("local"))
+        .map(|pending| pending.operation_id.clone())
+        .unwrap();
+    assert_eq!(
+        store_set
+            .bridge_state
+            .pending_playlist_import(&playlist_id("local"))
+            .map(|pending| pending.purpose),
+        Some(PendingPlaylistImportPurpose::RemoteObservation)
+    );
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    assert_eq!(
+        store_set
+            .bridge_state
+            .pending_playlist_import(&playlist_id("local"))
+            .map(|pending| pending.operation_id.as_str()),
+        Some(first_operation_id.as_str()),
+        "the B observation must remain the only batch until its owner acknowledgement"
+    );
+
+    runtime
+        .acknowledge_import(&mut store_set, &first_operation_id)
+        .unwrap();
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    let link = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(link.shadow.name, "Remote C");
+    assert_eq!(
+        link.shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| occurrence.item_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["c"]
+    );
+    let pending = store_set
+        .bridge_state
+        .pending_playlist_import(&playlist_id("local"))
+        .unwrap();
+    assert_ne!(pending.operation_id, first_operation_id);
+    assert_eq!(
+        pending.purpose,
+        PendingPlaylistImportPurpose::RemoteObservation
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn missing_local_beats_unacknowledged_remote_observation_and_keeps_server_copy() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    store_set
+        .bridge_state
+        .upsert_playlist_link(playlist_link("local", "Remote", &[("entry-a", "a")]))
+        .unwrap();
+    let mut observation = import_batch("remote-observation", "local");
+    observation.purpose = PendingPlaylistImportPurpose::RemoteObservation;
+    store_set
+        .bridge_state
+        .queue_playlist_import(observation)
+        .unwrap();
+    persist_store(&paths, &mut store_set);
+
+    runtime
+        .reconcile_linked_playlists(&mut store_set, &[])
+        .unwrap();
+
+    assert!(store_set.bridge_state.pending_playlist_imports().is_empty());
+    assert!(
+        store_set
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .is_none()
+    );
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert!(durable.bridge_state.pending_playlist_imports().is_empty());
+    assert!(
+        durable
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .is_none()
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn incompatible_local_content_isolated_per_link_and_recovers_after_content_changes() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    for (local, server, name) in [
+        ("a-missing", "server-a", "A"),
+        ("middle-valid", "server-middle", "Middle"),
+        ("z-invalid", "server-z", "Z"),
+    ] {
+        store_set
+            .bridge_state
+            .upsert_playlist_link(PlaylistLink {
+                local_playlist_id: playlist_id(local),
+                server_playlist_id: ServerPlaylistId::new(server).unwrap(),
+                managed_by_yututui: true,
+                state: PlaylistLinkState::Linked,
+                content_needs_attention: false,
+                shadow: PlaylistShadow {
+                    name: name.to_owned(),
+                    occurrences: Vec::new(),
+                    verified_at_unix: 100,
+                },
+            })
+            .unwrap();
+    }
+    persist_store(&paths, &mut store_set);
+    let mut invalid = local_snapshot(&store_set, "z-invalid", "Z", &[("entry", "item")]);
+    let valid = local_snapshot(
+        &store_set,
+        "middle-valid",
+        "Middle changed",
+        &[("valid-entry", "valid-item")],
+    );
+    let PortableTrackKey::OpenSubsonic { backend_id, .. } = &mut invalid.entries[0].track.key
+    else {
+        unreachable!();
+    };
+    *backend_id = "wrong-backend".to_owned();
+    runtime
+        .reconcile_linked_playlists(&mut store_set, &[valid, invalid])
+        .unwrap();
+
+    assert!(
+        store_set
+            .bridge_state
+            .playlist_link(&playlist_id("a-missing"))
+            .is_none(),
+        "an unrelated missing local still follows the safe unlink policy"
+    );
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .contains_key(&playlist_id("middle-valid")),
+        "the compatible link still advances"
+    );
+    assert_eq!(
+        store_set
+            .bridge_state
+            .playlist_link(&playlist_id("z-invalid"))
+            .map(|link| (link.state, link.content_needs_attention)),
+        Some((PlaylistLinkState::Linked, true))
+    );
+    assert_eq!(
+        store_set.bridge_state.playlist_contents_needing_attention(),
+        1
+    );
+    let status = read_status(&paths).unwrap();
+    assert_eq!(status.kind, OpenSubsonicStatusKind::NeedsAttention);
+    assert_eq!(status.playlist_contents_needing_attention, 1);
+    assert_eq!(
+        store_set
+            .bridge_state
+            .requeue_playlist_projections_needing_attention(),
+        0,
+        "connection setup must not clear a content error"
+    );
+
+    let repaired = local_snapshot(&store_set, "z-invalid", "Z repaired", &[("entry", "item")]);
+    let valid = local_snapshot(
+        &store_set,
+        "middle-valid",
+        "Middle changed",
+        &[("valid-entry", "valid-item")],
+    );
+    runtime
+        .reconcile_linked_playlists(&mut store_set, &[valid, repaired])
+        .unwrap();
+
+    assert_eq!(
+        store_set
+            .bridge_state
+            .playlist_link(&playlist_id("z-invalid"))
+            .map(|link| (link.state, link.content_needs_attention)),
+        Some((PlaylistLinkState::Linked, false))
+    );
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .contains_key(&playlist_id("z-invalid")),
+        "compatible replacement content automatically requeues projection"
+    );
+    assert_eq!(
+        load_store_set(&paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .playlist_contents_needing_attention(),
+        0
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn incompatible_content_does_not_abandon_ambiguous_or_readback_projection() {
+    for stage in [
+        PendingPlaylistProjectionStage::Ambiguous,
+        PendingPlaylistProjectionStage::Readback,
+    ] {
+        let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+        let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+        let base = strict_snapshot(&store_set, "Remote", &["a"]);
+        let pending = projection(
+            &base,
+            "In flight",
+            &[("entry-a", "a"), ("entry-b", "b")],
+            stage,
+        );
+        install_link_and_projection(&paths, &mut store_set, link.clone(), pending.clone());
+        let mut incompatible =
+            local_snapshot(&store_set, "local", "Bad", &[("entry-wrong", "wrong")]);
+        let PortableTrackKey::OpenSubsonic { backend_id, .. } =
+            &mut incompatible.entries[0].track.key
+        else {
+            unreachable!();
+        };
+        *backend_id = "wrong-backend".to_owned();
+
+        runtime
+            .reconcile_linked_playlists(&mut store_set, &[incompatible])
+            .unwrap();
+
+        let durable_link = store_set
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .unwrap();
+        assert_eq!(durable_link.state, link.state);
+        assert!(
+            durable_link.content_needs_attention,
+            "stage {stage:?} must report the independent content blocker"
+        );
+        assert_eq!(
+            store_set
+                .bridge_state
+                .pending_playlist_projections()
+                .get(&playlist_id("local")),
+            Some(&pending)
+        );
+        let status = read_status(&paths).unwrap();
+        assert_eq!(status.kind, OpenSubsonicStatusKind::NeedsAttention);
+        assert_eq!(status.playlist_contents_needing_attention, 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+}
+
+#[tokio::test]
+async fn access_attention_and_content_attention_are_independent_and_fail_closed() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let mut link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    link.state = PlaylistLinkState::AccessNeedsAttention;
+    store_set.bridge_state.upsert_playlist_link(link).unwrap();
+    persist_store(&paths, &mut store_set);
+    let mut incompatible = local_snapshot(&store_set, "local", "Bad", &[("entry-wrong", "wrong")]);
+    let PortableTrackKey::OpenSubsonic {
+        account_scope_id, ..
+    } = &mut incompatible.entries[0].track.key
+    else {
+        unreachable!();
+    };
+    *account_scope_id = "wrong-account".to_owned();
+
+    runtime
+        .reconcile_linked_playlists(&mut store_set, &[incompatible])
+        .unwrap();
+
+    let link = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(link.state, PlaylistLinkState::AccessNeedsAttention);
+    assert!(link.content_needs_attention);
+    assert_eq!(
+        store_set
+            .bridge_state
+            .requeue_playlist_projections_needing_attention(),
+        1
+    );
+    let link = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(link.state, PlaylistLinkState::Linked);
+    assert!(
+        link.content_needs_attention,
+        "reconnecting must not clear the separate content blocker"
+    );
+
+    let repaired = local_snapshot(&store_set, "local", "Repaired", &[("entry-b", "b")]);
+    runtime
+        .reconcile_linked_playlists(&mut store_set, &[repaired])
+        .unwrap();
+    let link = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(link.state, PlaylistLinkState::Linked);
+    assert!(!link.content_needs_attention);
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .contains_key(&playlist_id("local"))
+    );
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/src/open_subsonic/bridge_runtime_tests/playlists/concurrent_merge.rs
+++ b/src/open_subsonic/bridge_runtime_tests/playlists/concurrent_merge.rs
@@ -1,0 +1,363 @@
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[tokio::test]
+async fn queued_equal_local_and_remote_additions_stay_distinct_and_queue_union() {
+    let (port, server) = playlist_get_server(vec![PlaylistReply::Json(playlist_body(
+        "Remote",
+        &["a", "b"],
+    ))])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let pending = projection(
+        &base,
+        "Remote",
+        &[("entry-a", "a"), ("local-b", "b")],
+        PendingPlaylistProjectionStage::Queued,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, pending);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    let link = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(
+        link.shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| occurrence.item_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a", "b"],
+        "the durable shadow is the exact two-occurrence server readback"
+    );
+    let remote_b = link.shadow.occurrences[1].entry_id.clone();
+    assert_ne!(remote_b, entry_id("local-b"));
+
+    let follow_up = store_set
+        .bridge_state
+        .pending_playlist_projections()
+        .get(&playlist_id("local"))
+        .expect("the merged three-occurrence union still needs server projection");
+    assert_eq!(
+        follow_up
+            .ordered_entry_ids
+            .iter()
+            .map(PlaylistEntryId::as_str)
+            .collect::<Vec<_>>(),
+        vec!["entry-a", "local-b", remote_b.as_str()]
+    );
+    assert_eq!(
+        follow_up
+            .ordered_item_ids
+            .iter()
+            .map(ItemId::as_str)
+            .collect::<Vec<_>>(),
+        vec!["a", "b", "b"]
+    );
+    let import = store_set
+        .bridge_state
+        .pending_playlist_import(&playlist_id("local"))
+        .expect("the independent remote b is imported before projection");
+    assert_eq!(
+        import
+            .operations
+            .iter()
+            .filter_map(|input| match &input.operation {
+                Operation::UpsertPlaylistEntry {
+                    entry_id, track, ..
+                } => Some((entry_id, &track.key)),
+                _ => None,
+            })
+            .collect::<Vec<_>>(),
+        vec![(&remote_b, &portable_track(&store_set, "b").key)]
+    );
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert!(
+        durable
+            .bridge_state
+            .pending_playlist_import(&playlist_id("local"))
+            .is_some()
+    );
+    assert!(
+        durable
+            .bridge_state
+            .pending_playlist_projections()
+            .contains_key(&playlist_id("local"))
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn local_delete_beats_remote_move_then_restart_ack_projects_merged_order() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let requests = Arc::new(AtomicUsize::new(0));
+    let server_requests = Arc::clone(&requests);
+    let first = playlist_body("Remote", &["c", "b", "a"]);
+    let readback = playlist_body("Remote", &["c", "a"]);
+    let server = tokio::spawn(async move {
+        for (step, body) in [
+            (0, first.as_str()),
+            (1, first.as_str()),
+            (2, r#"{"subsonic-response":{"status":"ok"}}"#),
+            (3, readback.as_str()),
+        ] {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            server_requests.fetch_add(1, Ordering::SeqCst);
+            let request = read_request(&mut stream).await;
+            let request_line = request.lines().next().unwrap_or_default();
+            match step {
+                0 | 1 | 3 => assert!(request_line.contains("/rest/getPlaylist.view?")),
+                2 => {
+                    assert!(request_line.contains("/rest/updatePlaylist.view?"));
+                    assert!(request_line.contains("songIndexToRemove=1"));
+                }
+                _ => unreachable!(),
+            }
+            write_json(&mut stream, body).await;
+        }
+    });
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let link = playlist_link(
+        "local",
+        "Remote",
+        &[("entry-a", "a"), ("entry-b", "b"), ("entry-c", "c")],
+    );
+    let base = strict_snapshot(&store_set, "Remote", &["a", "b", "c"]);
+    let pending = projection(
+        &base,
+        "Remote",
+        &[("entry-a", "a"), ("entry-c", "c")],
+        PendingPlaylistProjectionStage::Queued,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, pending);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    assert_eq!(requests.load(Ordering::SeqCst), 1);
+
+    let mut restarted = load_store_set(&paths).unwrap().unwrap();
+    let link = restarted
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(
+        link.shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| (occurrence.entry_id.as_str(), occurrence.item_id.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("entry-c", "c"), ("entry-b", "b"), ("entry-a", "a")],
+        "the pre-ack shadow remains the exact current server state"
+    );
+    let follow_up = restarted
+        .bridge_state
+        .pending_playlist_projections()
+        .get(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(
+        follow_up
+            .ordered_entry_ids
+            .iter()
+            .map(PlaylistEntryId::as_str)
+            .collect::<Vec<_>>(),
+        vec!["entry-c", "entry-a"],
+        "the local deletion wins while the remote move order wins for survivors"
+    );
+
+    runtime
+        .flush_one_playlist_projection(&mut restarted, &client)
+        .await
+        .unwrap();
+    assert_eq!(
+        requests.load(Ordering::SeqCst),
+        1,
+        "the pending import barrier blocks the follow-up network write"
+    );
+    let import_id = restarted
+        .bridge_state
+        .pending_playlist_import(&playlist_id("local"))
+        .map(|pending| pending.operation_id.clone())
+        .unwrap();
+    runtime
+        .acknowledge_import(&mut restarted, &import_id)
+        .unwrap();
+    runtime
+        .flush_one_playlist_projection(&mut restarted, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    assert!(restarted.bridge_state.pending_playlist_imports().is_empty());
+    assert!(
+        restarted
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    let settled = restarted
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(
+        settled
+            .shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| (occurrence.entry_id.as_str(), occurrence.item_id.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("entry-c", "c"), ("entry-a", "a")]
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn duplicate_reorder_reuses_every_stable_occurrence_without_manual_attention() {
+    let (port, server) = playlist_get_server(vec![PlaylistReply::Json(playlist_body(
+        "Remote",
+        &["a", "b", "a"],
+    ))])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let link = playlist_link(
+        "local",
+        "Remote",
+        &[("first-a", "a"), ("second-a", "a"), ("entry-b", "b")],
+    );
+    let base = strict_snapshot(&store_set, "Remote", &["a", "a", "b"]);
+    let pending = projection(
+        &base,
+        "Remote",
+        &[("entry-b", "b"), ("second-a", "a"), ("first-a", "a")],
+        PendingPlaylistProjectionStage::Queued,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, pending);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    let link = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(
+        link.shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| (occurrence.entry_id.as_str(), occurrence.item_id.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("first-a", "a"), ("entry-b", "b"), ("second-a", "a")]
+    );
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    let import = store_set
+        .bridge_state
+        .pending_playlist_import(&playlist_id("local"))
+        .unwrap();
+    assert!(import.operations.iter().all(|input| !matches!(
+        input.operation,
+        Operation::UpsertPlaylistEntry { .. } | Operation::RemovePlaylistEntry { .. }
+    )));
+    assert!(
+        import
+            .operations
+            .iter()
+            .any(|input| matches!(input.operation, Operation::MovePlaylistEntry { .. }))
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn rename_merge_keeps_exact_remote_shadow_and_resolves_concurrent_winner() {
+    for (remote_name, expected_merged_name, expects_follow_up) in [
+        ("Base", "Local rename", true),
+        ("Remote rename", "Remote rename", false),
+    ] {
+        let (port, server) = playlist_get_server(vec![PlaylistReply::Json(playlist_body(
+            remote_name,
+            &["a", "remote"],
+        ))])
+        .await;
+        let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+        let link = playlist_link("local", "Base", &[("entry-a", "a")]);
+        let base = strict_snapshot(&store_set, "Base", &["a"]);
+        let pending = projection(
+            &base,
+            "Local rename",
+            &[("entry-a", "a")],
+            PendingPlaylistProjectionStage::Queued,
+        );
+        install_link_and_projection(&paths, &mut store_set, link, pending);
+
+        runtime
+            .flush_one_playlist_projection(&mut store_set, &client)
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        let link = store_set
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .unwrap();
+        assert_eq!(
+            link.shadow.name, remote_name,
+            "the durable shadow name is always the exact server readback"
+        );
+        let follow_up = store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&playlist_id("local"));
+        assert_eq!(follow_up.is_some(), expects_follow_up);
+        if let Some(follow_up) = follow_up {
+            assert_eq!(follow_up.desired_name, expected_merged_name);
+            assert_eq!(
+                follow_up.base_remote_fingerprint,
+                playlist_snapshot_fingerprint(&strict_snapshot(
+                    &store_set,
+                    remote_name,
+                    &["a", "remote"]
+                ))
+            );
+        }
+        let imported_name = store_set
+            .bridge_state
+            .pending_playlist_import(&playlist_id("local"))
+            .unwrap()
+            .operations
+            .iter()
+            .find_map(|input| match &input.operation {
+                Operation::UpsertPlaylist { name, .. } => Some(name.as_str()),
+                _ => None,
+            });
+        if remote_name == "Remote rename" {
+            assert_eq!(
+                imported_name,
+                Some("Remote rename"),
+                "a concurrent remote rename deterministically wins"
+            );
+        } else {
+            assert_eq!(
+                imported_name, None,
+                "an unchanged remote name leaves the pending local rename in the merged result"
+            );
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/src/open_subsonic/bridge_runtime_tests/playlists/recovery.rs
+++ b/src/open_subsonic/bridge_runtime_tests/playlists/recovery.rs
@@ -1,0 +1,641 @@
+use super::*;
+
+#[tokio::test]
+async fn ambiguous_crash_state_settles_exact_applied_readback_with_pending_entry_ids() {
+    let (port, server) = playlist_get_server(vec![PlaylistReply::Json(playlist_body(
+        "Desired",
+        &["a", "b"],
+    ))])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let pending = projection(
+        &base,
+        "Desired",
+        &[("entry-a", "a"), ("entry-b", "b")],
+        PendingPlaylistProjectionStage::Ambiguous,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, pending);
+
+    // Model a stop after updatePlaylist may have reached the server. The durable ambiguous stage
+    // makes an exact desired readback reuse the pending local identities without resubmission.
+    let mut restarted = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        restarted
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&playlist_id("local"))
+            .unwrap()
+            .stage,
+        PendingPlaylistProjectionStage::Ambiguous
+    );
+
+    runtime
+        .flush_one_playlist_projection(&mut restarted, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    assert!(
+        restarted
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    assert!(
+        restarted.bridge_state.pending_playlist_imports().is_empty(),
+        "an already-applied local projection must not become a new remote observation"
+    );
+    let linked = restarted
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(
+        linked
+            .shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| (occurrence.entry_id.as_str(), occurrence.item_id.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("entry-a", "a"), ("entry-b", "b")],
+        "settlement must retain the durable local occurrence identities"
+    );
+
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        durable
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .unwrap()
+            .shadow
+            .occurrences,
+        linked.shadow.occurrences
+    );
+    assert!(
+        durable
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    assert!(durable.bridge_state.pending_playlist_imports().is_empty());
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn third_state_readback_reuses_pending_occurrences_and_imports_only_remote_additions() {
+    let events = Arc::new(Mutex::new(Vec::<OpenSubsonicBridgeImport>::new()));
+    let sink_events = Arc::clone(&events);
+    let sink: OpenSubsonicBridgeSink = Arc::new(move |event| {
+        sink_events.lock().unwrap().push(event);
+    });
+    let (port, server) = playlist_get_server(vec![PlaylistReply::Json(playlist_body(
+        "Desired",
+        &["a", "b", "c"],
+    ))])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, Some(sink)).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let pending = projection(
+        &base,
+        "Desired",
+        &[("entry-a", "a"), ("entry-b", "b")],
+        PendingPlaylistProjectionStage::Readback,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, pending);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    let linked = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(
+        linked
+            .shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| occurrence.item_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a", "b", "c"]
+    );
+    assert_eq!(linked.shadow.occurrences[0].entry_id.as_str(), "entry-a");
+    assert_eq!(linked.shadow.occurrences[1].entry_id.as_str(), "entry-b");
+    let remote_c_entry_id = linked.shadow.occurrences[2].entry_id.clone();
+    assert_ne!(remote_c_entry_id, entry_id("entry-b"));
+
+    let pending_import = store_set
+        .bridge_state
+        .pending_playlist_imports()
+        .values()
+        .next()
+        .expect("remote-only c import");
+    assert_eq!(
+        pending_import
+            .operations
+            .iter()
+            .filter_map(|input| match &input.operation {
+                Operation::UpsertPlaylistEntry {
+                    entry_id,
+                    track:
+                        crate::personal_state::PortableTrack {
+                            key: PortableTrackKey::OpenSubsonic { item_id, .. },
+                            ..
+                        },
+                    ..
+                } => Some((entry_id.as_str(), item_id.as_str())),
+                _ => None,
+            })
+            .collect::<Vec<_>>(),
+        vec![(remote_c_entry_id.as_str(), "c")],
+        "the already-delivered pending b occurrence must not be imported under a second EntryId"
+    );
+
+    let observed = events.lock().unwrap()[0].clone();
+    let initial = OpenSubsonicBridgeImport::Playlist {
+        operation_id: "initial-local-desired".to_owned(),
+        backend_id: store_set.profile.backend_id().clone(),
+        local_playlist_id: playlist_id("local"),
+        purpose: PendingPlaylistImportPurpose::InitialOrImportCopy,
+        operations: vec![
+            ExternalOperationInput {
+                acknowledgement_id: "initial-playlist".to_owned(),
+                operation: Operation::UpsertPlaylist {
+                    playlist_id: playlist_id("local"),
+                    name: "Desired".to_owned(),
+                },
+                recorded_at_unix: 50,
+            },
+            ExternalOperationInput {
+                acknowledgement_id: "initial-entry-a".to_owned(),
+                operation: Operation::UpsertPlaylistEntry {
+                    playlist_id: playlist_id("local"),
+                    entry_id: entry_id("entry-a"),
+                    track: portable_track(&store_set, "a"),
+                    after_entry_id: None,
+                },
+                recorded_at_unix: 50,
+            },
+            ExternalOperationInput {
+                acknowledgement_id: "initial-entry-b".to_owned(),
+                operation: Operation::UpsertPlaylistEntry {
+                    playlist_id: playlist_id("local"),
+                    entry_id: entry_id("entry-b"),
+                    track: portable_track(&store_set, "b"),
+                    after_entry_id: Some(entry_id("entry-a")),
+                },
+                recorded_at_unix: 50,
+            },
+        ],
+    };
+    let mut app = crate::app::App::new(50);
+    let initial_state = crate::personal_state::legacy_state(
+        &app.library,
+        &app.playlists,
+        &app.signals,
+        &app.station,
+    )
+    .unwrap();
+    app.install_personal_state_runtime(initial_state).unwrap();
+    app.apply_open_subsonic_bridge_import(&initial).unwrap();
+    let first_envelopes = app.apply_open_subsonic_bridge_import(&observed).unwrap();
+    assert_eq!(
+        app.apply_open_subsonic_bridge_import(&observed).unwrap(),
+        first_envelopes
+    );
+    let snapshot = crate::personal_state::personal_playlist_snapshot(
+        &app.personal_state.ledger,
+        &playlist_id("local"),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(
+        snapshot
+            .entries
+            .iter()
+            .map(|entry| {
+                let PortableTrackKey::OpenSubsonic { item_id, .. } = &entry.track.key else {
+                    unreachable!("server playlist contains server tracks")
+                };
+                (entry.entry_id.as_str(), item_id.as_str())
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            ("entry-a", "a"),
+            ("entry-b", "b"),
+            (remote_c_entry_id.as_str(), "c")
+        ]
+    );
+
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert!(
+        durable
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    assert_eq!(durable.bridge_state.pending_playlist_imports().len(), 1);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn ambiguous_duplicate_third_state_converges_without_manual_review() {
+    let (port, server) = playlist_get_server(vec![PlaylistReply::Json(playlist_body(
+        "Desired",
+        &["a", "b", "b"],
+    ))])
+    .await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let pending = projection(
+        &base,
+        "Desired",
+        &[("entry-a", "a"), ("entry-b", "b")],
+        PendingPlaylistProjectionStage::Ambiguous,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, pending);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    let linked = store_set
+        .bridge_state
+        .playlist_link(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(
+        linked
+            .shadow
+            .occurrences
+            .iter()
+            .map(|occurrence| (occurrence.entry_id.as_str(), occurrence.item_id.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("entry-a", "a"),
+            ("entry-b", "b"),
+            (linked.shadow.occurrences[2].entry_id.as_str(), "b")
+        ]
+    );
+    assert_ne!(linked.shadow.occurrences[2].entry_id, entry_id("entry-b"));
+    let import = store_set
+        .bridge_state
+        .pending_playlist_imports()
+        .values()
+        .next()
+        .expect("the second exact b occurrence is a remote addition");
+    assert_eq!(
+        import
+            .operations
+            .iter()
+            .filter(|input| matches!(input.operation, Operation::UpsertPlaylistEntry { .. }))
+            .count(),
+        1
+    );
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert!(
+        durable
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    assert_eq!(durable.bridge_state.pending_playlist_imports().len(), 1);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn ambiguous_base_readback_only_requeues_after_proving_no_remote_change() {
+    let (port, server) =
+        playlist_get_server(vec![PlaylistReply::Json(playlist_body("Remote", &["a"]))]).await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let pending = projection(
+        &base,
+        "Desired",
+        &[("entry-a", "a"), ("entry-b", "b")],
+        PendingPlaylistProjectionStage::Ambiguous,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, pending);
+
+    runtime
+        .flush_one_playlist_projection(&mut store_set, &client)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    let pending = store_set
+        .bridge_state
+        .pending_playlist_projections()
+        .get(&playlist_id("local"))
+        .unwrap();
+    assert_eq!(pending.stage, PendingPlaylistProjectionStage::Queued);
+    assert_eq!(
+        store_set
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .unwrap()
+            .shadow
+            .name,
+        "Remote"
+    );
+    assert!(store_set.bridge_state.pending_playlist_imports().is_empty());
+    assert_eq!(
+        load_store_set(&paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&playlist_id("local"))
+            .unwrap()
+            .stage,
+        PendingPlaylistProjectionStage::Queued
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn mismatched_readback_never_blindly_resends_or_discards_pending_state() {
+    let (port, server) =
+        playlist_get_server(vec![PlaylistReply::Json(playlist_body("Remote", &["a"]))]).await;
+    let (root, paths, mut store_set, client, runtime) = fixture(port, None).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let pending = projection(
+        &base,
+        "Desired",
+        &[("entry-a", "a"), ("entry-b", "b")],
+        PendingPlaylistProjectionStage::Readback,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, pending.clone());
+
+    assert!(matches!(
+        runtime
+            .flush_one_playlist_projection(&mut store_set, &client)
+            .await,
+        Err(ServiceError::Server(ServerError::InvalidResponse))
+    ));
+    server.await.unwrap();
+
+    assert_eq!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&playlist_id("local")),
+        Some(&pending)
+    );
+    assert_eq!(
+        load_store_set(&paths)
+            .unwrap()
+            .unwrap()
+            .bridge_state
+            .pending_playlist_projections()
+            .get(&playlist_id("local")),
+        Some(&pending)
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn unlink_preserves_both_copies_and_removes_durable_link_state() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let local = local_snapshot(
+        &store_set,
+        "local",
+        "Local copy",
+        &[("entry-a", "a"), ("entry-b", "b")],
+    );
+    let local_before = local.clone();
+    let link = playlist_link("local", "Remote copy", &[("entry-a", "a")]);
+    let server_before = link.shadow.clone();
+    let base = strict_snapshot(&store_set, "Remote copy", &["a"]);
+    let pending = projection(
+        &base,
+        "Local copy",
+        &[("entry-a", "a"), ("entry-b", "b")],
+        PendingPlaylistProjectionStage::Queued,
+    );
+    install_link_and_projection(&paths, &mut store_set, link, pending);
+
+    runtime
+        .unlink_playlist(&mut store_set, &playlist_id("local"))
+        .unwrap();
+
+    assert_eq!(local, local_before);
+    assert_eq!(server_before.name, "Remote copy");
+    assert!(
+        store_set
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .is_none()
+    );
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    assert!(store_set.bridge_state.pending_playlist_imports().is_empty());
+
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert!(
+        durable
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .is_none()
+    );
+    assert!(
+        durable
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    assert!(durable.bridge_state.pending_playlist_imports().is_empty());
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn committed_delete_removes_link_and_queues_one_local_delete() {
+    let events = Arc::new(Mutex::new(Vec::<OpenSubsonicBridgeImport>::new()));
+    let sink_events = Arc::clone(&events);
+    let sink: OpenSubsonicBridgeSink = Arc::new(move |event| {
+        sink_events.lock().unwrap().push(event);
+    });
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, Some(sink)).await;
+    let link = playlist_link("local", "Remote", &[("entry-a", "a")]);
+    let base = strict_snapshot(&store_set, "Remote", &["a"]);
+    let pending = projection(
+        &base,
+        "Local",
+        &[("entry-a", "a")],
+        PendingPlaylistProjectionStage::Queued,
+    );
+    let mut stale_observation = import_batch("a-older-remote-observation", "local");
+    stale_observation.purpose = PendingPlaylistImportPurpose::RemoteObservation;
+    store_set
+        .bridge_state
+        .queue_playlist_import(stale_observation)
+        .unwrap();
+    install_link_and_projection(&paths, &mut store_set, link.clone(), pending);
+
+    runtime
+        .commit_deleted_playlist(&mut store_set, &link, "delete-both-operation".to_owned())
+        .unwrap();
+
+    assert!(
+        store_set
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .is_none()
+    );
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    let pending = store_set.bridge_state.pending_playlist_imports();
+    assert_eq!(pending.len(), 1);
+    let pending = pending.get("delete-both-operation").unwrap();
+    assert_eq!(pending.local_playlist_id, playlist_id("local"));
+    assert_eq!(pending.purpose, PendingPlaylistImportPurpose::Delete);
+    assert_eq!(pending.operations.len(), 1);
+    assert_eq!(
+        pending.operations[0].acknowledgement_id,
+        "delete-both-operation-delete"
+    );
+    assert!(matches!(
+        &pending.operations[0].operation,
+        Operation::DeletePlaylist {
+            playlist_id: deleted_playlist_id,
+            deleted: true,
+        } if deleted_playlist_id == &playlist_id("local")
+    ));
+
+    let emitted = events.lock().unwrap();
+    assert_eq!(emitted.len(), 1);
+    assert!(matches!(
+        &emitted[0],
+        OpenSubsonicBridgeImport::Playlist {
+            operation_id,
+            operations,
+            ..
+        } if operation_id == "delete-both-operation"
+            && operations.len() == 1
+            && matches!(
+                &operations[0].operation,
+                Operation::DeletePlaylist {
+                    playlist_id: deleted_playlist_id,
+                    deleted: true,
+                } if deleted_playlist_id == &playlist_id("local")
+            )
+    ));
+    drop(emitted);
+
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert!(
+        durable
+            .bridge_state
+            .playlist_link(&playlist_id("local"))
+            .is_none()
+    );
+    assert!(
+        durable
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    let durable_pending = durable.bridge_state.pending_playlist_imports();
+    assert_eq!(durable_pending.len(), 1);
+    assert_eq!(
+        durable_pending
+            .get("delete-both-operation")
+            .unwrap()
+            .operations
+            .len(),
+        1
+    );
+    assert!(
+        !durable_pending.contains_key("a-older-remote-observation"),
+        "the older observation must be retired in the same durable delete transaction"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn restoring_server_missing_link_replaces_server_identity_durably() {
+    let (root, paths, mut store_set, _client, runtime) = fixture(9, None).await;
+    let mut missing = playlist_link("local", "Missing server copy", &[("entry-a", "a")]);
+    missing.server_playlist_id = ServerPlaylistId::new("missing-server-playlist").unwrap();
+    missing.state = PlaylistLinkState::ServerMissing;
+    let base = strict_snapshot(&store_set, "Missing server copy", &["a"]);
+    let pending = projection(
+        &base,
+        "Local copy",
+        &[("entry-a", "a"), ("entry-b", "b")],
+        PendingPlaylistProjectionStage::Queued,
+    );
+    install_link_and_projection(&paths, &mut store_set, missing, pending);
+
+    let mut replacement = playlist_link(
+        "local",
+        "Restored server copy",
+        &[("entry-a", "a"), ("entry-b", "b")],
+    );
+    replacement.server_playlist_id = ServerPlaylistId::new("created-server-playlist").unwrap();
+    replacement.shadow.verified_at_unix = 200;
+    let current = local_snapshot(
+        &store_set,
+        "local",
+        "Restored server copy",
+        &[("entry-a", "a"), ("entry-b", "b")],
+    );
+    runtime
+        .commit_created_playlist_link(&mut store_set, replacement.clone(), &current, true)
+        .unwrap();
+
+    assert_eq!(
+        store_set.bridge_state.playlist_link(&playlist_id("local")),
+        Some(&replacement)
+    );
+    assert!(
+        store_set
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    assert!(store_set.bridge_state.pending_playlist_imports().is_empty());
+
+    let durable = load_store_set(&paths).unwrap().unwrap();
+    assert_eq!(
+        durable.bridge_state.playlist_link(&playlist_id("local")),
+        Some(&replacement)
+    );
+    assert!(
+        durable
+            .bridge_state
+            .pending_playlist_projections()
+            .is_empty()
+    );
+    assert!(durable.bridge_state.pending_playlist_imports().is_empty());
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/src/open_subsonic/bridge_store.rs
+++ b/src/open_subsonic/bridge_store.rs
@@ -8,12 +8,13 @@ use zeroize::Zeroizing;
 use super::model::{AccountScopeId, BackendId, ItemId};
 use super::profile::StoreError;
 use super::rating::{RawServerRating, map_server_rating};
-use crate::personal_state::{EngagementKind, PortableTrack, PortableTrackKey, Rating};
+use crate::personal_state::{EngagementKind, PlaylistId, PortableTrack, PortableTrackKey, Rating};
 
 mod aggregate_ranges;
 mod history_credits;
 mod history_cursor;
 mod outbound_lifecycle;
+pub(crate) mod playlists;
 
 pub(crate) use aggregate_ranges::PendingAggregateRange;
 pub use history_cursor::NativeHistoryHealth;
@@ -21,9 +22,15 @@ pub(crate) use history_cursor::{HistoryContinuation, HistoryCursor, PendingNativ
 use outbound_lifecycle::{
     completed_matches_pending, same_outbound_identity, validate_outbound_scrobble,
 };
+pub use playlists::PendingPlaylistImportPurpose;
+pub(crate) use playlists::{
+    PendingPlaylistCreate, PendingPlaylistImportBatch, PendingPlaylistProjection,
+    PendingPlaylistProjectionStage, PlaylistLink, PlaylistLinkState, PlaylistShadow,
+    PlaylistShadowOccurrence,
+};
 
 pub(crate) const BRIDGE_KIND: &str = "yututui_open_subsonic_bridge";
-pub(crate) const BRIDGE_SCHEMA_VERSION: u32 = 2;
+pub(crate) const BRIDGE_SCHEMA_VERSION: u32 = 3;
 pub(crate) const MAX_BRIDGE_BYTES: u64 = 16 * 1024 * 1024;
 
 const MAX_RATING_SHADOWS: usize = 20_000;
@@ -197,7 +204,7 @@ pub(crate) struct CompletedOutboundScrobble {
     pub kind: OutboundScrobbleKind,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct OpenSubsonicBridgeState {
     revision: u64,
     backend_id: BackendId,
@@ -214,6 +221,10 @@ pub struct OpenSubsonicBridgeState {
     outbound_scrobbles: VecDeque<PendingOutboundScrobble>,
     outbound_echoes: VecDeque<OutboundScrobbleEcho>,
     completed_outbound_scrobbles: VecDeque<CompletedOutboundScrobble>,
+    playlist_links: BTreeMap<PlaylistId, PlaylistLink>,
+    pending_playlist_imports: BTreeMap<String, PendingPlaylistImportBatch>,
+    pending_playlist_projections: BTreeMap<PlaylistId, PendingPlaylistProjection>,
+    pending_playlist_creates: BTreeMap<PlaylistId, PendingPlaylistCreate>,
 }
 
 #[allow(
@@ -238,6 +249,10 @@ impl OpenSubsonicBridgeState {
             outbound_scrobbles: VecDeque::new(),
             outbound_echoes: VecDeque::new(),
             completed_outbound_scrobbles: VecDeque::new(),
+            playlist_links: BTreeMap::new(),
+            pending_playlist_imports: BTreeMap::new(),
+            pending_playlist_projections: BTreeMap::new(),
+            pending_playlist_creates: BTreeMap::new(),
         }
     }
 
@@ -682,6 +697,7 @@ impl OpenSubsonicBridgeState {
     }
 
     fn validate(&self) -> Result<(), BridgeMutationError> {
+        self.validate_playlist_state()?;
         if self.rating_shadows.len() > MAX_RATING_SHADOWS
             || self.pending_rating_projections.len() > MAX_PENDING_RATING_PROJECTIONS
             || self.pending_rating_imports.len() > MAX_PENDING_RATING_IMPORTS
@@ -903,7 +919,7 @@ struct DiskBridgeStateV1 {
 
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct DiskBridgeStateV2 {
+struct DiskBridgeState {
     kind: String,
     schema_version: u32,
     revision: u64,
@@ -926,13 +942,21 @@ struct DiskBridgeStateV2 {
     outbound_echoes: VecDeque<OutboundScrobbleEcho>,
     #[serde(default)]
     completed_outbound_scrobbles: VecDeque<CompletedOutboundScrobble>,
+    #[serde(default)]
+    playlist_links: BTreeMap<PlaylistId, PlaylistLink>,
+    #[serde(default)]
+    pending_playlist_imports: BTreeMap<String, PendingPlaylistImportBatch>,
+    #[serde(default)]
+    pending_playlist_projections: BTreeMap<PlaylistId, PendingPlaylistProjection>,
+    #[serde(default)]
+    pending_playlist_creates: BTreeMap<PlaylistId, PendingPlaylistCreate>,
 }
 
 pub(crate) fn encode_bridge(
     state: &OpenSubsonicBridgeState,
 ) -> Result<Zeroizing<Vec<u8>>, StoreError> {
     state.validate().map_err(|_| StoreError::InvalidState)?;
-    let disk = DiskBridgeStateV2 {
+    let disk = DiskBridgeState {
         kind: BRIDGE_KIND.to_owned(),
         schema_version: BRIDGE_SCHEMA_VERSION,
         revision: state.revision,
@@ -950,6 +974,10 @@ pub(crate) fn encode_bridge(
         outbound_scrobbles: state.outbound_scrobbles.clone(),
         outbound_echoes: state.outbound_echoes.clone(),
         completed_outbound_scrobbles: state.completed_outbound_scrobbles.clone(),
+        playlist_links: state.playlist_links.clone(),
+        pending_playlist_imports: state.pending_playlist_imports.clone(),
+        pending_playlist_projections: state.pending_playlist_projections.clone(),
+        pending_playlist_creates: state.pending_playlist_creates.clone(),
     };
     let bytes =
         Zeroizing::new(serde_json::to_vec(&disk).map_err(|_| StoreError::SerializationFailed)?);
@@ -979,10 +1007,10 @@ pub(crate) fn decode_bridge(bytes: &[u8]) -> Result<OpenSubsonicBridgeState, Sto
             state.revision = disk.revision;
             state
         }
-        BRIDGE_SCHEMA_VERSION => {
-            let disk: DiskBridgeStateV2 =
+        2 | BRIDGE_SCHEMA_VERSION => {
+            let disk: DiskBridgeState =
                 serde_json::from_slice(bytes).map_err(|_| StoreError::InvalidState)?;
-            if disk.kind != BRIDGE_KIND || disk.schema_version != BRIDGE_SCHEMA_VERSION {
+            if disk.kind != BRIDGE_KIND || disk.schema_version != header.schema_version {
                 return Err(StoreError::InvalidState);
             }
             OpenSubsonicBridgeState {
@@ -1001,6 +1029,10 @@ pub(crate) fn decode_bridge(bytes: &[u8]) -> Result<OpenSubsonicBridgeState, Sto
                 outbound_scrobbles: disk.outbound_scrobbles,
                 outbound_echoes: disk.outbound_echoes,
                 completed_outbound_scrobbles: disk.completed_outbound_scrobbles,
+                playlist_links: disk.playlist_links,
+                pending_playlist_imports: disk.pending_playlist_imports,
+                pending_playlist_projections: disk.pending_playlist_projections,
+                pending_playlist_creates: disk.pending_playlist_creates,
             }
         }
         _ => return Err(StoreError::InvalidState),
@@ -1016,6 +1048,7 @@ mod tests {
     mod aggregate_continuation;
     mod outbound_scrobble;
     mod rating_coalescing;
+    mod schema;
 
     fn bridge() -> OpenSubsonicBridgeState {
         OpenSubsonicBridgeState::new(
@@ -1059,173 +1092,6 @@ mod tests {
             artist_key: "artist".to_owned(),
             observed_at_unix: 12,
         }
-    }
-
-    #[test]
-    fn bridge_round_trip_preserves_every_queue_and_invalid_raw_rating() {
-        let mut bridge = bridge();
-        bridge.set_native_history_health(NativeHistoryHealth::Detailed);
-        let item = ItemId::new("song").unwrap();
-        bridge
-            .upsert_rating_shadow(item.clone(), shadow(Some(99), true, 10))
-            .unwrap();
-        bridge
-            .queue_rating_projection(
-                item.clone(),
-                PendingRatingProjection {
-                    operation_id: "local-op".to_owned(),
-                    target: Rating::Disliked,
-                    stage: PendingRatingProjectionStage::SetStarred,
-                    last_readback: Some(RawServerRating {
-                        user_rating: Some(99),
-                        starred: true,
-                    }),
-                    queued_at_unix: 11,
-                },
-            )
-            .unwrap();
-        bridge
-            .queue_rating_import(
-                "server-observation".to_owned(),
-                PendingRatingImport {
-                    item_id: item.clone(),
-                    track: portable("song"),
-                    raw: RawServerRating {
-                        user_rating: Some(-9),
-                        starred: false,
-                    },
-                    mapped: Rating::Neutral,
-                    observed_at_unix: 12,
-                },
-            )
-            .unwrap();
-        bridge
-            .queue_engagement_import("history-row".to_owned(), engagement("song"))
-            .unwrap();
-        bridge
-            .upsert_aggregate_play_shadow(
-                item.clone(),
-                AggregatePlayShadow {
-                    play_count: 7,
-                    played_at: Some("2026-07-26T10:00:00Z".to_owned()),
-                    observed_at_unix: 13,
-                    counter_epoch: 2,
-                },
-            )
-            .unwrap();
-        bridge
-            .set_history_cursor(
-                "navidrome-native".to_owned(),
-                HistoryCursor {
-                    high_water_id: Some("row-7".to_owned()),
-                    overlap_started_at_unix: Some(14),
-                    updated_at_unix: 15,
-                    continuation: None,
-                    pending_metadata_rows: Vec::new(),
-                },
-            )
-            .unwrap();
-        bridge
-            .queue_outbound_scrobble(PendingOutboundScrobble {
-                event_id: "engagement-1".to_owned(),
-                item_id: item,
-                played_at_unix: 16,
-                kind: OutboundScrobbleKind::Submission,
-                delivery: OutboundScrobbleDelivery::Queued,
-                baseline_captured: false,
-                baseline_play_count: None,
-                baseline_played_at: None,
-                exact_credit_recorded: false,
-                exact_credit_epoch: None,
-                uncertain_readbacks: 0,
-                source_marker_acknowledged: false,
-            })
-            .unwrap();
-        bridge
-            .record_outbound_echo(OutboundScrobbleEcho {
-                event_id: "echo-1".to_owned(),
-                item_id: ItemId::new("song").unwrap(),
-                played_at_unix: 17,
-            })
-            .unwrap();
-
-        let decoded = decode_bridge(&encode_bridge(&bridge).unwrap()).unwrap();
-        assert_eq!(decoded, bridge);
-        assert_eq!(
-            decoded
-                .rating_shadow(&ItemId::new("song").unwrap())
-                .unwrap()
-                .raw
-                .user_rating,
-            Some(99)
-        );
-    }
-
-    #[test]
-    fn schema_one_empty_bridge_migrates_explicitly_to_schema_two() {
-        let legacy = br#"{
-            "kind":"yututui_open_subsonic_bridge",
-            "schema_version":1,
-            "revision":8,
-            "backend_id":"backend",
-            "account_scope_id":"account"
-        }"#;
-        let migrated = decode_bridge(legacy).unwrap();
-        assert_eq!(migrated.revision(), 8);
-        assert!(migrated.rating_shadows().is_empty());
-        assert!(migrated.pending_rating_projections().is_empty());
-        assert!(migrated.pending_rating_imports().is_empty());
-        assert!(migrated.pending_engagement_imports().is_empty());
-        assert!(migrated.aggregate_play_shadows().is_empty());
-        assert!(migrated.history_dedupe_credits().is_empty());
-        assert!(migrated.history_cursors().is_empty());
-        assert!(migrated.outbound_scrobbles().is_empty());
-        assert!(migrated.outbound_echoes().is_empty());
-        assert!(migrated.completed_outbound_scrobbles().is_empty());
-        assert_eq!(migrated.native_history_health(), NativeHistoryHealth::Off);
-        let encoded: serde_json::Value =
-            serde_json::from_slice(&encode_bridge(&migrated).unwrap()).unwrap();
-        assert_eq!(
-            encoded["schema_version"],
-            serde_json::Value::from(BRIDGE_SCHEMA_VERSION)
-        );
-    }
-
-    #[test]
-    fn schema_two_aggregate_shadow_without_counter_epoch_defaults_to_legacy_ids() {
-        let mut state = bridge();
-        state
-            .upsert_aggregate_play_shadow(
-                ItemId::new("song").unwrap(),
-                AggregatePlayShadow {
-                    play_count: 4,
-                    played_at: None,
-                    observed_at_unix: 12,
-                    counter_epoch: 3,
-                },
-            )
-            .unwrap();
-        let mut encoded: serde_json::Value =
-            serde_json::from_slice(&encode_bridge(&state).unwrap()).unwrap();
-        encoded["aggregate_play_shadows"]["song"]
-            .as_object_mut()
-            .unwrap()
-            .remove("counter_epoch");
-        encoded
-            .as_object_mut()
-            .unwrap()
-            .remove("native_history_health");
-
-        let decoded = decode_bridge(&serde_json::to_vec(&encoded).unwrap()).unwrap();
-        assert_eq!(
-            decoded
-                .aggregate_play_shadows()
-                .get(&ItemId::new("song").unwrap())
-                .unwrap()
-                .counter_epoch,
-            0
-        );
-        assert_eq!(decoded.native_history_health(), NativeHistoryHealth::Off);
     }
 
     #[test]

--- a/src/open_subsonic/bridge_store/playlists.rs
+++ b/src/open_subsonic/bridge_store/playlists.rs
@@ -1,0 +1,1294 @@
+//! Bounded durable state for explicitly linked OpenSubsonic playlists.
+
+#![allow(
+    dead_code,
+    reason = "the linked-playlist owner runtime consumes this durable API in the next integration step"
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use super::{BridgeMutationError, OpenSubsonicBridgeState};
+use crate::open_subsonic::model::{ItemId, ServerPlaylistId};
+use crate::personal_state::{
+    ExternalOperationInput, Operation, PlaylistEntryId, PlaylistId, PortableTrackKey,
+};
+
+pub(super) const MAX_PLAYLIST_LINKS: usize = 999;
+pub(super) const MAX_PENDING_PLAYLIST_IMPORTS: usize = 999;
+pub(super) const MAX_PENDING_PLAYLIST_PROJECTIONS: usize = 999;
+pub(super) const MAX_PENDING_PLAYLIST_CREATES: usize = 999;
+pub(super) const MAX_PLAYLIST_OCCURRENCES: usize = 999;
+
+const MAX_PLAYLIST_IMPORT_OPERATIONS: usize = MAX_PLAYLIST_OCCURRENCES * 2 + 2;
+const MAX_PLAYLIST_ID_CHARS: usize = 512;
+const MAX_PLAYLIST_OPERATION_ID_CHARS: usize = 256;
+const MAX_REMOTE_FINGERPRINT_CHARS: usize = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PlaylistLinkState {
+    Linked,
+    /// The remote row no longer proves exact ownership and writable access.
+    ///
+    /// The link and any local projection remain durable, but automatic reads and writes stay
+    /// dormant until an explicit same-account setup refresh requeues access verification.
+    AccessNeedsAttention,
+    ServerMissing,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PlaylistShadowOccurrence {
+    pub entry_id: PlaylistEntryId,
+    pub item_id: ItemId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PlaylistShadow {
+    pub name: String,
+    pub occurrences: Vec<PlaylistShadowOccurrence>,
+    pub verified_at_unix: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PlaylistLink {
+    pub local_playlist_id: PlaylistId,
+    pub server_playlist_id: ServerPlaylistId,
+    pub managed_by_yututui: bool,
+    pub state: PlaylistLinkState,
+    /// Independent of remote access/missing state: incompatible local content is resolved only by
+    /// a later compatible local snapshot, never by reconnect/setup.
+    #[serde(default)]
+    pub content_needs_attention: bool,
+    pub shadow: PlaylistShadow,
+}
+
+/// One all-or-nothing batch waiting to cross the personal-state owner boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PendingPlaylistImportPurpose {
+    /// The deletion-free initial merge used by both import-copy and explicit link setup.
+    InitialOrImportCopy,
+    /// A later exact server snapshot observed for an existing explicit link.
+    RemoteObservation,
+    /// An explicit local deletion after the corresponding server lifecycle choice.
+    Delete,
+}
+
+/// One all-or-nothing batch waiting to cross the personal-state owner boundary.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PendingPlaylistImportBatch {
+    /// Durable acknowledgement for the batch itself. The contained operations retain their own
+    /// deterministic acknowledgement IDs so a partially applied crash replay remains idempotent.
+    pub operation_id: String,
+    /// Explicit causal target; never infer queue ordering from the opaque operation ID.
+    pub local_playlist_id: PlaylistId,
+    pub purpose: PendingPlaylistImportPurpose,
+    pub operations: Vec<ExternalOperationInput>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PendingPlaylistProjectionStage {
+    Queued,
+    /// The write may have reached the server. Never resend it before a bounded readback.
+    Ambiguous,
+    Readback,
+    /// A deterministic policy or permission failure requires user action. Automatic delivery must
+    /// remain dormant until the link is explicitly resolved or a later setup refresh requeues it.
+    NeedsAttention,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PendingPlaylistProjection {
+    pub desired_name: String,
+    pub ordered_entry_ids: Vec<PlaylistEntryId>,
+    pub ordered_item_ids: Vec<ItemId>,
+    pub stage: PendingPlaylistProjectionStage,
+    pub base_remote_fingerprint: String,
+}
+
+/// A durable non-idempotent create intent.
+///
+/// This record crosses the storage boundary before `createPlaylist` is sent. If the response is
+/// lost, its absence of a confirmed server ID deliberately blocks another create instead of
+/// risking a duplicate server playlist.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PendingPlaylistCreate {
+    pub local_playlist_id: PlaylistId,
+    pub expected_missing_server_id: Option<ServerPlaylistId>,
+    pub created_server_playlist_id: Option<ServerPlaylistId>,
+    pub desired_name: String,
+    pub ordered_entry_ids: Vec<PlaylistEntryId>,
+    pub ordered_item_ids: Vec<ItemId>,
+    pub started_at_unix: i64,
+}
+
+impl OpenSubsonicBridgeState {
+    pub(crate) fn playlist_links(&self) -> &BTreeMap<PlaylistId, PlaylistLink> {
+        &self.playlist_links
+    }
+
+    pub(crate) fn playlist_link(&self, playlist_id: &PlaylistId) -> Option<&PlaylistLink> {
+        self.playlist_links.get(playlist_id)
+    }
+
+    /// Insert a new explicit link or refresh the shadow for the same exact local/server pair.
+    ///
+    /// Reusing either side for a different pair is rejected; equal server names are irrelevant.
+    pub(crate) fn upsert_playlist_link(
+        &mut self,
+        link: PlaylistLink,
+    ) -> Result<(), BridgeMutationError> {
+        validate_playlist_link(&link)?;
+        if let Some(existing) = self.playlist_links.get(&link.local_playlist_id)
+            && existing.server_playlist_id != link.server_playlist_id
+        {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+        if self.playlist_links.iter().any(|(local_id, existing)| {
+            local_id != &link.local_playlist_id
+                && existing.server_playlist_id == link.server_playlist_id
+        }) {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+        if !self.playlist_links.contains_key(&link.local_playlist_id)
+            && self.playlist_links.len() >= MAX_PLAYLIST_LINKS
+        {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        self.playlist_links
+            .insert(link.local_playlist_id.clone(), link);
+        Ok(())
+    }
+
+    pub(crate) fn remove_playlist_link(
+        &mut self,
+        playlist_id: &PlaylistId,
+    ) -> Option<PlaylistLink> {
+        self.playlist_links.remove(playlist_id)
+    }
+
+    pub(crate) fn pending_playlist_imports(&self) -> &BTreeMap<String, PendingPlaylistImportBatch> {
+        &self.pending_playlist_imports
+    }
+
+    pub(crate) fn pending_playlist_import(
+        &self,
+        playlist_id: &PlaylistId,
+    ) -> Option<&PendingPlaylistImportBatch> {
+        self.pending_playlist_imports
+            .values()
+            .find(|pending| &pending.local_playlist_id == playlist_id)
+    }
+
+    pub(crate) fn queue_playlist_import(
+        &mut self,
+        pending: PendingPlaylistImportBatch,
+    ) -> Result<(), BridgeMutationError> {
+        self.validate_pending_playlist_import(&pending)?;
+        if let Some(existing) = self.pending_playlist_imports.get(&pending.operation_id) {
+            return if existing == &pending {
+                Ok(())
+            } else {
+                Err(BridgeMutationError::ConflictingEntry)
+            };
+        }
+        if self
+            .pending_playlist_imports
+            .values()
+            .any(|existing| existing.local_playlist_id == pending.local_playlist_id)
+        {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+        let incoming_acknowledgements = pending
+            .operations
+            .iter()
+            .map(|operation| operation.acknowledgement_id.as_str())
+            .collect::<BTreeSet<_>>();
+        if self.pending_playlist_imports.values().any(|existing| {
+            existing.operations.iter().any(|operation| {
+                incoming_acknowledgements.contains(operation.acknowledgement_id.as_str())
+            })
+        }) {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+        if self.pending_playlist_imports.len() >= MAX_PENDING_PLAYLIST_IMPORTS {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        self.pending_playlist_imports
+            .insert(pending.operation_id.clone(), pending);
+        Ok(())
+    }
+
+    pub(crate) fn remove_playlist_import(
+        &mut self,
+        operation_id: &str,
+    ) -> Option<PendingPlaylistImportBatch> {
+        self.pending_playlist_imports.remove(operation_id)
+    }
+
+    pub(crate) fn retire_playlist_import(
+        &mut self,
+        playlist_id: &PlaylistId,
+    ) -> Option<PendingPlaylistImportBatch> {
+        let operation_id =
+            self.pending_playlist_imports
+                .iter()
+                .find_map(|(operation_id, pending)| {
+                    (&pending.local_playlist_id == playlist_id).then(|| operation_id.clone())
+                })?;
+        self.pending_playlist_imports.remove(&operation_id)
+    }
+
+    pub(crate) fn pending_playlist_projections(
+        &self,
+    ) -> &BTreeMap<PlaylistId, PendingPlaylistProjection> {
+        &self.pending_playlist_projections
+    }
+
+    pub(crate) fn playlist_projections_needing_attention(&self) -> usize {
+        let server_missing_ids = self
+            .playlist_links
+            .iter()
+            .filter(|(_, link)| link.state == PlaylistLinkState::ServerMissing)
+            .map(|(playlist_id, _)| playlist_id.clone())
+            .collect::<BTreeSet<_>>();
+        let mut playlist_ids = BTreeSet::new();
+        playlist_ids.extend(
+            self.playlist_links
+                .iter()
+                .filter(|(_, link)| link.state == PlaylistLinkState::AccessNeedsAttention)
+                .map(|(playlist_id, _)| playlist_id.clone()),
+        );
+        playlist_ids.extend(
+            self.pending_playlist_projections
+                .iter()
+                .filter(|(playlist_id, pending)| {
+                    pending.stage == PendingPlaylistProjectionStage::NeedsAttention
+                        && !server_missing_ids.contains(*playlist_id)
+                })
+                .map(|(playlist_id, _)| playlist_id.clone()),
+        );
+        playlist_ids.len()
+    }
+
+    pub(crate) fn playlist_contents_needing_attention(&self) -> usize {
+        self.playlist_links
+            .values()
+            .filter(|link| link.content_needs_attention)
+            .count()
+    }
+
+    /// Server-side deletions need an explicit keep/restore decision, not connection repair.
+    /// An in-progress restore is already represented by create recovery and is not counted twice.
+    pub(crate) fn playlist_links_needing_decision(&self) -> usize {
+        self.playlist_links
+            .iter()
+            .filter(|(playlist_id, link)| {
+                link.state == PlaylistLinkState::ServerMissing
+                    && !self.pending_playlist_creates.contains_key(*playlist_id)
+            })
+            .count()
+    }
+
+    pub(crate) fn requeue_playlist_projections_needing_attention(&mut self) -> usize {
+        let mut requeued = BTreeSet::new();
+        for (playlist_id, link) in &mut self.playlist_links {
+            if link.state == PlaylistLinkState::AccessNeedsAttention {
+                link.state = PlaylistLinkState::Linked;
+                requeued.insert(playlist_id.clone());
+            }
+        }
+        for (playlist_id, pending) in &mut self.pending_playlist_projections {
+            if pending.stage == PendingPlaylistProjectionStage::NeedsAttention {
+                pending.stage = PendingPlaylistProjectionStage::Queued;
+                requeued.insert(playlist_id.clone());
+            }
+        }
+        requeued.len()
+    }
+
+    pub(crate) fn queue_playlist_projection(
+        &mut self,
+        playlist_id: PlaylistId,
+        pending: PendingPlaylistProjection,
+    ) -> Result<(), BridgeMutationError> {
+        validate_playlist_id(&playlist_id)?;
+        validate_pending_playlist_projection(&pending)?;
+        if let Some(existing) = self.pending_playlist_projections.get(&playlist_id) {
+            return if existing == &pending {
+                Ok(())
+            } else {
+                Err(BridgeMutationError::ConflictingEntry)
+            };
+        }
+        if self.pending_playlist_projections.len() >= MAX_PENDING_PLAYLIST_PROJECTIONS {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        self.pending_playlist_projections
+            .insert(playlist_id, pending);
+        Ok(())
+    }
+
+    /// Advance delivery state without allowing the desired projection or its comparison base to
+    /// change underneath an ambiguous write.
+    pub(crate) fn replace_playlist_projection(
+        &mut self,
+        playlist_id: &PlaylistId,
+        pending: PendingPlaylistProjection,
+    ) -> Result<(), BridgeMutationError> {
+        validate_playlist_id(playlist_id)?;
+        validate_pending_playlist_projection(&pending)?;
+        let existing = self
+            .pending_playlist_projections
+            .get(playlist_id)
+            .ok_or(BridgeMutationError::ConflictingEntry)?;
+        if existing.desired_name != pending.desired_name
+            || existing.ordered_entry_ids != pending.ordered_entry_ids
+            || existing.ordered_item_ids != pending.ordered_item_ids
+            || existing.base_remote_fingerprint != pending.base_remote_fingerprint
+        {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+        self.pending_playlist_projections
+            .insert(playlist_id.clone(), pending);
+        Ok(())
+    }
+
+    pub(crate) fn remove_playlist_projection(
+        &mut self,
+        playlist_id: &PlaylistId,
+    ) -> Option<PendingPlaylistProjection> {
+        self.pending_playlist_projections.remove(playlist_id)
+    }
+
+    pub(crate) fn pending_playlist_creates(&self) -> &BTreeMap<PlaylistId, PendingPlaylistCreate> {
+        &self.pending_playlist_creates
+    }
+
+    pub(crate) fn queue_playlist_create(
+        &mut self,
+        pending: PendingPlaylistCreate,
+    ) -> Result<(), BridgeMutationError> {
+        validate_pending_playlist_create(self, &pending)?;
+        if let Some(existing) = self
+            .pending_playlist_creates
+            .get(&pending.local_playlist_id)
+        {
+            return if existing == &pending {
+                Ok(())
+            } else {
+                Err(BridgeMutationError::ConflictingEntry)
+            };
+        }
+        if self.pending_playlist_creates.len() >= MAX_PENDING_PLAYLIST_CREATES {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        self.pending_playlist_creates
+            .insert(pending.local_playlist_id.clone(), pending);
+        Ok(())
+    }
+
+    pub(crate) fn record_playlist_create_server_id(
+        &mut self,
+        playlist_id: &PlaylistId,
+        server_playlist_id: ServerPlaylistId,
+    ) -> Result<(), BridgeMutationError> {
+        if self.playlist_links.values().any(|link| {
+            link.local_playlist_id != *playlist_id && link.server_playlist_id == server_playlist_id
+        }) || self
+            .pending_playlist_creates
+            .iter()
+            .any(|(other_id, pending)| {
+                other_id != playlist_id
+                    && pending.created_server_playlist_id.as_ref() == Some(&server_playlist_id)
+            })
+        {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+        let pending = self
+            .pending_playlist_creates
+            .get_mut(playlist_id)
+            .ok_or(BridgeMutationError::ConflictingEntry)?;
+        if let Some(existing) = &pending.created_server_playlist_id {
+            return if existing == &server_playlist_id {
+                Ok(())
+            } else {
+                Err(BridgeMutationError::ConflictingEntry)
+            };
+        }
+        pending.created_server_playlist_id = Some(server_playlist_id);
+        Ok(())
+    }
+
+    pub(crate) fn remove_playlist_create(
+        &mut self,
+        playlist_id: &PlaylistId,
+    ) -> Option<PendingPlaylistCreate> {
+        self.pending_playlist_creates.remove(playlist_id)
+    }
+
+    pub(super) fn validate_playlist_state(&self) -> Result<(), BridgeMutationError> {
+        if self.playlist_links.len() > MAX_PLAYLIST_LINKS
+            || self.pending_playlist_imports.len() > MAX_PENDING_PLAYLIST_IMPORTS
+            || self.pending_playlist_projections.len() > MAX_PENDING_PLAYLIST_PROJECTIONS
+            || self.pending_playlist_creates.len() > MAX_PENDING_PLAYLIST_CREATES
+        {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+
+        let mut server_playlist_ids = BTreeSet::new();
+        for (local_playlist_id, link) in &self.playlist_links {
+            validate_playlist_id(local_playlist_id)?;
+            validate_playlist_link(link)?;
+            if local_playlist_id != &link.local_playlist_id
+                || !server_playlist_ids.insert(&link.server_playlist_id)
+            {
+                return Err(BridgeMutationError::ConflictingEntry);
+            }
+        }
+
+        let mut acknowledgement_ids = BTreeSet::new();
+        let mut pending_playlist_ids = BTreeSet::new();
+        for (operation_id, pending) in &self.pending_playlist_imports {
+            validate_playlist_identifier(operation_id, MAX_PLAYLIST_OPERATION_ID_CHARS)?;
+            self.validate_pending_playlist_import(pending)?;
+            if operation_id != &pending.operation_id {
+                return Err(BridgeMutationError::ConflictingEntry);
+            }
+            if !pending_playlist_ids.insert(&pending.local_playlist_id) {
+                return Err(BridgeMutationError::ConflictingEntry);
+            }
+            if pending.purpose == PendingPlaylistImportPurpose::Delete
+                && self.playlist_links.contains_key(&pending.local_playlist_id)
+            {
+                return Err(BridgeMutationError::ConflictingEntry);
+            }
+            for operation in &pending.operations {
+                if !acknowledgement_ids.insert(operation.acknowledgement_id.as_str()) {
+                    return Err(BridgeMutationError::ConflictingEntry);
+                }
+            }
+        }
+
+        for (playlist_id, pending) in &self.pending_playlist_projections {
+            validate_playlist_id(playlist_id)?;
+            validate_pending_playlist_projection(pending)?;
+            if !self.playlist_links.contains_key(playlist_id) {
+                return Err(BridgeMutationError::ConflictingEntry);
+            }
+        }
+        let mut pending_server_ids = BTreeSet::new();
+        for (playlist_id, pending) in &self.pending_playlist_creates {
+            validate_playlist_id(playlist_id)?;
+            validate_pending_playlist_create(self, pending)?;
+            if playlist_id != &pending.local_playlist_id
+                || pending
+                    .created_server_playlist_id
+                    .as_ref()
+                    .is_some_and(|id| !pending_server_ids.insert(id))
+            {
+                return Err(BridgeMutationError::ConflictingEntry);
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_pending_playlist_import(
+        &self,
+        pending: &PendingPlaylistImportBatch,
+    ) -> Result<(), BridgeMutationError> {
+        validate_playlist_identifier(&pending.operation_id, MAX_PLAYLIST_OPERATION_ID_CHARS)?;
+        validate_playlist_id(&pending.local_playlist_id)?;
+        if pending.operations.is_empty() {
+            return Err(BridgeMutationError::InvalidEntry);
+        }
+        if pending.operations.len() > MAX_PLAYLIST_IMPORT_OPERATIONS {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+
+        let mut acknowledgement_ids = BTreeSet::new();
+        let mut playlist_id = None::<&str>;
+        let mut inserted_occurrences = 0_usize;
+        let mut playlist_upserts = 0_usize;
+        for input in &pending.operations {
+            validate_playlist_identifier(
+                &input.acknowledgement_id,
+                MAX_PLAYLIST_OPERATION_ID_CHARS,
+            )?;
+            if !acknowledgement_ids.insert(input.acknowledgement_id.as_str()) {
+                return Err(BridgeMutationError::ConflictingEntry);
+            }
+            let operation_playlist_id =
+                self.validate_playlist_import_operation(&input.operation)?;
+            if operation_playlist_id != pending.local_playlist_id.as_str()
+                || playlist_id
+                    .replace(operation_playlist_id)
+                    .is_some_and(|existing| existing != operation_playlist_id)
+            {
+                return Err(BridgeMutationError::InvalidEntry);
+            }
+            let purpose_matches = match pending.purpose {
+                PendingPlaylistImportPurpose::InitialOrImportCopy => matches!(
+                    input.operation,
+                    Operation::UpsertPlaylist { .. } | Operation::UpsertPlaylistEntry { .. }
+                ),
+                PendingPlaylistImportPurpose::RemoteObservation => matches!(
+                    input.operation,
+                    Operation::UpsertPlaylist { .. }
+                        | Operation::UpsertPlaylistEntry { .. }
+                        | Operation::MovePlaylistEntry { .. }
+                        | Operation::RemovePlaylistEntry { .. }
+                ),
+                PendingPlaylistImportPurpose::Delete => matches!(
+                    input.operation,
+                    Operation::DeletePlaylist { deleted: true, .. }
+                ),
+            };
+            if !purpose_matches {
+                return Err(BridgeMutationError::InvalidEntry);
+            }
+            if matches!(input.operation, Operation::UpsertPlaylistEntry { .. }) {
+                inserted_occurrences += 1;
+            }
+            if matches!(input.operation, Operation::UpsertPlaylist { .. }) {
+                playlist_upserts += 1;
+            }
+        }
+        if pending.purpose == PendingPlaylistImportPurpose::Delete && pending.operations.len() != 1
+        {
+            return Err(BridgeMutationError::InvalidEntry);
+        }
+        if pending.purpose == PendingPlaylistImportPurpose::InitialOrImportCopy
+            && (playlist_upserts != 1
+                || !matches!(
+                    pending.operations.first().map(|input| &input.operation),
+                    Some(Operation::UpsertPlaylist { .. })
+                ))
+        {
+            return Err(BridgeMutationError::InvalidEntry);
+        }
+        if pending.purpose == PendingPlaylistImportPurpose::RemoteObservation
+            && playlist_upserts > 1
+        {
+            return Err(BridgeMutationError::InvalidEntry);
+        }
+        if inserted_occurrences > MAX_PLAYLIST_OCCURRENCES {
+            return Err(BridgeMutationError::CapacityExceeded);
+        }
+        Ok(())
+    }
+
+    fn validate_playlist_import_operation<'a>(
+        &self,
+        operation: &'a Operation,
+    ) -> Result<&'a str, BridgeMutationError> {
+        match operation {
+            Operation::UpsertPlaylist { playlist_id, name } => {
+                validate_playlist_id(playlist_id)?;
+                super::validate_portable_text(name)?;
+                Ok(playlist_id.as_str())
+            }
+            Operation::DeletePlaylist { playlist_id, .. } => {
+                validate_playlist_id(playlist_id)?;
+                Ok(playlist_id.as_str())
+            }
+            Operation::UpsertPlaylistEntry {
+                playlist_id,
+                entry_id,
+                track,
+                after_entry_id,
+            } => {
+                validate_playlist_entry_ids(playlist_id, entry_id, after_entry_id.as_ref())?;
+                track
+                    .validate()
+                    .map_err(|_| BridgeMutationError::InvalidEntry)?;
+                let PortableTrackKey::OpenSubsonic {
+                    backend_id,
+                    account_scope_id,
+                    item_id,
+                } = &track.key
+                else {
+                    return Err(BridgeMutationError::InvalidEntry);
+                };
+                if backend_id != self.backend_id.as_str()
+                    || account_scope_id != self.account_scope_id.as_str()
+                    || ItemId::new(item_id.clone()).is_err()
+                {
+                    return Err(BridgeMutationError::InvalidEntry);
+                }
+                Ok(playlist_id.as_str())
+            }
+            Operation::MovePlaylistEntry {
+                playlist_id,
+                entry_id,
+                after_entry_id,
+            } => {
+                validate_playlist_entry_ids(playlist_id, entry_id, after_entry_id.as_ref())?;
+                Ok(playlist_id.as_str())
+            }
+            Operation::RemovePlaylistEntry {
+                playlist_id,
+                entry_id,
+                ..
+            } => {
+                validate_playlist_entry_ids(playlist_id, entry_id, None)?;
+                Ok(playlist_id.as_str())
+            }
+            _ => Err(BridgeMutationError::InvalidEntry),
+        }
+    }
+}
+
+fn validate_playlist_link(link: &PlaylistLink) -> Result<(), BridgeMutationError> {
+    validate_playlist_id(&link.local_playlist_id)?;
+    super::validate_portable_text(&link.shadow.name)?;
+    if link.shadow.occurrences.len() > MAX_PLAYLIST_OCCURRENCES {
+        return Err(BridgeMutationError::CapacityExceeded);
+    }
+    let mut entry_ids = BTreeSet::new();
+    for occurrence in &link.shadow.occurrences {
+        validate_playlist_entry_id(&occurrence.entry_id)?;
+        if !entry_ids.insert(&occurrence.entry_id) {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+    }
+    Ok(())
+}
+
+fn validate_pending_playlist_projection(
+    pending: &PendingPlaylistProjection,
+) -> Result<(), BridgeMutationError> {
+    super::validate_portable_text(&pending.desired_name)?;
+    validate_playlist_identifier(
+        &pending.base_remote_fingerprint,
+        MAX_REMOTE_FINGERPRINT_CHARS,
+    )?;
+    if pending.ordered_entry_ids.len() != pending.ordered_item_ids.len() {
+        return Err(BridgeMutationError::InvalidEntry);
+    }
+    if pending.ordered_item_ids.len() > MAX_PLAYLIST_OCCURRENCES {
+        return Err(BridgeMutationError::CapacityExceeded);
+    }
+    let mut entry_ids = BTreeSet::new();
+    for entry_id in &pending.ordered_entry_ids {
+        validate_playlist_entry_id(entry_id)?;
+        if !entry_ids.insert(entry_id) {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+    }
+    Ok(())
+}
+
+fn validate_pending_playlist_create(
+    state: &OpenSubsonicBridgeState,
+    pending: &PendingPlaylistCreate,
+) -> Result<(), BridgeMutationError> {
+    validate_playlist_id(&pending.local_playlist_id)?;
+    super::validate_portable_text(&pending.desired_name)?;
+    if pending.ordered_entry_ids.len() != pending.ordered_item_ids.len() {
+        return Err(BridgeMutationError::InvalidEntry);
+    }
+    if pending.ordered_item_ids.len() > MAX_PLAYLIST_OCCURRENCES {
+        return Err(BridgeMutationError::CapacityExceeded);
+    }
+    let mut entry_ids = BTreeSet::new();
+    for entry_id in &pending.ordered_entry_ids {
+        validate_playlist_entry_id(entry_id)?;
+        if !entry_ids.insert(entry_id) {
+            return Err(BridgeMutationError::ConflictingEntry);
+        }
+    }
+    match (
+        state.playlist_links.get(&pending.local_playlist_id),
+        pending.expected_missing_server_id.as_ref(),
+    ) {
+        (None, None) => {}
+        (Some(link), Some(expected))
+            if link.state == PlaylistLinkState::ServerMissing
+                && &link.server_playlist_id == expected => {}
+        _ => return Err(BridgeMutationError::ConflictingEntry),
+    }
+    if let Some(created) = &pending.created_server_playlist_id
+        && state.playlist_links.values().any(|link| {
+            link.local_playlist_id != pending.local_playlist_id
+                && &link.server_playlist_id == created
+        })
+    {
+        return Err(BridgeMutationError::ConflictingEntry);
+    }
+    Ok(())
+}
+
+fn validate_playlist_entry_ids(
+    playlist_id: &PlaylistId,
+    entry_id: &PlaylistEntryId,
+    after_entry_id: Option<&PlaylistEntryId>,
+) -> Result<(), BridgeMutationError> {
+    validate_playlist_id(playlist_id)?;
+    validate_playlist_entry_id(entry_id)?;
+    if let Some(after_entry_id) = after_entry_id {
+        validate_playlist_entry_id(after_entry_id)?;
+        if after_entry_id == entry_id {
+            return Err(BridgeMutationError::InvalidEntry);
+        }
+    }
+    Ok(())
+}
+
+fn validate_playlist_id(playlist_id: &PlaylistId) -> Result<(), BridgeMutationError> {
+    validate_playlist_identifier(playlist_id.as_str(), MAX_PLAYLIST_ID_CHARS)
+}
+
+fn validate_playlist_entry_id(entry_id: &PlaylistEntryId) -> Result<(), BridgeMutationError> {
+    validate_playlist_identifier(entry_id.as_str(), MAX_PLAYLIST_ID_CHARS)
+}
+
+fn validate_playlist_identifier(value: &str, max_chars: usize) -> Result<(), BridgeMutationError> {
+    if value.trim().is_empty()
+        || value.chars().count() > max_chars
+        || value.chars().any(forbidden_playlist_character)
+    {
+        return Err(BridgeMutationError::InvalidEntry);
+    }
+    Ok(())
+}
+
+fn forbidden_playlist_character(character: char) -> bool {
+    character.is_control()
+        || matches!(
+            character,
+            '\u{061c}'
+                | '\u{200b}'
+                | '\u{200c}'
+                | '\u{200d}'
+                | '\u{200e}'
+                | '\u{200f}'
+                | '\u{202a}'..='\u{202e}'
+                | '\u{2066}'..='\u{2069}'
+                | '\u{feff}'
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::open_subsonic::bridge_store::{decode_bridge, encode_bridge};
+    use crate::open_subsonic::model::{AccountScopeId, BackendId};
+    use crate::personal_state::{PortableTrack, PortableTrackKey};
+
+    fn bridge() -> OpenSubsonicBridgeState {
+        OpenSubsonicBridgeState::new(
+            BackendId::new("backend").unwrap(),
+            AccountScopeId::new("account").unwrap(),
+        )
+    }
+
+    fn local_id(value: impl Into<String>) -> PlaylistId {
+        PlaylistId::new(value).unwrap()
+    }
+
+    fn entry_id(value: impl Into<String>) -> PlaylistEntryId {
+        PlaylistEntryId::new(value).unwrap()
+    }
+
+    fn item_id(value: impl Into<String>) -> ItemId {
+        ItemId::new(value).unwrap()
+    }
+
+    fn shadow(name: &str, occurrence_count: usize) -> PlaylistShadow {
+        PlaylistShadow {
+            name: name.to_owned(),
+            occurrences: (0..occurrence_count)
+                .map(|index| PlaylistShadowOccurrence {
+                    entry_id: entry_id(format!("entry-{index}")),
+                    item_id: item_id(format!("song-{index}")),
+                })
+                .collect(),
+            verified_at_unix: 42,
+        }
+    }
+
+    fn link(local: &str, server: &str) -> PlaylistLink {
+        PlaylistLink {
+            local_playlist_id: local_id(local),
+            server_playlist_id: ServerPlaylistId::new(server).unwrap(),
+            managed_by_yututui: false,
+            state: PlaylistLinkState::Linked,
+            content_needs_attention: false,
+            shadow: shadow("Remote playlist", 2),
+        }
+    }
+
+    fn portable(item: &str, backend: &str, account: &str) -> PortableTrack {
+        PortableTrack {
+            key: PortableTrackKey::OpenSubsonic {
+                backend_id: backend.to_owned(),
+                account_scope_id: account.to_owned(),
+                item_id: item.to_owned(),
+            },
+            title: "Title".to_owned(),
+            artist: "Artist".to_owned(),
+            album: None,
+            duration_secs: Some(180),
+            isrc: None,
+        }
+    }
+
+    fn import_batch(operation_id: &str, playlist_id: &str) -> PendingPlaylistImportBatch {
+        PendingPlaylistImportBatch {
+            operation_id: operation_id.to_owned(),
+            local_playlist_id: local_id(playlist_id),
+            purpose: PendingPlaylistImportPurpose::InitialOrImportCopy,
+            operations: vec![ExternalOperationInput {
+                acknowledgement_id: format!("{operation_id}-playlist"),
+                operation: Operation::UpsertPlaylist {
+                    playlist_id: local_id(playlist_id),
+                    name: "Imported playlist".to_owned(),
+                },
+                recorded_at_unix: 50,
+            }],
+        }
+    }
+
+    fn projection() -> PendingPlaylistProjection {
+        PendingPlaylistProjection {
+            desired_name: "Desired playlist".to_owned(),
+            ordered_entry_ids: vec![
+                entry_id("desired-entry-1"),
+                entry_id("desired-entry-2"),
+                entry_id("desired-entry-3"),
+            ],
+            ordered_item_ids: vec![item_id("song-1"), item_id("song-1"), item_id("song-2")],
+            stage: PendingPlaylistProjectionStage::Ambiguous,
+            base_remote_fingerprint: "sha256:0123456789abcdef".to_owned(),
+        }
+    }
+
+    fn pending_create(
+        local: &str,
+        expected_missing: Option<&str>,
+        created: Option<&str>,
+    ) -> PendingPlaylistCreate {
+        PendingPlaylistCreate {
+            local_playlist_id: local_id(local),
+            expected_missing_server_id: expected_missing
+                .map(|id| ServerPlaylistId::new(id).unwrap()),
+            created_server_playlist_id: created.map(|id| ServerPlaylistId::new(id).unwrap()),
+            desired_name: "Desired playlist".to_owned(),
+            ordered_entry_ids: vec![entry_id("desired-entry-1")],
+            ordered_item_ids: vec![item_id("song-1")],
+            started_at_unix: 52,
+        }
+    }
+
+    #[test]
+    fn schema_three_round_trip_preserves_every_playlist_lifecycle_record() {
+        let mut state = bridge();
+        let local = local_id("local");
+        state
+            .upsert_playlist_link(PlaylistLink {
+                managed_by_yututui: true,
+                state: PlaylistLinkState::ServerMissing,
+                ..link("local", "remote")
+            })
+            .unwrap();
+        let import = PendingPlaylistImportBatch {
+            operation_id: "remote-snapshot".to_owned(),
+            local_playlist_id: local.clone(),
+            purpose: PendingPlaylistImportPurpose::RemoteObservation,
+            operations: vec![
+                ExternalOperationInput {
+                    acknowledgement_id: "remote-snapshot-playlist".to_owned(),
+                    operation: Operation::UpsertPlaylist {
+                        playlist_id: local.clone(),
+                        name: "Remote playlist".to_owned(),
+                    },
+                    recorded_at_unix: 51,
+                },
+                ExternalOperationInput {
+                    acknowledgement_id: "remote-snapshot-entry".to_owned(),
+                    operation: Operation::UpsertPlaylistEntry {
+                        playlist_id: local.clone(),
+                        entry_id: entry_id("entry-1"),
+                        track: portable("song-1", "backend", "account"),
+                        after_entry_id: None,
+                    },
+                    recorded_at_unix: 51,
+                },
+            ],
+        };
+        state.queue_playlist_import(import.clone()).unwrap();
+        state
+            .queue_playlist_projection(local.clone(), projection())
+            .unwrap();
+        let create = pending_create("local", Some("remote"), Some("created-remote"));
+        state.queue_playlist_create(create.clone()).unwrap();
+
+        let decoded = decode_bridge(&encode_bridge(&state).unwrap()).unwrap();
+
+        assert_eq!(decoded.playlist_link(&local), state.playlist_link(&local));
+        assert_eq!(
+            decoded.pending_playlist_imports().get("remote-snapshot"),
+            Some(&import)
+        );
+        assert_eq!(
+            decoded.pending_playlist_projections().get(&local),
+            Some(&projection())
+        );
+        assert_eq!(
+            decoded.pending_playlist_creates().get(&local),
+            Some(&create)
+        );
+    }
+
+    #[test]
+    fn projection_attention_is_durable_and_explicit_setup_requeue_is_bounded() {
+        let mut state = bridge();
+        let local = local_id("local");
+        let mut linked = link("local", "remote");
+        linked.state = PlaylistLinkState::AccessNeedsAttention;
+        state.upsert_playlist_link(linked).unwrap();
+        let mut pending = projection();
+        pending.stage = PendingPlaylistProjectionStage::NeedsAttention;
+        state
+            .queue_playlist_projection(local.clone(), pending)
+            .unwrap();
+        let mut incompatible = link("content-local", "content-remote");
+        incompatible.content_needs_attention = true;
+        state.upsert_playlist_link(incompatible).unwrap();
+
+        let mut decoded = decode_bridge(&encode_bridge(&state).unwrap()).unwrap();
+
+        assert_eq!(decoded.playlist_projections_needing_attention(), 1);
+        assert_eq!(decoded.playlist_contents_needing_attention(), 1);
+        assert_eq!(decoded.requeue_playlist_projections_needing_attention(), 1);
+        assert_eq!(decoded.playlist_projections_needing_attention(), 0);
+        assert_eq!(
+            decoded.playlist_contents_needing_attention(),
+            1,
+            "connection setup cannot clear incompatible local content"
+        );
+        assert_eq!(
+            decoded
+                .pending_playlist_projections()
+                .get(&local)
+                .map(|pending| pending.stage),
+            Some(PendingPlaylistProjectionStage::Queued)
+        );
+        assert_eq!(
+            decoded.playlist_link(&local).map(|link| link.state),
+            Some(PlaylistLinkState::Linked)
+        );
+        assert_eq!(decoded.requeue_playlist_projections_needing_attention(), 0);
+    }
+
+    #[test]
+    fn pending_import_has_one_explicit_playlist_and_causal_purpose() {
+        let mut state = bridge();
+        let first = import_batch("z-first", "local");
+        state.queue_playlist_import(first.clone()).unwrap();
+        assert_eq!(
+            state.queue_playlist_import(import_batch("a-lexically-earlier", "local")),
+            Err(BridgeMutationError::ConflictingEntry),
+            "opaque map ordering must not create a per-playlist backlog"
+        );
+        state.queue_playlist_import(first).unwrap();
+
+        let mut wrong_target = import_batch("other", "other-local");
+        wrong_target.local_playlist_id = local_id("declared-local");
+        assert_eq!(
+            state.queue_playlist_import(wrong_target),
+            Err(BridgeMutationError::InvalidEntry)
+        );
+
+        let mut wrong_purpose = import_batch("delete-purpose", "delete-local");
+        wrong_purpose.purpose = PendingPlaylistImportPurpose::Delete;
+        assert_eq!(
+            state.queue_playlist_import(wrong_purpose),
+            Err(BridgeMutationError::InvalidEntry)
+        );
+    }
+
+    #[test]
+    fn missing_playlist_is_counted_once_as_a_decision_instead_of_a_reconnect() {
+        let mut state = bridge();
+        let local = local_id("local");
+        let mut missing = link("local", "remote");
+        missing.state = PlaylistLinkState::ServerMissing;
+        state.upsert_playlist_link(missing).unwrap();
+        let mut pending = projection();
+        pending.stage = PendingPlaylistProjectionStage::NeedsAttention;
+        state.queue_playlist_projection(local, pending).unwrap();
+
+        assert_eq!(state.playlist_links_needing_decision(), 1);
+        assert_eq!(state.playlist_projections_needing_attention(), 0);
+
+        state
+            .queue_playlist_create(pending_create("local", Some("remote"), None))
+            .unwrap();
+        assert_eq!(
+            state.playlist_links_needing_decision(),
+            0,
+            "an in-progress restore is represented once by create recovery"
+        );
+    }
+
+    #[test]
+    fn schema_two_migrates_with_empty_playlist_state_and_reencodes_as_three() {
+        let mut legacy: serde_json::Value =
+            serde_json::from_slice(&encode_bridge(&bridge()).unwrap()).unwrap();
+        legacy["schema_version"] = serde_json::Value::from(2);
+        let object = legacy.as_object_mut().unwrap();
+        object.remove("playlist_links");
+        object.remove("pending_playlist_imports");
+        object.remove("pending_playlist_projections");
+        object.remove("pending_playlist_creates");
+
+        let migrated = decode_bridge(&serde_json::to_vec(&legacy).unwrap()).unwrap();
+
+        assert!(migrated.playlist_links().is_empty());
+        assert!(migrated.pending_playlist_imports().is_empty());
+        assert!(migrated.pending_playlist_projections().is_empty());
+        assert!(migrated.pending_playlist_creates().is_empty());
+        let encoded: serde_json::Value =
+            serde_json::from_slice(&encode_bridge(&migrated).unwrap()).unwrap();
+        assert_eq!(
+            encoded["schema_version"],
+            serde_json::Value::from(super::super::BRIDGE_SCHEMA_VERSION)
+        );
+    }
+
+    #[test]
+    fn schema_three_rejects_projection_without_its_link() {
+        let mut state = bridge();
+        let local = local_id("local");
+        state.upsert_playlist_link(link("local", "remote")).unwrap();
+        state
+            .queue_playlist_projection(local.clone(), projection())
+            .unwrap();
+        let mut encoded: serde_json::Value =
+            serde_json::from_slice(&encode_bridge(&state).unwrap()).unwrap();
+        encoded["playlist_links"]
+            .as_object_mut()
+            .unwrap()
+            .remove(local.as_str());
+
+        assert!(matches!(
+            decode_bridge(&serde_json::to_vec(&encoded).unwrap()),
+            Err(crate::open_subsonic::StoreError::InvalidState)
+        ));
+    }
+
+    #[test]
+    fn schema_three_rejects_delete_import_while_link_is_still_present() {
+        let mut state = bridge();
+        let local = local_id("local");
+        state.upsert_playlist_link(link("local", "remote")).unwrap();
+        let mut encoded: serde_json::Value =
+            serde_json::from_slice(&encode_bridge(&state).unwrap()).unwrap();
+        let pending = PendingPlaylistImportBatch {
+            operation_id: "delete-local".to_owned(),
+            local_playlist_id: local.clone(),
+            purpose: PendingPlaylistImportPurpose::Delete,
+            operations: vec![ExternalOperationInput {
+                acknowledgement_id: "delete-local-operation".to_owned(),
+                operation: Operation::DeletePlaylist {
+                    playlist_id: local,
+                    deleted: true,
+                },
+                recorded_at_unix: 60,
+            }],
+        };
+        encoded["pending_playlist_imports"]["delete-local"] =
+            serde_json::to_value(pending).unwrap();
+
+        assert!(matches!(
+            decode_bridge(&serde_json::to_vec(&encoded).unwrap()),
+            Err(crate::open_subsonic::StoreError::InvalidState)
+        ));
+    }
+
+    #[test]
+    fn uncertain_create_is_single_identity_and_requires_the_expected_missing_link() {
+        let mut state = bridge();
+        let new_create = pending_create("new-local", None, None);
+        state.queue_playlist_create(new_create.clone()).unwrap();
+        state.queue_playlist_create(new_create).unwrap();
+        assert_eq!(
+            state.queue_playlist_create(pending_create("new-local", None, Some("server"))),
+            Err(BridgeMutationError::ConflictingEntry)
+        );
+        state
+            .record_playlist_create_server_id(
+                &local_id("new-local"),
+                ServerPlaylistId::new("server").unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            state
+                .pending_playlist_creates()
+                .get(&local_id("new-local"))
+                .and_then(|pending| pending.created_server_playlist_id.as_ref())
+                .map(ServerPlaylistId::as_str),
+            Some("server")
+        );
+
+        let missing = PlaylistLink {
+            state: PlaylistLinkState::ServerMissing,
+            ..link("missing-local", "missing-server")
+        };
+        state.upsert_playlist_link(missing).unwrap();
+        assert_eq!(
+            state.queue_playlist_create(pending_create(
+                "missing-local",
+                Some("wrong-server"),
+                None,
+            )),
+            Err(BridgeMutationError::ConflictingEntry)
+        );
+        state
+            .queue_playlist_create(pending_create(
+                "missing-local",
+                Some("missing-server"),
+                None,
+            ))
+            .unwrap();
+    }
+
+    #[test]
+    fn duplicate_links_and_wrong_scope_imports_are_rejected() {
+        let mut state = bridge();
+        state
+            .upsert_playlist_link(link("local-a", "server-a"))
+            .unwrap();
+        assert_eq!(
+            state.upsert_playlist_link(link("local-a", "server-b")),
+            Err(BridgeMutationError::ConflictingEntry)
+        );
+        assert_eq!(
+            state.upsert_playlist_link(link("local-b", "server-a")),
+            Err(BridgeMutationError::ConflictingEntry)
+        );
+
+        let bad_scope = PendingPlaylistImportBatch {
+            operation_id: "wrong-scope".to_owned(),
+            local_playlist_id: local_id("local-a"),
+            purpose: PendingPlaylistImportPurpose::RemoteObservation,
+            operations: vec![ExternalOperationInput {
+                acknowledgement_id: "wrong-scope-entry".to_owned(),
+                operation: Operation::UpsertPlaylistEntry {
+                    playlist_id: local_id("local-a"),
+                    entry_id: entry_id("entry"),
+                    track: portable("song", "backend", "other-account"),
+                    after_entry_id: None,
+                },
+                recorded_at_unix: 52,
+            }],
+        };
+        assert_eq!(
+            state.queue_playlist_import(bad_scope),
+            Err(BridgeMutationError::InvalidEntry)
+        );
+    }
+
+    #[test]
+    fn corrupt_duplicate_server_link_and_bidi_text_are_rejected_on_decode() {
+        let mut state = bridge();
+        state
+            .upsert_playlist_link(link("local-a", "server-a"))
+            .unwrap();
+        state
+            .upsert_playlist_link(link("local-b", "server-b"))
+            .unwrap();
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&encode_bridge(&state).unwrap()).unwrap();
+        value["playlist_links"]["local-b"]["server_playlist_id"] =
+            serde_json::Value::from("server-a");
+        assert_eq!(
+            decode_bridge(&serde_json::to_vec(&value).unwrap()),
+            Err(crate::open_subsonic::profile::StoreError::InvalidState)
+        );
+
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&encode_bridge(&state).unwrap()).unwrap();
+        value["playlist_links"]["local-a"]["shadow"]["name"] =
+            serde_json::Value::from("visible\u{202e}hidden");
+        assert_eq!(
+            decode_bridge(&serde_json::to_vec(&value).unwrap()),
+            Err(crate::open_subsonic::profile::StoreError::InvalidState)
+        );
+    }
+
+    #[test]
+    fn projection_occurrence_ids_must_be_unique_and_align_with_items() {
+        let mut state = bridge();
+        let mut misaligned = projection();
+        misaligned.ordered_entry_ids.pop();
+        assert_eq!(
+            state.queue_playlist_projection(local_id("misaligned"), misaligned),
+            Err(BridgeMutationError::InvalidEntry)
+        );
+
+        let mut duplicate = projection();
+        duplicate.ordered_entry_ids[1] = duplicate.ordered_entry_ids[0].clone();
+        assert_eq!(
+            state.queue_playlist_projection(local_id("duplicate"), duplicate),
+            Err(BridgeMutationError::ConflictingEntry)
+        );
+    }
+
+    #[test]
+    fn every_playlist_collection_and_occurrence_list_is_bounded() {
+        let mut links = bridge();
+        for index in 0..MAX_PLAYLIST_LINKS {
+            links
+                .upsert_playlist_link(link(&format!("local-{index}"), &format!("server-{index}")))
+                .unwrap();
+        }
+        assert_eq!(
+            links.upsert_playlist_link(link("local-overflow", "server-overflow")),
+            Err(BridgeMutationError::CapacityExceeded)
+        );
+
+        let mut imports = bridge();
+        for index in 0..MAX_PENDING_PLAYLIST_IMPORTS {
+            imports
+                .queue_playlist_import(import_batch(
+                    &format!("import-{index}"),
+                    &format!("local-{index}"),
+                ))
+                .unwrap();
+        }
+        assert_eq!(
+            imports.queue_playlist_import(import_batch("import-overflow", "local-overflow")),
+            Err(BridgeMutationError::CapacityExceeded)
+        );
+
+        let mut projections = bridge();
+        for index in 0..MAX_PENDING_PLAYLIST_PROJECTIONS {
+            projections
+                .queue_playlist_projection(local_id(format!("local-{index}")), projection())
+                .unwrap();
+        }
+        assert_eq!(
+            projections.queue_playlist_projection(local_id("local-overflow"), projection()),
+            Err(BridgeMutationError::CapacityExceeded)
+        );
+
+        let mut oversized_link = link("local", "server");
+        oversized_link.shadow = shadow("Remote playlist", MAX_PLAYLIST_OCCURRENCES + 1);
+        assert_eq!(
+            bridge().upsert_playlist_link(oversized_link),
+            Err(BridgeMutationError::CapacityExceeded)
+        );
+    }
+}

--- a/src/open_subsonic/bridge_store/tests/schema.rs
+++ b/src/open_subsonic/bridge_store/tests/schema.rs
@@ -1,0 +1,168 @@
+use super::*;
+
+#[test]
+fn bridge_round_trip_preserves_every_queue_and_invalid_raw_rating() {
+    let mut bridge = bridge();
+    bridge.set_native_history_health(NativeHistoryHealth::Detailed);
+    let item = ItemId::new("song").unwrap();
+    bridge
+        .upsert_rating_shadow(item.clone(), shadow(Some(99), true, 10))
+        .unwrap();
+    bridge
+        .queue_rating_projection(
+            item.clone(),
+            PendingRatingProjection {
+                operation_id: "local-op".to_owned(),
+                target: Rating::Disliked,
+                stage: PendingRatingProjectionStage::SetStarred,
+                last_readback: Some(RawServerRating {
+                    user_rating: Some(99),
+                    starred: true,
+                }),
+                queued_at_unix: 11,
+            },
+        )
+        .unwrap();
+    bridge
+        .queue_rating_import(
+            "server-observation".to_owned(),
+            PendingRatingImport {
+                item_id: item.clone(),
+                track: portable("song"),
+                raw: RawServerRating {
+                    user_rating: Some(-9),
+                    starred: false,
+                },
+                mapped: Rating::Neutral,
+                observed_at_unix: 12,
+            },
+        )
+        .unwrap();
+    bridge
+        .queue_engagement_import("history-row".to_owned(), engagement("song"))
+        .unwrap();
+    bridge
+        .upsert_aggregate_play_shadow(
+            item.clone(),
+            AggregatePlayShadow {
+                play_count: 7,
+                played_at: Some("2026-07-26T10:00:00Z".to_owned()),
+                observed_at_unix: 13,
+                counter_epoch: 2,
+            },
+        )
+        .unwrap();
+    bridge
+        .set_history_cursor(
+            "navidrome-native".to_owned(),
+            HistoryCursor {
+                high_water_id: Some("row-7".to_owned()),
+                overlap_started_at_unix: Some(14),
+                updated_at_unix: 15,
+                continuation: None,
+                pending_metadata_rows: Vec::new(),
+            },
+        )
+        .unwrap();
+    bridge
+        .queue_outbound_scrobble(PendingOutboundScrobble {
+            event_id: "engagement-1".to_owned(),
+            item_id: item,
+            played_at_unix: 16,
+            kind: OutboundScrobbleKind::Submission,
+            delivery: OutboundScrobbleDelivery::Queued,
+            baseline_captured: false,
+            baseline_play_count: None,
+            baseline_played_at: None,
+            exact_credit_recorded: false,
+            exact_credit_epoch: None,
+            uncertain_readbacks: 0,
+            source_marker_acknowledged: false,
+        })
+        .unwrap();
+    bridge
+        .record_outbound_echo(OutboundScrobbleEcho {
+            event_id: "echo-1".to_owned(),
+            item_id: ItemId::new("song").unwrap(),
+            played_at_unix: 17,
+        })
+        .unwrap();
+
+    let decoded = decode_bridge(&encode_bridge(&bridge).unwrap()).unwrap();
+    assert_eq!(decoded, bridge);
+    assert_eq!(
+        decoded
+            .rating_shadow(&ItemId::new("song").unwrap())
+            .unwrap()
+            .raw
+            .user_rating,
+        Some(99)
+    );
+}
+
+#[test]
+fn schema_one_empty_bridge_migrates_explicitly_to_current_schema() {
+    let legacy = br#"{
+        "kind":"yututui_open_subsonic_bridge",
+        "schema_version":1,
+        "revision":8,
+        "backend_id":"backend",
+        "account_scope_id":"account"
+    }"#;
+    let migrated = decode_bridge(legacy).unwrap();
+    assert_eq!(migrated.revision(), 8);
+    assert!(migrated.rating_shadows().is_empty());
+    assert!(migrated.pending_rating_projections().is_empty());
+    assert!(migrated.pending_rating_imports().is_empty());
+    assert!(migrated.pending_engagement_imports().is_empty());
+    assert!(migrated.aggregate_play_shadows().is_empty());
+    assert!(migrated.history_dedupe_credits().is_empty());
+    assert!(migrated.history_cursors().is_empty());
+    assert!(migrated.outbound_scrobbles().is_empty());
+    assert!(migrated.outbound_echoes().is_empty());
+    assert!(migrated.completed_outbound_scrobbles().is_empty());
+    assert_eq!(migrated.native_history_health(), NativeHistoryHealth::Off);
+    let encoded: serde_json::Value =
+        serde_json::from_slice(&encode_bridge(&migrated).unwrap()).unwrap();
+    assert_eq!(
+        encoded["schema_version"],
+        serde_json::Value::from(BRIDGE_SCHEMA_VERSION)
+    );
+}
+
+#[test]
+fn aggregate_shadow_without_counter_epoch_defaults_to_legacy_ids() {
+    let mut state = bridge();
+    state
+        .upsert_aggregate_play_shadow(
+            ItemId::new("song").unwrap(),
+            AggregatePlayShadow {
+                play_count: 4,
+                played_at: None,
+                observed_at_unix: 12,
+                counter_epoch: 3,
+            },
+        )
+        .unwrap();
+    let mut encoded: serde_json::Value =
+        serde_json::from_slice(&encode_bridge(&state).unwrap()).unwrap();
+    encoded["aggregate_play_shadows"]["song"]
+        .as_object_mut()
+        .unwrap()
+        .remove("counter_epoch");
+    encoded
+        .as_object_mut()
+        .unwrap()
+        .remove("native_history_health");
+
+    let decoded = decode_bridge(&serde_json::to_vec(&encoded).unwrap()).unwrap();
+    assert_eq!(
+        decoded
+            .aggregate_play_shadows()
+            .get(&ItemId::new("song").unwrap())
+            .unwrap()
+            .counter_epoch,
+        0
+    );
+    assert_eq!(decoded.native_history_health(), NativeHistoryHealth::Off);
+}

--- a/src/open_subsonic/catalog.rs
+++ b/src/open_subsonic/catalog.rs
@@ -4,7 +4,7 @@ use super::client::{BinaryPayload, Endpoint, OpenSubsonicClient, ServerError};
 use super::model::{
     AccountScopeId, AlbumId, ArtistId, BackendId, CoverArtId, OpenSubsonicItemRef, ServerAlbum,
     ServerArtist, ServerLibraryDetail, ServerLibraryPage, ServerLibraryRow, ServerLibrarySection,
-    ServerPlaylist, ServerPlaylistId, ServerPlaylistSummary, ServerSong,
+    ServerPlaylist, ServerPlaylistAccess, ServerPlaylistId, ServerPlaylistSummary, ServerSong,
 };
 use super::private_store::ServerCredential;
 use super::wire::{
@@ -459,51 +459,50 @@ fn artist(raw: RawArtist) -> Option<ServerArtist> {
 }
 
 fn playlist_summary(raw: RawPlaylistSummary) -> Option<ServerPlaylistSummary> {
-    playlist_fields(
-        raw.id,
-        raw.name,
-        raw.owner,
-        raw.song_count,
-        raw.duration,
-        raw.public,
-        raw.cover_art,
-    )
+    playlist_fields(raw)
 }
 
 fn playlist(raw: &RawPlaylist) -> Option<ServerPlaylistSummary> {
-    playlist_fields(
-        raw.id.clone(),
-        raw.name.clone(),
-        raw.owner.clone(),
-        raw.song_count,
-        raw.duration,
-        raw.public,
-        raw.cover_art.clone(),
-    )
+    playlist_fields(RawPlaylistSummary {
+        id: raw.id.clone(),
+        name: raw.name.clone(),
+        owner: raw.owner.clone(),
+        readonly: raw.readonly,
+        song_count: raw.song_count,
+        duration: raw.duration,
+        public: raw.public,
+        cover_art: raw.cover_art.clone(),
+    })
 }
 
-fn playlist_fields(
-    id: Option<String>,
-    name: Option<String>,
-    owner: Option<String>,
-    song_count: Option<u64>,
-    duration: Option<u64>,
-    public: Option<bool>,
-    cover_art: Option<String>,
-) -> Option<ServerPlaylistSummary> {
+fn playlist_fields(raw: RawPlaylistSummary) -> Option<ServerPlaylistSummary> {
+    let owner_evidence = raw.owner.as_deref().and_then(exact_owner_evidence);
     Some(ServerPlaylistSummary {
-        id: ServerPlaylistId::new(id?).ok()?,
-        name: name
+        id: ServerPlaylistId::new(raw.id?).ok()?,
+        name: raw
+            .name
             .map(|value| crate::api::sanitize_metadata_text(&value, 300))
             .filter(|value| !value.is_empty())?,
-        owner: owner
+        owner: raw
+            .owner
             .map(|value| crate::api::sanitize_metadata_text(&value, 200))
             .filter(|value| !value.is_empty()),
-        song_count: song_count.and_then(to_u32),
-        duration_secs: duration.and_then(to_u32),
-        public,
-        cover_art_id: cover_art.and_then(|id| CoverArtId::new(id).ok()),
+        song_count: raw.song_count.and_then(to_u32),
+        duration_secs: raw.duration.and_then(to_u32),
+        public: raw.public,
+        cover_art_id: raw.cover_art.and_then(|id| CoverArtId::new(id).ok()),
+        access: ServerPlaylistAccess::ReadOnly,
+        link: None,
+        readonly_evidence: raw.readonly,
+        owner_evidence,
     })
+}
+
+fn exact_owner_evidence(owner: &str) -> Option<String> {
+    const MAX_OWNER_EVIDENCE_CHARS: usize = 1_024;
+
+    let sanitized = crate::api::sanitize_metadata_text(owner, MAX_OWNER_EVIDENCE_CHARS);
+    (!sanitized.is_empty() && sanitized == owner).then_some(sanitized)
 }
 
 fn album_with_songs_summary(raw: &RawAlbumWithSongs) -> Option<ServerAlbum> {
@@ -638,5 +637,36 @@ mod tests {
             ..RawPlaylist::default()
         };
         assert_eq!(raw.entry.len(), 2);
+    }
+
+    #[test]
+    fn playlist_catalog_defaults_readonly_and_keeps_exact_access_evidence() {
+        let summary = playlist_summary(RawPlaylistSummary {
+            id: Some("playlist".to_owned()),
+            name: Some("Playlist".to_owned()),
+            owner: Some("alice".to_owned()),
+            readonly: Some(false),
+            ..RawPlaylistSummary::default()
+        })
+        .unwrap();
+        assert_eq!(summary.access, ServerPlaylistAccess::ReadOnly);
+        assert_eq!(summary.owner.as_deref(), Some("alice"));
+        assert_eq!(summary.readonly_evidence(), Some(false));
+        assert_eq!(summary.owner_evidence(), Some("alice"));
+    }
+
+    #[test]
+    fn sanitized_display_owner_is_never_accepted_as_owner_evidence() {
+        let summary = playlist_summary(RawPlaylistSummary {
+            id: Some("playlist".to_owned()),
+            name: Some("Playlist".to_owned()),
+            owner: Some(" alice ".to_owned()),
+            readonly: Some(false),
+            ..RawPlaylistSummary::default()
+        })
+        .unwrap();
+        assert_eq!(summary.owner.as_deref(), Some("alice"));
+        assert_eq!(summary.owner_evidence(), None);
+        assert_eq!(summary.access, ServerPlaylistAccess::ReadOnly);
     }
 }

--- a/src/open_subsonic/endpoint.rs
+++ b/src/open_subsonic/endpoint.rs
@@ -3,17 +3,25 @@
 //! All item mutations take a fully scoped identity. Query serialization remains owned by
 //! `reqwest`; opaque server IDs are never interpolated into URLs.
 
+#[path = "endpoint/playlists.rs"]
+mod playlists;
+#[cfg(test)]
+#[path = "endpoint/test_support.rs"]
+mod test_support;
+
 use super::super::model::OpenSubsonicItemRef;
-use super::super::private_store::ServerCredential;
+use super::super::private_store::{CredentialKind, ServerCredential};
 use super::super::wire::RawChild;
 use super::{MutationDeliveryError, OpenSubsonicClient, ServerError};
 
 const MAX_SCROBBLE_TIME_UNIX_MS: u64 = i64::MAX as u64;
+const MAX_TOKEN_INFO_USERNAME_BYTES: usize = 1_024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Endpoint {
     Ping,
     Extensions,
+    TokenInfo,
     Search3,
     AlbumList2,
     Artists,
@@ -26,6 +34,9 @@ pub(crate) enum Endpoint {
     Star,
     Unstar,
     Scrobble,
+    CreatePlaylist,
+    UpdatePlaylist,
+    DeletePlaylist,
     CoverArt,
     Stream,
 }
@@ -35,6 +46,7 @@ impl Endpoint {
         match self {
             Self::Ping => "ping",
             Self::Extensions => "getOpenSubsonicExtensions",
+            Self::TokenInfo => "tokenInfo",
             Self::Search3 => "search3",
             Self::AlbumList2 => "getAlbumList2",
             Self::Artists => "getArtists",
@@ -47,6 +59,9 @@ impl Endpoint {
             Self::Star => "star",
             Self::Unstar => "unstar",
             Self::Scrobble => "scrobble",
+            Self::CreatePlaylist => "createPlaylist",
+            Self::UpdatePlaylist => "updatePlaylist",
+            Self::DeletePlaylist => "deletePlaylist",
             Self::CoverArt => "getCoverArt",
             Self::Stream => "stream",
         }
@@ -72,6 +87,35 @@ impl OpenSubsonicClient {
             return Err(ServerError::InvalidResponse);
         }
         Ok(song)
+    }
+
+    /// Resolve the exact account identity associated with an API key.
+    ///
+    /// This endpoint itself is authenticated only with `apiKey`; the returned username is kept as
+    /// private ownership evidence and is never added to subsequent API-key requests.
+    pub(crate) async fn api_key_username(
+        &self,
+        credential: &ServerCredential,
+    ) -> Result<String, ServerError> {
+        if credential.kind() != CredentialKind::ApiKey {
+            return Err(ServerError::InvalidResponse);
+        }
+        let response = self
+            .request_json(credential, Endpoint::TokenInfo, &[])
+            .await?;
+        let username = response
+            .token_info
+            .and_then(|info| info.username)
+            .ok_or(ServerError::InvalidResponse)?;
+        let sanitized =
+            crate::api::sanitize_metadata_text(&username, MAX_TOKEN_INFO_USERNAME_BYTES);
+        if username.is_empty()
+            || username.len() > MAX_TOKEN_INFO_USERNAME_BYTES
+            || sanitized != username
+        {
+            return Err(ServerError::InvalidResponse);
+        }
+        Ok(username)
     }
 
     pub(crate) async fn set_rating(
@@ -205,367 +249,5 @@ impl OpenSubsonicClient {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use age::secrecy::SecretString;
-    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
-
-    use super::*;
-    use crate::open_subsonic::{
-        AccountScopeId, BackendId, ConfiguredPrivateOrigin, ItemId, OpenSubsonicProfile,
-        ServerCredential,
-    };
-
-    struct TestClient {
-        client: OpenSubsonicClient,
-        credential: ServerCredential,
-        backend_id: BackendId,
-        account_scope_id: AccountScopeId,
-    }
-
-    impl TestClient {
-        fn item(&self, item_id: &str) -> OpenSubsonicItemRef {
-            OpenSubsonicItemRef::new(
-                self.backend_id.clone(),
-                self.account_scope_id.clone(),
-                ItemId::new(item_id).unwrap(),
-            )
-        }
-    }
-
-    async fn test_client(port: u16) -> TestClient {
-        let profile = OpenSubsonicProfile::new(
-            "Test server",
-            ConfiguredPrivateOrigin::new(&format!("http://127.0.0.1:{port}/"), true).unwrap(),
-            None,
-        )
-        .unwrap();
-        let backend_id = profile.backend_id().clone();
-        let account_scope_id = profile.account_scope_id().clone();
-        let client = OpenSubsonicClient::connect(&profile).await.unwrap();
-        let credential =
-            ServerCredential::api_key(SecretString::from("sentinel-api-key".to_owned())).unwrap();
-        TestClient {
-            client,
-            credential,
-            backend_id,
-            account_scope_id,
-        }
-    }
-
-    async fn read_request(stream: &mut tokio::net::TcpStream) -> String {
-        let mut request = Vec::new();
-        let mut byte = [0_u8; 1];
-        while request.len() < 32 * 1024 {
-            if stream.read(&mut byte).await.unwrap() == 0 {
-                break;
-            }
-            request.push(byte[0]);
-            if request.ends_with(b"\r\n\r\n") {
-                break;
-            }
-        }
-        String::from_utf8(request).unwrap()
-    }
-
-    async fn write_json(stream: &mut tokio::net::TcpStream, body: &str) {
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-            body.len()
-        );
-        stream.write_all(response.as_bytes()).await.unwrap();
-    }
-
-    fn request_target(request: &str) -> &str {
-        request
-            .lines()
-            .next()
-            .and_then(|line| line.split_ascii_whitespace().nth(1))
-            .unwrap()
-    }
-
-    #[tokio::test]
-    async fn get_song_serializes_opaque_id_and_preserves_exact_server_fields() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let server = tokio::spawn(async move {
-            let (mut stream, _) = listener.accept().await.unwrap();
-            let request = read_request(&mut stream).await;
-            let target = request_target(&request);
-            assert!(target.starts_with("/rest/getSong.view?"));
-            assert!(target.contains("id=song+id%26admin%3Dtrue"));
-            assert!(!target.contains("&admin=true"));
-            write_json(
-                &mut stream,
-                r#"{"subsonic-response":{"status":"ok","song":{"id":"song id&admin=true","title":"Song","userRating":3,"starred":"2026-07-26T00:00:00Z","playCount":7,"played":"2026-07-26T00:00:00Z"}}}"#,
-            )
-            .await;
-        });
-        let fixture = test_client(port).await;
-        let song = fixture
-            .client
-            .get_song_raw(&fixture.credential, &fixture.item("song id&admin=true"))
-            .await
-            .unwrap();
-        assert_eq!(song.user_rating, Some(3));
-        assert_eq!(song.play_count, Some(7));
-        assert!(song.starred.is_some());
-        server.await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn mutations_use_exact_standard_parameters_and_validate_status() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let server = tokio::spawn(async move {
-            let expected = [
-                ("/rest/setRating.view?", &["id=song-1", "rating=5"][..]),
-                ("/rest/star.view?", &["id=song-1"][..]),
-                ("/rest/unstar.view?", &["id=song-1"][..]),
-                (
-                    "/rest/scrobble.view?",
-                    &["id=song-1", "submission=false"][..],
-                ),
-                (
-                    "/rest/scrobble.view?",
-                    &["id=song-1", "submission=true", "time=1785024000123"][..],
-                ),
-            ];
-            for (index, (endpoint, parameters)) in expected.into_iter().enumerate() {
-                let (mut stream, _) = listener.accept().await.unwrap();
-                let request = read_request(&mut stream).await;
-                let target = request_target(&request);
-                assert!(target.starts_with(endpoint), "{target}");
-                for parameter in parameters {
-                    assert!(target.contains(parameter), "{target}");
-                }
-                if index == 3 {
-                    assert!(!target.contains("&time="), "{target}");
-                }
-                let body = if index == 4 {
-                    r#"{"subsonic-response":{"status":"failed","error":{"code":50}}}"#
-                } else {
-                    r#"{"subsonic-response":{"status":"ok"}}"#
-                };
-                write_json(&mut stream, body).await;
-            }
-        });
-        let fixture = test_client(port).await;
-        let item = fixture.item("song-1");
-        fixture
-            .client
-            .set_rating(&fixture.credential, &item, 5)
-            .await
-            .unwrap();
-        fixture
-            .client
-            .star(&fixture.credential, &item)
-            .await
-            .unwrap();
-        fixture
-            .client
-            .unstar(&fixture.credential, &item)
-            .await
-            .unwrap();
-        fixture
-            .client
-            .scrobble(&fixture.credential, &item, false, None)
-            .await
-            .unwrap();
-        assert_eq!(
-            fixture
-                .client
-                .scrobble(&fixture.credential, &item, true, Some(1_785_024_000_123),)
-                .await,
-            Err(MutationDeliveryError::DefinitelyNotApplied(
-                ServerError::PermissionDenied
-            ))
-        );
-        server.await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn item_scope_invalid_rating_and_time_fail_before_network() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let fixture = test_client(port).await;
-        let wrong_backend = OpenSubsonicItemRef::new(
-            BackendId::new("another-backend").unwrap(),
-            fixture.account_scope_id.clone(),
-            ItemId::new("song").unwrap(),
-        );
-        let wrong_account = OpenSubsonicItemRef::new(
-            fixture.backend_id.clone(),
-            AccountScopeId::new("another-account").unwrap(),
-            ItemId::new("song").unwrap(),
-        );
-        assert!(matches!(
-            fixture
-                .client
-                .get_song_raw(&fixture.credential, &wrong_backend)
-                .await,
-            Err(ServerError::WrongAccountScope)
-        ));
-        assert_eq!(
-            fixture
-                .client
-                .star(&fixture.credential, &wrong_account)
-                .await,
-            Err(ServerError::WrongAccountScope)
-        );
-        let item = fixture.item("song");
-        assert_eq!(
-            fixture
-                .client
-                .set_rating(&fixture.credential, &item, 6)
-                .await,
-            Err(ServerError::InvalidResponse)
-        );
-        assert_eq!(
-            fixture
-                .client
-                .scrobble(&fixture.credential, &item, true, Some(u64::MAX))
-                .await,
-            Err(MutationDeliveryError::DefinitelyNotApplied(
-                ServerError::InvalidResponse
-            ))
-        );
-        assert!(
-            tokio::time::timeout(Duration::from_millis(50), listener.accept())
-                .await
-                .is_err()
-        );
-    }
-
-    #[tokio::test]
-    async fn scrobble_connect_failure_is_definitely_not_applied() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        drop(listener);
-        let fixture = test_client(port).await;
-        assert_eq!(
-            fixture
-                .client
-                .scrobble(&fixture.credential, &fixture.item("song"), true, None)
-                .await,
-            Err(MutationDeliveryError::DefinitelyNotApplied(
-                ServerError::Offline
-            ))
-        );
-    }
-
-    #[tokio::test]
-    async fn scrobble_response_loss_and_server_errors_are_ambiguous() {
-        for response in [
-            None,
-            Some(
-                b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
-                    .as_slice(),
-            ),
-            Some(
-                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx"
-                    .as_slice(),
-            ),
-        ] {
-            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-            let port = listener.local_addr().unwrap().port();
-            let server = tokio::spawn(async move {
-                let (mut stream, _) = listener.accept().await.unwrap();
-                let request = read_request(&mut stream).await;
-                assert!(request_target(&request).starts_with("/rest/scrobble.view?"));
-                if let Some(response) = response {
-                    stream.write_all(response).await.unwrap();
-                }
-            });
-            let fixture = test_client(port).await;
-            let error = fixture
-                .client
-                .scrobble(&fixture.credential, &fixture.item("song"), true, None)
-                .await
-                .unwrap_err();
-            assert!(matches!(error, MutationDeliveryError::Ambiguous(_)));
-            server.await.unwrap();
-        }
-    }
-
-    #[tokio::test]
-    async fn scrobble_redirects_are_ambiguous_and_never_followed() {
-        for redirect_kind in ["same-origin", "loop", "cross-origin"] {
-            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-            let port = listener.local_addr().unwrap().port();
-            let cross_target = if redirect_kind == "cross-origin" {
-                Some(tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap())
-            } else {
-                None
-            };
-            let location = match (&cross_target, redirect_kind) {
-                (Some(target), _) => format!(
-                    "http://127.0.0.1:{}/rest/scrobble.view",
-                    target.local_addr().unwrap().port()
-                ),
-                (None, "loop") => "/rest/scrobble.view".to_owned(),
-                _ => "/rest/scrobble-again".to_owned(),
-            };
-            let fixture = test_client(port).await;
-            let server = tokio::spawn(async move {
-                let (mut stream, _) = listener.accept().await.unwrap();
-                let request = read_request(&mut stream).await;
-                assert!(request_target(&request).starts_with("/rest/scrobble.view?"));
-                let response = format!(
-                    "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
-                );
-                stream.write_all(response.as_bytes()).await.unwrap();
-                drop(stream);
-                assert!(
-                    tokio::time::timeout(Duration::from_millis(100), listener.accept())
-                        .await
-                        .is_err(),
-                    "redirected scrobble must issue exactly one request"
-                );
-            });
-            assert_eq!(
-                fixture
-                    .client
-                    .scrobble(&fixture.credential, &fixture.item("song"), true, None)
-                    .await,
-                Err(MutationDeliveryError::Ambiguous(
-                    ServerError::OriginRejected
-                ))
-            );
-            server.await.unwrap();
-            if let Some(target) = cross_target {
-                assert!(
-                    tokio::time::timeout(Duration::from_millis(100), target.accept())
-                        .await
-                        .is_err(),
-                    "cross-origin redirect must not receive a credentialed request"
-                );
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn get_song_rejects_a_different_returned_item_id() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let server = tokio::spawn(async move {
-            let (mut stream, _) = listener.accept().await.unwrap();
-            let _ = read_request(&mut stream).await;
-            write_json(
-                &mut stream,
-                r#"{"subsonic-response":{"status":"ok","song":{"id":"different","title":"Song"}}}"#,
-            )
-            .await;
-        });
-        let fixture = test_client(port).await;
-        assert!(matches!(
-            fixture
-                .client
-                .get_song_raw(&fixture.credential, &fixture.item("requested"))
-                .await,
-            Err(ServerError::InvalidResponse)
-        ));
-        server.await.unwrap();
-    }
-}
+#[path = "endpoint/tests.rs"]
+mod tests;

--- a/src/open_subsonic/endpoint/playlists.rs
+++ b/src/open_subsonic/endpoint/playlists.rs
@@ -1,0 +1,455 @@
+//! Replay-safe playlist endpoints and strict write snapshots.
+
+use age::secrecy::ExposeSecret as _;
+
+use super::super::super::auth::{AuthParameters, common_parameters};
+use super::super::super::model::{
+    AlbumId, CoverArtId, ItemId, OpenSubsonicItemRef, ServerPlaylistId,
+    ServerPlaylistWriteSnapshot, ServerSong,
+};
+use super::super::super::private_store::ServerCredential;
+use super::super::super::wire::{RawChild, RawPlaylist, RawResponse, WireError};
+use super::super::{
+    MAX_JSON_BYTES, MutationDeliveryError, OpenSubsonicClient, REQUEST_TIMEOUT, ServerError,
+    classify_mutation_request_error, map_origin_error, map_wire_error, read_limited,
+    status_error_for,
+};
+use super::Endpoint;
+
+const MAX_SERVER_PLAYLIST_NAME_CHARS: usize = 300;
+const MAX_SERVER_PLAYLIST_OWNER_CHARS: usize = 1_024;
+const MAX_SERVER_PLAYLIST_WRITE_ENTRIES: usize = 999;
+
+impl OpenSubsonicClient {
+    pub(crate) async fn get_playlist_write_snapshot(
+        &self,
+        credential: &ServerCredential,
+        playlist_id: &ServerPlaylistId,
+    ) -> Result<ServerPlaylistWriteSnapshot, ServerError> {
+        let response = self
+            .request_json(
+                credential,
+                Endpoint::Playlist,
+                &[("id", playlist_id.as_str().to_owned())],
+            )
+            .await?;
+        let playlist = response.playlist.ok_or(ServerError::InvalidResponse)?;
+        self.strict_playlist_snapshot(playlist, Some(playlist_id))
+    }
+
+    pub(crate) async fn create_playlist(
+        &self,
+        credential: &ServerCredential,
+        name: &str,
+        entries: &[OpenSubsonicItemRef],
+    ) -> Result<Option<ServerPlaylistWriteSnapshot>, MutationDeliveryError> {
+        let name =
+            validated_playlist_name(name).map_err(MutationDeliveryError::DefinitelyNotApplied)?;
+        if entries.len() > MAX_SERVER_PLAYLIST_WRITE_ENTRIES {
+            return Err(MutationDeliveryError::DefinitelyNotApplied(
+                ServerError::InvalidResponse,
+            ));
+        }
+        let mut parameters = Vec::with_capacity(entries.len() + 1);
+        parameters.push(("name", name));
+        for entry in entries {
+            self.validate_item_scope(entry)
+                .map_err(MutationDeliveryError::DefinitelyNotApplied)?;
+            parameters.push(("songId", entry.item_id().as_str().to_owned()));
+        }
+        let response = self
+            .request_playlist_mutation(credential, Endpoint::CreatePlaylist, &parameters)
+            .await?;
+        response
+            .playlist
+            .map(|playlist| self.strict_playlist_snapshot(playlist, None))
+            .transpose()
+            .map_err(MutationDeliveryError::Ambiguous)
+    }
+
+    pub(crate) async fn update_playlist(
+        &self,
+        credential: &ServerCredential,
+        snapshot: &ServerPlaylistWriteSnapshot,
+        name: Option<&str>,
+        entries_to_add: &[OpenSubsonicItemRef],
+        indexes_to_remove: &[u32],
+    ) -> Result<(), MutationDeliveryError> {
+        self.update_playlist_with_access(
+            credential,
+            snapshot,
+            name,
+            entries_to_add,
+            indexes_to_remove,
+            PlaylistWriteAccess::VerifiedAccountOwner,
+        )
+        .await
+    }
+
+    /// Mutates only a playlist whose durable link is already marked `managed_by_yututui`.
+    ///
+    /// The actor/store must prove that link before selecting this path. The current remote
+    /// snapshot must still prove that the configured account is the exact writable owner.
+    pub(crate) async fn update_managed_playlist(
+        &self,
+        credential: &ServerCredential,
+        snapshot: &ServerPlaylistWriteSnapshot,
+        name: Option<&str>,
+        entries_to_add: &[OpenSubsonicItemRef],
+        indexes_to_remove: &[u32],
+    ) -> Result<(), MutationDeliveryError> {
+        self.update_playlist_with_access(
+            credential,
+            snapshot,
+            name,
+            entries_to_add,
+            indexes_to_remove,
+            PlaylistWriteAccess::ManagedByYututui,
+        )
+        .await
+    }
+
+    async fn update_playlist_with_access(
+        &self,
+        credential: &ServerCredential,
+        snapshot: &ServerPlaylistWriteSnapshot,
+        name: Option<&str>,
+        entries_to_add: &[OpenSubsonicItemRef],
+        indexes_to_remove: &[u32],
+        access: PlaylistWriteAccess,
+    ) -> Result<(), MutationDeliveryError> {
+        self.validate_playlist_snapshot_scope(snapshot)
+            .map_err(MutationDeliveryError::DefinitelyNotApplied)?;
+        let name = name
+            .map(validated_playlist_name)
+            .transpose()
+            .map_err(MutationDeliveryError::DefinitelyNotApplied)?
+            .filter(|name| name != snapshot.name());
+        for entry in entries_to_add {
+            self.validate_item_scope(entry)
+                .map_err(MutationDeliveryError::DefinitelyNotApplied)?;
+        }
+        let indexes_to_remove =
+            descending_unique_indexes(indexes_to_remove, snapshot.entries().len())
+                .map_err(MutationDeliveryError::DefinitelyNotApplied)?;
+        let final_entry_count = snapshot
+            .entries()
+            .len()
+            .saturating_sub(indexes_to_remove.len())
+            .saturating_add(entries_to_add.len());
+        if final_entry_count > MAX_SERVER_PLAYLIST_WRITE_ENTRIES {
+            return Err(MutationDeliveryError::DefinitelyNotApplied(
+                ServerError::InvalidResponse,
+            ));
+        }
+        if name.is_none() && entries_to_add.is_empty() && indexes_to_remove.is_empty() {
+            return Ok(());
+        }
+        ensure_playlist_write_allowed(snapshot, credential, access)
+            .map_err(MutationDeliveryError::DefinitelyNotApplied)?;
+
+        let mut parameters = Vec::with_capacity(
+            1 + usize::from(name.is_some()) + entries_to_add.len() + indexes_to_remove.len(),
+        );
+        parameters.push(("playlistId", snapshot.id().as_str().to_owned()));
+        if let Some(name) = name {
+            parameters.push(("name", name));
+        }
+        for entry in entries_to_add {
+            // Repeated IDs are positional occurrences. Never deduplicate them.
+            parameters.push(("songIdToAdd", entry.item_id().as_str().to_owned()));
+        }
+        for index in indexes_to_remove {
+            parameters.push(("songIndexToRemove", index.to_string()));
+        }
+        self.request_playlist_mutation(credential, Endpoint::UpdatePlaylist, &parameters)
+            .await
+            .map(drop)
+    }
+
+    pub(crate) async fn delete_playlist(
+        &self,
+        credential: &ServerCredential,
+        snapshot: &ServerPlaylistWriteSnapshot,
+    ) -> Result<(), MutationDeliveryError> {
+        self.delete_playlist_with_access(
+            credential,
+            snapshot,
+            PlaylistWriteAccess::VerifiedAccountOwner,
+        )
+        .await
+    }
+
+    /// Deletes only a playlist whose durable link is already marked `managed_by_yututui`.
+    ///
+    /// The actor/store must prove that link before selecting this path. The current remote
+    /// snapshot must still prove that the configured account is the exact writable owner.
+    pub(crate) async fn delete_managed_playlist(
+        &self,
+        credential: &ServerCredential,
+        snapshot: &ServerPlaylistWriteSnapshot,
+    ) -> Result<(), MutationDeliveryError> {
+        self.delete_playlist_with_access(
+            credential,
+            snapshot,
+            PlaylistWriteAccess::ManagedByYututui,
+        )
+        .await
+    }
+
+    async fn delete_playlist_with_access(
+        &self,
+        credential: &ServerCredential,
+        snapshot: &ServerPlaylistWriteSnapshot,
+        access: PlaylistWriteAccess,
+    ) -> Result<(), MutationDeliveryError> {
+        self.validate_playlist_snapshot_scope(snapshot)
+            .map_err(MutationDeliveryError::DefinitelyNotApplied)?;
+        ensure_playlist_write_allowed(snapshot, credential, access)
+            .map_err(MutationDeliveryError::DefinitelyNotApplied)?;
+        self.request_playlist_mutation(
+            credential,
+            Endpoint::DeletePlaylist,
+            &[("id", snapshot.id().as_str().to_owned())],
+        )
+        .await
+        .map(drop)
+    }
+
+    async fn request_playlist_mutation(
+        &self,
+        credential: &ServerCredential,
+        endpoint: Endpoint,
+        parameters: &[(&str, String)],
+    ) -> Result<RawResponse, MutationDeliveryError> {
+        debug_assert!(matches!(
+            endpoint,
+            Endpoint::CreatePlaylist | Endpoint::UpdatePlaylist | Endpoint::DeletePlaylist
+        ));
+        let target = self
+            .transport
+            .origin()
+            .endpoint(endpoint.method_name())
+            .map_err(map_origin_error)
+            .map_err(MutationDeliveryError::DefinitelyNotApplied)?;
+        let mut request = self
+            .transport
+            .client()
+            .request(reqwest::Method::GET, target)
+            .timeout(REQUEST_TIMEOUT)
+            .query(&common_parameters());
+        let auth = AuthParameters::fresh(credential)
+            .map_err(|_| MutationDeliveryError::DefinitelyNotApplied(ServerError::Offline))?;
+        request = request.query(auth.fields()).query(parameters);
+        let response = request
+            .send()
+            .await
+            .map_err(classify_mutation_request_error)?;
+
+        // Playlist mutations are replay-unsafe (especially repeated adds and index removals).
+        // A server may have committed before returning a redirect, so no redirect is followed.
+        if response.status().is_redirection() {
+            return Err(MutationDeliveryError::Ambiguous(
+                ServerError::OriginRejected,
+            ));
+        }
+        if !response.status().is_success() {
+            let error = status_error_for(endpoint, &response);
+            return if response.status().is_server_error() {
+                Err(MutationDeliveryError::Ambiguous(error))
+            } else {
+                Err(MutationDeliveryError::DefinitelyNotApplied(error))
+            };
+        }
+        let bytes = read_limited(response, MAX_JSON_BYTES)
+            .await
+            .map_err(MutationDeliveryError::Ambiguous)?;
+        match super::super::super::wire::decode(&bytes) {
+            Ok(response) => Ok(response),
+            Err(WireError::ApiFailure(error)) => Err(MutationDeliveryError::DefinitelyNotApplied(
+                map_wire_error(WireError::ApiFailure(error)),
+            )),
+            Err(error) => Err(MutationDeliveryError::Ambiguous(map_wire_error(error))),
+        }
+    }
+
+    fn strict_playlist_snapshot(
+        &self,
+        raw: RawPlaylist,
+        expected_id: Option<&ServerPlaylistId>,
+    ) -> Result<ServerPlaylistWriteSnapshot, ServerError> {
+        let id = ServerPlaylistId::new(raw.id.ok_or(ServerError::InvalidResponse)?)
+            .map_err(|_| ServerError::InvalidResponse)?;
+        if expected_id.is_some_and(|expected| expected != &id) {
+            return Err(ServerError::InvalidResponse);
+        }
+        let name = validated_playlist_name(&raw.name.ok_or(ServerError::InvalidResponse)?)?;
+        let owner = validated_playlist_owner(raw.owner)?;
+        if raw.entry.len() > MAX_SERVER_PLAYLIST_WRITE_ENTRIES
+            || raw
+                .song_count
+                .is_some_and(|count| count != raw.entry.len() as u64)
+        {
+            return Err(ServerError::InvalidResponse);
+        }
+        let entries = raw
+            .entry
+            .into_iter()
+            .map(|entry| self.strict_playlist_song(entry))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(ServerPlaylistWriteSnapshot::new(
+            self.backend_id.clone(),
+            self.account_scope_id.clone(),
+            id,
+            name,
+            owner,
+            raw.readonly,
+            entries,
+        ))
+    }
+
+    fn strict_playlist_song(&self, raw: RawChild) -> Result<ServerSong, ServerError> {
+        if raw.is_dir == Some(true)
+            || raw
+                .media_type
+                .as_deref()
+                .is_some_and(|media_type| media_type != "music")
+        {
+            return Err(ServerError::InvalidResponse);
+        }
+        let item_id = ItemId::new(raw.id.ok_or(ServerError::InvalidResponse)?)
+            .map_err(|_| ServerError::InvalidResponse)?;
+        let title = raw
+            .title
+            .map(|value| crate::api::sanitize_title(&value))
+            .filter(|value| !value.is_empty())
+            .ok_or(ServerError::InvalidResponse)?;
+        let artist = raw
+            .artist
+            .map(|value| crate::api::sanitize_artist(&value))
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "Unknown artist".to_owned());
+        let artists = raw
+            .artists
+            .into_iter()
+            .filter_map(|artist| artist.name)
+            .map(|name| crate::api::sanitize_artist(&name))
+            .filter(|name| !name.is_empty())
+            .collect();
+        let album_id = raw
+            .album_id
+            .map(AlbumId::new)
+            .transpose()
+            .map_err(|_| ServerError::InvalidResponse)?;
+        let cover_art_id = raw
+            .cover_art
+            .map(CoverArtId::new)
+            .transpose()
+            .map_err(|_| ServerError::InvalidResponse)?;
+        Ok(ServerSong {
+            item: OpenSubsonicItemRef::new(
+                self.backend_id.clone(),
+                self.account_scope_id.clone(),
+                item_id,
+            ),
+            title,
+            artist,
+            artists,
+            album: sanitize_optional(raw.album, crate::api::MAX_ALBUM_CHARS),
+            album_id,
+            album_artist: None,
+            duration_secs: raw.duration.and_then(|value| u32::try_from(value).ok()),
+            track_number: raw.track.and_then(|value| u32::try_from(value).ok()),
+            disc_number: raw.disc_number.and_then(|value| u32::try_from(value).ok()),
+            year: raw.year.and_then(|value| u32::try_from(value).ok()),
+            cover_art_id,
+            content_type: sanitize_optional(raw.content_type, 256),
+            suffix: sanitize_optional(raw.suffix, 256),
+            starred: raw.starred.is_some(),
+            user_rating: raw.user_rating,
+            play_count: raw.play_count,
+            played_at: sanitize_optional(raw.played, 64),
+        })
+    }
+
+    fn validate_playlist_snapshot_scope(
+        &self,
+        snapshot: &ServerPlaylistWriteSnapshot,
+    ) -> Result<(), ServerError> {
+        if snapshot.backend_id() != &self.backend_id
+            || snapshot.account_scope_id() != &self.account_scope_id
+        {
+            return Err(ServerError::WrongAccountScope);
+        }
+        Ok(())
+    }
+}
+
+fn validated_playlist_name(name: &str) -> Result<String, ServerError> {
+    let sanitized = crate::api::sanitize_metadata_text(name, MAX_SERVER_PLAYLIST_NAME_CHARS);
+    if sanitized.is_empty() || sanitized != name {
+        return Err(ServerError::InvalidResponse);
+    }
+    Ok(sanitized)
+}
+
+fn validated_playlist_owner(owner: Option<String>) -> Result<Option<String>, ServerError> {
+    let Some(owner) = owner else {
+        return Ok(None);
+    };
+    if owner.is_empty() {
+        return Ok(None);
+    }
+    let sanitized = crate::api::sanitize_metadata_text(&owner, MAX_SERVER_PLAYLIST_OWNER_CHARS);
+    if sanitized != owner {
+        return Err(ServerError::InvalidResponse);
+    }
+    Ok(Some(owner))
+}
+
+fn sanitize_optional(value: Option<String>, max_chars: usize) -> Option<String> {
+    value
+        .map(|value| crate::api::sanitize_metadata_text(&value, max_chars))
+        .filter(|value| !value.is_empty())
+}
+
+fn descending_unique_indexes(indexes: &[u32], entry_count: usize) -> Result<Vec<u32>, ServerError> {
+    let mut indexes = indexes.to_vec();
+    if indexes
+        .iter()
+        .any(|index| usize::try_from(*index).map_or(true, |index| index >= entry_count))
+    {
+        return Err(ServerError::InvalidResponse);
+    }
+    indexes.sort_unstable_by(|left, right| right.cmp(left));
+    indexes.dedup();
+    Ok(indexes)
+}
+
+#[derive(Clone, Copy)]
+enum PlaylistWriteAccess {
+    VerifiedAccountOwner,
+    ManagedByYututui,
+}
+
+fn ensure_playlist_write_allowed(
+    snapshot: &ServerPlaylistWriteSnapshot,
+    credential: &ServerCredential,
+    _access: PlaylistWriteAccess,
+) -> Result<(), ServerError> {
+    // A durable managed link proves which remote object the user selected; it cannot prove that
+    // the server still grants this account write access. Missing access metadata therefore fails
+    // closed on both paths.
+    let permitted = snapshot.read_only() == Some(false)
+        && credential
+            .username()
+            .is_some_and(|username| snapshot.owner() == Some(username.expose_secret()));
+    if !permitted {
+        return Err(ServerError::PermissionDenied);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "playlists/tests.rs"]
+mod tests;

--- a/src/open_subsonic/endpoint/playlists/tests.rs
+++ b/src/open_subsonic/endpoint/playlists/tests.rs
@@ -1,0 +1,450 @@
+use std::time::Duration;
+
+use age::secrecy::SecretString;
+use tokio::io::AsyncWriteExt as _;
+
+use super::super::test_support::*;
+use super::*;
+use crate::open_subsonic::{AccountScopeId, BackendId};
+
+#[tokio::test]
+async fn write_snapshot_preserves_duplicates_and_access_control() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let request = read_request(&mut stream).await;
+        assert!(request_target(&request).starts_with("/rest/getPlaylist.view?"));
+        write_json(
+            &mut stream,
+            r#"{"subsonic-response":{"status":"ok","playlist":{"id":"playlist","name":"Playlist","owner":"alice","readonly":false,"songCount":2,"entry":[{"id":"same","title":"First","type":"music"},{"id":"same","title":"Second","type":"music"}]}}}"#,
+        )
+        .await;
+    });
+    let fixture = test_client(port).await;
+    let snapshot = fixture
+        .client
+        .get_playlist_write_snapshot(
+            &fixture.credential,
+            &ServerPlaylistId::new("playlist").unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.owner(), Some("alice"));
+    assert_eq!(snapshot.read_only(), Some(false));
+    assert_eq!(snapshot.entries().len(), 2);
+    assert_eq!(
+        snapshot.entries()[0].item.item_id(),
+        snapshot.entries()[1].item.item_id()
+    );
+    assert_eq!(snapshot.entries()[0].title, "First");
+    assert_eq!(snapshot.entries()[1].title, "Second");
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn write_snapshot_rejects_any_unsafe_occurrence() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let bodies = [
+        r#"{"subsonic-response":{"status":"ok","playlist":{"id":"playlist","name":"Playlist","owner":"alice","readonly":false,"entry":[{"title":"Missing id"}]}}}"#,
+        r#"{"subsonic-response":{"status":"ok","playlist":{"id":"playlist","name":"Playlist","owner":"alice","readonly":false,"entry":[{"id":"directory","title":"Directory","isDir":true}]}}}"#,
+        r#"{"subsonic-response":{"status":"ok","playlist":{"id":"playlist","name":"Playlist","owner":"alice","readonly":false,"entry":[{"id":"video","title":"Video","type":"video"}]}}}"#,
+        r#"{"subsonic-response":{"status":"ok","playlist":{"id":"playlist","name":"Playlist","owner":"alice","readonly":false,"songCount":2,"entry":[{"id":"only-one","title":"Song","type":"music"}]}}}"#,
+    ];
+    let server = tokio::spawn(async move {
+        for body in bodies {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _ = read_request(&mut stream).await;
+            write_json(&mut stream, body).await;
+        }
+    });
+    let fixture = test_client(port).await;
+    let playlist_id = ServerPlaylistId::new("playlist").unwrap();
+
+    for _ in bodies {
+        assert!(matches!(
+            fixture
+                .client
+                .get_playlist_write_snapshot(&fixture.credential, &playlist_id)
+                .await,
+            Err(ServerError::InvalidResponse)
+        ));
+    }
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn mutations_preserve_add_occurrences_and_sort_removals() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let (mut create, _) = listener.accept().await.unwrap();
+        let create_request = read_request(&mut create).await;
+        assert!(request_target(&create_request).starts_with("/rest/createPlaylist.view?"));
+        assert_eq!(query_values(&create_request, "name"), ["Road trip"]);
+        assert_eq!(
+            query_values(&create_request, "songId"),
+            ["same", "same", "other"]
+        );
+        write_json(
+            &mut create,
+            r#"{"subsonic-response":{"status":"ok","playlist":{"id":"remote","name":"Road trip","owner":"alice","readonly":false,"songCount":3,"entry":[{"id":"same","title":"First","type":"music"},{"id":"same","title":"Second","type":"music"},{"id":"other","title":"Other","type":"music"}]}}}"#,
+        )
+        .await;
+
+        let (mut update, _) = listener.accept().await.unwrap();
+        let update_request = read_request(&mut update).await;
+        assert!(request_target(&update_request).starts_with("/rest/updatePlaylist.view?"));
+        assert_eq!(query_values(&update_request, "playlistId"), ["remote"]);
+        assert_eq!(query_values(&update_request, "name"), ["Renamed"]);
+        assert_eq!(
+            query_values(&update_request, "songIdToAdd"),
+            ["same", "same"]
+        );
+        assert_eq!(
+            query_values(&update_request, "songIndexToRemove"),
+            ["2", "0"]
+        );
+        write_json(&mut update, r#"{"subsonic-response":{"status":"ok"}}"#).await;
+
+        let (mut delete, _) = listener.accept().await.unwrap();
+        let delete_request = read_request(&mut delete).await;
+        assert!(request_target(&delete_request).starts_with("/rest/deletePlaylist.view?"));
+        assert_eq!(query_values(&delete_request, "id"), ["remote"]);
+        write_json(&mut delete, r#"{"subsonic-response":{"status":"ok"}}"#).await;
+    });
+    let fixture = test_client_with_password(port).await;
+    let same = fixture.item("same");
+    let other = fixture.item("other");
+    let snapshot = fixture
+        .client
+        .create_playlist(
+            &fixture.credential,
+            "Road trip",
+            &[same.clone(), same.clone(), other],
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    fixture
+        .client
+        .update_playlist(
+            &fixture.credential,
+            &snapshot,
+            Some("Renamed"),
+            &[same.clone(), same],
+            &[0, 2, 0],
+        )
+        .await
+        .unwrap();
+    fixture
+        .client
+        .delete_playlist(&fixture.credential, &snapshot)
+        .await
+        .unwrap();
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn writes_require_explicit_writable_and_exact_account_owner() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let bodies = [
+        r#"{"subsonic-response":{"status":"ok","playlist":{"id":"playlist","name":"Playlist","owner":"bob","readonly":false,"entry":[]}}}"#,
+        r#"{"subsonic-response":{"status":"ok","playlist":{"id":"playlist","name":"Playlist","owner":"alice","entry":[]}}}"#,
+        r#"{"subsonic-response":{"status":"ok","playlist":{"id":"playlist","name":"Playlist","owner":"alice","readonly":false,"entry":[]}}}"#,
+    ];
+    let server = tokio::spawn(async move {
+        for body in bodies {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _ = read_request(&mut stream).await;
+            write_json(&mut stream, body).await;
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err(),
+            "rejected playlist writes must not reach the network"
+        );
+    });
+    let fixture = test_client_with_password(port).await;
+    let playlist_id = ServerPlaylistId::new("playlist").unwrap();
+    let wrong_owner = fixture
+        .client
+        .get_playlist_write_snapshot(&fixture.credential, &playlist_id)
+        .await
+        .unwrap();
+    let unknown_readonly = fixture
+        .client
+        .get_playlist_write_snapshot(&fixture.credential, &playlist_id)
+        .await
+        .unwrap();
+    let api_key_snapshot = fixture
+        .client
+        .get_playlist_write_snapshot(&fixture.credential, &playlist_id)
+        .await
+        .unwrap();
+
+    for snapshot in [&wrong_owner, &unknown_readonly] {
+        assert_eq!(
+            fixture
+                .client
+                .update_playlist(&fixture.credential, snapshot, Some("Changed"), &[], &[])
+                .await,
+            Err(MutationDeliveryError::DefinitelyNotApplied(
+                ServerError::PermissionDenied
+            ))
+        );
+    }
+    let api_key =
+        ServerCredential::api_key(SecretString::from("different-api-key".to_owned())).unwrap();
+    assert_eq!(
+        fixture
+            .client
+            .delete_playlist(&api_key, &api_key_snapshot)
+            .await,
+        Err(MutationDeliveryError::DefinitelyNotApplied(
+            ServerError::PermissionDenied
+        ))
+    );
+    server.await.unwrap();
+}
+
+#[test]
+fn token_info_bound_api_key_proves_only_its_exact_owner() {
+    let fixture = test_snapshot("alice", Some(false));
+    let mut matching =
+        ServerCredential::api_key(SecretString::from("matching-api-key".to_owned())).unwrap();
+    matching.bind_api_key_username("alice").unwrap();
+    let mut different =
+        ServerCredential::api_key(SecretString::from("different-api-key".to_owned())).unwrap();
+    different.bind_api_key_username("bob").unwrap();
+
+    assert!(
+        ensure_playlist_write_allowed(
+            &fixture,
+            &matching,
+            PlaylistWriteAccess::VerifiedAccountOwner
+        )
+        .is_ok()
+    );
+    assert_eq!(
+        ensure_playlist_write_allowed(
+            &fixture,
+            &different,
+            PlaylistWriteAccess::VerifiedAccountOwner
+        ),
+        Err(ServerError::PermissionDenied)
+    );
+    assert_eq!(
+        ensure_playlist_write_allowed(
+            &test_snapshot("alice", None),
+            &matching,
+            PlaylistWriteAccess::VerifiedAccountOwner
+        ),
+        Err(ServerError::PermissionDenied)
+    );
+}
+
+#[test]
+fn managed_path_requires_exact_owner_and_explicit_writable_evidence() {
+    let matching = test_snapshot("alice", Some(false));
+    let password =
+        ServerCredential::password("alice", SecretString::from("password".to_owned())).unwrap();
+    let mut api_key = ServerCredential::api_key(SecretString::from("api-key".to_owned())).unwrap();
+    api_key.bind_api_key_username("alice").unwrap();
+
+    for credential in [&password, &api_key] {
+        assert!(
+            ensure_playlist_write_allowed(
+                &matching,
+                credential,
+                PlaylistWriteAccess::ManagedByYututui,
+            )
+            .is_ok()
+        );
+        assert_eq!(
+            ensure_playlist_write_allowed(
+                &test_snapshot("mallory", Some(false)),
+                credential,
+                PlaylistWriteAccess::ManagedByYututui,
+            ),
+            Err(ServerError::PermissionDenied)
+        );
+        assert_eq!(
+            ensure_playlist_write_allowed(
+                &test_snapshot("alice", None),
+                credential,
+                PlaylistWriteAccess::ManagedByYututui,
+            ),
+            Err(ServerError::PermissionDenied)
+        );
+        assert_eq!(
+            ensure_playlist_write_allowed(
+                &test_snapshot_with_access(None, Some(false)),
+                credential,
+                PlaylistWriteAccess::ManagedByYututui,
+            ),
+            Err(ServerError::PermissionDenied)
+        );
+        assert_eq!(
+            ensure_playlist_write_allowed(
+                &test_snapshot("alice", Some(true)),
+                credential,
+                PlaylistWriteAccess::ManagedByYututui,
+            ),
+            Err(ServerError::PermissionDenied)
+        );
+    }
+    let unbound =
+        ServerCredential::api_key(SecretString::from("unbound-api-key".to_owned())).unwrap();
+    assert_eq!(
+        ensure_playlist_write_allowed(&matching, &unbound, PlaylistWriteAccess::ManagedByYututui,),
+        Err(ServerError::PermissionDenied)
+    );
+}
+
+#[tokio::test]
+async fn managed_update_and_delete_use_exact_verified_owner_policy() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let (mut update, _) = listener.accept().await.unwrap();
+        let update_request = read_request(&mut update).await;
+        assert!(request_target(&update_request).starts_with("/rest/updatePlaylist.view?"));
+        write_json(&mut update, r#"{"subsonic-response":{"status":"ok"}}"#).await;
+
+        let (mut delete, _) = listener.accept().await.unwrap();
+        let delete_request = read_request(&mut delete).await;
+        assert!(request_target(&delete_request).starts_with("/rest/deletePlaylist.view?"));
+        write_json(&mut delete, r#"{"subsonic-response":{"status":"ok"}}"#).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err(),
+            "verified managed mutations must issue exactly one request each"
+        );
+    });
+    let fixture = test_client_with_password(port).await;
+    let managed = ServerPlaylistWriteSnapshot::new(
+        fixture.backend_id.clone(),
+        fixture.account_scope_id.clone(),
+        ServerPlaylistId::new("managed").unwrap(),
+        "Managed".to_owned(),
+        Some("alice".to_owned()),
+        Some(false),
+        Vec::new(),
+    );
+    fixture
+        .client
+        .update_managed_playlist(
+            &fixture.credential,
+            &managed,
+            Some("Managed renamed"),
+            &[],
+            &[],
+        )
+        .await
+        .unwrap();
+    fixture
+        .client
+        .delete_managed_playlist(&fixture.credential, &managed)
+        .await
+        .unwrap();
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn legacy_empty_create_response_has_no_confirmable_identity() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let request = read_request(&mut stream).await;
+        assert!(request_target(&request).starts_with("/rest/createPlaylist.view?"));
+        write_json(&mut stream, r#"{"subsonic-response":{"status":"ok"}}"#).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err(),
+            "an unconfirmed create must never be retried blindly"
+        );
+    });
+    let fixture = test_client(port).await;
+
+    assert!(
+        fixture
+            .client
+            .create_playlist(&fixture.credential, "Empty", &[])
+            .await
+            .unwrap()
+            .is_none()
+    );
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn response_loss_and_server_errors_are_ambiguous_and_single_shot() {
+    for response in [
+        None,
+        Some(
+            b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                .as_slice(),
+        ),
+        Some(
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx"
+                .as_slice(),
+        ),
+    ] {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut stream).await;
+            assert!(request_target(&request).starts_with("/rest/createPlaylist.view?"));
+            if let Some(response) = response {
+                stream.write_all(response).await.unwrap();
+            }
+            drop(stream);
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                    .await
+                    .is_err(),
+                "an ambiguous create must issue exactly one request"
+            );
+        });
+        let fixture = test_client(port).await;
+
+        assert!(matches!(
+            fixture
+                .client
+                .create_playlist(&fixture.credential, "Ambiguous", &[])
+                .await,
+            Err(MutationDeliveryError::Ambiguous(_))
+        ));
+        server.await.unwrap();
+    }
+}
+
+fn test_snapshot(owner: &str, read_only: Option<bool>) -> ServerPlaylistWriteSnapshot {
+    test_snapshot_with_access(Some(owner), read_only)
+}
+
+fn test_snapshot_with_access(
+    owner: Option<&str>,
+    read_only: Option<bool>,
+) -> ServerPlaylistWriteSnapshot {
+    ServerPlaylistWriteSnapshot::new(
+        BackendId::new("backend").unwrap(),
+        AccountScopeId::new("account").unwrap(),
+        ServerPlaylistId::new("playlist").unwrap(),
+        "Playlist".to_owned(),
+        owner.map(str::to_owned),
+        read_only,
+        Vec::new(),
+    )
+}

--- a/src/open_subsonic/endpoint/test_support.rs
+++ b/src/open_subsonic/endpoint/test_support.rs
@@ -1,0 +1,101 @@
+use age::secrecy::SecretString;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+use super::super::super::model::{AccountScopeId, BackendId, ItemId, OpenSubsonicItemRef};
+use super::super::super::{ConfiguredPrivateOrigin, OpenSubsonicProfile, ServerCredential};
+use super::super::OpenSubsonicClient;
+
+pub(super) struct TestClient {
+    pub(super) client: OpenSubsonicClient,
+    pub(super) credential: ServerCredential,
+    pub(super) backend_id: BackendId,
+    pub(super) account_scope_id: AccountScopeId,
+}
+
+impl TestClient {
+    pub(super) fn item(&self, item_id: &str) -> OpenSubsonicItemRef {
+        OpenSubsonicItemRef::new(
+            self.backend_id.clone(),
+            self.account_scope_id.clone(),
+            ItemId::new(item_id).unwrap(),
+        )
+    }
+}
+
+pub(super) async fn test_client(port: u16) -> TestClient {
+    test_client_with_credential(
+        port,
+        ServerCredential::api_key(SecretString::from("sentinel-api-key".to_owned())).unwrap(),
+    )
+    .await
+}
+
+pub(super) async fn test_client_with_password(port: u16) -> TestClient {
+    test_client_with_credential(
+        port,
+        ServerCredential::password("alice", SecretString::from("sentinel-password".to_owned()))
+            .unwrap(),
+    )
+    .await
+}
+
+pub(super) async fn test_client_with_credential(
+    port: u16,
+    credential: ServerCredential,
+) -> TestClient {
+    let profile = OpenSubsonicProfile::new(
+        "Test server",
+        ConfiguredPrivateOrigin::new(&format!("http://127.0.0.1:{port}/"), true).unwrap(),
+        None,
+    )
+    .unwrap();
+    let backend_id = profile.backend_id().clone();
+    let account_scope_id = profile.account_scope_id().clone();
+    let client = OpenSubsonicClient::connect(&profile).await.unwrap();
+    TestClient {
+        client,
+        credential,
+        backend_id,
+        account_scope_id,
+    }
+}
+
+pub(super) async fn read_request(stream: &mut tokio::net::TcpStream) -> String {
+    let mut request = Vec::new();
+    let mut byte = [0_u8; 1];
+    while request.len() < 32 * 1024 {
+        if stream.read(&mut byte).await.unwrap() == 0 {
+            break;
+        }
+        request.push(byte[0]);
+        if request.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    String::from_utf8(request).unwrap()
+}
+
+pub(super) async fn write_json(stream: &mut tokio::net::TcpStream, body: &str) {
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(response.as_bytes()).await.unwrap();
+}
+
+pub(super) fn request_target(request: &str) -> &str {
+    request
+        .lines()
+        .next()
+        .and_then(|line| line.split_ascii_whitespace().nth(1))
+        .unwrap()
+}
+
+pub(super) fn query_values(request: &str, name: &str) -> Vec<String> {
+    reqwest::Url::parse(&format!("http://fixture{}", request_target(request)))
+        .unwrap()
+        .query_pairs()
+        .filter(|(key, _)| key == name)
+        .map(|(_, value)| value.into_owned())
+        .collect()
+}

--- a/src/open_subsonic/endpoint/tests.rs
+++ b/src/open_subsonic/endpoint/tests.rs
@@ -1,0 +1,320 @@
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt as _;
+
+use super::test_support::*;
+use super::*;
+use crate::open_subsonic::{AccountScopeId, BackendId, ItemId};
+
+#[tokio::test]
+async fn get_song_serializes_opaque_id_and_preserves_exact_server_fields() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let request = read_request(&mut stream).await;
+        let target = request_target(&request);
+        assert!(target.starts_with("/rest/getSong.view?"));
+        assert!(target.contains("id=song+id%26admin%3Dtrue"));
+        assert!(!target.contains("&admin=true"));
+        write_json(
+            &mut stream,
+            r#"{"subsonic-response":{"status":"ok","song":{"id":"song id&admin=true","title":"Song","userRating":3,"starred":"2026-07-26T00:00:00Z","playCount":7,"played":"2026-07-26T00:00:00Z"}}}"#,
+        )
+        .await;
+    });
+    let fixture = test_client(port).await;
+    let song = fixture
+        .client
+        .get_song_raw(&fixture.credential, &fixture.item("song id&admin=true"))
+        .await
+        .unwrap();
+    assert_eq!(song.user_rating, Some(3));
+    assert_eq!(song.play_count, Some(7));
+    assert!(song.starred.is_some());
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn token_info_proves_api_key_owner_without_sending_a_username() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let request = read_request(&mut stream).await;
+        assert!(request_target(&request).starts_with("/rest/tokenInfo.view?"));
+        assert_eq!(query_values(&request, "apiKey"), ["sentinel-api-key"]);
+        assert!(query_values(&request, "u").is_empty());
+        write_json(
+            &mut stream,
+            r#"{"subsonic-response":{"status":"ok","tokenInfo":{"username":"alice"}}}"#,
+        )
+        .await;
+    });
+    let fixture = test_client(port).await;
+
+    assert_eq!(
+        fixture
+            .client
+            .api_key_username(&fixture.credential)
+            .await
+            .unwrap(),
+        "alice"
+    );
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn mutations_use_exact_standard_parameters_and_validate_status() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let expected = [
+            ("/rest/setRating.view?", &["id=song-1", "rating=5"][..]),
+            ("/rest/star.view?", &["id=song-1"][..]),
+            ("/rest/unstar.view?", &["id=song-1"][..]),
+            (
+                "/rest/scrobble.view?",
+                &["id=song-1", "submission=false"][..],
+            ),
+            (
+                "/rest/scrobble.view?",
+                &["id=song-1", "submission=true", "time=1785024000123"][..],
+            ),
+        ];
+        for (index, (endpoint, parameters)) in expected.into_iter().enumerate() {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut stream).await;
+            let target = request_target(&request);
+            assert!(target.starts_with(endpoint), "{target}");
+            for parameter in parameters {
+                assert!(target.contains(parameter), "{target}");
+            }
+            if index == 3 {
+                assert!(!target.contains("&time="), "{target}");
+            }
+            let body = if index == 4 {
+                r#"{"subsonic-response":{"status":"failed","error":{"code":50}}}"#
+            } else {
+                r#"{"subsonic-response":{"status":"ok"}}"#
+            };
+            write_json(&mut stream, body).await;
+        }
+    });
+    let fixture = test_client(port).await;
+    let item = fixture.item("song-1");
+    fixture
+        .client
+        .set_rating(&fixture.credential, &item, 5)
+        .await
+        .unwrap();
+    fixture
+        .client
+        .star(&fixture.credential, &item)
+        .await
+        .unwrap();
+    fixture
+        .client
+        .unstar(&fixture.credential, &item)
+        .await
+        .unwrap();
+    fixture
+        .client
+        .scrobble(&fixture.credential, &item, false, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        fixture
+            .client
+            .scrobble(&fixture.credential, &item, true, Some(1_785_024_000_123),)
+            .await,
+        Err(MutationDeliveryError::DefinitelyNotApplied(
+            ServerError::PermissionDenied
+        ))
+    );
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn item_scope_invalid_rating_and_time_fail_before_network() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let fixture = test_client(port).await;
+    let wrong_backend = OpenSubsonicItemRef::new(
+        BackendId::new("another-backend").unwrap(),
+        fixture.account_scope_id.clone(),
+        ItemId::new("song").unwrap(),
+    );
+    let wrong_account = OpenSubsonicItemRef::new(
+        fixture.backend_id.clone(),
+        AccountScopeId::new("another-account").unwrap(),
+        ItemId::new("song").unwrap(),
+    );
+    assert!(matches!(
+        fixture
+            .client
+            .get_song_raw(&fixture.credential, &wrong_backend)
+            .await,
+        Err(ServerError::WrongAccountScope)
+    ));
+    assert_eq!(
+        fixture
+            .client
+            .star(&fixture.credential, &wrong_account)
+            .await,
+        Err(ServerError::WrongAccountScope)
+    );
+    let item = fixture.item("song");
+    assert_eq!(
+        fixture
+            .client
+            .set_rating(&fixture.credential, &item, 6)
+            .await,
+        Err(ServerError::InvalidResponse)
+    );
+    assert_eq!(
+        fixture
+            .client
+            .scrobble(&fixture.credential, &item, true, Some(u64::MAX))
+            .await,
+        Err(MutationDeliveryError::DefinitelyNotApplied(
+            ServerError::InvalidResponse
+        ))
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), listener.accept())
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn scrobble_connect_failure_is_definitely_not_applied() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let fixture = test_client(port).await;
+    assert_eq!(
+        fixture
+            .client
+            .scrobble(&fixture.credential, &fixture.item("song"), true, None)
+            .await,
+        Err(MutationDeliveryError::DefinitelyNotApplied(
+            ServerError::Offline
+        ))
+    );
+}
+
+#[tokio::test]
+async fn scrobble_response_loss_and_server_errors_are_ambiguous() {
+    for response in [
+        None,
+        Some(
+            b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                .as_slice(),
+        ),
+        Some(
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx"
+                .as_slice(),
+        ),
+    ] {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut stream).await;
+            assert!(request_target(&request).starts_with("/rest/scrobble.view?"));
+            if let Some(response) = response {
+                stream.write_all(response).await.unwrap();
+            }
+        });
+        let fixture = test_client(port).await;
+        let error = fixture
+            .client
+            .scrobble(&fixture.credential, &fixture.item("song"), true, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, MutationDeliveryError::Ambiguous(_)));
+        server.await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn scrobble_redirects_are_ambiguous_and_never_followed() {
+    for redirect_kind in ["same-origin", "loop", "cross-origin"] {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let cross_target = if redirect_kind == "cross-origin" {
+            Some(tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap())
+        } else {
+            None
+        };
+        let location = match (&cross_target, redirect_kind) {
+            (Some(target), _) => format!(
+                "http://127.0.0.1:{}/rest/scrobble.view",
+                target.local_addr().unwrap().port()
+            ),
+            (None, "loop") => "/rest/scrobble.view".to_owned(),
+            _ => "/rest/scrobble-again".to_owned(),
+        };
+        let fixture = test_client(port).await;
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut stream).await;
+            assert!(request_target(&request).starts_with("/rest/scrobble.view?"));
+            let response = format!(
+                "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            drop(stream);
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                    .await
+                    .is_err(),
+                "redirected scrobble must issue exactly one request"
+            );
+        });
+        assert_eq!(
+            fixture
+                .client
+                .scrobble(&fixture.credential, &fixture.item("song"), true, None)
+                .await,
+            Err(MutationDeliveryError::Ambiguous(
+                ServerError::OriginRejected
+            ))
+        );
+        server.await.unwrap();
+        if let Some(target) = cross_target {
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), target.accept())
+                    .await
+                    .is_err(),
+                "cross-origin redirect must not receive a credentialed request"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn get_song_rejects_a_different_returned_item_id() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let _ = read_request(&mut stream).await;
+        write_json(
+            &mut stream,
+            r#"{"subsonic-response":{"status":"ok","song":{"id":"different","title":"Song"}}}"#,
+        )
+        .await;
+    });
+    let fixture = test_client(port).await;
+    assert!(matches!(
+        fixture
+            .client
+            .get_song_raw(&fixture.credential, &fixture.item("requested"))
+            .await,
+        Err(ServerError::InvalidResponse)
+    ));
+    server.await.unwrap();
+}

--- a/src/open_subsonic/linked_playlists.rs
+++ b/src/open_subsonic/linked_playlists.rs
@@ -1,0 +1,1293 @@
+//! Pure occurrence matching and write planning for linked OpenSubsonic playlists.
+//!
+//! OpenSubsonic identifies playlist members only by item ID and mutates playlists with
+//! index-based removals followed by appends. YuTuTui keeps a permanent entry ID for every local
+//! occurrence. This module bridges those representations without consulting playlist names,
+//! clocks, credentials, storage, or the network.
+//!
+//! Conflict authority deliberately lives outside this module. A caller turns [`RemoteDelta`]
+//! into personal-state entry operations, lets the causal reducer resolve concurrent edits, then
+//! passes the resulting exact item order to [`plan_remote_update`].
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use crate::personal_state::PlaylistEntryId;
+
+use super::ItemId;
+
+/// Existing collection limit shared by local and linked server playlists.
+pub const MAX_LINKED_PLAYLIST_ENTRIES: usize = 999;
+
+/// One local occurrence that can be matched back to a server playlist occurrence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkedPlaylistEntry {
+    pub entry_id: PlaylistEntryId,
+    pub item_id: ItemId,
+}
+
+impl LinkedPlaylistEntry {
+    pub fn new(entry_id: PlaylistEntryId, item_id: ItemId) -> Self {
+        Self { entry_id, item_id }
+    }
+}
+
+/// Identifies the bounded input that failed validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlaylistSequence {
+    LocalEntries,
+    PreviousRemoteShadow,
+    CurrentRemote,
+    DesiredRemote,
+    RemoteReadback,
+}
+
+impl fmt::Display for PlaylistSequence {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::LocalEntries => "local entries",
+            Self::PreviousRemoteShadow => "previous remote shadow",
+            Self::CurrentRemote => "current remote playlist",
+            Self::DesiredRemote => "desired remote playlist",
+            Self::RemoteReadback => "remote playlist readback",
+        })
+    }
+}
+
+/// A bounded planning or readback-verification failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkedPlaylistError {
+    TooManyEntries {
+        sequence: PlaylistSequence,
+        actual: usize,
+        maximum: usize,
+    },
+    DuplicateEntryId {
+        sequence: PlaylistSequence,
+        entry_id: PlaylistEntryId,
+    },
+    EntryItemMismatch {
+        entry_id: PlaylistEntryId,
+    },
+    ReadbackMismatch {
+        expected_len: usize,
+        actual_len: usize,
+        first_difference: usize,
+    },
+}
+
+impl fmt::Display for LinkedPlaylistError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooManyEntries {
+                sequence,
+                actual,
+                maximum,
+            } => write!(
+                formatter,
+                "{sequence} contains {actual} entries; the maximum is {maximum}"
+            ),
+            Self::DuplicateEntryId { sequence, entry_id } => write!(
+                formatter,
+                "{sequence} contains duplicate entry id {}",
+                entry_id.as_str()
+            ),
+            Self::EntryItemMismatch { entry_id } => write!(
+                formatter,
+                "entry id {} refers to different exact item ids",
+                entry_id.as_str()
+            ),
+            Self::ReadbackMismatch {
+                expected_len,
+                actual_len,
+                first_difference,
+            } => write!(
+                formatter,
+                "remote playlist readback differs at occurrence {first_difference} \
+                 (expected {expected_len} entries, received {actual_len})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LinkedPlaylistError {}
+
+/// A stable local/shadow occurrence matched to one exact remote occurrence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OccurrenceMatch {
+    pub entry_index: usize,
+    pub remote_index: usize,
+    pub entry_id: PlaylistEntryId,
+    pub item_id: ItemId,
+}
+
+/// An unmatched stable local/shadow occurrence, including its original position.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexedLinkedEntry {
+    pub index: usize,
+    pub entry: LinkedPlaylistEntry,
+}
+
+/// An unmatched remote occurrence, including its exact occurrence index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexedRemoteOccurrence {
+    pub index: usize,
+    pub item_id: ItemId,
+}
+
+/// Exact changes observed between the last verified server shadow and the current server order.
+///
+/// `removed` entries retain their stable local entry IDs. `added` entries intentionally do not
+/// invent local IDs; the owning actor creates those before appending ledger operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteDelta {
+    pub retained: Vec<OccurrenceMatch>,
+    pub removed: Vec<IndexedLinkedEntry>,
+    pub added: Vec<IndexedRemoteOccurrence>,
+}
+
+/// Match a previous verified remote shadow to a current remote playlist.
+///
+/// Matching is an exact-item-ID LCS. Duplicate item IDs remain separate occurrences. Reconstruction
+/// always takes an available exact diagonal, then skips a remote occurrence before a stable entry
+/// when either skip preserves the same maximum length. That fixed rule makes every tie
+/// deterministic on every device.
+pub fn plan_remote_delta(
+    previous_shadow: &[LinkedPlaylistEntry],
+    current_remote: &[ItemId],
+) -> Result<RemoteDelta, LinkedPlaylistError> {
+    ensure_bounded(
+        PlaylistSequence::PreviousRemoteShadow,
+        previous_shadow.len(),
+    )?;
+    ensure_bounded(PlaylistSequence::CurrentRemote, current_remote.len())?;
+
+    let mapping = exact_occurrence_mapping(previous_shadow, current_remote);
+    Ok(RemoteDelta {
+        retained: mapping.matches,
+        removed: mapping.unmatched_entries,
+        added: mapping.unmatched_remote,
+    })
+}
+
+/// What the caller knows about delivery of the pending local server projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingRemoteMergeMode {
+    /// The pending write has not started. Equal local/remote additions are independent.
+    LocalNotDelivered,
+    /// The server accepted the complete desired projection before this readback.
+    LocalDelivered,
+    /// Delivery is unknown. Exact desired additions found remotely reuse their stable IDs.
+    DeliveryUnknown,
+}
+
+/// One stable local occurrence preserved in a pending three-way merge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingExistingOccurrence {
+    /// Position in the base shadow, or `None` when this was a local addition.
+    pub base_index: Option<usize>,
+    pub desired_index: usize,
+    /// Exact position in the remote state, or `None` for an untransmitted local addition.
+    pub remote_index: Option<usize>,
+    pub entry: LinkedPlaylistEntry,
+}
+
+/// Provenance for one occurrence in a pending local/remote merged order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PendingMergeOccurrence {
+    /// A base survivor, delivered local addition, or locally anchored addition.
+    Existing(PendingExistingOccurrence),
+    /// An occurrence created remotely after the base shadow. The caller assigns its local ID.
+    RemoteOnly(IndexedRemoteOccurrence),
+}
+
+impl PendingMergeOccurrence {
+    pub fn item_id(&self) -> &ItemId {
+        match self {
+            Self::Existing(existing) => &existing.entry.item_id,
+            Self::RemoteOnly(remote) => &remote.item_id,
+        }
+    }
+}
+
+/// Provenance for one exact occurrence in the current server readback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PendingRemoteOccurrence {
+    /// The readback occurrence reuses a stable base or pending-local entry ID.
+    Existing(PendingRemoteExistingOccurrence),
+    /// The readback occurrence is a true remote addition and needs a new stable local ID.
+    RemoteOnly(IndexedRemoteOccurrence),
+}
+
+/// One current server occurrence with a reusable stable entry ID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingRemoteExistingOccurrence {
+    pub base_index: Option<usize>,
+    pub desired_index: Option<usize>,
+    pub remote_index: usize,
+    pub entry: LinkedPlaylistEntry,
+}
+
+/// Deterministic three-way result for an in-flight local projection and a changed server state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingRemoteMergePlan {
+    ordered_occurrences: Vec<PendingMergeOccurrence>,
+    remote_occurrences: Vec<PendingRemoteOccurrence>,
+    removed_existing: Vec<IndexedLinkedEntry>,
+    desired_remote: Vec<ItemId>,
+}
+
+impl PendingRemoteMergePlan {
+    pub fn ordered_occurrences(&self) -> &[PendingMergeOccurrence] {
+        &self.ordered_occurrences
+    }
+
+    /// Exact current server order. This always has one element per input remote occurrence.
+    pub fn remote_occurrences(&self) -> &[PendingRemoteOccurrence] {
+        &self.remote_occurrences
+    }
+
+    /// Stable desired entries removed by the remote side under the selected delivery policy.
+    pub fn removed_existing(&self) -> &[IndexedLinkedEntry] {
+        &self.removed_existing
+    }
+
+    pub fn desired_remote(&self) -> &[ItemId] {
+        &self.desired_remote
+    }
+}
+
+/// Merge an in-flight local projection with a concurrently changed remote playlist.
+///
+/// Base occurrences are first matched to exact remote occurrences by the same deterministic LCS
+/// used by [`plan_remote_delta`], then unmatched equal-item occurrences are paired in base/remote
+/// order. The latter step recognizes exact occurrence moves without treating titles or other
+/// metadata as identity. A base occurrence survives only when both local and remote retained it,
+/// so deletion on either side wins. Surviving base occurrences follow remote order.
+///
+/// Local additions attach to the nearest preceding surviving base occurrence in the pending local
+/// order. Additions sharing an anchor are ordered by stable entry ID and are inserted before the
+/// remote-only siblings following that anchor. This is independent of wall clocks and input map
+/// iteration order.
+pub fn plan_pending_remote_merge(
+    previous_shadow: &[LinkedPlaylistEntry],
+    desired: &[LinkedPlaylistEntry],
+    current_remote: &[ItemId],
+    mode: PendingRemoteMergeMode,
+) -> Result<PendingRemoteMergePlan, LinkedPlaylistError> {
+    ensure_bounded(
+        PlaylistSequence::PreviousRemoteShadow,
+        previous_shadow.len(),
+    )?;
+    ensure_bounded(PlaylistSequence::DesiredRemote, desired.len())?;
+    ensure_bounded(PlaylistSequence::CurrentRemote, current_remote.len())?;
+    validate_unique_entry_ids(PlaylistSequence::PreviousRemoteShadow, previous_shadow)?;
+    validate_unique_entry_ids(PlaylistSequence::DesiredRemote, desired)?;
+
+    let base_by_id = previous_shadow
+        .iter()
+        .enumerate()
+        .map(|(index, entry)| (entry.entry_id.clone(), (index, entry)))
+        .collect::<BTreeMap<_, _>>();
+    let desired_by_id = desired
+        .iter()
+        .enumerate()
+        .map(|(index, entry)| (entry.entry_id.clone(), (index, entry)))
+        .collect::<BTreeMap<_, _>>();
+    for (entry_id, (_, base_entry)) in &base_by_id {
+        if let Some((_, desired_entry)) = desired_by_id.get(entry_id)
+            && base_entry.item_id != desired_entry.item_id
+        {
+            return Err(LinkedPlaylistError::EntryItemMismatch {
+                entry_id: entry_id.clone(),
+            });
+        }
+    }
+
+    let (ordered_occurrences, remote_occurrences) = match mode {
+        PendingRemoteMergeMode::LocalDelivered => {
+            merge_after_confirmed_delivery(desired, current_remote, &base_by_id)
+        }
+        PendingRemoteMergeMode::LocalNotDelivered | PendingRemoteMergeMode::DeliveryUnknown => {
+            merge_before_or_unknown_delivery(
+                previous_shadow,
+                desired,
+                current_remote,
+                &base_by_id,
+                &desired_by_id,
+                mode,
+            )
+        }
+    };
+    ensure_bounded(PlaylistSequence::DesiredRemote, ordered_occurrences.len())?;
+    let retained_entry_ids = ordered_occurrences
+        .iter()
+        .filter_map(|occurrence| match occurrence {
+            PendingMergeOccurrence::Existing(existing) => Some(existing.entry.entry_id.clone()),
+            PendingMergeOccurrence::RemoteOnly(_) => None,
+        })
+        .collect::<BTreeSet<_>>();
+    let removed_existing = desired
+        .iter()
+        .enumerate()
+        .filter(|(_, entry)| !retained_entry_ids.contains(&entry.entry_id))
+        .map(|(index, entry)| IndexedLinkedEntry {
+            index,
+            entry: entry.clone(),
+        })
+        .collect();
+    let desired_remote = ordered_occurrences
+        .iter()
+        .map(|occurrence| occurrence.item_id().clone())
+        .collect();
+    Ok(PendingRemoteMergePlan {
+        ordered_occurrences,
+        remote_occurrences,
+        removed_existing,
+        desired_remote,
+    })
+}
+
+fn merge_after_confirmed_delivery(
+    desired: &[LinkedPlaylistEntry],
+    current_remote: &[ItemId],
+    base_by_id: &BTreeMap<PlaylistEntryId, (usize, &LinkedPlaylistEntry)>,
+) -> (Vec<PendingMergeOccurrence>, Vec<PendingRemoteOccurrence>) {
+    let (_, remote_to_desired) = complete_base_remote_mapping(desired, current_remote);
+    let mut ordered = Vec::with_capacity(current_remote.len());
+    let mut remote_occurrences = Vec::with_capacity(current_remote.len());
+    for (remote_index, item_id) in current_remote.iter().enumerate() {
+        if let Some(desired_index) = remote_to_desired[remote_index] {
+            let base_index = base_by_id
+                .get(&desired[desired_index].entry_id)
+                .map(|(index, _)| *index);
+            let entry = desired[desired_index].clone();
+            ordered.push(PendingMergeOccurrence::Existing(
+                PendingExistingOccurrence {
+                    base_index,
+                    desired_index,
+                    remote_index: Some(remote_index),
+                    entry: entry.clone(),
+                },
+            ));
+            remote_occurrences.push(PendingRemoteOccurrence::Existing(
+                PendingRemoteExistingOccurrence {
+                    base_index,
+                    desired_index: Some(desired_index),
+                    remote_index,
+                    entry,
+                },
+            ));
+        } else {
+            let remote_only = IndexedRemoteOccurrence {
+                index: remote_index,
+                item_id: item_id.clone(),
+            };
+            ordered.push(PendingMergeOccurrence::RemoteOnly(remote_only.clone()));
+            remote_occurrences.push(PendingRemoteOccurrence::RemoteOnly(remote_only));
+        }
+    }
+    (ordered, remote_occurrences)
+}
+
+fn merge_before_or_unknown_delivery(
+    previous_shadow: &[LinkedPlaylistEntry],
+    desired: &[LinkedPlaylistEntry],
+    current_remote: &[ItemId],
+    base_by_id: &BTreeMap<PlaylistEntryId, (usize, &LinkedPlaylistEntry)>,
+    desired_by_id: &BTreeMap<PlaylistEntryId, (usize, &LinkedPlaylistEntry)>,
+    mode: PendingRemoteMergeMode,
+) -> (Vec<PendingMergeOccurrence>, Vec<PendingRemoteOccurrence>) {
+    let (base_to_remote, remote_to_base) =
+        complete_base_remote_mapping(previous_shadow, current_remote);
+    let surviving_base = previous_shadow
+        .iter()
+        .enumerate()
+        .filter(|(base_index, entry)| {
+            base_to_remote[*base_index].is_some() && desired_by_id.contains_key(&entry.entry_id)
+        })
+        .map(|(_, entry)| entry.entry_id.clone())
+        .collect::<BTreeSet<_>>();
+
+    let local_additions = desired
+        .iter()
+        .enumerate()
+        .filter(|(_, entry)| !base_by_id.contains_key(&entry.entry_id))
+        .map(|(index, entry)| IndexedLinkedEntry {
+            index,
+            entry: entry.clone(),
+        })
+        .collect::<Vec<_>>();
+    let remote_available = remote_to_base
+        .iter()
+        .enumerate()
+        .filter(|(_, base_index)| base_index.is_none())
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    let mut remote_to_local = vec![None; current_remote.len()];
+    if mode == PendingRemoteMergeMode::DeliveryUnknown {
+        let local_entries = local_additions
+            .iter()
+            .map(|addition| addition.entry.clone())
+            .collect::<Vec<_>>();
+        let available_items = remote_available
+            .iter()
+            .map(|index| current_remote[*index].clone())
+            .collect::<Vec<_>>();
+        let (_, available_to_local) =
+            complete_base_remote_mapping(&local_entries, &available_items);
+        for (available_index, local_index) in available_to_local.into_iter().enumerate() {
+            if let Some(local_index) = local_index {
+                remote_to_local[remote_available[available_index]] =
+                    Some(local_additions[local_index].index);
+            }
+        }
+    }
+    let matched_local_ids = remote_to_local
+        .iter()
+        .flatten()
+        .map(|desired_index| desired[*desired_index].entry_id.clone())
+        .collect::<BTreeSet<_>>();
+    let local_groups =
+        group_local_additions(desired, base_by_id, &surviving_base, &matched_local_ids);
+
+    let mut ordered = Vec::with_capacity(desired.len() + current_remote.len());
+    let mut remote_occurrences = Vec::with_capacity(current_remote.len());
+    append_local_group(&mut ordered, local_groups.get(&None).map(Vec::as_slice));
+    for (remote_index, item_id) in current_remote.iter().enumerate() {
+        if let Some(base_index) = remote_to_base[remote_index] {
+            let base_entry = &previous_shadow[base_index];
+            if !surviving_base.contains(&base_entry.entry_id) {
+                remote_occurrences.push(PendingRemoteOccurrence::Existing(
+                    PendingRemoteExistingOccurrence {
+                        base_index: Some(base_index),
+                        desired_index: None,
+                        remote_index,
+                        entry: base_entry.clone(),
+                    },
+                ));
+                continue;
+            }
+            let (desired_index, desired_entry) = desired_by_id
+                .get(&base_entry.entry_id)
+                .expect("surviving base entry is present in desired");
+            remote_occurrences.push(PendingRemoteOccurrence::Existing(
+                PendingRemoteExistingOccurrence {
+                    base_index: Some(base_index),
+                    desired_index: Some(*desired_index),
+                    remote_index,
+                    entry: (*desired_entry).clone(),
+                },
+            ));
+            ordered.push(PendingMergeOccurrence::Existing(
+                PendingExistingOccurrence {
+                    base_index: Some(base_index),
+                    desired_index: *desired_index,
+                    remote_index: Some(remote_index),
+                    entry: (*desired_entry).clone(),
+                },
+            ));
+            append_local_group(
+                &mut ordered,
+                local_groups
+                    .get(&Some(base_entry.entry_id.clone()))
+                    .map(Vec::as_slice),
+            );
+        } else if let Some(desired_index) = remote_to_local[remote_index] {
+            remote_occurrences.push(PendingRemoteOccurrence::Existing(
+                PendingRemoteExistingOccurrence {
+                    base_index: None,
+                    desired_index: Some(desired_index),
+                    remote_index,
+                    entry: desired[desired_index].clone(),
+                },
+            ));
+            ordered.push(PendingMergeOccurrence::Existing(
+                PendingExistingOccurrence {
+                    base_index: None,
+                    desired_index,
+                    remote_index: Some(remote_index),
+                    entry: desired[desired_index].clone(),
+                },
+            ));
+        } else {
+            let remote_only = IndexedRemoteOccurrence {
+                index: remote_index,
+                item_id: item_id.clone(),
+            };
+            ordered.push(PendingMergeOccurrence::RemoteOnly(remote_only.clone()));
+            remote_occurrences.push(PendingRemoteOccurrence::RemoteOnly(remote_only));
+        }
+    }
+    (ordered, remote_occurrences)
+}
+
+fn group_local_additions(
+    desired: &[LinkedPlaylistEntry],
+    base_by_id: &BTreeMap<PlaylistEntryId, (usize, &LinkedPlaylistEntry)>,
+    surviving_base: &BTreeSet<PlaylistEntryId>,
+    matched_local_ids: &BTreeSet<PlaylistEntryId>,
+) -> BTreeMap<Option<PlaylistEntryId>, Vec<IndexedLinkedEntry>> {
+    let mut groups = BTreeMap::<Option<PlaylistEntryId>, Vec<IndexedLinkedEntry>>::new();
+    let mut anchor = None;
+    for (index, entry) in desired.iter().enumerate() {
+        if base_by_id.contains_key(&entry.entry_id) {
+            if surviving_base.contains(&entry.entry_id) {
+                anchor = Some(entry.entry_id.clone());
+            }
+        } else if !matched_local_ids.contains(&entry.entry_id) {
+            groups
+                .entry(anchor.clone())
+                .or_default()
+                .push(IndexedLinkedEntry {
+                    index,
+                    entry: entry.clone(),
+                });
+        }
+    }
+    for siblings in groups.values_mut() {
+        siblings.sort_by(|left, right| left.entry.entry_id.cmp(&right.entry.entry_id));
+    }
+    groups
+}
+
+fn append_local_group(
+    output: &mut Vec<PendingMergeOccurrence>,
+    group: Option<&[IndexedLinkedEntry]>,
+) {
+    output.extend(group.into_iter().flatten().map(|local| {
+        PendingMergeOccurrence::Existing(PendingExistingOccurrence {
+            base_index: None,
+            desired_index: local.index,
+            remote_index: None,
+            entry: local.entry.clone(),
+        })
+    }));
+}
+
+/// Counts shown before the first, deletion-free link is accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InitialMergePreview {
+    pub add_to_local: usize,
+    pub add_to_remote: usize,
+}
+
+/// The provenance of an occurrence in the first deletion-free merged order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InitialMergeOccurrence {
+    /// One exact occurrence already exists on both sides.
+    Matched(OccurrenceMatch),
+    /// The actor must create a stable local entry ID for this server-only occurrence.
+    RemoteOnly(IndexedRemoteOccurrence),
+    /// This local-only occurrence is appended to the unchanged server order.
+    LocalOnly(IndexedLinkedEntry),
+}
+
+impl InitialMergeOccurrence {
+    pub fn item_id(&self) -> &ItemId {
+        match self {
+            Self::Matched(matched) => &matched.item_id,
+            Self::RemoteOnly(remote) => &remote.item_id,
+            Self::LocalOnly(local) => &local.entry.item_id,
+        }
+    }
+}
+
+/// First-link plan that preserves every local and remote occurrence without removing either side.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InitialMergePlan {
+    preview: InitialMergePreview,
+    ordered_occurrences: Vec<InitialMergeOccurrence>,
+    desired_remote: Vec<ItemId>,
+}
+
+impl InitialMergePlan {
+    pub fn preview(&self) -> InitialMergePreview {
+        self.preview
+    }
+
+    pub fn ordered_occurrences(&self) -> &[InitialMergeOccurrence] {
+        &self.ordered_occurrences
+    }
+
+    pub fn desired_remote(&self) -> &[ItemId] {
+        &self.desired_remote
+    }
+}
+
+/// Plan the first merge without deleting local or server occurrences.
+///
+/// The current server order is retained byte-for-byte. Exact LCS matches reuse stable local entry
+/// IDs, server-only occurrences are imported in place, and unmatched local occurrences are
+/// appended in their existing local order. Playlist names are not an input and can never create a
+/// link or an occurrence match.
+pub fn plan_initial_merge(
+    local_entries: &[LinkedPlaylistEntry],
+    current_remote: &[ItemId],
+) -> Result<InitialMergePlan, LinkedPlaylistError> {
+    ensure_bounded(PlaylistSequence::LocalEntries, local_entries.len())?;
+    ensure_bounded(PlaylistSequence::CurrentRemote, current_remote.len())?;
+
+    let mapping = exact_occurrence_mapping(local_entries, current_remote);
+    let preview = InitialMergePreview {
+        add_to_local: mapping.unmatched_remote.len(),
+        add_to_remote: mapping.unmatched_entries.len(),
+    };
+    ensure_bounded(
+        PlaylistSequence::DesiredRemote,
+        current_remote.len() + mapping.unmatched_entries.len(),
+    )?;
+    let mut matches = mapping.matches.into_iter().peekable();
+    let mut remote_only = mapping.unmatched_remote.into_iter().peekable();
+    let mut ordered_occurrences =
+        Vec::with_capacity(current_remote.len() + mapping.unmatched_entries.len());
+
+    for remote_index in 0..current_remote.len() {
+        if matches
+            .peek()
+            .is_some_and(|matched| matched.remote_index == remote_index)
+        {
+            ordered_occurrences.push(InitialMergeOccurrence::Matched(
+                matches.next().expect("peeked match exists"),
+            ));
+        } else {
+            debug_assert!(
+                remote_only
+                    .peek()
+                    .is_some_and(|remote| remote.index == remote_index)
+            );
+            ordered_occurrences.push(InitialMergeOccurrence::RemoteOnly(
+                remote_only
+                    .next()
+                    .expect("unmatched remote occurrence exists"),
+            ));
+        }
+    }
+
+    ordered_occurrences.extend(
+        mapping
+            .unmatched_entries
+            .into_iter()
+            .map(InitialMergeOccurrence::LocalOnly),
+    );
+    let desired_remote = ordered_occurrences
+        .iter()
+        .map(|occurrence| occurrence.item_id().clone())
+        .collect();
+
+    Ok(InitialMergePlan {
+        preview,
+        ordered_occurrences,
+        desired_remote,
+    })
+}
+
+/// A server-compatible update plan.
+///
+/// OpenSubsonic removals are index-based and additions append to the end. The planner therefore
+/// retains the longest prefix of `desired` that is a subsequence of `current`, removes every
+/// other current occurrence in descending index order, then appends the remaining desired suffix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemotePlaylistUpdatePlan {
+    retained_current_indexes: Vec<usize>,
+    remove_indexes_descending: Vec<usize>,
+    append_item_ids: Vec<ItemId>,
+    desired: Vec<ItemId>,
+}
+
+impl RemotePlaylistUpdatePlan {
+    pub fn retained_current_indexes(&self) -> &[usize] {
+        &self.retained_current_indexes
+    }
+
+    pub fn remove_indexes_descending(&self) -> &[usize] {
+        &self.remove_indexes_descending
+    }
+
+    pub fn append_item_ids(&self) -> &[ItemId] {
+        &self.append_item_ids
+    }
+
+    pub fn desired(&self) -> &[ItemId] {
+        &self.desired
+    }
+
+    pub fn is_noop(&self) -> bool {
+        self.remove_indexes_descending.is_empty() && self.append_item_ids.is_empty()
+    }
+
+    /// Accept a write only after a complete playlist readback exactly matches the desired order.
+    pub fn verify_readback(&self, actual: &[ItemId]) -> Result<(), LinkedPlaylistError> {
+        ensure_bounded(PlaylistSequence::RemoteReadback, actual.len())?;
+        if self.desired == actual {
+            return Ok(());
+        }
+
+        let first_difference = self
+            .desired
+            .iter()
+            .zip(actual)
+            .position(|(expected, received)| expected != received)
+            .unwrap_or_else(|| self.desired.len().min(actual.len()));
+        Err(LinkedPlaylistError::ReadbackMismatch {
+            expected_len: self.desired.len(),
+            actual_len: actual.len(),
+            first_difference,
+        })
+    }
+}
+
+pub fn plan_remote_update(
+    current: &[ItemId],
+    desired: &[ItemId],
+) -> Result<RemotePlaylistUpdatePlan, LinkedPlaylistError> {
+    ensure_bounded(PlaylistSequence::CurrentRemote, current.len())?;
+    ensure_bounded(PlaylistSequence::DesiredRemote, desired.len())?;
+
+    let mut retained_current_indexes = Vec::new();
+    let mut search_from = 0;
+    for desired_item in desired {
+        let Some(relative_index) = current[search_from..]
+            .iter()
+            .position(|current_item| current_item == desired_item)
+        else {
+            break;
+        };
+        let current_index = search_from + relative_index;
+        retained_current_indexes.push(current_index);
+        search_from = current_index + 1;
+    }
+
+    let mut retained = vec![false; current.len()];
+    for &index in &retained_current_indexes {
+        retained[index] = true;
+    }
+    let remove_indexes_descending = (0..current.len())
+        .rev()
+        .filter(|index| !retained[*index])
+        .collect();
+    let append_item_ids = desired[retained_current_indexes.len()..].to_vec();
+
+    Ok(RemotePlaylistUpdatePlan {
+        retained_current_indexes,
+        remove_indexes_descending,
+        append_item_ids,
+        desired: desired.to_vec(),
+    })
+}
+
+struct ExactOccurrenceMapping {
+    matches: Vec<OccurrenceMatch>,
+    unmatched_entries: Vec<IndexedLinkedEntry>,
+    unmatched_remote: Vec<IndexedRemoteOccurrence>,
+}
+
+fn validate_unique_entry_ids(
+    sequence: PlaylistSequence,
+    entries: &[LinkedPlaylistEntry],
+) -> Result<(), LinkedPlaylistError> {
+    let mut seen = BTreeSet::new();
+    for entry in entries {
+        if !seen.insert(entry.entry_id.clone()) {
+            return Err(LinkedPlaylistError::DuplicateEntryId {
+                sequence,
+                entry_id: entry.entry_id.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Extend the deterministic LCS anchors with exact residual occurrence pairing.
+///
+/// LCS establishes the same stable anchors used by normal remote observation. Remaining equal
+/// items are paired in base order with remote order, recognizing moves while leaving duplicate
+/// occurrences distinct. Entries and remote positions without an exact counterpart remain `None`.
+fn complete_base_remote_mapping(
+    entries: &[LinkedPlaylistEntry],
+    remote: &[ItemId],
+) -> (Vec<Option<usize>>, Vec<Option<usize>>) {
+    let mapping = exact_occurrence_mapping(entries, remote);
+    let mut entry_to_remote = vec![None; entries.len()];
+    let mut remote_to_entry = vec![None; remote.len()];
+    for matched in &mapping.matches {
+        entry_to_remote[matched.entry_index] = Some(matched.remote_index);
+        remote_to_entry[matched.remote_index] = Some(matched.entry_index);
+    }
+
+    let mut remote_by_item = BTreeMap::<ItemId, Vec<usize>>::new();
+    for occurrence in mapping.unmatched_remote.iter().rev() {
+        remote_by_item
+            .entry(occurrence.item_id.clone())
+            .or_default()
+            .push(occurrence.index);
+    }
+    for unmatched in mapping.unmatched_entries {
+        let Some(remote_index) = remote_by_item
+            .get_mut(&unmatched.entry.item_id)
+            .and_then(Vec::pop)
+        else {
+            continue;
+        };
+        entry_to_remote[unmatched.index] = Some(remote_index);
+        remote_to_entry[remote_index] = Some(unmatched.index);
+    }
+    (entry_to_remote, remote_to_entry)
+}
+
+fn exact_occurrence_mapping(
+    entries: &[LinkedPlaylistEntry],
+    remote: &[ItemId],
+) -> ExactOccurrenceMapping {
+    let pairs = deterministic_lcs_pairs(entries, remote);
+    let mut matched_entries = vec![false; entries.len()];
+    let mut matched_remote = vec![false; remote.len()];
+    let matches = pairs
+        .into_iter()
+        .map(|(entry_index, remote_index)| {
+            matched_entries[entry_index] = true;
+            matched_remote[remote_index] = true;
+            OccurrenceMatch {
+                entry_index,
+                remote_index,
+                entry_id: entries[entry_index].entry_id.clone(),
+                item_id: entries[entry_index].item_id.clone(),
+            }
+        })
+        .collect();
+    let unmatched_entries = entries
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| !matched_entries[*index])
+        .map(|(index, entry)| IndexedLinkedEntry {
+            index,
+            entry: entry.clone(),
+        })
+        .collect();
+    let unmatched_remote = remote
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| !matched_remote[*index])
+        .map(|(index, item_id)| IndexedRemoteOccurrence {
+            index,
+            item_id: item_id.clone(),
+        })
+        .collect();
+
+    ExactOccurrenceMapping {
+        matches,
+        unmatched_entries,
+        unmatched_remote,
+    }
+}
+
+fn deterministic_lcs_pairs(
+    entries: &[LinkedPlaylistEntry],
+    remote: &[ItemId],
+) -> Vec<(usize, usize)> {
+    let stride = remote.len() + 1;
+    let mut lengths = vec![0usize; (entries.len() + 1) * stride];
+    let at = |entry_index: usize, remote_index: usize| entry_index * stride + remote_index;
+
+    for entry_index in (0..entries.len()).rev() {
+        for remote_index in (0..remote.len()).rev() {
+            lengths[at(entry_index, remote_index)] =
+                if entries[entry_index].item_id == remote[remote_index] {
+                    1 + lengths[at(entry_index + 1, remote_index + 1)]
+                } else {
+                    lengths[at(entry_index + 1, remote_index)]
+                        .max(lengths[at(entry_index, remote_index + 1)])
+                };
+        }
+    }
+
+    let mut pairs = Vec::with_capacity(lengths[at(0, 0)]);
+    let mut entry_index = 0;
+    let mut remote_index = 0;
+    while entry_index < entries.len() && remote_index < remote.len() {
+        let best = lengths[at(entry_index, remote_index)];
+        if entries[entry_index].item_id == remote[remote_index]
+            && best == 1 + lengths[at(entry_index + 1, remote_index + 1)]
+        {
+            pairs.push((entry_index, remote_index));
+            entry_index += 1;
+            remote_index += 1;
+        } else if lengths[at(entry_index, remote_index + 1)] == best {
+            // If both skips keep a maximum LCS, this fixed direction is the deterministic tie
+            // break used on every device.
+            remote_index += 1;
+        } else {
+            entry_index += 1;
+        }
+    }
+    pairs
+}
+
+fn ensure_bounded(sequence: PlaylistSequence, actual: usize) -> Result<(), LinkedPlaylistError> {
+    if actual <= MAX_LINKED_PLAYLIST_ENTRIES {
+        Ok(())
+    } else {
+        Err(LinkedPlaylistError::TooManyEntries {
+            sequence,
+            actual,
+            maximum: MAX_LINKED_PLAYLIST_ENTRIES,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(value: &str) -> ItemId {
+        ItemId::new(value).unwrap()
+    }
+
+    fn entry(entry_id: &str, item_id: &str) -> LinkedPlaylistEntry {
+        LinkedPlaylistEntry::new(PlaylistEntryId::new(entry_id).unwrap(), item(item_id))
+    }
+
+    fn item_values(items: &[ItemId]) -> Vec<&str> {
+        items.iter().map(ItemId::as_str).collect()
+    }
+
+    fn apply_update_plan(current: &[ItemId], plan: &RemotePlaylistUpdatePlan) -> Vec<ItemId> {
+        let mut result = current.to_vec();
+        for &index in plan.remove_indexes_descending() {
+            result.remove(index);
+        }
+        result.extend_from_slice(plan.append_item_ids());
+        result
+    }
+
+    #[test]
+    fn exact_lcs_preserves_duplicate_occurrences() {
+        let shadow = [entry("one", "a"), entry("two", "a"), entry("three", "b")];
+        let current = [item("a"), item("b"), item("a")];
+
+        let delta = plan_remote_delta(&shadow, &current).unwrap();
+
+        assert_eq!(
+            delta
+                .retained
+                .iter()
+                .map(|matched| (matched.entry_index, matched.remote_index))
+                .collect::<Vec<_>>(),
+            vec![(0, 0), (1, 2)]
+        );
+        assert_eq!(
+            delta
+                .removed
+                .iter()
+                .map(|removed| removed.entry.entry_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["three"]
+        );
+        assert_eq!(
+            delta
+                .added
+                .iter()
+                .map(|added| (added.index, added.item_id.as_str()))
+                .collect::<Vec<_>>(),
+            vec![(1, "b")]
+        );
+    }
+
+    #[test]
+    fn reorder_is_an_exact_remove_and_add_not_a_fuzzy_match() {
+        let shadow = [entry("a-entry", "a"), entry("b-entry", "b")];
+        let current = [item("b"), item("a")];
+
+        let delta = plan_remote_delta(&shadow, &current).unwrap();
+
+        assert_eq!(delta.retained.len(), 1);
+        assert_eq!(delta.retained[0].entry_id.as_str(), "a-entry");
+        assert_eq!(delta.retained[0].remote_index, 1);
+        assert_eq!(delta.removed[0].entry.entry_id.as_str(), "b-entry");
+        assert_eq!(delta.added[0].item_id.as_str(), "b");
+        assert_eq!(delta.added[0].index, 0);
+    }
+
+    #[test]
+    fn lcs_ties_use_the_fixed_remote_skip_before_entry_skip() {
+        let shadow = [entry("first", "a"), entry("second", "b")];
+        let reordered = [item("b"), item("a")];
+        let delta = plan_remote_delta(&shadow, &reordered).unwrap();
+        assert_eq!(
+            delta
+                .retained
+                .iter()
+                .map(|matched| (matched.entry_index, matched.remote_index))
+                .collect::<Vec<_>>(),
+            vec![(0, 1)]
+        );
+
+        let duplicate_shadow = [entry("first", "a"), entry("second", "a")];
+        let one_remote = [item("a")];
+        let delta = plan_remote_delta(&duplicate_shadow, &one_remote).unwrap();
+        assert_eq!(delta.retained[0].entry_index, 0);
+
+        let one_shadow = [entry("only", "a")];
+        let duplicate_remote = [item("a"), item("a")];
+        let delta = plan_remote_delta(&one_shadow, &duplicate_remote).unwrap();
+        assert_eq!(delta.retained[0].remote_index, 0);
+    }
+
+    #[test]
+    fn simultaneous_remote_add_and_remove_keep_stable_ids_for_the_reducer() {
+        let shadow = [
+            entry("first", "a"),
+            entry("removed", "b"),
+            entry("last", "c"),
+        ];
+        let current = [item("a"), item("new"), item("c")];
+
+        let delta = plan_remote_delta(&shadow, &current).unwrap();
+
+        assert_eq!(
+            delta
+                .retained
+                .iter()
+                .map(|matched| matched.entry_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first", "last"]
+        );
+        assert_eq!(delta.removed[0].entry.entry_id.as_str(), "removed");
+        assert_eq!(delta.added[0].index, 1);
+        assert_eq!(delta.added[0].item_id.as_str(), "new");
+    }
+
+    #[test]
+    fn first_merge_is_deletion_free_and_reports_both_counts() {
+        let local = [
+            entry("first-a", "a"),
+            entry("second-a", "a"),
+            entry("local-c", "c"),
+        ];
+        let remote = [item("a"), item("b"), item("a")];
+
+        let plan = plan_initial_merge(&local, &remote).unwrap();
+
+        assert_eq!(
+            plan.preview(),
+            InitialMergePreview {
+                add_to_local: 1,
+                add_to_remote: 1,
+            }
+        );
+        assert_eq!(item_values(plan.desired_remote()), vec!["a", "b", "a", "c"]);
+        assert!(matches!(
+            plan.ordered_occurrences(),
+            [
+                InitialMergeOccurrence::Matched(_),
+                InitialMergeOccurrence::RemoteOnly(_),
+                InitialMergeOccurrence::Matched(_),
+                InitialMergeOccurrence::LocalOnly(_)
+            ]
+        ));
+    }
+
+    #[test]
+    fn first_merge_does_not_collapse_equal_item_ids_or_consult_names() {
+        let local = [entry("local-first", "same"), entry("local-second", "same")];
+        let remote = [item("same")];
+
+        let plan = plan_initial_merge(&local, &remote).unwrap();
+
+        assert_eq!(plan.preview().add_to_local, 0);
+        assert_eq!(plan.preview().add_to_remote, 1);
+        assert_eq!(item_values(plan.desired_remote()), vec!["same", "same"]);
+        assert_eq!(
+            plan.ordered_occurrences()
+                .iter()
+                .filter(|occurrence| matches!(occurrence, InitialMergeOccurrence::Matched(_)))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn first_merge_handles_empty_sides_without_deletions() {
+        let local = [entry("local", "a")];
+        let no_remote = plan_initial_merge(&local, &[]).unwrap();
+        assert_eq!(
+            no_remote.preview(),
+            InitialMergePreview {
+                add_to_local: 0,
+                add_to_remote: 1,
+            }
+        );
+        assert_eq!(item_values(no_remote.desired_remote()), vec!["a"]);
+
+        let remote = [item("b")];
+        let no_local = plan_initial_merge(&[], &remote).unwrap();
+        assert_eq!(
+            no_local.preview(),
+            InitialMergePreview {
+                add_to_local: 1,
+                add_to_remote: 0,
+            }
+        );
+        assert_eq!(item_values(no_local.desired_remote()), vec!["b"]);
+    }
+
+    #[test]
+    fn remote_update_retains_longest_desired_prefix_subsequence() {
+        let current = [item("a"), item("x"), item("b"), item("y"), item("c")];
+        let desired = [item("a"), item("b"), item("d")];
+
+        let plan = plan_remote_update(&current, &desired).unwrap();
+
+        assert_eq!(plan.retained_current_indexes(), &[0, 2]);
+        assert_eq!(plan.remove_indexes_descending(), &[4, 3, 1]);
+        assert_eq!(item_values(plan.append_item_ids()), vec!["d"]);
+        assert_eq!(apply_update_plan(&current, &plan), desired);
+    }
+
+    #[test]
+    fn remote_update_handles_duplicate_reorder_deterministically() {
+        let current = [item("a"), item("b"), item("a"), item("c")];
+        let desired = [item("a"), item("a"), item("b"), item("a")];
+
+        let plan = plan_remote_update(&current, &desired).unwrap();
+
+        assert_eq!(plan.retained_current_indexes(), &[0, 2]);
+        assert_eq!(plan.remove_indexes_descending(), &[3, 1]);
+        assert_eq!(item_values(plan.append_item_ids()), vec!["b", "a"]);
+        assert_eq!(apply_update_plan(&current, &plan), desired);
+    }
+
+    #[test]
+    fn remote_update_noop_and_remove_all_are_explicit() {
+        let current = [item("a"), item("b")];
+        let noop = plan_remote_update(&current, &current).unwrap();
+        assert!(noop.is_noop());
+        assert_eq!(noop.retained_current_indexes(), &[0, 1]);
+        assert!(noop.remove_indexes_descending().is_empty());
+        assert!(noop.append_item_ids().is_empty());
+
+        let remove_all = plan_remote_update(&current, &[]).unwrap();
+        assert!(!remove_all.is_noop());
+        assert_eq!(remove_all.remove_indexes_descending(), &[1, 0]);
+        assert!(remove_all.append_item_ids().is_empty());
+        assert!(apply_update_plan(&current, &remove_all).is_empty());
+    }
+
+    #[test]
+    fn full_readback_requires_exact_order_and_duplicate_count() {
+        let current = [item("a")];
+        let desired = [item("a"), item("b"), item("a")];
+        let plan = plan_remote_update(&current, &desired).unwrap();
+
+        assert_eq!(plan.verify_readback(&desired), Ok(()));
+        assert_eq!(
+            plan.verify_readback(&[item("a"), item("a"), item("b")]),
+            Err(LinkedPlaylistError::ReadbackMismatch {
+                expected_len: 3,
+                actual_len: 3,
+                first_difference: 1,
+            })
+        );
+        assert_eq!(
+            plan.verify_readback(&[item("a"), item("b")]),
+            Err(LinkedPlaylistError::ReadbackMismatch {
+                expected_len: 3,
+                actual_len: 2,
+                first_difference: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn every_planner_input_rejects_more_than_999_occurrences() {
+        let too_many_items = vec![item("same"); MAX_LINKED_PLAYLIST_ENTRIES + 1];
+        let too_many_entries = (0..=MAX_LINKED_PLAYLIST_ENTRIES)
+            .map(|index| entry(&format!("entry-{index}"), "same"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            plan_initial_merge(&too_many_entries, &[]),
+            Err(LinkedPlaylistError::TooManyEntries {
+                sequence: PlaylistSequence::LocalEntries,
+                actual: 1000,
+                maximum: 999,
+            })
+        );
+        assert_eq!(
+            plan_initial_merge(&[], &too_many_items),
+            Err(LinkedPlaylistError::TooManyEntries {
+                sequence: PlaylistSequence::CurrentRemote,
+                actual: 1000,
+                maximum: 999,
+            })
+        );
+        let local_half = (0..600)
+            .map(|index| entry(&format!("local-{index}"), &format!("local-item-{index}")))
+            .collect::<Vec<_>>();
+        let remote_half = (0..600)
+            .map(|index| item(&format!("remote-item-{index}")))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            plan_initial_merge(&local_half, &remote_half),
+            Err(LinkedPlaylistError::TooManyEntries {
+                sequence: PlaylistSequence::DesiredRemote,
+                actual: 1200,
+                maximum: 999,
+            })
+        );
+        assert_eq!(
+            plan_remote_delta(&too_many_entries, &[]),
+            Err(LinkedPlaylistError::TooManyEntries {
+                sequence: PlaylistSequence::PreviousRemoteShadow,
+                actual: 1000,
+                maximum: 999,
+            })
+        );
+        assert_eq!(
+            plan_remote_update(&too_many_items, &[]),
+            Err(LinkedPlaylistError::TooManyEntries {
+                sequence: PlaylistSequence::CurrentRemote,
+                actual: 1000,
+                maximum: 999,
+            })
+        );
+        assert_eq!(
+            plan_remote_update(&[], &too_many_items),
+            Err(LinkedPlaylistError::TooManyEntries {
+                sequence: PlaylistSequence::DesiredRemote,
+                actual: 1000,
+                maximum: 999,
+            })
+        );
+
+        let plan = plan_remote_update(&[], &[]).unwrap();
+        assert_eq!(
+            plan.verify_readback(&too_many_items),
+            Err(LinkedPlaylistError::TooManyEntries {
+                sequence: PlaylistSequence::RemoteReadback,
+                actual: 1000,
+                maximum: 999,
+            })
+        );
+    }
+
+    #[test]
+    fn exact_limit_is_accepted() {
+        let items = vec![item("same"); MAX_LINKED_PLAYLIST_ENTRIES];
+        let entries = (0..MAX_LINKED_PLAYLIST_ENTRIES)
+            .map(|index| entry(&format!("entry-{index}"), "same"))
+            .collect::<Vec<_>>();
+
+        let initial = plan_initial_merge(&entries, &items).unwrap();
+        assert_eq!(initial.desired_remote().len(), MAX_LINKED_PLAYLIST_ENTRIES);
+        let delta = plan_remote_delta(&entries, &items).unwrap();
+        assert_eq!(delta.retained.len(), MAX_LINKED_PLAYLIST_ENTRIES);
+        let update = plan_remote_update(&items, &items).unwrap();
+        assert!(update.is_noop());
+        assert_eq!(update.verify_readback(&items), Ok(()));
+    }
+}
+
+#[cfg(test)]
+#[path = "linked_playlists/pending_merge_tests.rs"]
+mod pending_merge_tests;

--- a/src/open_subsonic/linked_playlists/pending_merge_tests.rs
+++ b/src/open_subsonic/linked_playlists/pending_merge_tests.rs
@@ -1,0 +1,399 @@
+use super::*;
+
+fn item(value: &str) -> ItemId {
+    ItemId::new(value).unwrap()
+}
+
+fn entry(entry_id: &str, item_id: &str) -> LinkedPlaylistEntry {
+    LinkedPlaylistEntry::new(PlaylistEntryId::new(entry_id).unwrap(), item(item_id))
+}
+
+fn occurrence_labels(plan: &PendingRemoteMergePlan) -> Vec<String> {
+    plan.ordered_occurrences()
+        .iter()
+        .map(|occurrence| match occurrence {
+            PendingMergeOccurrence::Existing(existing) => format!(
+                "existing:{}@{}",
+                existing.entry.entry_id.as_str(),
+                existing
+                    .remote_index
+                    .map_or_else(|| "local".to_owned(), |index| index.to_string())
+            ),
+            PendingMergeOccurrence::RemoteOnly(remote) => {
+                format!("remote:{}@{}", remote.item_id.as_str(), remote.index)
+            }
+        })
+        .collect()
+}
+
+fn remote_labels(plan: &PendingRemoteMergePlan) -> Vec<String> {
+    plan.remote_occurrences()
+        .iter()
+        .map(|occurrence| match occurrence {
+            PendingRemoteOccurrence::Existing(existing) => format!(
+                "existing:{}@{}",
+                existing.entry.entry_id.as_str(),
+                existing.remote_index
+            ),
+            PendingRemoteOccurrence::RemoteOnly(remote) => {
+                format!("remote:{}@{}", remote.item_id.as_str(), remote.index)
+            }
+        })
+        .collect()
+}
+
+fn item_values(items: &[ItemId]) -> Vec<&str> {
+    items.iter().map(ItemId::as_str).collect()
+}
+
+#[test]
+fn unknown_delivery_reuses_exact_local_echo_and_preserves_remote_addition() {
+    let base = [entry("entry-a", "a")];
+    let desired = [entry("entry-a", "a"), entry("entry-b", "b")];
+    let current = [item("a"), item("b"), item("c")];
+
+    let plan = plan_pending_remote_merge(
+        &base,
+        &desired,
+        &current,
+        PendingRemoteMergeMode::DeliveryUnknown,
+    )
+    .unwrap();
+
+    assert_eq!(
+        occurrence_labels(&plan),
+        ["existing:entry-a@0", "existing:entry-b@1", "remote:c@2"]
+    );
+    assert_eq!(item_values(plan.desired_remote()), ["a", "b", "c"]);
+    assert!(plan.removed_existing().is_empty());
+}
+
+#[test]
+fn queued_equal_local_and_remote_additions_remain_distinct_occurrences() {
+    let base = [entry("entry-a", "a")];
+    let desired = [entry("entry-a", "a"), entry("local-b", "b")];
+    let current = [item("a"), item("b")];
+
+    let plan = plan_pending_remote_merge(
+        &base,
+        &desired,
+        &current,
+        PendingRemoteMergeMode::LocalNotDelivered,
+    )
+    .unwrap();
+
+    assert_eq!(
+        occurrence_labels(&plan),
+        ["existing:entry-a@0", "existing:local-b@local", "remote:b@1"]
+    );
+    assert_eq!(item_values(plan.desired_remote()), ["a", "b", "b"]);
+}
+
+#[test]
+fn queued_local_and_remote_additions_merge_without_deletion() {
+    let base = [entry("entry-a", "a"), entry("entry-b", "b")];
+    let desired = [
+        entry("entry-a", "a"),
+        entry("local", "local"),
+        entry("entry-b", "b"),
+    ];
+    let current = [item("a"), item("remote"), item("b")];
+
+    let plan = plan_pending_remote_merge(
+        &base,
+        &desired,
+        &current,
+        PendingRemoteMergeMode::LocalNotDelivered,
+    )
+    .unwrap();
+
+    assert_eq!(
+        occurrence_labels(&plan),
+        [
+            "existing:entry-a@0",
+            "existing:local@local",
+            "remote:remote@1",
+            "existing:entry-b@2"
+        ]
+    );
+}
+
+#[test]
+fn confirmed_delivery_uses_desired_as_prior_for_remote_reorder_and_remove() {
+    let base = [entry("entry-a", "a")];
+    let desired = [entry("entry-a", "a"), entry("local-b", "b")];
+    let current = [item("b"), item("c")];
+
+    let plan = plan_pending_remote_merge(
+        &base,
+        &desired,
+        &current,
+        PendingRemoteMergeMode::LocalDelivered,
+    )
+    .unwrap();
+
+    assert_eq!(
+        occurrence_labels(&plan),
+        ["existing:local-b@0", "remote:c@1"]
+    );
+    assert_eq!(
+        plan.removed_existing()[0].entry.entry_id.as_str(),
+        "entry-a"
+    );
+}
+
+#[test]
+fn concurrent_base_reorder_follows_remote_order() {
+    let base = [
+        entry("entry-a", "a"),
+        entry("entry-b", "b"),
+        entry("entry-c", "c"),
+    ];
+    let desired = [
+        entry("entry-b", "b"),
+        entry("entry-a", "a"),
+        entry("entry-c", "c"),
+    ];
+    let current = [item("c"), item("a"), item("b")];
+
+    let plan = plan_pending_remote_merge(
+        &base,
+        &desired,
+        &current,
+        PendingRemoteMergeMode::LocalNotDelivered,
+    )
+    .unwrap();
+
+    assert_eq!(
+        occurrence_labels(&plan),
+        [
+            "existing:entry-c@0",
+            "existing:entry-a@1",
+            "existing:entry-b@2"
+        ]
+    );
+}
+
+#[test]
+fn deletion_of_base_occurrence_wins_over_other_side_move() {
+    let base = [
+        entry("entry-a", "a"),
+        entry("entry-b", "b"),
+        entry("entry-c", "c"),
+    ];
+    let locally_moved = [
+        entry("entry-b", "b"),
+        entry("entry-a", "a"),
+        entry("entry-c", "c"),
+    ];
+    let remote_deleted = [item("c"), item("a")];
+    let remote_wins = plan_pending_remote_merge(
+        &base,
+        &locally_moved,
+        &remote_deleted,
+        PendingRemoteMergeMode::LocalNotDelivered,
+    )
+    .unwrap();
+    assert_eq!(
+        occurrence_labels(&remote_wins),
+        ["existing:entry-c@0", "existing:entry-a@1"]
+    );
+    assert_eq!(
+        remote_wins.removed_existing()[0].entry.entry_id.as_str(),
+        "entry-b"
+    );
+
+    let locally_deleted = [entry("entry-a", "a"), entry("entry-c", "c")];
+    let remote_moved = [item("c"), item("b"), item("a")];
+    let local_wins = plan_pending_remote_merge(
+        &base,
+        &locally_deleted,
+        &remote_moved,
+        PendingRemoteMergeMode::LocalNotDelivered,
+    )
+    .unwrap();
+    assert_eq!(
+        occurrence_labels(&local_wins),
+        ["existing:entry-c@0", "existing:entry-a@2"]
+    );
+    assert_eq!(
+        remote_labels(&local_wins),
+        [
+            "existing:entry-c@0",
+            "existing:entry-b@1",
+            "existing:entry-a@2"
+        ],
+        "the exact server shadow retains provenance even for the locally deleted occurrence"
+    );
+    assert!(local_wins.removed_existing().is_empty());
+}
+
+#[test]
+fn duplicate_occurrences_keep_distinct_stable_ids() {
+    let base = [
+        entry("first-a", "a"),
+        entry("second-a", "a"),
+        entry("entry-b", "b"),
+    ];
+    let desired = [
+        entry("entry-b", "b"),
+        entry("second-a", "a"),
+        entry("first-a", "a"),
+        entry("local-a", "a"),
+    ];
+    let current = [item("a"), item("b"), item("a"), item("a")];
+
+    let plan = plan_pending_remote_merge(
+        &base,
+        &desired,
+        &current,
+        PendingRemoteMergeMode::DeliveryUnknown,
+    )
+    .unwrap();
+
+    assert_eq!(
+        occurrence_labels(&plan),
+        [
+            "existing:first-a@0",
+            "existing:entry-b@1",
+            "existing:second-a@2",
+            "existing:local-a@3"
+        ]
+    );
+}
+
+#[test]
+fn local_same_anchor_siblings_use_stable_entry_id_order() {
+    let base = [entry("entry-a", "a"), entry("entry-b", "b")];
+    let desired = [
+        entry("entry-a", "a"),
+        entry("z-local", "z"),
+        entry("a-local", "x"),
+        entry("entry-b", "b"),
+    ];
+    let current = [item("a"), item("b")];
+
+    let plan = plan_pending_remote_merge(
+        &base,
+        &desired,
+        &current,
+        PendingRemoteMergeMode::LocalNotDelivered,
+    )
+    .unwrap();
+
+    assert_eq!(
+        occurrence_labels(&plan),
+        [
+            "existing:entry-a@0",
+            "existing:a-local@local",
+            "existing:z-local@local",
+            "existing:entry-b@1"
+        ]
+    );
+}
+
+#[test]
+fn pending_merge_is_idempotently_deterministic() {
+    let base = [entry("entry-a", "a"), entry("entry-b", "b")];
+    let desired = [entry("entry-b", "b"), entry("local", "x")];
+    let current = [item("remote"), item("b"), item("x")];
+
+    let first = plan_pending_remote_merge(
+        &base,
+        &desired,
+        &current,
+        PendingRemoteMergeMode::DeliveryUnknown,
+    )
+    .unwrap();
+    let second = plan_pending_remote_merge(
+        &base,
+        &desired,
+        &current,
+        PendingRemoteMergeMode::DeliveryUnknown,
+    )
+    .unwrap();
+
+    assert_eq!(first, second);
+}
+
+#[test]
+fn duplicate_entry_ids_and_changed_exact_items_are_rejected() {
+    let duplicate = [entry("same", "a"), entry("same", "a")];
+    assert_eq!(
+        plan_pending_remote_merge(
+            &[],
+            &duplicate,
+            &[],
+            PendingRemoteMergeMode::LocalNotDelivered
+        ),
+        Err(LinkedPlaylistError::DuplicateEntryId {
+            sequence: PlaylistSequence::DesiredRemote,
+            entry_id: PlaylistEntryId::new("same").unwrap(),
+        })
+    );
+
+    assert_eq!(
+        plan_pending_remote_merge(
+            &[entry("same", "a")],
+            &[entry("same", "b")],
+            &[item("a")],
+            PendingRemoteMergeMode::DeliveryUnknown,
+        ),
+        Err(LinkedPlaylistError::EntryItemMismatch {
+            entry_id: PlaylistEntryId::new("same").unwrap(),
+        })
+    );
+}
+
+#[test]
+fn pending_inputs_and_merged_union_enforce_occurrence_bound() {
+    let too_many = (0..=MAX_LINKED_PLAYLIST_ENTRIES)
+        .map(|index| entry(&format!("entry-{index}"), "same"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        plan_pending_remote_merge(
+            &too_many,
+            &[],
+            &[],
+            PendingRemoteMergeMode::LocalNotDelivered,
+        ),
+        Err(LinkedPlaylistError::TooManyEntries {
+            sequence: PlaylistSequence::PreviousRemoteShadow,
+            actual: 1000,
+            maximum: 999,
+        })
+    );
+    assert_eq!(
+        plan_pending_remote_merge(
+            &[],
+            &too_many,
+            &[],
+            PendingRemoteMergeMode::LocalNotDelivered,
+        ),
+        Err(LinkedPlaylistError::TooManyEntries {
+            sequence: PlaylistSequence::DesiredRemote,
+            actual: 1000,
+            maximum: 999,
+        })
+    );
+
+    let local = (0..600)
+        .map(|index| entry(&format!("local-{index}"), &format!("local-item-{index}")))
+        .collect::<Vec<_>>();
+    let remote = (0..600)
+        .map(|index| item(&format!("remote-item-{index}")))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        plan_pending_remote_merge(
+            &[],
+            &local,
+            &remote,
+            PendingRemoteMergeMode::LocalNotDelivered,
+        ),
+        Err(LinkedPlaylistError::TooManyEntries {
+            sequence: PlaylistSequence::DesiredRemote,
+            actual: 1200,
+            maximum: 999,
+        })
+    );
+}

--- a/src/open_subsonic/mod.rs
+++ b/src/open_subsonic/mod.rs
@@ -11,10 +11,12 @@ pub mod capabilities;
 pub mod catalog;
 pub mod client;
 pub mod history;
+pub mod linked_playlists;
 pub mod model;
 pub mod native_history;
 pub mod origin;
 mod outbound_recovery;
+mod playlist_create_recovery;
 pub mod private_store;
 pub mod profile;
 pub mod proxy;
@@ -23,18 +25,21 @@ pub mod transaction;
 mod wire;
 
 pub use actor::{
-    OpenSubsonicHandle, OpenSubsonicProfileSummary, OpenSubsonicRatingReceipt, OpenSubsonicRuntime,
-    OpenSubsonicScrobbleReceipt, OpenSubsonicStatus, OpenSubsonicStatusKind,
-    OutboundScrobbleResolution, PreparedSetup, ServerLibraryDetailRequest, ServerLibraryRequest,
-    ServiceError, SetupIdentityIntent, SetupInput, commit_setup, current_handle,
-    current_proxy_handle, disable_native_history, load_actor, load_actor_read_only,
+    OpenSubsonicHandle, OpenSubsonicPlaylistReceipt, OpenSubsonicProfileSummary,
+    OpenSubsonicRatingReceipt, OpenSubsonicRuntime, OpenSubsonicScrobbleReceipt,
+    OpenSubsonicStatus, OpenSubsonicStatusKind, OutboundScrobbleResolution, PlaylistMergePreview,
+    PlaylistPreviewMode, PlaylistPreviewTarget, PreparedSetup, ServerLibraryDetailRequest,
+    ServerLibraryRequest, ServiceError, SetupIdentityIntent, SetupInput, commit_setup,
+    current_handle, current_proxy_handle, disable_native_history, load_actor, load_actor_read_only,
     load_actor_with_bridge_sink, read_status, remove_profile, test_and_prepare_setup,
     test_connection, test_connection_read_only,
 };
 pub use bridge_event::{
     OpenSubsonicBridgeImport, OpenSubsonicBridgeSink, OpenSubsonicScrobbleKind,
 };
-pub use bridge_store::{NativeHistoryHealth, OpenSubsonicBridgeState};
+pub use bridge_store::{
+    NativeHistoryHealth, OpenSubsonicBridgeState, PendingPlaylistImportPurpose,
+};
 pub use capabilities::{ServerCapabilities, ServerFeature};
 pub use catalog::{MAX_PAGE_SIZE, OpenSubsonicCatalog};
 pub use client::{BinaryPayload, OpenSubsonicClient, ServerError, ServerInfo};
@@ -42,11 +47,17 @@ pub use history::{
     AggregateHistoryShadow, AggregatePlan, AggregatePlay, MAX_AGGREGATE_DELTA, parse_rfc3339_unix,
     plan_aggregate_history,
 };
+pub use linked_playlists::{
+    IndexedLinkedEntry, IndexedRemoteOccurrence, InitialMergeOccurrence, InitialMergePlan,
+    InitialMergePreview, LinkedPlaylistEntry, LinkedPlaylistError, MAX_LINKED_PLAYLIST_ENTRIES,
+    OccurrenceMatch, PlaylistSequence, RemoteDelta, RemotePlaylistUpdatePlan, plan_initial_merge,
+    plan_remote_delta, plan_remote_update,
+};
 pub use model::{
     AccountScopeId, AlbumId, ArtistId, BackendId, CoverArtId, ItemId, LibraryWarning, ModelError,
     OpenSubsonicItemRef, Page, ServerAlbum, ServerArtist, ServerLibraryDetail, ServerLibraryPage,
-    ServerLibraryRow, ServerLibrarySection, ServerPlaylist, ServerPlaylistId,
-    ServerPlaylistSummary, ServerSong,
+    ServerLibraryRow, ServerLibrarySection, ServerPlaylist, ServerPlaylistAccess, ServerPlaylistId,
+    ServerPlaylistLinkHealth, ServerPlaylistLinkSummary, ServerPlaylistSummary, ServerSong,
 };
 pub use native_history::{
     MAX_NATIVE_HISTORY_PAGES, MAX_NATIVE_HISTORY_ROWS, NATIVE_HISTORY_PAGE_SIZE,
@@ -55,6 +66,10 @@ pub use native_history::{
 };
 pub use origin::{ConfiguredPrivateOrigin, OriginError};
 pub use outbound_recovery::{list_scrobble_attention_ids, resolve_scrobble_attention};
+pub use playlist_create_recovery::{
+    PlaylistCreateAttention, PlaylistCreateRecoveryState, abandon_playlist_create_attention,
+    list_playlist_create_attention,
+};
 pub use private_store::{CredentialKind, OpenSubsonicPrivateState, ServerCredential};
 pub use profile::{OpenSubsonicPaths, OpenSubsonicProfile, StoreError};
 pub use rating::{RawServerRating, canonical_server_rating, map_server_rating};

--- a/src/open_subsonic/model.rs
+++ b/src/open_subsonic/model.rs
@@ -193,7 +193,31 @@ pub struct ServerArtist {
     pub cover_art_id: Option<CoverArtId>,
 }
 
+/// Redacted playlist access state safe for library and TUI surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerPlaylistAccess {
+    /// The current password-authenticated account is the exact remote owner.
+    Server,
+    /// Remote write authority could not be proven.
+    ReadOnly,
+    /// A higher durable store explicitly linked this playlist for synchronization.
+    Linked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerPlaylistLinkHealth {
+    UpToDate,
+    NeedsAttention,
+    ServerMissing,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerPlaylistLinkSummary {
+    pub local_playlist_id: crate::personal_state::PlaylistId,
+    pub health: ServerPlaylistLinkHealth,
+}
+
+#[derive(Clone, PartialEq, Eq)]
 pub struct ServerPlaylistSummary {
     pub id: ServerPlaylistId,
     pub name: String,
@@ -202,12 +226,111 @@ pub struct ServerPlaylistSummary {
     pub duration_secs: Option<u32>,
     pub public: Option<bool>,
     pub cover_art_id: Option<CoverArtId>,
+    pub access: ServerPlaylistAccess,
+    pub link: Option<ServerPlaylistLinkSummary>,
+    pub(crate) readonly_evidence: Option<bool>,
+    pub(crate) owner_evidence: Option<String>,
+}
+
+impl fmt::Debug for ServerPlaylistSummary {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ServerPlaylistSummary")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("owner", &self.owner)
+            .field("song_count", &self.song_count)
+            .field("duration_secs", &self.duration_secs)
+            .field("public", &self.public)
+            .field("cover_art_id", &self.cover_art_id)
+            .field("access", &self.access)
+            .field("link", &self.link)
+            .finish()
+    }
+}
+
+impl ServerPlaylistSummary {
+    pub(crate) const fn readonly_evidence(&self) -> Option<bool> {
+        self.readonly_evidence
+    }
+
+    pub(crate) fn owner_evidence(&self) -> Option<&str> {
+        self.owner_evidence.as_deref()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServerPlaylist {
     pub summary: ServerPlaylistSummary,
     pub entries: Vec<ServerSong>,
+}
+
+/// Exact playlist detail used only at the server-write boundary.
+///
+/// Unlike the tolerant catalog projection, this snapshot is constructed only when every remote
+/// occurrence is a valid music entry. It deliberately has no `Debug`, `Display`, or serde
+/// implementation: the remote owner and access-control fields are protocol state, not UI/log
+/// metadata.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct ServerPlaylistWriteSnapshot {
+    backend_id: BackendId,
+    account_scope_id: AccountScopeId,
+    id: ServerPlaylistId,
+    name: String,
+    owner: Option<String>,
+    read_only: Option<bool>,
+    entries: Vec<ServerSong>,
+}
+
+impl ServerPlaylistWriteSnapshot {
+    pub(crate) fn new(
+        backend_id: BackendId,
+        account_scope_id: AccountScopeId,
+        id: ServerPlaylistId,
+        name: String,
+        owner: Option<String>,
+        read_only: Option<bool>,
+        entries: Vec<ServerSong>,
+    ) -> Self {
+        Self {
+            backend_id,
+            account_scope_id,
+            id,
+            name,
+            owner,
+            read_only,
+            entries,
+        }
+    }
+
+    pub(crate) fn backend_id(&self) -> &BackendId {
+        &self.backend_id
+    }
+
+    pub(crate) fn account_scope_id(&self) -> &AccountScopeId {
+        &self.account_scope_id
+    }
+
+    pub(crate) fn id(&self) -> &ServerPlaylistId {
+        &self.id
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn owner(&self) -> Option<&str> {
+        self.owner.as_deref()
+    }
+
+    /// `None` is intentionally distinct from `Some(false)`.
+    pub(crate) const fn read_only(&self) -> Option<bool> {
+        self.read_only
+    }
+
+    pub(crate) fn entries(&self) -> &[ServerSong] {
+        &self.entries
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -357,5 +480,53 @@ mod tests {
             item("ab", "c", "d").stable_track_id(),
             item("a", "bc", "d").stable_track_id()
         );
+    }
+
+    #[test]
+    fn write_snapshot_preserves_unknown_readonly_without_log_traits() {
+        let snapshot = ServerPlaylistWriteSnapshot::new(
+            BackendId::new("backend").unwrap(),
+            AccountScopeId::new("account").unwrap(),
+            ServerPlaylistId::new("playlist").unwrap(),
+            "Playlist".to_owned(),
+            Some("owner".to_owned()),
+            None,
+            Vec::new(),
+        );
+        assert_eq!(snapshot.backend_id().as_str(), "backend");
+        assert_eq!(snapshot.account_scope_id().as_str(), "account");
+        assert_eq!(snapshot.id().as_str(), "playlist");
+        assert_eq!(snapshot.name(), "Playlist");
+        assert_eq!(snapshot.owner(), Some("owner"));
+        assert_eq!(snapshot.read_only(), None);
+        assert!(snapshot.entries().is_empty());
+    }
+
+    #[test]
+    fn playlist_access_states_are_redacted_and_distinct() {
+        assert_eq!(format!("{:?}", ServerPlaylistAccess::Server), "Server");
+        assert_eq!(format!("{:?}", ServerPlaylistAccess::ReadOnly), "ReadOnly");
+        assert_eq!(format!("{:?}", ServerPlaylistAccess::Linked), "Linked");
+    }
+
+    #[test]
+    fn playlist_summary_debug_excludes_internal_access_evidence() {
+        let summary = ServerPlaylistSummary {
+            id: ServerPlaylistId::new("playlist").unwrap(),
+            name: "Playlist".to_owned(),
+            owner: None,
+            song_count: None,
+            duration_secs: None,
+            public: None,
+            cover_art_id: None,
+            access: ServerPlaylistAccess::ReadOnly,
+            link: None,
+            readonly_evidence: Some(false),
+            owner_evidence: Some("internal-owner-sentinel".to_owned()),
+        };
+        let rendered = format!("{summary:?}");
+        assert!(!rendered.contains("internal-owner-sentinel"));
+        assert!(!rendered.contains("readonly_evidence"));
+        assert!(!rendered.contains("owner_evidence"));
     }
 }

--- a/src/open_subsonic/playlist_create_recovery.rs
+++ b/src/open_subsonic/playlist_create_recovery.rs
@@ -1,0 +1,191 @@
+//! Offline owner-store recovery for replay-unsafe server playlist creates.
+//!
+//! Listing never starts an actor or performs network I/O. Abandoning an intent is an explicit
+//! user decision: the server may already contain a created copy, so callers must confirm before
+//! invoking it and must already own the process-wide persistence writer lease.
+
+use super::actor::ServiceError;
+use super::bridge_runtime::BridgeRuntime;
+use super::bridge_store::OpenSubsonicBridgeState;
+use super::profile::OpenSubsonicPaths;
+use super::transaction::{load_store_set, load_store_set_read_only};
+use crate::personal_state::PlaylistId;
+
+/// Redacted recovery evidence safe for status, CLI, and TUI surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlaylistCreateRecoveryState {
+    /// The create response was lost, so no remote identifier is known.
+    ServerIdentityUnknown,
+    /// A remote identifier is known, but exact owner/readback verification has not completed.
+    ReadbackNeeded,
+}
+
+impl PlaylistCreateRecoveryState {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::ServerIdentityUnknown => "server_identity_unknown",
+            Self::ReadbackNeeded => "readback_needed",
+        }
+    }
+}
+
+/// A local playlist identity plus the minimum evidence needed for an explicit recovery decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlaylistCreateAttention {
+    pub local_playlist_id: PlaylistId,
+    pub state: PlaylistCreateRecoveryState,
+}
+
+/// List pending create decisions from one coherent read-only snapshot.
+pub fn list_playlist_create_attention(
+    paths: &OpenSubsonicPaths,
+) -> Result<Vec<PlaylistCreateAttention>, ServiceError> {
+    let store_set = load_store_set_read_only(paths)?.ok_or(ServiceError::InvalidSetup)?;
+    Ok(playlist_create_attention_from_state(
+        &store_set.bridge_state,
+    ))
+}
+
+pub(crate) fn playlist_create_attention_from_state(
+    bridge_state: &OpenSubsonicBridgeState,
+) -> Vec<PlaylistCreateAttention> {
+    bridge_state
+        .pending_playlist_creates()
+        .values()
+        .map(|pending| PlaylistCreateAttention {
+            local_playlist_id: pending.local_playlist_id.clone(),
+            state: if pending.created_server_playlist_id.is_some() {
+                PlaylistCreateRecoveryState::ReadbackNeeded
+            } else {
+                PlaylistCreateRecoveryState::ServerIdentityUnknown
+            },
+        })
+        .collect()
+}
+
+/// Forget one durable create intent without contacting or deleting anything on the server.
+pub fn abandon_playlist_create_attention(
+    paths: &OpenSubsonicPaths,
+    local_playlist_id: &PlaylistId,
+) -> Result<(), ServiceError> {
+    let mut store_set = load_store_set(paths)?.ok_or(ServiceError::InvalidSetup)?;
+    BridgeRuntime::writable(paths.clone(), None)
+        .cancel_playlist_create(&mut store_set, local_playlist_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use age::secrecy::SecretString;
+
+    use super::*;
+    use crate::open_subsonic::bridge_store::PendingPlaylistCreate;
+    use crate::open_subsonic::{
+        ConfiguredPrivateOrigin, OpenSubsonicBridgeState, OpenSubsonicPrivateState,
+        OpenSubsonicProfile, OpenSubsonicStoreSet, ServerCredential, ServerPlaylistId,
+        StoreRevisions, commit_store_set,
+    };
+
+    fn fixture(
+        label: &str,
+    ) -> (
+        std::path::PathBuf,
+        OpenSubsonicPaths,
+        PlaylistId,
+        PlaylistId,
+    ) {
+        let root = std::env::temp_dir().join(format!(
+            "yututui-playlist-create-recovery-{label}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        crate::persist::initialize_persistence_writer_for_roots([&root], false).unwrap();
+        crate::util::safe_fs::ensure_private_dir(&root).unwrap();
+        let paths = OpenSubsonicPaths::for_data_root(root.clone());
+        let profile = OpenSubsonicProfile::new(
+            "Recovery fixture",
+            ConfiguredPrivateOrigin::new("http://127.0.0.1:9/", true).unwrap(),
+            None,
+        )
+        .unwrap();
+        let private_state = OpenSubsonicPrivateState::new(
+            profile.backend_id().clone(),
+            profile.account_scope_id().clone(),
+            ServerCredential::api_key(SecretString::from("recovery-secret".to_owned())).unwrap(),
+        );
+        let mut bridge_state = OpenSubsonicBridgeState::new(
+            profile.backend_id().clone(),
+            profile.account_scope_id().clone(),
+        );
+        let unknown = PlaylistId::new("local-unknown").unwrap();
+        let known = PlaylistId::new("local-known").unwrap();
+        for (local_playlist_id, created_server_playlist_id) in [
+            (unknown.clone(), None),
+            (
+                known.clone(),
+                Some(ServerPlaylistId::new("server-known").unwrap()),
+            ),
+        ] {
+            bridge_state
+                .queue_playlist_create(PendingPlaylistCreate {
+                    local_playlist_id,
+                    expected_missing_server_id: None,
+                    created_server_playlist_id,
+                    desired_name: "Private name sentinel".to_owned(),
+                    ordered_entry_ids: Vec::new(),
+                    ordered_item_ids: Vec::new(),
+                    started_at_unix: 42,
+                })
+                .unwrap();
+        }
+        let mut store_set =
+            OpenSubsonicStoreSet::new(profile, private_state, bridge_state).unwrap();
+        commit_store_set(&paths, StoreRevisions::MISSING, &mut store_set).unwrap();
+        (root, paths, unknown, known)
+    }
+
+    #[test]
+    fn list_is_redacted_sorted_and_abandon_is_durable() {
+        let (root, paths, unknown, known) = fixture("list-abandon");
+        assert_eq!(
+            list_playlist_create_attention(&paths).unwrap(),
+            vec![
+                PlaylistCreateAttention {
+                    local_playlist_id: known.clone(),
+                    state: PlaylistCreateRecoveryState::ReadbackNeeded,
+                },
+                PlaylistCreateAttention {
+                    local_playlist_id: unknown,
+                    state: PlaylistCreateRecoveryState::ServerIdentityUnknown,
+                },
+            ]
+        );
+
+        abandon_playlist_create_attention(&paths, &known).unwrap();
+        let attention = list_playlist_create_attention(&paths).unwrap();
+        assert_eq!(attention.len(), 1);
+        assert_eq!(
+            attention[0].state,
+            PlaylistCreateRecoveryState::ServerIdentityUnknown
+        );
+        assert!(
+            load_store_set(&paths)
+                .unwrap()
+                .unwrap()
+                .bridge_state
+                .pending_playlist_creates()
+                .get(&known)
+                .is_none()
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn abandon_rejects_an_identifier_that_is_not_pending() {
+        let (root, paths, _, _) = fixture("missing");
+        assert_eq!(
+            abandon_playlist_create_attention(&paths, &PlaylistId::new("not-pending").unwrap()),
+            Err(ServiceError::InvalidSetup)
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/src/open_subsonic/private_store.rs
+++ b/src/open_subsonic/private_store.rs
@@ -9,7 +9,7 @@ use super::native_history::NativeHistoryCredential;
 use super::profile::StoreError;
 
 pub(crate) const PRIVATE_KIND: &str = "yututui_open_subsonic_private";
-pub(crate) const PRIVATE_SCHEMA_VERSION: u32 = 2;
+pub(crate) const PRIVATE_SCHEMA_VERSION: u32 = 3;
 pub(crate) const MAX_PRIVATE_BYTES: u64 = 256 * 1024;
 const MAX_USERNAME_BYTES: usize = 1_024;
 const MAX_PASSWORD_BYTES: usize = 64 * 1024;
@@ -39,6 +39,23 @@ impl ServerCredential {
             username: None,
             secret: key,
         })
+    }
+
+    /// Attach the account identity proven by the authenticated `tokenInfo` endpoint.
+    ///
+    /// The username is private ownership evidence only. API-key requests continue to omit the
+    /// legacy `u` authentication parameter as required by the OpenSubsonic extension.
+    pub(crate) fn bind_api_key_username(
+        &mut self,
+        username: impl Into<String>,
+    ) -> Result<(), StoreError> {
+        if self.kind != CredentialKind::ApiKey {
+            return Err(StoreError::InvalidState);
+        }
+        let username = username.into();
+        validate_credential_part(&username, MAX_USERNAME_BYTES)?;
+        self.username = Some(SecretString::from(username));
+        Ok(())
     }
 
     pub fn password(
@@ -119,6 +136,13 @@ impl OpenSubsonicPrivateState {
 
     pub fn native_history_enabled(&self) -> bool {
         !matches!(self.native_history, NativeHistorySetting::Off)
+    }
+
+    pub(crate) fn bind_api_key_username(
+        &mut self,
+        username: impl Into<String>,
+    ) -> Result<(), StoreError> {
+        self.credential.bind_api_key_username(username)
     }
 
     pub fn enable_native_history_reusing_server_password(&mut self) -> Result<(), StoreError> {
@@ -300,7 +324,7 @@ pub(crate) fn decode_private(bytes: &[u8]) -> Result<OpenSubsonicPrivateState, S
     }
     let disk: DiskPrivateState =
         serde_json::from_slice(bytes).map_err(|_| StoreError::InvalidState)?;
-    if disk.kind != PRIVATE_KIND || !matches!(disk.schema_version, 1 | PRIVATE_SCHEMA_VERSION) {
+    if disk.kind != PRIVATE_KIND || !matches!(disk.schema_version, 1 | 2 | PRIVATE_SCHEMA_VERSION) {
         return Err(StoreError::InvalidState);
     }
     if disk.schema_version == 1
@@ -311,14 +335,23 @@ pub(crate) fn decode_private(bytes: &[u8]) -> Result<OpenSubsonicPrivateState, S
         return Err(StoreError::InvalidState);
     }
     let credential = match disk.credential_kind {
-        DiskCredentialKind::ApiKey if disk.username.is_none() => {
-            ServerCredential::api_key(SecretString::from(disk.secret.clone()))?
+        DiskCredentialKind::ApiKey
+            if disk.schema_version < PRIVATE_SCHEMA_VERSION && disk.username.is_some() =>
+        {
+            return Err(StoreError::InvalidState);
+        }
+        DiskCredentialKind::ApiKey => {
+            let mut credential =
+                ServerCredential::api_key(SecretString::from(disk.secret.clone()))?;
+            if let Some(username) = disk.username.clone() {
+                credential.bind_api_key_username(username)?;
+            }
+            credential
         }
         DiskCredentialKind::Password => {
             let username = disk.username.clone().ok_or(StoreError::InvalidState)?;
             ServerCredential::password(username, SecretString::from(disk.secret.clone()))?
         }
-        DiskCredentialKind::ApiKey => return Err(StoreError::InvalidState),
     };
     let native_history = match (
         disk.credential_kind,
@@ -403,6 +436,29 @@ mod tests {
     }
 
     #[test]
+    fn token_info_username_round_trips_as_private_api_key_owner_evidence() {
+        let mut credential =
+            ServerCredential::api_key(SecretString::from("secret-key".to_owned())).unwrap();
+        credential.bind_api_key_username("alice").unwrap();
+        let state = OpenSubsonicPrivateState::new(
+            BackendId::new("backend").unwrap(),
+            AccountScopeId::new("account").unwrap(),
+            credential,
+        );
+
+        let bytes = encode_private(&state).unwrap();
+        let disk: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(disk["schema_version"], PRIVATE_SCHEMA_VERSION);
+        assert_eq!(disk["username"], "alice");
+        let decoded = decode_private(&bytes).unwrap();
+        assert_eq!(decoded.credential_kind(), CredentialKind::ApiKey);
+        assert_eq!(
+            decoded.credential().username().unwrap().expose_secret(),
+            "alice"
+        );
+    }
+
+    #[test]
     fn password_round_trip_preserves_account_binding() {
         let mut state = OpenSubsonicPrivateState::new(
             BackendId::new("backend").unwrap(),
@@ -461,7 +517,7 @@ mod tests {
     }
 
     #[test]
-    fn schema_one_migrates_to_disabled_schema_two() {
+    fn schema_one_migrates_to_current_schema_with_history_disabled() {
         let legacy = br#"{
             "kind":"yututui_open_subsonic_private",
             "schema_version":1,
@@ -476,8 +532,27 @@ mod tests {
         assert!(!state.native_history_enabled());
         let encoded = encode_private(&state).unwrap();
         let disk: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
-        assert_eq!(disk["schema_version"], 2);
+        assert_eq!(disk["schema_version"], PRIVATE_SCHEMA_VERSION);
         assert_eq!(disk["native_history_enabled"], false);
+    }
+
+    #[test]
+    fn schema_two_api_key_without_owner_evidence_remains_readable() {
+        let legacy = br#"{
+            "kind":"yututui_open_subsonic_private",
+            "schema_version":2,
+            "revision":7,
+            "backend_id":"backend",
+            "account_scope_id":"account",
+            "credential_kind":"api_key",
+            "username":null,
+            "secret":"legacy-api-key",
+            "native_history_enabled":false
+        }"#;
+
+        let state = decode_private(legacy).unwrap();
+        assert_eq!(state.credential_kind(), CredentialKind::ApiKey);
+        assert!(state.credential().username().is_none());
     }
 
     #[test]

--- a/src/open_subsonic/wire.rs
+++ b/src/open_subsonic/wire.rs
@@ -38,6 +38,7 @@ pub(crate) struct RawResponse {
     pub server_version: Option<String>,
     pub open_subsonic: Option<bool>,
     pub error: Option<RawApiError>,
+    pub token_info: Option<RawTokenInfo>,
     #[serde(default, deserialize_with = "deserialize_extensions")]
     pub open_subsonic_extensions: Vec<RawExtension>,
     pub search_result3: Option<RawSearchResult3>,
@@ -48,6 +49,11 @@ pub(crate) struct RawResponse {
     pub album: Option<RawAlbumWithSongs>,
     pub artist: Option<RawArtistWithAlbums>,
     pub song: Option<RawChild>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct RawTokenInfo {
+    pub username: Option<String>,
 }
 
 impl RawResponse {
@@ -109,6 +115,7 @@ pub(crate) struct RawPlaylist {
     pub id: Option<String>,
     pub name: Option<String>,
     pub owner: Option<String>,
+    pub readonly: Option<bool>,
     pub song_count: Option<u64>,
     pub duration: Option<u64>,
     pub public: Option<bool>,
@@ -123,6 +130,7 @@ pub(crate) struct RawPlaylistSummary {
     pub id: Option<String>,
     pub name: Option<String>,
     pub owner: Option<String>,
+    pub readonly: Option<bool>,
     pub song_count: Option<u64>,
     pub duration: Option<u64>,
     pub public: Option<bool>,
@@ -500,12 +508,63 @@ mod tests {
     }
 
     #[test]
+    fn token_info_preserves_the_authenticated_username() {
+        let response =
+            decode(br#"{"subsonic-response":{"status":"ok","tokenInfo":{"username":"alice"}}}"#)
+                .unwrap();
+        assert_eq!(
+            response
+                .token_info
+                .and_then(|token_info| token_info.username)
+                .as_deref(),
+            Some("alice")
+        );
+    }
+
+    #[test]
     fn failed_envelope_is_not_treated_as_http_success() {
         assert!(matches!(
             decode(
                 br#"{"subsonic-response":{"status":"failed","error":{"code":40,"message":"bad"}}}"#
             ),
             Err(WireError::ApiFailure(Some(40)))
+        ));
+    }
+
+    #[test]
+    fn playlist_readonly_preserves_true_false_and_absent() {
+        for (raw, expected) in [
+            (
+                br#"{"subsonic-response":{"status":"ok","playlist":{"readonly":true}}}"#.as_slice(),
+                Some(true),
+            ),
+            (
+                br#"{"subsonic-response":{"status":"ok","playlist":{"readonly":false}}}"#
+                    .as_slice(),
+                Some(false),
+            ),
+            (
+                br#"{"subsonic-response":{"status":"ok","playlist":{}}}"#.as_slice(),
+                None,
+            ),
+        ] {
+            assert_eq!(decode(raw).unwrap().playlist.unwrap().readonly, expected);
+        }
+        let response = decode(
+            br#"{"subsonic-response":{"status":"ok","playlists":{"playlist":[{"readonly":false}]}}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            response.playlists.unwrap().playlist[0].readonly,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn playlist_readonly_rejects_non_boolean_values() {
+        assert!(matches!(
+            decode(br#"{"subsonic-response":{"status":"ok","playlist":{"readonly":"false"}}}"#),
+            Err(WireError::InvalidResponse)
         ));
     }
 

--- a/src/personal_state.rs
+++ b/src/personal_state.rs
@@ -9,6 +9,7 @@ mod import;
 pub(crate) mod legacy;
 mod model;
 mod reducer;
+mod server_playlist;
 mod server_rating;
 mod transaction;
 
@@ -16,11 +17,12 @@ pub(crate) use compaction::operation_survives_checkpoint;
 pub use compaction::{
     EngagementCompactionPlan, engagement_compaction_leader, plan_engagement_compaction,
 };
+pub(crate) use coordinator::reconcile_runtime;
 pub use coordinator::{
-    append_external_operation, append_external_operation_as, append_operation_as,
+    ExternalOperationInput, append_external_operation, append_external_operation_as,
+    append_external_operations, append_external_operations_as, append_operation_as,
     external_operation_envelope_id, reconcile_runtime_as,
 };
-pub(crate) use coordinator::{external_operation_envelope_id_for_state, reconcile_runtime};
 pub(crate) use import::validate_join_import_extension;
 pub use import::{ImportPlan, ImportSummary, plan_import, plan_join_import};
 pub use legacy::{LegacyProjection, legacy_state};
@@ -36,6 +38,10 @@ pub use model::{
 };
 pub(crate) use reducer::runtime_fingerprint;
 pub use reducer::{MergeSummary, PersonalProjection, merge, project};
+pub use server_playlist::{
+    PersonalPlaylistEntry, PersonalPlaylistSnapshot, personal_playlist_snapshot,
+    personal_playlist_snapshot_for_runtime_id, personal_playlist_snapshots,
+};
 pub use server_rating::{OpenSubsonicRatingWinner, open_subsonic_rating_winners};
 pub use transaction::{PersonalStateCommit, PersonalStatePaths, recover_pending_transactions};
 pub(crate) use transaction::{load_ledger, load_ledger_read_only};

--- a/src/personal_state/coordinator.rs
+++ b/src/personal_state/coordinator.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
+use serde::{Deserialize, Serialize};
+
 use super::legacy::{
     LegacyPlaylist, LegacyPlaylistEntry, LegacyProjection, rating_from_legacy, sha256_hex,
     stable_hash,
@@ -9,6 +11,20 @@ use super::{
     PersonalStateError, PersonalStateV2, PlaylistEntryId, PlaylistId, PortableTrack,
     PortableTrackKey, project, refresh_device_registry,
 };
+
+const MAX_EXTERNAL_OPERATION_BATCH: usize = 4_096;
+
+/// One operation in an external bridge batch.
+///
+/// The acknowledgement ID is portable bridge state. The ledger wraps it in a deterministic
+/// device-scoped envelope so two devices may observe and merge the same server change safely.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalOperationInput {
+    pub acknowledgement_id: String,
+    pub operation: Operation,
+    pub recorded_at_unix: i64,
+}
 
 /// Convert mutations visible in the four runtime projections into causal v2 operations.
 pub(crate) fn reconcile_runtime(
@@ -124,6 +140,31 @@ pub fn append_external_operation(
     )
 }
 
+/// Append one external batch under an explicitly enrolled local device.
+///
+/// The candidate is built and validated in memory before it is returned, so callers can persist
+/// every playlist entry change in one Personal State transaction. Replaying a completely or
+/// partially present batch is an idempotent no-op; conflicting reuse of any acknowledgement ID
+/// rejects the whole candidate.
+pub fn append_external_operations_as(
+    state: &PersonalStateV2,
+    local_device_id: &DeviceId,
+    origin: OperationOrigin,
+    operations: &[ExternalOperationInput],
+) -> Result<(PersonalStateV2, Vec<String>), PersonalStateError> {
+    append_external_operations_inner(state, local_device_id, origin, operations, true)
+}
+
+/// Append one external batch for the deterministic unsynced single-device ledger.
+pub fn append_external_operations(
+    state: &PersonalStateV2,
+    origin: OperationOrigin,
+    operations: &[ExternalOperationInput],
+) -> Result<(PersonalStateV2, Vec<String>), PersonalStateError> {
+    let local_device_id = local_device(state)?;
+    append_external_operations_inner(state, &local_device_id, origin, operations, false)
+}
+
 /// Return the stable ledger envelope ID for one external acknowledgement on one local device.
 ///
 /// The bridge acknowledgement remains portable across devices. Only the surrounding ledger
@@ -150,13 +191,6 @@ pub fn external_operation_envelope_id(
     Ok(format!("external-{}", sha256_hex(&material)))
 }
 
-pub(crate) fn external_operation_envelope_id_for_state(
-    state: &PersonalStateV2,
-    acknowledgement_id: &str,
-) -> Result<String, PersonalStateError> {
-    external_operation_envelope_id(&local_device(state)?, acknowledgement_id)
-}
-
 fn validate_external_origin(
     origin: &OperationOrigin,
     operation: &Operation,
@@ -164,23 +198,89 @@ fn validate_external_origin(
     let OperationOrigin::OpenSubsonic { backend_id } = origin else {
         return Ok(());
     };
-    let track = match operation {
-        Operation::SetRating { track, .. } | Operation::RecordEngagement { track, .. } => track,
-        _ => {
-            return Err(PersonalStateError::InvalidOperation(
-                "OpenSubsonic origin requires a track observation",
-            ));
-        }
-    };
-    match &track.key {
-        PortableTrackKey::OpenSubsonic {
-            backend_id: track_backend,
-            ..
-        } if track_backend == backend_id => Ok(()),
+    match operation {
+        Operation::SetRating { track, .. }
+        | Operation::RecordEngagement { track, .. }
+        | Operation::UpsertPlaylistEntry { track, .. } => match &track.key {
+            PortableTrackKey::OpenSubsonic {
+                backend_id: track_backend,
+                ..
+            } if track_backend == backend_id => Ok(()),
+            _ => Err(PersonalStateError::InvalidOperation(
+                "OpenSubsonic origin does not match track backend",
+            )),
+        },
+        Operation::UpsertPlaylist { .. }
+        | Operation::DeletePlaylist { .. }
+        | Operation::MovePlaylistEntry { .. }
+        | Operation::RemovePlaylistEntry { .. } => Ok(()),
         _ => Err(PersonalStateError::InvalidOperation(
-            "OpenSubsonic origin does not match track backend",
+            "OpenSubsonic origin requires a rating, engagement, or playlist observation",
         )),
     }
+}
+
+fn append_external_operations_inner(
+    state: &PersonalStateV2,
+    local_device_id: &DeviceId,
+    origin: OperationOrigin,
+    operations: &[ExternalOperationInput],
+    require_keyed: bool,
+) -> Result<(PersonalStateV2, Vec<String>), PersonalStateError> {
+    if matches!(origin, OperationOrigin::Local) {
+        return Err(PersonalStateError::InvalidOperation(
+            "external operation origin cannot be local",
+        ));
+    }
+    if operations.is_empty() || operations.len() > MAX_EXTERNAL_OPERATION_BATCH {
+        return Err(PersonalStateError::InvalidOperation(
+            "external operation batch size is invalid",
+        ));
+    }
+    state.validate()?;
+    validate_local_device_binding(state, local_device_id, require_keyed)?;
+
+    let mut acknowledgement_ids = HashSet::with_capacity(operations.len());
+    let mut envelope_ids = Vec::with_capacity(operations.len());
+    for input in operations {
+        if !acknowledgement_ids.insert(input.acknowledgement_id.as_str()) {
+            return Err(PersonalStateError::ConflictingOperationId);
+        }
+        validate_external_origin(&origin, &input.operation)?;
+        let envelope_id =
+            external_operation_envelope_id(local_device_id, &input.acknowledgement_id)?;
+        if let Some(existing) = state
+            .operations
+            .iter()
+            .find(|existing| existing.operation_id == envelope_id)
+            && (existing.origin != origin || existing.operation != input.operation)
+        {
+            return Err(PersonalStateError::ConflictingOperationId);
+        }
+        envelope_ids.push(envelope_id);
+    }
+
+    let mut candidate = state.clone();
+    let mut appender = OperationAppender::new(&mut candidate, local_device_id.clone());
+    for (input, envelope_id) in operations.iter().zip(&envelope_ids) {
+        if appender
+            .state
+            .operations
+            .iter()
+            .any(|existing| existing.operation_id == *envelope_id)
+        {
+            continue;
+        }
+        appender.append_with_metadata(
+            Some(envelope_id.clone()),
+            origin.clone(),
+            input.operation.clone(),
+            input.recorded_at_unix,
+        )?;
+    }
+    refresh_device_registry(&mut candidate)?;
+    candidate.normalize()?;
+    Ok((candidate, envelope_ids))
 }
 
 fn append_operation_with_origin_as(

--- a/src/personal_state/reducer.rs
+++ b/src/personal_state/reducer.rs
@@ -96,6 +96,20 @@ impl<T> Register<T> {
             *self = Self::new(envelope, value);
         }
     }
+
+    fn merge(&mut self, candidate: Self) {
+        if self.from_baseline
+            || stamp_order(
+                &candidate.stamp,
+                &candidate.operation_id,
+                &self.stamp,
+                &self.operation_id,
+            )
+            .is_gt()
+        {
+            *self = candidate;
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -111,6 +125,12 @@ struct EntryRegisters {
     track: Register<PortableTrack>,
     removed: Register<bool>,
     position: Register<Option<PlaylistEntryId>>,
+}
+
+#[derive(Clone, Default)]
+struct PendingEntryRegisters {
+    removed: Option<Register<bool>>,
+    position: Option<Register<Option<PlaylistEntryId>>>,
 }
 
 #[derive(Clone)]
@@ -203,6 +223,8 @@ pub(crate) fn project_at(
     let mut ratings = BTreeMap::<PortableTrackKey, Register<(PortableTrack, Rating)>>::new();
     let mut radio = BTreeMap::<PortableTrackKey, Register<(PortableTrack, bool)>>::new();
     let mut playlists = BTreeMap::<PlaylistId, PlaylistRegisters>::new();
+    let mut pending_playlist_entries =
+        BTreeMap::<(PlaylistId, PlaylistEntryId), PendingEntryRegisters>::new();
     let mut station_profile = None::<Register<(Option<String>, crate::station::Explore)>>;
     let mut avoided = BTreeMap::<String, Register<bool>>::new();
     let mut events = BTreeMap::<String, EngagementEvent>::new();
@@ -335,6 +357,8 @@ pub(crate) fn project_at(
                 track,
                 after_entry_id,
             } => {
+                let pending =
+                    pending_playlist_entries.remove(&(playlist_id.clone(), entry_id.clone()));
                 let playlist = playlists
                     .entry(playlist_id.clone())
                     .or_insert_with(|| empty_playlist(envelope, playlist_id, "Playlist"));
@@ -351,6 +375,14 @@ pub(crate) fn project_at(
                 entry.track.update(envelope, track.clone());
                 entry.removed.update(envelope, false);
                 entry.position.update(envelope, after_entry_id.clone());
+                if let Some(pending) = pending {
+                    if let Some(removed) = pending.removed {
+                        entry.removed.merge(removed);
+                    }
+                    if let Some(position) = pending.position {
+                        entry.position.merge(position);
+                    }
+                }
             }
             Operation::MovePlaylistEntry {
                 playlist_id,
@@ -362,6 +394,15 @@ pub(crate) fn project_at(
                     .and_then(|playlist| playlist.entries.get_mut(entry_id))
                 {
                     entry.position.update(envelope, after_entry_id.clone());
+                } else {
+                    let pending = pending_playlist_entries
+                        .entry((playlist_id.clone(), entry_id.clone()))
+                        .or_default();
+                    update_optional_register(
+                        &mut pending.position,
+                        envelope,
+                        after_entry_id.clone(),
+                    );
                 }
             }
             Operation::RemovePlaylistEntry {
@@ -374,6 +415,11 @@ pub(crate) fn project_at(
                     .and_then(|playlist| playlist.entries.get_mut(entry_id))
                 {
                     entry.removed.update(envelope, *removed);
+                } else {
+                    let pending = pending_playlist_entries
+                        .entry((playlist_id.clone(), entry_id.clone()))
+                        .or_default();
+                    update_optional_register(&mut pending.removed, envelope, *removed);
                 }
             }
             Operation::SetStationProfile { query, explore } => {

--- a/src/personal_state/server_playlist.rs
+++ b/src/personal_state/server_playlist.rs
@@ -1,0 +1,197 @@
+//! Exact playlist snapshots derived from the canonical personal-state ledger.
+//!
+//! Runtime `playlists.json` intentionally remains a compatibility projection and does not carry
+//! permanent entry identifiers. Server bridges must use this view so duplicate occurrences,
+//! removals, and moves never fall back to title or runtime `video_id` matching.
+
+use super::{
+    PersonalStateError, PersonalStateV2, PlaylistEntryId, PlaylistId, PortableTrack, project,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersonalPlaylistEntry {
+    pub entry_id: PlaylistEntryId,
+    pub track: PortableTrack,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersonalPlaylistSnapshot {
+    pub playlist_id: PlaylistId,
+    pub name: String,
+    pub entries: Vec<PersonalPlaylistEntry>,
+}
+
+pub fn personal_playlist_snapshots(
+    state: &PersonalStateV2,
+) -> Result<Vec<PersonalPlaylistSnapshot>, PersonalStateError> {
+    Ok(project(state)?
+        .legacy
+        .playlists
+        .into_iter()
+        .map(snapshot_from_legacy)
+        .collect())
+}
+
+/// Resolves the compatibility playlist ID shown by the local Library back to its permanent ID.
+///
+/// Runtime `playlists.json` stores the projection slug in `Playlist::id`; it must not be parsed
+/// as a [`PlaylistId`] because a v2 playlist's permanent ID and compatibility slug are separate.
+pub fn personal_playlist_snapshot_for_runtime_id(
+    state: &PersonalStateV2,
+    runtime_id: &str,
+) -> Result<Option<PersonalPlaylistSnapshot>, PersonalStateError> {
+    Ok(project(state)?
+        .legacy
+        .playlists
+        .into_iter()
+        .find(|playlist| playlist.slug == runtime_id)
+        .map(snapshot_from_legacy))
+}
+
+pub fn personal_playlist_snapshot(
+    state: &PersonalStateV2,
+    playlist_id: &PlaylistId,
+) -> Result<Option<PersonalPlaylistSnapshot>, PersonalStateError> {
+    Ok(personal_playlist_snapshots(state)?
+        .into_iter()
+        .find(|playlist| &playlist.playlist_id == playlist_id))
+}
+
+fn snapshot_from_legacy(playlist: super::legacy::LegacyPlaylist) -> PersonalPlaylistSnapshot {
+    PersonalPlaylistSnapshot {
+        playlist_id: playlist.playlist_id,
+        name: playlist.name,
+        entries: playlist
+            .entries
+            .into_iter()
+            .map(|entry| PersonalPlaylistEntry {
+                entry_id: entry.entry_id,
+                track: entry.track,
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::personal_state::{
+        ExternalOperationInput, Operation, OperationOrigin, PlaylistEntryId, PortableTrackKey,
+        append_external_operations, legacy_state,
+    };
+
+    fn track(id: &str) -> PortableTrack {
+        PortableTrack {
+            key: PortableTrackKey::OpenSubsonic {
+                backend_id: "backend".to_owned(),
+                account_scope_id: "account".to_owned(),
+                item_id: id.to_owned(),
+            },
+            title: format!("Track {id}"),
+            artist: "Artist".to_owned(),
+            album: None,
+            duration_secs: Some(180),
+            isrc: None,
+        }
+    }
+
+    #[test]
+    fn canonical_snapshot_preserves_duplicate_occurrence_ids() {
+        let state = legacy_state(
+            &crate::library::Library::default(),
+            &crate::playlists::Playlists::default(),
+            &crate::signals::Signals::default(),
+            &crate::station::StationStore::default(),
+        )
+        .unwrap();
+        let playlist_id = PlaylistId::new("playlist").unwrap();
+        let first = PlaylistEntryId::new("first").unwrap();
+        let second = PlaylistEntryId::new("second").unwrap();
+        let operations = [
+            ExternalOperationInput {
+                acknowledgement_id: "playlist".to_owned(),
+                operation: Operation::UpsertPlaylist {
+                    playlist_id: playlist_id.clone(),
+                    name: "Mix".to_owned(),
+                },
+                recorded_at_unix: 1,
+            },
+            ExternalOperationInput {
+                acknowledgement_id: "first".to_owned(),
+                operation: Operation::UpsertPlaylistEntry {
+                    playlist_id: playlist_id.clone(),
+                    entry_id: first.clone(),
+                    track: track("same"),
+                    after_entry_id: None,
+                },
+                recorded_at_unix: 2,
+            },
+            ExternalOperationInput {
+                acknowledgement_id: "second".to_owned(),
+                operation: Operation::UpsertPlaylistEntry {
+                    playlist_id: playlist_id.clone(),
+                    entry_id: second.clone(),
+                    track: track("same"),
+                    after_entry_id: Some(first.clone()),
+                },
+                recorded_at_unix: 2,
+            },
+        ];
+        let (state, _) = append_external_operations(
+            &state,
+            OperationOrigin::OpenSubsonic {
+                backend_id: "backend".to_owned(),
+            },
+            &operations,
+        )
+        .unwrap();
+
+        let snapshot = personal_playlist_snapshot(&state, &playlist_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            snapshot
+                .entries
+                .iter()
+                .map(|entry| entry.entry_id.clone())
+                .collect::<Vec<_>>(),
+            vec![first, second]
+        );
+        assert_eq!(snapshot.entries[0].track.key, snapshot.entries[1].track.key);
+    }
+
+    #[test]
+    fn runtime_projection_slug_resolves_to_permanent_playlist_id() {
+        let state = legacy_state(
+            &crate::library::Library::default(),
+            &crate::playlists::Playlists::default(),
+            &crate::signals::Signals::default(),
+            &crate::station::StationStore::default(),
+        )
+        .unwrap();
+        let playlist_id = PlaylistId::new("permanent-id").unwrap();
+        let (state, _) = append_external_operations(
+            &state,
+            OperationOrigin::Imported,
+            &[ExternalOperationInput {
+                acknowledgement_id: "runtime-slug".to_owned(),
+                operation: Operation::UpsertPlaylist {
+                    playlist_id: playlist_id.clone(),
+                    name: "Mix".to_owned(),
+                },
+                recorded_at_unix: 1,
+            }],
+        )
+        .unwrap();
+        let runtime = project(&state).unwrap().legacy.playlists.remove(0);
+
+        assert_ne!(runtime.slug, playlist_id.as_str());
+        assert_eq!(
+            personal_playlist_snapshot_for_runtime_id(&state, &runtime.slug)
+                .unwrap()
+                .unwrap()
+                .playlist_id,
+            playlist_id
+        );
+    }
+}

--- a/src/personal_state/tests.rs
+++ b/src/personal_state/tests.rs
@@ -8,6 +8,7 @@ use super::transaction::{CommitPoint, TargetFile};
 use super::*;
 
 mod external_observations;
+mod playlists;
 
 fn track(id: &str) -> PortableTrack {
     PortableTrack {

--- a/src/personal_state/tests/external_observations.rs
+++ b/src/personal_state/tests/external_observations.rs
@@ -131,3 +131,124 @@ fn external_observations_use_device_scoped_envelopes_and_portable_event_dedupe()
     assert_eq!(winner_ab, winner_ba);
     assert_eq!(winner_ab.rating, Rating::Disliked);
 }
+
+#[test]
+fn external_playlist_batch_is_atomic_and_partial_replay_appends_only_missing_operations() {
+    let device = DeviceId::new("device-a").unwrap();
+    let state = state_with_keyed_devices(&[device.as_str()]);
+    let playlist_id = PlaylistId::new("playlist-a").unwrap();
+    let first_entry = PlaylistEntryId::new("entry-a").unwrap();
+    let second_entry = PlaylistEntryId::new("entry-b").unwrap();
+    let origin = OperationOrigin::OpenSubsonic {
+        backend_id: "backend-a".to_owned(),
+    };
+    let batch = vec![
+        ExternalOperationInput {
+            acknowledgement_id: "playlist-name".to_owned(),
+            operation: Operation::UpsertPlaylist {
+                playlist_id: playlist_id.clone(),
+                name: "Server mix".to_owned(),
+            },
+            recorded_at_unix: 10,
+        },
+        ExternalOperationInput {
+            acknowledgement_id: "playlist-entry-a".to_owned(),
+            operation: Operation::UpsertPlaylistEntry {
+                playlist_id: playlist_id.clone(),
+                entry_id: first_entry.clone(),
+                track: open_subsonic_track("song-a"),
+                after_entry_id: None,
+            },
+            recorded_at_unix: 10,
+        },
+        ExternalOperationInput {
+            acknowledgement_id: "playlist-entry-b".to_owned(),
+            operation: Operation::UpsertPlaylistEntry {
+                playlist_id: playlist_id.clone(),
+                entry_id: second_entry.clone(),
+                track: open_subsonic_track("song-b"),
+                after_entry_id: Some(first_entry),
+            },
+            recorded_at_unix: 10,
+        },
+    ];
+
+    let partial = append_external_operation_as(
+        &state,
+        &device,
+        batch[0].acknowledgement_id.clone(),
+        origin.clone(),
+        batch[0].operation.clone(),
+        batch[0].recorded_at_unix,
+    )
+    .unwrap();
+    let (completed, envelope_ids) =
+        append_external_operations_as(&partial, &device, origin.clone(), &batch).unwrap();
+    assert_eq!(completed.operations.len(), partial.operations.len() + 2);
+    assert!(envelope_ids.iter().all(|id| {
+        completed
+            .operations
+            .iter()
+            .any(|operation| &operation.operation_id == id)
+    }));
+
+    let (replayed, replay_ids) =
+        append_external_operations_as(&completed, &device, origin.clone(), &batch).unwrap();
+    assert_eq!(replayed, completed);
+    assert_eq!(replay_ids, envelope_ids);
+
+    let mut conflicting = batch.clone();
+    conflicting[1].operation = Operation::RemovePlaylistEntry {
+        playlist_id,
+        entry_id: second_entry,
+        removed: true,
+    };
+    assert_eq!(
+        append_external_operations_as(&completed, &device, origin, &conflicting),
+        Err(PersonalStateError::ConflictingOperationId)
+    );
+}
+
+#[test]
+fn external_playlist_batch_rejects_one_wrong_backend_without_appending_anything() {
+    let device = DeviceId::new("device-a").unwrap();
+    let state = state_with_keyed_devices(&[device.as_str()]);
+    let playlist_id = PlaylistId::new("playlist-a").unwrap();
+    let mut wrong_track = open_subsonic_track("wrong");
+    let PortableTrackKey::OpenSubsonic { backend_id, .. } = &mut wrong_track.key else {
+        unreachable!();
+    };
+    *backend_id = "backend-b".to_owned();
+    let batch = [
+        ExternalOperationInput {
+            acknowledgement_id: "playlist-name".to_owned(),
+            operation: Operation::UpsertPlaylist {
+                playlist_id: playlist_id.clone(),
+                name: "Server mix".to_owned(),
+            },
+            recorded_at_unix: 10,
+        },
+        ExternalOperationInput {
+            acknowledgement_id: "wrong-entry".to_owned(),
+            operation: Operation::UpsertPlaylistEntry {
+                playlist_id,
+                entry_id: PlaylistEntryId::new("entry").unwrap(),
+                track: wrong_track,
+                after_entry_id: None,
+            },
+            recorded_at_unix: 10,
+        },
+    ];
+    assert!(
+        append_external_operations_as(
+            &state,
+            &device,
+            OperationOrigin::OpenSubsonic {
+                backend_id: "backend-a".to_owned(),
+            },
+            &batch,
+        )
+        .is_err()
+    );
+    assert_eq!(state.operations.len(), 1);
+}

--- a/src/personal_state/tests/playlists.rs
+++ b/src/personal_state/tests/playlists.rs
@@ -1,0 +1,241 @@
+use super::*;
+
+fn envelope(
+    operation_id: &str,
+    device_id: &str,
+    sequence: u64,
+    observed: VersionVector,
+    operation: Operation,
+) -> OperationEnvelope {
+    OperationEnvelope {
+        operation_id: operation_id.to_owned(),
+        stamp: CausalStamp {
+            dot: Dot {
+                device_id: DeviceId::new(device_id).unwrap(),
+                sequence,
+            },
+            observed,
+            recorded_at_unix: 10,
+        },
+        origin: OperationOrigin::Local,
+        operation,
+    }
+}
+
+fn vector(entries: &[(&str, u64)]) -> VersionVector {
+    VersionVector(
+        entries
+            .iter()
+            .map(|(device_id, sequence)| (DeviceId::new(*device_id).unwrap(), *sequence))
+            .collect(),
+    )
+}
+
+fn state_with_operations(operations: Vec<OperationEnvelope>) -> PersonalStateV2 {
+    let mut state = PersonalStateV2::empty("playlist-ordering".to_owned()).unwrap();
+    for operation in &operations {
+        state.version_vector.merge(&operation.stamp.observed);
+        state.version_vector.observe(&operation.stamp.dot);
+    }
+    state.operations = operations;
+    state
+}
+
+fn remove_after_upsert_operations() -> Vec<OperationEnvelope> {
+    let playlist_id = PlaylistId::new("playlist").unwrap();
+    let entry_id = PlaylistEntryId::new("entry").unwrap();
+    vec![
+        envelope(
+            "upsert-playlist",
+            "z-device",
+            1,
+            VersionVector::default(),
+            Operation::UpsertPlaylist {
+                playlist_id: playlist_id.clone(),
+                name: "Playlist".to_owned(),
+            },
+        ),
+        envelope(
+            "upsert-entry",
+            "z-device",
+            2,
+            vector(&[("z-device", 1)]),
+            Operation::UpsertPlaylistEntry {
+                playlist_id: playlist_id.clone(),
+                entry_id: entry_id.clone(),
+                track: track("song"),
+                after_entry_id: None,
+            },
+        ),
+        envelope(
+            "remove-entry",
+            "a-device",
+            1,
+            vector(&[("z-device", 2)]),
+            Operation::RemovePlaylistEntry {
+                playlist_id,
+                entry_id,
+                removed: true,
+            },
+        ),
+    ]
+}
+
+#[test]
+fn causally_later_remove_survives_every_operation_iteration_order() {
+    let operations = remove_after_upsert_operations();
+    for permutation in [
+        [0, 1, 2],
+        [0, 2, 1],
+        [1, 0, 2],
+        [1, 2, 0],
+        [2, 0, 1],
+        [2, 1, 0],
+    ] {
+        let state = state_with_operations(
+            permutation
+                .into_iter()
+                .map(|index| operations[index].clone())
+                .collect(),
+        );
+        let projection = project(&state).unwrap();
+        assert_eq!(projection.legacy.playlists.len(), 1);
+        assert!(
+            projection.legacy.playlists[0].entries.is_empty(),
+            "causally later removal was lost for iteration order {permutation:?}"
+        );
+    }
+}
+
+#[test]
+fn causally_later_move_survives_normalized_dot_order() {
+    let playlist_id = PlaylistId::new("playlist").unwrap();
+    let first_id = PlaylistEntryId::new("z-first").unwrap();
+    let second_id = PlaylistEntryId::new("a-second").unwrap();
+    let mut state = state_with_operations(vec![
+        envelope(
+            "upsert-playlist",
+            "z-device",
+            1,
+            VersionVector::default(),
+            Operation::UpsertPlaylist {
+                playlist_id: playlist_id.clone(),
+                name: "Playlist".to_owned(),
+            },
+        ),
+        envelope(
+            "upsert-first",
+            "z-device",
+            2,
+            vector(&[("z-device", 1)]),
+            Operation::UpsertPlaylistEntry {
+                playlist_id: playlist_id.clone(),
+                entry_id: first_id.clone(),
+                track: track("first"),
+                after_entry_id: None,
+            },
+        ),
+        envelope(
+            "upsert-second",
+            "z-device",
+            3,
+            vector(&[("z-device", 2)]),
+            Operation::UpsertPlaylistEntry {
+                playlist_id: playlist_id.clone(),
+                entry_id: second_id.clone(),
+                track: track("second"),
+                after_entry_id: Some(first_id.clone()),
+            },
+        ),
+        envelope(
+            "move-second",
+            "a-device",
+            1,
+            vector(&[("z-device", 3)]),
+            Operation::MovePlaylistEntry {
+                playlist_id,
+                entry_id: second_id,
+                after_entry_id: None,
+            },
+        ),
+    ]);
+    state.normalize().unwrap();
+    assert_eq!(
+        state.operations[0].operation_id, "move-second",
+        "the regression requires the move to be reduced before its upsert"
+    );
+
+    let entries = &project(&state).unwrap().legacy.playlists[0].entries;
+    assert_eq!(
+        entries
+            .iter()
+            .map(|entry| entry.track.key.clone())
+            .collect::<Vec<_>>(),
+        vec![track("second").key, track("first").key]
+    );
+}
+
+#[test]
+fn concurrent_pending_move_keeps_the_existing_dot_tie_break() {
+    let playlist_id = PlaylistId::new("playlist").unwrap();
+    let first_id = PlaylistEntryId::new("z-first").unwrap();
+    let second_id = PlaylistEntryId::new("a-second").unwrap();
+    let mut state = state_with_operations(vec![
+        envelope(
+            "upsert-playlist",
+            "z-device",
+            1,
+            VersionVector::default(),
+            Operation::UpsertPlaylist {
+                playlist_id: playlist_id.clone(),
+                name: "Playlist".to_owned(),
+            },
+        ),
+        envelope(
+            "upsert-first",
+            "z-device",
+            2,
+            vector(&[("z-device", 1)]),
+            Operation::UpsertPlaylistEntry {
+                playlist_id: playlist_id.clone(),
+                entry_id: first_id.clone(),
+                track: track("first"),
+                after_entry_id: None,
+            },
+        ),
+        envelope(
+            "upsert-second",
+            "z-device",
+            3,
+            vector(&[("z-device", 2)]),
+            Operation::UpsertPlaylistEntry {
+                playlist_id: playlist_id.clone(),
+                entry_id: second_id.clone(),
+                track: track("second"),
+                after_entry_id: Some(first_id),
+            },
+        ),
+        envelope(
+            "concurrent-move-second",
+            "a-device",
+            1,
+            vector(&[("z-device", 1)]),
+            Operation::MovePlaylistEntry {
+                playlist_id,
+                entry_id: second_id,
+                after_entry_id: None,
+            },
+        ),
+    ]);
+    state.normalize().unwrap();
+
+    let entries = &project(&state).unwrap().legacy.playlists[0].entries;
+    assert_eq!(
+        entries
+            .iter()
+            .map(|entry| entry.track.key.clone())
+            .collect::<Vec<_>>(),
+        vec![track("first").key, track("second").key],
+        "the higher concurrent upsert dot must keep its position"
+    );
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -628,15 +628,21 @@ pub struct RuntimeHandles {
     open_subsonic_runtime: Option<crate::open_subsonic::OpenSubsonicRuntime>,
     /// Latest reload generation requested by the owner. Out-of-order candidates are dropped.
     open_subsonic_reload_generation: u64,
-    /// Bridge acknowledgement IDs mapped to their device-scoped ledger envelope while persistence
-    /// is outstanding.
-    open_subsonic_pending_imports: std::collections::BTreeMap<String, String>,
+    /// Bridge acknowledgement IDs mapped to their device-scoped ledger envelopes while persistence
+    /// is outstanding. An empty list is a stale remote playlist observation retired by the current
+    /// local deletion; it still waits for that personal-state snapshot's durability boundary.
+    open_subsonic_pending_imports: std::collections::BTreeMap<String, Vec<String>>,
     /// Imports known durable and waiting for bridge-store acknowledgement.
     open_subsonic_committed_imports: std::collections::BTreeSet<String>,
     /// Ledger identity last admitted to the server rating projection.
     open_subsonic_rating_identity: Option<String>,
     /// Ledger identity awaiting proof that its rating projection crossed the bridge-store fsync.
     open_subsonic_pending_rating: Option<open_subsonic_bridge::PendingOpenSubsonicRatingProjection>,
+    /// Ledger identity last admitted to linked server-playlist projection.
+    open_subsonic_playlist_identity: Option<String>,
+    /// Ledger identity awaiting proof that playlist projection crossed the bridge-store fsync.
+    open_subsonic_pending_playlist:
+        Option<open_subsonic_bridge::PendingOpenSubsonicPlaylistProjection>,
     /// Exact playback reports retained while a runtime generation is being replaced.
     open_subsonic_pending_scrobbles:
         std::collections::VecDeque<open_subsonic_bridge::PendingOpenSubsonicScrobble>,
@@ -719,6 +725,8 @@ impl RuntimeHandles {
             open_subsonic_committed_imports: std::collections::BTreeSet::new(),
             open_subsonic_rating_identity: None,
             open_subsonic_pending_rating: None,
+            open_subsonic_playlist_identity: None,
+            open_subsonic_pending_playlist: None,
             open_subsonic_pending_scrobbles: std::collections::VecDeque::new(),
         }
     }

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -2,6 +2,8 @@
 
 use super::*;
 
+mod linked_playlists;
+
 impl RuntimeHandles {
     pub fn dispatch(&mut self, app: &mut App, cmd: Cmd) {
         self.background_tasks.reap_finished();
@@ -355,6 +357,71 @@ impl RuntimeHandles {
                             },
                         );
                     }
+                    crate::app::MusicServerCommand::AbandonPlaylistCreate {
+                        generation,
+                        local_playlist_id,
+                    } => {
+                        self.background_tasks.spawn_cancellable(
+                            "music_server_playlist_create_abandon",
+                            async move {
+                                let abandoned = if let Some(handle) =
+                                    crate::open_subsonic::current_handle()
+                                {
+                                    handle
+                                        .abandon_playlist_create(local_playlist_id)
+                                        .await
+                                        .map_err(|error| {
+                                            music_server_failure(
+                                                crate::open_subsonic::ServiceError::Server(error),
+                                            )
+                                        })
+                                } else {
+                                    tokio::task::spawn_blocking(move || {
+                                        let paths =
+                                            crate::open_subsonic::OpenSubsonicPaths::current()
+                                                .map_err(
+                                                    crate::open_subsonic::ServiceError::from,
+                                                )?;
+                                        crate::open_subsonic::abandon_playlist_create_attention(
+                                            &paths,
+                                            &local_playlist_id,
+                                        )
+                                    })
+                                    .await
+                                    .map_err(|_| crate::app::MusicServerFailure::Unavailable)
+                                    .and_then(|result| result.map_err(music_server_failure))
+                                };
+                                let result = match abandoned {
+                                    Ok(()) => tokio::task::spawn_blocking(|| {
+                                        let paths =
+                                            crate::open_subsonic::OpenSubsonicPaths::current()
+                                                .map_err(
+                                                    crate::open_subsonic::ServiceError::from,
+                                                )?;
+                                        crate::open_subsonic::read_status(&paths)
+                                    })
+                                    .await
+                                    .map_err(|_| crate::app::MusicServerFailure::Unavailable)
+                                    .and_then(|result| {
+                                        result
+                                            .map(music_server_summary)
+                                            .map_err(music_server_failure)
+                                    }),
+                                    Err(error) => Err(error),
+                                };
+                                emitter
+                                    .emit_terminal(RuntimeEvent::App(Msg::Server(
+                                        crate::app::ServerEvent::Settings(
+                                            crate::app::MusicServerEvent::PlaylistCreateAbandoned {
+                                                generation,
+                                                result,
+                                            },
+                                        ),
+                                    )))
+                                    .await;
+                            },
+                        );
+                    }
                 }
             }
             Cmd::ServerLibrary(command) => {
@@ -421,6 +488,69 @@ impl RuntimeHandles {
                                             },
                                         ),
                                     )))
+                                    .await;
+                            }
+                            crate::app::ServerLibraryCommand::PreparePlaylist {
+                                generation,
+                                server_playlist_id,
+                                kind,
+                            } => {
+                                emitter
+                                    .emit_terminal(
+                                        linked_playlists::prepare_playlist(
+                                            generation,
+                                            server_playlist_id,
+                                            kind,
+                                        )
+                                        .await,
+                                    )
+                                    .await;
+                            }
+                            crate::app::ServerLibraryCommand::ApplyPlaylistPreview {
+                                generation,
+                                preview_id,
+                                server_playlist_id,
+                            } => {
+                                emitter
+                                    .emit_terminal(
+                                        linked_playlists::apply_playlist_preview(
+                                            generation,
+                                            preview_id,
+                                            server_playlist_id,
+                                        )
+                                        .await,
+                                    )
+                                    .await;
+                            }
+                            crate::app::ServerLibraryCommand::CreateLinkedPlaylist {
+                                generation,
+                                snapshot,
+                            } => {
+                                emitter
+                                    .emit_terminal(
+                                        linked_playlists::create_linked_playlist(
+                                            generation, snapshot,
+                                        )
+                                        .await,
+                                    )
+                                    .await;
+                            }
+                            crate::app::ServerLibraryCommand::RecoverPlaylist {
+                                generation,
+                                action,
+                                server_playlist_id,
+                                snapshot,
+                            } => {
+                                emitter
+                                    .emit_terminal(
+                                        linked_playlists::recover_playlist(
+                                            generation,
+                                            action,
+                                            server_playlist_id,
+                                            snapshot,
+                                        )
+                                        .await,
+                                    )
                                     .await;
                             }
                         }
@@ -1108,7 +1238,13 @@ async fn refresh_music_server_runtime(
             let mut summary = crate::open_subsonic::read_status(&paths)
                 .map(music_server_summary)
                 .unwrap_or(local_summary);
-            summary.health = live_music_server_health(summary.playback_reports_needing_decision);
+            summary.health = live_music_server_health(
+                summary.playback_reports_needing_decision,
+                summary.playlist_creates_needing_decision,
+                summary.playlist_links_needing_decision,
+                summary.playlist_projections_needing_decision,
+                summary.playlist_contents_needing_decision,
+            );
             summary.configured = true;
             crate::app::MusicServerRefreshOutcome {
                 summary,
@@ -1256,6 +1392,11 @@ fn music_server_summary(
         lan_http: status.uses_lan_http,
         custom_ca: status.uses_custom_ca,
         playback_reports_needing_decision: status.outbound_scrobbles_needing_attention,
+        playlist_creates_needing_decision: status.playlist_creates_needing_attention,
+        playlist_create_attention: status.playlist_create_attention,
+        playlist_links_needing_decision: status.playlist_links_needing_decision,
+        playlist_projections_needing_decision: status.playlist_projections_needing_attention,
+        playlist_contents_needing_decision: status.playlist_contents_needing_attention,
         history: match status.native_history_health {
             crate::open_subsonic::NativeHistoryHealth::Off => {
                 crate::app::MusicServerHistoryHealth::Off
@@ -1278,8 +1419,17 @@ fn music_server_summary(
 
 pub(super) const fn live_music_server_health(
     playback_reports_needing_decision: usize,
+    playlist_creates_needing_decision: usize,
+    playlist_links_needing_decision: usize,
+    playlist_projections_needing_decision: usize,
+    playlist_contents_needing_decision: usize,
 ) -> crate::app::MusicServerHealth {
-    if playback_reports_needing_decision == 0 {
+    if playback_reports_needing_decision == 0
+        && playlist_creates_needing_decision == 0
+        && playlist_links_needing_decision == 0
+        && playlist_projections_needing_decision == 0
+        && playlist_contents_needing_decision == 0
+    {
         crate::app::MusicServerHealth::UpToDate
     } else {
         crate::app::MusicServerHealth::NeedsAttention

--- a/src/runtime/dispatch/linked_playlists.rs
+++ b/src/runtime/dispatch/linked_playlists.rs
@@ -1,0 +1,107 @@
+//! Runtime dispatch for explicit linked-server-playlist workflows.
+
+use crate::app::{
+    Msg, ServerEvent, ServerLibraryEvent, ServerLibraryFailure, ServerPlaylistPreviewKind,
+    ServerPlaylistRecoveryAction,
+};
+use crate::open_subsonic::{PlaylistPreviewTarget, ServerPlaylistId};
+use crate::personal_state::PersonalPlaylistSnapshot;
+
+use super::super::RuntimeEvent;
+
+pub(super) async fn prepare_playlist(
+    generation: u64,
+    server_playlist_id: ServerPlaylistId,
+    kind: ServerPlaylistPreviewKind,
+) -> RuntimeEvent {
+    let target = match kind {
+        ServerPlaylistPreviewKind::ImportCopy => PlaylistPreviewTarget::ImportCopy,
+        ServerPlaylistPreviewKind::LinkAndSync => PlaylistPreviewTarget::LinkNew,
+    };
+    let result = match crate::open_subsonic::current_handle() {
+        Some(handle) => handle
+            .prepare_playlist(server_playlist_id, target)
+            .await
+            .map_err(super::server_library_failure),
+        None => Err(ServerLibraryFailure::Unavailable),
+    };
+    server_library_event(ServerLibraryEvent::PlaylistPrepared { generation, result })
+}
+
+pub(super) async fn apply_playlist_preview(
+    generation: u64,
+    preview_id: String,
+    server_playlist_id: ServerPlaylistId,
+) -> RuntimeEvent {
+    let result = match crate::open_subsonic::current_handle() {
+        Some(handle) => handle
+            .apply_playlist_preview(preview_id, server_playlist_id, None)
+            .await
+            .map_err(super::server_library_failure),
+        None => Err(ServerLibraryFailure::Unavailable),
+    };
+    server_library_event(ServerLibraryEvent::PlaylistApplied { generation, result })
+}
+
+pub(super) async fn create_linked_playlist(
+    generation: u64,
+    snapshot: PersonalPlaylistSnapshot,
+) -> RuntimeEvent {
+    let local_playlist_id = snapshot.playlist_id.clone();
+    let result = match crate::open_subsonic::current_handle() {
+        Some(handle) => handle
+            .create_linked_playlist(snapshot)
+            .await
+            .map_err(super::server_library_failure),
+        None => Err(ServerLibraryFailure::Unavailable),
+    };
+    server_library_event(ServerLibraryEvent::PlaylistCreated {
+        generation,
+        local_playlist_id,
+        result,
+    })
+}
+
+pub(super) async fn recover_playlist(
+    generation: u64,
+    action: ServerPlaylistRecoveryAction,
+    server_playlist_id: ServerPlaylistId,
+    snapshot: Option<PersonalPlaylistSnapshot>,
+) -> RuntimeEvent {
+    let result = match crate::open_subsonic::current_handle() {
+        Some(handle) => {
+            let result = match action {
+                ServerPlaylistRecoveryAction::Restore => match snapshot {
+                    Some(snapshot) => handle
+                        .restore_linked_playlist(server_playlist_id, snapshot)
+                        .await
+                        .map(drop),
+                    None => Err(crate::open_subsonic::ServerError::InvalidResponse),
+                },
+                ServerPlaylistRecoveryAction::UnlinkKeepServer
+                | ServerPlaylistRecoveryAction::UnlinkKeepLocal => {
+                    handle.unlink_playlist(server_playlist_id).await
+                }
+                ServerPlaylistRecoveryAction::DeleteBoth => {
+                    handle.delete_linked_playlist(server_playlist_id).await
+                }
+                ServerPlaylistRecoveryAction::DeleteLocal => {
+                    handle
+                        .delete_missing_local_playlist(server_playlist_id)
+                        .await
+                }
+            };
+            result.map_err(super::server_library_failure)
+        }
+        None => Err(ServerLibraryFailure::Unavailable),
+    };
+    server_library_event(ServerLibraryEvent::PlaylistRecovered {
+        generation,
+        action,
+        result,
+    })
+}
+
+fn server_library_event(event: ServerLibraryEvent) -> RuntimeEvent {
+    RuntimeEvent::App(Msg::Server(ServerEvent::Library(event)))
+}

--- a/src/runtime/open_subsonic_bridge.rs
+++ b/src/runtime/open_subsonic_bridge.rs
@@ -3,6 +3,9 @@
 use super::{RuntimeHandles, persist_delivery};
 use crate::app::{App, PersistCmd};
 
+mod playlists;
+pub(super) use playlists::PendingOpenSubsonicPlaylistProjection;
+
 /// The durable bridge store can expose at most 20,000 rating plus 20,000 engagement imports.
 ///
 /// This owner-side set is only a hand-off ledger. Refusing new hand-offs at the same aggregate
@@ -142,10 +145,23 @@ fn poll_rating_projection_receipt(
 }
 
 fn bridge_import_tracking_has_capacity(
-    pending: &std::collections::BTreeMap<String, String>,
+    pending: &std::collections::BTreeMap<String, Vec<String>>,
     committed: &std::collections::BTreeSet<String>,
 ) -> bool {
     pending.len().saturating_add(committed.len()) < OWNER_BRIDGE_IMPORT_TRACKING_MAX
+}
+
+fn bridge_import_is_covered(app: &App, envelope_ids: &[String]) -> bool {
+    // Empty means the current durable playlist deletion superseded an older remote observation.
+    // The enclosing personal-state commit identity is still checked by the caller.
+    envelope_ids.is_empty()
+        || envelope_ids.iter().all(|envelope_id| {
+            app.personal_state
+                .ledger
+                .operations
+                .iter()
+                .any(|operation| operation.operation_id == envelope_id.as_str())
+        })
 }
 
 impl RuntimeHandles {
@@ -183,8 +199,8 @@ impl RuntimeHandles {
                 return;
             }
         }
-        let envelope_id = match app.apply_open_subsonic_bridge_import(&import) {
-            Ok(envelope_id) => envelope_id,
+        let envelope_ids = match app.apply_open_subsonic_bridge_import(&import) {
+            Ok(envelope_ids) => envelope_ids,
             Err(error) => {
                 tracing::warn!(%error, "music server observation could not be merged");
                 return;
@@ -193,7 +209,7 @@ impl RuntimeHandles {
         match persist_delivery::admit(&self.persist, app, PersistCmd::Library) {
             Ok(_) => {
                 self.open_subsonic_pending_imports
-                    .insert(operation_id, envelope_id);
+                    .insert(operation_id, envelope_ids);
                 debug_assert!(
                     self.open_subsonic_pending_imports
                         .len()
@@ -227,13 +243,7 @@ impl RuntimeHandles {
         let committed = self
             .open_subsonic_pending_imports
             .iter()
-            .filter(|(_, envelope_id)| {
-                app.personal_state
-                    .ledger
-                    .operations
-                    .iter()
-                    .any(|operation| operation.operation_id == envelope_id.as_str())
-            })
+            .filter(|(_, envelope_ids)| bridge_import_is_covered(app, envelope_ids))
             .map(|(acknowledgement_id, _)| acknowledgement_id.clone())
             .collect::<Vec<_>>();
         for acknowledgement_id in committed {
@@ -294,44 +304,53 @@ impl RuntimeHandles {
             self.open_subsonic_committed_imports.remove(&operation_id);
         }
 
-        match poll_rating_projection_receipt(&mut self.open_subsonic_pending_rating) {
-            RatingProjectionReceipt::Idle => {}
-            RatingProjectionReceipt::Waiting => return,
-            RatingProjectionReceipt::Durable(identity) => {
-                self.open_subsonic_rating_identity = Some(identity);
-            }
-            RatingProjectionReceipt::Retry(Some(error)) => {
-                tracing::warn!(
-                    reason = %error,
-                    "music server ratings are waiting for local durability"
-                );
-            }
-            RatingProjectionReceipt::Retry(None) => {}
-        }
+        let rating_waiting =
+            match poll_rating_projection_receipt(&mut self.open_subsonic_pending_rating) {
+                RatingProjectionReceipt::Idle => false,
+                RatingProjectionReceipt::Waiting => true,
+                RatingProjectionReceipt::Durable(identity) => {
+                    self.open_subsonic_rating_identity = Some(identity);
+                    false
+                }
+                RatingProjectionReceipt::Retry(Some(error)) => {
+                    tracing::warn!(
+                        reason = %error,
+                        "music server ratings are waiting for local durability"
+                    );
+                    false
+                }
+                RatingProjectionReceipt::Retry(None) => false,
+            };
+        let playlist_waiting = self.poll_open_subsonic_playlist_projection();
 
         let Ok(identity) = app.personal_state.ledger.identity() else {
             return;
         };
-        if self.open_subsonic_rating_identity.as_deref() == Some(identity.as_str()) {
-            return;
-        }
-        let winners =
+        if !rating_waiting
+            && self.open_subsonic_rating_identity.as_deref() != Some(identity.as_str())
+        {
             match crate::personal_state::open_subsonic_rating_winners(&app.personal_state.ledger) {
-                Ok(winners) => winners,
+                Ok(winners) => {
+                    if let Ok(receipt) = handle.reconcile_ratings(winners) {
+                        self.open_subsonic_pending_rating =
+                            Some(PendingOpenSubsonicRatingProjection {
+                                identity: identity.clone(),
+                                receipt,
+                            });
+                    }
+                }
                 Err(error) => {
                     tracing::warn!(%error, "music server rating projection could not be prepared");
-                    return;
                 }
-            };
-        if let Ok(receipt) = handle.reconcile_ratings(winners) {
-            self.open_subsonic_pending_rating =
-                Some(PendingOpenSubsonicRatingProjection { identity, receipt });
+            }
         }
+        self.reconcile_open_subsonic_playlists(app, &handle, &identity, playlist_waiting);
     }
 
     pub(crate) fn reset_open_subsonic_rating_projection(&mut self) {
         self.open_subsonic_rating_identity = None;
         self.open_subsonic_pending_rating = None;
+        self.reset_open_subsonic_playlist_projection();
     }
 
     /// Give already-ready bridge receipts one final owner-lane pump without waiting for the
@@ -341,14 +360,21 @@ impl RuntimeHandles {
         &mut self,
         _app: &App,
     ) -> Result<(), crate::open_subsonic::ServiceError> {
+        let mut projection_error = None;
         match poll_rating_projection_receipt(&mut self.open_subsonic_pending_rating) {
             RatingProjectionReceipt::Durable(identity) => {
                 self.open_subsonic_rating_identity = Some(identity);
             }
-            RatingProjectionReceipt::Retry(Some(error)) => return Err(error),
+            RatingProjectionReceipt::Retry(Some(error)) => projection_error = Some(error),
             RatingProjectionReceipt::Idle
             | RatingProjectionReceipt::Waiting
             | RatingProjectionReceipt::Retry(None) => {}
+        }
+        if let Some(error) = self.poll_open_subsonic_playlist_for_shutdown() {
+            projection_error.get_or_insert(error);
+        }
+        if let Some(error) = projection_error {
+            return Err(error);
         }
 
         loop {
@@ -615,7 +641,8 @@ mod tests {
     use super::{
         OWNER_BRIDGE_IMPORT_TRACKING_MAX, PendingOpenSubsonicRatingProjection,
         PendingOpenSubsonicScrobble, RatingProjectionReceipt, admit_pending_scrobble,
-        bridge_import_tracking_has_capacity, poll_rating_projection_receipt,
+        bridge_import_is_covered, bridge_import_tracking_has_capacity,
+        poll_rating_projection_receipt,
     };
 
     fn pending(
@@ -818,5 +845,16 @@ mod tests {
         assert_eq!(committed.len(), OWNER_BRIDGE_IMPORT_TRACKING_MAX);
         assert!(pending.is_empty());
         assert!(!committed.contains("overflow-import"));
+    }
+
+    #[test]
+    fn owner_commit_covers_stale_playlist_retirement_without_an_envelope() {
+        let app = crate::app::App::new(50);
+
+        assert!(bridge_import_is_covered(&app, &[]));
+        assert!(!bridge_import_is_covered(
+            &app,
+            &["not-in-the-ledger".to_owned()]
+        ));
     }
 }

--- a/src/runtime/open_subsonic_bridge/playlists.rs
+++ b/src/runtime/open_subsonic_bridge/playlists.rs
@@ -1,0 +1,168 @@
+//! Linked server-playlist projection on the interactive owner's durability lane.
+
+use super::RuntimeHandles;
+use crate::app::App;
+
+pub(in crate::runtime) struct PendingOpenSubsonicPlaylistProjection {
+    identity: String,
+    receipt: crate::open_subsonic::OpenSubsonicPlaylistReceipt,
+}
+
+enum PlaylistProjectionReceipt {
+    Idle,
+    Waiting,
+    Durable(String),
+    Retry(Option<crate::open_subsonic::ServiceError>),
+}
+
+fn poll_playlist_projection_receipt(
+    pending: &mut Option<PendingOpenSubsonicPlaylistProjection>,
+) -> PlaylistProjectionReceipt {
+    let Some(receipt) = pending.as_mut().map(|pending| &mut pending.receipt) else {
+        return PlaylistProjectionReceipt::Idle;
+    };
+    match receipt.try_recv() {
+        Ok(Ok(())) => PlaylistProjectionReceipt::Durable(
+            pending
+                .take()
+                .expect("playlist receipt was present")
+                .identity,
+        ),
+        Ok(Err(error)) => {
+            *pending = None;
+            PlaylistProjectionReceipt::Retry(Some(error))
+        }
+        Err(tokio::sync::oneshot::error::TryRecvError::Empty) => PlaylistProjectionReceipt::Waiting,
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+            *pending = None;
+            PlaylistProjectionReceipt::Retry(None)
+        }
+    }
+}
+
+impl RuntimeHandles {
+    pub(super) fn poll_open_subsonic_playlist_projection(&mut self) -> bool {
+        match poll_playlist_projection_receipt(&mut self.open_subsonic_pending_playlist) {
+            PlaylistProjectionReceipt::Idle => false,
+            PlaylistProjectionReceipt::Waiting => true,
+            PlaylistProjectionReceipt::Durable(identity) => {
+                self.open_subsonic_playlist_identity = Some(identity);
+                false
+            }
+            PlaylistProjectionReceipt::Retry(Some(error)) => {
+                tracing::warn!(
+                    reason = %error,
+                    "music server playlists are waiting for local durability"
+                );
+                false
+            }
+            PlaylistProjectionReceipt::Retry(None) => false,
+        }
+    }
+
+    pub(super) fn reconcile_open_subsonic_playlists(
+        &mut self,
+        app: &App,
+        handle: &crate::open_subsonic::OpenSubsonicHandle,
+        identity: &str,
+        receipt_pending: bool,
+    ) {
+        if receipt_pending || self.open_subsonic_playlist_identity.as_deref() == Some(identity) {
+            return;
+        }
+        match crate::personal_state::personal_playlist_snapshots(&app.personal_state.ledger) {
+            Ok(snapshots) => {
+                if let Ok(receipt) = handle.reconcile_playlists(snapshots) {
+                    self.open_subsonic_pending_playlist =
+                        Some(PendingOpenSubsonicPlaylistProjection {
+                            identity: identity.to_owned(),
+                            receipt,
+                        });
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "music server playlist projection could not be prepared"
+                );
+            }
+        }
+    }
+
+    pub(super) fn reset_open_subsonic_playlist_projection(&mut self) {
+        self.open_subsonic_playlist_identity = None;
+        self.open_subsonic_pending_playlist = None;
+    }
+
+    pub(super) fn poll_open_subsonic_playlist_for_shutdown(
+        &mut self,
+    ) -> Option<crate::open_subsonic::ServiceError> {
+        match poll_playlist_projection_receipt(&mut self.open_subsonic_pending_playlist) {
+            PlaylistProjectionReceipt::Durable(identity) => {
+                self.open_subsonic_playlist_identity = Some(identity);
+                None
+            }
+            PlaylistProjectionReceipt::Retry(Some(error)) => Some(error),
+            PlaylistProjectionReceipt::Idle
+            | PlaylistProjectionReceipt::Waiting
+            | PlaylistProjectionReceipt::Retry(None) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{
+        PendingOpenSubsonicRatingProjection, RatingProjectionReceipt,
+        poll_rating_projection_receipt,
+    };
+    use super::*;
+
+    #[test]
+    fn tui_playlist_projection_waits_for_durability_receipt() {
+        let (reply, receipt) = tokio::sync::oneshot::channel();
+        let mut pending = Some(PendingOpenSubsonicPlaylistProjection {
+            identity: "durable-playlists".to_owned(),
+            receipt,
+        });
+
+        assert!(matches!(
+            poll_playlist_projection_receipt(&mut pending),
+            PlaylistProjectionReceipt::Waiting
+        ));
+        assert!(pending.is_some());
+
+        reply.send(Ok(())).unwrap();
+        assert!(matches!(
+            poll_playlist_projection_receipt(&mut pending),
+            PlaylistProjectionReceipt::Durable(identity) if identity == "durable-playlists"
+        ));
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn tui_playlist_receipt_progresses_while_rating_receipt_is_pending() {
+        let (_rating_reply, rating_receipt) = tokio::sync::oneshot::channel();
+        let (playlist_reply, playlist_receipt) = tokio::sync::oneshot::channel();
+        let mut rating = Some(PendingOpenSubsonicRatingProjection {
+            identity: "rating-ledger".to_owned(),
+            receipt: rating_receipt,
+        });
+        let mut playlist = Some(PendingOpenSubsonicPlaylistProjection {
+            identity: "playlist-ledger".to_owned(),
+            receipt: playlist_receipt,
+        });
+        playlist_reply.send(Ok(())).unwrap();
+
+        assert!(matches!(
+            poll_rating_projection_receipt(&mut rating),
+            RatingProjectionReceipt::Waiting
+        ));
+        assert!(matches!(
+            poll_playlist_projection_receipt(&mut playlist),
+            PlaylistProjectionReceipt::Durable(identity) if identity == "playlist-ledger"
+        ));
+        assert!(rating.is_some());
+        assert!(playlist.is_none());
+    }
+}

--- a/src/runtime/read_only.rs
+++ b/src/runtime/read_only.rs
@@ -35,8 +35,14 @@ pub(super) fn durable_mutation_component(cmd: &Cmd) -> Option<&'static str> {
             crate::app::MusicServerCommand::TestAndPrepare { .. }
             | crate::app::MusicServerCommand::Commit { .. }
             | crate::app::MusicServerCommand::DisableHistory { .. }
-            | crate::app::MusicServerCommand::Remove { .. },
+            | crate::app::MusicServerCommand::Remove { .. }
+            | crate::app::MusicServerCommand::AbandonPlaylistCreate { .. },
         ) => Some("music server settings"),
+        Cmd::ServerLibrary(
+            crate::app::ServerLibraryCommand::ApplyPlaylistPreview { .. }
+            | crate::app::ServerLibraryCommand::CreateLinkedPlaylist { .. }
+            | crate::app::ServerLibraryCommand::RecoverPlaylist { .. },
+        ) => Some("music server playlist"),
         Cmd::PlayerControl(_)
         | Cmd::VideoConnect { .. }
         | Cmd::VideoLoad(_)
@@ -45,7 +51,11 @@ pub(super) fn durable_mutation_component(cmd: &Cmd) -> Option<&'static str> {
         | Cmd::VideoToggleMute
         | Cmd::Search(_)
         | Cmd::MusicServer(crate::app::MusicServerCommand::Refresh { .. })
-        | Cmd::ServerLibrary(_)
+        | Cmd::ServerLibrary(
+            crate::app::ServerLibraryCommand::LoadPage { .. }
+            | crate::app::ServerLibraryCommand::LoadDetail { .. }
+            | crate::app::ServerLibraryCommand::PreparePlaylist { .. },
+        )
         | Cmd::Data(
             DataCmd::ScanDownloads(_) | DataCmd::PersonalDataExport(_) | DataCmd::SyncUi(_),
         )
@@ -148,6 +158,36 @@ pub(super) fn reject_mutation(app: &mut App, cmd: &Cmd, component: &str, reason:
             app.dirty = true;
             Vec::new()
         }
+        Cmd::ServerLibrary(crate::app::ServerLibraryCommand::ApplyPlaylistPreview {
+            generation,
+            ..
+        }) => app.update(Msg::Server(crate::app::ServerEvent::Library(
+            crate::app::ServerLibraryEvent::PlaylistApplied {
+                generation: *generation,
+                result: Err(crate::app::ServerLibraryFailure::Unavailable),
+            },
+        ))),
+        Cmd::ServerLibrary(crate::app::ServerLibraryCommand::CreateLinkedPlaylist {
+            generation,
+            snapshot,
+        }) => app.update(Msg::Server(crate::app::ServerEvent::Library(
+            crate::app::ServerLibraryEvent::PlaylistCreated {
+                generation: *generation,
+                local_playlist_id: snapshot.playlist_id.clone(),
+                result: Err(crate::app::ServerLibraryFailure::Unavailable),
+            },
+        ))),
+        Cmd::ServerLibrary(crate::app::ServerLibraryCommand::RecoverPlaylist {
+            generation,
+            action,
+            ..
+        }) => app.update(Msg::Server(crate::app::ServerEvent::Library(
+            crate::app::ServerLibraryEvent::PlaylistRecovered {
+                generation: *generation,
+                action: *action,
+                result: Err(crate::app::ServerLibraryFailure::Unavailable),
+            },
+        ))),
         _ => Vec::new(),
     };
     app.set_status_error(match crate::i18n::current() {
@@ -212,5 +252,40 @@ mod tests {
             Some("music server settings")
         );
         assert_eq!(durable_mutation_component(&refresh), None);
+    }
+
+    #[test]
+    fn read_only_secondary_settles_linked_playlist_create_without_actor_work() {
+        let snapshot = crate::personal_state::PersonalPlaylistSnapshot {
+            playlist_id: crate::personal_state::PlaylistId::new("local").unwrap(),
+            name: "Local".to_owned(),
+            entries: Vec::new(),
+        };
+        let mut app = App::new(50);
+        app.server.library.playlist_create = Some(crate::app::ServerPlaylistCreateModal {
+            generation: 7,
+            snapshot: snapshot.clone(),
+            stage: crate::app::ServerPlaylistCreateStage::Applying,
+        });
+        let command = Cmd::ServerLibrary(crate::app::ServerLibraryCommand::CreateLinkedPlaylist {
+            generation: 7,
+            snapshot,
+        });
+
+        assert_eq!(
+            durable_mutation_component(&command),
+            Some("music server playlist")
+        );
+        assert!(
+            reject_mutation(
+                &mut app,
+                &command,
+                "music server playlist",
+                "test writer lease"
+            )
+            .is_empty()
+        );
+        assert!(app.server.library.playlist_create.is_none());
+        assert_eq!(app.status.kind, crate::app::StatusKind::Error);
     }
 }

--- a/src/runtime/tests/music_server.rs
+++ b/src/runtime/tests/music_server.rs
@@ -31,11 +31,27 @@ fn live_connection_does_not_hide_playback_reports_needing_a_decision() {
     use crate::app::MusicServerHealth;
 
     assert_eq!(
-        super::super::dispatch::live_music_server_health(0),
+        super::super::dispatch::live_music_server_health(0, 0, 0, 0, 0),
         MusicServerHealth::UpToDate
     );
     assert_eq!(
-        super::super::dispatch::live_music_server_health(1),
+        super::super::dispatch::live_music_server_health(1, 0, 0, 0, 0),
+        MusicServerHealth::NeedsAttention
+    );
+    assert_eq!(
+        super::super::dispatch::live_music_server_health(0, 1, 0, 0, 0),
+        MusicServerHealth::NeedsAttention
+    );
+    assert_eq!(
+        super::super::dispatch::live_music_server_health(0, 0, 1, 0, 0),
+        MusicServerHealth::NeedsAttention
+    );
+    assert_eq!(
+        super::super::dispatch::live_music_server_health(0, 0, 0, 1, 0),
+        MusicServerHealth::NeedsAttention
+    );
+    assert_eq!(
+        super::super::dispatch::live_music_server_health(0, 0, 0, 0, 1),
         MusicServerHealth::NeedsAttention
     );
 }

--- a/src/server_cli.rs
+++ b/src/server_cli.rs
@@ -12,11 +12,13 @@ use serde::Serialize;
 
 use yututui::open_subsonic::{
     CredentialKind, NativeHistoryHealth, OpenSubsonicPaths, OpenSubsonicStatus,
-    OpenSubsonicStatusKind, OutboundScrobbleResolution, ServerCredential, ServerFeature,
-    SetupIdentityIntent, SetupInput, commit_setup, commit_store_set, list_scrobble_attention_ids,
+    OpenSubsonicStatusKind, OutboundScrobbleResolution, PlaylistCreateAttention, ServerCredential,
+    ServerFeature, SetupIdentityIntent, SetupInput, abandon_playlist_create_attention,
+    commit_setup, commit_store_set, list_playlist_create_attention, list_scrobble_attention_ids,
     load_store_set, read_status, remove_profile, resolve_scrobble_attention,
     test_and_prepare_setup, test_connection_read_only,
 };
+use yututui::personal_state::PlaylistId;
 
 const EXIT_OK: i32 = 0;
 const EXIT_RUNTIME: i32 = 1;
@@ -50,6 +52,10 @@ Commands:
                     Treat one report as unsent and retry it
   scrobbles mark-sent <OPAQUE_ID>
                     Treat one report as sent without retrying it
+  playlists pending [--json]
+                    List local IDs for playlist creates needing a decision
+  playlists abandon <LOCAL_PLAYLIST_ID>
+                    Forget one create guard without deleting either copy
   remove            Remove the profile and credentials; keep local personal data
 
 Passwords and API keys are prompted with echo disabled and are never accepted as arguments.
@@ -66,6 +72,8 @@ enum Command {
     ScrobblesList { json: bool },
     ScrobbleRetry { event_id: String },
     ScrobbleMarkSent { event_id: String },
+    PlaylistCreatesPending { json: bool },
+    PlaylistCreateAbandon { local_playlist_id: String },
     Remove,
 }
 
@@ -88,12 +96,29 @@ struct JsonStatus<'a> {
     detailed_history_enabled: bool,
     detailed_history_status: &'static str,
     playback_reports_needing_decision: usize,
+    playlist_creates_needing_decision: usize,
+    playlist_create_attention: Vec<JsonPlaylistCreateAttention<'a>>,
+    playlist_links_needing_decision: usize,
+    playlist_updates_needing_reconnect: usize,
+    playlist_contents_needing_review: usize,
 }
 
 #[derive(Serialize)]
 struct JsonScrobbleAttention<'a> {
     count: usize,
     opaque_ids: &'a [String],
+}
+
+#[derive(Serialize)]
+struct JsonPlaylistCreateAttention<'a> {
+    local_playlist_id: &'a str,
+    state: &'static str,
+}
+
+#[derive(Serialize)]
+struct JsonPlaylistCreateAttentionList<'a> {
+    count: usize,
+    pending: Vec<JsonPlaylistCreateAttention<'a>>,
 }
 
 pub fn run(args: &[String]) -> i32 {
@@ -117,6 +142,10 @@ pub fn run(args: &[String]) -> i32 {
         Command::ScrobbleMarkSent { event_id } => {
             run_scrobble_resolution(&event_id, OutboundScrobbleResolution::MarkSent)
         }
+        Command::PlaylistCreatesPending { json } => run_playlist_creates_pending(json),
+        Command::PlaylistCreateAbandon { local_playlist_id } => {
+            run_playlist_create_abandon(&local_playlist_id)
+        }
         Command::Remove => run_remove(),
     };
     match result {
@@ -138,6 +167,7 @@ fn parse(args: &[String]) -> Result<Command, String> {
         "remove" => no_args(&args[1..], Command::Remove, "remove"),
         "history" => parse_history(&args[1..]),
         "scrobbles" => parse_scrobbles(&args[1..]),
+        "playlists" => parse_playlists(&args[1..]),
         "status" => match &args[1..] {
             [] => Ok(Command::Status { json: false }),
             [flag] if flag == "--json" => Ok(Command::Status { json: true }),
@@ -145,6 +175,25 @@ fn parse(args: &[String]) -> Result<Command, String> {
             _ => Err("status only accepts `--json`".to_owned()),
         },
         other => Err(format!("unknown command `{other}`")),
+    }
+}
+
+fn parse_playlists(args: &[String]) -> Result<Command, String> {
+    match args {
+        [action] if action == "pending" => Ok(Command::PlaylistCreatesPending { json: false }),
+        [action, flag] if action == "pending" && flag == "--json" => {
+            Ok(Command::PlaylistCreatesPending { json: true })
+        }
+        [action, local_playlist_id] if action == "abandon" => Ok(Command::PlaylistCreateAbandon {
+            local_playlist_id: local_playlist_id.clone(),
+        }),
+        [flag] | [_, flag] if matches!(flag.as_str(), "-h" | "--help" | "help") => {
+            Ok(Command::Help)
+        }
+        [] => Err("playlists requires `pending` or `abandon <LOCAL_PLAYLIST_ID>`".to_owned()),
+        _ => {
+            Err("playlists accepts `pending [--json]` or `abandon <LOCAL_PLAYLIST_ID>`".to_owned())
+        }
     }
 }
 
@@ -333,6 +382,36 @@ fn run_scrobble_resolution(
     Ok(())
 }
 
+fn run_playlist_creates_pending(json: bool) -> Result<(), String> {
+    initialize_reader()?;
+    let attention = list_playlist_create_attention(&paths()?).map_err(|error| error.to_string())?;
+    if json {
+        println!("{}", render_json_playlist_create_attention(&attention)?);
+    } else {
+        for line in human_playlist_create_attention_lines(&attention) {
+            println!("{line}");
+        }
+    }
+    Ok(())
+}
+
+fn run_playlist_create_abandon(local_playlist_id: &str) -> Result<(), String> {
+    let local_playlist_id = PlaylistId::new(local_playlist_id.to_owned()).map_err(|_| {
+        "playlist recovery requires the exact local ID from `playlists pending`".to_owned()
+    })?;
+    initialize_writer()?;
+    if !confirm(
+        "A server copy may already exist. Forget only the retry guard and leave both copies untouched? [y/N]: ",
+    )? {
+        println!("Pending playlist creation was not changed.");
+        return Ok(());
+    }
+    abandon_playlist_create_attention(&paths()?, &local_playlist_id)
+        .map_err(|error| error.to_string())?;
+    println!("Pending playlist creation was forgotten; neither copy was deleted.");
+    Ok(())
+}
+
 fn run_history_enable() -> Result<(), String> {
     initialize_writer()?;
     let paths = paths()?;
@@ -431,6 +510,8 @@ fn checked_status(paths: &OpenSubsonicPaths) -> Result<OpenSubsonicStatus, Strin
 }
 
 fn render_json_status(status: &OpenSubsonicStatus) -> Result<String, String> {
+    let playlist_create_attention =
+        json_playlist_create_attention(&status.playlist_create_attention);
     let value = JsonStatus {
         status: status_label(status.kind),
         display_name: status.display_name.as_deref(),
@@ -442,8 +523,35 @@ fn render_json_status(status: &OpenSubsonicStatus) -> Result<String, String> {
         detailed_history_enabled: status.native_history_enabled,
         detailed_history_status: history_status_label(status.native_history_health),
         playback_reports_needing_decision: status.outbound_scrobbles_needing_attention,
+        playlist_creates_needing_decision: status.playlist_creates_needing_attention,
+        playlist_create_attention,
+        playlist_links_needing_decision: status.playlist_links_needing_decision,
+        playlist_updates_needing_reconnect: status.playlist_projections_needing_attention,
+        playlist_contents_needing_review: status.playlist_contents_needing_attention,
     };
     serde_json::to_string_pretty(&value).map_err(|_| "could not encode status JSON".to_owned())
+}
+
+fn render_json_playlist_create_attention(
+    attention: &[PlaylistCreateAttention],
+) -> Result<String, String> {
+    serde_json::to_string_pretty(&JsonPlaylistCreateAttentionList {
+        count: attention.len(),
+        pending: json_playlist_create_attention(attention),
+    })
+    .map_err(|_| "could not encode playlist-create JSON".to_owned())
+}
+
+fn json_playlist_create_attention(
+    attention: &[PlaylistCreateAttention],
+) -> Vec<JsonPlaylistCreateAttention<'_>> {
+    attention
+        .iter()
+        .map(|pending| JsonPlaylistCreateAttention {
+            local_playlist_id: pending.local_playlist_id.as_str(),
+            state: pending.state.label(),
+        })
+        .collect()
 }
 
 fn render_json_scrobble_list(ids: &[String]) -> Result<String, String> {
@@ -462,6 +570,26 @@ fn human_scrobble_list_lines(ids: &[String]) -> Vec<String> {
     lines.push(playback_report_attention_summary(ids.len()));
     lines.extend(ids.iter().cloned());
     lines.push("Choose `retry <OPAQUE_ID>` or `mark-sent <OPAQUE_ID>` for each report.".to_owned());
+    lines
+}
+
+fn human_playlist_create_attention_lines(attention: &[PlaylistCreateAttention]) -> Vec<String> {
+    if attention.is_empty() {
+        return vec!["No server playlist creations need a decision.".to_owned()];
+    }
+    let mut lines = Vec::with_capacity(attention.len().saturating_add(2));
+    lines.push(playlist_create_attention_summary(attention.len()));
+    lines.extend(attention.iter().map(|pending| {
+        format!(
+            "{}  {}",
+            pending.local_playlist_id.as_str(),
+            pending.state.label()
+        )
+    }));
+    lines.push(
+        "Use `ytt server playlists abandon <LOCAL_PLAYLIST_ID>` only after checking the server."
+            .to_owned(),
+    );
     lines
 }
 
@@ -501,13 +629,55 @@ fn print_human_status(status: &OpenSubsonicStatus) {
         }
         OpenSubsonicStatusKind::NeedsAttention => {
             println!("Needs attention");
+            let mut showed_recovery = false;
             if status.outbound_scrobbles_needing_attention > 0 {
+                showed_recovery = true;
                 println!(
                     "{}",
                     playback_report_attention_summary(status.outbound_scrobbles_needing_attention)
                 );
                 println!("{}", playback_report_attention_action());
-            } else {
+            }
+            if status.playlist_creates_needing_attention > 0 {
+                showed_recovery = true;
+                println!(
+                    "{}",
+                    playlist_create_attention_summary(status.playlist_creates_needing_attention)
+                );
+                for pending in &status.playlist_create_attention {
+                    println!(
+                        "{}  {}",
+                        pending.local_playlist_id.as_str(),
+                        pending.state.label()
+                    );
+                }
+                println!("Action: review them with `ytt server playlists pending`.");
+            }
+            if status.playlist_links_needing_decision > 0 {
+                showed_recovery = true;
+                println!(
+                    "{}",
+                    playlist_link_attention_summary(status.playlist_links_needing_decision)
+                );
+                println!("{}", playlist_link_attention_action());
+            }
+            if status.playlist_projections_needing_attention > 0 {
+                showed_recovery = true;
+                println!(
+                    "{} playlist update(s) need a successful reconnect before retrying.",
+                    status.playlist_projections_needing_attention
+                );
+                println!("Action: update and test the connection settings.");
+            }
+            if status.playlist_contents_needing_attention > 0 {
+                showed_recovery = true;
+                println!(
+                    "{} linked playlist(s) contain tracks from outside this server account.",
+                    status.playlist_contents_needing_attention
+                );
+                println!("Action: review those local playlists in Server Library.");
+            }
+            if !showed_recovery {
                 println!("Action: update the connection settings");
             }
             println!(
@@ -516,6 +686,26 @@ fn print_human_status(status: &OpenSubsonicStatus) {
             );
         }
     }
+}
+
+fn playlist_create_attention_summary(count: usize) -> String {
+    if count == 1 {
+        "1 server playlist creation needs a decision.".to_owned()
+    } else {
+        format!("{count} server playlist creations need a decision.")
+    }
+}
+
+fn playlist_link_attention_summary(count: usize) -> String {
+    if count == 1 {
+        "1 linked server playlist is missing and needs a decision.".to_owned()
+    } else {
+        format!("{count} linked server playlists are missing and need a decision.")
+    }
+}
+
+fn playlist_link_attention_action() -> &'static str {
+    "Action: open Server Library and choose Restore, Unlink, or Delete local too."
 }
 
 fn playback_report_attention_summary(count: usize) -> String {
@@ -742,7 +932,8 @@ mod tests {
     use super::*;
     use yututui::open_subsonic::{
         ConfiguredPrivateOrigin, OpenSubsonicBridgeState, OpenSubsonicPrivateState,
-        OpenSubsonicProfile, OpenSubsonicStoreSet, StoreRevisions, commit_store_set,
+        OpenSubsonicProfile, OpenSubsonicStoreSet, PlaylistCreateRecoveryState, StoreRevisions,
+        commit_store_set,
     };
 
     fn args(values: &[&str]) -> Vec<String> {
@@ -921,6 +1112,54 @@ mod tests {
     }
 
     #[test]
+    fn playlist_create_recovery_parser_and_output_use_only_local_ids() {
+        assert_eq!(
+            parse(&args(&["playlists", "pending"])),
+            Ok(Command::PlaylistCreatesPending { json: false })
+        );
+        assert_eq!(
+            parse(&args(&["playlists", "pending", "--json"])),
+            Ok(Command::PlaylistCreatesPending { json: true })
+        );
+        assert_eq!(
+            parse(&args(&["playlists", "abandon", "local-opaque"])),
+            Ok(Command::PlaylistCreateAbandon {
+                local_playlist_id: "local-opaque".to_owned(),
+            })
+        );
+        assert!(parse(&args(&["playlists", "abandon"])).is_err());
+        assert!(parse(&args(&["playlists", "pending", "--verbose"])).is_err());
+        assert!(SERVER_USAGE.contains("playlists pending [--json]"));
+        assert!(SERVER_USAGE.contains("playlists abandon <LOCAL_PLAYLIST_ID>"));
+
+        let attention = vec![
+            PlaylistCreateAttention {
+                local_playlist_id: PlaylistId::new("local-a").unwrap(),
+                state: PlaylistCreateRecoveryState::ServerIdentityUnknown,
+            },
+            PlaylistCreateAttention {
+                local_playlist_id: PlaylistId::new("local-b").unwrap(),
+                state: PlaylistCreateRecoveryState::ReadbackNeeded,
+            },
+        ];
+        let json = render_json_playlist_create_attention(&attention).unwrap();
+        assert!(json.contains(r#""local_playlist_id": "local-a""#));
+        assert!(json.contains(r#""state": "server_identity_unknown""#));
+        assert!(json.contains(r#""state": "readback_needed""#));
+        assert!(!json.contains("server-known"));
+        assert!(!json.contains("Private name"));
+
+        let human = human_playlist_create_attention_lines(&attention);
+        assert_eq!(human[0], "2 server playlist creations need a decision.");
+        assert_eq!(human[1], "local-a  server_identity_unknown");
+        assert_eq!(human[2], "local-b  readback_needed");
+        assert_eq!(
+            human_playlist_create_attention_lines(&[]),
+            vec!["No server playlist creations need a decision."]
+        );
+    }
+
+    #[test]
     fn destructive_scrobble_choices_default_to_no() {
         for rejected in ["", "n", "no", "later", "1"] {
             assert!(!is_affirmative_confirmation(rejected));
@@ -1013,6 +1252,9 @@ mod tests {
         assert!(json.contains(r#""status": "needs_attention""#));
         assert!(json.contains(r#""detailed_history_status": "off""#));
         assert!(json.contains(r#""playback_reports_needing_decision": 0"#));
+        assert!(json.contains(r#""playlist_creates_needing_decision": 0"#));
+        assert!(json.contains(r#""playlist_links_needing_decision": 0"#));
+        assert!(json.contains(r#""playlist_contents_needing_review": 0"#));
         assert!(json.contains("Offline fixture"));
         assert!(!json.contains("json-secret-sentinel"));
         assert!(!json.contains("https://"));
@@ -1032,6 +1274,36 @@ mod tests {
         assert_eq!(
             playback_report_attention_action(),
             "Action: review them with `ytt server scrobbles list`."
+        );
+        playback_attention.playlist_creates_needing_attention = 1;
+        playback_attention.playlist_create_attention = vec![PlaylistCreateAttention {
+            local_playlist_id: PlaylistId::new("local-status").unwrap(),
+            state: PlaylistCreateRecoveryState::ReadbackNeeded,
+        }];
+        playback_attention.playlist_links_needing_decision = 1;
+        playback_attention.playlist_projections_needing_attention = 2;
+        playback_attention.playlist_contents_needing_attention = 3;
+        let json = render_json_status(&playback_attention).unwrap();
+        assert!(json.contains(r#""playlist_creates_needing_decision": 1"#));
+        assert!(json.contains(r#""local_playlist_id": "local-status""#));
+        assert!(json.contains(r#""playlist_links_needing_decision": 1"#));
+        assert!(json.contains(r#""playlist_updates_needing_reconnect": 2"#));
+        assert!(json.contains(r#""playlist_contents_needing_review": 3"#));
+        assert_eq!(
+            playlist_create_attention_summary(1),
+            "1 server playlist creation needs a decision."
+        );
+        assert_eq!(
+            playlist_link_attention_summary(1),
+            "1 linked server playlist is missing and needs a decision."
+        );
+        assert_eq!(
+            playlist_link_attention_summary(2),
+            "2 linked server playlists are missing and need a decision."
+        );
+        assert_eq!(
+            playlist_link_attention_action(),
+            "Action: open Server Library and choose Restore, Unlink, or Delete local too."
         );
         let _ = std::fs::remove_dir_all(root);
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -176,6 +176,17 @@ pub fn render(frame: &mut Frame, app: &App) {
     if app.library_ui.confirm_download.is_some() {
         views::library::render_confirm_download(frame, app, area);
     }
+    // Explicit server-playlist imports and links always show their deletion-free preview above
+    // the library before anything can be applied.
+    if app.server.library.playlist_preview.is_some() {
+        views::server_playlist_preview::render(frame, app, area);
+    }
+    if app.server.library.playlist_create.is_some() {
+        views::server_playlist_create::render(frame, app, area);
+    }
+    if app.server.library.playlist_recovery.is_some() {
+        views::server_playlist_recovery::render(frame, app, area);
+    }
     // The add-to-playlist picker floats over whichever screen opened it.
     if app.playlist_picker.is_some() {
         views::library::render_playlist_picker(frame, app, area);

--- a/src/ui/text.rs
+++ b/src/ui/text.rs
@@ -174,6 +174,51 @@ pub fn tail_to_width(s: &str, max: usize) -> String {
     out
 }
 
+/// Keep both ends of an identifier visible, inserting one ellipsis when it does not fit.
+/// Display-width accounting is CJK-aware and no character is split.
+pub fn middle_to_width(s: &str, max: usize) -> String {
+    if UnicodeWidthStr::width(s) <= max {
+        return s.to_owned();
+    }
+    if max == 0 {
+        return String::new();
+    }
+    if max == 1 {
+        return "…".to_owned();
+    }
+
+    let available = max - 1;
+    let head_limit = available.div_ceil(2);
+    let tail_limit = available / 2;
+
+    let mut head_end = 0usize;
+    let mut head_width = 0usize;
+    for (index, character) in s.char_indices() {
+        let width = UnicodeWidthChar::width(character).unwrap_or(0);
+        if head_width.saturating_add(width) > head_limit {
+            break;
+        }
+        head_end = index + character.len_utf8();
+        head_width = head_width.saturating_add(width);
+    }
+
+    let mut tail_start = s.len();
+    let mut tail_width = 0usize;
+    for (index, character) in s.char_indices().rev() {
+        if index < head_end {
+            break;
+        }
+        let width = UnicodeWidthChar::width(character).unwrap_or(0);
+        if tail_width.saturating_add(width) > tail_limit {
+            break;
+        }
+        tail_start = index;
+        tail_width = tail_width.saturating_add(width);
+    }
+
+    format!("{}…{}", &s[..head_end], &s[tail_start..])
+}
+
 /// Word-wrap `text` to at most `width` display cells per line (CJK-aware). Splits on
 /// whitespace, collapses runs of whitespace to a single break, and hard-breaks a single
 /// word longer than `width` at the cell boundary so nothing ever overflows. `width` is
@@ -313,6 +358,15 @@ mod tests {
         assert_eq!(truncate_to_width("가나다", 6), "가나다");
         assert_eq!(truncate_to_width("abcdef", 3), "abc");
         assert_eq!(truncate_to_width("", 4), "");
+    }
+
+    #[test]
+    fn middle_truncation_keeps_both_identifier_ends() {
+        assert_eq!(middle_to_width("head-0123456789-tail", 12), "head-0…-tail");
+        assert_eq!(middle_to_width("가나다라마바사", 9), "가나…바사");
+        assert_eq!(middle_to_width("abcdef", 1), "…");
+        assert_eq!(middle_to_width("abcdef", 0), "");
+        assert_eq!(middle_to_width("short", 8), "short");
     }
 
     #[test]

--- a/src/ui/views/mod.rs
+++ b/src/ui/views/mod.rs
@@ -20,5 +20,8 @@ mod player_lyrics;
 mod queue_actions;
 pub mod search;
 pub mod server_library;
+pub mod server_playlist_create;
+pub mod server_playlist_preview;
+pub mod server_playlist_recovery;
 pub mod settings;
 pub mod why_ai;

--- a/src/ui/views/server_library.rs
+++ b/src/ui/views/server_library.rs
@@ -1,4 +1,4 @@
-//! Read-only music-server library renderer.
+//! Music-server library renderer with explicit playlist access markers.
 
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
@@ -9,6 +9,7 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 use crate::app::{App, LibrarySource, MouseTarget, ScrollSurface};
 use crate::open_subsonic::model::{
     LibraryWarning, ServerLibraryDetail, ServerLibraryRow, ServerLibrarySection,
+    ServerPlaylistAccess,
 };
 use crate::t;
 use crate::theme::ThemeRole as R;
@@ -416,7 +417,31 @@ fn server_row_text(app: &App, index: usize) -> String {
                     let count = playlist.song_count.map_or_else(String::new, |count| {
                         format!("  ·  {count} {}", t!("songs", "곡", "曲"))
                     });
-                    format!("☷ {}{count}", playlist.name)
+                    let linked = match playlist.link.as_ref().map(|link| link.health) {
+                        Some(crate::open_subsonic::ServerPlaylistLinkHealth::NeedsAttention) => {
+                            format!(
+                                "  ·  {}",
+                                t!(
+                                    "Linked playlist needs attention",
+                                    "연결된 목록 확인 필요",
+                                    "連携リストを確認"
+                                )
+                            )
+                        }
+                        Some(crate::open_subsonic::ServerPlaylistLinkHealth::ServerMissing) => {
+                            format!(
+                                "  ·  {}",
+                                t!("Server copy missing", "서버 복사본 없음", "サーバー側なし")
+                            )
+                        }
+                        Some(crate::open_subsonic::ServerPlaylistLinkHealth::UpToDate) | None
+                            if playlist.access == ServerPlaylistAccess::Linked =>
+                        {
+                            format!("  ·  {}", t!("Linked", "연결됨", "リンク済み"))
+                        }
+                        _ => String::new(),
+                    };
+                    format!("☷ {}{count}{linked}", playlist.name)
                 }
             }),
     }
@@ -442,6 +467,7 @@ mod tests {
     use ratatui::backend::TestBackend;
 
     use super::*;
+    use crate::open_subsonic::{ServerLibraryPage, ServerPlaylistId, ServerPlaylistSummary};
 
     fn draw_server_library(app: &App, width: u16, height: u16) -> String {
         let backend = TestBackend::new(width, height);
@@ -547,6 +573,50 @@ mod tests {
                 assert!(width <= 28, "{language:?} compact row is {width} cells");
             }
         }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn linked_playlist_marker_is_localized_and_absent_for_unlinked_rows() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        let mut app = App::new(50);
+        app.server.library.page = Some(ServerLibraryPage {
+            section: ServerLibrarySection::Playlists,
+            rows: vec![ServerLibraryRow::Playlist(ServerPlaylistSummary {
+                id: ServerPlaylistId::new("playlist").unwrap(),
+                name: "Road Trip".to_owned(),
+                owner: Some("owner".to_owned()),
+                song_count: Some(2),
+                duration_secs: None,
+                public: Some(false),
+                cover_art_id: None,
+                access: ServerPlaylistAccess::Linked,
+                link: None,
+                readonly_evidence: Some(false),
+                owner_evidence: Some("owner".to_owned()),
+            })],
+            next_offset: None,
+            warning: None,
+        });
+        for (language, marker) in [
+            (crate::i18n::Language::English, "Linked"),
+            (crate::i18n::Language::Korean, "연결됨"),
+            (crate::i18n::Language::Japanese, "リンク済み"),
+        ] {
+            crate::i18n::set_language(language);
+            assert!(server_row_text(&app, 0).contains(marker));
+        }
+        if let Some(ServerLibraryRow::Playlist(playlist)) = app
+            .server
+            .library
+            .page
+            .as_mut()
+            .and_then(|page| page.rows.first_mut())
+        {
+            playlist.access = ServerPlaylistAccess::Server;
+        }
+        assert!(!server_row_text(&app, 0).contains("リンク済み"));
         crate::i18n::set_language(original);
     }
 }

--- a/src/ui/views/server_playlist_create.rs
+++ b/src/ui/views/server_playlist_create.rs
@@ -1,0 +1,255 @@
+//! Deletion-free confirmation for creating a linked server copy from a local playlist.
+
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::Modifier;
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use crate::app::{App, MouseTarget, ServerPlaylistCreateStage};
+use crate::t;
+use crate::theme::ThemeRole as R;
+use crate::ui::buttons;
+
+pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+    let Some(modal) = app.server.library.playlist_create.as_ref() else {
+        return;
+    };
+    let popup = centered_fixed(area, 58, 13);
+    crate::ui::render_popup_background(frame, app, popup);
+    let block = Block::default()
+        .title(t!(
+            " Create linked server playlist ",
+            " 서버 연결 목록 만들기 ",
+            " サーバー連携リストを作成 "
+        ))
+        .borders(Borders::ALL)
+        .border_style(crate::ui::confirm_border_style(app))
+        .style(crate::ui::popup_style(app, R::TextPrimary));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(4),
+        Constraint::Min(0),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+    frame.render_widget(
+        Paragraph::new(format!("{}: {}", t!("Name", "이름", "名前"), modal.name()))
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: true })
+            .style(crate::ui::popup_style(app, R::TextPrimary).add_modifier(Modifier::BOLD)),
+        rows[0],
+    );
+    frame.render_widget(
+        Paragraph::new(t!(
+            "Local removals: 0",
+            "로컬에서 삭제: 0",
+            "ローカルから削除: 0"
+        ))
+        .alignment(Alignment::Center)
+        .style(crate::ui::popup_style(app, R::Accent)),
+        rows[1],
+    );
+    frame.render_widget(
+        Paragraph::new(match crate::i18n::current() {
+            crate::i18n::Language::Korean => {
+                format!("서버에 추가: {}", modal.server_additions())
+            }
+            crate::i18n::Language::Japanese => {
+                format!("サーバーに追加: {}", modal.server_additions())
+            }
+            _ => format!("Server additions: {}", modal.server_additions()),
+        })
+        .alignment(Alignment::Center)
+        .style(crate::ui::popup_style(app, R::Accent)),
+        rows[2],
+    );
+    frame.render_widget(
+        Paragraph::new(t!(
+            "Your local playlist stays unchanged. No existing server playlist is removed.",
+            "로컬 목록은 그대로 유지돼요. 기존 서버 목록은 삭제하지 않아요.",
+            "ローカルリストは変わりません。既存のサーバーリストは削除しません。"
+        ))
+        .alignment(Alignment::Center)
+        .wrap(Wrap { trim: true })
+        .style(crate::ui::popup_style(app, R::TextMuted)),
+        rows[3],
+    );
+
+    if modal.stage == ServerPlaylistCreateStage::Applying {
+        buttons::render_segments(
+            frame,
+            app,
+            rows[5],
+            &[buttons::Seg::label(t!(
+                " Creating and checking… ",
+                " 만들고 확인하는 중… ",
+                " 作成して確認中… "
+            ))],
+            crate::ui::popup_style(app, R::TextMuted),
+            crate::ui::confirm_gap_style(app),
+            Alignment::Center,
+        );
+    } else {
+        let create_full = t!(
+            " Create & link (Enter) ",
+            " 만들고 연결 (Enter) ",
+            " 作成してリンク (Enter) "
+        );
+        let back_full = t!(" Back (Esc) ", " 뒤로 (Esc) ", " 戻る (Esc) ");
+        let full_width = buttons::text_width(create_full)
+            .saturating_add(2)
+            .saturating_add(buttons::text_width(back_full));
+        let (create, back) = if full_width <= rows[5].width {
+            (create_full, back_full)
+        } else {
+            (
+                t!(" Create ", " 만들기 ", " 作成 "),
+                t!(" Back ", " 뒤로 ", " 戻る "),
+            )
+        };
+        buttons::render_segments(
+            frame,
+            app,
+            rows[5],
+            &[
+                buttons::Seg::button(MouseTarget::ConfirmServerPlaylistCreate, create),
+                buttons::Seg::label("  "),
+                buttons::Seg::button(MouseTarget::CancelServerPlaylistCreate, back),
+            ],
+            crate::ui::confirm_button_style(app),
+            crate::ui::confirm_gap_style(app),
+            Alignment::Center,
+        );
+    }
+    crate::ui::seal_popup_background(frame, app, popup);
+    crate::ui::mark_art_rows_for_popup(frame, app, popup);
+}
+
+fn centered_fixed(area: Rect, preferred_width: u16, preferred_height: u16) -> Rect {
+    let margin_width = area.width.saturating_sub(2);
+    let width = preferred_width.min(if margin_width == 0 {
+        area.width
+    } else {
+        margin_width
+    });
+    let margin_height = area.height.saturating_sub(2);
+    let height = preferred_height.min(if margin_height == 0 {
+        area.height
+    } else {
+        margin_height
+    });
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+    .intersection(area)
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+    use crate::personal_state::{PersonalPlaylistSnapshot, PlaylistId};
+
+    fn app(stage: ServerPlaylistCreateStage) -> App {
+        let mut app = App::new(50);
+        app.server.library.playlist_create = Some(crate::app::ServerPlaylistCreateModal {
+            generation: 1,
+            snapshot: PersonalPlaylistSnapshot {
+                playlist_id: PlaylistId::new("local").unwrap(),
+                name: "A local list".to_owned(),
+                entries: Vec::new(),
+            },
+            stage,
+        });
+        app
+    }
+
+    fn render_at(app: &App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app, frame.area()))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn confirmation_fits_thirty_columns_with_hit_targets_in_all_languages() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for (language, expected) in [
+            (
+                crate::i18n::Language::English,
+                [
+                    "Yourlocalplayliststaysunchanged",
+                    "Noexistingserverplaylistisremoved",
+                ],
+            ),
+            (
+                crate::i18n::Language::Korean,
+                ["로컬목록은그대로유지돼요", "기존서버목록은삭제하지않아요"],
+            ),
+            (
+                crate::i18n::Language::Japanese,
+                [
+                    "ローカルリストは変わりません",
+                    "既存のサーバーリストは削除しません",
+                ],
+            ),
+        ] {
+            crate::i18n::set_language(language);
+            let app = app(ServerPlaylistCreateStage::Confirming);
+            let text = render_at(&app, 30, 30);
+            let comparable: String = text
+                .chars()
+                .filter(|ch| !ch.is_whitespace() && *ch != '│')
+                .collect();
+            assert!(comparable.contains('0'), "{language:?}: {text:?}");
+            for phrase in expected {
+                assert!(comparable.contains(phrase), "{language:?}: {text:?}");
+            }
+            for target in [
+                MouseTarget::ConfirmServerPlaylistCreate,
+                MouseTarget::CancelServerPlaylistCreate,
+            ] {
+                let rect = app.hits.rect_of_target(target).expect("visible button");
+                assert!(rect.right() <= 30, "{language:?}: {rect:?}");
+                assert!(rect.bottom() <= 30, "{language:?}: {rect:?}");
+            }
+        }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn applying_state_has_no_live_confirmation_target() {
+        let app = app(ServerPlaylistCreateStage::Applying);
+        let text = render_at(&app, 30, 30);
+        assert!(!text.trim().is_empty());
+        assert!(
+            app.hits
+                .rect_of_target(MouseTarget::ConfirmServerPlaylistCreate)
+                .is_none()
+        );
+        assert!(
+            app.hits
+                .rect_of_target(MouseTarget::CancelServerPlaylistCreate)
+                .is_none()
+        );
+    }
+}

--- a/src/ui/views/server_playlist_preview.rs
+++ b/src/ui/views/server_playlist_preview.rs
@@ -1,0 +1,307 @@
+//! Deletion-free first-sync preview for explicit server-playlist imports and links.
+
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::Modifier;
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use crate::app::{App, MouseTarget, ServerPlaylistPreviewKind, ServerPlaylistPreviewStage};
+use crate::t;
+use crate::theme::ThemeRole as R;
+use crate::ui::buttons;
+
+pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+    let Some(modal) = app.server.library.playlist_preview.as_ref() else {
+        return;
+    };
+    let popup = centered_fixed(area, 58, 13);
+    crate::ui::render_popup_background(frame, app, popup);
+
+    let title = match modal.kind {
+        ServerPlaylistPreviewKind::ImportCopy => t!(
+            " Import playlist copy ",
+            " 플레이리스트 복사본 가져오기 ",
+            " プレイリストをコピーとしてインポート "
+        ),
+        ServerPlaylistPreviewKind::LinkAndSync => t!(
+            " Link playlist ",
+            " 플레이리스트 연결 ",
+            " プレイリストをリンク "
+        ),
+    };
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(crate::ui::confirm_border_style(app))
+        .style(crate::ui::popup_style(app, R::TextPrimary));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    match &modal.stage {
+        ServerPlaylistPreviewStage::Preparing { .. } => {
+            render_busy(
+                frame,
+                app,
+                inner,
+                t!(
+                    "Preparing preview…",
+                    "미리보기를 준비하는 중…",
+                    "プレビューを準備しています…"
+                ),
+            );
+        }
+        ServerPlaylistPreviewStage::Ready(preview) => {
+            render_preview(frame, app, inner, preview, false);
+        }
+        ServerPlaylistPreviewStage::Applying(preview) => {
+            render_preview(frame, app, inner, preview, true);
+        }
+    }
+
+    crate::ui::seal_popup_background(frame, app, popup);
+    crate::ui::mark_art_rows_for_popup(frame, app, popup);
+}
+
+fn render_busy(frame: &mut Frame, app: &App, area: Rect, message: &str) {
+    let rows = Layout::vertical([
+        Constraint::Min(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+    ])
+    .split(area);
+    frame.render_widget(
+        Paragraph::new(message)
+            .alignment(Alignment::Center)
+            .style(crate::ui::popup_style(app, R::TextMuted)),
+        rows[0],
+    );
+    let segments = [buttons::Seg::button(
+        MouseTarget::CancelServerPlaylistPreview,
+        t!(" Back (Esc) ", " 뒤로 (Esc) ", " 戻る (Esc) "),
+    )];
+    buttons::render_segments(
+        frame,
+        app,
+        rows[2],
+        &segments,
+        crate::ui::confirm_button_style(app),
+        crate::ui::confirm_gap_style(app),
+        Alignment::Center,
+    );
+}
+
+fn render_preview(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    preview: &crate::open_subsonic::PlaylistMergePreview,
+    applying: bool,
+) {
+    let rows = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(2),
+        Constraint::Min(0),
+        Constraint::Length(1),
+    ])
+    .split(area);
+    frame.render_widget(
+        Paragraph::new(format!("{}: {}", t!("Name", "이름", "名前"), preview.name))
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: true })
+            .style(crate::ui::popup_style(app, R::TextPrimary).add_modifier(Modifier::BOLD)),
+        rows[0],
+    );
+    frame.render_widget(
+        Paragraph::new(match crate::i18n::current() {
+            crate::i18n::Language::Korean => {
+                format!("YuTuTui에 추가: {}", preview.add_to_local)
+            }
+            crate::i18n::Language::Japanese => {
+                format!("YuTuTui に追加: {}", preview.add_to_local)
+            }
+            _ => format!("Add to YuTuTui: {}", preview.add_to_local),
+        })
+        .alignment(Alignment::Center)
+        .style(crate::ui::popup_style(app, R::Accent)),
+        rows[1],
+    );
+    frame.render_widget(
+        Paragraph::new(match crate::i18n::current() {
+            crate::i18n::Language::Korean => {
+                format!("서버에 추가: {}", preview.add_to_server)
+            }
+            crate::i18n::Language::Japanese => {
+                format!("サーバーに追加: {}", preview.add_to_server)
+            }
+            _ => format!("Add to server: {}", preview.add_to_server),
+        })
+        .alignment(Alignment::Center)
+        .style(crate::ui::popup_style(app, R::Accent)),
+        rows[2],
+    );
+    frame.render_widget(
+        Paragraph::new(first_sync_message())
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: true })
+            .style(crate::ui::popup_style(app, R::TextMuted)),
+        rows[4],
+    );
+
+    if applying {
+        let segments = [buttons::Seg::label(t!(
+            " Applying… ",
+            " 적용 중… ",
+            " 適用中… "
+        ))];
+        buttons::render_segments(
+            frame,
+            app,
+            rows[6],
+            &segments,
+            crate::ui::popup_style(app, R::TextMuted),
+            crate::ui::confirm_gap_style(app),
+            Alignment::Center,
+        );
+    } else {
+        let segments = [
+            buttons::Seg::button(
+                MouseTarget::ConfirmServerPlaylistPreview,
+                t!(" Apply ", " 적용 ", " 適用 "),
+            ),
+            buttons::Seg::label("  "),
+            buttons::Seg::button(
+                MouseTarget::CancelServerPlaylistPreview,
+                t!(" Back ", " 뒤로 ", " 戻る "),
+            ),
+        ];
+        buttons::render_segments(
+            frame,
+            app,
+            rows[6],
+            &segments,
+            crate::ui::confirm_button_style(app),
+            crate::ui::confirm_gap_style(app),
+            Alignment::Center,
+        );
+    }
+}
+
+pub(crate) fn first_sync_message() -> &'static str {
+    t!(
+        "Nothing will be removed in this first sync.",
+        "첫 동기화에서는 아무것도 삭제하지 않아요.",
+        "初回同期では何も削除しません。"
+    )
+}
+
+fn centered_fixed(area: Rect, preferred_width: u16, preferred_height: u16) -> Rect {
+    let margin_width = area.width.saturating_sub(2);
+    let width = preferred_width.min(if margin_width == 0 {
+        area.width
+    } else {
+        margin_width
+    });
+    let margin_height = area.height.saturating_sub(2);
+    let height = preferred_height.min(if margin_height == 0 {
+        area.height
+    } else {
+        margin_height
+    });
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+    .intersection(area)
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+    use crate::open_subsonic::{PlaylistMergePreview, PlaylistPreviewMode, ServerPlaylistId};
+    use crate::personal_state::PlaylistId;
+
+    fn ready_app() -> App {
+        let mut app = App::new(50);
+        app.server.library.playlist_preview = Some(crate::app::ServerPlaylistPreviewModal {
+            generation: 7,
+            kind: ServerPlaylistPreviewKind::LinkAndSync,
+            stage: ServerPlaylistPreviewStage::Ready(PlaylistMergePreview {
+                preview_id: "preview".to_owned(),
+                mode: PlaylistPreviewMode::LinkNew,
+                server_playlist_id: ServerPlaylistId::new("remote").unwrap(),
+                local_playlist_id: PlaylistId::new("local").unwrap(),
+                name: "Road Trip".to_owned(),
+                remote_tracks: 12,
+                add_to_local: 12,
+                add_to_server: 3,
+            }),
+        });
+        app
+    }
+
+    #[test]
+    fn first_sync_copy_is_exact_in_all_languages() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for (language, expected) in [
+            (
+                crate::i18n::Language::English,
+                "Nothing will be removed in this first sync.",
+            ),
+            (
+                crate::i18n::Language::Korean,
+                "첫 동기화에서는 아무것도 삭제하지 않아요.",
+            ),
+            (
+                crate::i18n::Language::Japanese,
+                "初回同期では何も削除しません。",
+            ),
+        ] {
+            crate::i18n::set_language(language);
+            assert_eq!(first_sync_message(), expected);
+        }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn ready_preview_fits_thirty_by_thirty_and_registers_both_actions() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        crate::i18n::set_language(crate::i18n::Language::English);
+        let app = ready_app();
+        let backend = TestBackend::new(30, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, &app, frame.area()))
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("Road Trip"));
+        assert!(text.contains("12"));
+        assert!(text.contains("3"));
+        assert!(
+            app.hits
+                .rect_of_target(MouseTarget::ConfirmServerPlaylistPreview)
+                .is_some()
+        );
+        assert!(
+            app.hits
+                .rect_of_target(MouseTarget::CancelServerPlaylistPreview)
+                .is_some()
+        );
+        crate::i18n::set_language(original);
+    }
+}

--- a/src/ui/views/server_playlist_recovery.rs
+++ b/src/ui/views/server_playlist_recovery.rs
@@ -1,0 +1,333 @@
+//! Linked server-playlist recovery and destructive confirmation modal.
+
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::Modifier;
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use crate::app::{
+    App, MouseTarget, ServerPlaylistRecoveryAction as Action, ServerPlaylistRecoveryStage as Stage,
+};
+use crate::t;
+use crate::theme::ThemeRole as R;
+use crate::ui::buttons;
+
+pub fn render(frame: &mut Frame, app: &App, area: Rect) {
+    let Some(modal) = app.server.library.playlist_recovery.as_ref() else {
+        return;
+    };
+    let popup = centered_fixed(area, 58, 13);
+    crate::ui::render_popup_background(frame, app, popup);
+    let destructive = modal.action.destructive();
+    let block = Block::default()
+        .title(if destructive {
+            t!(
+                " Confirm playlist deletion ",
+                " 플레이리스트 삭제 확인 ",
+                " プレイリスト削除の確認 "
+            )
+        } else {
+            t!(
+                " Playlist recovery ",
+                " 플레이리스트 복구 ",
+                " プレイリストの復旧 "
+            )
+        })
+        .borders(Borders::ALL)
+        .border_style(
+            crate::ui::popup_style(app, if destructive { R::Error } else { R::Accent })
+                .add_modifier(Modifier::BOLD),
+        )
+        .style(crate::ui::popup_style(app, R::TextPrimary));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Length(4),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+    let (prompt, detail) = copy(modal.action, &modal.name, modal.stage);
+    frame.render_widget(
+        Paragraph::new(prompt)
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: true })
+            .style(crate::ui::popup_style(app, R::TextPrimary).add_modifier(Modifier::BOLD)),
+        rows[0],
+    );
+    frame.render_widget(
+        Paragraph::new(detail)
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: true })
+            .style(crate::ui::popup_style(
+                app,
+                if destructive {
+                    R::Warning
+                } else {
+                    R::TextMuted
+                },
+            )),
+        rows[1],
+    );
+    if modal.stage == Stage::Confirming {
+        let delete_full = t!(" Delete (Enter) ", " 삭제 (Enter) ", " 削除 (Enter) ");
+        let back_full = t!(" Back (Esc) ", " 뒤로 (Esc) ", " 戻る (Esc) ");
+        let full_width = buttons::text_width(delete_full)
+            .saturating_add(2)
+            .saturating_add(buttons::text_width(back_full));
+        let (delete, back) = if full_width <= rows[3].width {
+            (delete_full, back_full)
+        } else {
+            (
+                t!(" Delete ", " 삭제 ", " 削除 "),
+                t!(" Back ", " 뒤로 ", " 戻る "),
+            )
+        };
+        buttons::render_segments(
+            frame,
+            app,
+            rows[3],
+            &[
+                buttons::Seg::button(MouseTarget::ConfirmServerPlaylistRecovery, delete),
+                buttons::Seg::label("  "),
+                buttons::Seg::button(MouseTarget::CancelServerPlaylistRecovery, back),
+            ],
+            crate::ui::popup_style(app, R::Error).add_modifier(Modifier::BOLD),
+            crate::ui::confirm_gap_style(app),
+            Alignment::Center,
+        );
+    } else {
+        buttons::render_segments(
+            frame,
+            app,
+            rows[3],
+            &[buttons::Seg::label(t!(
+                " Applying… ",
+                " 적용 중… ",
+                " 適用中… "
+            ))],
+            crate::ui::popup_style(app, R::TextMuted),
+            crate::ui::confirm_gap_style(app),
+            Alignment::Center,
+        );
+    }
+    crate::ui::seal_popup_background(frame, app, popup);
+    crate::ui::mark_art_rows_for_popup(frame, app, popup);
+}
+
+fn copy(action: Action, name: &str, stage: Stage) -> (String, &'static str) {
+    if stage == Stage::Applying {
+        return (
+            format!(
+                "{}: {name}",
+                t!(
+                    "Updating playlist",
+                    "플레이리스트 업데이트",
+                    "プレイリストを更新"
+                )
+            ),
+            t!(
+                "This window will close when the result is verified.",
+                "결과가 확인되면 이 창이 닫혀요.",
+                "結果を確認するとこの画面は閉じます。"
+            ),
+        );
+    }
+    match action {
+        Action::DeleteBoth => (
+            format!(
+                "{} “{name}”?",
+                t!(
+                    "Delete both copies of",
+                    "두 복사본 모두 삭제:",
+                    "両方のコピーを削除:"
+                )
+            ),
+            t!(
+                "This deletes the local and server playlists and cannot be undone.",
+                "로컬과 서버 목록을 삭제하며 되돌릴 수 없어요.",
+                "ローカルとサーバーの両方を削除し、元に戻せません。"
+            ),
+        ),
+        Action::DeleteLocal => (
+            format!(
+                "{} “{name}”?",
+                t!(
+                    "Delete the local copy of",
+                    "로컬 복사본 삭제:",
+                    "ローカル側を削除:"
+                )
+            ),
+            t!(
+                "Another server copy may exist. This deletes only the local copy and cannot be undone.",
+                "다른 서버 복사본이 있을 수 있어요. 로컬 복사본만 삭제하며 되돌릴 수 없어요.",
+                "別のサーバー側コピーがある場合があります。ローカル側だけを削除し、元に戻せません。"
+            ),
+        ),
+        Action::Restore | Action::UnlinkKeepServer | Action::UnlinkKeepLocal => {
+            (name.to_owned(), t!("Applying…", "적용 중…", "適用中…"))
+        }
+    }
+}
+
+fn centered_fixed(area: Rect, preferred_width: u16, preferred_height: u16) -> Rect {
+    let width = preferred_width.min(area.width.saturating_sub(2).max(1));
+    let height = preferred_height.min(area.height.saturating_sub(2).max(1));
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+    .intersection(area)
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+    use crate::app::ServerPlaylistRecoveryModal;
+    use crate::open_subsonic::ServerPlaylistId;
+    use crate::personal_state::PlaylistId;
+
+    fn recovery_app(action: Action, stage: Stage) -> App {
+        let mut app = App::new(50);
+        app.server.library.playlist_recovery = Some(ServerPlaylistRecoveryModal {
+            generation: 3,
+            action,
+            server_playlist_id: ServerPlaylistId::new("remote").unwrap(),
+            local_playlist_id: PlaylistId::new("local").unwrap(),
+            name: "Road Trip".to_owned(),
+            stage,
+        });
+        app
+    }
+
+    fn draw(app: &App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app, frame.area()))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn destructive_recovery_modal_is_complete_at_thirty_by_thirty_in_all_languages() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for (language, delete, back) in [
+            (crate::i18n::Language::English, "Delete", "Back"),
+            (crate::i18n::Language::Korean, "삭제", "뒤로"),
+            (crate::i18n::Language::Japanese, "削除", "戻る"),
+        ] {
+            crate::i18n::set_language(language);
+            let app = recovery_app(Action::DeleteBoth, Stage::Confirming);
+            let text = draw(&app, 30, 30);
+            let comparable: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
+            let delete: String = delete.chars().filter(|ch| !ch.is_whitespace()).collect();
+            let back: String = back.chars().filter(|ch| !ch.is_whitespace()).collect();
+            assert!(
+                comparable.contains("Road") && comparable.contains("Trip"),
+                "{language:?}: {text:?}"
+            );
+            assert!(comparable.contains(&delete), "{language:?}: {text:?}");
+            assert!(comparable.contains(&back), "{language:?}: {text:?}");
+            for (target, expected_width) in [
+                (
+                    MouseTarget::ConfirmServerPlaylistRecovery,
+                    buttons::text_width(t!(" Delete ", " 삭제 ", " 削除 ")),
+                ),
+                (
+                    MouseTarget::CancelServerPlaylistRecovery,
+                    buttons::text_width(t!(" Back ", " 뒤로 ", " 戻る ")),
+                ),
+            ] {
+                let rect = app.hits.rect_of_target(target).expect("recovery action");
+                assert_eq!(rect.width, expected_width);
+                assert!(rect.right() <= 30);
+                assert!(rect.bottom() <= 30);
+            }
+        }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn applying_recovery_has_no_cancellable_mouse_target_at_thirty_by_thirty() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        crate::i18n::set_language(crate::i18n::Language::English);
+        let app = recovery_app(Action::DeleteLocal, Stage::Applying);
+        let text = draw(&app, 30, 30);
+        let comparable: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
+        assert!(comparable.contains("Road") && comparable.contains("Trip"));
+        assert!(comparable.contains("Applying"));
+        assert!(
+            app.hits
+                .rect_of_target(MouseTarget::ConfirmServerPlaylistRecovery)
+                .is_none()
+        );
+        assert!(
+            app.hits
+                .rect_of_target(MouseTarget::CancelServerPlaylistRecovery)
+                .is_none()
+        );
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn delete_local_warning_is_complete_at_thirty_by_thirty_in_every_language() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for (language, expected) in [
+            (
+                crate::i18n::Language::English,
+                [
+                    "Anotherservercopymayexist",
+                    "onlythelocalcopy",
+                    "cannotbeundone",
+                ],
+            ),
+            (
+                crate::i18n::Language::Korean,
+                ["다른서버복사본", "로컬복사본만", "되돌릴수없"],
+            ),
+            (
+                crate::i18n::Language::Japanese,
+                ["別のサーバー側コピー", "ローカル側だけ", "元に戻せません"],
+            ),
+        ] {
+            crate::i18n::set_language(language);
+            let app = recovery_app(Action::DeleteLocal, Stage::Confirming);
+            let text = draw(&app, 30, 30);
+            let comparable: String = text
+                .chars()
+                .filter(|ch| !ch.is_whitespace() && *ch != '│')
+                .collect();
+            for phrase in expected {
+                assert!(comparable.contains(phrase), "{language:?}: {text:?}");
+            }
+            assert!(
+                app.hits
+                    .rect_of_target(MouseTarget::ConfirmServerPlaylistRecovery)
+                    .is_some()
+            );
+            assert!(
+                app.hits
+                    .rect_of_target(MouseTarget::CancelServerPlaylistRecovery)
+                    .is_some()
+            );
+        }
+        crate::i18n::set_language(original);
+    }
+}

--- a/src/ui/views/settings/music_server.rs
+++ b/src/ui/views/settings/music_server.rs
@@ -11,6 +11,7 @@ use crate::app::{
     App, MouseTarget, MusicServerBusy, MusicServerCredentialMode, MusicServerHealth,
     MusicServerHistoryHealth, MusicServerSetupField, MusicServerWizard, SyncArea,
 };
+use crate::open_subsonic::{PlaylistCreateAttention, PlaylistCreateRecoveryState};
 use crate::settings::SettingsState;
 use crate::settings::sync::health_label;
 use crate::t;
@@ -124,7 +125,18 @@ pub(crate) fn render_status(frame: &mut Frame, app: &App, settings: &SettingsSta
         ])),
         rows[2],
     );
-    let server_detail = if server.playback_reports_needing_decision > 0 {
+    let server_detail = if server.playlist_creates_needing_decision > 0 {
+        playlist_create_attention_detail(
+            server.playlist_creates_needing_decision,
+            &server.playlist_create_attention,
+        )
+    } else if server.playlist_links_needing_decision > 0 {
+        playlist_link_attention_detail(server.playlist_links_needing_decision)
+    } else if server.playlist_contents_needing_decision > 0 {
+        playlist_content_attention_detail(server.playlist_contents_needing_decision)
+    } else if server.playlist_projections_needing_decision > 0 {
+        playlist_projection_attention_detail(server.playlist_projections_needing_decision)
+    } else if server.playback_reports_needing_decision > 0 {
         playback_report_attention_detail(server.playback_reports_needing_decision)
     } else if server.configured {
         t!(
@@ -143,13 +155,18 @@ pub(crate) fn render_status(frame: &mut Frame, app: &App, settings: &SettingsSta
     };
     frame.render_widget(
         Paragraph::new(server_detail)
-            .style(
-                theme.style(if server.playback_reports_needing_decision > 0 {
+            .style(theme.style(
+                if server.playback_reports_needing_decision > 0
+                    || server.playlist_creates_needing_decision > 0
+                    || server.playlist_links_needing_decision > 0
+                    || server.playlist_contents_needing_decision > 0
+                    || server.playlist_projections_needing_decision > 0
+                {
                     R::Error
                 } else {
                     R::TextMuted
-                }),
-            )
+                },
+            ))
             .wrap(Wrap { trim: true }),
         rows[3],
     );
@@ -193,7 +210,18 @@ pub(crate) fn render_music_server(
     );
     let detail = app.server.settings.failure.map_or_else(
         || {
-            if summary.playback_reports_needing_decision > 0 {
+            if summary.playlist_creates_needing_decision > 0 {
+                playlist_create_attention_detail(
+                    summary.playlist_creates_needing_decision,
+                    &summary.playlist_create_attention,
+                )
+            } else if summary.playlist_links_needing_decision > 0 {
+                playlist_link_attention_detail(summary.playlist_links_needing_decision)
+            } else if summary.playlist_contents_needing_decision > 0 {
+                playlist_content_attention_detail(summary.playlist_contents_needing_decision)
+            } else if summary.playlist_projections_needing_decision > 0 {
+                playlist_projection_attention_detail(summary.playlist_projections_needing_decision)
+            } else if summary.playback_reports_needing_decision > 0 {
                 playback_report_attention_detail(summary.playback_reports_needing_decision)
             } else if summary.configured {
                 let auth = summary
@@ -221,8 +249,12 @@ pub(crate) fn render_music_server(
         },
         |failure| format!("{}  ·  {}", failure.label(), failure.recovery_label()),
     );
-    let detail_is_error =
-        app.server.settings.failure.is_some() || summary.playback_reports_needing_decision > 0;
+    let detail_is_error = app.server.settings.failure.is_some()
+        || summary.playback_reports_needing_decision > 0
+        || summary.playlist_creates_needing_decision > 0
+        || summary.playlist_links_needing_decision > 0
+        || summary.playlist_contents_needing_decision > 0
+        || summary.playlist_projections_needing_decision > 0;
     frame.render_widget(
         Paragraph::new(detail)
             .style(theme.style(if detail_is_error {
@@ -234,13 +266,24 @@ pub(crate) fn render_music_server(
         rows[1],
     );
 
-    let labels: Vec<&str> = if summary.configured {
-        vec![
-            t!("Test connection", "연결 테스트", "接続テスト"),
-            t!("Edit connection", "연결 정보 수정", "接続情報を編集"),
-            history_action_label(summary.history),
-            t!("Remove server", "서버 제거", "サーバーを削除"),
-        ]
+    let labels: Vec<String> = if summary.configured {
+        let mut labels = vec![
+            t!("Test connection", "연결 테스트", "接続テスト").to_owned(),
+            t!("Edit connection", "연결 정보 수정", "接続情報を編集").to_owned(),
+            history_action_label(summary.history).to_owned(),
+        ];
+        if !summary.playlist_create_attention.is_empty() {
+            labels.push(
+                t!(
+                    "Review pending create",
+                    "보류 생성 확인",
+                    "保留中の作成を確認"
+                )
+                .to_owned(),
+            );
+        }
+        labels.push(t!("Remove server", "서버 제거", "サーバーを削除").to_owned());
+        labels
     } else {
         vec![
             t!(
@@ -250,6 +293,9 @@ pub(crate) fn render_music_server(
             ),
             t!("Check again", "다시 확인", "再確認"),
         ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect()
     };
     for (index, label) in labels.iter().enumerate().take(rows[2].height as usize) {
         let selected = index == app.server.settings.selected;
@@ -288,6 +334,84 @@ fn playback_report_attention_detail(count: usize) -> String {
             format!("{count} reports need a decision.\nytt server scrobbles list"),
             format!("재생 보고 {count}건 확인 필요\nytt server scrobbles list"),
             format!("再生レポート{count}件・確認が必要\nytt server scrobbles list")
+        )
+    }
+}
+
+fn playlist_create_attention_detail(count: usize, attention: &[PlaylistCreateAttention]) -> String {
+    let summary = if count == 1 {
+        t!(
+            "Review 1 playlist creation",
+            "플레이리스트 생성 1건 확인",
+            "プレイリスト作成1件を確認"
+        )
+        .to_owned()
+    } else {
+        t!(
+            format!("Review {count} playlist creations"),
+            format!("플레이리스트 생성 {count}건 확인"),
+            format!("プレイリスト作成{count}件を確認")
+        )
+    };
+    attention.first().map_or_else(
+        || format!("{summary}\nytt server playlists pending"),
+        |pending| {
+            format!(
+                "{summary}\n{}: {}",
+                t!("Local ID", "로컬 ID", "ローカルID"),
+                pending.local_playlist_id.as_str()
+            )
+        },
+    )
+}
+
+fn playlist_projection_attention_detail(count: usize) -> String {
+    if count == 1 {
+        t!(
+            "1 playlist update needs a reconnect\nEdit connection to retry",
+            "플레이리스트 업데이트 1건 재연결 필요\n연결 정보를 수정해 다시 시도",
+            "プレイリスト更新1件・再接続が必要\n接続を編集して再試行"
+        )
+        .to_owned()
+    } else {
+        t!(
+            format!("{count} playlist updates need a reconnect\nEdit connection to retry"),
+            format!("플레이리스트 업데이트 {count}건 재연결 필요\n연결 정보를 수정해 다시 시도"),
+            format!("プレイリスト更新{count}件・再接続が必要\n接続を編集して再試行")
+        )
+    }
+}
+
+fn playlist_content_attention_detail(count: usize) -> String {
+    if count == 1 {
+        t!(
+            "Mixed tracks: 1 linked list\nReview in Server Library",
+            "다른 출처 곡: 연결 목록 1개\n서버 보관함에서 확인",
+            "別の曲あり：連携リスト1件\nサーバーライブラリで確認"
+        )
+        .to_owned()
+    } else {
+        t!(
+            format!("Mixed tracks: {count} linked lists\nReview in Server Library"),
+            format!("다른 출처 곡: 연결 목록 {count}개\n서버 보관함에서 확인"),
+            format!("別の曲あり：連携リスト{count}件\nサーバーライブラリで確認")
+        )
+    }
+}
+
+fn playlist_link_attention_detail(count: usize) -> String {
+    if count == 1 {
+        t!(
+            "1 server playlist is missing\nLibrary: choose what to keep",
+            "서버 목록 1개가 사라짐\n보관함: 남길 항목 선택",
+            "サーバー側で1件消失\nライブラリ：残すものを選択"
+        )
+        .to_owned()
+    } else {
+        t!(
+            format!("{count} server playlists are missing\nLibrary: choose what to keep"),
+            format!("서버 목록 {count}개가 사라짐\n보관함: 남길 항목 선택"),
+            format!("サーバー側で{count}件消失\nライブラリ：残すものを選択")
         )
     }
 }
@@ -357,6 +481,7 @@ pub(crate) fn render_music_server_wizard(frame: &mut Frame, app: &App, area: Rec
         64,
         match wizard {
             MusicServerWizard::Setup(_) => 16,
+            MusicServerWizard::AbandonPlaylistCreateConfirm(_) => 13,
             MusicServerWizard::Waiting | MusicServerWizard::RemoveConfirm => 8,
         },
     );
@@ -387,6 +512,14 @@ pub(crate) fn render_music_server_wizard(frame: &mut Frame, app: &App, area: Rec
                 Some(MusicServerBusy::Removing) => {
                     (t!("Removing…", "제거하는 중…", "削除しています…"), false)
                 }
+                Some(MusicServerBusy::PlaylistRecovery) => (
+                    t!(
+                        "Forgetting the pending create…",
+                        "보류 중인 생성을 잊는 중…",
+                        "保留中の作成を破棄しています…"
+                    ),
+                    false,
+                ),
                 _ => (t!("Working…", "처리 중…", "処理中…"), true),
             };
             let detail = if cancel_allowed {
@@ -439,6 +572,100 @@ pub(crate) fn render_music_server_wizard(frame: &mut Frame, app: &App, area: Rec
                 },
                 MouseTarget::MusicServerWizardSecondary,
             );
+        }
+        MusicServerWizard::AbandonPlaylistCreateConfirm(attention) => {
+            let state = playlist_create_recovery_state_label(attention.state);
+            let rows = Layout::vertical([
+                Constraint::Length(2),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(3),
+                Constraint::Min(0),
+                Constraint::Length(1),
+            ])
+            .split(inner);
+            frame.render_widget(
+                Paragraph::new(t!(
+                    "A server copy may already exist.",
+                    "서버 복사본이 이미 있을 수 있어요.",
+                    "サーバーにコピーが既に存在する場合があります。"
+                ))
+                .alignment(Alignment::Center)
+                .wrap(Wrap { trim: true })
+                .style(app.theme.style(R::Warning).add_modifier(Modifier::BOLD)),
+                rows[0],
+            );
+            frame.render_widget(
+                Paragraph::new(playlist_create_local_id_line(attention, rows[1].width))
+                    .alignment(Alignment::Center)
+                    .style(app.theme.style(R::TextPrimary)),
+                rows[1],
+            );
+            frame.render_widget(
+                Paragraph::new(crate::ui::text::truncate_owned_to_width(
+                    format!("{}: {state}", t!("State", "상태", "状態")),
+                    usize::from(rows[2].width),
+                ))
+                .alignment(Alignment::Center)
+                .style(app.theme.style(R::TextMuted)),
+                rows[2],
+            );
+            frame.render_widget(
+                Paragraph::new(t!(
+                    "Forget only the retry guard. Neither copy is deleted.",
+                    "재시도 보호만 잊으며 어느 복사본도 삭제하지 않아요.",
+                    "再試行ガードだけを破棄し、どちらのコピーも削除しません。"
+                ))
+                .alignment(Alignment::Center)
+                .wrap(Wrap { trim: true })
+                .style(app.theme.style(R::TextMuted)),
+                rows[3],
+            );
+
+            let forget_full = t!(" Enter: Forget ", " Enter: 잊기 ", " Enter: 破棄 ");
+            let back_full = t!(" Esc: Back ", " Esc: 뒤로 ", " Esc: 戻る ");
+            let full_width = buttons::text_width(forget_full)
+                .saturating_add(2)
+                .saturating_add(buttons::text_width(back_full));
+            let (forget, back) = if full_width <= rows[5].width {
+                (forget_full, back_full)
+            } else {
+                (
+                    t!(" Forget ", " 잊기 ", " 破棄 "),
+                    t!(" Back ", " 뒤로 ", " 戻る "),
+                )
+            };
+            buttons::render_segments(
+                frame,
+                app,
+                rows[5],
+                &[
+                    buttons::Seg::button(MouseTarget::MusicServerWizardPrimary, forget),
+                    buttons::Seg::label("  "),
+                    buttons::Seg::button(MouseTarget::MusicServerWizardSecondary, back),
+                ],
+                app.theme.style(R::Warning).add_modifier(Modifier::BOLD),
+                crate::ui::confirm_gap_style(app),
+                Alignment::Center,
+            );
+        }
+    }
+}
+
+fn playlist_create_local_id_line(attention: &PlaylistCreateAttention, width: u16) -> String {
+    let label = t!("Local ID: ", "로컬 ID: ", "ローカルID: ");
+    let available = usize::from(width).saturating_sub(usize::from(buttons::text_width(label)));
+    let id = crate::ui::text::middle_to_width(attention.local_playlist_id.as_str(), available);
+    crate::ui::text::truncate_owned_to_width(format!("{label}{id}"), usize::from(width))
+}
+
+fn playlist_create_recovery_state_label(state: PlaylistCreateRecoveryState) -> &'static str {
+    match state {
+        PlaylistCreateRecoveryState::ServerIdentityUnknown => {
+            t!("server ID unknown", "서버 ID 미확인", "サーバーID不明")
+        }
+        PlaylistCreateRecoveryState::ReadbackNeeded => {
+            t!("readback needed", "재조회 필요", "再取得が必要")
         }
     }
 }
@@ -753,6 +980,175 @@ mod tests {
             let detail = playback_report_attention_detail(2);
             assert_eq!(detail, expected);
             assert!(detail.lines().all(|line| buttons::text_width(line) <= 30));
+        }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn playlist_create_attention_copy_is_localized_and_fits_narrow_layout() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for (language, expected) in [
+            (
+                crate::i18n::Language::English,
+                "Review 2 playlist creations\nLocal ID: local-a",
+            ),
+            (
+                crate::i18n::Language::Korean,
+                "플레이리스트 생성 2건 확인\n로컬 ID: local-a",
+            ),
+            (
+                crate::i18n::Language::Japanese,
+                "プレイリスト作成2件を確認\nローカルID: local-a",
+            ),
+        ] {
+            crate::i18n::set_language(language);
+            let attention = vec![PlaylistCreateAttention {
+                local_playlist_id: crate::personal_state::PlaylistId::new("local-a").unwrap(),
+                state: PlaylistCreateRecoveryState::ServerIdentityUnknown,
+            }];
+            let detail = playlist_create_attention_detail(2, &attention);
+            assert_eq!(detail, expected);
+            assert!(detail.lines().all(|line| buttons::text_width(line) <= 30));
+        }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn missing_playlist_copy_is_localized_and_asks_what_to_keep() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for (language, expected, reconnect_word) in [
+            (
+                crate::i18n::Language::English,
+                "2 server playlists are missing\nLibrary: choose what to keep",
+                "reconnect",
+            ),
+            (
+                crate::i18n::Language::Korean,
+                "서버 목록 2개가 사라짐\n보관함: 남길 항목 선택",
+                "재연결",
+            ),
+            (
+                crate::i18n::Language::Japanese,
+                "サーバー側で2件消失\nライブラリ：残すものを選択",
+                "再接続",
+            ),
+        ] {
+            crate::i18n::set_language(language);
+            let detail = playlist_link_attention_detail(2);
+            assert_eq!(detail, expected);
+            assert!(!detail.contains(reconnect_word));
+            assert!(detail.lines().all(|line| buttons::text_width(line) <= 30));
+        }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn playlist_create_abandon_confirmation_warns_and_exposes_the_local_id() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        for (language, warning, action) in [
+            (crate::i18n::Language::English, "mayalreadyexist", "Forget"),
+            (crate::i18n::Language::Korean, "이미있을수", "잊기"),
+            (crate::i18n::Language::Japanese, "既に存在する場合", "破棄"),
+        ] {
+            crate::i18n::set_language(language);
+            let mut app = App::new(50);
+            app.server.settings.wizard = Some(MusicServerWizard::AbandonPlaylistCreateConfirm(
+                PlaylistCreateAttention {
+                    local_playlist_id: crate::personal_state::PlaylistId::new("local-a").unwrap(),
+                    state: PlaylistCreateRecoveryState::ServerIdentityUnknown,
+                },
+            ));
+            let text = draw_wizard(&app, 30, 30);
+            let comparable: String = text
+                .chars()
+                .filter(|ch| ch.is_alphanumeric() || *ch == '-')
+                .collect();
+            assert!(comparable.contains("local-a"), "{language:?}: {text:?}");
+            assert!(comparable.contains(warning), "{language:?}: {text:?}");
+            assert!(comparable.contains(action), "{language:?}: {text:?}");
+            assert!(
+                comparable.contains("Enter") && comparable.contains("Esc"),
+                "{language:?}: {text:?}"
+            );
+            let forget = app
+                .hits
+                .rect_of_target(MouseTarget::MusicServerWizardPrimary)
+                .expect("visible Forget button");
+            let back = app
+                .hits
+                .rect_of_target(MouseTarget::MusicServerWizardSecondary)
+                .expect("visible Back button");
+            assert_eq!(forget.height, 1, "{language:?}: {forget:?}");
+            assert_eq!(back.height, 1, "{language:?}: {back:?}");
+            assert_eq!(forget.y, back.y, "{language:?}");
+        }
+        crate::i18n::set_language(original);
+    }
+
+    #[test]
+    fn maximum_local_id_keeps_both_ends_without_hiding_narrow_recovery_controls() {
+        let _guard = crate::i18n::lock_for_test();
+        let original = crate::i18n::current();
+        let local_id = format!("head-{}-tail", "x".repeat(502));
+        assert_eq!(local_id.chars().count(), 512);
+
+        for (language, warning, safety, action) in [
+            (
+                crate::i18n::Language::English,
+                "mayalreadyexist",
+                "Neithercopyisdeleted",
+                "Forget",
+            ),
+            (
+                crate::i18n::Language::Korean,
+                "이미있을수",
+                "어느복사본도삭제하지않아요",
+                "잊기",
+            ),
+            (
+                crate::i18n::Language::Japanese,
+                "既に存在する場合",
+                "どちらのコピーも削除しません",
+                "破棄",
+            ),
+        ] {
+            crate::i18n::set_language(language);
+            let mut app = App::new(50);
+            app.server.settings.wizard = Some(MusicServerWizard::AbandonPlaylistCreateConfirm(
+                PlaylistCreateAttention {
+                    local_playlist_id: crate::personal_state::PlaylistId::new(local_id.clone())
+                        .unwrap(),
+                    state: PlaylistCreateRecoveryState::ReadbackNeeded,
+                },
+            ));
+
+            let text = draw_wizard(&app, 30, 30);
+            let comparable: String = text
+                .chars()
+                .filter(|character| character.is_alphanumeric() || *character == '-')
+                .collect();
+            for expected in ["head-", "-tail", warning, safety, action, "Enter", "Esc"] {
+                assert!(
+                    comparable.contains(expected),
+                    "{language:?}, missing {expected:?}: {text:?}"
+                );
+            }
+            assert!(text.contains('…'), "{language:?}: {text:?}");
+
+            let forget = app
+                .hits
+                .rect_of_target(MouseTarget::MusicServerWizardPrimary)
+                .expect("visible Forget button");
+            let back = app
+                .hits
+                .rect_of_target(MouseTarget::MusicServerWizardSecondary)
+                .expect("visible Back button");
+            assert_eq!(forget.height, 1, "{language:?}: {forget:?}");
+            assert_eq!(back.height, 1, "{language:?}: {back:?}");
+            assert_eq!(forget.y, back.y, "{language:?}");
         }
         crate::i18n::set_language(original);
     }


### PR DESCRIPTION
Part of #114 — PR 8 of the cross-device/server integration series.

## What changed

- Exposes OpenSubsonic playlists as `Server`, `Linked`, or `Read-only` using exact owner and readonly evidence.
- Adds explicit `Import a copy` and `Link and sync` flows with deletion-free previews; playlist names never create links implicitly.
- Preserves exact occurrences and duplicate tracks with stable playlist/entry identities, and deterministically merges concurrent add/remove/move/rename changes through Personal State v2.
- Adds durable server shadows, pending projections, full readback verification, ambiguous-create recovery, and stale-owner guards so retries cannot resurrect deleted local playlists.
- Adds explicit unlink/delete/missing-server recovery choices and local-to-server creation with destructive confirmation where required.
- Adds TUI, CLI status/recovery, mouse/keyboard, narrow-layout, and English/Korean/Japanese coverage.

## Safety and behavior

- Only playlists explicitly created or linked by the user are modified.
- Read-only, foreign-owner, and owner-unknown playlists remain non-mutable.
- Initial linking is deletion-free and reports additions before apply.
- Server writes are verified by full readback; replay-unsafe or ambiguous operations remain durable and actionable.
- Secondary instances remain observational and cannot apply mutations.

## Validation

- `nix develop --command cargo fmt --all --check`
- `nix develop --command cargo clippy --workspace --all-targets -- -D warnings`
- `nix develop --command cargo test --workspace`
- `nix develop --command ~/.fable-harness/bin/run-gates .`
- Isolated `verify` tmux run with temporary HOME/XDG/YTM roots and a loopback fake OpenSubsonic server at 80×24 and 30×30; no playback or real credentials were used.
