### PR TITLE
fix: 1.7.2 defect fixes (settings trap, publish modes, test isolation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,12 @@ WebDAV credentials are prompted with echo disabled and are never accepted as arg
 endpoint must be HTTPS unless it is loopback. Status and audit output deliberately omit
 endpoints, paths and secrets.
 
+Self-signed or private-PKI endpoints can pin a custom CA (PEM) per connection; the PEM never
+leaves the device and is never logged. Custom-CA trust is covered by an automated test that is
+green on Linux, Windows, and hosted macOS 15. One local macOS machine recorded a Secure
+Transport rejection (`errSSLClosedAbort -9806`, 2026-07-26) that CI has never reproduced — if
+custom-CA trust fails for you, please report it with your macOS version.
+
 **Keep the recovery kit off this machine.** Nobody can regenerate it for you. Note that no
 command rebuilds a vault from the kit alone yet, so keep at least one approved device rather
 than treating the kit as a restore. Revoking a device re-locks everything uploaded afterwards,

--- a/src/app/settings_audio.rs
+++ b/src/app/settings_audio.rs
@@ -276,13 +276,16 @@ impl App {
         let Some(current) = self.settings.as_deref() else {
             self.mode = Mode::Player;
             self.dirty = true;
-            return match exit {
-                SettingsSaveExit::Close => Vec::new(),
-                SettingsSaveExit::Home => self.go_home(),
-                SettingsSaveExit::Navigate(mode) => self.navigate_to(mode),
-                SettingsSaveExit::Quit => self.quit_app(),
-            };
+            return self.settings_save_exit(exit);
         };
+        // The player batch exists so committed audio settings never diverge from live
+        // playback. With no usable mpv there is no live player to diverge from and the
+        // admission would never resolve, trapping every exit on the Settings screen.
+        if self.playback_tool_missing() {
+            let mut follow_ups = self.apply_settings_save(current.clone());
+            follow_ups.extend(self.settings_save_exit(exit));
+            return follow_ups;
+        }
         let draft = SettingsAudioSnapshot::from_draft(&current.draft);
         let plan = SettingsSavePlan {
             expected_draft: draft,
@@ -305,6 +308,21 @@ impl App {
                 PlayerCommit::SettingsSave(Box::new(plan)),
             ),
         )))]
+    }
+
+    fn settings_save_exit(&mut self, exit: SettingsSaveExit) -> Vec<Cmd> {
+        match exit {
+            SettingsSaveExit::Close => Vec::new(),
+            SettingsSaveExit::Home => self.go_home(),
+            SettingsSaveExit::Navigate(mode) => self.navigate_to(mode),
+            SettingsSaveExit::Quit => self.quit_app(),
+        }
+    }
+
+    /// The admission gate's premise (a live player) only holds when mpv can spawn at all.
+    /// `runtime_tool_checks` keeps unit tests independent of the developer machine's PATH.
+    fn playback_tool_missing(&self) -> bool {
+        self.runtime_tool_checks && crate::deps::missing().contains(&"mpv")
     }
 
     pub(in crate::app) fn commit_settings_audio_preview(
@@ -345,12 +363,7 @@ impl App {
             return Vec::new();
         }
         let mut follow_ups = self.apply_settings_save(*plan.settings);
-        follow_ups.extend(match plan.exit {
-            SettingsSaveExit::Close => Vec::new(),
-            SettingsSaveExit::Home => self.go_home(),
-            SettingsSaveExit::Navigate(mode) => self.navigate_to(mode),
-            SettingsSaveExit::Quit => self.quit_app(),
-        });
+        follow_ups.extend(self.settings_save_exit(plan.exit));
         follow_ups
     }
 
@@ -834,5 +847,38 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn settings_exits_commit_inline_when_playback_tool_is_missing() {
+        crate::test_util::env::with_vars(&[("PATH", Some("/nonexistent-ytm-test"))], || {
+            let mut app = app_with_settings();
+            app.enable_runtime_tool_checks();
+            app.settings.as_deref_mut().unwrap().draft.normalize = true;
+
+            let cmds = app.close_settings();
+            assert!(
+                cmds.iter().all(|cmd| !matches!(cmd, Cmd::PlayerControl(_))),
+                "a missing player must not gate the save on admission"
+            );
+            assert!(app.settings.is_none());
+            assert_eq!(app.mode, Mode::Player);
+            assert!(app.audio.normalize);
+            assert_eq!(
+                cmds.iter()
+                    .filter(|cmd| matches!(cmd, Cmd::Persist(PersistCmd::Config(_))))
+                    .count(),
+                1
+            );
+
+            let mut app = app_with_settings();
+            app.enable_runtime_tool_checks();
+            let cmds = app.close_settings_for_quit();
+            assert!(
+                cmds.iter().all(|cmd| !matches!(cmd, Cmd::PlayerControl(_))),
+                "Ctrl+Q must not gate on player admission when mpv is missing"
+            );
+            assert!(app.should_quit);
+        });
     }
 }

--- a/src/local/index.rs
+++ b/src/local/index.rs
@@ -266,20 +266,22 @@ fn unix_now() -> i64 {
 mod tests {
     use super::*;
 
-    fn temp_dir() -> PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
+    /// Same label+sequence scheme as `test_util::isolated_dir_pair`: the pid+nanos key this
+    /// replaced could hand two tests the same directory when the clock resolved coarsely.
+    fn temp_dir(label: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let sequence = NEXT.fetch_add(1, Ordering::Relaxed);
         std::env::temp_dir().join(format!(
-            "ytm-tui-local-index-test-{}-{nanos}",
+            "ytm-tui-local-index-test-{label}-{}-{sequence}",
             std::process::id()
         ))
     }
 
     #[test]
     fn index_round_trips_tracks() {
-        let dir = temp_dir();
+        let dir = temp_dir("round-trip");
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("local-index.json");
         let mut index = LocalIndex::default();
@@ -306,7 +308,7 @@ mod tests {
 
     #[test]
     fn corrupt_index_loads_empty() {
-        let dir = temp_dir();
+        let dir = temp_dir("corrupt");
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("local-index.json");
         std::fs::write(&path, b"{not json").unwrap();
@@ -320,7 +322,7 @@ mod tests {
 
     #[test]
     fn corrupt_index_load_preserves_bad_copy() {
-        let dir = temp_dir();
+        let dir = temp_dir("corrupt-preserve");
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("local-index.json");
         std::fs::write(&path, b"{not json").unwrap();
@@ -341,7 +343,7 @@ mod tests {
 
     #[test]
     fn unsupported_schema_version_loads_empty_and_preserves_bad_copy() {
-        let dir = temp_dir();
+        let dir = temp_dir("unsupported-schema");
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("local-index.json");
         let contents = br#"{"schema_version":999,"tracks":[],"updated_at":1}"#;
@@ -363,7 +365,7 @@ mod tests {
 
     #[test]
     fn oversized_index_loads_empty_and_moves_original_aside() {
-        let dir = temp_dir();
+        let dir = temp_dir("oversized");
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("local-index.json");
         let contents = br#"{"schema_version":1,"tracks":[],"updated_at":1}"#;
@@ -386,7 +388,7 @@ mod tests {
 
     #[test]
     fn missing_schema_version_loads_as_current_version() {
-        let dir = temp_dir();
+        let dir = temp_dir("missing-schema");
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("local-index.json");
         std::fs::write(&path, br#"{"tracks":[],"updated_at":1}"#).unwrap();

--- a/src/transfer/library_modes.rs
+++ b/src/transfer/library_modes.rs
@@ -56,9 +56,14 @@ pub(crate) fn publish_modes(
                 let directory = 0o700
                     | if group_visible { 0o050 } else { 0 }
                     | if other_visible { 0o005 } else { 0 };
-                let file = 0o600
-                    | if group_visible { 0o040 } else { 0 }
-                    | if other_visible { 0o004 } else { 0 };
+                // World visibility normalizes to the conventional 0o644 artifact: the mirrored
+                // 0o604 an other-only root (0o705) would produce is not an accepted publication
+                // mode, and the group bit it adds stays unreachable behind the 0o705 directory.
+                let file = match (group_visible, other_visible) {
+                    (_, true) => 0o644,
+                    (true, false) => 0o640,
+                    (false, false) => 0o600,
+                };
                 Ok(PublishModes {
                     file: Some(file),
                     sidecar: Some(0o600),

--- a/src/transfer/library_modes/tests.rs
+++ b/src/transfer/library_modes/tests.rs
@@ -101,11 +101,29 @@ fn an_inherited_audience_requests_no_mode_at_all() {
 }
 
 #[test]
+#[cfg(unix)]
+fn an_other_only_readable_root_publishes_a_conventional_world_readable_file() {
+    let root = temp_root("shared-from-other-only-root");
+    set_mode(&root, 0o705);
+
+    let modes = publish_modes(PublishAudience::SharedLibrary, &root).unwrap();
+
+    // The root grants the world what it denies the group. The file normalizes to 0o644 because
+    // the mirrored 0o604 is not an accepted publication mode; the directory mirror still denies
+    // group traversal, so effective access is unchanged.
+    assert_eq!(modes.file, Some(0o644));
+    assert_eq!(modes.directory, Some(0o705));
+    assert_eq!(modes.sidecar, Some(0o600));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn only_owner_readable_publication_modes_are_accepted() {
     validate_publish_mode(None).unwrap();
     validate_publish_mode(Some(0o600)).unwrap();
     validate_publish_mode(Some(0o640)).unwrap();
     validate_publish_mode(Some(0o644)).unwrap();
+    validate_publish_mode(Some(0o604)).unwrap_err();
     validate_publish_mode(Some(0o666)).unwrap_err();
     validate_publish_mode(Some(0o777)).unwrap_err();
 }


### PR DESCRIPTION
## yututui 1.7.2 — WP-A defect fixes

Four commits, each gated green locally (all 16 run-gates, per-gate lines).

- **`fix(settings)`** — With mpv missing, the player-gated settings save never resolved: Esc left a dirty Settings screen open and Ctrl+Q could not quit (recorded 2026-07-16). The save now commits inline when runtime tool checks report mpv missing; admission semantics (Busy/Closed rejection) are unchanged when mpv exists. Runtime-verified in isolated tmux: Esc closes + persists, Ctrl+Q quits, read-only secondary unaffected.
- **`fix(transfer)`** — A `0o705` library root derived file mode `0o604`, which `validate_publish_mode` rejects, so publishing into an other-only-readable root always failed. World visibility now normalizes to conventional `0o644`; directory mirror and the umask-077 refusal are unchanged (pinned by tests).
- **`test(local)`** — `local/index.rs` shared one pid+nanos temp dir across 6 tests (macOS CI failure 2026-07-28). Each test now gets a label+sequence directory, same scheme as `test_util::isolated_dir_pair`.
- **`docs(readme)`** — Custom-CA trust coverage note: green on Linux/Windows/hosted macOS 15; the one local-macOS Secure Transport rejection (2026-07-26) is unreproduced — reporters asked for their macOS version.

## Investigation-only items (closed with evidence, no code)
- **Stale writer lease after SIGABRT**: no defect — lease fd is `O_CLOEXEC` (std default), lock is `flock` (kernel-released); only fd inherited into children is the mpv IPC socketpair. Runtime-verified: kill -ABRT → locks gone within 8 s → relaunch writable; live second owner still fails closed (read-only secondary's writes rejected on disk).
- **Windows flakes**: `daemon::parity_tests::revision_checked_queue_remove_...` and `local_deck_import_review_keys_accept_and_reject_rows` green in all 4 hosted `Windows compile and test gate` runs since 2026-07-28; scrobble inverse-flake green in isolation. #136 instrumentation kept.

## Verification
- `run-gates .`: 16/16 PASS (fmt, clippy, workspace tests, vendored crossterm/ratatui-image matrices, arch gates).
- New test: `settings_exits_commit_inline_when_playback_tool_is_missing`; new pin: `an_other_only_readable_root_publishes_a_conventional_world_readable_file` (+ `0o604` rejection in `validate_publish_mode`).
- Runtime (isolated tmux, isolated `YTM_*_DIR`, silent): A2 trap reproduced on main, then verified fixed; A1 lease behavior verified with `lslocks` ground truth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Settings can now be saved and applied immediately when the playback tool is unavailable, including reliable close and quit actions.
  - Shared-library files now receive consistent, conventional permissions while preserving private sidecar and directory protections.

- **Documentation**
  - Added guidance for configuring custom CA certificate pinning with private or self-signed WebDAV endpoints.
  - Included local-only handling details and macOS troubleshooting guidance.

- **Tests**
  - Expanded coverage for settings behavior, cross-platform certificate handling, temporary test directories, and shared-library permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->