### PR TITLE
[verification only — do not merge] #127 + #128 combined Windows run

### DIFF
--- a/src/data_export/windows_private.rs
+++ b/src/data_export/windows_private.rs
@@ -582,19 +582,27 @@ fn verify_private_dacl(file: &File, expected_sid: PSID) -> io::Result<()> {
         ));
     }
     if owner.is_null() {
-        return Err(invalid_acl(
-            "private file is not owned by the current account",
-        ));
+        return Err(invalid_acl("private file has no owner"));
     }
     // SAFETY: `owner` points inside the live descriptor and was checked for null above.
     if unsafe { IsValidSid(owner) } == 0 {
-        return Err(invalid_acl(
-            "private file is not owned by the current account",
-        ));
+        return Err(invalid_acl("private file has an invalid owner SID"));
     }
-    // SAFETY: `owner` is a valid SID in the live descriptor, and `expected_sid` is the valid
-    // current-account SID retained by the caller for the duration of this check.
-    if unsafe { EqualSid(owner, expected_sid) } == 0 {
+    // Confidentiality comes from the protected single-ACE DACL verified below, not from the owner.
+    // `apply_private_dacl` deliberately passes a null owner to `SetSecurityInfo`, so the file keeps
+    // whatever owner Windows assigned at creation. Under the default "System objects: Default owner
+    // for objects created by members of the Administrators group" policy that owner is
+    // BUILTIN\Administrators, not the creating account, so demanding an exact match rejected files
+    // this process had just created. Accept the same two owners `verify_private_destination_chain`
+    // already accepts for the directories above this file; any other owner means the file was not
+    // created by this account and is still refused.
+    let administrators = well_known_sid(WinBuiltinAdministratorsSid)?;
+    // SAFETY: `owner` is a valid SID inside the live descriptor, `expected_sid` is the caller's
+    // valid current-account SID, and `administrators` stays live across both comparisons.
+    let owner_is_acceptable = unsafe {
+        EqualSid(owner, expected_sid) != 0 || EqualSid(owner, administrators.as_ptr()) != 0
+    };
+    if !owner_is_acceptable {
         return Err(invalid_acl(
             "private file is not owned by the current account",
         ));

--- a/src/sync/webdav/tls_tests.rs
+++ b/src/sync/webdav/tls_tests.rs
@@ -140,10 +140,15 @@ fn spawn_tls_server(expect_handshake: bool) -> (String, thread::JoinHandle<()>) 
             .unwrap();
         let result = acceptor.accept(stream);
         if !expect_handshake {
-            assert!(
-                result.is_err(),
-                "untrusted client unexpectedly completed TLS"
-            );
+            // Only the client's verdict is the contract here, and the caller asserts it
+            // (`WebDavError::CertificateFailed`). The server's own view is deliberately not
+            // asserted: under TLS 1.3 the server side is complete once it has sent Finished, so a
+            // client that rejects the certificate afterwards leaves this `accept` returning Ok and
+            // the rejection arrives as a later alert. SChannel on Windows does exactly that, while
+            // OpenSSL and Security.framework surface the client's abort as a handshake error.
+            // Asserting either outcome would pin a platform quirk rather than the behaviour under
+            // test. Dropping the result closes the connection on both paths.
+            drop(result);
             return;
         }
         let mut stream = result.expect("trusted client completes TLS");

--- a/src/sync/webdav/tls_tests.rs
+++ b/src/sync/webdav/tls_tests.rs
@@ -8,66 +8,114 @@ use base64::Engine as _;
 
 use super::*;
 
-pub(crate) const TEST_CA_PEM: &[u8] = br#"-----BEGIN CERTIFICATE-----
-MIIDPzCCAiegAwIBAgIUKGG2gqPOpWoVM6pSyPG7XiRVakswDQYJKoZIhvcNAQEL
-BQAwITEfMB0GA1UEAwwWWXV0dXR1aSBXZWJEQVYgVGVzdCBDQTAeFw0yNjA3MjQx
-NzMwNDFaFw0zNjA3MjExNzMwNDFaMCExHzAdBgNVBAMMFll1dHV0dWkgV2ViREFW
-IFRlc3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8oPKemgzH
-0d1vDoobLOSHE/gKS2mIG2eAFVbIJGWlSyKVsMca0VUCvlJQwldk4DnmmQizLF3Y
-bjnGB/2+2wBhg/BzGN+gR27KsCrCJS52pfOFkaOqfcWM3QJvfQbLmRZvyWNhy9q8
-FI26+cyqD4Hy9HvroiSmkQUmsNofu/gvrhB9G17eVtKdVLlKGku8njR+ufnSc6X+
-ZYFi715ecqORk3cc7TGZJBwqW5x/npNzEbPFQwWM02Hw/kctDnZGoC9dYKqFlk67
-I/hCEoojrFBBF+gB7pVGVdrw2R5R1KnFbZ/gLF+BaG73MLUwFfxTPV0UMoE1xfq7
-GQ0q8UoJNtxFAgMBAAGjbzBtMB0GA1UdDgQWBBQ4tEQ5cKWqwMOM7HVO/R9GYadK
-MDAfBgNVHSMEGDAWgBQ4tEQ5cKWqwMOM7HVO/R9GYadKMDAaBgNVHREEEzARhwR/
-AAABgglsb2NhbGhvc3QwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC
-AQEAGgF/DjvE5/YB8efdorH5CLZxBVQUObCU6wRKHcAU0xnAeI/Kwoz3fFB8duww
-rpsmjcFjZ3dn2k5jj4pkwmV3luzFf3L6IvQbCTQVQNOCGUVetZbVRicN5ksnnAGB
-OPMLheVNlKwMqAOBfG4xXTroycdGaOxFradaF2CCjYC7qlNz0btY+b82bjAFc1Dd
-3Thkrtr/narY1WiHpKoRycmowGEr5TgeYVGuuojsDP4Z21c2AOTxBlRp0t4teyZj
-CPgnDFOFsAJFyCozkgGosm8YZtBU/Tl9/ecL7r+/X6bAEoqzjyhNDVuvJP/aSrow
-KC23wFROeGlz9YHrMW/dbXm5xA==
+/// Test PKI for the loopback TLS server below.
+///
+/// The server certificate is a LEAF issued by this CA — not the CA itself. That distinction is
+/// load-bearing. The previous fixture presented the self-signed CA as the server certificate,
+/// with `CA:TRUE`, no `extendedKeyUsage`, and a ten-year validity. OpenSSL accepts that, so the
+/// test passed on Linux, while Security.framework on macOS and SChannel on Windows both rejected
+/// it — making a working product path look like a custom-CA bug on two of three platforms.
+///
+/// A replacement must keep all four properties the platform verifiers require of a server
+/// certificate: `CA:FALSE`, `extendedKeyUsage=serverAuth`, a subjectAltName (macOS ignores CN),
+/// and a validity of 825 days or fewer (Apple's limit for certificates issued after 2020-09-01).
+///
+/// The pinned leaf expires **2028-10-23**; the CA expires 2036-07-23. When the leaf lapses this
+/// test starts failing with a certificate error that looks exactly like a TLS regression, so
+/// regenerate both with:
+///
+/// ```sh
+/// openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes -keyout ca.key -out ca.crt \
+///   -subj "/CN=Yututui WebDAV Test CA" \
+///   -addext "basicConstraints=critical,CA:TRUE" \
+///   -addext "keyUsage=critical,keyCertSign,cRLSign"
+/// openssl req -newkey rsa:2048 -sha256 -nodes -keyout leaf.key -out leaf.csr -subj "/CN=localhost"
+/// cat > leaf.ext <<'EXT'
+/// basicConstraints=critical,CA:FALSE
+/// keyUsage=critical,digitalSignature,keyEncipherment
+/// extendedKeyUsage=serverAuth
+/// subjectAltName=IP:127.0.0.1,DNS:localhost
+/// EXT
+/// openssl x509 -req -in leaf.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out leaf.crt \
+///   -days 820 -sha256 -extfile leaf.ext
+/// openssl pkcs12 -export -out id.p12 -inkey leaf.key -in leaf.crt -certfile ca.crt \
+///   -passout pass:yututui-test -legacy -macalg sha1 \
+///   -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES
+/// ```
+///
+/// `-legacy` and the SHA-1 MAC/PBE are required: `native-tls` reads the identity through the
+/// platform PKCS#12 parser, which does not accept OpenSSL 3's AES-256/PBKDF2 default.
+pub(crate) const TEST_CA_PEM: &[u8] = br#"
+-----BEGIN CERTIFICATE-----
+MIIDMzCCAhugAwIBAgIUJAshzf3omUZUBEdLf8H+87tiuFQwDQYJKoZIhvcNAQEL
+BQAwITEfMB0GA1UEAwwWWXV0dXR1aSBXZWJEQVYgVGVzdCBDQTAeFw0yNjA3MjYx
+NTMyMjlaFw0zNjA3MjMxNTMyMjlaMCExHzAdBgNVBAMMFll1dHV0dWkgV2ViREFW
+IFRlc3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQD4WyRghC42
+WhkbLi/jedkbd7qH0AyjOQwVOao/9o9gDNbCirBQXMojOMgg/cKokg7QP8WsOr0m
+bgCYLcojamvSZGMf2JpNZ8IY+90ZM7GqeIqHzwU7AiBIhacClqEtZ7X5j5E7tdPG
+vmD22/9aTUlAp+LWiWyjzvA0S3m7wkCSYXIPvZ+3SOGrZifuL3gw+ubkplTjgTpB
+UVcAzlVBukDfW3MuOx3oeKrYSf7x8O1ki4w1/3dGO7HXa3mp/EtJ5gKFHqa1EnsC
+od7+BcetjYofiVGjGKtoDX65OSyl7/vJZsESn8J6bPYuSQL/fijw2W5whQZ3IcWy
+gx773Hymz609AgMBAAGjYzBhMB0GA1UdDgQWBBRDVBj0wcDObY7B2GgX9eOCowJ7
++DAfBgNVHSMEGDAWgBRDVBj0wcDObY7B2GgX9eOCowJ7+DAPBgNVHRMBAf8EBTAD
+AQH/MA4GA1UdDwEB/wQEAwIBBjANBgkqhkiG9w0BAQsFAAOCAQEAemXRpbCgFUJs
+Db3iHytnfwnC4XVDo0Kvf3xoH+vR3ozrajPCwYkXXbnnZQD9WzAe3YbMceLcObEl
+jGd3ZJ1C+qCUyisNW9qObNi4P/a2b1qH2PU06KKajrVECTV2mwFExUdHrYEv3IJR
+SN+VRsJo7kgL2pj/Kt8er7Z5OcfON31TYj/994Vle/5cIz+X6US37h457Ig51AVY
+4WlOc7CprtjbUtGL2L2wHwIEMKNE4Ppp+jWuubYbsGQHDPfj1OVfDizTScxkzF9C
+qnLeZFYm7hyqDmCwQjhXF5XYenUyHMhYbuoihiM+KsUbPYqjH2Lm80MafZe0VKXK
+ntr8u/fUdw==
 -----END CERTIFICATE-----
 "#;
 
 const TEST_IDENTITY_P12_B64: &str = concat!(
-    "MIIKJwIBAzCCCdUGCSqGSIb3DQEHAaCCCcYEggnCMIIJvjCCBCoGCSqGSIb3DQEHBqCCBBswggQXAgEAMIIEEAYJKoZIhvcN",
-    "AQcBMF8GCSqGSIb3DQEFDTBSMDEGCSqGSIb3DQEFDDAkBBAPdwiSM4OS0ekKzNzvNLruAgIIADAMBggqhkiG9w0CCQUAMB0G",
-    "CWCGSAFlAwQBKgQQdC064UksC6RQyzHSsG0IFYCCA6A2AAhs8TEdCuaXWuifJxr/FNKO1LHNEpNn67xGc7i3kGLp8whjsBu8",
-    "j6ek/tF91sxboHc5O+IJyp5DRvOZOR8eY7PAi/LF1MWjFkflZEJxT7IxluVK4ntVghCTLa1wRKuMN8kikjNf3M8XB3clcw2S",
-    "ulKTudIEivMfguAJrbSOI2D1hfSvrAHi4bgd8LQyXF+DKvD7KNf7/fA1bJNLXNCeQfgJU4FCjO3Gat4U+YCt08AIEuqueV3Z",
-    "w2j2gSOk26bu8/SjXPY3wOpmOU8lQ7KYXSsUaCLon6dwOMQBqpf7x9X368epYYzt70Uy8SHEYuxUp4Paowd/fG8OjJUv/Mdg",
-    "2cO3FQX7oKgpJ6wC5Ff7ORbT8fEG+++4r928wXFs/E5aRdOkchReX0VdYG52vtMzhJQHxLGGCTkJTRXwcy6G8yKg6QPPDq97",
-    "bfUeGjqqFDFThEd+07f5UcOi5pwBZPNhiqulFPTc21G9gG3SY0ZwdRPqr5YkmgNsloB2Lzfiy99UlfHZb7P02CdYZG3Fen2I",
-    "058do9VJ1RercX5o2KLLdzfOK8eCOQyYLDnUdhM3GGJ3uvYm114jvIF3ceIbW/vedCcHttbnxx79i0AXHxig3a/oO/NsI3/0",
-    "SAu2C5NdNvZbwv6+sfnLv55wyynFawlQ5l/PrPgNW9gHdtYi0C43zSo5XavDLW7XEmHWPaq6sSdCaTrbBG/xkRf+/VmIS+up",
-    "uULWhxXRM6W0zGRj6/u/vAn/FYcjllJy39fMKYnXIxFBLjQ4X1Uxk3ltGdG+5qh6Nv1n/Q82v2G5qwHnD/PqjoKqkTtBxGvl",
-    "aTqSn18bbuEF5Sdy7NwYg/benp55FTWsvQzFkK9+5L1tl/zP4CVrmVsrRWwFYciD54dreGz1XXho/neyxTjmyvtw3tlIb6zv",
-    "mR7XWwOo+lfDHKULoiJYj8YdqVxlrk5bC5ExxZSKNj9XtF+zBtAGx3fUz/p+lTOdG2z9gbLjgEXqqcPv32X3KedASG+ehBT0",
-    "PMq2SnCe4awaihbWW30GFibs2O1bTVID8yvcPbCssGXFKO3JAtWjDZ1Tt4FHaw0H42H7oDxtEyUy7Lm/i4mMLqa1ty2ctniZ",
-    "xhTIaIyACaqf5MIlpMZ1ZcjkNJbxNw0woyyU066xHOUC4Wt+nTW6lKKCUpmLJWFJzug1qO/MBnXNMyrN9csw/SXiylRS33h2",
-    "nflYTMueaL7zznh/vfNtbiUxMJS8Qt43MIIFjAYJKoZIhvcNAQcBoIIFfQSCBXkwggV1MIIFcQYLKoZIhvcNAQwKAQKgggU5",
-    "MIIFNTBfBgkqhkiG9w0BBQ0wUjAxBgkqhkiG9w0BBQwwJAQQYI4+Kx5EhZ0bz0S0zEIJmgICCAAwDAYIKoZIhvcNAgkFADAd",
-    "BglghkgBZQMEASoEEAeAwbZGsfHl28jk0059CxkEggTQWoildgjiG/YFj4CvznJ6syj8Eencf94e8TnoLTTs8UdoQlYRI0Pq",
-    "/TR3I3spedGaS6t+NGGjKjX6ChvEiv5zKDHDmYKzJe6D2i7t2jpYd9MrHI3abE5UPuh0pptnrCB+hnRDzXXcvbZfZ36Lq+Lq",
-    "E2Q25Whs7XUtLRqTHHbnymM6YXkOWyzIusBnYryFI94gO1gZBCFs/FJ7QGr8u0nh+c07PKUaZInSgKGL8zzgabZrRqOqTEKW",
-    "JnLYEAKpjgDIBkxO4QJDp9cewO+MstTqVn+JV50IFrJ/sdDNCMP4tc/96jGIM4F4rDMJRJailaS/HB4zyTb2T6SEw0QfsWW1",
-    "Wnw88VLQIN61zqV0QGs79DsxAGOqKGssiZlqLsC/F19IsODaGZKO9m6ltZjohwTwdQkaRJb5lJoIq9hOk49LZABKl8kse8mt",
-    "AR59RSwAahhelzTwSdg1oACqnPGwjU91LmfJb+kRJx9SbY5g6l1UH1Ix4GrCHkvLzyuIrZAQWTphroK0vGgXvQHS3Hh6H38p",
-    "Cj3ujVqxtwBFmYGliDcqxzlaVXaZnFq6zEy7vqjfoi6Z3P58212/VP6nB5VAGHT5X/QAVucQOBTpT+PmwjMhe2fUvkzKlHnr",
-    "jXVolwlazqpgrFhSvn7DSocEY1MFagz8FestSOCqruzdjUgqcesdf1D6vCYXqZkaqioYrk3HuuiB++AfZ9FVAy8erivQt+aV",
-    "6a+PMDaQosWUqxVHboTNS7XPzVhHM7P+pWRKBV9rjl70K2SgjHeMd8Fk6j4dZgq/j2BRzJpPhMJLGB9pvK6dzfvL6h0lznZa",
-    "3mvp7DiF1mRbPj/QgKmHU6tyemMXXXtrFLZa/SRt8eaO+vY1tombzJYEYfk/f82TRLanrcGmqUUFUuqvwn1M6jAgCYtQ7V9p",
-    "4u6OdJmq/zXSSKGv8jgHtpOSbb9J65GrwKJ0fM6Ulo7VlTIDntfhMMM4Z9MhzDKog5V/VdEEAjL/KSK4bZ9N7dNSlw0/acWQ",
-    "NJ61IV7+dWwMQfJnE+JAgEpijHdmOe3Mwk2tShr9XCdGvpeLWr2aPh5WAoJhoeh08omr6vMVxN+uoQ8kXhOrt/DtrJBD/efh",
-    "g+yl+/WGBTdSaj/bMhPWq+6iT/3a506B74GTNHgPI6gTSdhiNdTryfTFOxgC4bQpNHr04lhF5dx9KBcXhvkubdr2uUUDCa5H",
-    "7qEOoLSsJS0N4dOx0BCD443PhyHnaOOcnsALuIsXTRY4VgUAEEcMgH6n/jnurC0Zh+cndjFsnsrOBIqJZqERNQ63ZrE6X6EF",
-    "hLQ3tZuyT5MvN0us7Qk8i3FYWVcRJZcdSPv3CiJej16WfkqSbTCGSrWwbUzd63MSlqXC3CMCvcVej43yT0lqnGPLD6X1j9r7",
-    "J1cYbPvinxxYYM1S6KghB6UgNA3UAyfOsjTr3TUifH9ohsTbLXheqLe3EFzKHcsDVSVsLGWBfvss2Ah4raRbDZsBKBKxo1xQ",
-    "O9XkpvFIB9bNHXw8pSZ+uTx+zBbW+KDEiXIa/xi1k6H/DiyB0wK5RROvwGqJDKSu2+XZ8yHQyhCzVGo3k/FWJDI7cYY9VE5S",
-    "MFw7jMSmOmTgMlbPBLzMHTdRUoekphmPLk+ycT8Y70zYUcnTsMfU6gcxJTAjBgkqhkiG9w0BCRUxFgQUNRUekZfMoWSVsqSG",
-    "bCY7kERhM6owSTAxMA0GCWCGSAFlAwQCAQUABCBjuKwD7e17FX6jj8Nkr24ndjLdLqMfacZlCu+VLtNyLgQQDmWkQtqFomT6",
-    "XgV/3DhWtAICCAA=",
+    "MIINAQIBAzCCDL8GCSqGSIb3DQEHAaCCDLAEggysMIIMqDCCB18GCSqGSIb3DQEHBqCCB1AwggdMAgEAMIIHRQYJKoZIhvcN",
+    "AQcBMBwGCiqGSIb3DQEMAQMwDgQIxB1Pv4Ko8eUCAggAgIIHGNpl7/3K2/B37wjAvaE70M7mUD6mabExwT9U5rco0C+d99bV",
+    "o7OOsQr6tJiNp95he9Ol29YdZT7J0lBxN3IdJuAEm29Zct5cQ7nM178j3k2pvTOcKhXC/HTT41PFn6pwNxuo9hlueAaZUGev",
+    "xzKFckMl4NE+tW+v1zyIBG6PK2qveJCIOwviUovQ+9WScvSJWAmABPe1fC4cnVfIXKreI4ZeK60Ph4NL3yW51WLql/C6QWXv",
+    "1t4lkpCMQX+ioSDFtSCSyIGFiFdKDA7B5RpVk7+cb7Wr1vUVSZTyX8B3FiDurJEW0PKAwFV+4GXCKvQicgDgDJ5cYzJwV2JO",
+    "0uLtSN5FvV/hPwWFLVYuCSrGE4KxVbNRlV3tPtOgRya1LkOhxYoUOWaqmkcFtHk/p+Q4m/tlJWYund/MVJMkZx/gs85hwYgf",
+    "GZUXnfI7MCYArPbhTqHcPb/UygymFxzuOPBBEHDsgB1h1tXTb5ag2iEMkbNNqzYrLIK3YlyPmS8mYI55pyW6pbghA7maqclS",
+    "oi8bdzZ/eqoAGGtQWgRiB6Ed2+DLgAV0GifQvg7A2/EW4LrjzFIRH5Sx0tU/37b81qpt3Xt8lkkBXmYqqbQgEyUGUXi5b5aR",
+    "RdpsdBCmwRHm0o6DwcVFL6LHwCK87WvwTaMIDMMaEkgUAvL0Qr/NOErExlnqvPRqrPDNzu9U6U//PdJvJcxKE3VYC2pnj+OM",
+    "MNbFOa1+8DUICIE/zKc1uyBQz3BEV8daDuv+6YfJXrjivww8Eysvq68gSFD2haPbOKn8q59sBYYYJFCcJNqD/v1wzy6PsBux",
+    "lUievEWEylIWGe26PRBdhQNiXCpNXWOC5maZXZ1ph3AAl/aRjsVvWrdWy5fKr1N5XpzLhJ3tjrYSyDG0O2Pmx5UDH3bkiWOY",
+    "p1k79eE0pQUfuZe7wrX7qr9HTb0Sz9n9GtjEnDijWm87EQk2fNGoeLRROtzPyrLhlMRVAHRTCUa9Y2S518keEta4WEYvWVFP",
+    "OLHPnwd72Vp/rd9a6za1sdoe79xt8mwZkQRBX1VmvkvhKOzwgTSXexLq5g+RGg5mwTqSffNUCqlefYcxt9dQTp3F4VV9KvPh",
+    "65en+Xrcjr3H7SLL56MLmuD2oKj/kmqyqc6byvceTGBC004q+uCH/FtxiDlDLJsxBcE6bhPi0+dsyANZ5P2RWVAMXWp7QqZU",
+    "ME74di7GWlqygyNhyhF57X+N8AWEn7ikgALz+T09WfBdNcyaJLvwyYK669iiDIBRKX9hPFv8mUbBtadE2sRfvBSSGi9/0nss",
+    "6D0S/0SKZOLfqqlKg097Ogwhqy/NHNSzGb11flHb2jtkCDa3X7du2i+sZz3OnaClACOlcwVHb1tdxJfThumkCFr+nRQSc+3B",
+    "QIjAhu5DwJeQBwdcKwo1p4AwzvKfoJ7hoch6aa+/MvcMqFl/CDYxWoxtchEF/qNp9czkPKfvrrCa+/WDQJxs+hEymDqUzvaE",
+    "9uQkDR5zdb9sIFq796HAhZpO48icv8Qga3ZxMRs/GKQt0+an4YEemFmjOInRZ+h8ZKreY/EZOlSpQzDhePxRXyqGsUr1RqCi",
+    "y5SjMry+qJQC0xA241CzYPcyKUoZDn90PnEPfJGP+hEDteEw6DyeyGq8CHzPWmufu1K/G95MtzvUxJv9nTTFiHGYfsr1HFvI",
+    "fa8q0+89dmSBfisVcB3DnVwbD5riK4AMX/gMkZt0W4Oj7Pa9opfYpjZJt3RVRm4M4+Fzfxf4TV3GmarplgXWhz5eLbk+g0Jy",
+    "1s+dER6VLhSEV/pcHM8sXFbl3nqvdbp4sb6A7yOrg0f6KhV89bVRaTJ/CM8BdkSPqZjT7Q9FTGg/snB4UQ798j1PboBtV2NA",
+    "ft77hM0Q9vHuQHatWvGrIcfuvqDqCvrs8cNZy6mNy5fG0MLmpwKDYDlEDrK2IQRO6cn3HjOv3iMl3mBKa5KE/zQJOlz7dut7",
+    "av12Z4qMTJP7zabscCJTLN49edQXmWgl9thg4MWOt5SP33ngS98MRMYdXG87zA1vJAXU/Z+Gjedu7ANzYzoDz24FK+aebMof",
+    "vhekjQi1ct9Q3ATifn/KWvXnTFEVQSThDIZoCod+AfbOvHK3Ik5kl+SgL/fedxthLcEpHlqtVdx62WPG3Kc6cC6HqZkRYXja",
+    "qTXJ4ECNwHsoFBw5ivEZcrJ53bt/Cv9RIoos4Sxry2poxfvEIbSxwAq6SKn/2omFXidqXfn68j6LYkoGQa3nxoX1ZWji8lzW",
+    "vX9qJ6u0RSDdAKuKjcT7u9qFzXIWt3cvXIUSJ3kxvSR9P/yQvwY6YcH8ye/X+QJWUVMt+R6d2dtD/9sGHicF4BXKOjRWgpus",
+    "DHHTx9shIWjaLHkfn1beXVW8jSwmPPFbV3sb7g64VejVzUzmuArkQ4p+g2ZQjF1RKi6QTjMwggVBBgkqhkiG9w0BBwGgggUy",
+    "BIIFLjCCBSowggUmBgsqhkiG9w0BDAoBAqCCBO4wggTqMBwGCiqGSIb3DQEMAQMwDgQIXxq/fg8oab4CAggABIIEyP+hFl7l",
+    "dTz5UB4IiMeCPTlaBkPK4PFQ67gUSHO2rstc7C5Mw1QJStlgOeTIzU+asTeiQFdmXfb3hlHy78l7wwidlmOHcsmwyATL5tAs",
+    "xklA/vGcEHdHPIP6Dbk8RJw43SKBH9zM5t2z8XGpL7pUMnMLkiHhsojQ9XanVGy0xk+mBSHqvR1Psp2BHXvRy9J0LxzSuegG",
+    "HFPnMCG7zVfG+BItXJIK1RPh6diwFB15dJV7wnBDQLOIgiBzKJH1pnZjJuWoTXDfIWJJc1ZugXZSuq02CNqzV5FWtZd/ludn",
+    "TieNn6I8ZBbGBUaCZJZHLLxj1XFZ5L8M6hWo1gGw4sYWiaT0gEU8U3cvCaRLLYY9riaj4sIwbPfbv5wwHjkJ1SalTACpmIdP",
+    "7LJ3KzN+XTH5jXPihF04Rb7RSdCnVnr24EMUW32+C3fz/NR2WJ+AQn8h2M6y5CBHsdltHdcaMtzoLsur6CWxvIna+Doc0PtN",
+    "Qhr/aQfjKLeqTwk5EH03BWCKuy9ZSzV/LSIbiYcVVMV+Upd+LQQ1r7I9093RVNAwd4LgBfO2G45OEZOlMYTq3RNVXFDNQJxt",
+    "1F7jhaRi9lBscvZ//l/nIijB6MKz4ITNQKBFo0b0+F/iqP9dvNPiSffdjnx6hV3RLheieGp1tYbrw8oJqQSfXZfbTyTla3XO",
+    "AwWi5mATJtpW/T6Zlaa/V6nC8XrAuX1a846AjZWjqOkryeACqg+mHqrsCNZBIMeeGgidEIZ5xgo1gBo0f9yG4/z4GiAjDmQh",
+    "wW5+wLuJmoWIoR2JRUXFuex5WPnopuWWx3LyovZfKC7kEDEd6brJA+Z98Q8eKiYr1l/x7WPfhztJetZ5o9/bijxfWC4QQznJ",
+    "oTEREgUa/xM0a6dIGm0OxeIJ4ZjFiLqoHCstn//Aw7OiQ/i743F+IA4lW5n1qwGdsZzrknmF58gmMFpdTq8FOQA4DBrcxrJH",
+    "ZNw48CUm7haKCg+fdkiL9opUb/qp1xZWB9i49vc6CbPZj3VwC5L3AgflsL2LN50J9UbdPqK2QL8QE/DRVnEW22h8SDOcqhdU",
+    "nWaS9qJli0jqhGrX8rm2o2caQUVSpwj4XjLLPJFgh8FfPnoxxScIh0q+2b6WXjC7ikoLev0Gh8vl6chQyciZVXt7sIklkoKi",
+    "UbDAkCiv0ZxXnCNbiRCsOyYQXUNt5v3fh0fh1bVWcDcTzBUE+0/KM06WW+m2q9Lk6eGFQbGi0YqxL5N4G/2zs2pXvrTNOqrh",
+    "UCZmMeqLPATLVlXHv8kL+nhvz9gTyZ+ohHCD3IFDbmn1cDNwgrb+dfOVKUIBG1BjqxUptZPXBIaiVh2WyGZIZ+aOL0myT0zj",
+    "b5/K8GNxkm0MT10DyMWLByahhbYDL7zPsOiQyAJaP6AiwpJvY+63q83lAomUeLF1xb489F+bv/24jq7htBKkXDu8yhAcU6br",
+    "+IXCb4aPpGzuN42cXwfipi9Ds8x962JJ64S/5aHU7ki69syDHZwdeMPu/4di2u9taBKXtDqT3nKmzZt+TFAdzl58GuyyoQH/",
+    "dDDuoIiGnGhewIZLliLCqdh4VjUZI98WXhDWFqBlvrGmu1X8zbpWMYgkL98f0AJpXgc9H3JKW+23Lb5oMYYKU/PWhTElMCMG",
+    "CSqGSIb3DQEJFTEWBBSU99aGWCUWnoJLJ0RIh2KKurdF0TA5MCEwCQYFKw4DAhoFAAQUiSc82v08WjZrwSEAgr5qHTADEi4E",
+    "EDuyhePZiCrpTfCGIkvvHbECAggA",
 );
 
 fn credential() -> VaultCredential {


### PR DESCRIPTION
Temporary branch to measure the combined effect of #127 (Windows ACL owner check) and #128 (TLS test fixture) on the Windows suite, instead of asserting it from two separate runs.

Baseline on main: 182 failed.
- #127 alone: 9 failed.
- #128 alone: TLS test green on Windows and macOS; the other 182 remain (no ACL fix on that branch).

Expected here: the 8 `sync::manual::maintenance::tests::*` failures (`RemoteUnavailable`), which neither PR addresses.

Will be closed once the number is recorded.