### PR TITLE
fix(sync): record the terminal outcome of a no-op owner sync

### DIFF
--- a/src/sync/service/persistence.rs
+++ b/src/sync/service/persistence.rs
@@ -414,6 +414,40 @@ impl PersonalSyncPersistence {
         Ok(())
     }
 
+    /// Record the terminal health and audit outcome of a successful attempt.
+    fn record_terminal_success(
+        &self,
+        action: &PersonalSyncApplyKind,
+        summary: &crate::sync::manual::ManualSyncSummary,
+    ) {
+        self.record_terminal_success_at(action, crate::signals::unix_now(), summary);
+    }
+
+    fn record_terminal_success_at(
+        &self,
+        action: &PersonalSyncApplyKind,
+        now: i64,
+        summary: &crate::sync::manual::ManualSyncSummary,
+    ) {
+        match action {
+            PersonalSyncApplyKind::SyncNow => {
+                let _ = record_sync_success(&self.0.sync_paths, now, summary);
+            }
+            PersonalSyncApplyKind::AutomaticSync => {
+                let _ = record_sync_success_as(
+                    &self.0.sync_paths,
+                    now,
+                    summary,
+                    SyncAttemptKind::Automatic,
+                );
+            }
+            PersonalSyncApplyKind::Revoke(device_id) => {
+                let _ = record_revoke_success(&self.0.sync_paths, now, device_id, summary);
+            }
+            PersonalSyncApplyKind::PairApprove(_) => {}
+        }
+    }
+
     fn write_initial(
         &self,
         current_state: &PersonalStateV2,
@@ -449,6 +483,11 @@ impl PersonalSyncPersistence {
                     prepared,
                 )?;
             }
+            // The attempt still talked to the server, and preparing it marked health `Syncing`.
+            // A no-op result must record its terminal outcome too, or the status stays stuck on
+            // "Syncing" — which `status` reports as Needs attention / local changes arrived — and
+            // no audit row ever explains the attempt.
+            self.record_terminal_success(action, &candidate.summary);
             return Ok(self.0.target_state.clone());
         }
 
@@ -474,28 +513,7 @@ impl PersonalSyncPersistence {
             Ok(installed)
         })();
         match &result {
-            Ok(_) => match action {
-                PersonalSyncApplyKind::SyncNow => {
-                    let _ = record_sync_success(&self.0.sync_paths, now, &candidate.summary);
-                }
-                PersonalSyncApplyKind::AutomaticSync => {
-                    let _ = record_sync_success_as(
-                        &self.0.sync_paths,
-                        now,
-                        &candidate.summary,
-                        SyncAttemptKind::Automatic,
-                    );
-                }
-                PersonalSyncApplyKind::Revoke(device_id) => {
-                    let _ = record_revoke_success(
-                        &self.0.sync_paths,
-                        now,
-                        device_id,
-                        &candidate.summary,
-                    );
-                }
-                PersonalSyncApplyKind::PairApprove(_) => {}
-            },
+            Ok(_) => self.record_terminal_success_at(action, now, &candidate.summary),
             Err(error) => match action {
                 PersonalSyncApplyKind::AutomaticSync => {
                     let _ = record_sync_failure_as(

--- a/src/sync/service/persistence/tests.rs
+++ b/src/sync/service/persistence/tests.rs
@@ -355,3 +355,68 @@ fn pairing_approval_shutdown_extends_the_second_reconcile_boundary() {
     );
     assert_eq!(private.checkpoint_hash(), Some("b".repeat(64).as_str()));
 }
+
+#[test]
+fn a_no_op_owner_sync_still_records_its_terminal_health_and_audit() {
+    // Preparing an owner attempt marks health `Syncing`. When the candidate turns out to be
+    // already durable the apply path used to return early without recording anything, so status
+    // stayed on a stale `Syncing` — which `status` reports as Needs attention / local changes
+    // arrived — and no audit row ever explained the attempt.
+    let fixture = shutdown_fixture();
+    let paths = || SyncPaths::for_data_root(fixture.root.clone());
+    let sync_paths = paths();
+    let health = crate::sync::SyncHealthStore::new(sync_paths.health()).unwrap();
+    let started = health.load(true).unwrap();
+    let started = health
+        .save(&started, started.syncing(1_700_000_000))
+        .unwrap();
+    assert_eq!(started.state, crate::sync::SyncHealthState::Syncing);
+
+    let persistence = PersonalSyncPersistence::initial(
+        fixture.initial.clone(),
+        7,
+        fixture.candidate.clone(),
+        PersonalSyncApplyKind::SyncNow,
+        fixture.personal_paths.clone(),
+        paths(),
+    )
+    .unwrap();
+    persistence.write().unwrap();
+    let audit_after_first = crate::sync::SyncAuditStore::new(sync_paths.audit())
+        .unwrap()
+        .load(crate::signals::unix_now())
+        .unwrap()
+        .entries()
+        .len();
+
+    // The same candidate is now durable, so this write takes the already-durable path.
+    let repeated = PersonalSyncPersistence::initial(
+        fixture.initial.clone(),
+        7,
+        fixture.candidate.clone(),
+        PersonalSyncApplyKind::SyncNow,
+        fixture.personal_paths.clone(),
+        paths(),
+    )
+    .unwrap();
+    let health_before = health.load(true).unwrap();
+    let _ = health
+        .save(&health_before, health_before.syncing(1_700_000_100))
+        .unwrap();
+    repeated.write().unwrap();
+
+    let final_health = health.load(true).unwrap();
+    assert_eq!(
+        final_health.state,
+        crate::sync::SyncHealthState::UpToDate,
+        "an already-durable target must still leave a terminal health state"
+    );
+    let audit = crate::sync::SyncAuditStore::new(sync_paths.audit())
+        .unwrap()
+        .load(crate::signals::unix_now())
+        .unwrap();
+    assert!(
+        audit.entries().len() > audit_after_first,
+        "the no-op attempt must add its own audit row"
+    );
+}


### PR DESCRIPTION
## Symptom

On a clean profile with a working vault, the TUI's Settings → Sync showed **"Needs attention · Local changes arrived during sync"** immediately after launch and stayed there. `health-v1.json` sat at `{"state":"syncing"}`, the audit log only had the `setup` row, and pressing **Retry** or **Sync now** changed nothing visible — while `ytt sync now` on the very same profile answered `Up to date` instantly.

## Cause

Preparing an owner attempt marks health `Syncing` (`sync/service/mod.rs:95`). `write_initial_using` then returns early when `initial_target_is_already_durable(candidate)` — the ordinary "nothing to sync" result for an idle device — **before** `record_sync_started` / `record_sync_success`. So the terminal health and audit write never happened, health kept its `Syncing` marker, and `status.rs:256` deliberately reports a stale `Syncing` as `NeedsAttention` + `LocalStateChanged`.

The one-shot CLI path records around `apply_prepared_sync_now_as`, unconditionally, which is why only the app looked broken.

## Fix

One helper (`record_terminal_success{,_at}`) now records the terminal health and audit outcome, used by both the already-durable early return and the applied path. No behaviour change for attempts that actually transfer operations.

## Verification

- Same clean profile against real Nextcloud: after the fix the run ends with health `up_to_date`, a new `automatic_sync / no_changes` audit row, and "Personal sync — **Up to date**" in the TUI (the Retry row is gone).
- New regression test `a_no_op_owner_sync_still_records_its_terminal_health_and_audit`: writes a candidate, re-writes the now-durable candidate, and asserts health reaches `UpToDate` with an extra audit row. Mutation-checked — reverting the one-line recording call fails the test.
- `cargo fmt`, `check-file-size.sh`, `cargo clippy --workspace --all-targets -D warnings` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization status handling when requested data is already up to date.
  * Completed sync attempts now consistently reach a terminal status and record their outcome, including no-op synchronization attempts.
  * Revoke and automatic synchronization outcomes are now audited consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->