### PR TITLE
feat(1.7.4 WP-D): PO-token/oauth readiness + 403/429 guidance + release-note backfill

### DIFF
--- a/MANUAL.ja.md
+++ b/MANUAL.ja.md
@@ -466,6 +466,11 @@ ytt doctor
 
 補助プログラムをすべて点検し、何が足りず、どう入手すればいいかを正確に教えてくれます。それ以外のすべて — 再生できない曲、出ないアルバムアート、スクロブル、Spotify のエラー — は **[README のトラブルシューティング表](README.ja.md#トラブルシューティング)** に症状別でまとまっています。
 
+**YouTube が突然ストリームを拒否しますか（403/429）？** YouTube のボット対策です。確実に直す方法が 2 つあり、`ytt doctor --verbose` が準備状況を表示するようになりました:
+
+- **PO トークンプロバイダー**（[`bgutil-ytdlp-pot-provider`](https://github.com/Brainicism/bgutil-ytdlp-pot-provider)）— 導入後、その出力が示す yt-dlp 設定行を追加してください; または
+- **oauth プラグイン**（[`yt-dlp-youtube-oauth2`](https://github.com/coletdjnz/yt-dlp-youtube-oauth2)）— `yt-dlp --plugin-dirs … --username oauth --password ''` を一度実行すれば、サインインが維持されます。
+
 まだ困っていたら？ [issue を立てて](https://github.com/Ochichan/Yututui/issues)、見たままを書いてください — OS も添えて。
 
 ---

--- a/MANUAL.ko.md
+++ b/MANUAL.ko.md
@@ -446,6 +446,11 @@ ytt doctor
 
 보조 프로그램을 전부 점검하고, 뭐가 빠졌고 어떻게 구하는지 정확히 알려줍니다. 그 밖의 모든 것 — 재생 안 되는 곡, 안 보이는 앨범 아트, 스크로블, Spotify 오류 — 은 **[README 문제 해결 표](README.ko.md#문제-해결)** 에 증상별로 정리되어 있어요.
 
+**YouTube가 갑자기 스트림을 거부하나요(403/429)?** YouTube 봇 차단입니다. 확실한 해결책 두 가지가 있고, `ytt doctor --verbose`가 이제 준비 상태를 알려줍니다:
+
+- **PO 토큰 공급자**([`bgutil-ytdlp-pot-provider`](https://github.com/Brainicism/bgutil-ytdlp-pot-provider)) — 설치 후 그 출력이 알려주는 yt-dlp 설정 줄을 추가하세요; 또는
+- **oauth 플러그인**([`yt-dlp-youtube-oauth2`](https://github.com/coletdjnz/yt-dlp-youtube-oauth2)) — `yt-dlp --plugin-dirs … --username oauth --password ''`를 한 번 실행하면 로그인이 계속 유지됩니다.
+
 그래도 막히면? [이슈를 열고](https://github.com/Ochichan/Yututui/issues) 본 것을 그대로 적어주세요 — 운영체제도 함께요.
 
 ---

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -462,6 +462,11 @@ ytt doctor
 
 It checks all the helper programs and tells you exactly what's missing and how to get it. For everything else — songs that won't play, missing album art, scrobbles, Spotify errors — the **[README troubleshooting tables](README.md#troubleshooting)** cover the known cases, sorted by symptom.
 
+**YouTube suddenly rejects streams (403/429)?** That's YouTube's bot protection. Two things fix it for good, and `ytt doctor --verbose` now shows whether you have them:
+
+- a **PO-token provider** ([`bgutil-ytdlp-pot-provider`](https://github.com/Brainicism/bgutil-ytdlp-pot-provider)) — install it and add the yt-dlp config line it prints; or
+- the **oauth plugin** ([`yt-dlp-youtube-oauth2`](https://github.com/coletdjnz/yt-dlp-youtube-oauth2)) — run `yt-dlp --plugin-dirs … --username oauth --password ''` once and it keeps itself signed in.
+
 Still stuck? [Open an issue](https://github.com/Ochichan/Yututui/issues) and just describe what you saw — mention your operating system.
 
 ---

--- a/README.ja.md
+++ b/README.ja.md
@@ -304,7 +304,7 @@ audio-output.png · retro.png · transfer.gif · help.png · onboarding.gif · c
 | 何も再生されない、再生でエラー | mpv か yt-dlp がありません — `ytt doctor` を実行。 |
 | 音が違うデバイスから出る | 設定 → 再生 → **オーディオ出力** で検出されたローカル出力から選択; **オーディオバックエンド** は mpv オプションを公開します。 |
 | 昨日は動いたのに今日は動かない | YouTube が何か変えました — `ytt tools update` の後、`ytt tools status --why`; 管理版更新が原因なら `ytt tools use system`。 |
-| 複数の曲が 403/429 や "YouTube rejected the stream" で失敗 | `ytt doctor --verbose` を実行し、[リファレンス](#リファレンス)の Cookie の項を確認し、対応する JS ランタイムがあるか確認を; アクティブな yt-dlp は `ytt tools status --why` で。 |
+| 複数の曲が 403/429 や "YouTube rejected the stream" で失敗 | YouTube のボット対策です。`ytt doctor --verbose` を実行し（PO トークン/oauth の準備状況も表示されるようになりました）、[リファレンス](#リファレンス)の Cookie の項と対応する JS ランタイムを確認してください; アクティブな yt-dlp は `ytt tools status --why` で。[PO トークンプロバイダー](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#po-token-guide)または [oauth プラグイン](https://github.com/coletdjnz/yt-dlp-youtube-oauth2)でたいてい確実に直ります。 |
 | 特定の曲だけ再生できない | サインインが必要かも — [リファレンス](#リファレンス)の Cookie の項を参照。 |
 | アプリがシェルと違う yt-dlp を実行する | 仕様です（管理版コピー vs `PATH`）— [リファレンス](#リファレンス)の *yt-dlp の選択* を参照。 |
 
@@ -451,6 +451,8 @@ TUI の中でも: 設定 → **アカウント** → *Spotify からインポー
 
 <details>
 <summary><b>サインイン Cookie & ファイルの場所</b></summary>
+
+**PO トークン & oauth — Cookie を超えて。** YouTube が *公開* ストリームまで拒否し始めたら（HTTP 403/429 "YouTube rejected the stream"）、たいてい **PO トークンプロバイダー** が解決策です: [`bgutil-ytdlp-pot-provider`](https://github.com/Brainicism/bgutil-ytdlp-pot-provider) を導入し、その出力が示す yt-dlp 設定行を追加してください。より長持ちするサインインは [`yt-dlp-youtube-oauth2`](https://github.com/coletdjnz/yt-dlp-youtube-oauth2) プラグインです（`yt-dlp --plugin-dirs ... --username oauth --password ''` を一度実行すれば、あとは自動更新されます）。`ytt doctor --verbose` が両方の準備状況を表示するようになりました。
 
 **Cookie（任意）。** 公開曲は匿名で再生できます — メンバー限定/地域制限トラックとアカウントのプレイリストにだけ必要です。YouTube Music の Cookie を **Netscape 形式**で `~/Music/yututui/cookies.txt`（Windows: `%USERPROFILE%\Music\yututui\cookies.txt`）に書き出して再起動してください。**そのファイルはパスワードのように扱い**、*シークレットウィンドウ方式*で書き出すこと: プライベートウィンドウでサインインし、そのタブから `cookies.txt` を書き出して、ウィンドウを閉じます — ブラウザが消えたセッションはローテーションもサインアウトもされません。正しい書き出しには `SAPISID`/`SID` の行があります。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -302,7 +302,7 @@ audio-output.png · retro.png · transfer.gif · help.png · onboarding.gif · c
 | 아무것도 재생되지 않거나 재생 시 오류 | mpv 또는 yt-dlp가 없습니다 — `ytt doctor` 실행. |
 | 소리가 엉뚱한 장치로 나감 | 설정 → 재생 → **오디오 출력** 에서 감지된 로컬 출력 중 선택; **오디오 백엔드** 는 mpv 옵션을 노출합니다. |
 | 어제는 됐는데 오늘은 안 됨 | YouTube가 뭔가 바꿨어요 — `ytt tools update` 후 `ytt tools status --why`; 관리형 업데이트가 문제면 `ytt tools use system`. |
-| 여러 곡이 403/429 또는 "YouTube rejected the stream"으로 실패 | `ytt doctor --verbose`를 실행하고, [참고 자료](#참고-자료)의 쿠키 항목을 확인하고, 지원되는 JS 런타임이 있는지 보세요; 활성 yt-dlp는 `ytt tools status --why`로 확인. |
+| 여러 곡이 403/429 또는 "YouTube rejected the stream"으로 실패 | YouTube 봇 차단입니다. `ytt doctor --verbose`를 실행하고(이제 PO 토큰/oauth 준비 상태를 알려줍니다), [참고 자료](#참고-자료)의 쿠키 항목과 지원되는 JS 런타임을 확인하세요; 활성 yt-dlp는 `ytt tools status --why`로 확인. [PO 토큰 공급자](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#po-token-guide)나 [oauth 플러그인](https://github.com/coletdjnz/yt-dlp-youtube-oauth2)을 쓰면 보통 확실히 해결됩니다. |
 | 특정 곡만 재생 안 됨 | 로그인이 필요할 수 있어요 — [참고 자료](#참고-자료)의 쿠키 항목 참고. |
 | 앱이 셸과 다른 yt-dlp를 실행함 | 의도된 동작입니다(관리형 복사본 vs `PATH`) — [참고 자료](#참고-자료)의 *yt-dlp 선택* 참고. |
 
@@ -448,6 +448,8 @@ TUI 안에서도 됩니다: 설정 → **계정** → *Import from Spotify…* �
 
 <details>
 <summary><b>로그인 쿠키 & 파일 위치</b></summary>
+
+**PO 토큰 & oauth — 쿠키 너머의 해법.** YouTube가 *공개* 스트림까지 거부하기 시작하면(HTTP 403/429 "YouTube rejected the stream") 대개 **PO 토큰 공급자**가 해결책입니다: [`bgutil-ytdlp-pot-provider`](https://github.com/Brainicism/bgutil-ytdlp-pot-provider)를 설치하고 그 출력이 알려주는 yt-dlp 설정 줄을 추가하세요. 더 오래가는 로그인은 [`yt-dlp-youtube-oauth2`](https://github.com/coletdjnz/yt-dlp-youtube-oauth2) 플러그인입니다(`yt-dlp --plugin-dirs ... --username oauth --password ''`를 한 번 실행하면 이후 스스로 갱신합니다). `ytt doctor --verbose`가 이제 둘의 준비 상태를 알려줍니다.
 
 **쿠키 (선택).** 공개 곡은 익명으로 잘 재생됩니다 — 멤버 전용/지역 제한 트랙과 계정 플레이리스트에만 필요해요. YouTube Music 쿠키를 **Netscape 형식**으로 `~/Music/yututui/cookies.txt`(Windows: `%USERPROFILE%\Music\yututui\cookies.txt`)에 내보내고 재시작하세요. **그 파일은 비밀번호처럼 다루고**, *시크릿 창 방식*으로 내보내세요: 시크릿 창에서 로그인하고, 그 탭에서 `cookies.txt`를 내보낸 뒤, 창을 닫습니다 — 브라우저가 사라진 세션은 로테이션되거나 로그아웃되지 않아요. 제대로 된 내보내기에는 `SAPISID`/`SID` 줄이 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ First aid, always: **`ytt doctor`** checks mpv, yt-dlp and ffmpeg and tells you 
 | Nothing plays, or it errors on play | mpv or yt-dlp missing — run `ytt doctor`. |
 | Sound goes to the wrong device | Settings → Playback → **Audio output** picks from the detected local outputs; **Audio backend** exposes the mpv options. |
 | Worked yesterday, not today | YouTube changed something — `ytt tools update`, then `ytt tools status --why`; if a managed update is bad, `ytt tools use system`. |
-| Several tracks fail with 403/429 or "YouTube rejected the stream" | Run `ytt doctor --verbose`, check the [cookies reference](#reference), and make sure a supported JS runtime is available; `ytt tools status --why` shows the active yt-dlp. |
+| Several tracks fail with 403/429 or "YouTube rejected the stream" | YouTube's bot protection. Run `ytt doctor --verbose` (it now reports PO-token/oauth readiness), check the [cookies reference](#reference), and make sure a supported JS runtime is available; `ytt tools status --why` shows the active yt-dlp. A [PO-token provider](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#po-token-guide) or the [oauth plugin](https://github.com/coletdjnz/yt-dlp-youtube-oauth2) usually fixes it for good. |
 | A specific song won't play | It may need sign-in — see the cookies section in the [reference](#reference). |
 | The app runs a different yt-dlp than your shell | That's by design (managed copy vs `PATH`) — see *yt-dlp selection* in the [reference](#reference). |
 
@@ -450,6 +450,8 @@ For a destructive, one-shot exact mirror, use an explicit playlist ID with `--to
 
 <details>
 <summary><b>Sign-in cookies & file locations</b></summary>
+
+**PO tokens & oauth — beyond cookies.** When YouTube starts rejecting *public* streams too (HTTP 403/429 "YouTube rejected the stream"), the fix is usually a **PO-token provider**: install [`bgutil-ytdlp-pot-provider`](https://github.com/Brainicism/bgutil-ytdlp-pot-provider) and add the yt-dlp config line it prints. A more durable sign-in is the [`yt-dlp-youtube-oauth2`](https://github.com/coletdjnz/yt-dlp-youtube-oauth2) plugin (`yt-dlp --plugin-dirs ... --username oauth --password ''` once, then it refreshes itself). `ytt doctor --verbose` now reports which of these are ready on your machine.
 
 **Cookies (optional).** Public songs play anonymously — only members-only/region-locked tracks and account playlists need this. Export your YouTube Music cookies in **Netscape format** to `~/Music/yututui/cookies.txt` (Windows: `%USERPROFILE%\Music\yututui\cookies.txt`) and restart. **Treat that file like a password**, and export the *incognito way*: sign in inside a private window, export `cookies.txt` from that tab, then close the window — a session whose browser is gone never gets rotated or signed out. A good export has `SAPISID`/`SID` lines in it.
 

--- a/src/app/playback_error.rs
+++ b/src/app/playback_error.rs
@@ -11,9 +11,9 @@ pub(in crate::app) fn skipped_status_for_failure(class: PlaybackFailureClass) ->
         )
         .to_owned(),
         PlaybackFailureClass::Http403 | PlaybackFailureClass::RateLimited => t!(
-            "⚠ YouTube rejected the stream — skipped; run `ytt doctor --verbose`",
-            "⚠ YouTube가 스트림을 거부함 — 건너뜀; `ytt doctor --verbose` 확인",
-            "⚠ YouTube がストリームを拒否 — スキップ; `ytt doctor --verbose` を確認"
+            "⚠ YouTube rejected the stream — skipped; run `ytt doctor --verbose` (PO token or oauth often fixes this)",
+            "⚠ YouTube가 스트림을 거부함 — 건너뜀; `ytt doctor --verbose` 확인 (PO 토큰 또는 oauth가 해결책인 경우가 많음)",
+            "⚠ YouTube がストリームを拒否 — スキップ; `ytt doctor --verbose` を確認 (PO トークンまたは oauth で直ることが多い)"
         )
         .to_owned(),
         PlaybackFailureClass::Network => t!(
@@ -40,9 +40,9 @@ pub(in crate::app) fn breaker_status_for_failure(class: PlaybackFailureClass) ->
         )
         .to_owned(),
         PlaybackFailureClass::Http403 | PlaybackFailureClass::RateLimited => t!(
-            "Several tracks failed — YouTube is rejecting streams. Run `ytt doctor --verbose`; check cookies and JS runtime.",
-            "여러 곡 재생 실패 — YouTube가 스트림을 거부합니다. `ytt doctor --verbose`를 실행하고 쿠키와 JS runtime을 확인하세요.",
-            "複数の曲の再生に失敗 — YouTube がストリームを拒否しています。`ytt doctor --verbose` を実行し、Cookie と JS runtime を確認してください。"
+            "Several tracks failed — YouTube is rejecting streams. Run `ytt doctor --verbose`; check cookies, JS runtime, and PO-token/oauth setup.",
+            "여러 곡 재생 실패 — YouTube가 스트림을 거부합니다. `ytt doctor --verbose`를 실행하고 쿠키, JS runtime, PO 토큰/oauth 설정을 확인하세요.",
+            "複数の曲の再生に失敗 — YouTube がストリームを拒否しています。`ytt doctor --verbose` を実行し、Cookie、JS runtime、PO トークン/oauth の設定を確認してください。"
         )
         .to_owned(),
         PlaybackFailureClass::Network => t!(
@@ -72,9 +72,9 @@ pub(in crate::app) fn playback_error_status_for_failure(
         )
         .to_owned(),
         PlaybackFailureClass::Http403 | PlaybackFailureClass::RateLimited => t!(
-            "Playback error: YouTube rejected the stream; run `ytt doctor --verbose`, check cookies and JS runtime",
-            "재생 오류: YouTube가 스트림을 거부함; `ytt doctor --verbose`를 실행하고 쿠키와 JS runtime을 확인하세요",
-            "再生エラー: YouTube がストリームを拒否; `ytt doctor --verbose` を実行し Cookie と JS runtime を確認してください"
+            "Playback error: YouTube rejected the stream; run `ytt doctor --verbose` — a PO token or the oauth plugin often fixes this",
+            "재생 오류: YouTube가 스트림을 거부함; `ytt doctor --verbose`를 실행하세요 — PO 토큰 또는 oauth 플러그인이 해결책인 경우가 많습니다",
+            "再生エラー: YouTube がストリームを拒否; `ytt doctor --verbose` を実行してください — PO トークンまたは oauth プラグインで直ることが多いです"
         )
         .to_owned(),
         PlaybackFailureClass::Network => t!(

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -546,6 +546,11 @@ fn run_inner(verbose: bool) -> i32 {
     }
     println!();
 
+    // 1d) YouTube bot-protection readiness (advisory; the 403/429 era). Read-only:
+    // never downloads or runs a provider — it only reports what is already installed.
+    print_potoken_readiness(&cfg, lang);
+    println!();
+
     // 2) Directories the app needs to write into.
     println!(
         "{}",
@@ -752,6 +757,96 @@ fn linux_wsl_detected() -> bool {
         || std::fs::read_to_string("/proc/sys/kernel/osrelease")
             .map(|s| s.to_ascii_lowercase().contains("microsoft"))
             .unwrap_or(false)
+}
+
+/// YouTube bot-protection readiness (advisory; the 403/429 era). Read-only: it never
+/// downloads or runs a provider — it reports the PO-token provider script, the oauth
+/// plugin, and the cookies file the app would actually use.
+fn print_potoken_readiness(cfg: &config::Config, lang: i18n::Language) {
+    println!(
+        "{}",
+        match lang {
+            i18n::Language::Korean => "YouTube 보안 / 로그인 준비 (권고)",
+            i18n::Language::Japanese => "YouTube 保護 / サインイン準備 (参考)",
+            _ => "YouTube bot protection / sign-in readiness (advisory)",
+        }
+    );
+
+    // The PO-token provider script: yt-dlp runs it via its config when configured.
+    let provider = deps::on_path("bgutil-ytdlp-pot-provider");
+    println!(
+        "  {}",
+        match lang {
+            i18n::Language::Korean => match provider {
+                true => "✓ PO 토큰 공급자 — bgutil-ytdlp-pot-provider 발견됨",
+                false =>
+                    "✗ PO 토큰 공급자 없음 — `bgutil-ytdlp-pot-provider`를 설치하면 403/429 차단을 우회하는 데 도움이 됩니다",
+            },
+            i18n::Language::Japanese => match provider {
+                true => "✓ POトークンプロバイダー — bgutil-ytdlp-pot-provider が見つかりました",
+                false =>
+                    "✗ POトークンプロバイダーなし — `bgutil-ytdlp-pot-provider` を導入すると 403/429 対策に役立ちます",
+            },
+            _ => match provider {
+                true => "✓ PO-token provider — bgutil-ytdlp-pot-provider found on PATH",
+                false =>
+                    "✗ no PO-token provider — installing `bgutil-ytdlp-pot-provider` helps when YouTube blocks streams (403/429)",
+            },
+        }
+    );
+
+    // The oauth plugin: `--list-plugins` is local; older yt-dlp without the flag reads
+    // as "not found" and the guidance line covers it.
+    let oauth = crate::tools::ytdlp_selection().is_some_and(|sel| {
+        command_stdout(&sel.path.to_string_lossy(), &["--list-plugins"])
+            .to_ascii_lowercase()
+            .contains("oauth")
+    });
+    println!(
+        "  {}",
+        match lang {
+            i18n::Language::Korean => match oauth {
+                true => "✓ yt-dlp oauth 플러그인 — youtube-oauth2 발견됨",
+                false =>
+                    "✗ yt-dlp oauth 플러그인 없음 — `yt-dlp-youtube-oauth2`를 설치하면 쿠키보다 오래가는 로그인을 제공합니다",
+            },
+            i18n::Language::Japanese => match oauth {
+                true => "✓ yt-dlp oauth プラグイン — youtube-oauth2 が見つかりました",
+                false =>
+                    "✗ yt-dlp oauth プラグインなし — `yt-dlp-youtube-oauth2` を導入すると Cookie より長持ちするサインインが得られます",
+            },
+            _ => match oauth {
+                true => "✓ yt-dlp oauth plugin — youtube-oauth2 detected",
+                false =>
+                    "✗ no yt-dlp oauth plugin — installing `yt-dlp-youtube-oauth2` gives a sign-in that outlives cookie exports",
+            },
+        }
+    );
+
+    // The cookies file the app resolves at startup (config path or the default location).
+    let cookies = cfg
+        .effective_cookies_file()
+        .is_some_and(|path| path.is_file());
+    println!(
+        "  {}",
+        match lang {
+            i18n::Language::Korean => match cookies {
+                true => "✓ 쿠키 파일 발견됨 — 멤버 전용/지역 제한 곡 재생에 사용됩니다",
+                false =>
+                    "— 쿠키 파일 없음 — 공개 곡은 그대로 재생되고, 제한 곡은 쿠키가 필요합니다",
+            },
+            i18n::Language::Japanese => match cookies {
+                true =>
+                    "✓ Cookie ファイルが見つかりました — メンバー限定/地域制限の曲の再生に使われます",
+                false =>
+                    "— Cookie ファイルなし — 公開曲はそのまま再生でき、制限曲には Cookie が必要です",
+            },
+            _ => match cookies {
+                true => "✓ cookies file found — used for members-only and region-locked tracks",
+                false => "— no cookies file — public tracks still play; gated tracks need one",
+            },
+        }
+    );
 }
 
 /// The "Managed yt-dlp" section: whether the app-managed copy is enabled/installed,

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -11,9 +11,7 @@
 use crate::deps::{self, Need};
 use crate::{config, i18n};
 use std::path::{Path, PathBuf};
-#[cfg(target_os = "linux")]
-use std::time::Duration;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[path = "doctor/audio_report.rs"]
 mod audio_report;

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -708,7 +708,6 @@ fn print_path_probe(bin: &str) {
     }
 }
 
-#[cfg(target_os = "linux")]
 fn command_stdout(program: &str, args: &[&str]) -> String {
     if !deps::on_path(program) {
         return "missing".to_owned();

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -407,7 +407,7 @@ pub fn playback_failure_actionable_error(
             "stream resolution failed; run `ytt tools update`, then `ytt doctor --verbose`: {player_error}"
         ),
         PlaybackFailureClass::Http403 | PlaybackFailureClass::RateLimited => format!(
-            "YouTube rejected the stream; run `ytt doctor --verbose`, check cookies and JS runtime: {player_error}"
+            "YouTube rejected the stream; run `ytt doctor --verbose` (a PO token or the oauth plugin often fixes this): {player_error}"
         ),
         PlaybackFailureClass::Network => {
             format!("network error while opening stream: {player_error}")


### PR DESCRIPTION
## 1.7.4 WP-D — PO-token readiness & release notes

- `ytt doctor` gains a read-only YouTube bot-protection section: PO-token provider (`bgutil-ytdlp-pot-provider`), the yt-dlp oauth plugin (`--list-plugins`), and the resolved cookies file — localized EN/KO/JA.
- 403/429 playback failures now point at the PO-token/oauth fix in the TUI status line, the breaker message, and the daemon's actionable error (once per track, not per retry).
- README troubleshooting + MANUAL §9 cover PO tokens and oauth in all three languages.
- Release notes v1.7.0–v1.7.3 backfilled and the v1.7.4 entry written (the notes file is gitignored by convention; the v1.7.0–v1.7.3 GitHub release bodies were set to the same text, and the v1.7.4 body goes up with the release).

Draft — human merges. Merge after WP-C (base branch).