### PR TITLE
release: 1.7.5 artifact preflight

### DIFF
--- a/.github/workflows/release-preflight-1.7.5.yml
+++ b/.github/workflows/release-preflight-1.7.5.yml
@@ -1,24 +1,24 @@
-name: release preflight 1.7.4
+name: release preflight 1.7.5
 
 on:
   pull_request:
     branches: [main]
 
 concurrency:
-  group: release-preflight-1.7.4-${{ github.event.pull_request.number }}
+  group: release-preflight-1.7.5-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 env:
-  PREFLIGHT_VERSION: 1.7.4
+  PREFLIGHT_VERSION: 1.7.5
 
 permissions:
   contents: read
 
 jobs:
   verify-version:
-    name: Verify synchronized 1.7.4 source versions
+    name: Verify synchronized 1.7.5 source versions
     if: >-
-      github.head_ref == 'agent/aggregate-1.7.4-preflight' &&
+      github.head_ref == 'agent/aggregate-1.7.5-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +53,7 @@ jobs:
   release-build:
     name: Native release build and package
     if: >-
-      github.head_ref == 'agent/aggregate-1.7.4-preflight' &&
+      github.head_ref == 'agent/aggregate-1.7.5-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: verify-version
     uses: ./.github/workflows/native-release-build.yml
@@ -62,9 +62,9 @@ jobs:
       pull-requests: read
 
   aggregate:
-    name: Aggregate 1.7.4 preflight artifacts
+    name: Aggregate 1.7.5 preflight artifacts
     if: >-
-      github.head_ref == 'agent/aggregate-1.7.4-preflight' &&
+      github.head_ref == 'agent/aggregate-1.7.5-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: release-build
     runs-on: ubuntu-latest
@@ -146,7 +146,7 @@ jobs:
       - name: Upload complete preflight bundle
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: yututui-1.7.4-preflight
+          name: yututui-1.7.5-preflight
           if-no-files-found: error
           retention-days: 14
           path: |
@@ -158,10 +158,10 @@ jobs:
             checksums.txt
 
   preflight-result:
-    name: Release preflight 1.7.4 result
+    name: Release preflight 1.7.5 result
     if: >-
       always() &&
-      github.head_ref == 'agent/aggregate-1.7.4-preflight' &&
+      github.head_ref == 'agent/aggregate-1.7.5-preflight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: [verify-version, release-build, aggregate]
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6873,7 +6873,7 @@ dependencies = [
 
 [[package]]
 name = "yututui"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "age",
  "anyhow",
@@ -6933,7 +6933,7 @@ dependencies = [
 
 [[package]]
 name = "yututui-core"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2024"
 # Releases are repository-built binaries. The application depends on a private workspace core,
 # so make the existing non-crates.io distribution contract explicit and fail closed on publish.

--- a/crates/yututui-core/Cargo.toml
+++ b/crates/yututui-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yututui-core"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2024"
 publish = false
 description = "Pure playback policies shared by yututui playback owners."

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           lib = pkgs.lib;
           yututui = pkgs.rustPlatform.buildRustPackage {
             pname = "yututui";
-            version = "1.7.4"; # keep in sync with Cargo.toml
+            version = "1.7.5"; # keep in sync with Cargo.toml
 
             # Drop build artifacts and flake results from the copied source so the store path
             # stays small and rebuilds aren't invalidated by a local `target/`.


### PR DESCRIPTION
Prepare 1.7.5 and build every release archive in a PR preflight using the same native build, test, smoke, and packaging workflow as tagged releases.

Synchronize `Cargo.toml`, `crates/yututui-core/Cargo.toml`, both workspace package entries in `Cargo.lock`, and `flake.nix` to 1.7.5. Rename and retarget the preflight workflow to `agent/aggregate-1.7.5-preflight`, including all version checks, job names, concurrency scope, and the aggregate artifact name. Windows executable metadata, macOS bundle metadata, and both binary version strings derive from the Cargo version.

The preflight verifies the exact archive set and required package contents, checks every SHA-256 sidecar, and uploads `yututui-1.7.5-preflight` with:

- `yututui-linux-x64.tar.gz` and `yututui-linux-arm64.tar.gz`
- `yututui-macos-x64.tar.gz` and `yututui-macos-arm64.tar.gz`, including both app bundles and the tray companion
- `yututui-windows-x64.zip`, including `ytt.exe`, `yututray.exe`, and the icon
- Five `.sha256` sidecars, `checksums.txt`, `install.sh`, and `install.ps1`

The artifact bundle is retained for 14 days. The workflow uses read-only repository permissions and retains the same-repository PR guards. This PR builds artifacts only; tag creation, release publication, and package-channel publishing remain separate.

Validation: locked Cargo metadata and manifest/lockfile/Nix version parity passed; all 11 preflight version references verified; `actionlint` and `git diff --check` passed. The canonical 16-gate suite passed locally, and all regular PR CI checks passed. Native release builds and the final artifact aggregation are running in the preflight workflow.
