### PR TITLE
fix(sync,export): make real WebDAV servers and used profiles work

### DIFF
--- a/src/data_export/offline.rs
+++ b/src/data_export/offline.rs
@@ -7,7 +7,6 @@
 use std::io;
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
 use serde::de::Error as _;
 use serde::de::{self, DeserializeOwned, DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use sha2::{Digest, Sha256};
@@ -19,6 +18,8 @@ use crate::playlists::Playlists;
 use crate::signals::Signals;
 use crate::station::StationStore;
 
+use crate::persist::{PendingStoreIntent, StoreKind, pending_store_intent};
+
 // Keep these aligned with the owning stores. They are repeated here rather than widening the
 // production persistence API solely for an export-only reader.
 const CONFIG_MAX_BYTES: u64 = 1024 * 1024;
@@ -26,7 +27,6 @@ const LIBRARY_MAX_BYTES: u64 = 50 * 1024 * 1024;
 const PLAYLISTS_MAX_BYTES: u64 = 50 * 1024 * 1024;
 const SIGNALS_MAX_BYTES: u64 = 32 * 1024 * 1024;
 const STATION_MAX_BYTES: u64 = 16 * 1024 * 1024;
-const INTENT_JOURNAL_MAX_BYTES: u64 = 1024 * 1024;
 const INTENT_SNAPSHOT_MAX_BYTES: u64 = 64 * 1024 * 1024;
 
 // Raw byte limits do not bound serde allocation: a small JSON token such as `""` can become a
@@ -529,7 +529,7 @@ pub(crate) fn load_playlists_read_only(
 
 #[cfg(test)]
 fn load_playlists_at(path: &Path) -> Result<Playlists, ExportError> {
-    load_store("playlists", path, PLAYLISTS_MAX_BYTES, "playlists")
+    load_store("playlists", path, PLAYLISTS_MAX_BYTES, StoreKind::Playlists)
 }
 
 fn load_playlists_at_with_prior_budget(
@@ -540,7 +540,7 @@ fn load_playlists_at_with_prior_budget(
         "playlists",
         path,
         PLAYLISTS_MAX_BYTES,
-        "playlists",
+        StoreKind::Playlists,
         prior_estimate,
     )
     .map(|loaded| loaded.value)
@@ -553,35 +553,35 @@ fn load_sources_at(paths: SourcePaths) -> Result<OfflineSources, ExportError> {
             "config",
             required_path("config", paths.config.as_deref())?,
             CONFIG_MAX_BYTES,
-            "config",
+            StoreKind::Config,
             &mut budget,
         )?,
         library: load_store_budgeted(
             "library",
             required_path("library", paths.library.as_deref())?,
             LIBRARY_MAX_BYTES,
-            "library",
+            StoreKind::Library,
             &mut budget,
         )?,
         playlists: load_store_budgeted(
             "playlists",
             required_path("playlists", paths.playlists.as_deref())?,
             PLAYLISTS_MAX_BYTES,
-            "playlists",
+            StoreKind::Playlists,
             &mut budget,
         )?,
         signals: load_store_budgeted(
             "signals",
             required_path("signals", paths.signals.as_deref())?,
             SIGNALS_MAX_BYTES,
-            "signals",
+            StoreKind::Signals,
             &mut budget,
         )?,
         station: load_store_budgeted(
             "station profile",
             required_path("station profile", paths.station.as_deref())?,
             STATION_MAX_BYTES,
-            "station profile",
+            StoreKind::Station,
             &mut budget,
         )?,
     })
@@ -603,25 +603,25 @@ fn load_store<T>(
     store: &'static str,
     path: &Path,
     max_bytes: u64,
-    journal_kind: &'static str,
+    kind: StoreKind,
 ) -> Result<T, ExportError>
 where
     T: DeserializeOwned + Default,
 {
-    load_store_parsed(store, path, max_bytes, journal_kind, 0).map(|loaded| loaded.value)
+    load_store_parsed(store, path, max_bytes, kind, 0).map(|loaded| loaded.value)
 }
 
 fn load_store_budgeted<T>(
     store: &'static str,
     path: &Path,
     max_bytes: u64,
-    journal_kind: &'static str,
+    kind: StoreKind,
     budget: &mut AggregateBudget,
 ) -> Result<T, ExportError>
 where
     T: DeserializeOwned + Default,
 {
-    let loaded = load_store_parsed(store, path, max_bytes, journal_kind, budget.estimated_heap)?;
+    let loaded = load_store_parsed(store, path, max_bytes, kind, budget.estimated_heap)?;
     budget.add(store, loaded.estimate)?;
     Ok(loaded.value)
 }
@@ -630,13 +630,13 @@ fn load_store_parsed<T>(
     store: &'static str,
     path: &Path,
     max_bytes: u64,
-    journal_kind: &'static str,
+    kind: StoreKind,
     prior_estimate: usize,
 ) -> Result<ParsedStore<T>, ExportError>
 where
     T: DeserializeOwned + Default,
 {
-    let profile = StoreProfile::for_kind(journal_kind);
+    let profile = StoreProfile::for_kind(kind.label());
     let base_bytes = read_optional(store, "snapshot", path, max_bytes)?;
     let base = match base_bytes {
         Some(bytes) => {
@@ -659,50 +659,55 @@ where
         }
     };
 
-    let journal_path = sibling_with_suffix(path, ".intent.jsonl", store)?;
-    let sidecar_path = sibling_with_suffix(path, ".intent.latest.json", store)?;
-    let journal = read_optional(
-        store,
-        "persistence journal",
-        &journal_path,
-        INTENT_JOURNAL_MAX_BYTES,
-    )?;
-    let sidecar = read_optional(
-        store,
-        "persistence journal sidecar",
-        &sidecar_path,
-        max_bytes.min(INTENT_SNAPSHOT_MAX_BYTES),
-    )?;
+    // The journal is the persist actor's own record of a write that may not have reached the
+    // snapshot yet. Resolving it through `crate::persist` keeps one reader for one format.
+    let intent = resolve_intent(store, kind, path)?;
+    let legacy_sidecar_path = sibling_with_suffix(path, ".intent.latest.json", store)?;
 
-    let Some(journal) = journal else {
-        return match sidecar {
-            None => Ok(ParsedStore {
-                value: base.value,
-                estimate: base.estimate,
-            }),
-            Some(sidecar) if base.bytes.as_deref() == Some(sidecar.as_slice()) => {
-                // A crash while clearing a fully persisted intent can leave only the sidecar.
-                // Byte equality proves it contains no state newer than the already validated main
-                // snapshot, so parsing a second full T would only increase peak memory.
-                Ok(ParsedStore {
-                    value: base.value,
-                    estimate: base.estimate,
-                })
-            }
-            Some(_) => Err(source_error(
+    match intent {
+        PendingStoreIntent::Unreadable => Err(source_error(
+            store,
+            "persistence journal contains no record this store can interpret",
+        )),
+        PendingStoreIntent::Delete => {
+            let estimate = std::mem::size_of::<T>();
+            ensure_combined_budget(store, prior_estimate, estimate)?;
+            drop(base);
+            Ok(ParsedStore {
+                value: T::default(),
+                estimate,
+            })
+        }
+        PendingStoreIntent::Replace { sidecar, sha256 } => {
+            let Some(bytes) = read_optional(
                 store,
-                "an orphan persistence sidecar may contain newer data",
-            )),
-        };
-    };
-
-    let record = parse_latest_intent(store, journal_kind, path, &journal)?;
-    match sidecar {
-        Some(sidecar) => {
-            if sha256_hex(&sidecar) != record.sha256 {
+                "persistence journal sidecar",
+                &sidecar,
+                max_bytes.min(INTENT_SNAPSHOT_MAX_BYTES),
+            )?
+            else {
+                return Err(source_error(
+                    store,
+                    "the store changed while exporting; run the export again",
+                ));
+            };
+            if sha256_hex(&bytes) != sha256 {
                 return Err(source_error(
                     store,
                     "persistence journal sidecar checksum does not match its latest intent",
+                ));
+            }
+            // The snapshot and the sidecar were read one after another. Re-resolving proves the
+            // actor did not land a newer write in between, so the export is never a torn view.
+            if resolve_intent(store, kind, path)?
+                != (PendingStoreIntent::Replace {
+                    sidecar,
+                    sha256: sha256.clone(),
+                })
+            {
+                return Err(source_error(
+                    store,
+                    "the store changed while exporting; run the export again",
                 ));
             }
             // The present base was validated above to retain fail-closed corruption semantics, but
@@ -712,97 +717,46 @@ where
             parse_store(
                 store,
                 "persistence journal sidecar",
-                &sidecar,
+                &bytes,
                 profile,
                 prior_estimate,
             )
         }
-        None => {
-            let Some(base_bytes) = base.bytes.as_deref() else {
-                return Err(source_error(
-                    store,
-                    "persistence journal exists but its snapshot and sidecar are missing",
-                ));
-            };
-            if sha256_hex(base_bytes) != record.sha256 {
-                return Err(source_error(
-                    store,
-                    "persistence journal sidecar is missing before its data reached the main snapshot",
-                ));
+        // Nothing is pending. A journal-less profile written by an older build can still hold a
+        // legacy sidecar; refusing a newer one keeps the original fail-closed guarantee.
+        PendingStoreIntent::Committed => {
+            match read_optional(
+                store,
+                "persistence journal sidecar",
+                &legacy_sidecar_path,
+                max_bytes.min(INTENT_SNAPSHOT_MAX_BYTES),
+            )? {
+                Some(sidecar) if base.bytes.as_deref() != Some(sidecar.as_slice()) => {
+                    Err(source_error(
+                        store,
+                        "an orphan persistence sidecar may contain newer data",
+                    ))
+                }
+                _ => Ok(ParsedStore {
+                    value: base.value,
+                    estimate: base.estimate,
+                }),
             }
-            // Main data already matches the intent; the process likely stopped while clearing
-            // journal files after a successful atomic store write.
-            Ok(ParsedStore {
-                value: base.value,
-                estimate: base.estimate,
-            })
         }
     }
+}
+
+fn resolve_intent(
+    store: &'static str,
+    kind: StoreKind,
+    path: &Path,
+) -> Result<PendingStoreIntent, ExportError> {
+    pending_store_intent(kind, path)
+        .map_err(|error| source_error(store, format!("persistence journal is unusable: {error}")))
 }
 
 fn required_path<'a>(store: &'static str, path: Option<&'a Path>) -> Result<&'a Path, ExportError> {
     path.ok_or_else(|| source_error(store, "storage location cannot be resolved"))
-}
-
-#[derive(Deserialize)]
-struct IntentRecord {
-    v: u64,
-    op: String,
-    kind: String,
-    sidecar: String,
-    sha256: String,
-}
-
-fn parse_latest_intent(
-    store: &'static str,
-    expected_kind: &str,
-    snapshot_path: &Path,
-    bytes: &[u8],
-) -> Result<IntentRecord, ExportError> {
-    let text = std::str::from_utf8(bytes)
-        .map_err(|_| source_error(store, "persistence journal is not valid UTF-8 JSON Lines"))?;
-    let expected_sidecar = sibling_file_name(snapshot_path, ".intent.latest.json", store)?;
-    let mut latest = None;
-    for (index, line) in text.lines().enumerate() {
-        if line.trim().is_empty() {
-            return Err(source_error(
-                store,
-                format!(
-                    "persistence journal contains an empty record at line {}",
-                    index + 1
-                ),
-            ));
-        }
-        let record: IntentRecord = serde_json::from_str(line).map_err(|error| {
-            source_error(
-                store,
-                format!(
-                    "persistence journal contains invalid JSON at line {}: {error}",
-                    index + 1
-                ),
-            )
-        })?;
-        if record.v != 1
-            || record.op != "replace"
-            || record.kind != expected_kind
-            || record.sidecar != expected_sidecar
-            || record.sha256.len() != 64
-            || !record
-                .sha256
-                .bytes()
-                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
-        {
-            return Err(source_error(
-                store,
-                format!(
-                    "persistence journal record {} has an unsafe or unsupported shape",
-                    index + 1
-                ),
-            ));
-        }
-        latest = Some(record);
-    }
-    latest.ok_or_else(|| source_error(store, "persistence journal is empty"))
 }
 
 fn read_optional(
@@ -1071,10 +1025,11 @@ mod tests {
         fs::write(&path, base).expect("write base");
         let sidecar_path = path.with_file_name("counted.json.intent.latest.json");
         fs::write(&sidecar_path, sidecar).expect("write sidecar");
+        // Any store whose label has no dedicated preflight profile keeps this fixture generic.
         let journal = serde_json::json!({
             "v": 1,
             "op": "replace",
-            "kind": "counted",
+            "kind": StoreKind::Session.label(),
             "sidecar": "counted.json.intent.latest.json",
             "sha256": sha256_hex(sidecar),
         });
@@ -1090,7 +1045,7 @@ mod tests {
                 "counted",
                 &path,
                 PLAYLISTS_MAX_BYTES,
-                "counted",
+                StoreKind::Session,
                 prior_estimate,
             ),
             "oversized replacement must fail before its typed decode",
@@ -1268,7 +1223,7 @@ mod tests {
         let journal_path = path.with_file_name("library.json.intent.jsonl");
         fs::write(&journal_path, format!("{journal}\n")).expect("write journal");
 
-        let loaded: Library = load_store("library", &path, LIBRARY_MAX_BYTES, "library")
+        let loaded: Library = load_store("library", &path, LIBRARY_MAX_BYTES, StoreKind::Library)
             .expect("replay valid journal");
         assert_eq!(loaded.favorites[0].title, "Newest");
         assert_eq!(fs::read(&path).expect("base unchanged"), base_bytes);
@@ -1276,6 +1231,109 @@ mod tests {
             fs::read(&sidecar_path).expect("sidecar unchanged"),
             sidecar_bytes
         );
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn a_committed_generation_journal_exports_the_snapshot() {
+        // The steady state of every profile the app has actually written: an ordered replace whose
+        // commit record proves the bytes already reached the snapshot. Requiring `sidecar` on every
+        // record used to fail this with `missing field 'sidecar'`.
+        let root = test_directory("journal-committed");
+        let path = root.join("library.json");
+        let mut stored = Library::default();
+        stored
+            .favorites
+            .push(Song::remote("dQw4w9WgXcQ", "Stored", "Artist", "3:32"));
+        let base_bytes = serde_json::to_vec_pretty(&stored).expect("base JSON");
+        fs::write(&path, &base_bytes).expect("write base");
+        let journal_path = path.with_file_name("library.json.intent.jsonl");
+        let journal = format!(
+            "{}\n{}\n",
+            serde_json::json!({
+                "v": 1,
+                "op": "replace",
+                "kind": StoreKind::Library.label(),
+                "generation": "6ab4fa846d94e0d88c3c259d1aa5c91d",
+                "process_epoch": "18",
+                "sequence": "8",
+                "sidecar": "library.json.intent.18-8.json",
+                "sha256": sha256_hex(&base_bytes),
+            }),
+            serde_json::json!({
+                "v": 1,
+                "op": "commit",
+                "kind": StoreKind::Library.label(),
+                "generation": "6ab4fa846d94e0d88c3c259d1aa5c91d",
+                "process_epoch": "18",
+                "sequence": "8",
+            })
+        );
+        fs::write(&journal_path, &journal).expect("write journal");
+
+        let loaded: Library = load_store("library", &path, LIBRARY_MAX_BYTES, StoreKind::Library)
+            .expect("a committed journal must not block the export");
+
+        assert_eq!(loaded.favorites[0].title, "Stored");
+        assert_eq!(fs::read(&path).expect("base unchanged"), base_bytes);
+        assert_eq!(
+            fs::read_to_string(&journal_path).expect("journal unchanged"),
+            journal
+        );
+        assert_eq!(
+            fs::read_dir(&root).expect("list root").count(),
+            2,
+            "an export must not create lock or repair files"
+        );
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn an_uncommitted_generation_journal_replays_its_unique_sidecar() {
+        let root = test_directory("journal-uncommitted");
+        let path = root.join("library.json");
+        let base_bytes = serde_json::to_vec_pretty(&Library::default()).expect("base JSON");
+        fs::write(&path, &base_bytes).expect("write base");
+
+        let mut pending = Library::default();
+        pending
+            .favorites
+            .push(Song::remote("dQw4w9WgXcQ", "Pending", "Artist", "3:32"));
+        let sidecar_bytes = serde_json::to_vec_pretty(&pending).expect("sidecar JSON");
+        let sidecar_name = "library.json.intent.19-3.json";
+        fs::write(path.with_file_name(sidecar_name), &sidecar_bytes).expect("write sidecar");
+        let journal = format!(
+            "{}\n{}\n",
+            serde_json::json!({
+                "v": 1,
+                "op": "commit",
+                "kind": StoreKind::Library.label(),
+                "generation": "6ab4fa846d94e0d88c3c259d1aa5c91d",
+                "process_epoch": "19",
+                "sequence": "2",
+            }),
+            serde_json::json!({
+                "v": 1,
+                "op": "replace",
+                "kind": StoreKind::Library.label(),
+                "generation": "6ab4fa846d94e0d88c3c259d1aa5c91d",
+                "process_epoch": "19",
+                "sequence": "3",
+                "sidecar": sidecar_name,
+                "sha256": sha256_hex(&sidecar_bytes),
+            })
+        );
+        fs::write(path.with_file_name("library.json.intent.jsonl"), journal)
+            .expect("write journal");
+
+        let loaded: Library = load_store("library", &path, LIBRARY_MAX_BYTES, StoreKind::Library)
+            .expect("an uncommitted replace must be replayed");
+
+        assert_eq!(
+            loaded.favorites[0].title, "Pending",
+            "the newest uncommitted sidecar is authoritative, whatever it is named"
+        );
+        assert_eq!(fs::read(&path).expect("base unchanged"), base_bytes);
         fs::remove_dir_all(root).expect("cleanup");
     }
 
@@ -1299,7 +1357,7 @@ mod tests {
         let journal_path = path.with_file_name("library.json.intent.jsonl");
         fs::write(&journal_path, format!("{journal}\n")).expect("write journal");
 
-        let error = load_store::<Library>("library", &path, LIBRARY_MAX_BYTES, "library")
+        let error = load_store::<Library>("library", &path, LIBRARY_MAX_BYTES, StoreKind::Library)
             .expect_err("a valid journal must not hide a corrupt base");
 
         assert!(error.to_string().contains("snapshot"));
@@ -1319,8 +1377,13 @@ mod tests {
         fs::write(&corrupt_path, &base).expect("write base");
         let journal_path = corrupt_path.with_file_name("library.json.intent.jsonl");
         fs::write(&journal_path, b"not-json\n").expect("write bad journal");
-        let error = load_store::<Library>("library", &corrupt_path, LIBRARY_MAX_BYTES, "library")
-            .expect_err("corrupt journal must fail");
+        let error = load_store::<Library>(
+            "library",
+            &corrupt_path,
+            LIBRARY_MAX_BYTES,
+            StoreKind::Library,
+        )
+        .expect_err("corrupt journal must fail");
         assert!(error.to_string().contains("persistence journal"));
         assert_eq!(
             fs::read(&journal_path).expect("journal unchanged"),
@@ -1340,8 +1403,13 @@ mod tests {
             serde_json::to_vec_pretty(&newer).expect("sidecar JSON"),
         )
         .expect("write orphan sidecar");
-        let error = load_store::<Library>("library", &orphan_path, LIBRARY_MAX_BYTES, "library")
-            .expect_err("orphan newer sidecar must fail");
+        let error = load_store::<Library>(
+            "library",
+            &orphan_path,
+            LIBRARY_MAX_BYTES,
+            StoreKind::Library,
+        )
+        .expect_err("orphan newer sidecar must fail");
         assert!(error.to_string().contains("orphan persistence sidecar"));
         fs::remove_dir_all(orphan_root).expect("cleanup");
     }

--- a/src/data_import.rs
+++ b/src/data_import.rs
@@ -72,8 +72,8 @@ fn plan_from_file_with_recovery(
     }
     let imported = crate::data_export::decode_personal_state_export(&bytes)?;
     let paths = PersonalStatePaths::current()?;
-    let current = load_current_state(&paths, recover_pending)?;
-    let plan = plan_import(&current, &imported)?;
+    let (current, local_device) = load_current_state(&paths, recover_pending)?;
+    let plan = plan_import(&current, &imported, local_device.as_ref())?;
     Ok((paths, plan))
 }
 
@@ -88,10 +88,11 @@ pub fn apply_plan(
     commit.commit(paths).map_err(ImportError::from)
 }
 
+/// The installed frontier plus the device this installation syncs as, when sync is configured.
 fn load_current_state(
     paths: &PersonalStatePaths,
     recover_pending: bool,
-) -> Result<PersonalStateV2, ImportError> {
+) -> Result<(PersonalStateV2, Option<crate::personal_state::DeviceId>), ImportError> {
     let loaded = if recover_pending {
         crate::personal_state::load_ledger(paths)
     } else {
@@ -112,21 +113,24 @@ fn load_current_state(
         Some(state) => {
             let local_device = crate::persist::load_personal_state_device_id(&state)
                 .map_err(|error| ImportError::LegacySource(error.to_string()))?;
-            crate::data_export::reconcile_v2_sources(
+            let reconciled = crate::data_export::reconcile_v2_sources(
                 &state,
                 local_device.as_ref(),
                 &sources.library,
                 &sources.playlists,
                 &sources.signals,
                 &sources.station,
-            )
+            )?;
+            Ok((reconciled, local_device))
         }
-        None => legacy_state(
-            &sources.library,
-            &sources.playlists,
-            &sources.signals,
-            &sources.station,
-        ),
+        None => Ok((
+            legacy_state(
+                &sources.library,
+                &sources.playlists,
+                &sources.signals,
+                &sources.station,
+            )?,
+            None,
+        )),
     }
-    .map_err(ImportError::from)
 }

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -27,6 +27,8 @@ use tokio::sync::{Notify, mpsc, oneshot};
 
 #[path = "persist/durable.rs"]
 mod durable;
+#[path = "persist/export_view.rs"]
+mod export_view;
 #[path = "persist/handle.rs"]
 mod handle;
 #[path = "persist/locking.rs"]
@@ -52,6 +54,7 @@ mod writer_lease;
 #[cfg(test)]
 use durable::allocate_process_epoch_at;
 use durable::{AcceptedJournalOrder, JournalGeneration, JournalOrder, JournalOrderSource};
+pub(crate) use export_view::{PendingStoreIntent, pending_store_intent};
 #[cfg(test)]
 pub(crate) use locking::with_intent_lock_contention_observer;
 pub(crate) use locking::with_store_intent_lock;

--- a/src/persist/export_view.rs
+++ b/src/persist/export_view.rs
@@ -1,0 +1,79 @@
+//! What a reader outside the persist actor must honour before trusting a store snapshot.
+//!
+//! The persist actor journals an intent before it rewrites a store, so a snapshot on disk can be
+//! one write behind an authoritative sidecar. Readers that skip the journal see stale data;
+//! readers that reimplement it drift. `data_export` reimplemented it and drifted: it required
+//! every record to be `op: "replace"` with a mandatory `sidecar` field named
+//! `<store>.intent.latest.json`, while the actor writes generation-ordered records whose
+//! steady-state newest entry is `op: "commit"` (no sidecar) and whose replace records name a
+//! unique per-order sidecar. Every profile the app had actually used therefore failed to export
+//! with `missing field 'sidecar'`.
+//!
+//! This is the one crate-internal seam for that question, resolved exactly as the app's own
+//! recovery replay resolves it.
+
+use std::path::{Path, PathBuf};
+
+use super::{
+    INTENT_JOURNAL_MAX_BYTES, JournalOperation, StoreKind, intent_journal_path, read_journal_state,
+    sibling_path_from_record,
+};
+
+/// The pending persistence intent for one store, resolved against the journal's commit frontier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PendingStoreIntent {
+    /// Nothing is pending; the store's own snapshot file is authoritative.
+    Committed,
+    /// A sidecar holds bytes newer than the snapshot. `sha256` must match before they are used.
+    Replace { sidecar: PathBuf, sha256: String },
+    /// The store is pending deletion; readers must treat it as empty.
+    Delete,
+    /// The journal has content but not one record this store can interpret. The app repairs by
+    /// ignoring such a journal; a fail-closed reader such as an export must refuse the store.
+    Unreadable,
+}
+
+/// Resolve the pending intent for `path`'s store.
+///
+/// This is a pure read: an export must never write to the profile it is backing up, so no lock
+/// file is created and no journal is repaired. Callers that then read the named sidecar must
+/// resolve again afterwards and compare — an unchanged answer proves the actor did not write
+/// underneath them, and a changed one is reported instead of exporting a torn view.
+pub(crate) fn pending_store_intent(
+    kind: StoreKind,
+    path: &Path,
+) -> std::io::Result<PendingStoreIntent> {
+    let state = read_journal_state(kind, path)?;
+    let Some(candidate) = state.candidate else {
+        if state.committed_through.is_none() && journal_has_content(path)? {
+            return Ok(PendingStoreIntent::Unreadable);
+        }
+        return Ok(PendingStoreIntent::Committed);
+    };
+    match candidate.operation {
+        JournalOperation::Delete => Ok(PendingStoreIntent::Delete),
+        JournalOperation::Replace { sidecar, sha256 } => {
+            let sidecar = sibling_path_from_record(path, &sidecar).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("{} journal names an invalid sidecar", kind.label()),
+                )
+            })?;
+            Ok(PendingStoreIntent::Replace { sidecar, sha256 })
+        }
+    }
+}
+
+/// Whether the journal file holds at least one non-blank line.
+fn journal_has_content(path: &Path) -> std::io::Result<bool> {
+    let Some(journal_path) = intent_journal_path(path) else {
+        return Ok(false);
+    };
+    match crate::util::safe_fs::read_no_symlink_limited(&journal_path, INTENT_JOURNAL_MAX_BYTES) {
+        Ok(bytes) => Ok(String::from_utf8_lossy(&bytes)
+            .lines()
+            .any(|line| !line.trim().is_empty())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}

--- a/src/personal_state.rs
+++ b/src/personal_state.rs
@@ -47,4 +47,6 @@ pub use transaction::{PersonalStateCommit, PersonalStatePaths, recover_pending_t
 pub(crate) use transaction::{load_ledger, load_ledger_read_only};
 
 #[cfg(test)]
+mod import_tests;
+#[cfg(test)]
 mod tests;

--- a/src/personal_state/compaction_tests.rs
+++ b/src/personal_state/compaction_tests.rs
@@ -474,8 +474,8 @@ fn non_adjacent_compaction_generations_merge_and_import_in_both_directions() {
     assert_eq!(first_then_third, third);
     assert_eq!(third_then_first, third);
 
-    let import_old = crate::personal_state::plan_import(&third, &first).unwrap();
-    let import_new = crate::personal_state::plan_import(&first, &third).unwrap();
+    let import_old = crate::personal_state::plan_import(&third, &first, None).unwrap();
+    let import_new = crate::personal_state::plan_import(&first, &third, None).unwrap();
     assert_eq!(import_old.candidate, third);
     assert_eq!(import_new.candidate.operations, third.operations);
     assert_eq!(import_new.candidate.version_vector, third.version_vector);

--- a/src/personal_state/coordinator.rs
+++ b/src/personal_state/coordinator.rs
@@ -467,7 +467,7 @@ impl<'a> OperationAppender<'a> {
     }
 }
 
-fn local_device(state: &PersonalStateV2) -> Result<DeviceId, PersonalStateError> {
+pub(super) fn local_device(state: &PersonalStateV2) -> Result<DeviceId, PersonalStateError> {
     state.validate()?;
     let mut active = state
         .device_registry
@@ -485,7 +485,7 @@ fn local_device(state: &PersonalStateV2) -> Result<DeviceId, PersonalStateError>
     Ok(device)
 }
 
-fn validate_local_device_binding(
+pub(super) fn validate_local_device_binding(
     state: &PersonalStateV2,
     local_device_id: &DeviceId,
     require_keyed: bool,

--- a/src/personal_state/import.rs
+++ b/src/personal_state/import.rs
@@ -36,9 +36,14 @@ pub struct ImportPlan {
 /// export becomes one deterministic, deletion-free legacy baseline operation in the current
 /// dataset. The imported baseline observes prior baselines, but not later local edits; this keeps
 /// explicit local changes authoritative while retaining every positive item from both baselines.
+/// `local_device_id` is the device this installation syncs as, when personal sync is configured.
+/// A foreign baseline is owned by that device, so the vault's membership covers it; without a
+/// binding the single active device owns it, and an ambiguous registry is refused rather than
+/// authored by a synthetic device no membership can ever accept.
 pub fn plan_import(
     current: &PersonalStateV2,
     imported: &PersonalStateV2,
+    local_device_id: Option<&DeviceId>,
 ) -> Result<ImportPlan, PersonalStateError> {
     current.validate()?;
     imported.validate()?;
@@ -54,7 +59,7 @@ pub fn plan_import(
             )
         } else {
             let imported_projection = project(imported)?.legacy;
-            rewrite_foreign_projection(current, imported_projection)?
+            rewrite_foreign_projection(current, imported_projection, local_device_id)?
         };
     let changed = candidate.operations != current.operations
         || candidate.device_registry != current.device_registry
@@ -382,10 +387,15 @@ fn tracks_are_retained(before: &[PortableTrack], after: &[PortableTrack]) -> boo
 fn rewrite_foreign_projection(
     current: &PersonalStateV2,
     imported: LegacyProjection,
+    local_device_id: Option<&DeviceId>,
 ) -> Result<(PersonalStateV2, usize, usize), PersonalStateError> {
     imported.validate()?;
-    let imported_hash = stable_hash(&serde_json::to_string(&imported)?);
-    let operation_id = format!("imported-baseline-{imported_hash}");
+    let import_device = import_author(current, local_device_id)?;
+    // The owning device belongs in the identity, exactly as the join path already does it. Two
+    // devices importing the same bundle then produce two content-equal baselines instead of one id
+    // carrying two different stamps, which the reducer rejects as a conflicting operation id.
+    let material = serde_json::to_string(&(import_device.as_str(), &imported))?;
+    let operation_id = format!("imported-baseline-{}", stable_hash(&material));
     if current
         .operations
         .iter()
@@ -419,7 +429,6 @@ fn rewrite_foreign_projection(
     let combined = merge_baselines(current_baseline, imported);
     combined.validate()?;
     let mut candidate = current.clone();
-    let import_device = DeviceId::new("000-import")?;
     let sequence = candidate
         .version_vector
         .observed(&import_device)
@@ -447,6 +456,25 @@ fn rewrite_foreign_projection(
     candidate.projection_fingerprint = None;
     candidate.normalize()?;
     Ok((candidate, 1, 0))
+}
+
+/// Which device owns an imported foreign baseline.
+///
+/// Every dot in a synced ledger must belong to a device the vault's membership knows: a version
+/// vector entry for anything else makes `ytt sync` reject the whole dataset. So the caller's
+/// binding wins, a single-device registry needs no binding, and anything else is an error the
+/// caller can act on.
+fn import_author(
+    current: &PersonalStateV2,
+    local_device_id: Option<&DeviceId>,
+) -> Result<DeviceId, PersonalStateError> {
+    match local_device_id {
+        Some(device_id) => {
+            super::coordinator::validate_local_device_binding(current, device_id, false)?;
+            Ok(device_id.clone())
+        }
+        None => super::coordinator::local_device(current),
+    }
 }
 
 fn merge_baselines(mut local: LegacyProjection, imported: LegacyProjection) -> LegacyProjection {

--- a/src/personal_state/import_tests.rs
+++ b/src/personal_state/import_tests.rs
@@ -1,0 +1,78 @@
+//! Import authorship: the vault can only publish operations owned by a membership device.
+
+use super::tests::state_with_keyed_devices;
+use super::{DeviceId, OperationOrigin, PersonalStateError, legacy_state, plan_import};
+
+#[test]
+fn foreign_import_is_owned_by_a_registry_device_so_sync_can_publish_it() {
+    // A version-vector entry for a device the vault's membership does not know makes `ytt sync`
+    // reject the whole dataset, so an imported baseline must never invent its own author.
+    let mut imported_library = crate::library::Library::default();
+    imported_library.toggle_favorite(&crate::api::Song::remote(
+        "remote".to_owned(),
+        "Remote".to_owned(),
+        "Artist".to_owned(),
+        "3:00".to_owned(),
+    ));
+    let mut imported = legacy_state(
+        &imported_library,
+        &crate::playlists::Playlists::default(),
+        &crate::signals::Signals::default(),
+        &crate::station::StationStore::default(),
+    )
+    .unwrap();
+    imported.dataset_id = "foreign-dataset".to_owned();
+
+    let single = legacy_state(
+        &crate::library::Library::default(),
+        &crate::playlists::Playlists::default(),
+        &crate::signals::Signals::default(),
+        &crate::station::StationStore::default(),
+    )
+    .unwrap();
+    let candidate = plan_import(&single, &imported, None).unwrap().candidate;
+    for device_id in candidate.version_vector.0.keys() {
+        assert!(
+            device_id.as_str() == "legacy" || candidate.device_registry.contains_key(device_id),
+            "{device_id:?} is not a registry device"
+        );
+    }
+
+    let first = DeviceId::new("device-a").unwrap();
+    let second = DeviceId::new("device-b").unwrap();
+    let paired = state_with_keyed_devices(&[first.as_str(), second.as_str()]);
+    let bound = plan_import(&paired, &imported, Some(&second))
+        .unwrap()
+        .candidate;
+    let owner = bound
+        .operations
+        .iter()
+        .find(|envelope| envelope.origin == OperationOrigin::Imported)
+        .expect("the foreign baseline is one imported operation")
+        .stamp
+        .dot
+        .device_id
+        .clone();
+    assert_eq!(owner, second, "the bound local device owns the import");
+    assert!(bound.version_vector.0.contains_key(&second));
+
+    assert!(
+        matches!(
+            plan_import(&paired, &imported, None),
+            Err(PersonalStateError::InvalidOperation(
+                "multiple active devices require an explicit local device binding"
+            ))
+        ),
+        "an ambiguous registry must be refused, not authored by a synthetic device"
+    );
+    assert!(matches!(
+        plan_import(
+            &paired,
+            &imported,
+            Some(&DeviceId::new("000-import").unwrap())
+        ),
+        Err(PersonalStateError::InvalidOperation(
+            "local device binding is not in the registry"
+        ))
+    ));
+}

--- a/src/personal_state/tests.rs
+++ b/src/personal_state/tests.rs
@@ -82,7 +82,7 @@ fn membership_operation(
     }
 }
 
-fn state_with_keyed_devices(device_ids: &[&str]) -> PersonalStateV2 {
+pub(super) fn state_with_keyed_devices(device_ids: &[&str]) -> PersonalStateV2 {
     let mut state = PersonalStateV2::empty("device-test".to_owned()).unwrap();
     for (index, device_id) in device_ids.iter().enumerate() {
         let device_id = DeviceId::new(*device_id).unwrap();
@@ -943,7 +943,7 @@ fn foreign_import_is_deletion_free_and_repeated_import_is_a_noop() {
     .unwrap();
     imported.dataset_id = "foreign-dataset".to_owned();
 
-    let first = plan_import(&local, &imported).unwrap();
+    let first = plan_import(&local, &imported, None).unwrap();
     assert!(first.summary.changed);
     let ids = project(&first.candidate)
         .unwrap()
@@ -962,7 +962,7 @@ fn foreign_import_is_deletion_free_and_repeated_import_is_a_noop() {
         HashSet::from(["local".to_owned(), "remote".to_owned()])
     );
 
-    let second = plan_import(&first.candidate, &imported).unwrap();
+    let second = plan_import(&first.candidate, &imported, None).unwrap();
     assert!(!second.summary.changed);
     assert_eq!(second.candidate.operations, first.candidate.operations);
 }
@@ -1101,7 +1101,7 @@ fn foreign_baseline_does_not_override_an_explicit_local_rating() {
 
     let mut imported = baseline.clone();
     imported.dataset_id = "foreign".to_owned();
-    let plan = plan_import(&explicit_neutral, &imported).unwrap();
+    let plan = plan_import(&explicit_neutral, &imported, None).unwrap();
     assert!(
         project(&plan.candidate)
             .unwrap()
@@ -1155,7 +1155,7 @@ fn same_dataset_import_persists_causal_changes_even_when_projection_is_unchanged
     remote.projection_fingerprint = None;
     remote.normalize().unwrap();
 
-    let plan = plan_import(&local, &remote).unwrap();
+    let plan = plan_import(&local, &remote, None).unwrap();
     assert!(plan.summary.changed);
     assert_eq!(
         project(&plan.candidate).unwrap().fingerprint,
@@ -1434,7 +1434,7 @@ fn terminal_revision_rejects_mutation_import_and_commit_preparation() {
     ));
 
     assert!(matches!(
-        plan_import(&exhausted, &changed),
+        plan_import(&exhausted, &changed, None),
         Err(PersonalStateError::InvalidOperation(
             "personal-state revision exhausted"
         ))

--- a/src/sync/webdav/capability.rs
+++ b/src/sync/webdav/capability.rs
@@ -1,0 +1,81 @@
+//! Real-server tolerances the WebDAV vault client needs at connection time.
+//!
+//! Both behaviours here exist because of measured servers, not specification reading:
+//!
+//! - The configured vault root may not exist yet. `ensure_ancestor_collections` only creates
+//!   collections *below* the root, so the first `MKCOL <root>/yututui` used to fail with 409 on
+//!   Nextcloud and never explain why. Creating the root itself first is idempotent (405 means it
+//!   was already there) and keeps a fresh endpoint path usable.
+//! - Apache mod_dav marks an entity tag weak (`W/"…"`) for as long as the file's mtime is within
+//!   one second of the response, and returns no `ETag` at all on PUT. A write followed by an
+//!   immediate readback therefore observes a weak tag and fails closed with
+//!   `MissingStrongEntityTag`, even though the very same object reports a strong tag a moment
+//!   later. Only that transient case is retried; a server that never produces a strong tag still
+//!   fails, because compare-and-swap correctness depends on it.
+
+use super::*;
+
+/// Waits before re-reading an object whose entity tag came back weak. Sized for the one-second
+/// mtime window in Apache's `ETag` weakening rule, with one extra attempt for clock skew.
+const WEAK_ETAG_READBACK_DELAYS: [Duration; 2] =
+    [Duration::from_millis(400), Duration::from_millis(900)];
+
+impl WebDavCapabilities {
+    /// Whether the endpoint answered OPTIONS as a WebDAV class 1 collection.
+    ///
+    /// The individual method flags are diagnostics, not gates. RFC 4918 defines `Allow` per
+    /// resource: MKCOL is never legal on a collection that already exists, and PUT is never legal
+    /// on a collection at all, so no conforming server advertises both on the vault root. The
+    /// servers measured for this fix disagree exactly that way — Nextcloud omits MKCOL on an
+    /// existing collection, Apache mod_dav omits PUT and MKCOL, and on a missing path Apache omits
+    /// GET and PROPFIND instead. [`super::BlockingWebDavTransport::probe_capabilities`] therefore
+    /// proves MKCOL, PUT, GET and PROPFIND by performing them against a dedicated marker object —
+    /// stronger evidence than a header list — and records the outcome in these flags.
+    pub fn supports_encrypted_sync(self) -> bool {
+        self.dav_class_1 && self.options
+    }
+}
+
+impl WebDavClient {
+    /// Create the configured vault root collection if it is missing.
+    ///
+    /// `AlreadyPresent` (405) is the normal answer for an endpoint the user already created, and a
+    /// 409 still surfaces as an error because it means the root's own parent does not exist — that
+    /// is a wrong endpoint, not something to paper over.
+    pub(super) async fn mkcol_root(
+        &self,
+        credential: &VaultCredential,
+    ) -> Result<CollectionWriteResult, WebDavError> {
+        let method = Method::from_bytes(b"MKCOL").map_err(|_| WebDavError::InvalidResponse)?;
+        let request = self.authenticated_request(method, self.base.clone(), credential)?;
+        let response = self.execute(request).await?;
+        match response.status() {
+            StatusCode::CREATED => Ok(CollectionWriteResult::Created),
+            StatusCode::METHOD_NOT_ALLOWED => Ok(CollectionWriteResult::AlreadyPresent),
+            _ => Err(status_error(&response)),
+        }
+    }
+
+    /// Read an object back after writing it, tolerating a briefly weak entity tag.
+    pub(super) async fn get_readback(
+        &self,
+        key: &ObjectKey,
+        credential: &VaultCredential,
+        body_limit: usize,
+        deadline: Option<VaultDeadline>,
+    ) -> Result<Option<(EncryptedObject, ObjectMetadata)>, WebDavError> {
+        for delay in WEAK_ETAG_READBACK_DELAYS {
+            match self.get_inner(key, credential, body_limit, deadline).await {
+                Err(WebDavError::MissingStrongEntityTag) => {
+                    await_with_deadline(deadline, async move {
+                        tokio::time::sleep(delay).await;
+                        Ok(())
+                    })
+                    .await?;
+                }
+                result => return result,
+            }
+        }
+        self.get_inner(key, credential, body_limit, deadline).await
+    }
+}

--- a/src/sync/webdav/capability_tests.rs
+++ b/src/sync/webdav/capability_tests.rs
@@ -1,0 +1,359 @@
+//! Real-server tolerances: the connection probe must judge methods by using them, create a
+//! missing vault root, and survive an entity tag that is only briefly weak.
+
+use age::secrecy::SecretString;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::{TcpListener, TcpStream};
+
+use super::*;
+use crate::sync::{DeviceSecretMaterial, encrypt_json_to_recipients};
+
+/// Exactly what Apache 2.4.68 mod_dav answers for an existing collection: no PUT (illegal on a
+/// collection) and no MKCOL (illegal on a collection that already exists).
+const APACHE_COLLECTION_ALLOW: &str =
+    "OPTIONS,GET,HEAD,POST,DELETE,TRACE,PROPFIND,PROPPATCH,COPY,MOVE,LOCK,UNLOCK";
+
+fn credential() -> VaultCredential {
+    VaultCredential::password("sync-user", SecretString::from("sync-password")).unwrap()
+}
+
+fn encrypted_object() -> EncryptedObject {
+    let device = DeviceSecretMaterial::generate_for("capability-test-device").unwrap();
+    encrypt_json_to_recipients(
+        &serde_json::json!({"protected": true}),
+        &[device.public_identity().age_recipient],
+    )
+    .unwrap()
+}
+
+async fn read_request(stream: &mut TcpStream) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    let header_end = loop {
+        let read = stream.read(&mut buffer).await.unwrap();
+        assert!(read > 0, "request ended before its headers");
+        bytes.extend_from_slice(&buffer[..read]);
+        assert!(bytes.len() <= 2 * 1024 * 1024, "test request exceeded cap");
+        if let Some(position) = bytes.windows(4).position(|part| part == b"\r\n\r\n") {
+            break position + 4;
+        }
+    };
+    let headers = String::from_utf8_lossy(&bytes[..header_end]);
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().unwrap())
+        })
+        .unwrap_or(0);
+    while bytes.len() < header_end + content_length {
+        let read = stream.read(&mut buffer).await.unwrap();
+        assert!(read > 0, "request ended before its body");
+        bytes.extend_from_slice(&buffer[..read]);
+    }
+    bytes
+}
+
+async fn respond(stream: &mut TcpStream, head: &str, body: &[u8]) {
+    stream.write_all(head.as_bytes()).await.unwrap();
+    stream.write_all(body).await.unwrap();
+    stream.shutdown().await.unwrap();
+}
+
+fn request_body(request: &[u8]) -> &[u8] {
+    let end = request
+        .windows(4)
+        .position(|part| part == b"\r\n\r\n")
+        .expect("test request has headers");
+    &request[end + 4..]
+}
+
+fn endpoint(listener: &TcpListener, path: &str) -> String {
+    format!("http://{}{path}", listener.local_addr().unwrap())
+}
+
+async fn accept_and_respond(listener: &TcpListener, head: &str, body: &[u8]) -> Vec<u8> {
+    let (mut stream, _) = listener.accept().await.unwrap();
+    let request = read_request(&mut stream).await;
+    respond(&mut stream, head, body).await;
+    request
+}
+
+/// Serve the whole conditional-write proof after OPTIONS: the vault root, the three protocol
+/// collections, then create/repeat/mismatch/readback/matched/readback and the bounded PROPFIND.
+async fn serve_conditional_write_proof(listener: &TcpListener, root_status: &str) -> Vec<u8> {
+    let root = accept_and_respond(listener, root_status, &[]).await;
+    assert!(String::from_utf8_lossy(&root).starts_with("MKCOL /vault/ HTTP/1.1\r\n"));
+    for expected in [
+        "/vault/yututui",
+        "/vault/yututui/v2",
+        "/vault/yututui/v2/capability",
+    ] {
+        let request = accept_and_respond(
+            listener,
+            "HTTP/1.1 201 Created\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+        assert!(
+            String::from_utf8_lossy(&request)
+                .starts_with(&format!("MKCOL {expected} HTTP/1.1\r\n"))
+        );
+    }
+
+    accept_and_respond(
+        listener,
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        &[],
+    )
+    .await;
+    let create = accept_and_respond(
+        listener,
+        "HTTP/1.1 201 Created\r\nETag: \"probe-1\"\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        &[],
+    )
+    .await;
+    let marker = request_body(&create).to_vec();
+    accept_and_respond(
+        listener,
+        "HTTP/1.1 412 Precondition Failed\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        &[],
+    )
+    .await;
+    accept_and_respond(
+        listener,
+        "HTTP/1.1 412 Precondition Failed\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        &[],
+    )
+    .await;
+    let ok = format!(
+        "HTTP/1.1 200 OK\r\nETag: \"probe-1\"\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        marker.len()
+    );
+    accept_and_respond(listener, &ok, &marker).await;
+    accept_and_respond(
+        listener,
+        "HTTP/1.1 204 No Content\r\nETag: \"probe-2\"\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        &[],
+    )
+    .await;
+    accept_and_respond(listener, &ok, &marker).await;
+
+    let propfind = br#"<d:multistatus xmlns:d="DAV:"><d:response><d:href>/vault/yututui/v2/capability/</d:href><d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>"#;
+    accept_and_respond(
+        listener,
+        &format!(
+            "HTTP/1.1 207 Multi-Status\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            propfind.len()
+        ),
+        propfind,
+    )
+    .await;
+    marker
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn allow_header_without_mkcol_or_put_still_passes_when_the_methods_work() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = endpoint(&listener, "/vault");
+    let server = tokio::spawn(async move {
+        let options = accept_and_respond(
+            &listener,
+            &format!(
+                "HTTP/1.1 200 OK\r\nDAV: 1,2\r\nAllow: {APACHE_COLLECTION_ALLOW}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            ),
+            &[],
+        )
+        .await;
+        assert!(String::from_utf8_lossy(&options).starts_with("OPTIONS /vault/ HTTP/1.1"));
+        serve_conditional_write_proof(
+            &listener,
+            "HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        )
+        .await;
+    });
+
+    let capabilities = tokio::task::spawn_blocking(move || {
+        let credential = credential();
+        BlockingWebDavTransport::new(&url, &credential)
+            .unwrap()
+            .probe_capabilities()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert!(capabilities.supports_encrypted_sync());
+    assert!(capabilities.mkcol, "a performed MKCOL is proof of MKCOL");
+    assert!(capabilities.put, "a performed PUT is proof of PUT");
+    assert!(capabilities.get);
+    assert!(capabilities.propfind);
+    server.await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn missing_vault_root_is_created_before_the_protocol_collections() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = endpoint(&listener, "/vault");
+    let server = tokio::spawn(async move {
+        accept_and_respond(
+            &listener,
+            "HTTP/1.1 200 OK\r\nDAV: 1\r\nAllow: OPTIONS, PROPFIND, GET\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+        serve_conditional_write_proof(
+            &listener,
+            "HTTP/1.1 201 Created\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        )
+        .await;
+    });
+
+    let url_for_probe = url.clone();
+    tokio::task::spawn_blocking(move || {
+        let credential = credential();
+        BlockingWebDavTransport::new(&url_for_probe, &credential)
+            .unwrap()
+            .probe_capabilities()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    server.await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn a_vault_root_whose_parent_is_missing_fails_closed() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = endpoint(&listener, "/vault");
+    let server = tokio::spawn(async move {
+        accept_and_respond(
+            &listener,
+            "HTTP/1.1 200 OK\r\nDAV: 1\r\nAllow: OPTIONS, PROPFIND, MKCOL, GET, PUT\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+        let root = accept_and_respond(
+            &listener,
+            "HTTP/1.1 409 Conflict\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+        assert!(String::from_utf8_lossy(&root).starts_with("MKCOL /vault/ HTTP/1.1\r\n"));
+    });
+
+    let error = tokio::task::spawn_blocking(move || {
+        let credential = credential();
+        BlockingWebDavTransport::new(&url, &credential)
+            .unwrap()
+            .probe_capabilities()
+            .expect_err("a vault root that cannot be created must not enable sync")
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(error, WebDavError::Conflict);
+    server.await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn readback_retries_through_a_transient_weak_entity_tag() {
+    let object = encrypted_object();
+    let body = object.as_bytes().to_vec();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = endpoint(&listener, "/vault");
+    let server = tokio::spawn(async move {
+        // Apache mod_dav answers PUT without any ETag at all.
+        accept_and_respond(
+            &listener,
+            "HTTP/1.1 201 Created\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+        for tag in ["W/\"2-weak\"", "\"2-strong\""] {
+            let request = accept_and_respond(
+                &listener,
+                &format!(
+                    "HTTP/1.1 200 OK\r\nETag: {tag}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                ),
+                &body,
+            )
+            .await;
+            assert!(String::from_utf8_lossy(&request).starts_with("GET /vault/manifest HTTP/1.1"));
+        }
+    });
+
+    let credential = credential();
+    let client = WebDavClient::new(&url).unwrap();
+    let key = ObjectKey::new("manifest").unwrap();
+    let result = client
+        .put(&key, &object, ObjectCondition::CreateOnly, &credential)
+        .await
+        .expect("a tag that turns strong on the next read must not fail the write");
+
+    match result {
+        ObjectWriteResult::Created(metadata) => assert_eq!(metadata.etag, "\"2-strong\""),
+        other => panic!("unexpected write result: {other:?}"),
+    }
+    server.await.unwrap();
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "GitHub Windows loopback can abort or stall this raw-socket fixture"
+)]
+async fn a_server_that_only_ever_reports_weak_entity_tags_still_fails() {
+    let object = encrypted_object();
+    let body = object.as_bytes().to_vec();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = endpoint(&listener, "/vault");
+    let server = tokio::spawn(async move {
+        accept_and_respond(
+            &listener,
+            "HTTP/1.1 201 Created\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            &[],
+        )
+        .await;
+        for _ in 0..3 {
+            accept_and_respond(
+                &listener,
+                &format!(
+                    "HTTP/1.1 200 OK\r\nETag: W/\"2-weak\"\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                ),
+                &body,
+            )
+            .await;
+        }
+    });
+
+    let credential = credential();
+    let client = WebDavClient::new(&url).unwrap();
+    let key = ObjectKey::new("manifest").unwrap();
+    let error = client
+        .put(&key, &object, ObjectCondition::CreateOnly, &credential)
+        .await
+        .expect_err("compare-and-swap requires a strong entity tag eventually");
+
+    assert_eq!(error, WebDavError::MissingStrongEntityTag);
+    server.await.unwrap();
+}

--- a/src/sync/webdav/mod.rs
+++ b/src/sync/webdav/mod.rs
@@ -4,6 +4,7 @@
 //! follows at most three exact-origin redirects, and never includes endpoint or credential text in
 //! its errors. Merge policy, retries, scheduling, and primary-writer ownership live above it.
 
+mod capability;
 mod delete;
 mod retry_after;
 mod xml;
@@ -238,12 +239,6 @@ pub struct WebDavCapabilities {
     pub mkcol: bool,
     pub get: bool,
     pub put: bool,
-}
-
-impl WebDavCapabilities {
-    pub fn supports_encrypted_sync(self) -> bool {
-        self.dav_class_1 && self.options && self.propfind && self.mkcol && self.get && self.put
-    }
 }
 
 /// HTTP client rooted at one WebDAV collection.
@@ -578,8 +573,10 @@ impl WebDavClient {
         object: &EncryptedObject,
         credential: &VaultCredential,
     ) -> Result<(), WebDavError> {
+        // Both probe reads follow a write closely enough to observe a server that marks a fresh
+        // entity tag weak for one second (Apache mod_dav), so they use the tolerant readback.
         let existing = self
-            .get(key, credential, CONDITIONAL_PROBE_PLAINTEXT_LIMIT)
+            .get_readback(key, credential, CONDITIONAL_PROBE_PLAINTEXT_LIMIT, None)
             .await?;
         if existing.is_none() {
             let response = self
@@ -621,7 +618,7 @@ impl WebDavClient {
         // does not prove that the server implements the compare-and-swap primitive used by heads
         // and manifests.
         let (_, metadata) = self
-            .get(key, credential, CONDITIONAL_PROBE_PLAINTEXT_LIMIT)
+            .get_readback(key, credential, CONDITIONAL_PROBE_PLAINTEXT_LIMIT, None)
             .await?
             .ok_or(WebDavError::MethodUnsupported)?;
         let matched_update = self
@@ -809,7 +806,7 @@ impl WebDavClient {
         deadline: Option<VaultDeadline>,
     ) -> Result<ObjectMetadata, WebDavError> {
         let Some((actual, metadata)) = self
-            .get_inner(key, credential, MAX_PROTECTED_PAYLOAD_BYTES, deadline)
+            .get_readback(key, credential, MAX_PROTECTED_PAYLOAD_BYTES, deadline)
             .await?
         else {
             return Err(WebDavError::AmbiguousWrite);
@@ -891,12 +888,13 @@ impl BlockingWebDavTransport {
     /// must not call this method because the valid If-Match proof intentionally rewrites that
     /// marker.
     pub fn probe_capabilities(&self) -> Result<WebDavCapabilities, WebDavError> {
-        let capabilities = self.block_on(self.client.options(&self.credential))?;
+        let mut capabilities = self.block_on(self.client.options(&self.credential))?;
         if capabilities.supports_encrypted_sync() {
             let key =
                 ObjectKey::new(CONDITIONAL_PROBE_KEY).map_err(|_| WebDavError::InvalidResponse)?;
             let object = conditional_probe_object()?;
             self.block_on(async {
+                self.client.mkcol_root(&self.credential).await?;
                 self.ensure_ancestor_collections(&key, None).await?;
                 self.client
                     .probe_conditional_writes(&key, &object, &self.credential)
@@ -914,6 +912,12 @@ impl BlockingWebDavTransport {
                     .await?;
                 Ok(())
             })?;
+            // Every method the sync protocol needs was just exercised end to end. Report what the
+            // server did rather than what its `Allow` header claimed.
+            capabilities.mkcol = true;
+            capabilities.propfind = true;
+            capabilities.get = true;
+            capabilities.put = true;
         }
         Ok(capabilities)
     }
@@ -1499,6 +1503,8 @@ fn longer_retry_after(left: Option<Duration>, right: Option<Duration>) -> Option
     }
 }
 
+#[cfg(test)]
+mod capability_tests;
 #[cfg(test)]
 mod delete_tests;
 #[cfg(test)]

--- a/src/sync/webdav/tests.rs
+++ b/src/sync/webdav/tests.rs
@@ -493,6 +493,7 @@ async fn setup_and_fresh_pair_join_probe_conditional_writes_before_enabling_sync
         .await;
 
         for expected in [
+            "/vault/",
             "/vault/yututui",
             "/vault/yututui/v2",
             "/vault/yututui/v2/capability",
@@ -640,7 +641,8 @@ async fn preexisting_capability_marker_still_requires_a_valid_matched_write() {
         )
         .await;
 
-        for _ in 0..3 {
+        // The vault root itself plus its three protocol collections.
+        for _ in 0..4 {
             let (mut collection, _) = listener.accept().await.unwrap();
             read_request(&mut collection).await;
             respond(
@@ -770,7 +772,8 @@ async fn capability_probe_rejects_a_server_that_rejects_valid_matched_writes() {
             &[],
         )
         .await;
-        for _ in 0..3 {
+        // The vault root itself plus its three protocol collections.
+        for _ in 0..4 {
             let (mut collection, _) = listener.accept().await.unwrap();
             read_request(&mut collection).await;
             respond(
@@ -874,7 +877,8 @@ async fn capability_probe_rejects_a_server_that_ignores_if_match() {
             &[],
         )
         .await;
-        for _ in 0..3 {
+        // The vault root itself plus its three protocol collections.
+        for _ in 0..4 {
             let (mut collection, _) = listener.accept().await.unwrap();
             read_request(&mut collection).await;
             respond(


### PR DESCRIPTION
## Why

Every WebDAV and export test on `main` runs against a hand-written `TcpListener` mock (called out in `docs/rfc-114-status.md`). Testing 1.7.0 against real servers found three failures, all reproduced and then fixed here.

| Symptom on 1.7.0 | Cause | Fix |
|---|---|---|
| `ytt sync setup` → `sync_server_unsupported` on **every** real WebDAV server | the gate required MKCOL + PUT in the vault root's `Allow` header; RFC 4918 defines `Allow` per resource, so no conforming server advertises MKCOL on an existing collection (Nextcloud 31) or PUT on a collection at all (Apache mod_dav) | gate needs only `DAV: 1` + a successful OPTIONS; `probe_capabilities` proves MKCOL/PUT/GET/PROPFIND by performing them and records the result in the flags |
| a fresh endpoint path → `sync_invalid_remote_data` | nothing created the vault root, so the first `MKCOL <root>/yututui` got 409 | new `mkcol_root` creates the root (405 = already present); a 409 there means the endpoint's parent is missing and still fails closed |
| Apache mod_dav → `sync_invalid_remote_data` | Apache returns no `ETag` on PUT and marks tags weak while mtime is within one second, so the readback failed with `MissingStrongEntityTag` | new `get_readback` retries only that case (400 ms, 900 ms); `get`/`list` stay strict and a permanently weak server still fails |
| `ytt data export` → `missing field 'sidecar'` on any profile the app has used | `data_export` reimplemented the persistence journal and drifted from the actor's generation/commit format and unique sidecar names | new crate-internal seam `persist::pending_store_intent` resolves the journal exactly as the app's recovery replay does, read-only and lock-free; the export re-resolves after reading the sidecar to reject a torn view |

## Verification

Built binary against real servers, all with throwaway `YTM_*_DIR` profiles:

- **Nextcloud 31, no `Allow` shim, existing vault base** → setup succeeds (was `sync_server_unsupported`).
- **Apache 2.4.68 mod_dav, non-existent vault path** → root created, setup succeeds (previously failed twice: gate, then readback).
- **This machine's real 56 MB profile** → `ytt data export` writes 656 KB of schema-2 state with 120 operations (was `missing field 'sidecar'`).
- Two-device vault (macOS + Debian) pairs and merges against real Nextcloud; vault contents are `age` ciphertext only, and `sync audit` output carries no endpoint, path or secret.

New tests: `src/sync/webdav/capability_tests.rs` (Apache's `Allow` accepted when the methods work, root created, root 409 fails closed, transient weak tag retried, permanently weak tag still fails) plus two `data_export::offline` tests (committed generation journal exports the snapshot; uncommitted ordered replace replays its uniquely named sidecar). Four existing probe mocks now answer the root MKCOL.

`run-gates .`: all gates PASS except `cargo test --workspace`, whose only failure is `tools::ytdlp::signature::tests::signature_verifier_rejects_invalid_signature_when_gpg_is_available` ("import yt-dlp signing key timed out"). It reproduces on a clean stashed tree, so it is a pre-existing environment failure and was left untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved WebDAV compatibility by creating missing vault roots automatically.
  * Added resilient readback handling for temporarily weak entity tags after writes.
  * Encrypted sync support is now verified through end-to-end server behavior.

* **Bug Fixes**
  * Export operations now fail closed when persistence journals are unreadable or incomplete.
  * Improved handling of pending replacements, deletions, and sidecar integrity checks to avoid stale/torn views.
  * Personal state imports now better respect local device ownership when rewriting foreign baselines.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->