### PR TITLE
ci: repair red CI — quit-test persistence flake + h2 RUSTSEC-2026-0258 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/src/daemon/engine/tests.rs
+++ b/src/daemon/engine/tests.rs
@@ -531,6 +531,7 @@ fn media_snapshot_for_radio_stream_disables_track_specific_music_controls() {
 #[tokio::test]
 async fn remote_commands_cover_no_load_branches() {
     let mut engine = engine_with_queue(&[]);
+    engine.silence_remote_persistence_for_test();
 
     for command in [
         RemoteCommand::Next,


### PR DESCRIPTION
## Two independent CI failures, two commits

### 1. Windows compile and test gate — flaky test (main run 31873499244)

`ci-pr` on main (merge of #158) failed with one failure out of 4407:

```
---- daemon::engine::tests::remote_commands_cover_no_load_branches stdout ----
thread '...' panicked at src\daemon\engine\tests.rs:561:5:
assertion failed: response.ok
```

Same code passed ci-pr on the PR branch → Windows-only flake, not a logic regression.

**Root cause:** `RemoteCommand::Quit` returns `RemoteResponse::ok(...)` unconditionally, but `handle_remote`'s epilogue `finish_remote_persistence` swaps any success response for `err(durability_unconfirmed)` when the command's saves failed. Quit calls `save_session()`, and under `cfg(test)` every store resolves into **one process-wide sandbox shared by all 4400+ parallel tests**. Under full-suite load on the Windows runner that real write can transiently fail, flipping the asserted response.

**Fix:** `silence_remote_persistence_for_test()` — the documented seam for tests that never intended to exercise durability (see its doc comment in `persistence_gate.rs`; same pattern as the parity harness).

### 2. Quality gates — RustSec advisories step

`cargo deny --all-features check advisories` fails with `RUSTSEC-2026-0258` (h2 0.4.15, unbounded empty DATA frames, low severity, patched in 0.4.16). The advisory postdates the last green run, so every branch is red on this today.

**Fix:** Cargo.lock-only bump h2 0.4.15 → 0.4.16. Hand-edited the lock entry (version + checksum from cargo's own resolution) because cargo 1.95 `cargo update -p h2` additionally rewrites six unrelated windows-sys dependency edges (lockfile normalization against existing entries); `cargo metadata --locked` confirms consistency. h2's dependency list is unchanged.

Not fixed (warning only): `proc-macro-error3 3.0.3` yanked, via i18n-embed-fl ← age. `yanked = "warn"` in deny.toml keeps it non-blocking.

## Verification

- Canonical gate (`nix develop -c run-gates .`): all PASS — fmt, clippy workspace, `cargo test --workspace`, arch/size/doc gates.
- Local cannot reproduce the Windows file-contention race; the real proof is this PR's Windows job.

## Latent risk (not fixed here)

Other engine tests with unsilenced success-path saves share the same theoretical flake surface; only this test has ever failed. Per-test sandbox isolation would be the systemic fix — deliberately out of scope.