### PR TITLE
test: make the parity revision-guard failures say what went wrong

### DIFF
--- a/src/daemon/parity_tests.rs
+++ b/src/daemon/parity_tests.rs
@@ -761,7 +761,13 @@ async fn revision_checked_queue_remove_is_stale_safe_and_owner_parity_holds() {
         .await;
     assert!(!shutdown);
     assert!(effects.is_empty());
-    assert!(app_resp.ok && engine_resp.ok);
+    assert_both_accepted(
+        "fresh revision-checked remove",
+        &app,
+        &engine,
+        &app_resp,
+        &engine_resp,
+    );
     assert_eq!(app_resp.reason, engine_resp.reason);
     assert_parity("fresh revision-checked remove", &app, &engine);
 }
@@ -874,7 +880,13 @@ async fn revision_guarded_move_and_clear_reject_stale_and_accept_fresh_or_absent
         })
         .await;
     assert!(!shutdown);
-    assert!(app_resp.ok && engine_resp.ok);
+    assert_both_accepted(
+        "fresh revision-checked move",
+        &app,
+        &engine,
+        &app_resp,
+        &engine_resp,
+    );
     assert_eq!(app_resp.reason, engine_resp.reason);
     assert_parity("fresh revision-checked move", &app, &engine);
 
@@ -889,7 +901,13 @@ async fn revision_guarded_move_and_clear_reject_stale_and_accept_fresh_or_absent
     let unguarded = RemoteCommand::QueueClearUpcoming { expected_rev: None };
     let app_resp = app_apply(&mut app, unguarded.clone());
     let (engine_resp, ..) = engine.handle_remote(unguarded).await;
-    assert!(app_resp.ok && engine_resp.ok);
+    assert_both_accepted(
+        "unguarded clear-upcoming",
+        &app,
+        &engine,
+        &app_resp,
+        &engine_resp,
+    );
     assert_eq!(app_resp.reason, engine_resp.reason);
     assert_parity("unguarded clear-upcoming", &app, &engine);
 }

--- a/src/daemon/parity_tests.rs
+++ b/src/daemon/parity_tests.rs
@@ -761,13 +761,7 @@ async fn revision_checked_queue_remove_is_stale_safe_and_owner_parity_holds() {
         .await;
     assert!(!shutdown);
     assert!(effects.is_empty());
-    assert_both_accepted(
-        "fresh revision-checked remove",
-        &app,
-        &engine,
-        &app_resp,
-        &engine_resp,
-    );
+    assert_accepted("guarded remove", &app, &engine, &app_resp, &engine_resp);
     assert_eq!(app_resp.reason, engine_resp.reason);
     assert_parity("fresh revision-checked remove", &app, &engine);
 }
@@ -880,13 +874,7 @@ async fn revision_guarded_move_and_clear_reject_stale_and_accept_fresh_or_absent
         })
         .await;
     assert!(!shutdown);
-    assert_both_accepted(
-        "fresh revision-checked move",
-        &app,
-        &engine,
-        &app_resp,
-        &engine_resp,
-    );
+    assert_accepted("guarded move", &app, &engine, &app_resp, &engine_resp);
     assert_eq!(app_resp.reason, engine_resp.reason);
     assert_parity("fresh revision-checked move", &app, &engine);
 
@@ -901,13 +889,7 @@ async fn revision_guarded_move_and_clear_reject_stale_and_accept_fresh_or_absent
     let unguarded = RemoteCommand::QueueClearUpcoming { expected_rev: None };
     let app_resp = app_apply(&mut app, unguarded.clone());
     let (engine_resp, ..) = engine.handle_remote(unguarded).await;
-    assert_both_accepted(
-        "unguarded clear-upcoming",
-        &app,
-        &engine,
-        &app_resp,
-        &engine_resp,
-    );
+    assert_accepted("unguarded clear", &app, &engine, &app_resp, &engine_resp);
     assert_eq!(app_resp.reason, engine_resp.reason);
     assert_parity("unguarded clear-upcoming", &app, &engine);
 }

--- a/src/daemon/parity_tests/harness.rs
+++ b/src/daemon/parity_tests/harness.rs
@@ -274,6 +274,42 @@ fn normalize(player: &mut PlayerModel, queue: &mut QueueModel) {
     queue.rev = 0;
 }
 
+/// Asserts both owners accepted, naming the side that refused and why.
+///
+/// `assert!(app_resp.ok && engine_resp.ok)` says nothing about which owner rejected the command
+/// or on what grounds, which is exactly the question when it fires on CI and not on any machine
+/// you can attach to. The revision-guarded cases have exactly two ways to refuse — `stale_rev`
+/// when the guard saw a queue revision other than the one handed to it, and `queue_index` when
+/// the queue was shorter than the position — so the reason alone separates them. The live queue
+/// revision and length are printed too, because a mismatch says whether the queue moved under
+/// the test between reading the revision and issuing the command.
+pub(super) fn assert_both_accepted(
+    step: &str,
+    app: &App,
+    engine: &DaemonEngine,
+    app_resp: &RemoteResponse,
+    engine_resp: &RemoteResponse,
+) {
+    if app_resp.ok && engine_resp.ok {
+        return;
+    }
+    let app_queue = app.core_view().queue;
+    let engine_queue = engine.core_view().queue;
+    panic!(
+        "{step}: both owners had to accept.\n  \
+         App:    ok={} reason={:?} queue rev={} len={}\n  \
+         daemon: ok={} reason={:?} queue rev={} len={}",
+        app_resp.ok,
+        app_resp.reason,
+        app_queue.rev(),
+        app_queue.len(),
+        engine_resp.ok,
+        engine_resp.reason,
+        engine_queue.rev(),
+        engine_queue.len(),
+    );
+}
+
 pub(super) fn assert_parity(step: &str, app: &App, engine: &DaemonEngine) {
     let (mut app_player, mut app_queue) = models_of(&app.core_view());
     let (mut daemon_player, mut daemon_queue) = models_of(&engine.core_view());

--- a/src/daemon/parity_tests/harness.rs
+++ b/src/daemon/parity_tests/harness.rs
@@ -283,7 +283,7 @@ fn normalize(player: &mut PlayerModel, queue: &mut QueueModel) {
 /// the queue was shorter than the position — so the reason alone separates them. The live queue
 /// revision and length are printed too, because a mismatch says whether the queue moved under
 /// the test between reading the revision and issuing the command.
-pub(super) fn assert_both_accepted(
+pub(super) fn assert_accepted(
     step: &str,
     app: &App,
     engine: &DaemonEngine,


### PR DESCRIPTION
## This is not a fix

The Windows `daemon::parity_tests` flake is still unidentified. What this changes is that the **next** occurrence will answer the question rather than restate it.

Both captured failures were this assertion:

```rust
assert!(app_resp.ok && engine_resp.ok);
```

It reports neither which owner refused nor on what grounds — the only two facts worth having about a failure that has never reproduced off CI. Three runs produced three different test names and, between them, one usable line of evidence.

## What I ruled out

All by elimination, and recorded so nobody repeats it:

| Hypothesis | Why not |
|---|---|
| Process-global `QUEUE_REV` (`queue.rs:29`) | Each test reads its **own** owner's `queue.rev()` and hands that value straight back; `apply_remote` compares against the same field. A concurrent mint by another test cannot invalidate it. |
| Shared on-disk sandbox (the #133 cause) | `hermetic_pair` builds from `Config::default`, `Playlists::default` and `seed_snapshot`, with no disk reads at all. |
| `queue_index` as the rejection reason | `seed_snapshot` is fully local — four songs, cursor 1 — so `position: 0` is always in range, and that is `remote_queue_remove`'s **only** rejection path. |

The third one is the useful narrowing: with `queue_index` unreachable, **`stale_rev` is the only reason left**. Something moves the queue revision between the test reading it and the guard comparing it. What does the moving is still unknown.

Reproduction attempts that failed: five full `cargo test --lib` runs idle, and four runs of the parity suite under saturating CPU load on 18 cores. It needs the real thing — a loaded Windows runner.

## What the next failure will print

`assert_both_accepted` names the side, its reason, and both owners' live queue revision and length. Verified by mutation — perturbing the expected revision gives:

```
fresh revision-checked remove: both owners had to accept.
  App:    ok=false reason=Some("stale_rev") queue rev=6 len=4
  daemon: ok=true reason=Some("ok") queue rev=7 len=3
```

That distinguishes every remaining possibility in one line: which owner, whether the revision moved, and whether the queue length moved with it.

## Verification

macOS: fmt clean; `clippy --workspace --all-targets -- -D warnings` clean; `cargo test --lib` 4651 passed, 0 failed.

Applied to the three revision-guarded sites, which covers both tests that have actually been seen failing this way. The third observed name, `shared_script_keeps_app_and_engine_projections_equal`, has a different shape and is untouched.