### PR TITLE
fix(test): stop the parity engine persisting through the shared test sandbox

### DIFF
--- a/src/daemon/engine.rs
+++ b/src/daemon/engine.rs
@@ -58,6 +58,8 @@ use engine_session::{DaemonOutcome, DaemonSessionEvent, data_dir};
 pub(super) use gui_search::RequesterKey;
 use gui_search::{GuiSearchAdmission, GuiSearchIndex};
 #[cfg(test)]
+pub(in crate::daemon) use persistence_gate::fail_store_saves_for_test;
+#[cfg(test)]
 use transport::TransportRecovery;
 use transport::TransportRecoveryState;
 
@@ -183,6 +185,9 @@ pub struct DaemonEngine {
     remote_persistence_error: Option<String>,
     remote_persistence_command_active: bool,
     remote_persistence_read_only: bool,
+    /// Test-only standing choice; see `silence_remote_persistence_for_test`.
+    #[cfg(test)]
+    persistence_disabled_for_test: bool,
     consecutive_play_errors: u8,
     /// yt-dlp self-heal bookkeeping (mirrors the TUI's `YtdlpHeal`): the in-flight
     /// healed track, the per-track one-shot guard, and the update-check cooldown.
@@ -376,6 +381,8 @@ impl DaemonEngine {
             remote_persistence_error: None,
             remote_persistence_command_active: false,
             remote_persistence_read_only: false,
+            #[cfg(test)]
+            persistence_disabled_for_test: false,
             consecutive_play_errors: 0,
             heal_pending: None,
             heal_attempted: HashSet::new(),

--- a/src/daemon/engine/persistence_gate.rs
+++ b/src/daemon/engine/persistence_gate.rs
@@ -126,6 +126,10 @@ impl DaemonEngine {
     }
 
     fn should_skip_remote_save(&self) -> bool {
+        #[cfg(test)]
+        if self.persistence_disabled_for_test {
+            return true;
+        }
         self.remote_persistence_command_active
             && (self.remote_persistence_write_failed || self.remote_persistence_read_only)
     }
@@ -313,6 +317,21 @@ impl DaemonEngine {
         }
     }
 
+    /// Test seam: make every durable save a no-op for an engine built outside a real daemon.
+    ///
+    /// Under `#[cfg(test)]` every store resolves inside one process-wide sandbox, so an engine
+    /// constructed for a unit test writes the same files as every other test. A save that fails
+    /// there is not merely a lost write: `finish_remote_persistence` replaces the command's
+    /// success-shaped response with `durability_unconfirmed`, which reads as a behavioural
+    /// difference the test never intended to exercise.
+    ///
+    /// Deliberately not `remote_persistence_read_only`: `preflight_remote_persistence` resets that
+    /// on every command, so it cannot express a standing choice made once at construction.
+    #[cfg(test)]
+    pub(in crate::daemon) fn silence_remote_persistence_for_test(&mut self) {
+        self.persistence_disabled_for_test = true;
+    }
+
     pub(super) fn finish_remote_persistence(
         &mut self,
         response: RemoteResponse,
@@ -366,7 +385,7 @@ pub(super) fn fail_recovery_for_test(error: StartupRecoveryError) -> TestRecover
 }
 
 #[cfg(test)]
-pub(super) struct TestSaveFailureGuard {
+pub(in crate::daemon) struct TestSaveFailureGuard {
     previous: Option<StoreKind>,
 }
 
@@ -378,7 +397,7 @@ impl Drop for TestSaveFailureGuard {
 }
 
 #[cfg(test)]
-pub(super) fn fail_store_saves_for_test(kind: StoreKind) -> TestSaveFailureGuard {
+pub(in crate::daemon) fn fail_store_saves_for_test(kind: StoreKind) -> TestSaveFailureGuard {
     let previous = TEST_SAVE_FAILURE.with(|failure| failure.replace(Some(kind)));
     TestSaveFailureGuard { previous }
 }

--- a/src/daemon/engine/tests.rs
+++ b/src/daemon/engine/tests.rs
@@ -92,6 +92,7 @@ pub(in crate::daemon) fn engine_with_queue(ids: &[&str]) -> DaemonEngine {
         remote_persistence_error: None,
         remote_persistence_command_active: false,
         remote_persistence_read_only: false,
+        persistence_disabled_for_test: false,
         consecutive_play_errors: 0,
         heal_pending: None,
         heal_attempted: HashSet::new(),

--- a/src/daemon/parity_tests/harness.rs
+++ b/src/daemon/parity_tests/harness.rs
@@ -163,6 +163,23 @@ pub(super) fn seed_snapshot() -> QueueSnapshot {
     queue.snapshot()
 }
 
+/// Stop the parity engine writing through real stores.
+///
+/// Under `#[cfg(test)]` every store resolves inside one process-wide sandbox, so the engine's
+/// `save_session` — which `queue_remove` ends in — targets one `<cache dir>/session.json` shared by
+/// the whole suite. On Windows a concurrent replace there can fail, and a daemon command whose save
+/// fails does not merely lose a write: `finish_remote_persistence` replaces its success-shaped
+/// response with `durability_unconfirmed`. The App owner has no such gate and still reports
+/// success, so the parity assertion reads it as the two owners disagreeing about a queue edit when
+/// nothing about playback diverged.
+///
+/// These tests compare projections and responses, never durability; the persistence gate has its
+/// own coverage in `engine/persistence_gate_tests.rs`. Same reason and same mechanism as
+/// `engine/accounts.rs`, which sets this flag so "saves become no-ops in tests".
+fn silence_engine_persistence(engine: &mut DaemonEngine) {
+    engine.silence_remote_persistence_for_test();
+}
+
 /// Both owners on identical default config + the same restored queue, with the known baseline
 /// differences aligned.
 pub(super) fn hermetic_pair() -> (App, DaemonEngine) {
@@ -178,6 +195,7 @@ pub(super) fn hermetic_pair() -> (App, DaemonEngine) {
         },
         Arc::new(|_event| {}),
     );
+    silence_engine_persistence(&mut engine);
     engine.restore_queue_snapshot(snap.clone(), RNG_SEED);
 
     let mut app = App::new(Config::default().volume);
@@ -203,6 +221,7 @@ pub(super) fn hermetic_pair_from_config(
         },
         Arc::new(|_event| {}),
     );
+    silence_engine_persistence(&mut engine);
     engine.restore_queue_snapshot(snap.clone(), RNG_SEED);
 
     let mut app = App::new(config.volume);
@@ -345,5 +364,36 @@ pub(super) fn gui_repeat(repeat: Repeat) -> RemoteCommand {
             field: "repeat".to_owned(),
             value: serde_json::to_value(repeat).unwrap(),
         },
+    }
+}
+
+#[cfg(test)]
+mod persistence_isolation_tests {
+    use super::*;
+
+    /// `queue_remove` ends in `save_session`, and under `#[cfg(test)]` that targets the one
+    /// `<cache dir>/session.json` the whole suite shares. On Windows a concurrent replace there can
+    /// fail, and `finish_remote_persistence` then answers `durability_unconfirmed` instead of the
+    /// command's success — which the parity assertion reads as the two owners disagreeing.
+    ///
+    /// Injecting the failure proves the seam rather than inferring it: with saves silenced the
+    /// engine never attempts one, so a failure that would otherwise rewrite the response cannot.
+    /// Asserting on the shared file itself would measure whatever else the suite is writing.
+    #[tokio::test]
+    async fn a_silenced_engine_survives_a_session_save_failure() {
+        let _fail =
+            crate::daemon::engine::fail_store_saves_for_test(crate::persist::StoreKind::Session);
+
+        let (_app, mut engine) = hermetic_pair();
+        let (response, _shutdown, _effects) = engine
+            .handle_remote(RemoteCommand::QueueRemove { position: 0 })
+            .await;
+
+        assert!(response.ok, "{response:?}");
+        assert_ne!(
+            response.reason.as_deref(),
+            Some("durability_unconfirmed"),
+            "the parity engine still persisted, so a failed save rewrote its response"
+        );
     }
 }

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -1,29 +1,51 @@
 pub mod env;
 
-/// Runs `f` with `YTM_DATA_DIR` pointed at a directory no other test uses.
+/// Runs `f` with `YTM_DATA_DIR` and `YTM_CACHE_DIR` pointed at directories no other test uses.
 ///
 /// Under `#[cfg(test)]` every store resolves inside one process-wide sandbox, so each test that
-/// writes through a real store shares the same files — `<data dir>/playlists.json` in particular.
-/// Two tests interleaving a load-modify-save there lose one of the writes, which surfaces as an
-/// assertion that a playlist the test had just created is missing. It only reproduces under load,
-/// which is why it looked like a platform flake on CI rather than a shared-state bug.
+/// writes through a real store shares the same files — `<data dir>/playlists.json` and
+/// `<cache dir>/session.json` in particular. Two tests interleaving a load-modify-save there lose
+/// one of the writes, which surfaces as an assertion that a playlist the test had just created is
+/// missing. It only reproduces under load, which is why it looked like a platform flake on CI
+/// rather than a shared-state bug.
 ///
-/// The override is thread-scoped by `paths::env_dir`, so it isolates the calling test without
+/// The cache half matters for a second reason. On Windows a concurrent atomic replace of the same
+/// file can fail outright, and a daemon command whose save fails does not merely lose a write: the
+/// engine replaces its success-shaped response with `durability_unconfirmed`, while the App owner
+/// has no such gate and still reports success. In the App/daemon parity tests that reads as the
+/// two owners disagreeing about a queue edit — a projection divergence that never happened.
+///
+/// The overrides are thread-scoped by `paths::env_dir`, so they isolate the calling test without
 /// changing what parallel readers on other threads see.
 #[cfg(test)]
 pub fn with_isolated_data_dir<T>(label: &str, f: impl FnOnce() -> T) -> T {
+    let (data, cache) = isolated_dir_pair(label);
+    env::with_vars(
+        &[
+            ("YTM_DATA_DIR", Some(&*data.to_string_lossy())),
+            ("YTM_CACHE_DIR", Some(&*cache.to_string_lossy())),
+        ],
+        f,
+    )
+}
+
+#[cfg(test)]
+fn isolated_dir_pair(label: &str) -> (std::path::PathBuf, std::path::PathBuf) {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static NEXT: AtomicU64 = AtomicU64::new(0);
     let sequence = NEXT.fetch_add(1, Ordering::Relaxed);
-    let dir = crate::paths::test_base().join(format!("isolated-data-{label}-{sequence}"));
-    std::fs::create_dir_all(&dir).expect("create the isolated test data directory");
-    env::with_var("YTM_DATA_DIR", Some(&dir.to_string_lossy()), f)
+    let base = crate::paths::test_base();
+    let data = base.join(format!("isolated-data-{label}-{sequence}"));
+    let cache = base.join(format!("isolated-cache-{label}-{sequence}"));
+    std::fs::create_dir_all(&data).expect("create the isolated test data directory");
+    std::fs::create_dir_all(&cache).expect("create the isolated test cache directory");
+    (data, cache)
 }
 
-/// Drives `future` to completion with an isolated data directory installed.
+/// Drives `future` to completion with isolated data and cache directories installed.
 ///
-/// The env override and the thread-scoped flag that exposes it both live on one thread, so the
+/// The env overrides and the thread-scoped flag that exposes them both live on one thread, so the
 /// future has to run there too: a current-thread runtime built inside the scope. Tests needing
 /// this cannot stay `#[tokio::test]`, whose runtime is created outside any scope we control.
 #[cfg(test)]
@@ -64,6 +86,36 @@ mod tests {
         assert_ne!(first, second, "two calls must not share a directory");
         assert_eq!(
             crate::paths::data_dir(),
+            Some(shared),
+            "the override must not outlive its scope"
+        );
+    }
+
+    /// `session.json` lives under the cache dir, not the data dir. Isolating only the data half
+    /// left every parity test writing one shared file, and on Windows a failed write there turns
+    /// an engine command into `durability_unconfirmed` while the App still reports success.
+    #[test]
+    fn isolated_scope_moves_the_session_cache_too() {
+        let shared = crate::session::session_cache_path().expect("sandboxed session path");
+
+        let first = with_isolated_data_dir("selftest-cache", || {
+            let cache = crate::paths::cache_dir().expect("isolated cache dir");
+            let path = crate::session::session_cache_path().expect("isolated session path");
+            assert_ne!(path, shared, "session.json did not follow the override");
+            assert_eq!(
+                path,
+                cache.join("session.json"),
+                "session.json must resolve inside the isolated cache dir"
+            );
+            path
+        });
+
+        let second = with_isolated_data_dir("selftest-cache", || {
+            crate::session::session_cache_path().expect("isolated session path")
+        });
+        assert_ne!(first, second, "two calls must not share a session file");
+        assert_eq!(
+            crate::session::session_cache_path(),
             Some(shared),
             "the override must not outlive its scope"
         );


### PR DESCRIPTION
Root-causes the Windows parity flake that has been blocking promotion of the Windows/macOS jobs to required checks. Instrumentation added in #135 is what made it identifiable.

## What CI reported

```
step 6: QueueRemove { position: 0 }: owners disagree on ok
  app:    ok: true,  reason: "ok"
  engine: ok: false, reason: "durability_unconfirmed"
```

## What it actually was

**Not an App↔daemon divergence, and no playback-parity bug.** Each link verified in the tree:

| | |
|---|---|
| `queue_remove` (`engine.rs`) | ends in `save_session` |
| `session_cache_path` (`session.rs:173`) | `cache_dir()/session.json` |
| `cache_dir()` under `cfg(test)` (`paths.rs:126`) | `test_base()/cache` — **one file for the whole suite** |
| save fails | `remote_persistence_write_failed` |
| `finish_remote_persistence` (`persistence_gate.rs:329`) | **replaces the success response** with `durability_unconfirmed` |

The App owner has no such gate, so it still reports success. On Windows a concurrent replace of that shared file can fail, and the parity assertion reports a failed disk write on one side as a disagreement about playback.

The mechanism was already proven in-tree by `engine/persistence_gate_tests.rs`. What was missing was the shared path feeding it.

## Fix

The engine takes a standing test-only choice to make durable saves no-ops, applied by `hermetic_pair`.

**Deliberately not `remote_persistence_read_only`** — `preflight_remote_persistence` resets that field on *every* command, so it cannot express a choice made once at construction. Setting it there looked correct and silently did nothing; the regression test caught it.

`with_isolated_data_dir` now also moves `YTM_CACHE_DIR`. It claimed to isolate a test's stores while leaving `session.json` on the shared path — measured before the change, the path was byte-identical inside and outside the scope. `playlists.json` is data, `session.json` is cache; a helper covering one and not the other invites this class of bug.

## Two approaches discarded on evidence, not taste

- **Env override held for the whole test** (matching the #133 precedent): serialized every parity test behind the process-global env mutex. The gate run showed parity tests running over 60 seconds. Abandoned.
- **Asserting the shared session file's size is unchanged**: passed in isolation, failed under the full suite, because other tests write that file legitimately. Asserting on shared state was the same mistake being fixed. The test now injects a save failure, proving the seam rather than observing the suite.

## Corrects an earlier wrong conclusion

The decision log recorded "shared test sandbox" as a **rejected** hypothesis, reasoning that `hermetic_pair()` builds from defaults "with no disk reads". That argument only covered reads — writes go through `save_store` regardless of how state was constructed. A rejection recorded with wrong reasoning is worse than none, because it tells the next person not to look there. Corrected in the harness log.

## Validation

`run-gates .` — 16/16 PASS. Full parallel lib suite: 4715 passed, 0 failed. Parity suite 33/33 in 0.03 s (versus the 60 s+ the discarded approach produced).

**Mutation-verified**: removing the silencing call fails the new test with "the parity engine still persisted, so a failed save rewrote its response".

Windows is what actually matters here and only CI can speak to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parity-test reliability by preventing background persistence activity from altering expected responses.
  * Ensured session-save failures do not incorrectly change successful queue operations to durability warnings.

* **Tests**
  * Strengthened test isolation by separating data and cache directories for each test scope.
  * Added coverage confirming session caches remain isolated and temporary overrides are properly restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->