### PR TITLE
refactor: readability pass 2 — extract duplicated blocks (re-land on main)

### DIFF
--- a/src/app/context_menu.rs
+++ b/src/app/context_menu.rs
@@ -309,33 +309,12 @@ impl App {
     /// Whether another modal owns input. The queue and search-filter popups are deliberately
     /// excluded: their semantic rows are valid context-menu targets.
     fn context_menu_blocked(&self) -> bool {
-        self.personal_state.sync_ui.modal_open()
+        self.blocking_modal_open()
+            || self.personal_state.sync_ui.modal_open()
             || self.server.settings.modal_open()
-            || self.server.library.playlist_preview.is_some()
-            || self.server.library.playlist_create.is_some()
-            || self.server.library.playlist_recovery.is_some()
-            || self.overlays.help_visible
-            || self.overlays.mouse_help_visible
-            || self.overlays.about_visible
-            || self.overlays.why_gem_video_id.is_some()
             || self.overlays.now_playing_overlay.is_some()
-            || self.overlays.key_conflict.is_some()
-            || self.overlays.pending_settings_confirm.is_some()
-            || self.overlays.spotify_picker.is_some()
             || self.overlays.audio_output_picker.is_some()
-            || self.overlays.recordings_browser.is_some()
-            || self.overlays.recording_settings.is_some()
-            || self.radio_mode.pending_radio_mode_confirm.is_some()
-            || self.local_mode.pending_confirm.is_some()
-            || self.local_mode.find.pending_bulk_confirm.is_some()
-            || self.local_mode.find.pending_rebuild_confirm
-            || self.local_mode.find.refine_popup.open
-            || self.local_import_confirmation_open()
-            || self.library_ui.confirm_delete.is_some()
             || self.library_ui.confirm_download.is_some()
-            || self.library_ui.confirm_playlist_delete.is_some()
-            || self.library_ui.create_input.is_some()
-            || self.playlist_picker.is_some()
             || self.dropdowns.eq_open
             || self.dropdowns.streaming_open
             || self.dropdowns.search_source_open

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -140,29 +140,11 @@ impl App {
             self.dirty = true;
             return Vec::new();
         }
-        // Modal overlays treat a double-click like a single click.
-        if self.overlays.help_visible
-            || self.overlays.context_menu.is_some()
-            || self.overlays.mouse_help_visible
-            || self.overlays.about_visible
-            || self.overlays.why_gem_video_id.is_some()
-            || self.overlays.key_conflict.is_some()
-            || self.radio_mode.pending_radio_mode_confirm.is_some()
-            || self.local_mode.pending_confirm.is_some()
-            || self.local_mode.find.pending_bulk_confirm.is_some()
-            || self.local_mode.find.pending_rebuild_confirm
-            || self.local_mode.find.refine_popup.open
-            || self.local_import_confirmation_open()
-            || self.overlays.pending_settings_confirm.is_some()
-            || self.server.library.playlist_modal_open()
-            || self.library_ui.confirm_delete.is_some()
-            || self.library_ui.confirm_playlist_delete.is_some()
-            || self.library_ui.create_input.is_some()
-            || self.playlist_picker.is_some()
-            || self.overlays.spotify_picker.is_some()
-            || self.overlays.recordings_browser.is_some()
-            || self.overlays.recording_settings.is_some()
-        {
+        // Modal overlays treat a double-click like a single click. The sync/settings wizards
+        // are swallowed in the reducer dispatcher and the audio-output picker is routed above;
+        // of the extra surfaces `context_menu_blocked` lists, only the dropdowns, download
+        // confirm and now-playing overlay fall through here.
+        if self.overlays.context_menu.is_some() || self.blocking_modal_open() {
             return self.on_mouse_click(col, row, false);
         }
         // Double-clicking a filter-popup row plays it (the mouse Enter), mirroring the

--- a/src/app/mouse_routing.rs
+++ b/src/app/mouse_routing.rs
@@ -3,6 +3,31 @@
 use super::*;
 
 impl App {
+    /// Overlays that own pointer input on every surface. Callers add the surfaces they must
+    /// additionally treat as modal; register a new overlay here so no caller drifts.
+    pub(in crate::app) fn blocking_modal_open(&self) -> bool {
+        self.overlays.help_visible
+            || self.overlays.mouse_help_visible
+            || self.overlays.about_visible
+            || self.overlays.why_gem_video_id.is_some()
+            || self.overlays.key_conflict.is_some()
+            || self.overlays.pending_settings_confirm.is_some()
+            || self.overlays.spotify_picker.is_some()
+            || self.overlays.recordings_browser.is_some()
+            || self.overlays.recording_settings.is_some()
+            || self.radio_mode.pending_radio_mode_confirm.is_some()
+            || self.local_mode.pending_confirm.is_some()
+            || self.local_mode.find.pending_bulk_confirm.is_some()
+            || self.local_mode.find.pending_rebuild_confirm
+            || self.local_mode.find.refine_popup.open
+            || self.local_import_confirmation_open()
+            || self.server.library.playlist_modal_open()
+            || self.library_ui.confirm_delete.is_some()
+            || self.library_ui.confirm_playlist_delete.is_some()
+            || self.library_ui.create_input.is_some()
+            || self.playlist_picker.is_some()
+    }
+
     pub(in crate::app) fn route_mouse_click(
         &mut self,
         col: u16,

--- a/src/player/ipc/incoming.rs
+++ b/src/player/ipc/incoming.rs
@@ -254,6 +254,34 @@ fn forward_time_pos(emit: &EventSink, state: &mut DispatchState, position: f64) 
     }
 }
 
+/// Forward `demuxer-cache-time`, deduplicated to whole seconds like time-pos. Unlike time-pos,
+/// a null is a signal the reducer needs — the property became unavailable (stream teardown,
+/// cache-less demuxer) — so it is forwarded once as `CacheTime(None)`.
+fn observe_cache_time(
+    emit: &EventSink,
+    state: &mut DispatchState,
+    name: &str,
+    value: Option<f64>,
+) {
+    match value {
+        Some(t) => {
+            let t = crate::playback_policy::norm_position(t);
+            let sec = t as i64;
+            if state.last_sent_cache_sec != Some(sec) {
+                state.last_sent_cache_sec = Some(sec);
+                emit_file_event(emit, state, PlayerEvent::CacheTime(Some(t)));
+                record_numeric_forward(state, name);
+            }
+        }
+        None => {
+            if state.last_sent_cache_sec.take().is_some() {
+                emit_file_event(emit, state, PlayerEvent::CacheTime(None));
+                record_numeric_forward(state, name);
+            }
+        }
+    }
+}
+
 fn emit_file_event(emit: &EventSink, state: &mut DispatchState, event: PlayerEvent) {
     if let Some(generation) = state.active_file_generation {
         emit(PlayerEvent::file_scoped(generation, event));
@@ -665,23 +693,7 @@ fn dispatch_incoming(line: &str, emit: &EventSink, state: &mut DispatchState) {
             }
             "demuxer-cache-time" => {
                 record_numeric_input(state, property.name, true);
-                match property.data {
-                    Some(t) => {
-                        let t = crate::playback_policy::norm_position(t);
-                        let sec = t as i64;
-                        if state.last_sent_cache_sec != Some(sec) {
-                            state.last_sent_cache_sec = Some(sec);
-                            emit_file_event(emit, state, PlayerEvent::CacheTime(Some(t)));
-                            record_numeric_forward(state, property.name);
-                        }
-                    }
-                    None => {
-                        if state.last_sent_cache_sec.take().is_some() {
-                            emit_file_event(emit, state, PlayerEvent::CacheTime(None));
-                            record_numeric_forward(state, property.name);
-                        }
-                    }
-                }
+                observe_cache_time(emit, state, property.name, property.data);
                 return;
             }
             _ => {}
@@ -814,28 +826,10 @@ fn dispatch_incoming(line: &str, emit: &EventSink, state: &mut DispatchState) {
                     emit_file_event(emit, state, PlayerEvent::Eof);
                 }
             }
-            "demuxer-cache-time" => match value.as_f64() {
-                // High-rate like time-pos → dedup to whole seconds.
-                Some(t) => {
-                    record_numeric_input(state, &name, false);
-                    let t = crate::playback_policy::norm_position(t);
-                    let sec = t as i64;
-                    if state.last_sent_cache_sec != Some(sec) {
-                        state.last_sent_cache_sec = Some(sec);
-                        emit_file_event(emit, state, PlayerEvent::CacheTime(Some(t)));
-                        record_numeric_forward(state, &name);
-                    }
-                }
-                // Unlike time-pos, a null here is a signal the reducer needs: the
-                // property became unavailable (stream teardown, cache-less demuxer).
-                None => {
-                    record_numeric_input(state, &name, false);
-                    if state.last_sent_cache_sec.take().is_some() {
-                        emit_file_event(emit, state, PlayerEvent::CacheTime(None));
-                        record_numeric_forward(state, &name);
-                    }
-                }
-            },
+            "demuxer-cache-time" => {
+                record_numeric_input(state, &name, false);
+                observe_cache_time(emit, state, &name, value.as_f64());
+            }
             _ => {}
         },
         MpvIncoming::StartFile { playlist_entry_id } => {

--- a/src/remote/sessions.rs
+++ b/src/remote/sessions.rs
@@ -984,6 +984,12 @@ pub(crate) async fn run_session(
             page_id,
             op,
         } = frame;
+        let reply_err = |reason: &str| {
+            Some(ServerFrame::Reply {
+                id: frame_id,
+                resp: RemoteResponse::err(reason),
+            })
+        };
         let reply = match op {
             // Pings never touch the owner loop: answered right here.
             ClientOp::Ping => Some(ServerFrame::Pong { id: frame_id }),
@@ -996,15 +1002,9 @@ pub(crate) async fn run_session(
                     .as_deref()
                     .is_some_and(|page_id| !super::requests::valid_page_id(page_id))
                 {
-                    Some(ServerFrame::Reply {
-                        id: frame_id,
-                        resp: RemoteResponse::err("bad_page_id"),
-                    })
+                    reply_err("bad_page_id")
                 } else if topics.len() > REMOTE_MAX_TOPICS {
-                    Some(ServerFrame::Reply {
-                        id: frame_id,
-                        resp: RemoteResponse::err("too_many_topics"),
-                    })
+                    reply_err("too_many_topics")
                 } else {
                     let session = RemoteSessionRef {
                         session_id,
@@ -1023,18 +1023,9 @@ pub(crate) async fn run_session(
                         })
                     }) {
                         SubscribeIngress::Accepted => None,
-                        SubscribeIngress::Busy => Some(ServerFrame::Reply {
-                            id: frame_id,
-                            resp: RemoteResponse::err("server_busy"),
-                        }),
-                        SubscribeIngress::StalePage => Some(ServerFrame::Reply {
-                            id: frame_id,
-                            resp: RemoteResponse::err("stale_page"),
-                        }),
-                        SubscribeIngress::ShuttingDown => Some(ServerFrame::Reply {
-                            id: frame_id,
-                            resp: RemoteResponse::err("shutting_down"),
-                        }),
+                        SubscribeIngress::Busy => reply_err("server_busy"),
+                        SubscribeIngress::StalePage => reply_err("stale_page"),
+                        SubscribeIngress::ShuttingDown => reply_err("shutting_down"),
                     }
                 }
             }
@@ -1043,15 +1034,9 @@ pub(crate) async fn run_session(
                     .as_deref()
                     .is_some_and(|page_id| !super::requests::valid_page_id(page_id))
                 {
-                    Some(ServerFrame::Reply {
-                        id: frame_id,
-                        resp: RemoteResponse::err("bad_page_id"),
-                    })
+                    reply_err("bad_page_id")
                 } else if topics.len() > REMOTE_MAX_TOPICS {
-                    Some(ServerFrame::Reply {
-                        id: frame_id,
-                        resp: RemoteResponse::err("too_many_topics"),
-                    })
+                    reply_err("too_many_topics")
                 } else {
                     let session = RemoteSessionRef {
                         session_id,
@@ -1063,10 +1048,7 @@ pub(crate) async fn run_session(
                             resp: RemoteResponse::ok("unsubscribed".to_string()),
                         })
                     } else {
-                        Some(ServerFrame::Reply {
-                            id: frame_id,
-                            resp: RemoteResponse::err("stale_page"),
-                        })
+                        reply_err("stale_page")
                     }
                 }
             }
@@ -1075,20 +1057,11 @@ pub(crate) async fn run_session(
                     .as_deref()
                     .is_some_and(|page_id| !super::requests::valid_page_id(page_id))
                 {
-                    Some(ServerFrame::Reply {
-                        id: frame_id,
-                        resp: RemoteResponse::err("bad_page_id"),
-                    })
+                    reply_err("bad_page_id")
                 } else if !handle.page_is_current(page_id.as_deref()) {
-                    Some(ServerFrame::Reply {
-                        id: frame_id,
-                        resp: RemoteResponse::err("stale_page"),
-                    })
+                    reply_err("stale_page")
                 } else if let Err(err) = command.validate() {
-                    Some(ServerFrame::Reply {
-                        id: frame_id,
-                        resp: RemoteResponse::err(err.reason()),
-                    })
+                    reply_err(err.reason())
                 } else {
                     let origin = RemoteSessionScope::new(
                         RemoteSessionRef {

--- a/src/terminal_runtime/runner.rs
+++ b/src/terminal_runtime/runner.rs
@@ -461,16 +461,9 @@ pub async fn run(
     }
     let mut perf = PerfStats::from_env();
     if let Err(error) = draw_app_frame(terminal, &mut app, &mut perf, None) {
-        if shutdown.is_triggered() {
-            return finish_interrupted_startup(&app, &persist, None).await;
-        }
-        let owner_error = anyhow::Error::from(error);
-        return match flush_owner_persistence(&app, &persist).await {
-            Ok(()) => Err(owner_error),
-            Err(persistence_error) => Err(owner_error.context(format!(
-                "persistence shutdown also failed: {persistence_error:#}"
-            ))),
-        };
+        // A draw failure during an already-requested shutdown is not the owner error.
+        let error = (!shutdown.is_triggered()).then_some(error);
+        return finish_interrupted_startup(&app, &persist, error).await;
     }
     startup.mark("first_draw");
     if shutdown.is_triggered() {
@@ -489,16 +482,8 @@ pub async fn run(
         match terminal_events::start(shutdown.clone()) {
             Ok(source) => source,
             Err(error) => {
-                if shutdown.was_triggered_by_signal() {
-                    return finish_interrupted_startup(&app, &persist, None).await;
-                }
-                let owner_error = anyhow::Error::from(error);
-                return match flush_owner_persistence(&app, &persist).await {
-                    Ok(()) => Err(owner_error),
-                    Err(persistence_error) => Err(owner_error.context(format!(
-                        "persistence shutdown also failed: {persistence_error:#}"
-                    ))),
-                };
+                let error = (!shutdown.was_triggered_by_signal()).then_some(error);
+                return finish_interrupted_startup(&app, &persist, error).await;
             }
         };
     startup.mark("terminal_liveness_ready");
@@ -904,13 +889,11 @@ pub async fn run(
         Worker(RuntimeEvent),
     }
 
-    'owner: while !app.should_quit {
-        if shutdown.is_triggered() {
-            handles.begin_player_shutdown(&mut app);
-            break;
-        }
-        if app.dirty {
-            let Some(_drew) = capture_owner_io_result(
+    // Draw the full frame; a terminal write failure records the first owner error and leaves
+    // the loop so teardown can restore the terminal.
+    macro_rules! draw_or_break {
+        ($label:lifetime) => {
+            if capture_owner_io_result(
                 terminal_output.run_io(|deadline| {
                     draw_full_app_frame(
                         terminal,
@@ -921,9 +904,21 @@ pub async fn run(
                     )
                 }),
                 &mut owner_error,
-            ) else {
-                break 'owner;
-            };
+            )
+            .is_none()
+            {
+                break $label;
+            }
+        };
+    }
+
+    'owner: while !app.should_quit {
+        if shutdown.is_triggered() {
+            handles.begin_player_shutdown(&mut app);
+            break;
+        }
+        if app.dirty {
+            draw_or_break!('owner);
             perf.maybe_log(&app);
             if app.dirty {
                 continue;
@@ -1025,20 +1020,7 @@ pub async fn run(
                     handles.handle_player_ready(result, &mut app);
                     reducer_turn_unrendered = true;
                     if app.dirty {
-                        let Some(_drew) = capture_owner_io_result(
-                            terminal_output.run_io(|deadline| {
-                                draw_full_app_frame(
-                                    terminal,
-                                    &mut app,
-                                    &mut perf,
-                                    &mut reducer_turn_unrendered,
-                                    deadline,
-                                )
-                            }),
-                            &mut owner_error,
-                        ) else {
-                            break 'owner;
-                        };
+                        draw_or_break!('owner);
                         perf.maybe_log(&app);
                     }
                     continue;
@@ -1073,20 +1055,7 @@ pub async fn run(
                         }
                     };
                     if !fast_succeeded {
-                        let Some(_drew) = capture_owner_io_result(
-                            terminal_output.run_io(|deadline| {
-                                draw_full_app_frame(
-                                    terminal,
-                                    &mut app,
-                                    &mut perf,
-                                    &mut reducer_turn_unrendered,
-                                    deadline,
-                                )
-                            }),
-                            &mut owner_error,
-                        ) else {
-                            break 'owner;
-                        };
+                        draw_or_break!('owner);
                     }
                     perf.maybe_log(&app);
                     continue;
@@ -1292,20 +1261,7 @@ pub async fn run(
         // running it *after* the frame lags the OS/remote surfaces by well under one frame while
         // leaving the resting on-screen output identical.
         if app.dirty {
-            let Some(_drew) = capture_owner_io_result(
-                terminal_output.run_io(|deadline| {
-                    draw_full_app_frame(
-                        terminal,
-                        &mut app,
-                        &mut perf,
-                        &mut reducer_turn_unrendered,
-                        deadline,
-                    )
-                }),
-                &mut owner_error,
-            ) else {
-                break 'owner;
-            };
+            draw_or_break!('owner);
         }
 
         // Only a turn that can mutate projected state may toggle/rebuild OS metadata. Progress

--- a/src/transfer/engine.rs
+++ b/src/transfer/engine.rs
@@ -504,12 +504,7 @@ async fn match_stage(
         cache_dirty |= apply_persistent_cache(cp, cache);
     }
     let mut local_capacity_keys = local_destination_keys(cp, local_snapshot);
-    if let Some(keys) = local_capacity_keys.as_mut() {
-        enforce_matched_capacity(cp, keys);
-        if keys.len() >= crate::playlists::SONGS_PER_PLAYLIST_MAX {
-            mark_pending_capacity_skipped(cp);
-        }
-    }
+    enforce_local_capacity(cp, local_capacity_keys.as_mut());
     if !to_spotify
         && cp.spec.media_kind == ImportMediaKind::Track
         && cp.tracks.iter().any(|track| track.outcome.is_none())
@@ -529,12 +524,7 @@ async fn match_stage(
             .map_err(|error| defer_ytm_match_error(cp, None, error))?;
         }
     }
-    if let Some(keys) = local_capacity_keys.as_mut() {
-        enforce_matched_capacity(cp, keys);
-        if keys.len() >= crate::playlists::SONGS_PER_PLAYLIST_MAX {
-            mark_pending_capacity_skipped(cp);
-        }
-    }
+    enforce_local_capacity(cp, local_capacity_keys.as_mut());
     let (mut matched_count, mut ambiguous_count, mut not_found_count) = outcome_counts(&cp.tracks);
     let mut completed_count = cp
         .tracks
@@ -962,6 +952,20 @@ async fn match_track_spotify(
         );
     }
     Ok(outcome)
+}
+
+/// Re-apply the local playlist cap after a step that may have matched more rows, marking the
+/// still-pending rows as capacity-skipped once the destination is full.
+fn enforce_local_capacity(
+    cp: &mut Checkpoint,
+    keys: Option<&mut std::collections::HashSet<String>>,
+) {
+    if let Some(keys) = keys {
+        enforce_matched_capacity(cp, keys);
+        if keys.len() >= crate::playlists::SONGS_PER_PLAYLIST_MAX {
+            mark_pending_capacity_skipped(cp);
+        }
+    }
 }
 
 async fn write_stage(

--- a/src/ui/views/library.rs
+++ b/src/ui/views/library.rs
@@ -193,6 +193,92 @@ fn render_filter(frame: &mut Frame, app: &App, area: Rect, matches: usize) {
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
+/// The message for an empty list: a filtered-to-nothing list gets a filter-specific message,
+/// not the per-tab "empty" hint.
+fn empty_list_message(app: &App) -> String {
+    if !app.library_ui.filter_query.is_empty() {
+        match crate::i18n::current() {
+            Language::Korean => {
+                format!("'{}' 와 일치하는 곡이 없어요.", app.library_ui.filter_query)
+            }
+            Language::Japanese => {
+                format!(
+                    "'{}' に一致する曲はありません。",
+                    app.library_ui.filter_query
+                )
+            }
+            _ => format!("No tracks match \"{}\".", app.library_ui.filter_query),
+        }
+    } else if app.library_ui.tab == LibraryTab::Playlists {
+        // The root level never reaches here (it renders via `render_playlist_list`),
+        // so this is an opened-but-empty playlist. Built from the live keymap so a
+        // rebind updates the hint in lock-step.
+        let add = app.keymap.label_for_display(
+            crate::keymap::KeyContext::Library,
+            crate::keymap::Action::AddToPlaylist,
+            app.retro_mode(),
+        );
+        let gem = app.keymap.label_for_display(
+            crate::keymap::KeyContext::Playlists,
+            crate::keymap::Action::OpenAi,
+            app.retro_mode(),
+        );
+        match crate::i18n::current() {
+            Language::Korean => format!(
+                "빈 플레이리스트예요 — 다른 목록에서 {add} 로 곡을 추가하거나 DJ Gem({gem})에게 부탁하세요."
+            ),
+            Language::Japanese => format!(
+                "空のプレイリストです — 他のリストで {add} を押して曲を追加するか、DJ Gem({gem})に頼んでください。"
+            ),
+            _ => format!(
+                "This playlist is empty — press {add} on any song to add it here, or ask DJ Gem ({gem})."
+            ),
+        }
+    } else {
+        match app.library_ui.tab {
+            LibraryTab::All => t!(
+                "No library tracks yet — play, favorite, or download something.",
+                "아직 라이브러리에 곡이 없어요 — 재생하거나 즐겨찾기하거나 다운로드해 보세요.",
+                "まだライブラリに曲がありません — 再生・お気に入り・ダウンロードしてみてください。"
+            ),
+            LibraryTab::Favorites => t!(
+                "No favorites yet — press f on a track to save it.",
+                "즐겨찾기가 없어요 — 곡에서 f 를 눌러 저장하세요.",
+                "お気に入りがありません — 曲で f を押して保存してください。"
+            ),
+            LibraryTab::History => {
+                t!(
+                    "No history yet — play something.",
+                    "재생 기록이 없어요 — 뭐든 재생해 보세요.",
+                    "再生履歴がありません — 何か再生してみてください。"
+                )
+            }
+            LibraryTab::RadioFavorites => t!(
+                "No radio favorites yet — press f on a Radio Browser station.",
+                "라디오 즐겨찾기가 없어요 — Radio Browser 방송에서 f 를 눌러 저장하세요.",
+                "ラジオのお気に入りがありません — Radio Browser の放送局で f を押して保存してください。"
+            ),
+            LibraryTab::Radio => t!(
+                "No recent radio stations yet — play one from Radio Browser search.",
+                "최근 라디오가 없어요 — Radio Browser 검색에서 재생해 보세요.",
+                "最近のラジオがありません — Radio Browser 検索から再生してみてください。"
+            ),
+            LibraryTab::Downloads => t!(
+                "No downloaded tracks found in the download folder.",
+                "다운로드 폴더에 받은 곡이 없어요.",
+                "ダウンロードフォルダーに曲が見つかりません。"
+            ),
+            // Handled by the keymap-aware branch above; benign fallback for exhaustiveness.
+            LibraryTab::Playlists => t!(
+                "This playlist is empty.",
+                "빈 플레이리스트예요.",
+                "空のプレイリストです。"
+            ),
+        }
+        .to_owned()
+    }
+}
+
 fn render_list(
     frame: &mut Frame,
     app: &App,
@@ -204,90 +290,10 @@ fn render_list(
     app.bridges.list_viewport_rows.set(area.height);
 
     if len == 0 {
-        // A filtered-to-nothing list gets a filter-specific message, not the per-tab "empty" hint.
-        let msg: String = if !app.library_ui.filter_query.is_empty() {
-            match crate::i18n::current() {
-                Language::Korean => {
-                    format!("'{}' 와 일치하는 곡이 없어요.", app.library_ui.filter_query)
-                }
-                Language::Japanese => {
-                    format!(
-                        "'{}' に一致する曲はありません。",
-                        app.library_ui.filter_query
-                    )
-                }
-                _ => format!("No tracks match \"{}\".", app.library_ui.filter_query),
-            }
-        } else if app.library_ui.tab == LibraryTab::Playlists {
-            // The root level never reaches here (it renders via `render_playlist_list`),
-            // so this is an opened-but-empty playlist. Built from the live keymap so a
-            // rebind updates the hint in lock-step.
-            let add = app.keymap.label_for_display(
-                crate::keymap::KeyContext::Library,
-                crate::keymap::Action::AddToPlaylist,
-                app.retro_mode(),
-            );
-            let gem = app.keymap.label_for_display(
-                crate::keymap::KeyContext::Playlists,
-                crate::keymap::Action::OpenAi,
-                app.retro_mode(),
-            );
-            match crate::i18n::current() {
-                Language::Korean => format!(
-                    "빈 플레이리스트예요 — 다른 목록에서 {add} 로 곡을 추가하거나 DJ Gem({gem})에게 부탁하세요."
-                ),
-                Language::Japanese => format!(
-                    "空のプレイリストです — 他のリストで {add} を押して曲を追加するか、DJ Gem({gem})に頼んでください。"
-                ),
-                _ => format!(
-                    "This playlist is empty — press {add} on any song to add it here, or ask DJ Gem ({gem})."
-                ),
-            }
-        } else {
-            match app.library_ui.tab {
-                LibraryTab::All => t!(
-                    "No library tracks yet — play, favorite, or download something.",
-                    "아직 라이브러리에 곡이 없어요 — 재생하거나 즐겨찾기하거나 다운로드해 보세요.",
-                    "まだライブラリに曲がありません — 再生・お気に入り・ダウンロードしてみてください。"
-                ),
-                LibraryTab::Favorites => t!(
-                    "No favorites yet — press f on a track to save it.",
-                    "즐겨찾기가 없어요 — 곡에서 f 를 눌러 저장하세요.",
-                    "お気に入りがありません — 曲で f を押して保存してください。"
-                ),
-                LibraryTab::History => {
-                    t!(
-                        "No history yet — play something.",
-                        "재생 기록이 없어요 — 뭐든 재생해 보세요.",
-                        "再生履歴がありません — 何か再生してみてください。"
-                    )
-                }
-                LibraryTab::RadioFavorites => t!(
-                    "No radio favorites yet — press f on a Radio Browser station.",
-                    "라디오 즐겨찾기가 없어요 — Radio Browser 방송에서 f 를 눌러 저장하세요.",
-                    "ラジオのお気に入りがありません — Radio Browser の放送局で f を押して保存してください。"
-                ),
-                LibraryTab::Radio => t!(
-                    "No recent radio stations yet — play one from Radio Browser search.",
-                    "최근 라디오가 없어요 — Radio Browser 검색에서 재생해 보세요.",
-                    "最近のラジオがありません — Radio Browser 検索から再生してみてください。"
-                ),
-                LibraryTab::Downloads => t!(
-                    "No downloaded tracks found in the download folder.",
-                    "다운로드 폴더에 받은 곡이 없어요.",
-                    "ダウンロードフォルダーに曲が見つかりません。"
-                ),
-                // Handled by the keymap-aware branch above; benign fallback for exhaustiveness.
-                LibraryTab::Playlists => t!(
-                    "This playlist is empty.",
-                    "빈 플레이리스트예요.",
-                    "空のプレイリストです。"
-                ),
-            }
-            .to_owned()
-        };
         frame.render_widget(
-            Paragraph::new(Line::from(msg).style(app.theme.style(R::TextMuted))),
+            Paragraph::new(
+                Line::from(empty_list_message(app)).style(app.theme.style(R::TextMuted)),
+            ),
             area,
         );
         return;

--- a/src/ui/views/onboarding.rs
+++ b/src/ui/views/onboarding.rs
@@ -310,22 +310,12 @@ fn coach_copy(app: &App, mini: bool, confirming: bool) -> CoachCopy {
                 )
                 .to_owned()
             } else {
-                format!(
-                    "{} {} {}",
+                open_with_hint(
                     t!("Open Search with", "검색 화면은", "検索画面は"),
-                    key(KeyContext::Player, Action::OpenSearch),
-                    t!(
-                        "or the top navigation.",
-                        "키 또는 위쪽 메뉴로 열 수 있어요.",
-                        "キーまたは上部メニューで開けます。"
-                    )
+                    &key(KeyContext::Player, Action::OpenSearch),
                 )
             },
-            primary: if reached {
-                t!("Continue", "계속", "続行").to_owned()
-            } else {
-                t!("Open Search", "검색 열기", "検索を開く").to_owned()
-            },
+            primary: continue_or_open(reached, t!("Open Search", "검색 열기", "検索を開く")),
         },
         BeginnerStep::Player => CoachCopy {
             heading: t!("Player controls", "플레이어 조작", "プレイヤー操作").to_owned(),
@@ -347,11 +337,7 @@ fn coach_copy(app: &App, mini: bool, confirming: bool) -> CoachCopy {
                     key(KeyContext::Global, Action::Home)
                 )
             },
-            primary: if reached {
-                t!("Continue", "계속", "続行").to_owned()
-            } else {
-                t!("Open Player", "플레이어 열기", "プレイヤーを開く").to_owned()
-            },
+            primary: continue_or_open(reached, t!("Open Player", "플레이어 열기", "プレイヤーを開く")),
         },
         BeginnerStep::Library => CoachCopy {
             heading: t!("Your Library", "내 라이브러리", "マイライブラリ").to_owned(),
@@ -363,22 +349,12 @@ fn coach_copy(app: &App, mini: bool, confirming: bool) -> CoachCopy {
                 )
                 .to_owned()
             } else {
-                format!(
-                    "{} {} {}",
+                open_with_hint(
                     t!("Open Library with", "라이브러리는", "ライブラリは"),
-                    key(KeyContext::Player, Action::OpenLibrary),
-                    t!(
-                        "or the top navigation.",
-                        "키 또는 위쪽 메뉴로 열 수 있어요.",
-                        "キーまたは上部メニューで開けます。"
-                    )
+                    &key(KeyContext::Player, Action::OpenLibrary),
                 )
             },
-            primary: if reached {
-                t!("Continue", "계속", "続行").to_owned()
-            } else {
-                t!("Open Library", "라이브러리 열기", "ライブラリを開く").to_owned()
-            },
+            primary: continue_or_open(reached, t!("Open Library", "라이브러리 열기", "ライブラリを開く")),
         },
         BeginnerStep::DjGem => CoachCopy {
             heading: t!("Meet DJ Gem", "DJ Gem 만나기", "DJ Gemの紹介").to_owned(),
@@ -410,28 +386,40 @@ fn coach_copy(app: &App, mini: bool, confirming: bool) -> CoachCopy {
                         .to_owned()
                     },
                     |context| {
-                        format!(
-                            "{} {} {}",
+                        open_with_hint(
                             t!("Open DJ Gem with", "DJ Gem은", "DJ Gemは"),
-                            key(context, Action::OpenAi),
-                            t!(
-                                "or the top navigation.",
-                                "키 또는 위쪽 메뉴로 열 수 있어요.",
-                                "キーまたは上部メニューで開けます。"
-                            )
+                            &key(context, Action::OpenAi),
                         )
                     },
                 )
             },
-            primary: if reached {
-                t!("Continue", "계속", "続行").to_owned()
-            } else {
-                t!("Open DJ Gem", "DJ Gem 열기", "DJ Gemを開く").to_owned()
-            },
+            primary: continue_or_open(reached, t!("Open DJ Gem", "DJ Gem 열기", "DJ Gemを開く")),
         },
         BeginnerStep::Settings => settings_copy(app, &key),
         BeginnerStep::Finish => finish_copy(app, &key),
     }
+}
+
+/// Primary button for a screen step: advance once the screen has been visited, otherwise
+/// offer to open it.
+fn continue_or_open(reached: bool, open: &str) -> String {
+    if reached {
+        t!("Continue", "계속", "続行").to_owned()
+    } else {
+        open.to_owned()
+    }
+}
+
+/// "Open <screen> with <key> or the top navigation." for a step whose screen is not open yet.
+fn open_with_hint(lead: &str, key: &str) -> String {
+    format!(
+        "{lead} {key} {}",
+        t!(
+            "or the top navigation.",
+            "키 또는 위쪽 메뉴로 열 수 있어요.",
+            "キーまたは上部メニューで開けます。"
+        )
+    )
 }
 
 fn settings_copy(app: &App, key: &impl Fn(KeyContext, Action) -> String) -> CoachCopy {

--- a/src/ui/views/settings.rs
+++ b/src/ui/views/settings.rs
@@ -29,7 +29,6 @@ use crate::app::{App, MouseTarget, ScrollSurface};
 use crate::config::{
     FPS_DEFAULT, FPS_MAX, FPS_MIN, SEEK_SECONDS_MAX, SEEK_SECONDS_MIN, SPEED_MAX, SPEED_MIN,
 };
-use crate::i18n::Language;
 use crate::keymap::{self, Action, KeyContext};
 use crate::settings::{BAND_GAIN_MAX, BAND_GAIN_MIN};
 use crate::settings::{Field, FieldKind, SettingsState, SettingsTab};
@@ -38,6 +37,120 @@ use crate::theme::ThemeConfig;
 use crate::theme::ThemeRole as R;
 use crate::ui::buttons;
 use crate::ui::text::pad_to_width;
+
+/// Footer hint for the Settings screen. Reflects the *committed* keymap, since that's what
+/// operates the screen until the edits are saved.
+fn footer_hint(app: &App, st: &SettingsState) -> String {
+    let k = |a| {
+        app.keymap
+            .label_for_display(KeyContext::Settings, a, app.retro_mode())
+    };
+    let save_quit = t!("save + quit", "저장하고 닫기", "保存して閉じる");
+    let switch_tab = t!("switch tab", "탭 전환", "タブ切替");
+    let reset = t!("reset", "초기화", "リセット");
+    if st.editing_text && matches!(st.current_field(), Some(Field::ThemeColor(_))) {
+        t!(
+            "type #RRGGBB or none  ·  Enter save  ·  Backspace delete",
+            "#RRGGBB 또는 none 입력  ·  Enter 저장  ·  Backspace 삭제",
+            "#RRGGBB または none を入力  ·  Enter 保存  ·  Backspace 削除"
+        )
+        .to_owned()
+    } else if st.editing_text {
+        // While typing a path/key, Enter or Esc both commit *and* persist it immediately,
+        // so the value can't be lost by leaving the screen later.
+        t!(
+            "type value  ·  Enter or Esc save  ·  Backspace delete",
+            "값 입력  ·  Enter 또는 Esc 저장  ·  Backspace 삭제",
+            "値を入力  ·  Enter または Esc 保存  ·  Backspace 削除"
+        )
+        .to_owned()
+    } else if matches!(st.current_field(), Some(Field::ExportPersonalData)) {
+        format!(
+            "{} {}",
+            k(Action::Confirm),
+            t!(
+                "export · unencrypted JSON · includes private listening history",
+                "내보내기 · 암호화되지 않은 JSON · 개인 감상 기록 포함",
+                "エクスポート · 暗号化されないJSON · 個人の再生履歴を含む"
+            )
+        )
+    } else if st.tab == SettingsTab::Sync {
+        format!(
+            "{}/{} {}  ·  {} {}  ·  {} {}  ·  {} {}",
+            k(Action::MoveUp),
+            k(Action::MoveDown),
+            t!("select", "선택", "選択"),
+            k(Action::Confirm),
+            t!("open", "열기", "開く"),
+            k(Action::FocusNext),
+            switch_tab,
+            k(Action::SettingsCancel),
+            t!("close", "닫기", "閉じる"),
+        )
+    } else if st.tab == SettingsTab::Keys {
+        let mouse_row = st.row >= keymap::editable_entries().len();
+        let rebind = if mouse_row {
+            format!(
+                "{}/{} {} {} {}",
+                k(Action::ChangeDecrease),
+                k(Action::ChangeIncrease),
+                t!("or", "또는", "または"),
+                k(Action::Confirm),
+                t!("change", "변경", "変更"),
+            )
+        } else {
+            format!(
+                "{} {}",
+                k(Action::Confirm),
+                t!("rebind", "재설정", "再割り当て")
+            )
+        };
+        format!(
+            "{}/{} {}  ·  {}  ·  {} {}  ·  {} {}  ·  {} {}",
+            k(Action::MoveUp),
+            k(Action::MoveDown),
+            t!("select", "선택", "選択"),
+            rebind,
+            k(Action::DeleteChar),
+            reset,
+            k(Action::FocusNext),
+            switch_tab,
+            k(Action::SettingsCancel),
+            save_quit,
+        )
+    } else if matches!(st.current_field(), Some(Field::ThemeColor(_))) {
+        format!(
+            "{}/{} {}  ·  {} {}  ·  {} {}  ·  {} {}  ·  {} {}",
+            k(Action::MoveUp),
+            k(Action::MoveDown),
+            t!("color", "색상", "カラー"),
+            k(Action::Confirm),
+            t!("edit", "편집", "編集"),
+            k(Action::DeleteChar),
+            reset,
+            k(Action::FocusNext),
+            switch_tab,
+            k(Action::SettingsCancel),
+            save_quit,
+        )
+    } else {
+        format!(
+            "{}/{} {}  ·  {}/{} {}  ·  {} {}  ·  {} {}  ·  {} {}",
+            k(Action::MoveUp),
+            k(Action::MoveDown),
+            t!("field", "이동", "移動"),
+            k(Action::ChangeDecrease),
+            k(Action::ChangeIncrease),
+            t!("change", "변경", "変更"),
+            k(Action::Confirm),
+            t!("edit/toggle", "편집/전환", "編集/切替"),
+            k(Action::FocusNext),
+            switch_tab,
+            k(Action::SettingsCancel),
+            save_quit,
+        )
+    }
+}
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     // No screen without state — but render defensively rather than panic.
@@ -98,180 +211,7 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     }
     crate::ui::control_box::render_docked(frame, app, rows[3]);
 
-    // Footer reflects the *committed* keymap, since that's what operates the screen until
-    // the edits are saved.
-    let k = |a| {
-        app.keymap
-            .label_for_display(KeyContext::Settings, a, app.retro_mode())
-    };
-    let lang = crate::i18n::current();
-    let help_text = if st.editing_text && matches!(st.current_field(), Some(Field::ThemeColor(_))) {
-        t!(
-            "type #RRGGBB or none  ·  Enter save  ·  Backspace delete",
-            "#RRGGBB 또는 none 입력  ·  Enter 저장  ·  Backspace 삭제",
-            "#RRGGBB または none を入力  ·  Enter 保存  ·  Backspace 削除"
-        )
-        .to_owned()
-    } else if st.editing_text {
-        // While typing a path/key, Enter or Esc both commit *and* persist it immediately,
-        // so the value can't be lost by leaving the screen later.
-        t!(
-            "type value  ·  Enter or Esc save  ·  Backspace delete",
-            "값 입력  ·  Enter 또는 Esc 저장  ·  Backspace 삭제",
-            "値を入力  ·  Enter または Esc 保存  ·  Backspace 削除"
-        )
-        .to_owned()
-    } else if matches!(st.current_field(), Some(Field::ExportPersonalData)) {
-        format!(
-            "{} {}",
-            k(Action::Confirm),
-            t!(
-                "export · unencrypted JSON · includes private listening history",
-                "내보내기 · 암호화되지 않은 JSON · 개인 감상 기록 포함",
-                "エクスポート · 暗号化されないJSON · 個人の再生履歴を含む"
-            )
-        )
-    } else if st.tab == SettingsTab::Sync {
-        format!(
-            "{}/{} {}  ·  {} {}  ·  {} {}  ·  {} {}",
-            k(Action::MoveUp),
-            k(Action::MoveDown),
-            t!("select", "선택", "選択"),
-            k(Action::Confirm),
-            t!("open", "열기", "開く"),
-            k(Action::FocusNext),
-            t!("switch tab", "탭 전환", "タブ切替"),
-            k(Action::SettingsCancel),
-            t!("close", "닫기", "閉じる"),
-        )
-    } else if st.tab == SettingsTab::Keys {
-        let mouse_row = st.row >= keymap::editable_entries().len();
-        match (lang, mouse_row) {
-            (Language::Korean, true) => format!(
-                "{}/{} 선택  ·  {}/{} 또는 {} 변경  ·  {} 초기화  ·  {} 탭 전환  ·  {} 저장하고 닫기",
-                k(Action::MoveUp),
-                k(Action::MoveDown),
-                k(Action::ChangeDecrease),
-                k(Action::ChangeIncrease),
-                k(Action::Confirm),
-                k(Action::DeleteChar),
-                k(Action::FocusNext),
-                k(Action::SettingsCancel),
-            ),
-            (Language::Korean, false) => format!(
-                "{}/{} 선택  ·  {} 재설정  ·  {} 초기화  ·  {} 탭 전환  ·  {} 저장하고 닫기",
-                k(Action::MoveUp),
-                k(Action::MoveDown),
-                k(Action::Confirm),
-                k(Action::DeleteChar),
-                k(Action::FocusNext),
-                k(Action::SettingsCancel),
-            ),
-            (Language::Japanese, true) => format!(
-                "{}/{} 選択  ·  {}/{} または {} 変更  ·  {} リセット  ·  {} タブ切替  ·  {} 保存して閉じる",
-                k(Action::MoveUp),
-                k(Action::MoveDown),
-                k(Action::ChangeDecrease),
-                k(Action::ChangeIncrease),
-                k(Action::Confirm),
-                k(Action::DeleteChar),
-                k(Action::FocusNext),
-                k(Action::SettingsCancel),
-            ),
-            (Language::Japanese, false) => format!(
-                "{}/{} 選択  ·  {} 再割り当て  ·  {} リセット  ·  {} タブ切替  ·  {} 保存して閉じる",
-                k(Action::MoveUp),
-                k(Action::MoveDown),
-                k(Action::Confirm),
-                k(Action::DeleteChar),
-                k(Action::FocusNext),
-                k(Action::SettingsCancel),
-            ),
-            (_, true) => format!(
-                "{}/{} select  ·  {}/{} or {} change  ·  {} reset  ·  {} switch tab  ·  {} save + quit",
-                k(Action::MoveUp),
-                k(Action::MoveDown),
-                k(Action::ChangeDecrease),
-                k(Action::ChangeIncrease),
-                k(Action::Confirm),
-                k(Action::DeleteChar),
-                k(Action::FocusNext),
-                k(Action::SettingsCancel),
-            ),
-            (_, false) => format!(
-                "{}/{} select  ·  {} rebind  ·  {} reset  ·  {} switch tab  ·  {} save + quit",
-                k(Action::MoveUp),
-                k(Action::MoveDown),
-                k(Action::Confirm),
-                k(Action::DeleteChar),
-                k(Action::FocusNext),
-                k(Action::SettingsCancel),
-            ),
-        }
-    } else if matches!(st.current_field(), Some(Field::ThemeColor(_))) {
-        match lang {
-            Language::Korean => format!(
-                "{}/{} 색상  ·  {} 편집  ·  {} 초기화  ·  {} 탭 전환  ·  {} 저장하고 닫기",
-                k(Action::MoveUp),
-                k(Action::MoveDown),
-                k(Action::Confirm),
-                k(Action::DeleteChar),
-                k(Action::FocusNext),
-                k(Action::SettingsCancel),
-            ),
-            Language::Japanese => format!(
-                "{}/{} カラー  ·  {} 編集  ·  {} リセット  ·  {} タブ切替  ·  {} 保存して閉じる",
-                k(Action::MoveUp),
-                k(Action::MoveDown),
-                k(Action::Confirm),
-                k(Action::DeleteChar),
-                k(Action::FocusNext),
-                k(Action::SettingsCancel),
-            ),
-            _ => format!(
-                "{}/{} color  ·  {} edit  ·  {} reset  ·  {} switch tab  ·  {} save + quit",
-                k(Action::MoveUp),
-                k(Action::MoveDown),
-                k(Action::Confirm),
-                k(Action::DeleteChar),
-                k(Action::FocusNext),
-                k(Action::SettingsCancel),
-            ),
-        }
-    } else {
-        match lang {
-            Language::Korean => format!(
-                "{}/{} 이동  ·  {}/{} 변경  ·  {} 편집/전환  ·  {} 탭 전환  ·  {} 저장하고 닫기",
-                k(Action::MoveUp),
-                k(Action::MoveDown),
-                k(Action::ChangeDecrease),
-                k(Action::ChangeIncrease),
-                k(Action::Confirm),
-                k(Action::FocusNext),
-                k(Action::SettingsCancel),
-            ),
-            Language::Japanese => format!(
-                "{}/{} 移動  ·  {}/{} 変更  ·  {} 編集/切替  ·  {} タブ切替  ·  {} 保存して閉じる",
-                k(Action::MoveUp),
-                k(Action::MoveDown),
-                k(Action::ChangeDecrease),
-                k(Action::ChangeIncrease),
-                k(Action::Confirm),
-                k(Action::FocusNext),
-                k(Action::SettingsCancel),
-            ),
-            _ => format!(
-                "{}/{} field  ·  {}/{} change  ·  {} edit/toggle  ·  {} switch tab  ·  {} save + quit",
-                k(Action::MoveUp),
-                k(Action::MoveDown),
-                k(Action::ChangeDecrease),
-                k(Action::ChangeIncrease),
-                k(Action::Confirm),
-                k(Action::FocusNext),
-                k(Action::SettingsCancel),
-            ),
-        }
-    };
+    let help_text = footer_hint(app, st);
     // The footer row doubles as the status/toast surface. An active status message (Spotify
     // connect/import feedback, errors, the browser/clipboard-fallback hint) takes the row so it
     // is visible without leaving Settings; otherwise the keybinding hint shows. Every other view


### PR DESCRIPTION
Re-lands #171. That PR was merged into `refactor/readability-pass-1` *after* #170 had already merged pass-1 into `main`, so its commit `c325feed` never reached `main`. This PR is the same single commit, retargeted at `main`.

See #171 for the review record (gates green, adversarial review Go, both nits applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)