### PR TITLE
feat(tui): copy a downloaded track to the music server from the Library

### DIFF
--- a/src/app/context_menu.rs
+++ b/src/app/context_menu.rs
@@ -152,6 +152,7 @@ pub(crate) enum ContextCommand {
     DeleteLinkedPlaylistLocal,
     OpenPlaylist,
     OpenArtist,
+    PublishToServer,
     Remove,
 }
 
@@ -236,6 +237,13 @@ impl ContextMenuItem {
             ContextCommand::LinkServerPlaylist => {
                 t!("Link and sync", "연결 및 동기화", "リンクして同期").to_owned()
             }
+            // Kept short enough to survive the 30-column menu in every language.
+            ContextCommand::PublishToServer => t!(
+                "Copy to music server",
+                "음악 서버로 복사",
+                "音楽サーバーへコピー"
+            )
+            .to_owned(),
             ContextCommand::CreateLinkedServerPlaylist => t!(
                 "Create linked server playlist",
                 "서버 연결 목록 만들기",
@@ -896,12 +904,24 @@ impl App {
                 }
                 _ => Vec::new(),
             },
-            ContextTarget::LibrarySongs { tab, .. } => {
+            ContextTarget::LibrarySongs { rows, tab, .. } => {
                 let mut commands = vec![C::PlayNow, C::Enqueue];
                 if target.count() == 1 {
                     commands.push(C::ToggleFavorite);
                 }
                 commands.extend([C::AddToPlaylist, C::Download]);
+                // Only for a single row that actually has a downloaded file, and only when a
+                // server is connected. Offering it otherwise would promise something that can
+                // only fail once the user picks it.
+                if target.count() == 1
+                    && self.server.settings.summary.configured
+                    && rows
+                        .first()
+                        .and_then(|&row| self.library_songs().get(row).cloned())
+                        .is_some_and(|song| song.local_path.is_some())
+                {
+                    commands.push(C::PublishToServer);
+                }
                 if *tab != LibraryTab::All {
                     commands.push(C::Remove);
                 }
@@ -1205,6 +1225,9 @@ impl App {
                     self.clamp_library_selection();
                 }
                 commands
+            }
+            ContextCommand::PublishToServer if selected.len() == 1 => {
+                self.start_publish_track_to_server(&selected[0])
             }
             ContextCommand::AddToPlaylist => {
                 self.open_playlist_picker(selected);

--- a/src/app/context_menu/tests.rs
+++ b/src/app/context_menu/tests.rs
@@ -645,3 +645,113 @@ fn delayed_missing_playlist_recovery_rejects_a_changed_link_health() {
     assert!(app.server.library.playlist_recovery.is_none());
     assert!(app.status.text.contains("list changed"));
 }
+
+#[test]
+fn publish_to_server_is_complete_at_thirty_columns_in_all_languages() {
+    let _guard = crate::i18n::lock_for_test();
+    let original = crate::i18n::current();
+    for (language, expected) in [
+        (crate::i18n::Language::English, "Copy to music server"),
+        (crate::i18n::Language::Korean, "음악 서버로 복사"),
+        (crate::i18n::Language::Japanese, "音楽サーバーへコピー"),
+    ] {
+        crate::i18n::set_language(language);
+        let label = ContextMenuItem::new(ContextCommand::PublishToServer).label(1);
+        assert_eq!(label, expected);
+        // The menu renders inside a bordered box, so the label has to fit well inside 30 columns
+        // or the narrow layout truncates it into something the user cannot act on.
+        let width: usize = unicode_width::UnicodeWidthStr::width(label.as_str());
+        assert!(
+            width <= 26,
+            "{language:?} label is {width} columns: {label}"
+        );
+    }
+    crate::i18n::set_language(original);
+}
+
+/// Put one downloaded track in the Library and register its row for a right-click.
+fn downloads_app_with_one_track() -> App {
+    let mut app = App::new(50);
+    app.mode = Mode::Library;
+    app.library_ui.tab = LibraryTab::Downloads;
+    let mut song = crate::api::Song::local_file(std::path::PathBuf::from(
+        "/tmp/Verify Track [dQw4w9WgXcQ].m4a",
+    ));
+    song.video_id = "dQw4w9WgXcQ".to_owned();
+    song.title = "Verify Track".to_owned();
+    song.local_path = Some(std::path::PathBuf::from(
+        "/tmp/Verify Track [dQw4w9WgXcQ].m4a",
+    ));
+    app.library_ui.downloaded = vec![song];
+    app
+}
+
+fn right_click_first_library_row(app: &mut App) {
+    app.register_mouse_button(Rect::new(1, 1, 20, 1), MouseTarget::ListRow(0));
+    app.on_mouse_right_click(2, 1);
+}
+
+#[test]
+fn publish_is_offered_for_a_downloaded_track_once_a_server_is_connected() {
+    let mut app = downloads_app_with_one_track();
+    app.server.settings.summary.configured = true;
+
+    right_click_first_library_row(&mut app);
+
+    let items = &app.overlays.context_menu.as_ref().expect("menu").items;
+    assert!(
+        items.contains(&ContextMenuItem::new(ContextCommand::PublishToServer)),
+        "{items:?}"
+    );
+}
+
+#[test]
+fn publish_is_hidden_without_a_connected_server() {
+    let mut app = downloads_app_with_one_track();
+    app.server.settings.summary.configured = false;
+
+    right_click_first_library_row(&mut app);
+
+    // Offering it here would promise something that can only fail once the user picks it.
+    let items = &app.overlays.context_menu.as_ref().expect("menu").items;
+    assert!(
+        !items.contains(&ContextMenuItem::new(ContextCommand::PublishToServer)),
+        "{items:?}"
+    );
+}
+
+#[test]
+fn publish_is_hidden_for_a_track_that_was_never_downloaded() {
+    let mut app = downloads_app_with_one_track();
+    app.server.settings.summary.configured = true;
+    app.library_ui.downloaded[0].local_path = None;
+
+    right_click_first_library_row(&mut app);
+
+    let items = &app.overlays.context_menu.as_ref().expect("menu").items;
+    assert!(
+        !items.contains(&ContextMenuItem::new(ContextCommand::PublishToServer)),
+        "{items:?}"
+    );
+}
+
+#[test]
+fn publish_is_hidden_for_a_multi_row_selection() {
+    let mut app = downloads_app_with_one_track();
+    app.server.settings.summary.configured = true;
+    let second = app.library_ui.downloaded[0].clone();
+    app.library_ui.downloaded.push(second);
+    app.library_ui.picked = [0, 1].into_iter().collect();
+    app.library_ui.selected = 1;
+    app.library_ui.anchor = 0;
+    app.register_mouse_button(Rect::new(1, 1, 20, 1), MouseTarget::ListRow(0));
+    app.on_mouse_right_click(2, 1);
+
+    // Publishing is one track at a time; a bulk copy into someone's music library is a
+    // different decision and is not what this entry does.
+    let items = &app.overlays.context_menu.as_ref().expect("menu").items;
+    assert!(
+        !items.contains(&ContextMenuItem::new(ContextCommand::PublishToServer)),
+        "{items:?}"
+    );
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -98,6 +98,7 @@ pub use server_settings::{
     MusicServerFailure, MusicServerHealth, MusicServerHistoryHealth, MusicServerIdentityIntent,
     MusicServerRefreshOutcome, MusicServerSettingsState, MusicServerSetupField,
     MusicServerSetupForm, MusicServerSetupInput, MusicServerSummary, MusicServerWizard, SyncArea,
+    TrackPublishOutcome, TrackPublishReport,
 };
 mod server;
 pub use server::{ServerEvent, ServerUiState};

--- a/src/app/server_settings.rs
+++ b/src/app/server_settings.rs
@@ -5,6 +5,7 @@
 //! connection test has produced a prepared core transaction.
 
 mod playlist_create_recovery;
+mod publish;
 mod state;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -202,6 +203,10 @@ pub enum MusicServerCommand {
         generation: u64,
         local_playlist_id: crate::personal_state::PlaylistId,
     },
+    PublishTrack {
+        generation: u64,
+        video_id: String,
+    },
 }
 
 pub enum MusicServerEvent {
@@ -229,6 +234,29 @@ pub enum MusicServerEvent {
         generation: u64,
         result: Result<MusicServerSummary, MusicServerFailure>,
     },
+    TrackPublished {
+        generation: u64,
+        result: Result<TrackPublishOutcome, MusicServerFailure>,
+    },
+}
+
+/// What one publish actually achieved, kept separate from whether the copy succeeded.
+///
+/// The scan is a courtesy: the bytes are in the music folder before it runs, so a server that
+/// cannot or will not scan never turns a completed publication into a failure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TrackPublishOutcome {
+    pub report: TrackPublishReport,
+    pub scan: crate::open_subsonic::LibraryScanRequest,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TrackPublishReport {
+    Published,
+    /// The same bytes were already there; nothing was written.
+    AlreadyPublished,
+    /// Something else occupies the name. Never replaced, always reported.
+    Conflict,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -879,7 +907,8 @@ impl App {
             | MusicServerEvent::Committed { generation, .. }
             | MusicServerEvent::HistoryDisabled { generation, .. }
             | MusicServerEvent::Removed { generation, .. }
-            | MusicServerEvent::PlaylistCreateAbandoned { generation, .. } => *generation,
+            | MusicServerEvent::PlaylistCreateAbandoned { generation, .. }
+            | MusicServerEvent::TrackPublished { generation, .. } => *generation,
         };
         if event_generation != self.server.settings.generation {
             return Vec::new();
@@ -1038,6 +1067,7 @@ impl App {
             MusicServerEvent::PlaylistCreateAbandoned { result, .. } => {
                 self.finish_playlist_create_abandoned(result)
             }
+            MusicServerEvent::TrackPublished { result, .. } => self.finish_track_published(result),
         }
     }
 }

--- a/src/app/server_settings/publish.rs
+++ b/src/app/server_settings/publish.rs
@@ -1,0 +1,126 @@
+//! Publishing one downloaded track into the music server's folder, from the Library.
+//!
+//! Deliberately without a confirmation step. Publication never overwrites and never deletes — an
+//! occupied name is reported, not replaced — so there is nothing here for a user to undo, and
+//! `ytt server publish` omits the prompt for the same reason. Adding one on this surface only
+//! would make the two disagree about how dangerous the same operation is.
+
+use super::*;
+use crate::api::Song;
+
+impl App {
+    pub(in crate::app) fn start_publish_track_to_server(&mut self, song: &Song) -> Vec<Cmd> {
+        if self.server.settings.busy.is_some() {
+            return Vec::new();
+        }
+        if song.local_path.is_none() {
+            self.status.kind = StatusKind::Error;
+            self.status.text = crate::t!(
+                "Download this track before copying it to the server",
+                "서버로 복사하려면 먼저 이 트랙을 다운로드하세요",
+                "サーバーへコピーする前にこのトラックをダウンロードしてください"
+            )
+            .to_owned();
+            self.dirty = true;
+            return Vec::new();
+        }
+        let generation = self.server.settings.next_generation();
+        self.server.settings.busy = Some(MusicServerBusy::PlaylistRecovery);
+        self.status.kind = StatusKind::Info;
+        self.status.text = crate::t!(
+            "Copying into the music server's folder…",
+            "음악 서버 폴더로 복사하는 중…",
+            "音楽サーバーのフォルダーへコピー中…"
+        )
+        .to_owned();
+        self.dirty = true;
+        vec![Cmd::MusicServer(MusicServerCommand::PublishTrack {
+            generation,
+            video_id: song.video_id.clone(),
+        })]
+    }
+
+    pub(super) fn finish_track_published(
+        &mut self,
+        result: Result<TrackPublishOutcome, MusicServerFailure>,
+    ) -> Vec<Cmd> {
+        self.server.settings.busy = None;
+        match result {
+            Ok(outcome) => {
+                self.status.kind = match outcome.report {
+                    TrackPublishReport::Conflict => StatusKind::Error,
+                    _ => StatusKind::Info,
+                };
+                self.status.text = publish_status_text(&outcome);
+            }
+            Err(failure) => {
+                self.status.kind = StatusKind::Error;
+                self.status.text = failure.label().to_owned();
+            }
+        }
+        self.dirty = true;
+        Vec::new()
+    }
+}
+
+/// Say what was established and nothing more.
+///
+/// A copy proves only that bytes reached the folder the user named. Whether the server can see
+/// them is a separate claim, and the configured path cannot be checked against the server at all —
+/// `getMusicFolders` returns ids and names, never paths.
+fn publish_status_text(outcome: &TrackPublishOutcome) -> String {
+    use crate::open_subsonic::LibraryScanRequest as Scan;
+
+    let copied = match outcome.report {
+        TrackPublishReport::Published => crate::t!(
+            "Copied to the music server",
+            "음악 서버로 복사했어요",
+            "音楽サーバーへコピーしました"
+        ),
+        TrackPublishReport::AlreadyPublished => crate::t!(
+            "Already on the music server, unchanged",
+            "이미 음악 서버에 있어요. 그대로 뒀어요",
+            "すでに音楽サーバーにあります。変更していません"
+        ),
+        TrackPublishReport::Conflict => {
+            return crate::t!(
+                "A different file already has that name on the server; nothing was replaced",
+                "서버에 같은 이름의 다른 파일이 있어요. 아무것도 바꾸지 않았어요",
+                "サーバーに同名の別ファイルがあります。何も置き換えていません"
+            )
+            .to_owned();
+        }
+    };
+
+    let scan = match outcome.scan {
+        Scan::Started => crate::t!(
+            "your server is rescanning",
+            "서버가 다시 검색하는 중이에요",
+            "サーバーが再スキャン中です"
+        ),
+        Scan::NoServer => crate::t!(
+            "no server is connected to rescan",
+            "다시 검색할 서버가 연결되어 있지 않아요",
+            "再スキャンするサーバーが接続されていません"
+        ),
+        Scan::Unsupported => crate::t!(
+            "it appears at your server's next scan",
+            "서버가 다음에 검색할 때 나타나요",
+            "サーバーの次のスキャンで表示されます"
+        ),
+        Scan::NotPermitted => crate::t!(
+            "this account cannot start a scan, so it appears at the next scheduled one",
+            "이 계정은 검색을 시작할 수 없어요. 다음 예약 검색 때 나타나요",
+            "このアカウントはスキャンを開始できません。次の定期スキャンで表示されます"
+        ),
+        Scan::Unavailable => crate::t!(
+            "the server could not be reached to rescan",
+            "다시 검색을 요청하려 했지만 서버에 연결하지 못했어요",
+            "再スキャンを要求できませんでした"
+        ),
+    };
+    format!("{copied} — {scan}")
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/app/server_settings/publish/tests.rs
+++ b/src/app/server_settings/publish/tests.rs
@@ -1,0 +1,162 @@
+use std::path::PathBuf;
+
+use super::*;
+use crate::open_subsonic::LibraryScanRequest as Scan;
+
+fn downloaded(video_id: &str) -> Song {
+    let mut song = Song::local_file(PathBuf::from(format!("/tmp/{video_id}.m4a")));
+    song.video_id = video_id.to_owned();
+    song.title = "Song".to_owned();
+    song.local_path = Some(PathBuf::from(format!("/tmp/{video_id}.m4a")));
+    song
+}
+
+fn outcome(report: TrackPublishReport, scan: Scan) -> TrackPublishOutcome {
+    TrackPublishOutcome { report, scan }
+}
+
+#[test]
+fn publishing_a_downloaded_track_emits_one_generation_stamped_command() {
+    let mut app = App::new(50);
+    app.server.settings.summary.configured = true;
+
+    let commands = app.start_publish_track_to_server(&downloaded("abcdefghijk"));
+
+    let generation = app.server.settings.generation;
+    assert!(matches!(
+        commands.as_slice(),
+        [Cmd::MusicServer(MusicServerCommand::PublishTrack {
+            generation: emitted,
+            video_id,
+        })] if *emitted == generation && video_id == "abcdefghijk"
+    ));
+    assert_eq!(
+        app.server.settings.busy,
+        Some(MusicServerBusy::PlaylistRecovery)
+    );
+}
+
+#[test]
+fn a_track_without_a_downloaded_file_is_refused_before_any_command() {
+    let mut app = App::new(50);
+    app.server.settings.summary.configured = true;
+    let mut song = downloaded("abcdefghijk");
+    song.local_path = None;
+
+    let commands = app.start_publish_track_to_server(&song);
+
+    assert!(commands.is_empty());
+    assert_eq!(app.status.kind, StatusKind::Error);
+    assert!(app.server.settings.busy.is_none());
+}
+
+#[test]
+fn a_second_publish_is_ignored_while_one_is_in_flight() {
+    let mut app = App::new(50);
+    app.server.settings.summary.configured = true;
+    assert_eq!(
+        app.start_publish_track_to_server(&downloaded("first"))
+            .len(),
+        1
+    );
+
+    let commands = app.start_publish_track_to_server(&downloaded("second"));
+
+    assert!(commands.is_empty());
+}
+
+#[test]
+fn a_stale_result_is_dropped_without_touching_the_status() {
+    let mut app = App::new(50);
+    app.server.settings.summary.configured = true;
+    app.start_publish_track_to_server(&downloaded("abcdefghijk"));
+    let stale = app.server.settings.generation.wrapping_sub(1);
+    app.status.text = "untouched".to_owned();
+
+    let commands = app.finish_music_server_event(MusicServerEvent::TrackPublished {
+        generation: stale,
+        result: Ok(outcome(TrackPublishReport::Published, Scan::Started)),
+    });
+
+    assert!(commands.is_empty());
+    assert_eq!(app.status.text, "untouched");
+    // The in-flight publish still owns the busy slot; a stale reply must not free it.
+    assert_eq!(
+        app.server.settings.busy,
+        Some(MusicServerBusy::PlaylistRecovery)
+    );
+}
+
+#[test]
+fn a_conflict_reports_that_nothing_was_replaced() {
+    let mut app = App::new(50);
+    app.server.settings.summary.configured = true;
+
+    app.finish_track_published(Ok(outcome(TrackPublishReport::Conflict, Scan::Started)));
+
+    assert_eq!(app.status.kind, StatusKind::Error);
+    assert!(
+        app.status.text.contains("nothing was replaced"),
+        "{}",
+        app.status.text
+    );
+    // A conflict says nothing about scanning, because nothing was published to scan for.
+    assert!(
+        !app.status.text.contains("rescanning"),
+        "{}",
+        app.status.text
+    );
+    assert!(app.server.settings.busy.is_none());
+}
+
+#[test]
+fn every_scan_outcome_keeps_a_successful_copy_successful() {
+    for scan in [
+        Scan::Started,
+        Scan::NoServer,
+        Scan::Unsupported,
+        Scan::NotPermitted,
+        Scan::Unavailable,
+    ] {
+        let mut app = App::new(50);
+        app.server.settings.summary.configured = true;
+
+        app.finish_track_published(Ok(outcome(TrackPublishReport::Published, scan)));
+
+        // The bytes are in the music folder before the scan is asked for, so no scan outcome may
+        // demote a completed publication into an error.
+        assert_eq!(app.status.kind, StatusKind::Info, "{scan:?}");
+        assert!(
+            app.status.text.contains("Copied to the music server"),
+            "{scan:?}"
+        );
+        assert!(app.server.settings.busy.is_none(), "{scan:?}");
+    }
+}
+
+#[test]
+fn an_idempotent_republish_says_it_changed_nothing() {
+    let mut app = App::new(50);
+    app.server.settings.summary.configured = true;
+
+    app.finish_track_published(Ok(outcome(
+        TrackPublishReport::AlreadyPublished,
+        Scan::Unsupported,
+    )));
+
+    assert_eq!(app.status.kind, StatusKind::Info);
+    assert!(app.status.text.contains("unchanged"), "{}", app.status.text);
+}
+
+#[test]
+fn a_failure_surfaces_its_own_label_and_frees_the_busy_slot() {
+    let mut app = App::new(50);
+    app.server.settings.summary.configured = true;
+    app.start_publish_track_to_server(&downloaded("abcdefghijk"));
+
+    app.finish_track_published(Err(MusicServerFailure::Unavailable));
+
+    assert_eq!(app.status.kind, StatusKind::Error);
+    assert_eq!(app.status.text, MusicServerFailure::Unavailable.label());
+    assert!(app.server.settings.busy.is_none());
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -30,6 +30,7 @@ mod open_subsonic_runtime;
 mod persist_delivery;
 mod personal_sync_commit;
 pub(crate) mod player_delivery;
+mod publish_track_task;
 mod read_only;
 mod recorder_recovery;
 mod sync_activation_commit;

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1,5 +1,6 @@
 //! Dispatch reducer commands to runtime-owned actors and background jobs.
 
+use super::publish_track_task;
 use super::*;
 
 mod linked_playlists;
@@ -355,6 +356,15 @@ impl RuntimeHandles {
                                     )))
                                     .await;
                             },
+                        );
+                    }
+                    crate::app::MusicServerCommand::PublishTrack {
+                        generation,
+                        video_id,
+                    } => {
+                        self.background_tasks.spawn_cancellable(
+                            "music_server_publish_track",
+                            publish_track_task::run(emitter.clone(), generation, video_id),
                         );
                     }
                     crate::app::MusicServerCommand::AbandonPlaylistCreate {

--- a/src/runtime/publish_track_task.rs
+++ b/src/runtime/publish_track_task.rs
@@ -1,0 +1,80 @@
+//! The publish-one-track background task, split out of `dispatch.rs` for the size ratchet.
+
+use super::*;
+
+/// Copy one downloaded track into the music folder, then ask the server to rescan.
+///
+/// The scan runs only after the copy succeeded and its outcome never demotes the result: the bytes
+/// are already in place, so a server that cannot or will not scan is a slower route to the same
+/// track, not a failed publication.
+pub(super) async fn run(
+    emitter: super::task_set::RuntimeTaskEmitter,
+    generation: u64,
+    video_id: String,
+) {
+    let published = tokio::task::spawn_blocking(move || publish_downloaded_track(&video_id))
+        .await
+        .map_err(|_| crate::app::MusicServerFailure::Unavailable)
+        .and_then(|result| result);
+    let result = match published {
+        Ok(report) => {
+            let scan = match crate::open_subsonic::OpenSubsonicPaths::current() {
+                Ok(paths) => crate::open_subsonic::request_library_scan(&paths).await,
+                Err(_) => crate::open_subsonic::LibraryScanRequest::NoServer,
+            };
+            Ok(crate::app::TrackPublishOutcome { report, scan })
+        }
+        Err(failure) => Err(failure),
+    };
+    emitter
+        .emit_terminal(RuntimeEvent::App(Msg::Server(
+            crate::app::ServerEvent::Settings(crate::app::MusicServerEvent::TrackPublished {
+                generation,
+                result,
+            }),
+        )))
+        .await;
+}
+
+/// Resolve one downloaded track and copy it into the configured music folder.
+///
+/// Blocking on purpose: this is filesystem work, and the ledger it updates is committed with the
+/// same atomic-write discipline as the rest of the store.
+fn publish_downloaded_track(
+    video_id: &str,
+) -> Result<crate::app::TrackPublishReport, crate::app::MusicServerFailure> {
+    use crate::app::{MusicServerFailure, TrackPublishReport};
+    use crate::open_subsonic::publish::{PublishReport, PublishRequest, publish_track};
+
+    let paths = crate::open_subsonic::OpenSubsonicPaths::current()
+        .map_err(|_| MusicServerFailure::Unavailable)?;
+    let store = crate::downloads::DownloadStore::load();
+    let song = store
+        .tracks()
+        .iter()
+        .find(|song| song.video_id == video_id)
+        .ok_or(MusicServerFailure::Unavailable)?;
+    let source = song
+        .local_path
+        .clone()
+        .ok_or(MusicServerFailure::Unavailable)?;
+    let request = PublishRequest {
+        video_id: song.video_id.clone(),
+        title: song.title.clone(),
+        artist: Some(song.artist.clone()),
+        album_artist: song.album_artist.clone(),
+        album: song.album.clone(),
+        track_number: song.track_number,
+        source,
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs() as i64)
+        .unwrap_or_default();
+    match publish_track(&paths, &request, now) {
+        Ok(PublishReport::Published { .. }) => Ok(TrackPublishReport::Published),
+        Ok(PublishReport::AlreadyPublished { .. }) => Ok(TrackPublishReport::AlreadyPublished),
+        Ok(PublishReport::Conflict { .. }) => Ok(TrackPublishReport::Conflict),
+        Err(_) => Err(MusicServerFailure::Unavailable),
+    }
+}

--- a/src/runtime/read_only.rs
+++ b/src/runtime/read_only.rs
@@ -36,7 +36,8 @@ pub(super) fn durable_mutation_component(cmd: &Cmd) -> Option<&'static str> {
             | crate::app::MusicServerCommand::Commit { .. }
             | crate::app::MusicServerCommand::DisableHistory { .. }
             | crate::app::MusicServerCommand::Remove { .. }
-            | crate::app::MusicServerCommand::AbandonPlaylistCreate { .. },
+            | crate::app::MusicServerCommand::AbandonPlaylistCreate { .. }
+            | crate::app::MusicServerCommand::PublishTrack { .. },
         ) => Some("music server settings"),
         Cmd::ServerLibrary(
             crate::app::ServerLibraryCommand::ApplyPlaylistPreview { .. }
@@ -228,6 +229,21 @@ mod tests {
             Some("read_only_secondary")
         );
         assert!(!app.personal_state.sync.in_progress);
+    }
+
+    #[test]
+    fn publishing_a_track_is_a_durable_mutation_a_secondary_must_refuse() {
+        // A read-only secondary writing into the music folder would do it behind the primary's
+        // back, with no lease serialising the two.
+        let command = Cmd::MusicServer(crate::app::MusicServerCommand::PublishTrack {
+            generation: 1,
+            video_id: "abcdefghijk".to_owned(),
+        });
+
+        assert_eq!(
+            durable_mutation_component(&command),
+            Some("music server settings")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Part of #114. Completes the publish feature merged in #139 (engine + CLI).

Without a TUI surface the feature is only reachable by quitting the app: `initialize_writer` takes the exclusive settings writer lease (`server_cli.rs:766`), so a CLI publish is refused while the TUI holds it. #117 set the split precedent in this series and `ytt sync now` carries the same constraint; this closes it for publishing.

## Shape

A **context-menu entry** on a Downloads row, not a new keybinding. Publishing is occasional, and a global chord would have to be threaded through the keymap, the cheat sheet, the config schema and the exported GUI types. `Create linked server playlist` already established that server actions live in this menu.

**No confirmation step, deliberately.** Publication never overwrites and never deletes — an occupied name is reported, not replaced — so there is nothing to undo. `ytt server publish` omits the prompt for that reason, and a modal here alone would make the two surfaces disagree about how dangerous the same operation is.

## Gating

The entry appears only when all of these hold, each pinned by a test:

- exactly one row is selected — a bulk copy into someone's music library is a different decision;
- that row has a downloaded file;
- a music server is connected.

Offering it otherwise would promise something that can only fail once picked.

## What the status line claims

A copy proves only that bytes reached the folder the user named — the configured path cannot be checked against the server, because `getMusicFolders` returns ids and names but never paths. So the copy result and the scan result are stated separately, and **none of the five scan outcomes can demote a completed publication into an error**: the bytes are in place before the scan is asked for. A conflict says nothing about scanning at all, because nothing was published to scan for.

## Tests

16 new: 8 reducer (generation stamping, stale-result drop, busy-slot lifecycle, every scan outcome, conflict, idempotent republish, failure label, missing-file refusal), 4 context-menu gating through the real `on_mouse_right_click`, 1 label completeness at 30 columns in all three languages, 1 read-only classification, plus the existing suites.

## Validation

`~/.fable-harness/bin/run-gates .` — all 17 gates PASS, including `check-unsafe-inventory`.

Runtime check through `.claude/skills/verify` (isolated tmux, isolated config, seeded download store): the app launches with the change and the Downloads tab renders the track. **The menu itself was not exercised at runtime** — right-click cannot be injected through tmux, which is why the repo's own guidance routes mouse-path claims to the test harness; the four gating tests drive the real `on_mouse_right_click`, and the 30-column test renders through the real `context_menu::render`.

Not covered by any gate, still a human step: publish into a real Navidrome folder and confirm the track appears after a scan and streams to an Android client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Copy to music server” action for individual downloaded tracks.
  * The action appears only when a server is configured and the selected track is available locally.
  * Displays progress, success, unchanged, conflict, and failure statuses.
  * Automatically requests a library rescan after publishing when needed.

* **Bug Fixes**
  * Prevented publishing during another server operation, for unavailable tracks, or multi-track selections.
  * Added handling for stale publish results and publish conflicts.

* **Tests**
  * Added coverage for visibility rules, publishing outcomes, status messages, and server availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->