### PR TITLE
test: keep lock files out of the cli_smoke tree snapshot

### DIFF
--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -207,6 +207,20 @@ fn snapshot_tree(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
             if file_type.is_dir() {
                 visit(root, &path, out);
             } else if file_type.is_file() {
+                // Lock files are coordination artifacts, not data, and they are the one thing in
+                // here that cannot simply be read. A live owner holds a byte-range lock on its
+                // writer lease; Windows enforces those, so this read returns ERROR_LOCK_VIOLATION
+                // instead of bytes, while the same lock on Unix is advisory and reads fine. That
+                // asymmetry is what made `personal_data_import_preview_...` fail only on Windows.
+                // Excluding them is also more correct than including them: detecting contention
+                // means opening and try-locking the lease, so a lock file legitimately changes
+                // even when nothing about the data tree does.
+                let is_lock = path
+                    .file_name()
+                    .is_some_and(|name| name.to_string_lossy().ends_with(".lock"));
+                if is_lock {
+                    continue;
+                }
                 out.push((
                     path.strip_prefix(root)
                         .expect("snapshot path below root")
@@ -647,6 +661,19 @@ fn personal_data_import_preview_runs_beside_owner_but_apply_requires_writer_leas
     .expect("open writer lease")
     .expect("hold simulated owner lease");
     let before = snapshot_tree(&data_dir);
+    // The lease this test is holding lives inside the tree being snapshotted. Windows enforces
+    // its byte-range lock, so a snapshot that tried to read it would fail here rather than in
+    // the comparison below. Pin the exclusion so restoring it cannot silently reintroduce that.
+    assert!(
+        data_dir.join(".ytt-persistence-writer.lock").exists(),
+        "the simulated owner lease should exist on disk"
+    );
+    assert!(
+        !before
+            .iter()
+            .any(|(path, _)| path.to_string_lossy().ends_with(".lock")),
+        "lock files must stay out of the snapshot"
+    );
 
     let preview = isolated_command(
         &root,


### PR DESCRIPTION
## The failure

Twice on Windows, never on Unix:

```
tests\cli_smoke.rs:214
snapshot file bytes: Os { code: 33, kind: Uncategorized,
  message: "The process cannot access the file because another process has locked a portion of the file." }
```

Error 33 is `ERROR_LOCK_VIOLATION`.

## Cause

The test takes the writer lease itself to simulate a live owner:

```rust
let owner_lock = try_lock_private_file(&data_dir.join(".ytt-persistence-writer.lock"))...;
let before = snapshot_tree(&data_dir);
```

`snapshot_tree` walks that directory and `std::fs::read`s **every** file — including the lease it is currently holding.

`LockFileEx` is **mandatory** on Windows, so that read is refused. The same lock under `flock` on Unix is **advisory**, so the read succeeds and the test passes. That asymmetry is the whole bug; there is nothing platform-specific about the behaviour under test.

## Fix

`snapshot_tree` skips `*.lock`.

This is more correct than the previous behaviour, not weaker coverage. Lock files are coordination artifacts rather than data, and detecting write contention *means* opening and try-locking the lease — so a lock file can legitimately change while the data tree it guards does not. Including them made the "preview must not mutate the owner's data tree" assertion sensitive to something that is not the data tree.

The test now also pins the intent:

```rust
assert!(data_dir.join(".ytt-persistence-writer.lock").exists(), ...);
assert!(!before.iter().any(|(path, _)| path.to_string_lossy().ends_with(".lock")), ...);
```

so restoring the read cannot silently bring the failure back.

## Verified by mutation

Disabling the skip:

```
test personal_data_import_preview_runs_beside_owner_but_apply_requires_writer_lease ... FAILED
panicked at tests/cli_smoke.rs:671:5
```

and it passes again on revert.

## Verification

macOS: fmt clean; `clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace` green on every target (lib 4651, cli_smoke 20).

Windows CI on this PR is the real test — the failure needs `LockFileEx` semantics that macOS and Linux do not have.

## Where this leaves the flake list

With #131, #132, #133 and this one merged, the remaining known flakes are `daemon::parity_tests` on Windows (three tests observed across runs, cause still unidentified — I checked and ruled out the process-global `QUEUE_REV`) and the vendored crossterm `event::source::unix::mio` timing test on Linux.