### PR TITLE
fix(ci): drop redundant trait imports flagged by rustc 1.98

### DIFF
--- a/src/open_subsonic/actor/tests.rs
+++ b/src/open_subsonic/actor/tests.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use age::secrecy::{ExposeSecret as _, SecretString};
+use age::secrecy::SecretString;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
 use super::playlist_catalog::merge_missing_playlist_recovery_rows;

--- a/src/open_subsonic/bridge_runtime/history_metadata.rs
+++ b/src/open_subsonic/bridge_runtime/history_metadata.rs
@@ -2,8 +2,6 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use futures::StreamExt as _;
-
 use super::*;
 
 const METADATA_ITEMS_PER_REFRESH: usize = 64;

--- a/src/sync/crypto/tests.rs
+++ b/src/sync/crypto/tests.rs
@@ -1,6 +1,6 @@
 use age::secrecy::ExposeSecret;
-use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD;
+
 use data_encoding::HEXLOWER;
 use ed25519_dalek::{Signer, SigningKey};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Problem

`ci-pr` on main is red since 2026-08-20 17:57 UTC. Same commit (17c05df) was green at 16:35 on rustc 1.97.1; the later run installed rustc 1.98.0 (stable bumped 2026-08-18) and clippy -D warnings failed with 3 unused_imports errors in `yututui` lib and lib-test targets, on both Windows and Linux:

- `src/open_subsonic/bridge_runtime/history_metadata.rs:5` — `use futures::StreamExt as _;`
- `src/open_subsonic/actor/tests.rs:3` — `ExposeSecret as _` from `age::secrecy`
- `src/sync/crypto/tests.rs:2` — `use base64::Engine as _;`

## Root cause

Each file's parent module already imports the same trait (`bridge_runtime.rs` → `futures::StreamExt`, `actor.rs` → `ExposeSecret`, `crypto.rs` → `base64::Engine`), and child modules receive parent trait imports through `use super::*;` globs — so the child-local imports are redundant. rustc 1.97.1 silently accepted them; 1.98.0's unused_imports reports them.

## Fix

Delete the three redundant imports. Resolution is unchanged: the parent glob still provides each trait. Verified the method resolution path is identical via an E0034 ambiguity probe (candidate #1 = `futures::StreamExt` through the glob).

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` with rustc 1.98.0 (88d9e12ae) — the exact CI toolchain — passes.
- Canonical local gate `~/.fable-harness/bin/run-gates .` (rustc 1.95.0, nix dev shell): all gates PASS (fmt, workspace clippy, 4 vendored clippy matrices, workspace tests, vendored test matrices, arch).
- Minimal repro confirmed the pre-fix construct fails without an import on 1.95 while the fixed tree compiles.

## Note

CI's `toolchain: stable` is floating, so this class of drift can recur at each 6-week stable release (local nixpkgs-pinned gates can't see it). Optionally pin `toolchain:` to a released stable in `ci-pr.yml`; left floating for now per current policy.
