### PR TITLE
fix(search): anonymous search overflowed the 512 KiB worker stacks in debug builds

### DIFF
--- a/src/api/ytmusic.rs
+++ b/src/api/ytmusic.rs
@@ -565,7 +565,15 @@ impl YtMusicApi {
 /// Shared with the DJ Gem assistant actor, which resolves the model's tool queries the same
 /// way (public YouTube, no auth) — hence `pub(crate)` and a caller-chosen `limit`.
 pub(crate) async fn ytdlp_search(query: &str, limit: usize) -> Result<Vec<Song>> {
-    ytdlp_flat_search(SearchSource::Youtube, "ytsearch", query, limit).await
+    // Boxed: this future's debug-mode state is large enough to matter on the runtime's
+    // deliberately small worker stacks (see the runtime builder in main.rs).
+    Box::pin(ytdlp_flat_search(
+        SearchSource::Youtube,
+        "ytsearch",
+        query,
+        limit,
+    ))
+    .await
 }
 
 async fn ytdlp_flat_search(
@@ -592,8 +600,15 @@ async fn ytdlp_flat_search(
         .arg("--retry-sleep")
         .arg("extractor:1")
         .arg("--no-warnings");
-    let json =
-        crate::tools::run_ytdlp_json(cmd, YTDLP_SEARCH_TIMEOUT, YTDLP_JSON_MAX, "search").await?;
+    // Boxed for the same worker-stack reason as [`ytdlp_search`]: subprocess capture plus
+    // the multi-megabyte JSON parse dominate this chain's frame footprint.
+    let json = Box::pin(crate::tools::run_ytdlp_json(
+        cmd,
+        YTDLP_SEARCH_TIMEOUT,
+        YTDLP_JSON_MAX,
+        "search",
+    ))
+    .await?;
     let entries = json
         .get("entries")
         .and_then(|e| e.as_array())

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,9 +269,17 @@ fn run() -> Result<()> {
     // Custom runtime: 2 workers + 512 KB stacks keeps stack RSS ~1.5 MB (vs ~4.5 MB
     // at the 2 MB default). The render loop runs on the main task; actors run on the
     // worker threads so a blocked IPC read never stalls rendering.
+    // Debug builds get the tokio default instead: the unoptimized poll frames of the
+    // anonymous yt-dlp search chain overflow 512 KiB and abort the worker (SIGABRT),
+    // while optimized frames fit comfortably.
+    let worker_stack = if cfg!(debug_assertions) {
+        2 * 1024 * 1024
+    } else {
+        512 * 1024
+    };
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(2)
-        .thread_stack_size(512 * 1024)
+        .thread_stack_size(worker_stack)
         .enable_all()
         .build()?;
     startup.mark("runtime_built");


### PR DESCRIPTION
## Root cause

The TUI runtime pins its two tokio workers to **512 KiB stacks** (deliberate stack-RSS budget, `main.rs`). The unoptimized poll frames of the anonymous yt-dlp search chain (`api actor → search_songs_reported → … → ytdlp_search → run_ytdlp_json` + the multi-MB `--dump-single-json` parse) exceed that in debug builds: the moment an anonymous YT search returns, the worker hits its guard page and the process SIGABRTs. Root-caused from a systemd coredump — the faulting frame is `ytdlp_search`'s poll on a multi-thread worker.

Repro required a working `yt-dlp` on PATH (without one the search fails at spawn and never parses), which is why it reproduced intermittently across environments. **Release builds do not overflow** — verified against the same live scenario — so end users were never affected.

## Fix (two layers)

1. Debug builds use the 2 MiB tokio default stack; release keeps the slim 512 KiB (RSS contract unchanged).
2. The two heaviest futures in the chain (`ytdlp_flat_search`, its subprocess-JSON runner call) are `Box::pin`ed, so release keeps real headroom too instead of sitting near the limit.

## Verification

- Before: 100% SIGABRT on debug `ytt` → anonymous search "jazz" (isolated tmux, yt-dlp on PATH, no mpv). After: same scenario renders full results.
- Release binary: same scenario, no crash, results render (unchanged).
- `cargo clippy --workspace --all-targets -D warnings`, fmt, `api::` test filter (81/81), file-size ratchet, architecture gates: all green.

## Follow-up (separate)

~~Stale lease follow-up~~ — resolved during this session: the lease is flock-based and kernel-released on death. The earlier "stale lease" observation was an immediate respawn landing inside the 1–2 s systemd-coredump window, followed by the designed read-only-secondary behavior. Verified empirically (SIGABRT → settle → relaunch acquires the lease). No change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWataUqhg17xXKfwgZ7HMn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Stability**
  * Improved runtime handling for background operations to reduce the risk of stack-related issues.
  * Adjusted worker thread stack sizing based on the build configuration.
* **Bug Fixes**
  * Improved reliability during media search and metadata processing without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
