### PR TITLE
refactor: readability pass 1 (honest comments, named constants) + mpv request-id seed fix

### DIFF
--- a/src/api/actor.rs
+++ b/src/api/actor.rs
@@ -504,8 +504,13 @@ where
                 } else {
                     vec![streaming_source]
                 };
+                // With every source enabled, split the budget evenly but never below a handful
+                // per source, so a provider with thin results still contributes variety.
+                const MIN_PER_SOURCE_CANDIDATES: usize = 4;
                 let per_source_limit = if streaming_source == SearchSource::All {
-                    (limit / selected_sources.len().max(1)).max(4).min(limit)
+                    (limit / selected_sources.len().max(1))
+                        .max(MIN_PER_SOURCE_CANDIDATES)
+                        .min(limit)
                 } else {
                     limit
                 };

--- a/src/app/local/rows_cache.rs
+++ b/src/app/local/rows_cache.rs
@@ -12,6 +12,8 @@ use super::super::local_import_helpers::import_session_row_status_label;
 use super::super::*;
 use super::import_fingerprint::{local_import_files_fingerprint, stable_import_cache_key};
 
+/// Sentinel for a row whose track is no longer in the index: deliberately out of range so
+/// `tracks().get(idx)` misses and readers fall back to the uncached per-row path.
 const MISSING_LOCAL_TRACK_INDEX: usize = usize::MAX;
 const LOCAL_VISIBLE_VALUE_CACHE_CAP: usize = 512;
 const LOCAL_SELECTED_VALUE_CACHE_CAP: usize = 64;
@@ -302,6 +304,9 @@ impl App {
         }
     }
 
+    /// Classify a rows list by its first entry. Lists are produced one kind at a time, so the
+    /// first row decides; any row of another variant maps to [`MISSING_LOCAL_TRACK_INDEX`]
+    /// and simply takes the uncached path.
     fn local_rows_kind(&self, rows: &[crate::local::LocalRowId]) -> LocalRowsKind {
         let Some(first) = rows.first() else {
             return LocalRowsKind::Empty;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -479,7 +479,7 @@ pub struct App {
 
     /// Last-rendered mouse hit map: the clickable button rects and the seekbar rect views
     /// publish each frame, kept behind [`HitMap`]'s method API so the reducer and views never
-    /// touch the raw cells (extracted from [`RenderBridges`]).
+    /// touch the raw cells.
     pub hits: HitMap,
 
     /// When the last radio re-sync (seek-to-live or reconnect) was issued. A second

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -8,8 +8,7 @@ mod scrollbar;
 /// The last-rendered mouse hit map: the clickable button rects views publish each frame plus
 /// the seekbar's screen rect. Kept behind a small method API so the reducer and views never
 /// touch the raw cells. Interior-mutable throughout because the render pass only holds `&App`
-/// yet must record this frame's geometry for the next event to hit-test against (extracted
-/// from [`RenderBridges`], behaviour-preserving).
+/// yet must record this frame's geometry for the next event to hit-test against.
 #[derive(Default)]
 pub struct HitMap {
     /// Screen rect of the seekbar, written by the player view each render so a mouse click can

--- a/src/app/reducer.rs
+++ b/src/app/reducer.rs
@@ -5,7 +5,6 @@ use std::time::Instant;
 use super::*;
 
 impl App {
-    /// The reducer: apply one message, returning effects for the run loop to dispatch.
     /// Reducer entry point. Wraps [`Self::dispatch`] to centrally track when a transient
     /// `status` notification is set or cleared (any of the ~40 `self.status.text = …` sites), so
     /// the main loop can expire it after [`STATUS_TTL`] and bring the song title back —
@@ -129,7 +128,7 @@ impl App {
         if let crate::remote::proto::RemoteCommand::ExportPersonalData { directory, schema } = cmd {
             return self.start_personal_export(
                 PathBuf::from(directory),
-                schema.unwrap_or(2),
+                schema.unwrap_or(crate::remote::proto::DEFAULT_EXPORT_SCHEMA),
                 Some(reply),
             );
         }

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -164,19 +164,14 @@ impl App {
                     }
                     return Vec::new();
                 }
+                let action = self.keymap.action(KeyContext::SearchInput, k.into());
                 // Ctrl+A selects the whole query (desktop-style); idempotent re-select.
-                if matches!(
-                    self.keymap.action(KeyContext::SearchInput, k.into()),
-                    Some(Action::SelectAll)
-                ) {
+                if action == Some(Action::SelectAll) {
                     self.search.select_all = !self.search.input.is_empty();
                     self.dirty = true;
                     return Vec::new();
                 }
-                if matches!(
-                    self.keymap.action(KeyContext::SearchInput, k.into()),
-                    Some(Action::ToggleSearchSourceMenu)
-                ) {
+                if action == Some(Action::ToggleSearchSourceMenu) {
                     return self.toggle_search_source_menu();
                 }
                 // With the query selected, the next key consumes the selection: a character
@@ -231,10 +226,7 @@ impl App {
                     }
                     return Vec::new();
                 }
-                match self.keymap.action(KeyContext::SearchInput, k.into()) {
-                    Some(Action::ToggleSearchSourceMenu) => {
-                        return self.toggle_search_source_menu();
-                    }
+                match action {
                     Some(Action::ToggleSearchKind) => {
                         return self.toggle_search_kind();
                     }
@@ -923,7 +915,7 @@ impl App {
         self.status.kind = StatusKind::Info;
         self.status.text = format!(
             "{}: {}",
-            t!("Search source", "검색 소스", "検索ソース"),
+            crate::settings::Field::SearchSource.label(),
             source.label()
         );
         self.dirty = true;

--- a/src/app/settings_reducer.rs
+++ b/src/app/settings_reducer.rs
@@ -1,4 +1,4 @@
-//! Settings-screen reducer methods, split out of the monolithic `app.rs` (behaviour-preserving).
+//! Settings-screen reducer arms: draft navigation, per-field value cycling, and save/cancel.
 use super::*;
 
 mod commit;
@@ -69,8 +69,6 @@ fn search_source_for(field: Field) -> Option<SearchSource> {
 }
 
 impl App {
-    // --- Settings screen ----------------------------------------------------
-
     /// The live settings draft, mutable. Valid **only** in `Mode::Settings`, where the reducer
     /// upholds the invariant that `self.settings` is `Some`: `open_settings` sets it on entry and
     /// `close_settings` clears it on exit, and every caller below is reached through a
@@ -586,7 +584,7 @@ impl App {
                     .cycled_source(s.draft.search.source, dir >= 0);
                 self.status.text = format!(
                     "{}: {}",
-                    t!("Search source", "검색 소스", "検索ソース"),
+                    Field::SearchSource.label(),
                     s.draft.search.source.label()
                 );
                 Vec::new()
@@ -599,7 +597,7 @@ impl App {
                     .cycled_streaming_source(s.draft.search.streaming_source, dir >= 0);
                 self.status.text = format!(
                     "{}: {}",
-                    t!("Streaming source", "추천 소스", "ストリーミングソース"),
+                    Field::StreamingSource.label(),
                     s.draft
                         .search
                         .normalized_streaming_source(s.draft.search.streaming_source)

--- a/src/daemon/engine/open_subsonic_bridge.rs
+++ b/src/daemon/engine/open_subsonic_bridge.rs
@@ -485,6 +485,8 @@ impl DaemonEngine {
                 match confirmation.confirm_bridge_durable() {
                     Ok(()) | Err(crate::util::delivery::DeliveryError::Busy) => return,
                     Err(crate::util::delivery::DeliveryError::Closed) => {
+                        // The marker remains in its Pending state and will replay against the
+                        // bridge's durable row on restart.
                         self.open_subsonic_pending_scrobbles.pop_front();
                         continue;
                     }
@@ -539,6 +541,8 @@ impl DaemonEngine {
             match confirmation.confirm_source_acknowledged() {
                 Ok(()) | Err(crate::util::delivery::DeliveryError::Busy) => return,
                 Err(crate::util::delivery::DeliveryError::Closed) => {
+                    // The bridge already knows the source is acknowledged. The intermediate
+                    // journal marker will replay only this idempotent finalization after restart.
                     self.open_subsonic_pending_scrobbles.pop_front();
                     continue;
                 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -431,7 +431,10 @@ async fn run_owner_loop(
             DaemonEvent::Remote(RemoteEvent::Command(command, reply)) => match command {
                 RemoteCommand::ExportPersonalData { directory, schema } => {
                     personal_export.start_engine(
-                        personal_export::Target::new(directory, schema.unwrap_or(2)),
+                        personal_export::Target::new(
+                            directory,
+                            schema.unwrap_or(crate::remote::proto::DEFAULT_EXPORT_SCHEMA),
+                        ),
                         reply,
                         &engine,
                         &event_tx,
@@ -474,7 +477,10 @@ async fn run_owner_loop(
             }) => match command {
                 RemoteCommand::ExportPersonalData { directory, schema } => {
                     personal_export.start_engine(
-                        personal_export::Target::new(directory, schema.unwrap_or(2)),
+                        personal_export::Target::new(
+                            directory,
+                            schema.unwrap_or(crate::remote::proto::DEFAULT_EXPORT_SCHEMA),
+                        ),
                         reply,
                         &engine,
                         &event_tx,
@@ -672,8 +678,9 @@ async fn run_owner_loop(
             break;
         }
 
-        // Preserve origin/main's platform-clock correction cadence on progress turns without
-        // rebuilding the owned media projection.
+        // Progress turns only rebase the platform clock: Linux/Windows backends interpolate their
+        // own position and need every time-pos sample to correct it, while rebuilding the owned
+        // media projection for a scalar update would allocate on the hottest turn.
         let media_progress_publish_due = media_position_turn
             && engine
                 .media_position_update()
@@ -714,8 +721,9 @@ async fn run_owner_loop(
                 break;
             }
         }
-        // Preserve origin's baseline-refresh/event ordering on every dispatched daemon event.
-        // The view is borrowed and unchanged topics do not allocate or serialize models.
+        // Observe after every dispatched event, in dispatch order, so remote subscribers see
+        // baseline refreshes and events in the sequence the engine applied them. The view is
+        // borrowed and unchanged topics do not allocate or serialize models.
         let view = engine.core_view();
         publisher.observe(&view);
         lyrics_host.observe(&mut publisher, view.queue.current());

--- a/src/data_cli.rs
+++ b/src/data_cli.rs
@@ -572,7 +572,7 @@ fn parse_export_args(args: &[String]) -> Result<ParseExport, String> {
 
     Ok(ParseExport::Request(ExportRequest {
         destination,
-        schema: schema.unwrap_or(2),
+        schema: schema.unwrap_or(crate::remote::proto::DEFAULT_EXPORT_SCHEMA),
     }))
 }
 

--- a/src/download/import_inbox.rs
+++ b/src/download/import_inbox.rs
@@ -1,10 +1,27 @@
+//! Private import inbox under the download root:
+//! `<root>/.yututui-inbox/<session>/{incoming,complete,failed}`.
+//!
+//! The download root is user-writable and may be shared with other tools, so nothing here
+//! trusts a path it did not just verify: every directory component is re-checked as a real
+//! (non-link, non-reparse) directory that still resolves under the root, and files are opened
+//! without following symlinks. The checks are repeated at each boundary (prepare, validate,
+//! reclaim) rather than cached, because the tree can change between calls.
+//!
+//! Admission is bounded before a new import starts so a stalled or hostile inbox cannot grow
+//! without limit: retained artifacts are capped by count and bytes, and the inventory walk
+//! itself is capped by entries and depth so a deep or wide tree fails closed instead of hanging.
+
 use std::collections::VecDeque;
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context as _, Result, bail};
 
+const INBOX_DIR_NAME: &str = ".yututui-inbox";
+/// Raw downloads retained after commit for explicit recovery. Past either cap, new imports are
+/// refused until the user reviews the retained work.
 const RETAINED_FILE_CAP: usize = 512;
 const RETAINED_SOURCE_BYTES_CAP: u64 = 8 * 1024 * 1024 * 1024;
+/// Bounds on the inventory walk itself, so admission stays cheap even for a tampered tree.
 const RETAINED_SCAN_ENTRY_CAP: usize = 2_048;
 const RETAINED_SCAN_DEPTH_CAP: usize = 3;
 
@@ -31,7 +48,7 @@ pub(super) fn ensure_retained_import_capacity(root: &Path) -> Result<()> {
 }
 
 pub(super) fn retained_import_inventory(root: &Path) -> Result<RetainedImportInventory> {
-    let base = root.join(".yututui-inbox");
+    let base = root.join(INBOX_DIR_NAME);
     let metadata = match std::fs::symlink_metadata(&base) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -94,7 +111,7 @@ pub(super) fn reclaim_import_file(
     path: &Path,
     expected: crate::util::safe_fs::FileObjectId,
 ) -> Result<bool> {
-    let base = std::fs::canonicalize(root.join(".yututui-inbox"))?;
+    let base = std::fs::canonicalize(root.join(INBOX_DIR_NAME))?;
     let parent_path = path
         .parent()
         .context("retained import file has no parent")?;
@@ -127,7 +144,7 @@ pub(super) struct ImportInboxDirs {
 
 pub(super) fn import_inbox_dirs(root: &Path, session_id: &str) -> Result<ImportInboxDirs> {
     let session = safe_import_session_component(session_id)?;
-    let base = root.join(".yututui-inbox").join(session);
+    let base = root.join(INBOX_DIR_NAME).join(session);
     Ok(ImportInboxDirs {
         incoming: base.join("incoming"),
         complete: base.join("complete"),
@@ -139,7 +156,7 @@ pub(super) fn prepare_import_inbox_dirs(root: &Path, session_id: &str) -> Result
     let dirs = import_inbox_dirs(root, session_id)?;
     crate::util::safe_fs::ensure_dir_durable(root)
         .with_context(|| format!("create download root {}", root.display()))?;
-    let private_base = root.join(".yututui-inbox");
+    let private_base = root.join(INBOX_DIR_NAME);
     crate::util::safe_fs::ensure_private_dir_durable(&private_base)
         .with_context(|| format!("create private import root {}", private_base.display()))?;
     ensure_private_ignore_file(&private_base)?;
@@ -157,6 +174,10 @@ pub(super) fn prepare_import_inbox_dirs(root: &Path, session_id: &str) -> Result
     Ok(dirs)
 }
 
+/// Keep an empty `.ignore` marker in the private root as an ownership canary: it is created
+/// mode 0600 by this user and re-validated (empty, regular, owner-only on Unix) on every
+/// prepare, so a private root created or tampered with by someone else fails inbox
+/// preparation instead of being reused.
 fn ensure_private_ignore_file(private_base: &Path) -> Result<()> {
     let pinned =
         crate::util::safe_fs::PinnedDir::open_private_existing(private_base, Path::new(""))
@@ -282,7 +303,7 @@ pub(super) fn find_retryable_audio(directory: &Path, video_id: &str) -> Result<O
 }
 
 fn validate_import_inbox_dirs(root: &Path, dirs: &ImportInboxDirs) -> Result<()> {
-    let base = root.join(".yututui-inbox");
+    let base = root.join(INBOX_DIR_NAME);
     let canonical_base = std::fs::canonicalize(&base)
         .with_context(|| format!("canonicalize private import root {}", base.display()))?;
     for directory in [&dirs.incoming, &dirs.complete, &dirs.failed] {
@@ -352,7 +373,10 @@ fn is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
     #[cfg(windows)]
     {
         use std::os::windows::fs::MetadataExt as _;
-        metadata.file_type().is_symlink() || metadata.file_attributes() & 0x0000_0400 != 0
+        // Junctions and mount points are reparse points without being symlinks to `file_type()`.
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+        metadata.file_type().is_symlink()
+            || metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
     }
     #[cfg(not(windows))]
     {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1,11 +1,9 @@
 //! Central keybinding map: the single source of truth for which key triggers which
 //! semantic [`Action`], per input [`KeyContext`].
 //!
-//! Key handling used to be inline `match k.code` literals scattered across the five
-//! `on_key_*` methods, and the on-screen hints were hand-synced string constants. This
-//! module decouples *intent* (`Action`) from the physical key ([`Chord`]): handlers
-//! resolve an `Action` for their context and act on it, while footers and the `?`
-//! cheat-sheet render the bound chords back out — so hints can never drift from behavior.
+//! Intent (`Action`) is decoupled from the physical key ([`Chord`]): handlers resolve an
+//! `Action` for their context and act on it, while footers and the `?` cheat-sheet render
+//! the bound chords back out — so on-screen hints can never drift from behavior.
 //!
 //! Bindings are user-remappable (the Settings → Keys tab) and persisted to `config.json`
 //! as `"<context>.<action>" -> "<chord>"`, storing only entries that differ from the

--- a/src/local/model.rs
+++ b/src/local/model.rs
@@ -86,9 +86,10 @@ impl AudioFormat {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum FileFingerprint {
-    /// Phase-3 fallback identity: stable for the same path/mtime/size, but not
-    /// intended to survive renames. Scanner phases can upgrade this when they
-    /// can read platform file identity cheaply.
+    /// The only variant the scanner currently produces: stable for the same
+    /// path/mtime/size, but not intended to survive renames. The platform-id
+    /// variants below are reserved wire shapes for scanners that can read file
+    /// identity cheaply.
     PathMtimeSize {
         path_hash: u64,
         mtime: i64,

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -583,10 +583,10 @@ impl MediaSession {
 
     /// Rebase only the scalar playback clock after a `time-pos` update.
     ///
-    /// `origin/main` handed every progress snapshot to the platform backend even though the
-    /// snapshot diff had no changed facets. Linux and Windows used those calls to correct their
-    /// interpolated clocks. Keep that observable cadence while reusing the retained metadata, so
-    /// a progress turn neither rebuilds nor clones track strings, paths, artwork, or capabilities.
+    /// Every progress sample must still reach the platform backend even when no snapshot facet
+    /// changed: Linux and Windows interpolate their own clocks and use these calls to correct
+    /// them. Reusing the retained metadata keeps that cadence while a progress turn neither
+    /// rebuilds nor clones track strings, paths, artwork, or capabilities.
     /// Returns `true` only when the platform has not activated yet and the caller must publish one
     /// full current snapshot. This preserves lazy first-play activation on macOS/Windows.
     pub fn rebase_position(&mut self, position: f64, captured_at: Instant) -> bool {

--- a/src/media/smtc.rs
+++ b/src/media/smtc.rs
@@ -497,8 +497,9 @@ impl Session {
         }
     }
 
-    /// Apply one logical event completely before the next snapshot is installed.
-    /// The facet/timeline/timer order mirrors `origin/main`'s `apply_inner`.
+    /// Apply one logical event completely before the next snapshot is installed: facets,
+    /// then the timeline, then the timer, so the timeline is always pushed against the facets
+    /// it belongs to and the timer decision reads fully installed state.
     fn apply_event(&mut self, changes: MediaChanges) -> windows::core::Result<()> {
         self.apply_facets(changes)?;
         if changes.track || changes.position || changes.status || changes.options {

--- a/src/personal_state/legacy.rs
+++ b/src/personal_state/legacy.rs
@@ -10,6 +10,7 @@ use super::{
 };
 
 pub(crate) const FAVORITES_MAX: usize = 999;
+pub(crate) const AVOID_ARTISTS_MAX: usize = 200;
 pub(crate) const HISTORY_MAX: usize = 999;
 pub(crate) const RADIO_MAX: usize = 999;
 pub(crate) const PLAYLISTS_MAX: usize = 999;

--- a/src/personal_state/reducer.rs
+++ b/src/personal_state/reducer.rs
@@ -5,10 +5,10 @@ use super::compaction::{
     operation_survives_checkpoint, retained_engagement_operation_ids, select_checkpoint,
 };
 use super::legacy::{
-    ENGAGEMENT_EVENTS_MAX, FAVORITES_MAX, HISTORY_MAX, LegacyPlayEvent, LegacyPlaylist,
-    LegacyPlaylistEntry, LegacyProjection, LegacySignals, LegacyStation, LegacyTrackSignal,
-    PLAYLIST_ENTRIES_MAX, PLAYLISTS_MAX, RADIO_MAX, SIGNAL_TRACKS_MAX, rating_from_legacy,
-    sha256_hex,
+    AVOID_ARTISTS_MAX, ENGAGEMENT_EVENTS_MAX, FAVORITES_MAX, HISTORY_MAX, LegacyPlayEvent,
+    LegacyPlaylist, LegacyPlaylistEntry, LegacyProjection, LegacySignals, LegacyStation,
+    LegacyTrackSignal, PLAYLIST_ENTRIES_MAX, PLAYLISTS_MAX, RADIO_MAX, SIGNAL_TRACKS_MAX,
+    rating_from_legacy, sha256_hex,
 };
 use super::model::{derive_device_registry, operation_set};
 use super::{
@@ -462,7 +462,7 @@ pub(crate) fn project_at(
         avoid_artist_keys: avoided
             .into_iter()
             .filter_map(|(artist, register)| register.value.then_some(artist))
-            .take(200)
+            .take(AVOID_ARTISTS_MAX)
             .collect(),
     };
     enforce_projection_caps(&mut legacy);
@@ -1000,6 +1000,9 @@ fn enforce_projection_caps(legacy: &mut LegacyProjection) {
         legacy.signals.play_log.drain(..remove);
     }
     if legacy.signals.tracks.len() > SIGNAL_TRACKS_MAX {
+        // Eviction order: never-disliked tracks first, oldest play first among them. A dislike is
+        // a deliberate signal the station must keep honouring, so disliked entries outlive stale
+        // neutral plays.
         let mut eviction = legacy
             .signals
             .tracks

--- a/src/player/ipc.rs
+++ b/src/player/ipc.rs
@@ -415,7 +415,7 @@ pub(super) async fn run_actor(input: ActorInput) {
     }
 
     // Subscribe to the properties the player view needs. IDs are arbitrary but stable.
-    for (id, prop) in [
+    let observed_properties = [
         (1u64, "time-pos"),
         (2, "duration"),
         (3, "pause"),
@@ -441,15 +441,15 @@ pub(super) async fn run_actor(input: ActorInput) {
         (14, "partially-seekable"),
         (15, "cache-speed"),
         (16, "paused-for-cache"),
-        // Audio-output observation IDs follow the seek/cache range. Dynamic commands start
-        // above 19 so replies can never collide with a property subscription.
+        // Audio-output observation IDs follow the seek/cache range.
         (17, "audio-device-list"),
         (18, "audio-device"),
         (19, "current-ao"),
         // Chapter boundaries for the long-form player (`!`/`@` jumps + seekbar ticks). mpv
         // re-emits this per file, so an empty list reliably clears the previous file's markers.
         (20, "chapter-list"),
-    ] {
+    ];
+    for &(id, prop) in &observed_properties {
         remember_pending_command(&mut state, id, format!("observe {prop}"));
         if let Err(error) = write_json(&conn, &proto::cmd_observe(id, prop)).await {
             let exit = transport_exit_or_shutdown(
@@ -467,7 +467,13 @@ pub(super) async fn run_actor(input: ActorInput) {
 
     let mut reader = BufReader::new(&conn);
     let mut line: Vec<u8> = Vec::new();
-    let mut request_id: u64 = 19;
+    // Dynamic command ids continue above every observation id, so a command reply can never
+    // share a pending-table key with a property subscription.
+    let mut request_id: u64 = observed_properties
+        .iter()
+        .map(|&(id, _)| id)
+        .max()
+        .unwrap_or(0);
     let mut validating_load: Option<PendingLoadValidation> = None;
     let mut pending_load_boundary: Option<PendingLoadBoundary> = None;
     // This barrier is process-global rather than load-owned. A newer Load/Stop may supersede

--- a/src/player/proto.rs
+++ b/src/player/proto.rs
@@ -114,8 +114,8 @@ pub fn parse_line(line: &str) -> Option<MpvIncoming> {
                     .unwrap_or_default()
                     .to_owned();
                 // Move potentially large demuxer-cache-state payloads out of the parsed
-                // object. Cloning here used to duplicate every seekable-ranges entry on the
-                // watchdog path before the pending request could decide how much it needed.
+                // object instead of cloning: the watchdog path would otherwise duplicate every
+                // seekable-ranges entry before the pending request decides how much it needs.
                 let data = v.as_object_mut().and_then(|object| object.remove("data"));
                 Some(MpvIncoming::CommandReply {
                     request_id,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -18,7 +18,7 @@ pub(crate) mod mutation;
 pub(crate) use mutation::{QueueMutationPlan, QueueRemovalPlayback, QueueReplacementDraft};
 
 /// Hard cap on queued tracks (priority #1: bounded memory).
-const MAX: usize = 999;
+const MAX_QUEUE_LEN: usize = 999;
 
 /// Owner-global queue revision source. One counter per process —
 /// deliberately NOT per-`Queue`: radio mode and `--resume` swap whole queues through
@@ -113,11 +113,11 @@ impl Queue {
     }
 
     pub(crate) fn remaining_capacity(&self) -> usize {
-        MAX.saturating_sub(self.songs.len())
+        MAX_QUEUE_LEN.saturating_sub(self.songs.len())
     }
 
     pub(crate) const fn max_len() -> usize {
-        MAX
+        MAX_QUEUE_LEN
     }
 
     /// The membership/order revision. Equal revs ⇒ identical contents and play order
@@ -170,10 +170,10 @@ impl Queue {
 
     fn restore_snapshot_without_revision(&mut self, snapshot: QueueSnapshot) {
         self.songs = snapshot.songs;
-        // Enforce the same MAX cap every other mutation applies, so a corrupt/tampered session
-        // snapshot can't inject an unbounded queue. Over-cap truncation drops the tail; the
+        // Enforce the same MAX_QUEUE_LEN cap every other mutation applies, so a corrupt/tampered
+        // session snapshot can't inject an unbounded queue. Over-cap truncation drops the tail; the
         // permutation check below then rebuilds a clean play order for the trimmed songs.
-        self.songs.truncate(MAX);
+        self.songs.truncate(MAX_QUEUE_LEN);
         self.order = snapshot.order;
         self.shuffle = snapshot.shuffle;
         self.repeat = snapshot.repeat;
@@ -353,7 +353,7 @@ impl Queue {
         self.order.len().saturating_sub(self.cursor + 1)
     }
 
-    /// Append `more` tracks to the end of the queue, respecting the [`MAX`] cap. Returns
+    /// Append `more` tracks to the end of the queue, respecting the [`MAX_QUEUE_LEN`] cap. Returns
     /// the number actually added — fewer than requested (or zero) when near the cap, so
     /// the caller can report the *real* count rather than what was asked for. The new
     /// tracks are made reachable from the current cursor; with shuffle on they're
@@ -367,7 +367,7 @@ impl Queue {
     }
 
     fn extend_without_revision(&mut self, more: Vec<Song>) -> usize {
-        let free = MAX.saturating_sub(self.songs.len());
+        let free = MAX_QUEUE_LEN.saturating_sub(self.songs.len());
         if free == 0 {
             return 0;
         }
@@ -395,7 +395,7 @@ impl Queue {
     /// Shuffle-agnostic: the inserted block stays directly after the current track so the
     /// "next" promise holds even while shuffle is enabled.
     pub fn insert_next_many(&mut self, more: Vec<Song>) -> usize {
-        let free = MAX.saturating_sub(self.songs.len());
+        let free = MAX_QUEUE_LEN.saturating_sub(self.songs.len());
         if free == 0 {
             return 0;
         }
@@ -419,19 +419,18 @@ impl Queue {
         self.bump_rev();
         added
     }
-
-    /// Insert `song` immediately after the current track in the play order and make it the
-    /// new current — "play this now" without disturbing the rest of the queue, which resumes
-    /// after this track ends. Into an empty queue it simply becomes the sole track. Returns
-    /// `false` (nothing inserted) when the queue is already at the [`MAX`] cap, so the caller
-    /// can report it; `true` otherwise. Shuffle-agnostic: it always lands right after the
-    /// cursor in play order, so the "now playing next" promise holds either way.
+    /// Insert `song` immediately after the current track in the play order and make it the new
+    /// current — "play this now" without disturbing the rest of the queue, which resumes after
+    /// this track ends. Into an empty queue it simply becomes the sole track. Returns `false`
+    /// (nothing inserted) when the queue is already at the [`MAX_QUEUE_LEN`] cap, so the caller
+    /// can report it; `true` otherwise. Shuffle-agnostic: it always lands right after the cursor
+    /// in play order, so the "now playing next" promise holds either way.
     pub fn play_now(&mut self, song: Song) -> bool {
         self.play_now_many(vec![song]) == 1
     }
 
     /// Insert `more` immediately after the current track and make the first inserted track
-    /// current. Returns the number actually inserted, bounded by [`MAX`].
+    /// current. Returns the number actually inserted, bounded by [`MAX_QUEUE_LEN`].
     pub fn play_now_many(&mut self, more: Vec<Song>) -> usize {
         let added = self.play_now_many_without_revision(more);
         if added > 0 {
@@ -441,7 +440,7 @@ impl Queue {
     }
 
     fn play_now_many_without_revision(&mut self, more: Vec<Song>) -> usize {
-        let free = MAX.saturating_sub(self.songs.len());
+        let free = MAX_QUEUE_LEN.saturating_sub(self.songs.len());
         if free == 0 {
             return 0;
         }
@@ -674,7 +673,7 @@ impl Queue {
     }
 
     fn replace_without_revision(&mut self, mut songs: Vec<Song>, start: usize) {
-        songs.truncate(MAX);
+        songs.truncate(MAX_QUEUE_LEN);
         let start = start.min(songs.len().saturating_sub(1));
         self.songs = songs;
         self.rebuild_order(start);
@@ -875,18 +874,21 @@ mod tests {
     fn replacement_plan_caps_clamps_and_handles_empty_input() {
         let mut q = Queue::default();
         let plan = q.prepare_replacement(QueueReplacementDraft::new(
-            songs(MAX + 50),
+            songs(MAX_QUEUE_LEN + 50),
             usize::MAX,
             None,
         ));
-        assert_eq!(plan.len(), MAX);
-        assert_eq!(plan.cursor_pos(), MAX - 1);
-        assert_eq!(plan.current().unwrap().video_id, (MAX - 1).to_string());
-        assert_eq!(plan.ordered_iter().count(), MAX);
+        assert_eq!(plan.len(), MAX_QUEUE_LEN);
+        assert_eq!(plan.cursor_pos(), MAX_QUEUE_LEN - 1);
+        assert_eq!(
+            plan.current().unwrap().video_id,
+            (MAX_QUEUE_LEN - 1).to_string()
+        );
+        assert_eq!(plan.ordered_iter().count(), MAX_QUEUE_LEN);
         q.commit_mutation(plan);
-        assert_eq!(q.len(), MAX);
-        assert_eq!(q.cursor_pos(), MAX - 1);
-        assert_eq!(id(&q), (MAX - 1).to_string());
+        assert_eq!(q.len(), MAX_QUEUE_LEN);
+        assert_eq!(q.cursor_pos(), MAX_QUEUE_LEN - 1);
+        assert_eq!(id(&q), (MAX_QUEUE_LEN - 1).to_string());
 
         let plan = q.prepare_replacement(QueueReplacementDraft::new(
             Vec::new(),
@@ -908,7 +910,7 @@ mod tests {
     fn play_now_preparation_is_pure_matches_eager_and_commits_one_revision() {
         let make_base = || {
             let mut q = Queue::default();
-            q.set(songs(MAX - 1), 17);
+            q.set(songs(MAX_QUEUE_LEN - 1), 17);
             q.seed_rng(0x51de);
             q.set_shuffle(true);
             q.repeat = Repeat::All;
@@ -1055,16 +1057,16 @@ mod tests {
     #[test]
     fn set_truncates_to_cap() {
         let mut q = Queue::default();
-        q.set(songs(MAX + 50), 0);
-        assert_eq!(q.len(), MAX);
+        q.set(songs(MAX_QUEUE_LEN + 50), 0);
+        assert_eq!(q.len(), MAX_QUEUE_LEN);
     }
 
     #[test]
     fn restore_snapshot_enforces_the_cap() {
-        // A corrupt/tampered session snapshot with more than MAX songs must be trimmed on
+        // A corrupt/tampered session snapshot with more than MAX_QUEUE_LEN songs must be trimmed on
         // restore, matching the cap every other mutation applies (set/extend/insert) — so a
         // hostile session cache can't inject an unbounded queue.
-        let over = MAX + 50;
+        let over = MAX_QUEUE_LEN + 50;
         let snapshot = QueueSnapshot {
             songs: songs(over),
             order: (0..over).collect(),
@@ -1074,7 +1076,11 @@ mod tests {
         };
         let mut q = Queue::default();
         q.restore_snapshot(snapshot);
-        assert_eq!(q.len(), MAX, "restore must enforce the MAX cap");
+        assert_eq!(
+            q.len(),
+            MAX_QUEUE_LEN,
+            "restore must enforce the MAX_QUEUE_LEN cap"
+        );
         // A clean play order was rebuilt for the trimmed songs; the cursor stays in-bounds.
         assert!(q.current().is_some());
     }
@@ -1105,13 +1111,13 @@ mod tests {
     #[test]
     fn extend_respects_the_cap_and_reports_real_count() {
         let mut q = Queue::default();
-        q.set(songs(MAX - 2), 0);
+        q.set(songs(MAX_QUEUE_LEN - 2), 0);
         let added = q.extend(songs(10)); // only 2 slots free
         assert_eq!(added, 2);
-        assert_eq!(q.len(), MAX);
+        assert_eq!(q.len(), MAX_QUEUE_LEN);
         // Full queue: further extend adds nothing.
         assert_eq!(q.extend(songs(5)), 0);
-        assert_eq!(q.len(), MAX);
+        assert_eq!(q.len(), MAX_QUEUE_LEN);
     }
 
     #[test]
@@ -1358,9 +1364,9 @@ mod tests {
     #[test]
     fn play_now_respects_the_cap() {
         let mut q = Queue::default();
-        q.set(songs(MAX), 0);
+        q.set(songs(MAX_QUEUE_LEN), 0);
         assert!(!q.play_now(song("overflow"))); // full → rejected
-        assert_eq!(q.len(), MAX);
+        assert_eq!(q.len(), MAX_QUEUE_LEN);
     }
 
     #[test]
@@ -1413,11 +1419,11 @@ mod tests {
 
         // No-op mutations don't bump either.
         let mut full = Queue::default();
-        full.set(songs(MAX), 0);
+        full.set(songs(MAX_QUEUE_LEN), 0);
         let at_cap = full.rev();
         assert_eq!(full.extend(songs(3)), 0);
         assert_eq!(full.rev(), at_cap, "capped extend added nothing");
-        assert_eq!(full.remove_at(MAX + 5), None);
+        assert_eq!(full.remove_at(MAX_QUEUE_LEN + 5), None);
         assert_eq!(full.rev(), at_cap, "out-of-range remove changed nothing");
     }
 

--- a/src/remote/proto/command.rs
+++ b/src/remote/proto/command.rs
@@ -260,6 +260,10 @@ fn validate_query(query: &str) -> Result<(), RemoteCommandValidationError> {
     Ok(())
 }
 
+/// Export schema used when a remote `ExportPersonalData` command omits the field: the newest
+/// personal-state export schema, so older clients keep receiving current exports.
+pub const DEFAULT_EXPORT_SCHEMA: u32 = 2;
+
 fn validate_export_directory(directory: &str) -> Result<(), RemoteCommandValidationError> {
     if directory.is_empty() {
         return Err(validation_error("empty_export_directory"));

--- a/src/remote/proto/mod.rs
+++ b/src/remote/proto/mod.rs
@@ -28,8 +28,8 @@ mod session;
 
 pub(crate) use command::RequestRetryClass;
 pub use command::{
-    REMOTE_MAX_EXPORT_DIRECTORY_BYTES, REMOTE_MAX_QUERY_BYTES, REMOTE_MAX_TOPICS,
-    REMOTE_MAX_TRACK_IDS, RemoteCommand, RemoteSettingChange,
+    DEFAULT_EXPORT_SCHEMA, REMOTE_MAX_EXPORT_DIRECTORY_BYTES, REMOTE_MAX_QUERY_BYTES,
+    REMOTE_MAX_TOPICS, REMOTE_MAX_TRACK_IDS, RemoteCommand, RemoteSettingChange,
 };
 pub use model::{ArtworkRef, LyricLineModel, TrackModel, WhyGemModel};
 pub use model_player::{EqModel, PlayerModel, QueueModel};

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -466,8 +466,8 @@ impl From<RuntimeEvent> for Msg {
                 ..
             }) => {
                 // Session ops are intercepted in the run loop (the Publisher's owner
-                // lane) before Msg conversion — the reducer never sees sessions
-                //. Reaching here means a host forgot the intercept.
+                // lane) before Msg conversion — the reducer never sees sessions.
+                // Reaching here means a host forgot the intercept.
                 unreachable!("SessionSubscribe must be handled in the owner loop, not the reducer")
             }
             RuntimeEvent::Resolver(crate::resolver::ResolverEvent::Resolved {

--- a/src/scrobble/actor.rs
+++ b/src/scrobble/actor.rs
@@ -1045,8 +1045,9 @@ impl Actor {
             || self.pending_compaction.is_some()
     }
 
-    /// Drain the queue: compact, deliver per healthy service in ≤50 chunks (compacting
-    /// after every successful chunk), and reschedule while anything stays pending.
+    /// Drain the queue: compact, deliver per healthy service in chunks of at most
+    /// [`SCROBBLE_BATCH_MAX`] (compacting after every successful chunk), and reschedule while
+    /// anything stays pending.
     async fn flush(&mut self) -> Result<(), DeliveryError> {
         self.next_flush = None;
         if self.pending_compaction.is_some() {
@@ -1309,9 +1310,9 @@ impl Actor {
     }
 }
 
-/// Deliver everything `kind` still owes, oldest first, ≤50 per call; strip the marker
-/// (and rewrite the file) after each successful chunk so a crash re-sends at most one
-/// chunk. Content rejections count as delivered.
+/// Deliver everything `kind` still owes, oldest first, in chunks of [`SCROBBLE_BATCH_MAX`]
+/// until nothing is pending; strip the marker (and rewrite the file) after each successful
+/// chunk so a crash re-sends at most one chunk. Content rejections count as delivered.
 async fn flush_service<S: ScrobbleService>(
     service: &S,
     entries: &mut Vec<QueueEntry>,

--- a/src/streaming/score.rs
+++ b/src/streaming/score.rs
@@ -146,7 +146,6 @@ pub fn classify_pool(
     let recent: HashSet<&str> = st.recent_track_ids.iter().map(String::as_str).collect();
     let mut verdicts = Vec::with_capacity(pool.len());
 
-    // Phase 1: hard filter.
     let mut survivors: Vec<&Candidate> = Vec::new();
     for c in pool {
         match reject_reason(c, st, sig, cfg, &recent) {
@@ -155,7 +154,7 @@ pub fn classify_pool(
         }
     }
 
-    // Phase 2: gimmick reject (only when in force and not pool-starving — mirrors `block_gimmicks`).
+    // Gimmick rejection only when in force and not pool-starving — mirrors `block_gimmicks`.
     if gimmick_block_active(survivors.len(), st, cfg)
         && survivors
             .iter()
@@ -171,7 +170,8 @@ pub fn classify_pool(
         survivors = kept_survivors;
     }
 
-    // Phase 3: dedup by canonical key.
+    // Dedup runs after the filters so a rejected first occurrence never shadows a surviving
+    // duplicate of the same canonical key.
     let mut seen: HashSet<&str> = HashSet::new();
     for c in survivors {
         if seen.insert(&c.canonical_key) {

--- a/src/sync/manual/engine.rs
+++ b/src/sync/manual/engine.rs
@@ -207,11 +207,11 @@ impl<'a, T: VaultTransport + ?Sized> ManualSyncEngine<'a, T> {
             return Err(VaultError::RegistryMismatch);
         }
 
-        if membership_advanced {
-            // Membership operations and their new recipient set become visible atomically through
-            // the next signed checkpoint. Publishing a partial membership segment would make the
-            // batch reducer's registry invariant temporarily false.
-        } else {
+        // Membership operations and their new recipient set become visible atomically through
+        // the next signed checkpoint, so nothing is uploaded on a membership transition:
+        // publishing a partial membership segment would make the batch reducer's registry
+        // invariant temporarily false.
+        if !membership_advanced {
             let pending = pending_local_operations(
                 input.local_state,
                 &remote_state,

--- a/src/terminal_runtime/runner.rs
+++ b/src/terminal_runtime/runner.rs
@@ -868,8 +868,8 @@ pub async fn run(
     // Drives the optional player-view animations at the configured frame rate - but only ticks
     // while `app.animation_active()` holds (player view, master + an effect enabled, a track
     // playing, focused unless the user opted out of focus-pausing). With every animation toggle
-    // off (the default) the guard is false, this timer never wakes, and the loop stays exactly as
-    // light as before.
+    // off (the default) the guard is false and this timer never wakes, so the loop pays nothing
+    // for animation support.
     // `Skip` drops missed frames so a busy moment can't build up a backlog of redraws. The period
     // is rebuilt below whenever the user changes the rate in Settings.
     let mut anim_fps = app.animation_tick_fps();
@@ -1337,9 +1337,10 @@ pub async fn run(
                 media.publish(snapshot);
             }
         }
-        // Remote elapsed remains outside the player fingerprint. Match origin's observer call
-        // gates so late subscriptions and follow-up snapshot ordering stay byte-for-byte stable;
-        // unchanged turns perform only borrowed comparisons and never build owned models.
+        // Remote elapsed remains outside the player fingerprint. Observation is gated on
+        // `should_observe` rather than on the fingerprint so late subscriptions and follow-up
+        // snapshot ordering stay byte-for-byte stable; unchanged turns perform only borrowed
+        // comparisons and never build owned models.
         if observer_plan != ObserverPlan::INERT
             && let Some(publisher) = publisher.as_mut()
             && publisher.should_observe(media_changed || media_enabled_changed)

--- a/src/transfer/artifact_move.rs
+++ b/src/transfer/artifact_move.rs
@@ -386,10 +386,15 @@ pub(crate) fn reconcile_all_pending() -> anyhow::Result<ArtifactMoveRecoveryRepo
     Ok(report)
 }
 
+/// Stage filenames carry a prefix of the SHA-256 operation key: 16 hex chars (64 bits) keeps
+/// them short while leaving collisions among the few concurrent stages in one directory
+/// practically impossible; recovery re-derives the same prefix to recognise its own stages.
+const STAGE_TAG_CHARS: usize = 16;
+
 fn prepare_transaction(request: ArtifactMoveRequest) -> anyhow::Result<ArtifactMoveTxn> {
     let operation_key = transaction_key(&request.session_id, &request.row_id, request.source_order);
     let stage_tag = operation_key
-        .get(..16)
+        .get(..STAGE_TAG_CHARS)
         .context("artifact operation key is too short")?;
     reject_parent_components(&request.audio_from)?;
     reject_parent_components(&request.audio_to)?;
@@ -962,7 +967,7 @@ fn validate_transaction(txn: &ArtifactMoveTxn) -> anyhow::Result<()> {
     validate_identity_components(&txn.session_id, &txn.row_id, txn.source_order)?;
     let operation_key = transaction_key(&txn.session_id, &txn.row_id, txn.source_order);
     let stage_tag = operation_key
-        .get(..16)
+        .get(..STAGE_TAG_CHARS)
         .context("artifact operation key is too short")?;
     if txn.audio_stage_name != format!(".ytt-stage-{stage_tag}-audio")
         || txn.sidecar_stage_name != format!(".ytt-stage-{stage_tag}-sidecar")

--- a/src/transfer/matching.rs
+++ b/src/transfer/matching.rs
@@ -25,6 +25,17 @@ pub use crate::track_identity::{normalize, normalize_stripped, similarity};
 
 use super::{ImportMediaKind, MatchPolicy};
 
+// Seed-score weights. They sum to 1.0 so a perfect candidate scores exactly 1 and the
+// `MatchConfig` accept/margin thresholds stay comparable across releases; each term has a
+// distinct semantic role so missing metadata cannot be mistaken for negative evidence.
+const W_TITLE: f32 = 0.42;
+const W_ARTIST: f32 = 0.23;
+const W_ARTIST_COVERAGE: f32 = 0.08;
+const W_DURATION: f32 = 0.12;
+const W_ALBUM_YEAR: f32 = 0.08;
+const W_VERSION_AGREEMENT: f32 = 0.05;
+const W_TRACK_NUMBER: f32 = 0.02;
+
 mod identity;
 mod music_video;
 mod quality;
@@ -789,17 +800,15 @@ pub fn score_candidate_breakdown_with_config(
         (Some(_), Some(_)) => 0.0,
         _ => 0.5,
     };
-    let album_bonus = 0.08 * album_year;
-    let track_number_bonus = 0.02 * track_number;
+    let album_bonus = W_ALBUM_YEAR * album_year;
+    let track_number_bonus = W_TRACK_NUMBER * track_number;
 
-    // Bounded seed model.  Each term has a distinct semantic role so missing metadata
-    // cannot be mistaken for negative evidence and quality adjustments remain auditable.
-    let raw_total = (0.42 * title
-        + 0.23 * artist
-        + 0.08 * artist_coverage
-        + 0.12 * duration
+    let raw_total = (W_TITLE * title
+        + W_ARTIST * artist
+        + W_ARTIST_COVERAGE * artist_coverage
+        + W_DURATION * duration
         + album_bonus
-        + 0.05 * version_agreement
+        + W_VERSION_AGREEMENT * version_agreement
         + track_number_bonus)
         .clamp(0.0, 1.0);
     let mut gate = identity_gate(input, cand);
@@ -808,18 +817,15 @@ pub fn score_candidate_breakdown_with_config(
     }
     let delta_secs = duration_delta_secs(input, cand);
     if let Some(delta) = delta_secs.map(i32::unsigned_abs) {
-        if delta > hard_duration_limit(input)
-            && !(delta_secs.is_some_and(|signed| signed > 0)
-                && is_official_video_presentation(cand)
-                && delta <= official_video_runtime_limit(input))
-        {
+        // An official video presentation is allowed a one-sided runtime difference up to
+        // `official_video_runtime_limit` (intros, credits, end cards), exempt from both limits.
+        let official_runtime_exempt = delta_secs.is_some_and(|signed| signed > 0)
+            && is_official_video_presentation(cand)
+            && delta <= official_video_runtime_limit(input);
+        if delta > hard_duration_limit(input) && !official_runtime_exempt {
             gate.hard_reject = Some("duration_mismatch");
             gate.reasons.push("duration_mismatch");
-        } else if delta > soft_duration_limit(input)
-            && !(delta_secs.is_some_and(|signed| signed > 0)
-                && is_official_video_presentation(cand)
-                && delta <= official_video_runtime_limit(input))
-        {
+        } else if delta > soft_duration_limit(input) && !official_runtime_exempt {
             gate.accept_blocked = true;
             gate.reasons.push("duration_mismatch");
         } else if delta > soft_duration_limit(input) {

--- a/src/transfer/matching/identity.rs
+++ b/src/transfer/matching/identity.rs
@@ -84,11 +84,16 @@ pub(super) enum EvidenceField {
     ExplicitMetadata,
 }
 
+/// Confidence tiers for [`VersionEvidence::confidence`].
+pub(super) const EVIDENCE_EXPLICIT: u8 = 100;
+pub(super) const EVIDENCE_STRONG_PHRASE: u8 = 70;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct VersionEvidence {
     pub marker: &'static str,
     pub field: EvidenceField,
-    /// 100 = explicit structured/annotation evidence, 70 = strong phrase, lower values
+    /// [`EVIDENCE_EXPLICIT`] = explicit structured/annotation evidence,
+    /// [`EVIDENCE_STRONG_PHRASE`] = strong phrase, lower values
     /// are corroboration only and must not independently reject a candidate.
     pub confidence: u8,
 }
@@ -141,7 +146,7 @@ pub(super) fn parse_version_profile(
                 "clean_metadata"
             },
             field: EvidenceField::ExplicitMetadata,
-            confidence: 100,
+            confidence: EVIDENCE_EXPLICIT,
         });
     }
 
@@ -281,28 +286,28 @@ fn parse_title_markers(title: &TitleContext, profile: &mut VersionProfile) {
         "伴奏",
     ]) {
         profile.vocal = VocalKind::Instrumental;
-        push_evidence(profile, "instrumental", field, 100);
+        push_evidence(profile, "instrumental", field, EVIDENCE_EXPLICIT);
     } else if let Some(field) = title.version_context("inst") {
         // `inst` is intentionally annotation/suffix-only so `Instinct` and artists
         // containing those letters never trigger it.
         profile.vocal = VocalKind::Instrumental;
-        push_evidence(profile, "instrumental", field, 100);
+        push_evidence(profile, "instrumental", field, EVIDENCE_EXPLICIT);
     }
     if let Some(field) = first_context(&["karaoke", "노래방", "カラオケ"]) {
         profile.vocal = VocalKind::Karaoke;
-        push_evidence(profile, "karaoke", field, 100);
+        push_evidence(profile, "karaoke", field, EVIDENCE_EXPLICIT);
     }
     if let Some(field) = first_context(&["backing track", "accompaniment", "mr version"]) {
         profile.vocal = VocalKind::BackingTrack;
-        push_evidence(profile, "backing_track", field, 100);
+        push_evidence(profile, "backing_track", field, EVIDENCE_EXPLICIT);
     }
     if let Some(field) = first_context(&["acapella", "a cappella"]) {
         profile.vocal = VocalKind::Acapella;
-        push_evidence(profile, "acapella", field, 100);
+        push_evidence(profile, "acapella", field, EVIDENCE_EXPLICIT);
     }
     if let Some(field) = first_context(&["vocal removed", "vocal remover", "no vocals"]) {
         profile.vocal = VocalKind::VocalRemoved;
-        push_evidence(profile, "vocal_removed", field, 100);
+        push_evidence(profile, "vocal_removed", field, EVIDENCE_EXPLICIT);
     }
 
     // A lone "live" is only a recording marker in annotation/suffix form. Longer
@@ -314,61 +319,68 @@ fn parse_title_markers(title: &TitleContext, profile: &mut VersionProfile) {
     });
     if let Some(field) = live_field {
         profile.performance = PerformanceKind::Live;
-        push_evidence(profile, "live", field, 100);
+        push_evidence(profile, "live", field, EVIDENCE_EXPLICIT);
     }
     if let Some(field) = first_context(&["acoustic", "어쿠스틱", "アコースティック"]) {
         profile.performance = PerformanceKind::Acoustic;
-        push_evidence(profile, "acoustic", field, 100);
+        push_evidence(profile, "acoustic", field, EVIDENCE_EXPLICIT);
     }
     if let Some(field) = title.version_context("demo") {
         profile.performance = PerformanceKind::Demo;
-        push_evidence(profile, "demo", field, 100);
+        push_evidence(profile, "demo", field, EVIDENCE_EXPLICIT);
     }
     if let Some(field) = first_context(&["rehearsal", "practice recording"]) {
         profile.performance = PerformanceKind::Rehearsal;
-        push_evidence(profile, "rehearsal", field, 100);
+        push_evidence(profile, "rehearsal", field, EVIDENCE_EXPLICIT);
     }
 
+    // Mix markers form one exclusive chain, most specific first, so a compound marker such as
+    // "slowed reverb" is never filed under its plain prefix further down.
     if let Some(field) = first_context(&["slowed reverb", "slowed and reverb"]) {
         profile.mix = MixKind::SlowedReverb;
-        push_evidence(profile, "slowed_reverb", field, 100);
+        push_evidence(profile, "slowed_reverb", field, EVIDENCE_EXPLICIT);
     } else if title.raw_lower.contains("slowed + reverb")
         || title.raw_lower.contains("slowed+reverb")
     {
         profile.mix = MixKind::SlowedReverb;
-        push_evidence(profile, "slowed_reverb", EvidenceField::TitlePhrase, 100);
+        push_evidence(
+            profile,
+            "slowed_reverb",
+            EvidenceField::TitlePhrase,
+            EVIDENCE_EXPLICIT,
+        );
     } else if let Some(field) = first_context(&["sped up", "speed up", "spedup"]) {
         profile.mix = MixKind::SpedUp;
-        push_evidence(profile, "sped_up", field, 100);
+        push_evidence(profile, "sped_up", field, EVIDENCE_EXPLICIT);
     } else if let Some(field) = first_context(&["nightcore"]) {
         profile.mix = MixKind::Nightcore;
-        push_evidence(profile, "nightcore", field, 100);
+        push_evidence(profile, "nightcore", field, EVIDENCE_EXPLICIT);
     } else if let Some(field) = first_context(&["8d audio", "8d version"]) {
         profile.mix = MixKind::EightD;
-        push_evidence(profile, "8d", field, 100);
+        push_evidence(profile, "8d", field, EVIDENCE_EXPLICIT);
     } else if let Some(field) = title.version_context("8d") {
         profile.mix = MixKind::EightD;
-        push_evidence(profile, "8d", field, 100);
+        push_evidence(profile, "8d", field, EVIDENCE_EXPLICIT);
     } else if let Some(field) = first_context(&["bass boosted", "bass boost"]) {
         profile.mix = MixKind::BassBoosted;
-        push_evidence(profile, "bass_boosted", field, 100);
+        push_evidence(profile, "bass_boosted", field, EVIDENCE_EXPLICIT);
     } else if let Some(field) = title.version_context("lofi") {
         profile.mix = MixKind::Lofi;
-        push_evidence(profile, "lofi", field, 100);
+        push_evidence(profile, "lofi", field, EVIDENCE_EXPLICIT);
     } else if let Some(field) = title.version_context("slowed") {
         profile.mix = MixKind::Slowed;
-        push_evidence(profile, "slowed", field, 100);
+        push_evidence(profile, "slowed", field, EVIDENCE_EXPLICIT);
     } else if let Some(field) = first_context(&["radio edit", "radio version"]) {
         profile.mix = MixKind::RadioEdit;
         profile.edition.radio_edit = true;
-        push_evidence(profile, "radio_edit", field, 100);
+        push_evidence(profile, "radio_edit", field, EVIDENCE_EXPLICIT);
     } else if let Some(field) = first_context(&["extended mix", "extended version"]) {
         profile.mix = MixKind::Extended;
         profile.edition.extended = true;
-        push_evidence(profile, "extended", field, 100);
+        push_evidence(profile, "extended", field, EVIDENCE_EXPLICIT);
     } else if let Some(field) = first_context(&["remix", "리믹스", "リミックス"]) {
         profile.mix = MixKind::Remix;
-        push_evidence(profile, "remix", field, 100);
+        push_evidence(profile, "remix", field, EVIDENCE_EXPLICIT);
     }
 
     let cover_field = ["covered by", "cover by", "tribute to", "ai cover"]
@@ -383,27 +395,37 @@ fn parse_title_markers(title: &TitleContext, profile: &mut VersionProfile) {
         } else {
             AuthorshipKind::Cover
         };
-        push_evidence(profile, "cover", field, 100);
+        push_evidence(profile, "cover", field, EVIDENCE_EXPLICIT);
     } else if title.raw_lower.contains("歌ってみた") || title.raw_lower.contains("커버") {
         profile.authorship = AuthorshipKind::Cover;
-        push_evidence(profile, "cover", EvidenceField::TitlePhrase, 100);
+        push_evidence(
+            profile,
+            "cover",
+            EvidenceField::TitlePhrase,
+            EVIDENCE_EXPLICIT,
+        );
     }
 
     if title.raw_lower.contains("taylor's version") || title.raw_lower.contains("taylors version") {
         profile.edition.taylor_version = true;
-        push_evidence(profile, "taylor_version", EvidenceField::TitlePhrase, 100);
+        push_evidence(
+            profile,
+            "taylor_version",
+            EvidenceField::TitlePhrase,
+            EVIDENCE_EXPLICIT,
+        );
     }
     if let Some(field) = first_context(&["mono"]) {
         profile.edition.stereo = StereoKind::Mono;
-        push_evidence(profile, "mono", field, 100);
+        push_evidence(profile, "mono", field, EVIDENCE_EXPLICIT);
     } else if let Some(field) = first_context(&["stereo"]) {
         profile.edition.stereo = StereoKind::Stereo;
-        push_evidence(profile, "stereo", field, 100);
+        push_evidence(profile, "stereo", field, EVIDENCE_EXPLICIT);
     }
     if let Some((year, field)) = remaster_marker(title) {
         profile.edition.remastered = true;
         profile.edition.remaster_year = year;
-        push_evidence(profile, "remaster", field, 100);
+        push_evidence(profile, "remaster", field, EVIDENCE_EXPLICIT);
     }
     if first_context(&[
         "deluxe edition",
@@ -425,16 +447,26 @@ fn parse_title_markers(title: &TitleContext, profile: &mut VersionProfile) {
     ] {
         if let Some(field) = title.unambiguous_phrase(marker) {
             profile.edition.language_version = Some(language.to_owned());
-            push_evidence(profile, "language_version", field, 100);
+            push_evidence(profile, "language_version", field, EVIDENCE_EXPLICIT);
             break;
         }
     }
     if title.version_context("clean").is_some() || title.phrase("clean version") {
         profile.explicit = Some(false);
-        push_evidence(profile, "clean_title", EvidenceField::TitlePhrase, 70);
+        push_evidence(
+            profile,
+            "clean_title",
+            EvidenceField::TitlePhrase,
+            EVIDENCE_STRONG_PHRASE,
+        );
     } else if title.version_context("explicit").is_some() || title.phrase("explicit version") {
         profile.explicit = Some(true);
-        push_evidence(profile, "explicit_title", EvidenceField::TitlePhrase, 70);
+        push_evidence(
+            profile,
+            "explicit_title",
+            EvidenceField::TitlePhrase,
+            EVIDENCE_STRONG_PHRASE,
+        );
     }
 }
 
@@ -447,7 +479,7 @@ fn parse_supporting_markers(text: &str, field: EvidenceField, profile: &mut Vers
         if profile.authorship == AuthorshipKind::OriginalOrUnknown {
             profile.authorship = AuthorshipKind::Cover;
         }
-        push_evidence(profile, "cover_support", field, 70);
+        push_evidence(profile, "cover_support", field, EVIDENCE_STRONG_PHRASE);
     }
     if contains_phrase(&normalized, "karaoke") {
         profile.vocal = VocalKind::Karaoke;

--- a/src/transfer/organize_plan.rs
+++ b/src/transfer/organize_plan.rs
@@ -380,6 +380,10 @@ fn format_disc_track(disc: Option<u32>, track: Option<u32>) -> String {
     }
 }
 
+/// Make one metadata-derived path component safe to place under the organize root:
+/// separators, Windows-reserved characters and control characters become `_`, repeated
+/// spaces collapse, `..` runs collapse so a tag value can never climb out of its directory,
+/// and leading/trailing dots and spaces are trimmed because Windows rejects them.
 fn sanitize_component(raw: &str) -> String {
     let mut out = String::new();
     for ch in raw.trim().chars() {

--- a/src/transfer/review_action.rs
+++ b/src/transfer/review_action.rs
@@ -41,11 +41,11 @@ pub struct ReviewReadyPlan {
 }
 
 #[derive(Debug, Clone)]
-struct SelectedCandidate {
-    key: String,
-    score: f32,
-    display: String,
-    score_breakdown: Option<MatchScoreBreakdown>,
+pub(super) struct SelectedCandidate {
+    pub(super) key: String,
+    pub(super) score: f32,
+    pub(super) display: String,
+    pub(super) score_breakdown: Option<MatchScoreBreakdown>,
 }
 
 pub fn accept_first_candidate(
@@ -272,7 +272,7 @@ fn row_order_to_index(cp: &Checkpoint, source_order: u32) -> anyhow::Result<usiz
     Ok(index)
 }
 
-fn ensure_not_written(cp: &Checkpoint, index: usize) -> anyhow::Result<()> {
+pub(super) fn ensure_not_written(cp: &Checkpoint, index: usize) -> anyhow::Result<()> {
     let entry = cp
         .tracks
         .get(index)
@@ -286,7 +286,7 @@ fn ensure_not_written(cp: &Checkpoint, index: usize) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn candidates_from_outcome(outcome: &Option<MatchOutcome>) -> Vec<SelectedCandidate> {
+pub(super) fn candidates_from_outcome(outcome: &Option<MatchOutcome>) -> Vec<SelectedCandidate> {
     match outcome {
         Some(MatchOutcome::Matched {
             key,

--- a/src/transfer/review_cli.rs
+++ b/src/transfer/review_cli.rs
@@ -1,10 +1,11 @@
 //! CLI review actions for persisted import sessions.
 
-use anyhow::{anyhow, bail};
-
 use super::checkpoint::{Checkpoint, ReviewDecision};
 use super::cli::{EXIT_FAILED, EXIT_OK, EXIT_USAGE};
 use super::matching::{MatchOutcome, MatchScoreBreakdown};
+use super::review_action::{
+    SelectedCandidate, candidates_from_outcome, ensure_not_written, ensure_review_candidate_allowed,
+};
 use super::session::{
     ImportRecordGuard, ImportSession, ImportSessionRow, ImportSessionRowStatus,
     ensure_review_row_mutable_unlocked,
@@ -333,14 +334,6 @@ fn row_decision_label(decision: Option<&ReviewDecision>) -> &'static str {
     }
 }
 
-#[derive(Debug, Clone)]
-struct SelectedCandidate {
-    key: String,
-    score: f32,
-    display: String,
-    score_breakdown: Option<MatchScoreBreakdown>,
-}
-
 fn selected_candidate(
     outcome: &Option<MatchOutcome>,
     selector: Option<&str>,
@@ -361,33 +354,6 @@ fn selected_candidate(
         let label = selector.unwrap_or("first candidate");
         format!("candidate `{label}` was not found on that row")
     })
-}
-
-fn candidates_from_outcome(outcome: &Option<MatchOutcome>) -> Vec<SelectedCandidate> {
-    match outcome {
-        Some(MatchOutcome::Matched {
-            key,
-            score,
-            display,
-            score_breakdown,
-            ..
-        }) => vec![SelectedCandidate {
-            key: key.clone(),
-            score: *score,
-            display: display.clone(),
-            score_breakdown: score_breakdown.as_deref().cloned(),
-        }],
-        Some(MatchOutcome::Ambiguous { candidates }) => candidates
-            .iter()
-            .map(|candidate| SelectedCandidate {
-                key: candidate.key.clone(),
-                score: candidate.score,
-                display: candidate.display.clone(),
-                score_breakdown: candidate.score_breakdown.clone(),
-            })
-            .collect(),
-        _ => Vec::new(),
-    }
 }
 
 fn resolve_row_index(cp: &Checkpoint, row_ref: &str) -> Result<usize, String> {
@@ -419,10 +385,7 @@ fn apply_accept(
     selected: SelectedCandidate,
 ) -> anyhow::Result<String> {
     ensure_not_written(cp, index)?;
-    super::review_action::ensure_review_candidate_allowed(
-        &cp.spec,
-        selected.score_breakdown.as_ref(),
-    )?;
+    ensure_review_candidate_allowed(&cp.spec, selected.score_breakdown.as_ref())?;
     cp.tracks[index].outcome = Some(MatchOutcome::Matched {
         key: selected.key.clone(),
         score: selected.score,
@@ -458,20 +421,6 @@ fn apply_terminal_decision(
         decision.label().to_ascii_uppercase(),
         index + 1
     ))
-}
-
-fn ensure_not_written(cp: &Checkpoint, index: usize) -> anyhow::Result<()> {
-    let entry = cp
-        .tracks
-        .get(index)
-        .ok_or_else(|| anyhow!("row {} is out of range", index + 1))?;
-    if entry.written {
-        bail!(
-            "row {} is already written; review cannot change it",
-            index + 1
-        );
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/ui/control_box.rs
+++ b/src/ui/control_box.rs
@@ -381,7 +381,7 @@ fn without_optional_why_gem(mut parts: StatusLineParts) -> StatusLineParts {
     parts
 }
 
-/// Build the transport status-line as `(target, text)` segments from app state — split out
+/// Build the transport status-line as `(target, text)` segments from app state, kept apart
 /// from [`render_status_line`] so the conditional assembly (queue position, rating, shuffle /
 /// repeat, speed, EQ, streaming mode, download tag) is unit-testable without a frame
 /// buffer. A `None` target is a static label/spacing; spacing is its own label so a clickable
@@ -459,7 +459,10 @@ pub(in crate::ui) fn render_controls(frame: &mut Frame, app: &App, area: Rect, a
     let beginner_buttons = app
         .beginner_labels_enabled()
         .then(|| beginner::volume_buttons(app));
-    let tight_transport_width = 13u16;
+    // The transport strip is three 3-cell glyph buttons plus the two gaps between them and
+    // the gap before the volume cluster: 9 + 1 + 1 + 2 tight, 9 + 3 + 3 + 6 roomy.
+    const TIGHT_TRANSPORT_WIDTH: u16 = 13;
+    const ROOMY_TRANSPORT_WIDTH: u16 = 21;
     let cluster_width = |label: &str, down: &str, up: &str| {
         buttons::text_width(label)
             .saturating_add(buttons::text_width(down))
@@ -467,7 +470,7 @@ pub(in crate::ui) fn render_controls(frame: &mut Frame, app: &App, area: Rect, a
             .saturating_add(buttons::text_width(up))
     };
     let fits_tight = |label: &str, down: &str, up: &str| {
-        tight_transport_width.saturating_add(cluster_width(label, down, up)) <= area.width
+        TIGHT_TRANSPORT_WIDTH.saturating_add(cluster_width(label, down, up)) <= area.width
     };
     let (volume_label, volume_down, volume_up) = match beginner_buttons.as_ref() {
         Some((down, up)) if fits_tight(beginner_volume_label, down, up) => {
@@ -478,7 +481,8 @@ pub(in crate::ui) fn render_controls(frame: &mut Frame, app: &App, area: Rect, a
         }
         _ => (compact_volume_label, plain_down, plain_up),
     };
-    let full = 21u16.saturating_add(cluster_width(volume_label, volume_down, volume_up));
+    let full =
+        ROOMY_TRANSPORT_WIDTH.saturating_add(cluster_width(volume_label, volume_down, volume_up));
     let (gap, vol_gap) = if full <= area.width {
         ("   ", "      ")
     } else {

--- a/src/ui/views/ai.rs
+++ b/src/ui/views/ai.rs
@@ -490,7 +490,7 @@ fn fixture_messages_match(cached: &TranscriptCache, app: &App) -> bool {
 
 /// Wrap one styled message under its role tag. The tag renders as a reversed-video chip
 /// (its trailing padding stays plain) so who-said-what reads at a glance; continuation
-/// lines hang-indent under the message body exactly as before.
+/// lines hang-indent under the message body.
 fn push_wrapped_styled(
     out: &mut Vec<TranscriptLine>,
     prefix: &str,

--- a/src/ui/views/library.rs
+++ b/src/ui/views/library.rs
@@ -325,6 +325,10 @@ fn render_list(
             .library_scroll
             .resolve(cursor, area.height, len, crate::ui::scroll::SCROLLOFF);
 
+    // Two always-rendered 2-cell prefixes ("▶ " / "♥ ") so text never shifts as the cursor
+    // or favourite state changes, plus one trailing blank cell of breathing room.
+    const ROW_GUTTER: usize = 4;
+    const ROW_RIGHT_MARGIN: usize = 1;
     let body_w = area.width.saturating_sub(del_w) as usize;
     let render_rows = app.library_render_window(start, visible);
     for (vis, song) in render_rows.into_iter().enumerate() {
@@ -341,23 +345,22 @@ fn render_list(
             "  "
         };
         let text = app.library_row_text_at(i, song);
-        // The cursor row marquees when clipped (the 4-cell marker+heart gutter stays
-        // put) so the full text stays readable even in a sliver-narrow window; every
-        // other row hard-truncates as before.
+        // The cursor row marquees when clipped (the gutter stays put) so the full text stays
+        // readable even in a sliver-narrow window; every other row hard-truncates.
         let text = if i == cursor {
             std::borrow::Cow::Owned(crate::ui::anim::selected_marquee(
                 app,
                 ScrollSurface::Library,
                 i,
                 &text,
-                body_w.saturating_sub(5),
+                body_w.saturating_sub(ROW_GUTTER + ROW_RIGHT_MARGIN),
             ))
         } else {
             std::borrow::Cow::Borrowed(text.as_ref())
         };
         let body = crate::ui::text::truncate_owned_to_width(
             format!("{marker}{heart}{text}"),
-            body_w.saturating_sub(1),
+            body_w.saturating_sub(ROW_RIGHT_MARGIN),
         );
 
         let base = if selected {


### PR DESCRIPTION
## Summary
Readability/comment cleanup across 35 files plus one real fix split into its own commit.

- **fix(player)**: dynamic mpv `request_id` seed was 19 while the observe table already used id 20 (`chapter-list`), so the first dynamic command collided with the observe entry in the pending table. Seed now derives from the table's max id.
- **refactor**: remove change-history narration / banners / `origin/main` references (restated as the invariants they guarded); fix docs that no longer matched code; explain unexplained invariants (import-inbox threat model + caps, rows-cache sentinel, eviction order, gate dedup ordering, daemon-side replay markers); name magic numbers (match-score weights, evidence tiers, transport widths, stage-tag length, queue cap, export schema default); drop an unreachable search arm and an empty `if` branch; share review helpers between CLI and `review_action`.

**One intentional rendered change**: Japanese status text when cycling *Streaming source* in Settings now uses the shared field label (おすすめソース) instead of a drifted inline literal (ストリーミングソース).

## Verification
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`: green
- `cargo test --workspace`: 4665/4665 (one earlier run flaked on `sync::service::persistence::tests::actor_coalescing_rolls_forward_evicted_local_snapshot_before_sync`; passes 3/3 isolated and on full re-run — untouched file, parallel-suite flake)
- `check-file-size` / `check-doc-honesty` / `check-architecture` / `check-unsafe-inventory`: green
- Adversarial review: Go-with-fixes → all 7 findings applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
