### PR TITLE
test: stop two timing assumptions from failing under runner load

### DIFF
--- a/src/sync/webdav/proxy_tests.rs
+++ b/src/sync/webdav/proxy_tests.rs
@@ -131,16 +131,37 @@ fn accept_until_done(
 fn read_headers(stream: &mut std::net::TcpStream) -> Vec<u8> {
     use std::io::Read as _;
 
+    // A short per-read timeout keeps a wedged peer from hanging the suite, but its expiry is not
+    // by itself a failure: the probe runs in a separate process and may simply not have been
+    // scheduled yet. Retry until one overall deadline — the same shape `accept_until_done` above
+    // already uses — instead of unwrapping. The previous single 2 s read surfaced a slow child as
+    // `WouldBlock` and failed the test on loaded runners.
     stream
-        .set_read_timeout(Some(Duration::from_secs(2)))
+        .set_read_timeout(Some(Duration::from_millis(250)))
         .unwrap();
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
     let mut request = Vec::new();
     let mut buffer = [0_u8; 1024];
     while !request.ends_with(b"\r\n\r\n") {
-        let read = stream.read(&mut buffer).unwrap();
-        assert!(read > 0, "request ended before its headers");
-        request.extend_from_slice(&buffer[..read]);
-        assert!(request.len() <= 16 * 1024, "test request exceeded cap");
+        match stream.read(&mut buffer) {
+            Ok(0) => panic!("request ended before its headers"),
+            Ok(read) => {
+                request.extend_from_slice(&buffer[..read]);
+                assert!(request.len() <= 16 * 1024, "test request exceeded cap");
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "timed out waiting for the probe's request headers"
+                );
+            }
+            Err(error) => panic!("test listener read failed: {error}"),
+        }
     }
     request
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -319,12 +319,21 @@ fn restore_reports_output_failure_but_still_attempts_raw_mode_and_later_controls
 #[cfg(unix)]
 #[test]
 fn raw_mode_restore_cannot_hold_the_caller_past_its_wall_clock_budget() {
+    // The contract is that the caller returns without waiting for the worker, so the two
+    // durations only need to be far enough apart to tell those cases apart. They used to be
+    // 200 ms and a 150 ms assertion, which left 50 ms for thread spawn plus a channel wait to
+    // land in — under load on a shared CI runner that slipped and failed the test. Keep the
+    // budget small and move the worker far away instead: passing still proves the caller did
+    // not wait for it, with room for a scheduler that is not paying attention.
+    const WORKER: std::time::Duration = std::time::Duration::from_secs(4);
+    const CALLER_LIMIT: std::time::Duration = std::time::Duration::from_secs(2);
+
     let started = std::time::Instant::now();
     let error = run_bounded_restore(
         "synthetic blocked raw-mode restore",
         std::time::Duration::from_millis(25),
         || {
-            std::thread::sleep(std::time::Duration::from_millis(200));
+            std::thread::sleep(WORKER);
             Ok(())
         },
     )
@@ -332,8 +341,9 @@ fn raw_mode_restore_cannot_hold_the_caller_past_its_wall_clock_budget() {
 
     assert_eq!(error.kind(), io::ErrorKind::TimedOut);
     assert!(
-        started.elapsed() < std::time::Duration::from_millis(150),
-        "bounded restore waited for its blocked worker"
+        started.elapsed() < CALLER_LIMIT,
+        "bounded restore waited for its blocked worker: returned after {:?}",
+        started.elapsed()
     );
 }
 


### PR DESCRIPTION
## Scope

Two of the six flakes observed this cycle, fixed where the cause is certain. The rest are catalogued below with evidence rather than guessed at.

**Reproduction first:** five back-to-back `cargo test --lib` runs on an idle macOS machine were clean (4649 passed each time). None of these reproduce without load, which matches every CI observation — they are load-sensitive, not order-sensitive.

## Fixed

**`sync::webdav::proxy_tests`** — `read_headers` set one 2 s socket read timeout and unwrapped:

```rust
stream.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
let read = stream.read(&mut buffer).unwrap();   // <- Os { code: 35, WouldBlock }
```

The peer is a **separate child process**. A read timeout expiring means "not scheduled yet", not "broken", so on a loaded runner this failed at `proxy_tests.rs:140` and propagated to the parent as `Any { .. }` from `target_server.join().unwrap()` — which is exactly the pair of failures seen on macOS. It now polls with a short read timeout against a single overall deadline. That is not a new idea: `accept_until_done` a few lines above already does exactly this for `accept`.

**`tui::tests::raw_mode_restore_cannot_hold_the_caller_past_its_wall_clock_budget`** — a 200 ms worker against a 150 ms assertion left 50 ms for a thread spawn plus a channel wait to fit into. The contract under test is only that the caller returns *without waiting for the worker*, so the two durations now sit far apart (4 s worker, 2 s limit) and the message reports the measured elapsed time. The worker thread is detached, so the test still finishes in ~0.04 s.

## Diagnosed but not fixed here

**`transfer::engine::tests` × 4 share one on-disk `playlists.json`.** They use the real `DiskLocalPlaylistStore`, whose `apply` does `Playlists::load()` → plan → `save()`. Under `#[cfg(test)]`, `paths::data_dir()` resolves to `test_base().join("data")` — one directory for the whole test process — so the file at `<data dir>/playlists.json` is shared. Two tests interleaving produce a lost update, which matches the observed `liked songs local import should create a playlist`.

I did not fix it because a mutex over those four would not close it: `persist/owned_snapshot.rs:149` writes the same file from a second, independent group of tests. The correct fix is per-test data-dir isolation, which is test-infrastructure surgery affecting every test, and I would rather not do that blind against a failure I cannot reproduce locally.

To be clear about an earlier worry of mine: these tests do **not** touch the developer's real playlists — the `#[cfg(test)]` branch in `paths.rs` keeps them inside the test base.

## Observed, not yet diagnosed

**`daemon::parity_tests` on Windows** — three different tests across three runs: `revision_checked_queue_remove_is_stale_safe_and_owner_parity_holds`, `shared_script_keeps_app_and_engine_projections_equal`, `revision_guarded_move_and_clear_reject_stale_and_accept_fresh_or_absent`. The one captured failure was `assertion failed: app_resp.ok && engine_resp.ok` on a revision-guarded command.

I checked and discarded the obvious hypothesis: `QUEUE_REV` in `queue.rs:29` is process-global, but the tests capture each owner's own `rev()` and pass it straight back, so a concurrent mint by another test does not invalidate it. Whatever it is, it is not that, and I would be guessing to go further without a reproduction.

**`open_subsonic::proxy::tests::unused_route_expiry_returns_not_found_and_reclaims_capacity`** on macOS — mixes `tokio::time::advance` on a paused clock with a real socket round trip; that combination is a plausible source, unconfirmed.

**Vendored crossterm `event::source::unix::mio::tests::queued_focus_continuation_is_drained_before_stale_escape_expires`** on Linux — inside the fork, which has its own patch-invariant gate. Out of scope for a test-only change here.

## Why this matters beyond the noise

These jobs are deliberately **not** required checks in the `main-pr-self-hosted-gates` ruleset. The remaining flakes are the reason they cannot be promoted yet — every extra failure a run reports is one a reader has to triage before trusting the real result.

## Verification

fmt clean; `clippy --workspace --all-targets -- -D warnings` clean; `cargo test --lib` 4649 passed, 0 failed.