### PR TITLE
fix(sync): scope acknowledgement keys in one component instead of three

### DIFF
--- a/src/sync/compaction.rs
+++ b/src/sync/compaction.rs
@@ -307,6 +307,23 @@ pub fn compaction_quorum(
     Ok(!active.is_empty() && acknowledged == active)
 }
 
+/// Scoping component for acknowledgement keys.
+///
+/// This used to be three separate path components — the checkpoint id plus two 64-character
+/// hashes — which made the relative key 255 characters before any vault root was prepended. That
+/// is 5 characters below Windows' 260-character `MAX_PATH`, so writing an acknowledgement failed
+/// on Windows under every root, and the whole `sync::manual::maintenance` suite failed there while
+/// passing everywhere else. Truncating the individual hashes was not enough on its own: two
+/// truncated hashes still leave 191 characters, and a typical Windows temp or AppData root pushes
+/// that back over the limit.
+///
+/// One derived component scopes the same thing in 32 characters. Nothing is weakened: the full
+/// values stay in the signed acknowledgement payload, which is what `SignedCompactionAck::verify`
+/// authenticates, and `compaction_generation_hash` already binds the checkpoint id and every other
+/// compaction field, so a change to any input still yields a different scope.
+const ACK_PATH_SCOPE_DOMAIN: &[u8] = b"yututui/compaction-ack-path-scope/v1";
+pub(crate) const ACK_PATH_SCOPE_CHARS: usize = 32;
+
 pub fn compaction_ack_prefix(
     dataset_id: &str,
     compaction: &CompactionCheckpoint,
@@ -318,10 +335,19 @@ pub fn compaction_ack_prefix(
     if membership.dataset_id != dataset_id || !valid_hash(&membership.head_hash) {
         return Err(VaultError::InvalidObjectKey);
     }
-    ObjectKey::new(format!(
-        "yututui/v2/{dataset_id}/compaction-acks/{}/{generation_hash}/{}",
-        compaction.checkpoint_id, membership.head_hash
-    ))
+    let scope = sha256_domain_hex(
+        ACK_PATH_SCOPE_DOMAIN,
+        &[
+            dataset_id.as_bytes(),
+            compaction.checkpoint_id.as_bytes(),
+            generation_hash.as_bytes(),
+            membership.head_hash.as_bytes(),
+        ],
+    );
+    let scope = scope
+        .get(..ACK_PATH_SCOPE_CHARS)
+        .ok_or(VaultError::InvalidObjectKey)?;
+    ObjectKey::new(format!("yututui/v2/{dataset_id}/compaction-acks/{scope}"))
 }
 
 pub fn compaction_ack_key(
@@ -711,22 +737,46 @@ mod tests {
         let fixture = fixture();
         let membership = fixture.verified();
         let device = DeviceId::new("device-a").unwrap();
-        let generation_hash =
-            compaction_generation_hash("compaction-ack-dataset", &fixture.compaction).unwrap();
-        assert_eq!(
-            compaction_ack_key(
-                "compaction-ack-dataset",
-                &fixture.compaction,
-                &membership,
-                &device,
-            )
-            .unwrap()
-            .as_str(),
-            format!(
-                "yututui/v2/compaction-ack-dataset/compaction-acks/compaction-001/{generation_hash}/{}/device-a.age",
-                membership.head_hash
-            )
+        let key = compaction_ack_key(
+            "compaction-ack-dataset",
+            &fixture.compaction,
+            &membership,
+            &device,
+        )
+        .unwrap();
+        let prefix = "yututui/v2/compaction-ack-dataset/compaction-acks/";
+        let scope = key
+            .as_str()
+            .strip_prefix(prefix)
+            .and_then(|rest| rest.strip_suffix("/device-a.age"))
+            .expect("the key is dataset-scoped and device-named");
+        assert_eq!(scope.len(), ACK_PATH_SCOPE_CHARS);
+        assert!(scope.bytes().all(|byte| byte.is_ascii_hexdigit()));
+
+        // Windows `MAX_PATH` is 260 for the whole path, so the relative key has to leave room for
+        // a real vault root. The three-component form was 255 characters and could not.
+        assert!(
+            key.as_str().len() < 128,
+            "acknowledgement key grew back past the Windows path budget: {}",
+            key.as_str().len()
         );
+
+        // The scope must still separate different compactions and different membership epochs.
+        let mut other_epoch = fixture.verified();
+        other_epoch.head_hash = "f".repeat(64);
+        let other_key = compaction_ack_key(
+            "compaction-ack-dataset",
+            &fixture.compaction,
+            &other_epoch,
+            &device,
+        )
+        .unwrap();
+        assert_ne!(
+            key.as_str(),
+            other_key.as_str(),
+            "a different membership head must not share an acknowledgement scope"
+        );
+
         assert!(compaction_ack_prefix("../dataset", &fixture.compaction, &membership).is_err());
         let mut wrong_membership = membership;
         wrong_membership.head_hash = "not-a-hash".to_owned();

--- a/src/sync/manual/maintenance.rs
+++ b/src/sync/manual/maintenance.rs
@@ -570,29 +570,24 @@ fn valid_acknowledgement_key(root: &ObjectKey, key: &ObjectKey) -> bool {
         return false;
     };
     let mut components = relative.split('/');
-    let (
-        Some(compaction_id),
-        Some(generation_hash),
-        Some(membership_hash),
-        Some(device_file),
-        None,
-    ) = (
-        components.next(),
-        components.next(),
-        components.next(),
-        components.next(),
-        components.next(),
-    )
+    let (Some(scope), Some(device_file), None) =
+        (components.next(), components.next(), components.next())
     else {
         return false;
     };
-    !compaction_id.is_empty()
-        && is_lower_hash(generation_hash)
-        && is_lower_hash(membership_hash)
+    is_ack_path_scope(scope)
         && device_file
             .strip_suffix(".age")
             .and_then(|device_id| DeviceId::new(device_id).ok())
             .is_some()
+}
+
+/// Matches the single derived component produced by `compaction_ack_prefix`.
+fn is_ack_path_scope(scope: &str) -> bool {
+    scope.len() == crate::sync::compaction::ACK_PATH_SCOPE_CHARS
+        && scope
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
 fn checkpoint_hash_from_key(key: &ObjectKey) -> Option<String> {


### PR DESCRIPTION
## The cluster

All eight `sync::manual::maintenance` tests failed on Windows and passed everywhere else — the last coherent cluster after #127 took Windows from 182 failures to 9.

## Root cause, measured

The acknowledgement key was:

```
yututui/v2/<dataset>/compaction-acks/<checkpoint-id>/<64-hex>/<64-hex>/<device>.age
```

Walking the vault after a maintenance run gave the actual number:

```
PROBE rel_len=255
.../compaction-acks/03879e48…d0e6/7d2a7136…0370/ef2c5f8d…49f7/device-2.age
```

**255 characters of relative key**, 192 of them hex. Windows' `MAX_PATH` is 260 for the *whole* path, so there were five characters left before any vault root was prepended. Every acknowledgement write failed under every root.

`put_acknowledgement` converts a failed write followed by a re-read that finds nothing into `VaultError::RemoteUnavailable` — exactly the error all eight tests reported.

## Why the key, not the platform layer

Two facts from the same Windows run separate them:

- The thirteen `sync::manual::tests` — multi-client convergence, segment splitting, ETag races, readback, deadlines, all on the same `FileVaultTransport` — **passed**. So put/get/list/lock work on Windows.
- Acknowledgements are the **only** key with three consecutive hash components. `registry_key` has one, `checkpoint_key` has one, `segment_key` and `device_head_key` have none.

A deterministic 100% failure confined to the one module with the one outlier key shape.

## Why truncation alone was not enough

| Form | Relative key | + typical Windows root (~77) |
|---|---|---|
| Three components (before) | 255 | 332 ❌ |
| Two hashes truncated to 32 | 191 | 268 ❌ |
| All three truncated to 32 | 159 | 236 ⚠️ no margin |
| **One 32-char scope (this PR)** | **114** | **191** ✅ |

Measured after the change: `PROBE rel_len=114`, and the longest path in the vault is now a checkpoint key, not an acknowledgement.

## Why this is safe

The scope is `sha256_domain_hex(b"yututui/compaction-ack-path-scope/v1", [dataset_id, checkpoint_id, generation_hash, membership_head_hash])` truncated to 32 characters.

- The full values stay in the **signed payload** that `SignedCompactionAck::verify` authenticates. The path was never the authenticator.
- `compaction_generation_hash` already binds the checkpoint id and every other compaction field, so the scope separates exactly what the three components separated.
- 128 bits of scope is not a collision concern for a per-dataset namespace.
- `valid_acknowledgement_key` follows the new two-component shape via a shared `ACK_PATH_SCOPE_CHARS` constant.

The key-shape test now asserts the scope length, its hex form, that a different membership head yields a different key, **and a path budget** so the key cannot silently grow back past the Windows limit.

## Format note

The on-vault layout for acknowledgements changes. Sync is unreleased, so no user vault exists to migrate — a pre-fix acknowledgement simply reads as absent and is rewritten. This is the moment to change it; after a release it would need a migration.

## Verification

macOS: fmt clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; the eight maintenance tests pass; `cargo test --workspace` 4643 passed with two pre-existing failures unrelated to this change — the TLS fixture (fixed in #128) and the `webdav::proxy_tests` loopback flake.

Windows is the platform that matters here and it runs on this PR now that #124 is merged.