### PR TITLE
feat(safe-fs): allow a named stage to promote inside its own directory

### DIFF
--- a/src/util/safe_fs/pinned.rs
+++ b/src/util/safe_fs/pinned.rs
@@ -397,6 +397,17 @@ impl OwnedGeneration {
     /// Anonymous generations are linked from their exact handle. Named fallbacks are moved with
     /// the platform's no-replace primitive; Windows binds the rename directly to this file
     /// handle. The returned handle is reopened read-only at the final name.
+    ///
+    /// A named stage may also be promoted inside a directory the app does not privately own, but
+    /// only when it never leaves that one directory: the source parent and `destination` must be
+    /// the same pinned object. Staying inside one directory is what makes a user-selected
+    /// destination reachable at all, because the anonymous residence is Linux-only and a rename
+    /// out of an app-owned staging directory fails with `EXDEV` across a mount. The private
+    /// namespace was standing in for the identity checks that bracket the rename below, which
+    /// still run. What it cannot promise for a directory other writers can reach is that the name
+    /// is not swapped between the pre-rename check and the rename itself; a swap is detected
+    /// afterwards and reported, and it grants nothing a writer of that directory did not already
+    /// have.
     pub(crate) fn promote_noreplace(
         self,
         destination: &PinnedDir,
@@ -409,10 +420,14 @@ impl OwnedGeneration {
         self.verify()?;
         self.file.sync_all()?;
 
-        if self.residence == GenerationResidence::Named && !self.parent.inner.private_namespace {
+        let promotes_within_one_directory = self.parent.identity() == destination.identity();
+        if self.residence == GenerationResidence::Named
+            && !self.parent.inner.private_namespace
+            && !promotes_within_one_directory
+        {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
-                "named no-replace promotion requires an app-owned private source namespace",
+                "named no-replace promotion out of its own directory requires an app-owned private source namespace",
             ));
         }
 

--- a/src/util/safe_fs/pinned/tests.rs
+++ b/src/util/safe_fs/pinned/tests.rs
@@ -201,19 +201,96 @@ fn unsupported_ephemeral_creation_never_falls_back_in_an_untrusted_directory() {
 }
 
 #[test]
-fn untrusted_named_generation_cannot_be_promoted() {
+fn untrusted_named_generation_cannot_be_promoted_out_of_its_directory() {
     let _revoke_reset = MutationRevokeReset::clear();
     let root = temp_root("untrusted-named-promote");
+    let stage_dir = root.join("stage");
+    let publish_dir = root.join("publish");
+    fs::create_dir_all(&stage_dir).unwrap();
+    fs::create_dir_all(&publish_dir).unwrap();
+    let staged = PinnedDir::open_existing(&stage_dir, PathBuf::new().as_path()).unwrap();
+    let published = PinnedDir::open_existing(&publish_dir, PathBuf::new().as_path()).unwrap();
+    let stage = staged.create_new(OsStr::new("owned.stage")).unwrap();
+
+    let error = stage
+        .promote_noreplace(&published, OsStr::new("final.audio"))
+        .expect_err("untrusted cross-directory promotion must fail closed");
+
+    assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
+    assert!(stage_dir.join("owned.stage").is_file());
+    assert!(!publish_dir.join("final.audio").exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn untrusted_named_generation_promotes_within_one_directory() {
+    let _revoke_reset = MutationRevokeReset::clear();
+    let root = temp_root("untrusted-same-dir-promote");
     fs::create_dir_all(&root).unwrap();
     let pinned = PinnedDir::open_existing(&root, PathBuf::new().as_path()).unwrap();
-    let stage = pinned.create_new(OsStr::new("owned.stage")).unwrap();
+    let mut stage = pinned.create_new(OsStr::new("owned.stage")).unwrap();
+    stage.file_mut().unwrap().write_all(b"published").unwrap();
+    stage.sync_durable().unwrap();
+
+    let published = stage
+        .promote_noreplace(&pinned, OsStr::new("final.audio"))
+        .expect("a stage that never leaves its own directory must promote");
+
+    assert_eq!(fs::read(root.join("final.audio")).unwrap(), b"published");
+    assert!(!root.join("owned.stage").exists());
+    let mut contents = Vec::new();
+    published
+        .file()
+        .unwrap()
+        .read_to_end(&mut contents)
+        .unwrap();
+    assert_eq!(contents, b"published");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn untrusted_same_directory_promotion_never_replaces_an_existing_name() {
+    let _revoke_reset = MutationRevokeReset::clear();
+    let root = temp_root("untrusted-same-dir-noreplace");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("final.audio"), b"already here").unwrap();
+    let pinned = PinnedDir::open_existing(&root, PathBuf::new().as_path()).unwrap();
+    let mut stage = pinned.create_new(OsStr::new("owned.stage")).unwrap();
+    stage.file_mut().unwrap().write_all(b"published").unwrap();
+    stage.sync_durable().unwrap();
 
     let error = stage
         .promote_noreplace(&pinned, OsStr::new("final.audio"))
-        .expect_err("untrusted named promotion must fail closed");
+        .expect_err("an occupied destination name must never be replaced");
 
-    assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
+    assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+    assert_eq!(fs::read(root.join("final.audio")).unwrap(), b"already here");
     assert!(root.join("owned.stage").is_file());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn untrusted_same_directory_promotion_rejects_a_stage_name_swap() {
+    let _revoke_reset = MutationRevokeReset::clear();
+    let root = temp_root("untrusted-same-dir-stage-swap");
+    fs::create_dir_all(&root).unwrap();
+    let pinned = PinnedDir::open_existing(&root, PathBuf::new().as_path()).unwrap();
+    let mut stage = pinned.create_new(OsStr::new("owned.stage")).unwrap();
+    stage.file_mut().unwrap().write_all(b"owned").unwrap();
+    stage.sync_durable().unwrap();
+    fs::rename(root.join("owned.stage"), root.join("displaced-owned.stage")).unwrap();
+    fs::write(root.join("owned.stage"), b"foreign").unwrap();
+
+    let error = stage
+        .promote_noreplace(&pinned, OsStr::new("final.audio"))
+        .expect_err("a foreign stage name must not be promoted");
+
+    assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+    assert_eq!(fs::read(root.join("owned.stage")).unwrap(), b"foreign");
+    assert_eq!(
+        fs::read(root.join("displaced-owned.stage")).unwrap(),
+        b"owned"
+    );
     assert!(!root.join("final.audio").exists());
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## Summary

`OwnedGeneration::promote_noreplace` refused every `Named` residence whose source parent was not an app-owned private namespace. Relax that gate for the single case where the stage **never leaves one directory** — the source parent and the destination are the same pinned object.

Cross-directory promotion from an untrusted parent stays refused.

## Why

This is the prerequisite for publishing a downloaded track into a user-configured Navidrome music folder (RFC #114, OpenSubsonic workstream item 5). Without it there is no reachable path into a directory YuTuTui does not own:

- `PinnedDir::create_ephemeral` gates its `Unsupported` fallback on `private_namespace` (`pinned.rs:170`), and the non-Linux Unix `create_ephemeral_file_at` is an unconditional `Unsupported` stub (`pinned.rs:743`). A user-selected directory is never private, so staging in the destination fails outright on macOS, and on Linux over SMB/NFS where `O_TMPFILE` returns `EOPNOTSUPP`.
- Staging in an app-owned private directory instead just moves the failure to the rename: `renameat2`/`renameatx_np` return `EXDEV` across a mount, which is exactly the mounted-NAS case.

`artifact_move.rs:558` already documents this asymmetry, which is why `source_private_stage` exists there.

## Why it is safe

A policy change, not a capability one — the underlying primitives always worked.

The private-namespace requirement was standing in for the two identity checks that bracket the rename, and both still run: `open_child_readonly` compares the stage's `identity()` before (`pinned.rs:426-434`), and the reopened destination is compared after (`pinned.rs:448-455`).

What it cannot promise for a directory other writers can reach is that the name is not swapped between the pre-rename check and the rename itself. That is detected afterwards and reported — and a writer of that directory could already create the final name directly, so it grants nothing new.

Staying inside one directory also removes the `EXDEV` class entirely, which is what makes a network-mounted destination work.

`remove_from_private_parent` keeps its private-only contract, unchanged.

## Tests

- `untrusted_named_generation_cannot_be_promoted` → re-pointed to a **cross-directory** case and renamed `..._out_of_its_directory`, so its original intent is pinned rather than deleted.
- new: same-directory promotion in an untrusted root succeeds and lands the exact bytes.
- new: same-directory promotion still fails `AlreadyExists` when the final name is occupied, leaving both files untouched.
- new: a stage swapped between create and promote is rejected on identity, in an untrusted root.

**Mutation-verified.** Reverting the source change fails exactly the three new tests with `Unsupported`, while the re-pointed cross-directory test keeps passing.

## Validation

`~/.fable-harness/bin/run-gates .` — all 17 gates PASS, including `check-unsafe-inventory` (which CI does not run) and the full `arch` bundle. `cargo test --workspace`: 4654 lib tests, 0 failed.

Verified on macOS, the platform where the pre-existing behavior blocked this entirely.

## Risk

Relaxes a deliberately fail-closed boundary in the repo's most security-sensitive module. That is why it is a standalone PR and why the test encoding the current refusal was re-pointed rather than removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted promotion of named generations across pinned directories when private namespaces are not used.
  * Added safeguards to prevent stage-name swaps and unintended replacement of existing content.
  * Preserved staged and foreign content when promotion is rejected.

* **Tests**
  * Expanded coverage for successful same-directory promotion and failure scenarios, including cross-directory attempts and existing destination names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->