### PR TITLE
chore(1.7.4 WP-E): preflight — every version surface at 1.7.4 + regenerated preflight workflow

### DIFF
--- a/.github/workflows/release-preflight-1.7.4.yml
+++ b/.github/workflows/release-preflight-1.7.4.yml
@@ -1,24 +1,24 @@
-name: release preflight 1.7.3
+name: release preflight 1.7.4
 
 on:
   pull_request:
     branches: [main]
 
 concurrency:
-  group: release-preflight-1.7.3-${{ github.event.pull_request.number }}
+  group: release-preflight-1.7.4-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 env:
-  PREFLIGHT_VERSION: 1.7.3
+  PREFLIGHT_VERSION: 1.7.4
 
 permissions:
   contents: read
 
 jobs:
   verify-version:
-    name: Verify synchronized 1.7.3 source versions
+    name: Verify synchronized 1.7.4 source versions
     if: >-
-      github.head_ref == 'agent/aggregate-1.7.3-preflight' &&
+      github.head_ref == 'agent/aggregate-1.7.4-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +53,7 @@ jobs:
   release-build:
     name: Native release build and package
     if: >-
-      github.head_ref == 'agent/aggregate-1.7.3-preflight' &&
+      github.head_ref == 'agent/aggregate-1.7.4-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: verify-version
     uses: ./.github/workflows/native-release-build.yml
@@ -62,9 +62,9 @@ jobs:
       pull-requests: read
 
   aggregate:
-    name: Aggregate 1.7.3 preflight artifacts
+    name: Aggregate 1.7.4 preflight artifacts
     if: >-
-      github.head_ref == 'agent/aggregate-1.7.3-preflight' &&
+      github.head_ref == 'agent/aggregate-1.7.4-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: release-build
     runs-on: ubuntu-latest
@@ -146,7 +146,7 @@ jobs:
       - name: Upload complete preflight bundle
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: yututui-1.7.3-preflight
+          name: yututui-1.7.4-preflight
           if-no-files-found: error
           retention-days: 14
           path: |
@@ -158,10 +158,10 @@ jobs:
             checksums.txt
 
   preflight-result:
-    name: Release preflight 1.7.3 result
+    name: Release preflight 1.7.4 result
     if: >-
       always() &&
-      github.head_ref == 'agent/aggregate-1.7.3-preflight' &&
+      github.head_ref == 'agent/aggregate-1.7.4-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: [verify-version, release-build, aggregate]
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6873,7 +6873,7 @@ dependencies = [
 
 [[package]]
 name = "yututui"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "age",
  "anyhow",
@@ -6933,7 +6933,7 @@ dependencies = [
 
 [[package]]
 name = "yututui-core"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui"
-version = "1.7.3"
+version = "1.7.4"
 edition = "2024"
 # Releases are repository-built binaries. The application depends on a private workspace core,
 # so make the existing non-crates.io distribution contract explicit and fail closed on publish.

--- a/crates/yututui-core/Cargo.toml
+++ b/crates/yututui-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui-core"
-version = "1.7.3"
+version = "1.7.4"
 edition = "2024"
 publish = false
 description = "Pure playback policies shared by yututui playback owners."

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           lib = pkgs.lib;
           yututui = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui";
-            version = "1.7.3"; # keep in sync with Cargo.toml
+            version = "1.7.4"; # keep in sync with Cargo.toml
 
             # Drop build artifacts and flake results from the copied source so the store path
             # stays small and rebuilds aren't invalidated by a local `target/`.


### PR DESCRIPTION
## 1.7.4 WP-E — release preflight

- All six version surfaces bumped to 1.7.4: Cargo.toml, yututui-core, flake.nix, Cargo.lock (×2), `cargo metadata --locked` verified (yututui=1.7.4, yututui-core=1.7.4).
- Release-preflight workflow regenerated: renamed to 1.7.4 and all 11 pin occurrences moved.

Local gate state at draft time: canonical run-gates 16/16 PASS on this branch's content (fmt, workspace + vendored-crate clippy with `-D warnings`, workspace + vendored-crate tests, arch incl. file-size/doc-honesty/unsafe-inventory).

Draft — human merges, LAST, after WP-B/C/D. Release itself stays human (`release-mode publish`). No tags created.