### PR TITLE
test(remote): fix flaky CI from two tests sharing a socket name

### DIFF
--- a/src/remote/client/tests.rs
+++ b/src/remote/client/tests.rs
@@ -447,7 +447,7 @@ async fn status_fresh_retry_takes_the_fresh_response_verbatim() {
 
 #[tokio::test]
 async fn status_accepts_a_fresh_retry_rejection_without_confirmation_semantics() {
-    let endpoint = test_endpoint("status-fresh-retry-rejected");
+    let endpoint = test_endpoint("status-fresh-retry-shutdown");
     let listener = bind_test_listener(&endpoint);
     let server = tokio::spawn(serve_eof_then_fresh_response(
         listener,


### PR DESCRIPTION
## Problem

`ci-pr` failed intermittently on `main` (e.g. run [32907157813](https://github.com/Ochichan/Yututui/actions/runs/32907157813)):

```
test remote::client::tests::status_fresh_retry_takes_the_fresh_response_verbatim ... FAILED
called `Result::unwrap()` on an `Err` value: Os { code: 98, kind: AddrInUse, message: "Address already in use" }
```

## Root cause

`status_fresh_retry_takes_the_fresh_response_verbatim` and `status_accepts_a_fresh_retry_rejection_without_confirmation_semantics` both called `test_endpoint("status-fresh-retry-rejected")`. Since `test_endpoint` only appends the process PID, both resolve to the *same* Unix socket path. The tokio tests run in parallel, so they race on `bind` and one panics with `AddrInUse`.

## Fix

Give the second test its own socket name (`status-fresh-retry-shutdown`).

Verified locally: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass.