### PR TITLE
chore: ignore design-sync build output and machine state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,12 @@ cookies.txt
 
 # Cursor IDE / debug session artifacts
 .cursor/
+
+# design-sync (claude.ai/design import): staged scripts, build output, machine state
+/.ds-sync/
+/ds-bundle/
+/.design-sync/.cache/
+/.design-sync/learnings/
+/.design-sync/node_modules
+/.design-sync/kit/node_modules/
+/.design-sync/kit/dist/


### PR DESCRIPTION
The claude.ai/design import drops a `.design-sync/` workspace in the repo root. Its kit source and config are worth keeping visible, but the staging dirs, installed deps and build output are machine-local noise that shows up in every `git status`.

Ignores `/.ds-sync/`, `/ds-bundle/`, and the `.cache/` / `learnings/` / `node_modules` / `kit/dist/` subpaths under `/.design-sync/`.

Verified no currently-tracked file is shadowed by the new rules (`git ls-files` against the patterns returns empty). `.gitignore`-only — no build or test surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aYr4WqEanaGskYXJKDEeu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project exclusions to prevent generated design-sync assets, caches, and build artifacts from being tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->