### PR TITLE
test: give the disk-backed transfer tests their own data directory

### DIFF
--- a/src/paths.rs
+++ b/src/paths.rs
@@ -49,8 +49,11 @@ fn env_dir(name: &str) -> Option<PathBuf> {
 }
 
 /// The process-unique sandbox root used to isolate every store under `#[cfg(test)]`.
+///
+/// Shared with `test_util::with_isolated_data_dir`, which carves per-test directories out of it
+/// for tests that write through a real store.
 #[cfg(test)]
-fn test_base() -> PathBuf {
+pub(crate) fn test_base() -> PathBuf {
     use std::sync::OnceLock;
     static BASE: OnceLock<PathBuf> = OnceLock::new();
     BASE.get_or_init(|| {

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -1,1 +1,80 @@
 pub mod env;
+
+/// Runs `f` with `YTM_DATA_DIR` pointed at a directory no other test uses.
+///
+/// Under `#[cfg(test)]` every store resolves inside one process-wide sandbox, so each test that
+/// writes through a real store shares the same files — `<data dir>/playlists.json` in particular.
+/// Two tests interleaving a load-modify-save there lose one of the writes, which surfaces as an
+/// assertion that a playlist the test had just created is missing. It only reproduces under load,
+/// which is why it looked like a platform flake on CI rather than a shared-state bug.
+///
+/// The override is thread-scoped by `paths::env_dir`, so it isolates the calling test without
+/// changing what parallel readers on other threads see.
+#[cfg(test)]
+pub fn with_isolated_data_dir<T>(label: &str, f: impl FnOnce() -> T) -> T {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    let sequence = NEXT.fetch_add(1, Ordering::Relaxed);
+    let dir = crate::paths::test_base().join(format!("isolated-data-{label}-{sequence}"));
+    std::fs::create_dir_all(&dir).expect("create the isolated test data directory");
+    env::with_var("YTM_DATA_DIR", Some(&dir.to_string_lossy()), f)
+}
+
+/// Drives `future` to completion with an isolated data directory installed.
+///
+/// The env override and the thread-scoped flag that exposes it both live on one thread, so the
+/// future has to run there too: a current-thread runtime built inside the scope. Tests needing
+/// this cannot stay `#[tokio::test]`, whose runtime is created outside any scope we control.
+#[cfg(test)]
+pub fn block_on_isolated<F: std::future::Future>(label: &str, future: F) -> F::Output {
+    with_isolated_data_dir(label, || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build the isolated test runtime")
+            .block_on(future)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An override that silently failed to apply would leave every caller sharing the sandbox
+    /// again while still passing, so assert the redirection rather than assuming it.
+    #[test]
+    fn isolated_data_dir_redirects_and_differs_per_call() {
+        let shared = crate::paths::data_dir().expect("sandboxed data dir");
+
+        let first = with_isolated_data_dir("selftest", || {
+            let dir = crate::paths::data_dir().expect("isolated data dir");
+            assert_ne!(dir, shared, "the override did not take effect");
+            assert_eq!(
+                crate::playlists::playlists_path().expect("playlists path"),
+                dir.join("playlists.json"),
+                "playlists.json must follow the override"
+            );
+            dir
+        });
+
+        let second = with_isolated_data_dir("selftest", || {
+            crate::paths::data_dir().expect("isolated dir")
+        });
+        assert_ne!(first, second, "two calls must not share a directory");
+        assert_eq!(
+            crate::paths::data_dir(),
+            Some(shared),
+            "the override must not outlive its scope"
+        );
+    }
+
+    #[test]
+    fn block_on_isolated_applies_the_override_inside_the_future() {
+        let shared = crate::paths::data_dir().expect("sandboxed data dir");
+        let inside = block_on_isolated("selftest-async", async {
+            crate::paths::data_dir().expect("isolated data dir")
+        });
+        assert_ne!(inside, shared, "the future ran outside the override scope");
+    }
+}

--- a/src/transfer/engine/tests.rs
+++ b/src/transfer/engine/tests.rs
@@ -970,64 +970,66 @@ fn ytm_playlist_pause_is_only_between_chunks() {
     assert!(!should_pause_after_chunk(9, 10));
 }
 
-#[tokio::test]
-async fn run_job_resume_rematch_resets_checkpointed_matches_without_persisting() {
-    let original_spec = spec(TransferDest::YtmLikes);
-    let mut cp = Checkpoint::new(
-        "job_with_underscores_no_persist".to_owned(),
-        original_spec.clone(),
-        vec![
-            TrackEntry {
-                input: TrackInput {
-                    known_video_id: Some("cached-yt-id".to_owned()),
-                    ..input("Known Id", &["Artist A"])
+#[test]
+fn run_job_resume_rematch_resets_checkpointed_matches_without_persisting() {
+    crate::test_util::block_on_isolated("resume-rematch", async {
+        let original_spec = spec(TransferDest::YtmLikes);
+        let mut cp = Checkpoint::new(
+            "job_with_underscores_no_persist".to_owned(),
+            original_spec.clone(),
+            vec![
+                TrackEntry {
+                    input: TrackInput {
+                        known_video_id: Some("cached-yt-id".to_owned()),
+                        ..input("Known Id", &["Artist A"])
+                    },
+                    outcome: Some(matched("cached-yt-id")),
+                    review_decision: None,
+                    written: true,
                 },
-                outcome: Some(matched("cached-yt-id")),
-                review_decision: None,
-                written: true,
-            },
-            entry(
-                input("Already Missing", &["Artist B"]),
-                Some(MatchOutcome::NotFound),
-            ),
-        ],
-    );
-    cp.stage = Stage::Writing;
-    cp.skipped_local = 2;
+                entry(
+                    input("Already Missing", &["Artist B"]),
+                    Some(MatchOutcome::NotFound),
+                ),
+            ],
+        );
+        cp.stage = Stage::Writing;
+        cp.skipped_local = 2;
 
-    let mut resumed_spec = original_spec;
-    resumed_spec.dry_run = true;
-    resumed_spec.rematch = true;
-    let mut ctx = JobCtx {
-        ytm: None,
-        spotify: None,
-        search_config: SearchConfig::default(),
-        market: None,
-    };
-    let mut progress = Vec::new();
-    let mut local_playlists = crate::transfer::local_playlist::DiskLocalPlaylistStore;
+        let mut resumed_spec = original_spec;
+        resumed_spec.dry_run = true;
+        resumed_spec.rematch = true;
+        let mut ctx = JobCtx {
+            ytm: None,
+            spotify: None,
+            search_config: SearchConfig::default(),
+            market: None,
+        };
+        let mut progress = Vec::new();
+        let mut local_playlists = crate::transfer::local_playlist::DiskLocalPlaylistStore;
 
-    let report = run_job_with_store(
-        cp.job_id.clone(),
-        resumed_spec,
-        Some(cp),
-        &mut ctx,
-        &mut local_playlists,
-        &mut |p| progress.push(p),
-    )
-    .await
-    .unwrap_or_else(|err| panic!("resume dry-run should not need clients: {}", err.error));
+        let report = run_job_with_store(
+            cp.job_id.clone(),
+            resumed_spec,
+            Some(cp),
+            &mut ctx,
+            &mut local_playlists,
+            &mut |p| progress.push(p),
+        )
+        .await
+        .unwrap_or_else(|err| panic!("resume dry-run should not need clients: {}", err.error));
 
-    assert_eq!(report.job_id, "job_with_underscores_no_persist");
-    assert_eq!(report.total, 2);
-    assert_eq!(report.matched, 0);
-    assert_eq!(report.skipped_local, 2);
-    assert!(report.ambiguous.is_empty());
-    assert!(report.not_found.is_empty());
-    assert!(
-        progress.is_empty(),
-        "writing-stage dry-run should not emit progress"
-    );
+        assert_eq!(report.job_id, "job_with_underscores_no_persist");
+        assert_eq!(report.total, 2);
+        assert_eq!(report.matched, 0);
+        assert_eq!(report.skipped_local, 2);
+        assert!(report.ambiguous.is_empty());
+        assert!(report.not_found.is_empty());
+        assert!(
+            progress.is_empty(),
+            "writing-stage dry-run should not emit progress"
+        );
+    });
 }
 
 #[tokio::test]
@@ -1054,57 +1056,59 @@ async fn match_stage_requires_ytm_client_for_unresolved_tracks() {
     assert!(cp.tracks[0].outcome.is_none());
 }
 
-#[tokio::test]
-async fn write_stage_dedupes_matches_before_missing_client_error() {
-    let mut cp = Checkpoint::new(
-        "job_write_missing_client".to_owned(),
-        spec(TransferDest::YtmLikes),
-        vec![
-            entry(input("First", &["A"]), Some(matched("dup-id"))),
-            entry(input("Duplicate", &["B"]), Some(matched("dup-id"))),
-            entry(
-                input("Take Best", &["C"]),
-                Some(MatchOutcome::Ambiguous {
-                    candidates: vec![AmbiguousCandidate {
-                        key: "ambig-id".to_owned(),
-                        score: 0.79,
-                        display: "C - Candidate".to_owned(),
-                        score_breakdown: None,
-                    }],
-                }),
-            ),
-            entry(input("Missing", &["D"]), Some(MatchOutcome::NotFound)),
-        ],
-    );
-    cp.stage = Stage::Writing;
-    cp.spec.take_best = true;
-    let mut ctx = JobCtx {
-        ytm: None,
-        spotify: None,
-        search_config: SearchConfig::default(),
-        market: None,
-    };
-    let mut report = build_report(&cp, 0);
-    let mut progress = Vec::new();
-    let mut local_playlists = crate::transfer::local_playlist::DiskLocalPlaylistStore;
+#[test]
+fn write_stage_dedupes_matches_before_missing_client_error() {
+    crate::test_util::block_on_isolated("dedupe-missing-client", async {
+        let mut cp = Checkpoint::new(
+            "job_write_missing_client".to_owned(),
+            spec(TransferDest::YtmLikes),
+            vec![
+                entry(input("First", &["A"]), Some(matched("dup-id"))),
+                entry(input("Duplicate", &["B"]), Some(matched("dup-id"))),
+                entry(
+                    input("Take Best", &["C"]),
+                    Some(MatchOutcome::Ambiguous {
+                        candidates: vec![AmbiguousCandidate {
+                            key: "ambig-id".to_owned(),
+                            score: 0.79,
+                            display: "C - Candidate".to_owned(),
+                            score_breakdown: None,
+                        }],
+                    }),
+                ),
+                entry(input("Missing", &["D"]), Some(MatchOutcome::NotFound)),
+            ],
+        );
+        cp.stage = Stage::Writing;
+        cp.spec.take_best = true;
+        let mut ctx = JobCtx {
+            ytm: None,
+            spotify: None,
+            search_config: SearchConfig::default(),
+            market: None,
+        };
+        let mut report = build_report(&cp, 0);
+        let mut progress = Vec::new();
+        let mut local_playlists = crate::transfer::local_playlist::DiskLocalPlaylistStore;
 
-    let err = write_stage(
-        &mut cp,
-        &mut ctx,
-        &mut local_playlists,
-        None,
-        &mut |p| progress.push(p),
-        &mut report,
-    )
-    .await
-    .expect_err("YTM likes write should require a YTM client");
+        let err = write_stage(
+            &mut cp,
+            &mut ctx,
+            &mut local_playlists,
+            None,
+            &mut |p| progress.push(p),
+            &mut report,
+        )
+        .await
+        .expect_err("YTM likes write should require a YTM client");
 
-    assert!(!err.resumable);
-    assert!(err.error.to_string().contains("YouTube Music cookie"));
-    assert_eq!(report.duplicates_dropped, 1);
-    assert_eq!(report.written, 0);
-    assert!(progress.is_empty());
-    assert!(cp.tracks.iter().all(|track| !track.written));
+        assert!(!err.resumable);
+        assert!(err.error.to_string().contains("YouTube Music cookie"));
+        assert_eq!(report.duplicates_dropped, 1);
+        assert_eq!(report.written, 0);
+        assert!(progress.is_empty());
+        assert!(cp.tracks.iter().all(|track| !track.written));
+    });
 }
 
 #[tokio::test]
@@ -1310,140 +1314,144 @@ fn fast_auto_accept_never_promotes_blocked_or_rejected_candidates() {
     ));
 }
 
-#[tokio::test]
-async fn write_stage_creates_local_playlist_for_spotify_liked_source() {
-    let playlist_name = "Spotify Liked Songs Local Write Test".to_owned();
-    let mut cp = Checkpoint::new(
-        "job-liked-local-playlist".to_owned(),
-        spec(TransferDest::LocalPlaylist {
-            name: Some(playlist_name.clone()),
-        }),
-        vec![entry(
-            input("Liked Song", &["Artist A"]),
-            Some(matched("vid-liked")),
-        )],
-    );
-    cp.stage = Stage::Writing;
-    cp.dest_name = Some(default_dest_name(&cp.spec.dest, "Spotify Liked Songs"));
-    let mut ctx = JobCtx {
-        ytm: None,
-        spotify: None,
-        search_config: SearchConfig::default(),
-        market: None,
-    };
-    let mut report = build_report(&cp, 0);
-    let mut progress = Vec::new();
-    let mut local_playlists = crate::transfer::local_playlist::DiskLocalPlaylistStore;
+#[test]
+fn write_stage_creates_local_playlist_for_spotify_liked_source() {
+    crate::test_util::block_on_isolated("liked-local-playlist", async {
+        let playlist_name = "Spotify Liked Songs Local Write Test".to_owned();
+        let mut cp = Checkpoint::new(
+            "job-liked-local-playlist".to_owned(),
+            spec(TransferDest::LocalPlaylist {
+                name: Some(playlist_name.clone()),
+            }),
+            vec![entry(
+                input("Liked Song", &["Artist A"]),
+                Some(matched("vid-liked")),
+            )],
+        );
+        cp.stage = Stage::Writing;
+        cp.dest_name = Some(default_dest_name(&cp.spec.dest, "Spotify Liked Songs"));
+        let mut ctx = JobCtx {
+            ytm: None,
+            spotify: None,
+            search_config: SearchConfig::default(),
+            market: None,
+        };
+        let mut report = build_report(&cp, 0);
+        let mut progress = Vec::new();
+        let mut local_playlists = crate::transfer::local_playlist::DiskLocalPlaylistStore;
 
-    write_stage(
-        &mut cp,
-        &mut ctx,
-        &mut local_playlists,
-        None,
-        &mut |p| progress.push(p),
-        &mut report,
-    )
-    .await
-    .unwrap_or_else(|err| panic!("local write should not need service clients: {}", err.error));
+        write_stage(
+            &mut cp,
+            &mut ctx,
+            &mut local_playlists,
+            None,
+            &mut |p| progress.push(p),
+            &mut report,
+        )
+        .await
+        .unwrap_or_else(|err| panic!("local write should not need service clients: {}", err.error));
 
-    let store = crate::playlists::Playlists::load();
-    let playlist = store
-        .find(&playlist_name)
-        .expect("liked songs local import should create a playlist");
+        let store = crate::playlists::Playlists::load();
+        let playlist = store
+            .find(&playlist_name)
+            .expect("liked songs local import should create a playlist");
 
-    assert_eq!(playlist.songs.len(), 1);
-    assert_eq!(playlist.songs[0].video_id, "vid-liked");
-    assert_eq!(playlist.songs[0].title, "Liked Song");
-    assert_eq!(cp.dest_id.as_deref(), Some(playlist.id.as_str()));
-    assert_eq!(report.written, 1);
-    assert_eq!(progress.len(), 1);
-    assert!(cp.tracks[0].written);
+        assert_eq!(playlist.songs.len(), 1);
+        assert_eq!(playlist.songs[0].video_id, "vid-liked");
+        assert_eq!(playlist.songs[0].title, "Liked Song");
+        assert_eq!(cp.dest_id.as_deref(), Some(playlist.id.as_str()));
+        assert_eq!(report.written, 1);
+        assert_eq!(progress.len(), 1);
+        assert!(cp.tracks[0].written);
+    });
 }
 
-#[tokio::test]
-async fn write_reviewed_local_job_writes_ready_rows_idempotently() {
-    let job_id = random_job_id("job-local-reviewed-write");
-    let playlist_name = format!("Reviewed Write {}", job_id);
-    let mut accepted = entry(
-        input("Accepted Song", &["Artist"]),
-        Some(ambiguous(vec![ambiguous_candidate(
-            "vid-accepted",
-            0.78,
-            false,
-            None,
-        )])),
-    );
-    accepted.review_decision = Some(ReviewDecision::Accepted {
-        key: "vid-accepted".to_owned(),
-        score: 0.78,
-        display: "Artist - Accepted Song".to_owned(),
+#[test]
+fn write_reviewed_local_job_writes_ready_rows_idempotently() {
+    crate::test_util::block_on_isolated("reviewed-local-idempotent", async {
+        let job_id = random_job_id("job-local-reviewed-write");
+        let playlist_name = format!("Reviewed Write {}", job_id);
+        let mut accepted = entry(
+            input("Accepted Song", &["Artist"]),
+            Some(ambiguous(vec![ambiguous_candidate(
+                "vid-accepted",
+                0.78,
+                false,
+                None,
+            )])),
+        );
+        accepted.review_decision = Some(ReviewDecision::Accepted {
+            key: "vid-accepted".to_owned(),
+            score: 0.78,
+            display: "Artist - Accepted Song".to_owned(),
+        });
+        let already_written = TrackEntry {
+            written: true,
+            ..entry(
+                input("Already Written", &["Artist"]),
+                Some(matched("vid-written")),
+            )
+        };
+        let mut cp = Checkpoint::new(
+            job_id.clone(),
+            spec(TransferDest::LocalPlaylist {
+                name: Some(playlist_name.clone()),
+            }),
+            vec![
+                entry(
+                    input("Duplicate First", &["Artist"]),
+                    Some(matched("vid-duplicate")),
+                ),
+                accepted,
+                entry(
+                    input("Duplicate Second", &["Artist"]),
+                    Some(matched("vid-duplicate")),
+                ),
+                already_written,
+            ],
+        );
+        cp.source_name = Some("Spotify source".to_owned());
+        cp.dest_name = Some(playlist_name.clone());
+        cp.stage = Stage::Done;
+        cp.save().expect("save completed dry-run checkpoint");
+        crate::transfer::session::ImportSession::from_checkpoint(&cp)
+            .save()
+            .expect("save completed import session");
+        let mut progress = Vec::new();
+        let mut local_playlists = crate::transfer::local_playlist::DiskLocalPlaylistStore;
+
+        let report = write_reviewed_local_job_with_store(&job_id, &mut local_playlists, &mut |p| {
+            progress.push(p)
+        })
+        .await
+        .unwrap_or_else(|err| panic!("reviewed local write failed: {}", err.error));
+
+        assert_eq!(report.written, 2);
+        assert_eq!(report.job_id, job_id);
+        assert_eq!(progress.len(), 3);
+        assert_eq!(progress.last().map(|p| p.written), Some(4));
+        let saved = Checkpoint::load(&job_id).expect("load written checkpoint");
+        assert!(saved.tracks.iter().all(|track| track.written));
+        assert_eq!(saved.stage, Stage::Done);
+        let playlist_id = saved.dest_id.clone().expect("destination id checkpointed");
+
+        let store = crate::playlists::Playlists::load();
+        let playlist = store.find(&playlist_id).expect("playlist remains");
+        let ids: Vec<_> = playlist
+            .songs
+            .iter()
+            .map(|song| song.video_id.as_str())
+            .collect();
+        assert_eq!(ids.iter().filter(|id| **id == "vid-duplicate").count(), 1);
+        assert_eq!(ids.iter().filter(|id| **id == "vid-accepted").count(), 1);
+
+        let session = crate::transfer::session::ImportSession::load(&job_id)
+            .expect("load written import session");
+        assert_eq!(
+            session.destination.key.as_deref(),
+            Some(playlist_id.as_str())
+        );
     });
-    let already_written = TrackEntry {
-        written: true,
-        ..entry(
-            input("Already Written", &["Artist"]),
-            Some(matched("vid-written")),
-        )
-    };
-    let mut cp = Checkpoint::new(
-        job_id.clone(),
-        spec(TransferDest::LocalPlaylist {
-            name: Some(playlist_name.clone()),
-        }),
-        vec![
-            entry(
-                input("Duplicate First", &["Artist"]),
-                Some(matched("vid-duplicate")),
-            ),
-            accepted,
-            entry(
-                input("Duplicate Second", &["Artist"]),
-                Some(matched("vid-duplicate")),
-            ),
-            already_written,
-        ],
-    );
-    cp.source_name = Some("Spotify source".to_owned());
-    cp.dest_name = Some(playlist_name.clone());
-    cp.stage = Stage::Done;
-    cp.save().expect("save completed dry-run checkpoint");
-    crate::transfer::session::ImportSession::from_checkpoint(&cp)
-        .save()
-        .expect("save completed import session");
-    let mut progress = Vec::new();
-    let mut local_playlists = crate::transfer::local_playlist::DiskLocalPlaylistStore;
-
-    let report = write_reviewed_local_job_with_store(&job_id, &mut local_playlists, &mut |p| {
-        progress.push(p)
-    })
-    .await
-    .unwrap_or_else(|err| panic!("reviewed local write failed: {}", err.error));
-
-    assert_eq!(report.written, 2);
-    assert_eq!(report.job_id, job_id);
-    assert_eq!(progress.len(), 3);
-    assert_eq!(progress.last().map(|p| p.written), Some(4));
-    let saved = Checkpoint::load(&job_id).expect("load written checkpoint");
-    assert!(saved.tracks.iter().all(|track| track.written));
-    assert_eq!(saved.stage, Stage::Done);
-    let playlist_id = saved.dest_id.clone().expect("destination id checkpointed");
-
-    let store = crate::playlists::Playlists::load();
-    let playlist = store.find(&playlist_id).expect("playlist remains");
-    let ids: Vec<_> = playlist
-        .songs
-        .iter()
-        .map(|song| song.video_id.as_str())
-        .collect();
-    assert_eq!(ids.iter().filter(|id| **id == "vid-duplicate").count(), 1);
-    assert_eq!(ids.iter().filter(|id| **id == "vid-accepted").count(), 1);
-
-    let session = crate::transfer::session::ImportSession::load(&job_id)
-        .expect("load written import session");
-    assert_eq!(
-        session.destination.key.as_deref(),
-        Some(playlist_id.as_str())
-    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## The last Windows failure, and it was never a platform bug

`transfer::engine::tests::write_stage_creates_local_playlist_for_spotify_liked_source` was the single remaining failure on the Windows suite (`4430 passed; 1 failed` on #132) and had shown up on macOS too.

Four tests in that module write through the real `DiskLocalPlaylistStore`:

```rust
async fn apply(&mut self, patch: LocalPlaylistPatch) -> ... {
    let current = Playlists::load();          // <- read
    let plan = plan_apply_local_playlist_patch(&current, &patch)?;
    plan.candidate.save()?;                   // <- write
}
```

Under `#[cfg(test)]`, `paths::data_dir()` resolves inside **one process-wide sandbox**, so all four share `<data dir>/playlists.json` — and so does a second, independent group of writers via `persist::owned_snapshot`. Two interleaved load-modify-saves lose one write, and the test then cannot `find` the playlist it just created:

```
liked songs local import should create a playlist
```

That is the assertion, verbatim. It only reproduces under load, which is why it looked like a Windows flake.

## Why isolation and not a lock

A mutex around the store's load→save would make that pair atomic, but the `persist::owned_snapshot` writers reach the same file **without going through the store**, so the race would survive. Isolating the data directory closes it regardless of who else writes.

## The primitive already existed

`paths::env_dir` deliberately exposes `YTM_DATA_DIR` only to the thread currently inside a `test_util::env` scope:

```rust
#[cfg(test)]
if !crate::test_util::env::scoped_mutation_active() {
    return None;
}
```

There is even a test in `paths.rs` asserting a parallel reader does not see it. What was missing is an ergonomic wrapper, so this adds:

- `test_util::with_isolated_data_dir(label, f)` — a per-call directory under the existing sandbox
- `test_util::block_on_isolated(label, future)` — the same, driving a future to completion

The four tests stop being `#[tokio::test]`: that runtime is created outside any scope we control, and the override plus the thread-local flag that exposes it must live on the thread running the future. `paths::test_base` becomes `pub(crate)` so the per-test directories come out of the sandbox the suite already cleans.

## The helper is tested, and the tests can fail

Two self-tests assert the override actually redirects `data_dir()` **and** `playlists_path()`, that two calls do not share a directory, that it does not outlive its scope, and that it reaches inside the future.

An isolation helper that silently did nothing would leave every caller sharing the sandbox while still passing, so I mutated it — pointing it at a different variable name:

```
test test_util::tests::isolated_data_dir_redirects_and_differs_per_call ... FAILED
test test_util::tests::block_on_isolated_applies_the_override_inside_the_future ... FAILED
assertion `left != right` failed: the override did not take effect
assertion `left != right` failed: the future ran outside the override scope
```

and both pass again on revert.

## Verification

macOS: fmt clean; `clippy --workspace --all-targets -- -D warnings` clean; **two consecutive** `cargo test --lib` runs at 4651 passed (4649 plus the two new self-tests); architecture, file-size, doc-honesty and unsafe-inventory gates green.

The Windows job on this PR is the real test — the failure it targets only appears under load.

## After this

If Windows comes back clean, the remaining known flakes are `daemon::parity_tests` on Windows (three tests observed, cause still unknown), a single `tests/cli_smoke.rs` observation, and the vendored crossterm `event::source::unix::mio` timing test.