### PR TITLE
release: 1.7.0 version bump + preflight

### DIFF
--- a/.github/workflows/release-preflight-1.7.0.yml
+++ b/.github/workflows/release-preflight-1.7.0.yml
@@ -1,24 +1,24 @@
-name: release preflight 1.6.36
+name: release preflight 1.7.0
 
 on:
   pull_request:
     branches: [main]
 
 concurrency:
-  group: release-preflight-1.6.36-${{ github.event.pull_request.number }}
+  group: release-preflight-1.7.0-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 env:
-  PREFLIGHT_VERSION: 1.6.36
+  PREFLIGHT_VERSION: 1.7.0
 
 permissions:
   contents: read
 
 jobs:
   verify-version:
-    name: Verify synchronized 1.6.36 source versions
+    name: Verify synchronized 1.7.0 source versions
     if: >-
-      github.head_ref == 'agent/aggregate-1.6.36-preflight' &&
+      github.head_ref == 'agent/aggregate-1.7.0-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +53,7 @@ jobs:
   release-build:
     name: Native release build and package
     if: >-
-      github.head_ref == 'agent/aggregate-1.6.36-preflight' &&
+      github.head_ref == 'agent/aggregate-1.7.0-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: verify-version
     uses: ./.github/workflows/native-release-build.yml
@@ -62,9 +62,9 @@ jobs:
       pull-requests: read
 
   aggregate:
-    name: Aggregate 1.6.36 preflight artifacts
+    name: Aggregate 1.7.0 preflight artifacts
     if: >-
-      github.head_ref == 'agent/aggregate-1.6.36-preflight' &&
+      github.head_ref == 'agent/aggregate-1.7.0-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: release-build
     runs-on: ubuntu-latest
@@ -146,7 +146,7 @@ jobs:
       - name: Upload complete preflight bundle
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: yututui-1.6.36-preflight
+          name: yututui-1.7.0-preflight
           if-no-files-found: error
           retention-days: 14
           path: |
@@ -158,10 +158,10 @@ jobs:
             checksums.txt
 
   preflight-result:
-    name: Release preflight 1.6.36 result
+    name: Release preflight 1.7.0 result
     if: >-
       always() &&
-      github.head_ref == 'agent/aggregate-1.6.36-preflight' &&
+      github.head_ref == 'agent/aggregate-1.7.0-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: [verify-version, release-build, aggregate]
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7010,7 +7010,7 @@ dependencies = [
 
 [[package]]
 name = "yututui"
-version = "1.6.36"
+version = "1.7.0"
 dependencies = [
  "age",
  "anyhow",
@@ -7071,7 +7071,7 @@ dependencies = [
 
 [[package]]
 name = "yututui-core"
-version = "1.6.36"
+version = "1.7.0"
 dependencies = [
  "serde",
  "ts-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui"
-version = "1.6.36"
+version = "1.7.0"
 edition = "2024"
 # Releases are repository-built binaries. The application depends on a private workspace core,
 # so make the existing non-crates.io distribution contract explicit and fail closed on publish.

--- a/crates/yututui-core/Cargo.toml
+++ b/crates/yututui-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui-core"
-version = "1.6.36"
+version = "1.7.0"
 edition = "2024"
 publish = false
 description = "Pure playback policies shared by yututui playback owners."

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           lib = pkgs.lib;
           yututui = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui";
-            version = "1.6.36"; # keep in sync with Cargo.toml
+            version = "1.7.0"; # keep in sync with Cargo.toml
 
             # Drop build artifacts and flake results from the copied source so the store path
             # stays small and rebuilds aren't invalidated by a local `target/`.
@@ -72,7 +72,7 @@
           # correct hash to paste here (docs/gui/04 §9 risk 2).
           guiDist = pkgs.buildNpmPackage {
             pname = "yututui-gui";
-            version = "1.6.36"; # private GUI package version; not part of the release surface
+            version = "1.7.0"; # private GUI package version; not part of the release surface
             src = ./gui;
             npmDepsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
             dontNpmInstall = true;
@@ -84,7 +84,7 @@
           };
           yututui-desktop = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui-desktop";
-            version = "1.6.36"; # keep the yututray binary version in sync with Cargo.toml
+            version = "1.7.0"; # keep the yututray binary version in sync with Cargo.toml
             src = desktopSrc;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = [ pkgs.makeWrapper pkgs.pkg-config ];

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yututui-gui",
-  "version": "1.6.31",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yututui-gui",
-      "version": "1.6.31",
+      "version": "1.7.0",
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@testing-library/svelte": "^5.2.6",

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yututui-gui",
   "private": true,
-  "version": "1.6.31",
+  "version": "1.7.0",
   "type": "module",
   "description": "Svelte 5 frontend for the yututui desktop app (embedded into yututray).",
   "scripts": {

--- a/scripts/windows-daemon-smoke.ps1
+++ b/scripts/windows-daemon-smoke.ps1
@@ -21,6 +21,10 @@ $WorkRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("yututui-windows-smoke-
 $BackupRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("yututui-windows-smoke-backup-" + [Guid]::NewGuid().ToString("N"))
 $RunKey = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run"
 $RunName = "YuTuTray!"
+# Mirror unix-daemon-smoke.sh's wait budget (YTM_SMOKE_WAIT_SECONDS, default 30s). The old
+# 10s default flaked on hosted runners: the resume wait covers the job's first-ever mpv
+# launch, where Defender scans the freshly extracted, unsigned mpv.exe before it can play.
+$SmokeWaitSeconds = if ($env:YTM_SMOKE_WAIT_SECONDS) { [int]$env:YTM_SMOKE_WAIT_SECONDS } else { 30 }
 
 function Assert-FileExists {
     param([string]$Path)
@@ -73,7 +77,7 @@ function Wait-Until {
     param(
         [scriptblock]$Condition,
         [string]$Label,
-        [int]$TimeoutSeconds = 10
+        [int]$TimeoutSeconds = $script:SmokeWaitSeconds
     )
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     do {

--- a/scripts/windows-daemon-smoke.ps1
+++ b/scripts/windows-daemon-smoke.ps1
@@ -21,9 +21,7 @@ $WorkRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("yututui-windows-smoke-
 $BackupRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("yututui-windows-smoke-backup-" + [Guid]::NewGuid().ToString("N"))
 $RunKey = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run"
 $RunName = "YuTuTray!"
-# Mirror unix-daemon-smoke.sh's wait budget (YTM_SMOKE_WAIT_SECONDS, default 30s). The old
-# 10s default flaked on hosted runners: the resume wait covers the job's first-ever mpv
-# launch, where Defender scans the freshly extracted, unsigned mpv.exe before it can play.
+# Match unix-daemon-smoke.sh's configurable 30s wait budget.
 $SmokeWaitSeconds = if ($env:YTM_SMOKE_WAIT_SECONDS) { [int]$env:YTM_SMOKE_WAIT_SECONDS } else { 30 }
 
 function Assert-FileExists {
@@ -227,7 +225,6 @@ $profileBackups = @()
 $hadRunValue = $false
 $oldRunValue = $null
 $oldMpvExtra = [Environment]::GetEnvironmentVariable("YTM_MPV_EXTRA", "Process")
-$oldRustLog = [Environment]::GetEnvironmentVariable("RUST_LOG", "Process")
 $mpvBaseline = @(Get-Process -Name "mpv" -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
 
 try {
@@ -275,6 +272,22 @@ try {
     $wavTwo = Join-Path $WorkRoot "windows-smoke-two.wav"
     New-SilentWav -Path $wavOne
     New-SilentWav -Path $wavTwo
+    $songs = @(
+        @{
+            video_id = "local:windows-smoke-one"
+            title = "Windows Smoke One"
+            artist = "yututui"
+            duration = "0:20"
+            local_path = $wavOne
+        },
+        @{
+            video_id = "local:windows-smoke-two"
+            title = "Windows Smoke Two"
+            artist = "yututui"
+            duration = "0:20"
+            local_path = $wavTwo
+        }
+    )
 
     @{
         volume = 0
@@ -291,34 +304,28 @@ try {
 
     @{
         last_mode = "normal"
-    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $cacheDir "session.json") -Encoding UTF8
+        # Local filesystem paths are device-private and personal-state v2 deliberately projects
+        # library history entries to non-playable `local-placeholder:*` rows. Session queues are
+        # the trusted same-device resume boundary, matching unix-daemon-smoke.sh.
+        normal_queue = @{
+            songs = $songs
+            order = @(0, 1)
+            cursor = 0
+            shuffle = $false
+            repeat = "off"
+        }
+        radio_queue = $null
+        local_queue = $null
+    } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $cacheDir "session.json") -Encoding UTF8
 
     @{
         favorites = @()
-        history = @(
-            @{
-                video_id = "local:windows-smoke-one"
-                title = "Windows Smoke One"
-                artist = "yututui"
-                duration = "0:20"
-                local_path = $wavOne
-            },
-            @{
-                video_id = "local:windows-smoke-two"
-                title = "Windows Smoke Two"
-                artist = "yututui"
-                duration = "0:20"
-                local_path = $wavTwo
-            }
-        )
+        history = @()
         radio_favorites = @()
         radios = @()
     } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $dataDir "library.json") -Encoding UTF8
 
     [Environment]::SetEnvironmentVariable("YTM_MPV_EXTRA", "--ao=null --volume=0", "Process")
-    # RUST_LOG is on the daemon-child env allowlist (util/process.rs): debug-level daemon.log
-    # is the only Windows-side evidence when a wait below times out.
-    [Environment]::SetEnvironmentVariable("RUST_LOG", "debug", "Process")
 
     Invoke-Checked $Ytt @("daemon", "start") | Out-Null
     Wait-Until -Label "idle daemon status" -Condition {
@@ -424,7 +431,6 @@ try {
     } catch {
     }
     [Environment]::SetEnvironmentVariable("YTM_MPV_EXTRA", $oldMpvExtra, "Process")
-    [Environment]::SetEnvironmentVariable("RUST_LOG", $oldRustLog, "Process")
     if ($hadRunValue) {
         New-Item -Path $RunKey -Force | Out-Null
         New-ItemProperty -Path $RunKey -Name $RunName -Value $oldRunValue -PropertyType String -Force | Out-Null

--- a/scripts/windows-daemon-smoke.ps1
+++ b/scripts/windows-daemon-smoke.ps1
@@ -227,6 +227,7 @@ $profileBackups = @()
 $hadRunValue = $false
 $oldRunValue = $null
 $oldMpvExtra = [Environment]::GetEnvironmentVariable("YTM_MPV_EXTRA", "Process")
+$oldRustLog = [Environment]::GetEnvironmentVariable("RUST_LOG", "Process")
 $mpvBaseline = @(Get-Process -Name "mpv" -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
 
 try {
@@ -315,6 +316,9 @@ try {
     } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $dataDir "library.json") -Encoding UTF8
 
     [Environment]::SetEnvironmentVariable("YTM_MPV_EXTRA", "--ao=null --volume=0", "Process")
+    # RUST_LOG is on the daemon-child env allowlist (util/process.rs): debug-level daemon.log
+    # is the only Windows-side evidence when a wait below times out.
+    [Environment]::SetEnvironmentVariable("RUST_LOG", "debug", "Process")
 
     Invoke-Checked $Ytt @("daemon", "start") | Out-Null
     Wait-Until -Label "idle daemon status" -Condition {
@@ -330,7 +334,7 @@ try {
         throw "idle daemon spawned mpv unexpectedly: $($idleMpv.Id -join ', ')"
     }
 
-    Invoke-Checked $Ytt @("daemon", "start", "--resume") | Out-Null
+    Write-Host ("daemon start --resume: " + (Invoke-Checked $Ytt @("daemon", "start", "--resume")))
     Wait-Until -Label "resumed daemon playback" -Condition {
         try {
             $status = Get-DaemonStatus
@@ -403,12 +407,24 @@ try {
     }
 
     Write-Host "Windows daemon/tray smoke passed"
+} catch {
+    Write-Host "--- smoke failure diagnostics ---"
+    Write-Host "failure: $_"
+    & $Ytt daemon status --json 2>&1 | ForEach-Object { Write-Host "daemon status: $_" }
+    $global:LASTEXITCODE = 0
+    Get-ChildItem -LiteralPath (Join-Path $cacheDir "logs") -Filter "daemon.log*" -File -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            Write-Host "--- daemon log tail: $($_.FullName) ---"
+            Get-Content -LiteralPath $_.FullName -Tail 250 | ForEach-Object { Write-Host $_ }
+        }
+    throw
 } finally {
     try {
         Invoke-Checked $Ytt @("daemon", "stop") | Out-Null
     } catch {
     }
     [Environment]::SetEnvironmentVariable("YTM_MPV_EXTRA", $oldMpvExtra, "Process")
+    [Environment]::SetEnvironmentVariable("RUST_LOG", $oldRustLog, "Process")
     if ($hadRunValue) {
         New-Item -Path $RunKey -Force | Out-Null
         New-ItemProperty -Path $RunKey -Name $RunName -Value $oldRunValue -PropertyType String -Force | Out-Null

--- a/src/terminal_runtime/runner/ordered_fallback_tests.rs
+++ b/src/terminal_runtime/runner/ordered_fallback_tests.rs
@@ -83,8 +83,12 @@ async fn quit_timeout_retries_every_newest_store_when_each_store_is_contended_in
             .seal_with_snapshots(snapshots)
             .expect("all-store quit seal is admitted atomically");
         let actor_handle = persist.clone();
+        // INVARIANT(test budget): this deadline starts before the orchestrated contention
+        // window and must dominate every budget inside it (the 5s writer release, the two
+        // 25ms bounded waits, and nine ACL-heavy Windows writes on a loaded CI runner).
+        // Bounded-flush truthfulness is asserted by the 25ms flush below, not here.
         let actor_flush =
-            tokio::spawn(async move { actor_handle.flush(Duration::from_secs(3)).await });
+            tokio::spawn(async move { actor_handle.flush(Duration::from_secs(30)).await });
         tokio::task::spawn_blocking(move || {
             started_rx
                 .recv_timeout(Duration::from_secs(5))


### PR DESCRIPTION
## What
- Bump every version surface 1.6.36 -> 1.7.0: `Cargo.toml`, `crates/yututui-core/Cargo.toml`, `Cargo.lock`, `flake.nix` (x3), `gui/package.json` (+lock, was drifted at 1.6.31).
- Retarget the release-preflight workflow to 1.7.0 (renamed `release-preflight-1.7.0.yml`); this branch name triggers it, so the native release build + artifact/checksum verification run on this PR.
- `packaging/**` templates untouched (`__VERSION__` rendered at tag time).

## Checks
- Local canonical gate (`run-gates .` in `nix develop`): all 16 gates PASS (fmt/clippy/test workspace + vendored crossterm/ratatui-image matrices + arch gates).
- Cross-target (Windows/macOS) coverage comes from the preflight jobs on this PR.

## Next
Human merge -> `release-mode publish v1.7.0` sanction -> tag push fires `build.yml` (Homebrew/Scoop/AUR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Updated application, desktop, GUI, and Rust crate versions to **1.7.0**.
* **CI / Release Process**
  * Updated the **1.7.0** release preflight workflow to use the correct concurrency, gating, naming, and **1.7.0**-specific result/artifact labeling.
* **Tests**
  * Increased an ordered-fallback flush timeout in terminal runtime tests (**3s → 30s**) and clarified timing expectations.
* **Scripts**
  * Made Windows daemon/tray smoke polling configurable via `YTM_SMOKE_WAIT_SECONDS` (fallback **30s**) and improved timeout diagnostics/logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->