### PR TITLE
fix(windows): accept the administrators owner on owner-only private files

### DIFF
--- a/src/data_export/windows_private.rs
+++ b/src/data_export/windows_private.rs
@@ -582,19 +582,27 @@ fn verify_private_dacl(file: &File, expected_sid: PSID) -> io::Result<()> {
         ));
     }
     if owner.is_null() {
-        return Err(invalid_acl(
-            "private file is not owned by the current account",
-        ));
+        return Err(invalid_acl("private file has no owner"));
     }
     // SAFETY: `owner` points inside the live descriptor and was checked for null above.
     if unsafe { IsValidSid(owner) } == 0 {
-        return Err(invalid_acl(
-            "private file is not owned by the current account",
-        ));
+        return Err(invalid_acl("private file has an invalid owner SID"));
     }
-    // SAFETY: `owner` is a valid SID in the live descriptor, and `expected_sid` is the valid
-    // current-account SID retained by the caller for the duration of this check.
-    if unsafe { EqualSid(owner, expected_sid) } == 0 {
+    // Confidentiality comes from the protected single-ACE DACL verified below, not from the owner.
+    // `apply_private_dacl` deliberately passes a null owner to `SetSecurityInfo`, so the file keeps
+    // whatever owner Windows assigned at creation. Under the default "System objects: Default owner
+    // for objects created by members of the Administrators group" policy that owner is
+    // BUILTIN\Administrators, not the creating account, so demanding an exact match rejected files
+    // this process had just created. Accept the same two owners `verify_private_destination_chain`
+    // already accepts for the directories above this file; any other owner means the file was not
+    // created by this account and is still refused.
+    let administrators = well_known_sid(WinBuiltinAdministratorsSid)?;
+    // SAFETY: `owner` is a valid SID inside the live descriptor, `expected_sid` is the caller's
+    // valid current-account SID, and `administrators` stays live across both comparisons.
+    let owner_is_acceptable = unsafe {
+        EqualSid(owner, expected_sid) != 0 || EqualSid(owner, administrators.as_ptr()) != 0
+    };
+    if !owner_is_acceptable {
         return Err(invalid_acl(
             "private file is not owned by the current account",
         ));


### PR DESCRIPTION
## The bug

`verify_private_dacl` rejects files this process just created, so **every owner-only write and read fails on Windows**. The encrypted sync vault cannot write its own files. On current `main`, 182 tests fail on Windows (surfaced by #124).

## Why it is a regression, not a latent gap

The owner check did not exist at `v1.6.36`:

```console
$ git show v1.6.36:src/data_export/windows_private.rs | grep -c 'not owned by the current account'
0
```

`v1.6.36` requested only `DACL_SECURITY_INFORMATION` and verified the DACL alone. Windows tests passed. Commit `63715508 fix Windows ACL safety checks` added `OWNER_SECURITY_INFORMATION` plus an exact `EqualSid(owner, current_user)` match.

That commit could not be executed on Windows — the self-hosted job is label-gated and was skipped on every PR in that batch, and the always-on hosted job only compiled — so it introduced a contradiction with code sitting ~50 lines above it:

`apply_private_dacl` deliberately does not set an owner:

```rust
// SAFETY: ... Owner/group/SACL are intentionally unchanged via null pointers.
SetSecurityInfo(handle, SE_FILE_OBJECT,
    DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
    null_mut(),   // <- owner
    null_mut(), dacl, null())
```

Under the default *"System objects: Default owner for objects created by members of the Administrators group"* policy, a file created by a member of Administrators is owned by `BUILTIN\Administrators`, not the creating account. **The code asserted an owner it never set**, and the two disagree for any administrator account.

## The fix

Accept the current user **or** `BUILTIN\Administrators` — the same rule `verify_private_destination_chain` already applies to every directory above the file, per its own doc comment:

> Owners and dangerous writers are limited to the current user, LocalSystem, **Administrators**, and the exact Windows Modules Installer (TrustedInstaller) service SID.

Any other owner is still refused. The two null/invalid-owner branches now carry their own messages rather than all three blaming the same wrong cause.

## Why this does not weaken confidentiality

The guarantee comes from the DACL, which is **unchanged and still verified in full**: present, protected (non-inheritable), exactly one explicit `ACCESS_ALLOWED` ACE granting `FILE_ALL_ACCESS` to the current user and nobody else. Ownership does not grant read access. An administrator can take ownership of any file regardless, so requiring an exact owner match never stopped an attacker it could otherwise stop — it only stopped the program itself.

Considered and rejected: setting the owner explicitly at creation (`OWNER_SECURITY_INFORMATION` + `WRITE_OWNER`). It would keep the strict assertion, but it changes the creation path and adds failure modes in code that still cannot be runtime-tested here. Worth revisiting once Windows CI is trustworthy.

## Verification — read this before merging

| | |
|---|---|
| `cargo clippy --target x86_64-pc-windows-msvc --lib --all-targets -- -D warnings` | **clean** |
| `cargo fmt --all --check` | clean |
| architecture / file-size / doc-honesty / unsafe-inventory gates | pass |
| **Runtime behaviour on Windows** | **NOT verified** |

The cross-target lint matters here because this file is `#![cfg(windows)]` and is invisible to every host lint — that is the same blind spot that let the bug in. But it proves only that the code compiles and that the `unsafe` blocks satisfy `undocumented_unsafe_blocks`.

I cannot execute this on Windows. Branched from `main` as requested, so this PR gets the current compile-only Windows gate. To actually confirm the 182 failures clear, either:

- add the `ci:windows` label to this PR (runs the self-hosted Windows suite, if that machine is on), or
- merge #124 first, which makes the always-on hosted Windows job run the suite.

## Expected scope

Failure clusters from #124's Windows run, with what this should address:

| Count | Failure | Expected |
|---|---|---|
| 96 | `StorageUnavailable` | fixed (downstream of the owner check) |
| 39 | `StorageFailed` | fixed (downstream) |
| 12 | `PermissionDenied: private file is not owned...` | fixed (direct) |
| 10 | `create: StorageFailed` | fixed (downstream) |
| 8 | `RemoteUnavailable` | likely fixed (downstream) |
| 7 | `RecoveryKitNotConfirmed` | likely fixed (downstream) |
| 1–2 | `sync::webdav::tls_tests::custom_ca_...` | **not fixed** — separate custom-CA/TLS defect, also fails on macOS |

The downstream attribution is a hypothesis, supported by `util::safe_fs::owner_only::platform::{create,validate}` routing every owner-only file operation through `verify_current_user_private_file`. CI has to confirm it. If failures remain after this, they are separate bugs.