### PR TITLE
chore: ignore the whole design-sync trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,11 +66,9 @@ cookies.txt
 # Cursor IDE / debug session artifacts
 .cursor/
 
-# design-sync (claude.ai/design import): staged scripts, build output, machine state
+# design-sync (claude.ai/design import): staged scripts, build output, machine state.
+# The whole tree is machine-local — nothing under it is tracked.
 /.ds-sync/
 /ds-bundle/
-/.design-sync/.cache/
-/.design-sync/learnings/
-/.design-sync/node_modules
-/.design-sync/kit/node_modules/
-/.design-sync/kit/dist/
+/.design-sync/
+/docs/.design-sync/


### PR DESCRIPTION
Nothing under `.design-sync/` or `docs/.design-sync/` is tracked; the per-subdirectory ignores from #143 left both roots as permanent untracked noise in `git status`. One ignore line each replaces them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWataUqhg17xXKfwgZ7HMn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project file-ignoring rules to better exclude local design-sync assets, generated files, and machine state.
  * Added coverage for design-sync files within the documentation directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->