### PR TITLE
test: stop the import-review helper swallowing its action's error

### DIFF
--- a/src/app/tests/local_import.rs
+++ b/src/app/tests/local_import.rs
@@ -176,6 +176,14 @@ fn finish_import_review_cmd(app: &mut App, cmd: Cmd) {
         }
     }
     .map_err(|error| format!("{error:#}"));
+    // The review action ran synchronously just above, and every caller goes on to assert that
+    // its decision reached the persisted session. Handing a failure to the reducer and saying
+    // nothing turns any transient error — a busy record lock, an IO failure — into an assertion
+    // about a session that simply never changed, several lines away and with the cause gone.
+    // `local_deck_import_review_keys_accept_and_reject_rows` failed exactly that way on Windows.
+    if let Err(error) = &result {
+        panic!("{action:?} on row {source_order} of session `{session_id}` failed: {error}");
+    }
     app.update(Msg::Local(LocalMsg::ImportReviewFinished {
         op_id,
         session_id,


### PR DESCRIPTION
## The observation

One failure on `main`'s Windows job after #134:

```
app::tests::local_import::local_deck_import_review_keys_accept_and_reject_rows
src\app\tests\local_import.rs:1101
test result: FAILED. 4432 passed; 1 failed
```

Line 1101 asserts a just-accepted row carries its review decision. The session **loaded fine** — the decision simply was not in it.

## Why the failure told us nothing

`finish_import_review_cmd` runs the review action synchronously and then discards its verdict:

```rust
let result = match action { ... }.map_err(|error| format!("{error:#}"));
app.update(Msg::Local(LocalMsg::ImportReviewFinished { result, .. }));
```

All four callers go on to assert the decision reached the persisted session. So a transient failure inside `accept_first_candidate` — `ImportRecordGuard::try_acquire` finding the record lock busy, an IO error on the write — surfaced as an assertion about a session that never changed, six lines later, with the cause already thrown away.

## What changes

The helper now fails at the action, naming the action, row, session and error. No caller exercises the error path, so nothing else moves.

## Why this is worth doing rather than guessing

I could not reproduce it, and one observation is not a pattern. But the change **splits the two possibilities cleanly**, which is what the next occurrence needs:

- the new panic fires → the action failed, and its message says why;
- the old assertion still fires → the action reported **success** but its write did not persist. That would be a considerably more serious finding than a flaky lock, and right now the two are indistinguishable.

## Ruled out while looking

Not the shared-sandbox class fixed in #133. Every path here is keyed by session id — `record-locks/{id}.lock` via `open_record_lock`, `session_path(id)` — and each test uses its own fixed id (`sp2yt-local-review-accept`, `-reject`, `-choose`, `-skip`), so two tests cannot collide on a file.

## Verified by mutation

Holding the record lock before the action runs:

```
ChooseNext on row 1 of session `sp2yt-local-review-choose` failed:
import job `sp2yt-local-review-choose` is still active
```

and the suite is green again on revert.

## Verification

macOS: fmt clean; `clippy --workspace --all-targets -- -D warnings` clean; `cargo test --lib` 4651 passed; file-size, architecture and doc-honesty gates green.

I ran `check-file-size.sh` deliberately this time — #135 was rejected by that gate after rustfmt expanded a call past `fn_call_width`, and a lines-added change is exactly when it matters.