### PR TITLE
test: stop the proxy fixtures racing Tokio's virtual clock

### DIFF
--- a/src/open_subsonic/proxy.rs
+++ b/src/open_subsonic/proxy.rs
@@ -959,6 +959,12 @@ mod tests {
         )
     }
 
+    /// Reads one whole proxy response off a real loopback socket.
+    ///
+    /// Callers must have Tokio's clock **running**. The timeout below is measured on that clock,
+    /// and with it paused Tokio auto-advances to the nearest timer whenever the runtime idles —
+    /// which is exactly what waiting on this socket does — so the timeout would fire before the
+    /// proxy could answer. A `start_paused` test must `tokio::time::resume()` first.
     async fn raw_proxy_request(url: &reqwest::Url, headers: &str) -> Vec<u8> {
         let mut stream = open_raw_proxy_request(url, headers).await;
         let mut response = Vec::new();
@@ -1092,11 +1098,10 @@ mod tests {
         upstream_task.await.unwrap();
     }
 
-    #[tokio::test(start_paused = true)]
-    #[cfg_attr(
-        windows,
-        ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
-    )]
+    // Deliberately not `start_paused`: this test never advances the clock, and a paused clock
+    // would let Tokio auto-advance to `raw_proxy_request`'s timeout the moment the runtime idles
+    // on the real socket — firing it before the proxy has answered.
+    #[tokio::test]
     async fn revoked_episode_returns_not_found() {
         let (upstream_url, upstream_task) = static_upstream(
             b"HTTP/1.1 200 OK\r\nContent-Type: audio/mpeg\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
@@ -1116,10 +1121,6 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    #[cfg_attr(
-        windows,
-        ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
-    )]
     async fn unused_route_expiry_returns_not_found_and_reclaims_capacity() {
         let upstream_url = reqwest::Url::parse("http://127.0.0.1:9/unused").unwrap();
         let origin = ProxyOrigin::from_url(&upstream_url).unwrap();
@@ -1139,6 +1140,11 @@ mod tests {
         assert_eq!(capacity_error.reason(), "route_capacity_reached");
 
         tokio::time::advance(unused_ttl + Duration::from_millis(1)).await;
+        // The expiry above needs the paused clock; the request below waits on a real loopback
+        // socket. Hand the clock back before doing real I/O, exactly as
+        // `admitted_body_stream_outlives_unused_route_deadline` does — otherwise Tokio
+        // auto-advances to `raw_proxy_request`'s timeout as soon as the runtime idles on the read.
+        tokio::time::resume();
         let response = raw_proxy_request(&routes[0].0, "").await;
         assert!(response.starts_with(b"HTTP/1.1 404 Not Found\r\n"));
 
@@ -1161,10 +1167,6 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    #[cfg_attr(
-        windows,
-        ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
-    )]
     async fn admitted_body_stream_outlives_unused_route_deadline() {
         let (upstream_url, finish_tx, upstream_task) = controlled_upstream().await;
         let origin = ProxyOrigin::from_url(&upstream_url).unwrap();


### PR DESCRIPTION
## The bug

`open_subsonic::proxy::tests` rotated failures on macOS across runs — `unused_route_expiry_returns_not_found_and_reclaims_capacity` in one, `revoked_episode_returns_not_found` in another — both panicking at the same line:

```rust
tokio::time::timeout(Duration::from_secs(2), stream.read_to_end(&mut response))
    .await
    .expect("proxy response timeout")   // proxy.rs:967
```

**It is not the loopback socket.** Those tests are `#[tokio::test(start_paused = true)]`, and the helper measures its timeout on that same paused clock. Tokio auto-advances to the nearest timer whenever the runtime goes idle — and waiting on a real socket is precisely when it goes idle — so the 2 s timeout elapses in virtual time before the proxy can answer. Whether that beats the server task to the scheduler is a race, which is why it was load-sensitive and why it rotated between tests rather than sticking to one.

Note this also means **raising the timeout would not have helped**: auto-advance jumps to the next timer regardless of how far away it is.

## The evidence it was already known — and misfiled

`admitted_body_stream_outlives_unused_route_deadline` in the same module already handles it:

```rust
// Give the OS-backed loopback sockets real time to become readable. The admission expiry
// itself remains deterministic below while Tokio's clock is paused.
tokio::time::resume();
tokio::time::timeout(Duration::from_secs(2), async { ... }).await.expect(...);
tokio::time::pause();
tokio::time::advance(unused_ttl + Duration::from_secs(1)).await;
```

So the conflict was understood and fixed in one test, and the other two never got the same treatment.

## The fix

| Test | Change |
|---|---|
| `revoked_episode_returns_not_found` | Never advances the clock, so it stops being `start_paused` at all |
| `unused_route_expiry_...` | Needs the paused clock for the TTL, so it `resume()`s before the real request — the existing in-module pattern |
| `raw_proxy_request` | Documents that callers must have the clock running, so the next paused test does not reintroduce this |

## Dropping three Windows ignores

All three carried:

```rust
cfg_attr(windows, ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture")
```

That reason attributed a clock bug to the platform. The tell: `admitted_body_stream_outlives_unused_route_deadline` carried the ignore too, despite already handling the clock correctly — it was disabled for something that had already been fixed in it.

I removed the ignore from these three so **CI adjudicates the hypothesis**. If Windows still fails them, the ignores come back before this merges and I will say so plainly. If it passes, Windows regains coverage of the proxy path it has not had.

The other four ignores in this file are on tests that are **not** `start_paused`, so the clock does not explain them. Left alone deliberately.

## Verification

macOS: fmt clean; `clippy --workspace --all-targets -- -D warnings` clean; **three consecutive** `cargo test --lib` runs at 4649 passed, 0 failed. The proxy module alone: 11 passed, 0 ignored.

Local runs cannot reproduce the original failure — it needs a loaded runner — so the Windows and macOS jobs on this PR are the real test.