### PR TITLE
test: make test socket paths collision-proof by construction

### DIFF
--- a/src/desktop/gateway/page_lifetime.rs
+++ b/src/desktop/gateway/page_lifetime.rs
@@ -421,11 +421,7 @@ mod socket_tests {
 
     #[tokio::test]
     async fn common_window_replacement_cycles_topics_for_full_resnapshot() {
-        let nonce = crate::remote::requests::fresh_request_id();
-        let endpoint = std::env::temp_dir()
-            .join(format!("ygp-{}-{}.sock", std::process::id(), &nonce[..8]))
-            .to_string_lossy()
-            .into_owned();
+        let endpoint = crate::test_util::isolated_socket_path("gw-page-lifetime");
         let name = endpoint.as_str().to_fs_name::<GenericFilePath>().unwrap();
         let listener: Listener = ListenerOptions::new().name(name).create_tokio().unwrap();
         let name = endpoint.as_str().to_fs_name::<GenericFilePath>().unwrap();

--- a/src/desktop/gateway/shutdown_tests.rs
+++ b/src/desktop/gateway/shutdown_tests.rs
@@ -7,17 +7,7 @@ use super::{GatewayHandle, OutEnvelope, SubscriptionState};
 
 #[cfg(unix)]
 fn socket_endpoint(label: &str) -> String {
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    std::env::temp_dir()
-        .join(format!(
-            "ytt-gw-{label}-{}-{nonce}.sock",
-            std::process::id()
-        ))
-        .to_string_lossy()
-        .into_owned()
+    crate::test_util::isolated_socket_path(label)
 }
 
 fn handle_with_worker(

--- a/src/desktop/gateway/subscription_tests.rs
+++ b/src/desktop/gateway/subscription_tests.rs
@@ -24,10 +24,7 @@ async fn connect(endpoint: &str) -> Stream {
 
 #[tokio::test]
 async fn live_session_reconciles_the_latest_topic_set_without_command_queue_capacity() {
-    let endpoint = std::env::temp_dir()
-        .join(format!("ytt-gw-sub-{}.sock", std::process::id()))
-        .to_string_lossy()
-        .into_owned();
+    let endpoint = crate::test_util::isolated_socket_path("gw-sub");
     let listener = bind(&endpoint);
     let conn = connect(&endpoint).await;
     let (initial_seen_tx, initial_seen_rx) = oneshot::channel();
@@ -131,10 +128,7 @@ async fn live_session_reconciles_the_latest_topic_set_without_command_queue_capa
 
 #[tokio::test]
 async fn busy_subscription_reply_ends_the_session_for_reconnect_without_losing_desired_state() {
-    let endpoint = std::env::temp_dir()
-        .join(format!("ytt-gw-sub-busy-{}.sock", std::process::id()))
-        .to_string_lossy()
-        .into_owned();
+    let endpoint = crate::test_util::isolated_socket_path("gw-sub-busy");
     let listener = bind(&endpoint);
     let conn = connect(&endpoint).await;
     let server = tokio::spawn(async move {
@@ -189,10 +183,7 @@ async fn busy_subscription_reply_ends_the_session_for_reconnect_without_losing_d
 
 #[tokio::test]
 async fn missing_subscription_reply_times_out_without_losing_desired_state() {
-    let endpoint = std::env::temp_dir()
-        .join(format!("ytt-gw-sub-timeout-{}.sock", std::process::id()))
-        .to_string_lossy()
-        .into_owned();
+    let endpoint = crate::test_util::isolated_socket_path("gw-sub-timeout");
     let listener = bind(&endpoint);
     let conn = connect(&endpoint).await;
     let (release_tx, release_rx) = oneshot::channel();
@@ -242,10 +233,7 @@ async fn missing_subscription_reply_times_out_without_losing_desired_state() {
 
 #[tokio::test]
 async fn replacement_command_waits_for_its_page_subscription_ack() {
-    let endpoint = std::env::temp_dir()
-        .join(format!("ytt-gw-page-search-{}.sock", std::process::id()))
-        .to_string_lossy()
-        .into_owned();
+    let endpoint = crate::test_util::isolated_socket_path("gw-page-search");
     let listener = bind(&endpoint);
     let conn = connect(&endpoint).await;
     let (initial_seen_tx, initial_seen_rx) = oneshot::channel();

--- a/src/desktop/gateway/tests.rs
+++ b/src/desktop/gateway/tests.rs
@@ -44,10 +44,7 @@ async fn serve_hello(listener: Listener, ack: HelloAck) {
 
 #[tokio::test]
 async fn hello_handshake_succeeds() {
-    let endpoint = std::env::temp_dir()
-        .join(format!("ytt-gw-ok-{}.sock", std::process::id()))
-        .to_string_lossy()
-        .into_owned();
+    let endpoint = crate::test_util::isolated_socket_path("gw-ok");
     let listener = bind(&endpoint);
     let ack = HelloAck {
         ok: true,
@@ -68,10 +65,7 @@ async fn hello_handshake_succeeds() {
 
 #[tokio::test]
 async fn hello_rejection_surfaces_the_reason() {
-    let endpoint = std::env::temp_dir()
-        .join(format!("ytt-gw-bad-{}.sock", std::process::id()))
-        .to_string_lossy()
-        .into_owned();
+    let endpoint = crate::test_util::isolated_socket_path("gw-bad");
     let listener = bind(&endpoint);
     let ack = HelloAck {
         ok: false,
@@ -93,10 +87,7 @@ async fn hello_rejection_surfaces_the_reason() {
 #[tokio::test]
 async fn missing_core_is_reported() {
     let err = connect_and_hello(test_instance(
-        std::env::temp_dir()
-            .join("ytt-gw-nope.sock")
-            .to_string_lossy()
-            .into_owned(),
+        crate::test_util::isolated_socket_path("gw-nope"),
         "tok",
     ))
     .await
@@ -120,10 +111,7 @@ async fn connect(endpoint: &str) -> Stream {
 
 #[tokio::test]
 async fn forward_cmd_translates_and_rewrites_the_id() {
-    let endpoint = std::env::temp_dir()
-        .join(format!("ytt-gw-fwd-{}.sock", std::process::id()))
-        .to_string_lossy()
-        .into_owned();
+    let endpoint = crate::test_util::isolated_socket_path("gw-fwd");
     let listener = bind(&endpoint);
     let server = tokio::spawn(accept_one_line(listener));
     let conn = connect(&endpoint).await;
@@ -182,10 +170,7 @@ async fn forward_cmd_translates_and_rewrites_the_id() {
 
 #[tokio::test]
 async fn forward_req_records_the_reply_correlation() {
-    let endpoint = std::env::temp_dir()
-        .join(format!("ytt-gw-req-{}.sock", std::process::id()))
-        .to_string_lossy()
-        .into_owned();
+    let endpoint = crate::test_util::isolated_socket_path("gw-req");
     let listener = bind(&endpoint);
     let server = tokio::spawn(accept_one_line(listener));
     let conn = connect(&endpoint).await;

--- a/src/desktop/single_instance.rs
+++ b/src/desktop/single_instance.rs
@@ -675,14 +675,12 @@ pub fn signal_activation(intent: ActivationIntent) -> io::Result<()> {
 #[cfg(all(test, unix))]
 mod tests {
     use std::os::unix::io::AsRawFd;
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex};
 
     use tokio::io::AsyncWriteExt;
 
     use super::*;
-
-    static NEXT_ENDPOINT: AtomicU64 = AtomicU64::new(1);
 
     #[test]
     fn activation_intents_round_trip_and_reject_unknown_values() {
@@ -799,12 +797,7 @@ mod tests {
 
     #[tokio::test]
     async fn owned_listener_accepts_fragmented_intent_and_joins_on_stop() {
-        let serial = NEXT_ENDPOINT.fetch_add(1, Ordering::Relaxed);
-        let path = std::env::temp_dir().join(format!(
-            "ytt-si-transport-{}-{serial}.sock",
-            std::process::id()
-        ));
-        let endpoint = path.to_string_lossy().into_owned();
+        let endpoint = crate::test_util::isolated_socket_path("si-transport");
         let seen = Arc::new(Mutex::new(Vec::new()));
         let seen_in_callback = Arc::clone(&seen);
         let listener = spawn_activation_listener_at(endpoint.clone(), move |intent| {
@@ -839,17 +832,15 @@ mod tests {
                 .unwrap_or_else(std::sync::PoisonError::into_inner),
             vec![ActivationIntent::ShowMini]
         );
-        assert!(!path.exists(), "listener shutdown should remove its socket");
+        assert!(
+            !std::path::Path::new(&endpoint).exists(),
+            "listener shutdown should remove its socket"
+        );
     }
 
     #[tokio::test]
     async fn slow_connection_does_not_block_a_valid_second_activation() {
-        let serial = NEXT_ENDPOINT.fetch_add(1, Ordering::Relaxed);
-        let path = std::env::temp_dir().join(format!(
-            "ytt-si-concurrent-{}-{serial}.sock",
-            std::process::id()
-        ));
-        let endpoint = path.to_string_lossy().into_owned();
+        let endpoint = crate::test_util::isolated_socket_path("si-concurrent");
         let seen = Arc::new(Mutex::new(Vec::new()));
         let seen_in_callback = Arc::clone(&seen);
         let listener = spawn_activation_listener_at(endpoint.clone(), move |intent| {
@@ -898,17 +889,15 @@ mod tests {
                 .unwrap_or_else(std::sync::PoisonError::into_inner),
             vec![ActivationIntent::ShowMini]
         );
-        assert!(!path.exists(), "listener shutdown should remove its socket");
+        assert!(
+            !std::path::Path::new(&endpoint).exists(),
+            "listener shutdown should remove its socket"
+        );
     }
 
     #[tokio::test]
     async fn ten_concurrent_secondaries_each_receive_one_acknowledgement() {
-        let serial = NEXT_ENDPOINT.fetch_add(1, Ordering::Relaxed);
-        let path = std::env::temp_dir().join(format!(
-            "ytt-si-ten-secondaries-{}-{serial}.sock",
-            std::process::id()
-        ));
-        let endpoint = path.to_string_lossy().into_owned();
+        let endpoint = crate::test_util::isolated_socket_path("si-ten-secondaries");
         let seen = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let seen_in_callback = Arc::clone(&seen);
         let listener = spawn_activation_listener_at(endpoint.clone(), move |intent| {
@@ -949,7 +938,10 @@ mod tests {
 
         listener.stop();
         assert_eq!(seen.load(Ordering::Acquire), 10);
-        assert!(!path.exists(), "listener shutdown should remove its socket");
+        assert!(
+            !std::path::Path::new(&endpoint).exists(),
+            "listener shutdown should remove its socket"
+        );
     }
 
     #[test]

--- a/src/remote/client/tests.rs
+++ b/src/remote/client/tests.rs
@@ -8,10 +8,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::io::AsyncBufReadExt;
 
 fn test_endpoint(name: &str) -> String {
-    std::env::temp_dir()
-        .join(format!("yututui-client-{name}-{}.sock", std::process::id()))
-        .to_string_lossy()
-        .into_owned()
+    crate::test_util::isolated_socket_path(name)
 }
 
 fn test_instance(endpoint: String) -> InstanceFile {

--- a/src/remote/server/one_shot_tests.rs
+++ b/src/remote/server/one_shot_tests.rs
@@ -182,14 +182,7 @@ async fn one_shot_reports_server_busy_when_retained_request_cache_is_saturated()
 
 #[tokio::test]
 async fn one_shot_personal_sync_replays_one_retained_same_id_outcome() {
-    let path = std::env::temp_dir()
-        .join(format!(
-            "yututui-remote-replay-proof-test-{}.sock",
-            std::process::id()
-        ))
-        .to_string_lossy()
-        .into_owned();
-    let _ = std::fs::remove_file(&path);
+    let path = crate::test_util::isolated_socket_path("remote-replay-proof");
     let listener = bind(&path).unwrap();
 
     let executions = Arc::new(AtomicUsize::new(0));
@@ -264,11 +257,7 @@ async fn one_shot_response_write_is_deadline_bounded() {
 
 #[tokio::test]
 async fn server_round_trips_request_through_the_reducer() {
-    let path = std::env::temp_dir()
-        .join(format!("yututui-remote-test-{}.sock", std::process::id()))
-        .to_string_lossy()
-        .into_owned();
-    let _ = std::fs::remove_file(&path);
+    let path = crate::test_util::isolated_socket_path("remote-roundtrip");
     let listener = bind(&path).unwrap();
 
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<RemoteEvent>();
@@ -354,14 +343,7 @@ async fn server_round_trips_request_through_the_reducer() {
 
 #[tokio::test]
 async fn oversized_request_is_rejected_before_reducer() {
-    let path = std::env::temp_dir()
-        .join(format!(
-            "yututui-remote-oversized-test-{}.sock",
-            std::process::id()
-        ))
-        .to_string_lossy()
-        .into_owned();
-    let _ = std::fs::remove_file(&path);
+    let path = crate::test_util::isolated_socket_path("remote-oversized");
     let listener = bind(&path).unwrap();
 
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<RemoteEvent>();

--- a/src/remote/server/session_socket_tests.rs
+++ b/src/remote/server/session_socket_tests.rs
@@ -9,21 +9,13 @@ pub(super) fn test_endpoint(tag: &str) -> String {
     #[cfg(windows)]
     {
         format!(
-            r"\\.\pipe\yututui-session-test-{}-{tag}",
-            std::process::id()
+            r"\\.\pipe\yututui-session-test-{}",
+            crate::test_util::unique_socket_tag(tag)
         )
     }
     #[cfg(unix)]
     {
-        let ep = std::env::temp_dir()
-            .join(format!(
-                "yututui-session-test-{}-{tag}.sock",
-                std::process::id()
-            ))
-            .to_string_lossy()
-            .into_owned();
-        let _ = std::fs::remove_file(&ep);
-        ep
+        crate::test_util::isolated_socket_path(tag)
     }
 }
 

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -43,6 +43,63 @@ fn isolated_dir_pair(label: &str) -> (std::path::PathBuf, std::path::PathBuf) {
     (data, cache)
 }
 
+/// Longest path `isolated_socket_path` will spend: under the shortest platform cap for
+/// `sun_path` (104 on macOS, 108 on Linux) with room to spare for the trailing NUL.
+#[cfg(test)]
+const MAX_SOCKET_PATH_LEN: usize = 100;
+
+/// A filesystem endpoint for a test that binds a local socket, unique on every call.
+///
+/// Uniqueness comes from the counter, never from `label`: two tests that happen to pick the same
+/// label still get separate paths. Hand-picked labels were the only thing keeping these apart
+/// before, and when two of them collided the pair raced on bind and one panicked with
+/// `AddrInUse` — a failure that only reproduces under the parallel suite, so it read as CI
+/// flakiness rather than as a name clash.
+///
+/// `label` is truncated to whatever room is left, because a Unix socket path is capped at 104
+/// bytes by `sun_path` and the per-user temp dir on macOS already spends 48 of them. The pid and
+/// the counter are what make the path unique, so they are never the part that gives way.
+#[cfg(test)]
+pub fn isolated_socket_path(label: &str) -> String {
+    const PREFIX: &str = "ytt-";
+
+    let dir = std::env::temp_dir();
+    let suffix = format!("-{}.sock", unique_socket_tag(""));
+    let room =
+        MAX_SOCKET_PATH_LEN.saturating_sub(dir.as_os_str().len() + 1 + PREFIX.len() + suffix.len());
+    // Bytes, not chars: `room` is a byte budget, and taking `room` characters of a multi-byte
+    // label would spend up to four times it. Cut on a char boundary so the result stays valid.
+    let label: String = label
+        .char_indices()
+        .take_while(|(offset, ch)| offset + ch.len_utf8() <= room)
+        .map(|(_, ch)| ch)
+        .collect();
+
+    let path = dir.join(format!("{PREFIX}{label}{suffix}"));
+    // A recycled pid can leave a previous run's file here, and bind fails on a stale one.
+    let _ = std::fs::remove_file(&path);
+    path.to_string_lossy().into_owned()
+}
+
+/// The unique part of a test socket name, for endpoints that are not filesystem paths.
+///
+/// Windows named pipes have no `sun_path` budget to stay under, so they take the tag directly
+/// instead of going through [`isolated_socket_path`]. Both share one counter so a process cannot
+/// hand out the same tag twice.
+#[cfg(test)]
+pub fn unique_socket_tag(label: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    let sequence = NEXT.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    if label.is_empty() {
+        format!("{pid}-{sequence}")
+    } else {
+        format!("{label}-{pid}-{sequence}")
+    }
+}
+
 /// Drives `future` to completion with isolated data and cache directories installed.
 ///
 /// The env overrides and the thread-scoped flag that exposes them both live on one thread, so the
@@ -119,6 +176,53 @@ mod tests {
             Some(shared),
             "the override must not outlive its scope"
         );
+    }
+
+    /// The whole point of the helper is that a duplicate label stops being a collision, so assert
+    /// the duplicate case rather than the easy one where the labels already differ.
+    #[test]
+    fn isolated_socket_paths_differ_even_for_one_repeated_label() {
+        let first = isolated_socket_path("selftest-socket");
+        let second = isolated_socket_path("selftest-socket");
+        assert_ne!(first, second, "two calls must not share a socket path");
+    }
+
+    /// A path over `sun_path` fails at bind, not here, so a silent overflow would only surface as
+    /// an unrelated-looking macOS failure. Asserts the budget the code promises, not the platform
+    /// cap it sits under, so shrinking headroom cannot pass unnoticed. The non-ASCII label is the
+    /// case that catches spending a byte budget a character at a time.
+    #[test]
+    fn isolated_socket_path_spends_no_more_than_its_budget() {
+        // With nothing left to truncate the helper cannot get under the budget on a temp dir long
+        // enough to blow it unaided, so that length is the honest floor to compare against.
+        let floor = isolated_socket_path("").len();
+
+        for label in ["x".repeat(200), "재생큐".repeat(60)] {
+            let path = isolated_socket_path(&label);
+            assert!(
+                path.len() <= MAX_SOCKET_PATH_LEN.max(floor),
+                "truncation overshot the {MAX_SOCKET_PATH_LEN}-byte budget: {} bytes for {path}",
+                path.len()
+            );
+        }
+    }
+
+    /// Truncation may eat the label, but never the counter that makes the path unique.
+    #[test]
+    fn isolated_socket_path_keeps_the_counter_when_the_label_is_truncated() {
+        let first = isolated_socket_path(&"x".repeat(200));
+        let second = isolated_socket_path(&"x".repeat(200));
+        assert_ne!(
+            first, second,
+            "truncation dropped the unique part instead of the label"
+        );
+    }
+
+    #[test]
+    fn unique_socket_tags_never_repeat() {
+        let tags: std::collections::HashSet<String> =
+            (0..64).map(|_| unique_socket_tag("selftest")).collect();
+        assert_eq!(tags.len(), 64, "the shared counter handed out a duplicate");
     }
 
     #[test]


### PR DESCRIPTION
## Why

CI flaked on main with `AddrInUse` in `remote::client::tests::status_fresh_retry_takes_the_fresh_response_verbatim` (run 32907157813). Two tests had picked the same label, `test_endpoint` turned both into one Unix socket path, and they raced on bind.

#168 renamed one label. That fixed the instance and left the class untouched: nothing checks that labels are unique, so the next copy-paste reintroduces it. This replaces the convention with a mechanism.

## What

- `test_util::isolated_socket_path(label)` — a filesystem endpoint unique on every call, from one process-wide `AtomicU64`. A repeated label is now harmless.
- `test_util::unique_socket_tag(label)` — the same counter for the Windows named pipe, which has no filesystem path to build.
- Every socket-binding test site migrated (18 call sites across 8 files), and four separate ad-hoc uniqueness schemes removed with them: a nanosecond nonce (`gateway/shutdown_tests.rs`), a request-id nonce (`gateway/page_lifetime.rs`), a private `NEXT_ENDPOINT` counter (`desktop/single_instance.rs`), and three pid-only literals in `remote/server/one_shot_tests.rs` that were unique only because nobody had copied them yet.

## The `sun_path` constraint

Worth a look during review — it is why the helper truncates instead of appending.

`sun_path` caps a Unix socket path at 104 bytes on macOS, where the per-user temp dir already spends 48. The longest pre-existing path measured **102/104**. Appending a sequence naively overflows, and only on the GitHub-hosted macOS job.

So the helper spends a byte budget and truncates the **label**; pid and counter never truncate, because they are what makes the path unique. Cutting on a char boundary keeps a multi-byte label from spending up to 4x the budget. Shortening the prefix to `ytt-` brings the worst case to **96/104**.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` 4665 pass; `cargo test --features desktop -- desktop::` 173 pass
- All six architecture gate scripts pass
- Socket suites stress-run 6x with no failure
- Four self-tests in `test_util`, including a byte-budget assertion mutation-tested against the char-truncation bug it guards (it fails at 165 bytes vs the 100-byte budget when the bug is reintroduced)

## Not fixed here (pre-existing, out of scope)

`cargo clippy --features desktop` reports 3 `unsafe block missing a safety comment` errors at `src/desktop/single_instance.rs:1003,1017,1024`. These are present on clean main and are **not caught by CI**, because `ci-pr.yml` lints the workspace without `--features desktop`. This PR touches that file's tests but neither causes nor fixes those.